### PR TITLE
Add ParallelDims helper and --pp_degree option

### DIFF
--- a/torchtrain/parallelisms/parallelize_llama.py
+++ b/torchtrain/parallelisms/parallelize_llama.py
@@ -3,6 +3,7 @@
 
 import os
 import torch
+import logging
 
 from torch.distributed.device_mesh import init_device_mesh
 
@@ -19,12 +20,57 @@ from torch.distributed.fsdp import (
 from torch.distributed.fsdp.wrap import enable_wrap, wrap
 
 from torchtrain.logging_utils import rank0_log
+from typing import Dict
+from dataclasses import dataclass
 
+logger = logging.getLogger(__name__)
 
 # Uses PTD FSDP AC wrapper
 def checkpoint_wrapper(module, config):
     return ptd_checkpoint_wrapper(module, checkpoint_impl=CheckpointImpl.NO_REENTRANT, preserve_rng_state=False)
 
+@dataclass
+class ParallelDims:
+    dp: int
+    sp: int
+    pp: int
+    world_size: int
+
+    def __post_init__(self):
+        self._validate()
+
+    def _validate(self):
+        dp, sp, pp = self.dp, self.sp, self.pp
+        if dp == -1:
+            self.dp = dp = self.world_size // (sp * pp)
+        assert dp >= 1, dp
+        assert sp >= 1, sp
+        assert pp >= 1, pp
+        assert dp * sp * pp == self.world_size, (
+            f"Invalid parallel dims: dp({dp}) * sp({sp}) * pp({pp}) != WORLD_SIZE({self.world_size})"
+        )
+
+    def build_mesh(self, device_type):
+        dims = []
+        names = []
+        for d, name in zip([self.dp, self.sp, self.pp], ["dp", "sp", "pp"]):
+            if d > 1:
+                dims.append(d)
+                names.append(name)
+        logger.info(f"Building {len(dims)}-D device mesh with {names}, {dims}")
+        return init_device_mesh(device_type, dims, mesh_dim_names=names)
+
+    @property
+    def dp_enabled(self):
+        return self.dp > 1
+
+    @property
+    def sp_enabled(self):
+        return self.sp > 1
+
+    @property
+    def pp_enabled(self):
+        return self.pp > 1
 
 def parallelize_llama(model, args):
     """
@@ -39,43 +85,40 @@ def parallelize_llama(model, args):
     device_type = "cuda"
     # distributed init
     world_size = int(os.environ["WORLD_SIZE"])
-    if args.enable_sp:
-        sp_degree = args.sp_degree
-        dp_degree = world_size // sp_degree
-        world_mesh = init_device_mesh(
-            device_type, (dp_degree, sp_degree), mesh_dim_names=("dp", "tp")
-        )
-        dp_mesh = world_mesh["dp"]
-    else:
-        world_mesh = init_device_mesh(device_type, (world_size,))
-        dp_mesh = world_mesh
-
+    parallel_dims = ParallelDims(dp=args.dp_degree, sp=args.sp_degree, pp=args.pp_degree, world_size=world_size)
+    world_mesh = parallel_dims.build_mesh(device_type)
     # apply PTD parallelisms
-    fsdp_config = {
-        "mixed_precision": MixedPrecision(
-            param_dtype=torch.bfloat16,
-            # TODO: see whether we should expose a option to user
-            reduce_dtype=torch.float32,
-        ),
-        "sharding_strategy": ShardingStrategy.FULL_SHARD,
-        "backward_prefetch": BackwardPrefetch.BACKWARD_PRE,
-        # When torch.compile is active, it requires us to set use_orig_params=True
-        "use_orig_params": True,
-        "device_mesh": dp_mesh,
-    }
+    if parallel_dims.pp_enabled:
+        raise NotImplementedError("PP not implemented yet.")
+    if parallel_dims.sp_enabled:
+        raise NotImplementedError("SP not implemented yet.")
+    if parallel_dims.dp_enabled:
+        dp_mesh = world_mesh["dp"]
+        fsdp_config = {
+            "mixed_precision": MixedPrecision(
+                param_dtype=torch.bfloat16,
+                # TODO: see whether we should expose a option to user
+                reduce_dtype=torch.float32,
+            ),
+            "sharding_strategy": ShardingStrategy.FULL_SHARD,
+            "backward_prefetch": BackwardPrefetch.BACKWARD_PRE,
+            # When torch.compile is active, it requires us to set use_orig_params=True
+            "use_orig_params": True,
+            "device_mesh": dp_mesh,
+        }
 
-    with enable_wrap(wrapper_cls=FSDP, **fsdp_config):
-        for layer_id, transformer_block in enumerate(model.layers):
-            # apply AC to each layer
-            # before wrapping with FSDP, we need to make sure the layer is on GPU
-            transformer_block = transformer_block.cuda()
-            transformer_block = checkpoint_wrapper(transformer_block, args)
+        with enable_wrap(wrapper_cls=FSDP, **fsdp_config):
+            for layer_id, transformer_block in enumerate(model.layers):
+                # apply AC to each layer
+                # before wrapping with FSDP, we need to make sure the layer is on GPU
+                transformer_block = transformer_block.cuda()
+                transformer_block = checkpoint_wrapper(transformer_block, args)
 
-            # Wraps each layer with FSDP
-            model.layers[layer_id]= wrap(transformer_block)
+                # Wraps each layer with FSDP
+                model.layers[layer_id]= wrap(transformer_block)
 
-        # wrap the rest layers with FSDP
-        model = wrap(model.cuda())
+            # wrap the rest layers with FSDP
+            model = wrap(model.cuda())
 
     rank0_log(f"Applied parallelisms to the model...")
 

--- a/train.py
+++ b/train.py
@@ -148,13 +148,22 @@ if __name__ == "__main__":
         "--steps", type=int, default=-1, help="how many train steps to run"
     )
     parser.add_argument(
-        "--enable_sp", action="store_true", help="Whether to use Sequence Parallelism."
+        "--dp_degree",
+        type=int,
+        default=-1,
+        help="Data Parallelism degree. -1 means leftover ranks will be used (After SP/PP). 1 means disabled.",
     )
     parser.add_argument(
         "--sp_degree",
         type=int,
         default=LOCAL_WORLD_SIZE,
-        help="Sequence Parallelism degree",
+        help="Sequence Parallelism degree.  1 means disabled.",
+    )
+    parser.add_argument(
+        "--pp_degree",
+        type=int,
+        default=1,
+        help="Pipeline Parallelism degree (default of 1 means disabled)",
     )
     parser.add_argument(
         "--compile", action="store_true", help="Whether to compile the model."


### PR DESCRIPTION
Make dp_degree configurable (=-1 consumes the rest of the mesh not used by PP/SP, =1 disables, >1 specifies requested data paralell size.

Local tests showed these outputs:

with --dp_degree=-1 and pp, sp = 1
Building 1-D device mesh with ['dp'], [8]

with sp=4
Building 2-D device mesh with ['dp', 'sp'], [2, 4]

with sp=2, pp=2
Building 3-D device mesh with ['dp', 'sp', 'pp'], [2, 2, 2]

with sp=2, pp=3 (WS=8)
AssertionError: Invalid parallel dims: dp(1) * sp(2) * pp(3) != WORLD_SIZE8

with sp=2, pp=3 (WS=6)
Building 2-D device mesh with ['sp', 'pp'], [2, 3]