### PR TITLE
update GPU metrics logging to GiB (gibibytes)

### DIFF
--- a/torchtrain/metrics.py
+++ b/torchtrain/metrics.py
@@ -21,15 +21,15 @@ _gib_in_bytes = 1024 * 1024 * 1024
 _mib_in_bytes = 1024 * 1024
 
 
-def format_to_gib(item, precision=4):
+def _format_to_gib(item, precision=4):
     """quick function to format numbers to gibibyte and round to (default) 4 digit precision"""
     metric_num = item / _gib_in_bytes
     metric_num = round(metric_num, ndigits=precision)
     return metric_num
 
 
-def convert_to_gpu_pct(value, total_gpu_memory):
-    return round(100 * (value / total_gpu_memory), 2)
+def _convert_to_gpu_pct(value, total_gpu_memory, precision=4):
+    return round(100 * (value / total_gpu_memory), precision)
 
 
 # named tuple for passing memory stats (as % of device capacity) for Tensorboard logging
@@ -59,7 +59,7 @@ class GPUMemoryMonitor:
         self.device_capacity = torch.cuda.get_device_properties(
             self.device
         ).total_memory
-        self.device_capacity_gib = format_to_gib(self.device_capacity)
+        self.device_capacity_gib = _format_to_gib(self.device_capacity)
         self.num_retries = 0
         self.num_ooms = 0
         self.peak_active_memory = 0
@@ -77,8 +77,8 @@ class GPUMemoryMonitor:
 
         # current stats
         self.device_alloc_memory_usage = torch.cuda.memory_allocated(self.device)
-        self.device_alloc_memory_gib = format_to_gib(self.device_alloc_memory_usage)
-        self.device_alloc_memory_pct = convert_to_gpu_pct(
+        self.device_alloc_memory_gib = _format_to_gib(self.device_alloc_memory_usage)
+        self.device_alloc_memory_pct = _convert_to_gpu_pct(
             self.device_alloc_memory_usage, self.device_capacity
         )
 
@@ -92,9 +92,7 @@ class GPUMemoryMonitor:
         return pct_memory
 
     def get_gib_memory(self, memory_num):
-        gib_memory = memory_num / _gib_in_bytes
-        gib_memory = round(gib_memory, 2)
-        return gib_memory
+        return _format_to_gib(memory_num, precision=2)
 
     def get_current_stats(self, return_data: bool = False):
         """
@@ -105,23 +103,23 @@ class GPUMemoryMonitor:
         curr_mem = torch.cuda.memory_stats(self.device)
 
         self.device_alloc_memory_usage = curr_mem["allocated_bytes.all.current"]
-        self.device_alloc_memory_gib = format_to_gib(self.device_alloc_memory_usage)
-        self.device_alloc_memory_pct = convert_to_gpu_pct(
+        self.device_alloc_memory_gib = _format_to_gib(self.device_alloc_memory_usage)
+        self.device_alloc_memory_pct = _convert_to_gpu_pct(
             self.device_alloc_memory_usage, self.device_capacity
         )
 
         self.device_reserved_memory_usage = curr_mem["reserved_bytes.all.current"]
-        self.device_reserved_memory_gib = format_to_gib(
+        self.device_reserved_memory_gib = _format_to_gib(
             self.device_reserved_memory_usage
         )
-        self.device_reserved_memory_pct = convert_to_gpu_pct(
+        self.device_reserved_memory_pct = _convert_to_gpu_pct(
             self.device_reserved_memory_usage, self.device_capacity
         )
 
         self.device_active_memory_usage = curr_mem["active_bytes.all.current"]
-        self.device_active_memory_gib = format_to_gib(self.device_active_memory_usage)
-        self.device_active_memory_pct = convert_to_gpu_pct(
-            self.device_active_memory_usage, self.device_capacity
+        self.device_active_memory_gib = _format_to_gib(self.device_active_memory_usage)
+        self.device_active_memory_pct = _convert_to_gpu_pct(
+            self.device_active_memory_usage, self.device_capacity, precision=2
         )
 
         display_str = ""


### PR DESCRIPTION
this PR updates the GPU metrics to labelling as GiB - we were calculating GiB but calling it GB.  
(credit to @awgu  for flagging this - issue https://github.com/pytorch/torchtrain/issues/94)

function names and member vars in metrics.py have been updated to _gib instead of _gb for clarity, and the logging output now labels as GiB:
<img width="851" alt="Screenshot 2024-02-27 at 11 28 23 AM" src="https://github.com/pytorch/torchtrain/assets/46302957/85eb260a-77e9-4c49-be8a-b1aaa10dc3e2">

