### PR TITLE
Ensured `losses` is a list

### DIFF
--- a/train.py
+++ b/train.py
@@ -57,7 +57,10 @@ class TrainState:
     def load_state_dict(self, state_dict) -> None:
         self.step = state_dict["step"].item()
         self.current_loss = state_dict["current_loss"].item()
-        self.losses = state_dict["losses"].tolist()
+        losses = state_dict["losses"].tolist()
+        if not isinstance(losses, list):
+            losses = [losses]
+        self.losses = losses
 
 
 def build_optimizer(model, job_config: JobConfig):


### PR DESCRIPTION
[`Tensor.tolist()`](https://pytorch.org/docs/stable/generated/torch.Tensor.tolist.html) can return a `float` if the `Tensor` is a scaler tensor.

Without this, we may hit
```
[rank0]:[rank0]:     train_state.losses.append(train_state.current_loss)
[rank0]:[rank0]: AttributeError: 'float' object has no attribute 'append'
```
when loading from a checkpoint.