### PR TITLE
run sdpa with dtensor

### DIFF
--- a/torchtrain/parallelisms/parallelize_llama.py
+++ b/torchtrain/parallelisms/parallelize_llama.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from typing import Tuple
 
 import torch
-from torch.distributed._tensor import Replicate, Shard, distribute_tensor
+from torch.distributed._tensor import distribute_tensor, Replicate, Shard
 
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163

There are several caveats:
1. FSDP + TP uses bfloat16 as default param dtype, which seems to create minor numerical discrepancies. I'm still investigating if the discrepancies are caused by collectives or dtensor.
2. Flash attention only supports bfloat16 and float16.
(1) if `dtype` is `torch.float32`, efficient attention will be used, which is not supported by DTensor yet (will add this);
(2) if `dtype` is `torch.float64`, decomposed attention will be used, which is not compatible with DTensor due to the usage of intermediate torch.Tensor mask.
3. 1D TP only parallelism would fail with this PR by default for the reason mentioned in 2.(1).
