### PR TITLE
disable buffer reuse for compile for now

### DIFF
--- a/train.py
+++ b/train.py
@@ -196,6 +196,7 @@ def main(job_config: JobConfig):
 
     # torch.compile model for improved performance
     if job_config.training.compile:
+        torch._inductor.config.allow_buffer_reuse = False
         if (
             job_config.activation_checkpoint.mode == "selective"
             and job_config.activation_checkpoint.selective_ac_option == "op"


### PR DESCRIPTION
disable buffer reuse for compile to have close numerics to eager mode, as suggested by @Chillee 

This is probably only a temp change until buff reuse fix in inductor