### PR TITLE
Fill missing options in toml file wih argparse defaults

### DIFF
--- a/test/test_job_config.py
+++ b/test/test_job_config.py
@@ -13,9 +13,7 @@ class TestJobConfig:
 
     def test_job_config_file(self):
         config = JobConfig()
-        config.parse_args(
-            ["--job.config_file", "./train_configs/debug_model.toml"]
-        )
+        config.parse_args(["--job.config_file", "./train_configs/debug_model.toml"])
         assert config.training.steps == 10
 
     def test_job_file_does_not_exist(self):

--- a/torchtrain/config_manager.py
+++ b/torchtrain/config_manager.py
@@ -1,4 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 import argparse
 import sys


### PR DESCRIPTION
Summary:

Summary:
Follow up on config unification, options not available in config file are picked from command line defaults.

Test Plan:
============================= test session starts ============================== platform linux -- Python 3.10.13, pytest-8.0.1, pluggy-1.4.0 -- /home/gnadathur/local/a/pytorch-env/bin/python cachedir: .pytest_cache rootdir: /data/users/gnadathur/a/torchtrain
configfile: pyproject.toml
plugins: cov-4.1.0
collecting ... collected 3 items

test/test_job_config.py::TestJobConfig::test_command_line_args PASSED [ 33%] test/test_job_config.py::TestJobConfig::test_job_config_file PASSED [ 66%] test/test_job_config.py::TestJobConfig::test_job_file_does_not_exist PASSED [100%]

---------- coverage: platform linux, python 3.10.13-final-0 ---------- Coverage XML written to file coverage.xml

============================= slowest 20 durations ============================= 0.00s call test/test_job_config.py::TestJobConfig::test_job_config_file 0.00s call test/test_job_config.py::TestJobConfig::test_command_line_args 0.00s call test/test_job_config.py::TestJobConfig::test_job_file_does_not_exist 0.00s setup test/test_job_config.py::TestJobConfig::test_command_line_args 0.00s teardown test/test_job_config.py::TestJobConfig::test_command_line_args 0.00s setup test/test_job_config.py::TestJobConfig::test_job_config_file 0.00s setup test/test_job_config.py::TestJobConfig::test_job_file_does_not_exist 0.00s teardown test/test_job_config.py::TestJobConfig::test_job_config_file 0.00s teardown test/test_job_config.py::TestJobConfig::test_job_file_does_not_exist ============================== 3 passed in 0.06s ===============================

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: