### PR TITLE
Remove the accidentally added --compile

### DIFF
--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -13,5 +13,5 @@ CHECKPOINT_FOLDER=""
 CHECKPOINT_INTERVAL=5
 
 torchrun --nproc_per_node=${NGPU} \
-train.py --steps 10 --compile \
+train.py --steps 10 \
 --checkpoint-folder=${CHECKPOINT_FOLDER} --checkpoint-interval=${CHECKPOINT_INTERVAL}


### PR DESCRIPTION
Summary:
Remove this flag to avoid the time to compile.