### PR TITLE
simple meta init

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,6 @@ from torchtrain.datasets import create_tokenizer, dataloader_fn
 from torchtrain.float8_linear import build_fp8_linear
 from torchtrain.logging_utils import init_logger, logger
 from torchtrain.lr_scheduling import get_lr_scheduler
-from torchtrain.meta_init import meta_model_init
 from torchtrain.metrics import build_gpu_memory_monitor, build_metric_logger
 from torchtrain.models import model_name_to_cls, model_name_to_tokenizer, models_config
 from torchtrain.parallelisms import models_parallelize_fns, ParallelDims
@@ -152,7 +151,7 @@ def main(job_config: JobConfig):
     model_cls = model_name_to_cls[model_name]
     model_config = models_config[model_name][job_config.model.flavor]
     model_config.vocab_size = tokenizer.n_words
-    with meta_model_init():
+    with torch.device("meta"):
         logger.info(
             f"Building {model_name} {job_config.model.flavor} with {model_config}"
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #164

Since the variable `freqs_cis` is not a parameter nor a buffer in `RotaryEmbedding`, we can just delay its initialization to `reset_parameters()` and thus use `with torch.device("meta"):` to do simple meta init.

After that, `reset_parameters()` can be explicitly and recursively called (starting from `Transformer`), which works on both GPU and CPU.