### PR TITLE
support infinite loop over alpaca dataset

### DIFF
--- a/train.py
+++ b/train.py
@@ -158,6 +158,8 @@ def main(args):
     )
     checkpoint.load()
 
+    data_iterator = iter(data_loader)
+
     with maybe_run_profiler() as torch_profiler:
         checkpoint.reset()
         # variables used to keep info for metrics logging
@@ -167,7 +169,7 @@ def main(args):
         while train_state.step < args.steps or args.steps == -1:
             train_state.step += 1
             # get batch
-            batch = next(iter(data_loader))
+            batch = next(data_iterator)
             input_ids, labels = batch
             input_ids = input_ids.cuda()
             labels = labels.cuda()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #66

Previously, alpaca dataset is consumed up after only ~50 iterations with 8 data parallel ranks and 8 batch size. This PR adds the (default) option to loop infinitely on the dataset, so that we can unblock integrating other functionalities. Note that loss-related metrics should be read with caution as this will cause overfit.

Update: moved to #92 because migrating to pytorch/ confused ghstack.