### PR TITLE
Separate timeout during init and training

### DIFF
--- a/torchtrain/config_manager.py
+++ b/torchtrain/config_manager.py
@@ -266,10 +266,19 @@ class JobConfig:
 
         # communications library settings
         parser.add_argument(
-            "--comm.timeout_seconds",
+            "--comm.init_timeout_seconds",
+            type=int,
+            default=300,
+            help="Timeout for communication operations, during initialization and first train step.",
+        )
+        parser.add_argument(
+            "--comm.train_timeout_seconds",
             type=int,
             default=5,
-            help="Timeout for async communication operations",
+            help=(
+                "Timeout for communication operations after the first train step-"
+                "usually a tighter bound than during initialization."
+            ),
         )
         parser.add_argument(
             "--comm.trace_buf_size",


### PR DESCRIPTION
Allow a tighter timeout during training than during init.

Init includes the first train step, as well as any loading and setup. It can be slower and less predictable due to various factors including lazy initialization or jit compilation.

After the first train step, we expect more predictable runtime and benefit from a tighter timeout to give quick feedback on a hang.

Tested by pasting this code in 2 places
```
if dp_mesh.get_local_rank() == 0 and train_state.step == 1:
   import time
   time.sleep(10)
```

(a) before calling set_pg_timeout, which did not cause a timeout (b) after calling set_pg_timeout, which timed out