### PR TITLE
[WIP] Used  per-parameter FSDP

### DIFF
--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -17,8 +17,8 @@ NGPU=${NGPU:-"8"}
 LOG_RANK=${LOG_RANK:-0}
 
 
-CONFIG_FILE=${CONFIG_FILE:-"./train_configs/debug_model.toml"}
+CONFIG_FILE=${CONFIG_FILE:-"./train_configs/llama_7b.toml"}
 
-torchrun --nproc_per_node=${NGPU} --rdzv_endpoint="localhost:5972" \
+torchrun --nproc_per_node=${NGPU} --rdzv-backend=c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
 train.py --job.config_file ${CONFIG_FILE}

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -4,7 +4,7 @@ dump_folder = "./outputs"
 description = "debug training"
 
 [profiling]
-run_profiler = true
+run_profiler = false
 save_traces_folder = "profiling/traces"
 # profiling frequency - example: 10 means every 10th iter will be profiled
 profile_every_x_iter = 10

--- a/train_configs/llama_7b.toml
+++ b/train_configs/llama_7b.toml
@@ -7,7 +7,7 @@ description = "llama 7b training"
 run_profiler = true
 save_traces_folder = "profiling/traces"
 # profiling frequency - example: 10 means every 10th iter will be profiled
-profile_every_x_iter = 100
+profile_every_x_iter = 10
 
 [metrics]
 enable_tensorboard = true
@@ -29,12 +29,13 @@ batch_size = 8
 seq_len = 2048
 warmup_steps = 200  # lr scheduler warm up
 max_norm = 1.0  # grad norm clipping
-steps = 1000
+steps = 10
 # only dp would be sufficient for 7B
 data_parallel_degree = -1
 sequence_parallel_degree = 1
 pipeline_parallel_degree = 1
 compile = false
+enable_selective_ac = false
 checkpoint_interval = 3600
 checkpoint_interval_type = "steps"
 checkpoint_folder = ""


### PR DESCRIPTION
This PR shows how we would modify torchtrain to use per-parameter FSDP (sometimes called FSDP2 or ppFSDP). Detailed context can be found in https://github.com/pytorch/pytorch/issues/114299.

**Progress Tracking**
Gaps for 1D FSDP:
- Support gradient norm clipping
    - The plan is to rely on `DTensor`'s op dispatch to implement `vector_norm` and `stack`. This approach will allow us to use `torch.nn.utils.clip_grad_norm_()` out of the box as long as all `DTensor` parameters share the same sharding.
    - [x] Gradient norm clipping w/o `foreach=True`: https://github.com/pytorch/pytorch/pull/120238
    - [x] Gradient norm clipping w/ `foreach=True`
- [ ] Integrate with distributed checkpointing
- [ ] Meta-device initialization
    - The plan is to allow FSDP to shard on meta device without materializing parameters. After applying FSDP, the user can call `model.to_empty(device="cuda")` and initialize parameters/buffers as needed (e.g. via `reset_parameters()` on each module). The initialization will use `DTensor`'s randomness, which ensures correct randomness with respect to the global shape.
    - There are some minor gaps in core that will be fixed soon.

Goal is to land PRs to address these gaps by 3/8. The overall execution tracker can be found in https://github.com/pytorch/pytorch/issues/120003.

Gaps for 2D FSDP + TP/SP:
- [ ] Support `torch.compile`
    - Current error: P1192664996
    - We may need to add FSDP2 to some skipfiles similar to FSDP so that we graph break cleanly on FSDP's pre-forward hook.

**Experiments**
LLama2-7B
8 H100 GPUs, local batch size 8, sequence length 2048, activation checkpointing and `torch.compile` each transformer block
- Baseline: Existing flat-parameter (`FULL_SHARD`):
  - 2124 ms per iteration
  - 23.24 GB peak active
- Per-parameter (`reshard_after_forward=True`)
  - 2143 ms per iteration
  - 22.11 GB peak active
- Per-parameter (`reshard_after_forward=False` for last transformer block)
  - 2127 ms per iteration
  - 22.49 GB peak active (if peak is at beginning of backward, then this increase makes sense)

(Ideally, we can have some per-GPU MFU or tokens-per-second metric rather than time per iteration, which is less interpretable.)
