### PR TITLE
Shorten nccl comm  timeout and enable flight recorder dumping

### DIFF
--- a/torchtrain/config_manager.py
+++ b/torchtrain/config_manager.py
@@ -263,4 +263,18 @@ class JobConfig:
             default="2",  # 2 = checkpoint every other layer
             help="['int', 'op'] = selective activation checkpointing options, 'int' for every nth layer, or 'op' for op level ac.",
         )
+
+        # communications library settings
+        parser.add_argument(
+            "--comm.timeout_seconds",
+            type=int,
+            default=5,
+            help="Timeout for async communication operations",
+        )
+        parser.add_argument(
+            "--comm.trace_buf_size",
+            type=int,
+            default=20000,
+            help="Flight recorder ring buffer size, >0 means recording by default, 0 means disabled",
+        )
         return parser.parse_args(args_list)

--- a/train.py
+++ b/train.py
@@ -25,7 +25,11 @@ from torchtrain.lr_scheduling import get_lr_scheduler
 from torchtrain.meta_init import meta_model_init
 from torchtrain.metrics import build_metric_logger, get_num_params, GPUMemoryMonitor
 from torchtrain.models import model_name_to_cls, model_name_to_tokenizer, models_config
-from torchtrain.parallelisms import models_parallelize_fns, ParallelDims
+from torchtrain.parallelisms import (
+    init_distributed,
+    models_parallelize_fns,
+    ParallelDims,
+)
 from torchtrain.profiling import maybe_run_profiler
 from torchtrain.utils import Color, dist_max, dist_mean
 
@@ -100,6 +104,9 @@ def main(job_config: JobConfig):
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
     )
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    init_distributed(job_config)
+
     world_mesh = parallel_dims.build_mesh(device_type="cuda")
 
     model_name = job_config.model.name


### PR DESCRIPTION
Timeout
-------

It's convenient whether during iterative debugging or long running training to find out asap about a failure.  The default timeout is way too long and leads to wasted cluster time or developer frustration.
  
Timeout can be adjusted via cmdline or in .toml if it needs to be larger for a particular model.

Another useful pattern can be to set a large timeout for initialization and then tighten it after iteration 1.  We can add this later if desired.

Ideally we could pass the timeout to the device mesh ctor, but it's not ready yet.  Also, we can change timeouts of the existing PGs after creating them, but that's more LOC and not necessary unless we want to change the timeouts at runtime.

Dumps
-----

Dumping on timeout should be a safe default for everyone. It has the side-effect of requiring a dump path which defaults to ~/pgnccl_dump but can be overridden via DUMP_PATH env.

The raw content of the dump is a pickle that is intended to be consumed through scripts/tools which are under development, so it may not be easy to know how to use these for now.  As the tooling matures, we should provide reference docs and probably print out pointers in the logs when we perform the dump.


Test plan:
tested locally by adding a rank0 sleep for 10sec inside the training loop, validating all 8 ranks dumped a trace.