### PR TITLE
add iter time tracking via cuda events, add data loading times, add columnar display to show both, show avg iter & data loading times at end of training

### DIFF
--- a/train.py
+++ b/train.py
@@ -267,8 +267,8 @@ def main(job_config: JobConfig):
                 time_last_log = timer()
 
             rank0_log(
-                f"step: {train_state.step},  loss: {round(train_state.current_loss,4)},"
-                f"  iter: {curr_iter_time},  data: {data_load_time},  lr: {round(float(scheduler.get_last_lr()[0]), 8)}"
+                f"step: {train_state.step:>2}  loss: {round(train_state.current_loss,4):>7}"
+                f"  iter: {curr_iter_time:>7}  data: {data_load_time:>5}  lr: {round(float(scheduler.get_last_lr()[0]), 8):<6}"
             )
             scheduler.step()
 


### PR DESCRIPTION
This PR adds basic perf timing and display for 'per iter' and 'final iter average' display.  (in part based on Andrew's comment about having to open the trace to compare iter timing). 

1. tracking list is housed in TrainState, but I do not save it as part of the state dict as I view this as useful but not saveable info. 
2. iter times are tracked after dataloading is done each iter and after optimizer step.  The idea is to make this timing expressly the model training iter (not data loading or post iter other metrics calcs). 

3. 'time' is now displayed at each iter along with the usual loss and lr. 

4. at the end of training, assuming more than 3 iters run, then the average iter time is calculated by igoring the first three iters (consider these as warmup esp as cudaCacheAllocator gets warmed up) and displayed. 
5. based on @tianyu-l feedback:   I have added data loading times as well. 
I used the same timeit.default_timer() from timeit to be consistent.
(cpu side so no synch's needed :)

6 - after fiddling with printf width formatting options, added beautiful aligned columnar display for the per iter updates:
Now: 
<img width="1282" alt="Screenshot 2024-02-26 at 9 39 25 AM" src="https://github.com/pytorch/torchtrain/assets/46302957/9ee2ea7b-5c28-4d41-ba91-d4176c64fc66">

before: 
<img width="1282" alt="Screenshot 2024-02-26 at 8 39 46 AM" src="https://github.com/pytorch/torchtrain/assets/46302957/37cbfa20-7f1d-4d94-be94-3505ef4498c0">




