### PR TITLE
update _config_file to train_config*s* (fix break)

### DIFF
--- a/torchtrain/profiling.py
+++ b/torchtrain/profiling.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
 
 from torchtrain.logging_utils import rank0_log
 
-_config_file = "./torchtrain/train_config/train_config.toml"
+_config_file = "./torchtrain/train_configs/train_config.toml"
 
 
 def get_config_from_toml(config_path: str = _config_file) -> dict:


### PR DESCRIPTION
got distracted with merge conflicts and had renamed config folder to 'train_configs', but did not update the default loading path.
This quick PR fixes that to ensure no break on running. 