### PR TITLE
Add 2D integration test (FSDP + TP)

### DIFF
--- a/train_configs/debug_model_2d.toml
+++ b/train_configs/debug_model_2d.toml
@@ -1,0 +1,47 @@
+# TorchTrain Config.toml
+[job]
+dump_folder = "./outputs"
+description = "LLaMA debug training"
+use_for_integration_test = true
+
+[profiling]
+run_profiler = true
+save_traces_folder = "profiling/traces"
+# profiling frequency - example: 10 means every 10th iter will be profiled
+profile_every_x_iter = 10
+
+[metrics]
+log_freq = 1
+enable_tensorboard = true
+save_tb_folder = "tb"
+use_for_integration_test = true
+
+[model]
+name = "llama"
+flavor = "debugmodel"
+tokenizer_path = "./torchtrain/datasets/tokenizer/tokenizer.model"
+
+[optimizer]
+name = "AdamW"
+lr = 8e-4
+
+
+[training]
+batch_size = 8
+seq_len = 2048
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+max_norm = 1.0  # grad norm clipping
+steps = 10
+data_parallel_degree = -1
+tensor_parallel_degree = 2
+pipeline_parallel_degree = 1
+fp8_linear = ""
+compile = false
+checkpoint_interval = 3600
+checkpoint_interval_type = "steps"
+checkpoint_folder = ""
+dataset = "alpaca"   # supported datasets = alpaca (52K), minipile (1M), c4 (177M)
+
+[activation_checkpoint]
+mode = 'selective'  # ['none', 'full', 'selective']
+selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy


### PR DESCRIPTION
Summary:
Add a 2D test to integration test suite

Test Plan:

```

=====Integration test: CONFIG_FILE=./train_configs/debug_model.toml NGPU=4 ./run_llama_train.sh=====
+ export USE_LIBUV=1
+ USE_LIBUV=1
+ TRAINER_DIR=/home/gnadathur/local/torchtrain
+ NGPU=4
+ LOG_RANK=0
+ CONFIG_FILE=./train_configs/debug_model.toml
+ torchrun --nproc_per_node=4 --rdzv_endpoint=localhost:5972 --local-ranks-filter 0 --role rank --tee 3 train.py --job.config_file ./train_configs/debug_model.toml
W0327 14:29:47.734000 140642626999296 torch/distributed/run.py:757]
W0327 14:29:47.734000 140642626999296 torch/distributed/run.py:757] *****************************************
W0327 14:29:47.734000 140642626999296 torch/distributed/run.py:757] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
W0327 14:29:47.734000 140642626999296 torch/distributed/run.py:757] *****************************************
[rank0]:2024-03-27 14:29:49,466 - root - INFO - Starting job: LLaMA debug training
[rank0]:2024-03-27 14:29:49,615 - root - WARNING - ENV[TORCH_NCCL_ASYNC_ERROR_HANDLING] = 1 will be overridden to 3 based on job config
[rank0]:2024-03-27 14:29:49,621 - root - INFO - Building 1-D device mesh with ['dp'], [4]
[rank0]:2024-03-27 14:29:49,623 - root - INFO - Building sentencepiece tokenizer locally from ./torchtrain/datasets/tokenizer/tokenizer.model
[rank0]:2024-03-27 14:29:49,630 - root - INFO - SentencePieceTokenizer built: #words 32000, BOS ID 1, EOS ID 2
[rank0]:2024-03-27 14:29:49,630 - root - INFO - Preparing alpaca dataset from HuggingFace
[rank0]:2024-03-27 14:29:51,114 - root - INFO - Building llama debugmodel with ModelArgs(dim=256, n_layers=2, n_heads=16, n_kv_heads=None, vocab_size=32000, multiple_of=256, ffn_dim_multiplier=None, norm_eps=1e-05, max_batch_size=32, max_seq_len=32768, depth_init=True)
[rank0]:2024-03-27 14:29:51,124 - root - INFO - [34mModel llama debugmodel [31msize: 18,089,216 total parameters[39m
[rank0]:2024-03-27 14:29:51,124 - root - INFO - GPU capacity: NVIDIA H100 (0) with 95.04GiB memory
[rank0]:2024-03-27 14:29:51,259 - root - INFO - Applied selective activation checkpointing to the model
[rank0]:2024-03-27 14:29:51,259 - root - INFO - Applied FSDP to the model
[rank0]:2024-03-27 14:29:51,284 - root - INFO - Model fully initialized via reset_parameters
[rank0]:2024-03-27 14:29:51,284 - root - INFO - Gradient scaling not enabled
[rank0]:2024-03-27 14:29:51,285 - root - INFO - Metrics logging active. Tensorboard logs will be saved at ./outputs/tb/20240327-1429
[rank0]:2024-03-27 14:29:52,056 - root - INFO - Profiling active. Traces will be saved at ./outputs/profiling/traces
[rank0]:/data/users/gnadathur/a/pytorch/torch/utils/checkpoint.py:144: UserWarning: Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. Device state will only be saved for devices of a single device type, and the remaining devices will be ignored. Consequently, if any checkpointed functions involve randomness, this may result in incorrect gradients. (Note that if CUDA devices are among the devices detected, it will be prioritized; otherwise, the first device encountered will be selected.)
[rank0]:  warnings.warn(
[rank0]:2024-03-27 14:29:52,825 - root - INFO - [36mstep:  1  [32mloss: 10.7425  [33mmemory:  9.42GiB(9.91%)  [34mwps: 21,337  [35mmfu: 0.26%[39m
[rank0]:2024-03-27 14:29:52,825 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:00:05
[rank0]:2024-03-27 14:29:52,905 - root - INFO - [36mstep:  2  [32mloss: 10.6722  [33mmemory: 11.38GiB(11.97%)  [34mwps: 208,060  [35mmfu: 2.55%[39m
[rank0]:2024-03-27 14:29:52,982 - root - INFO - [36mstep:  3  [32mloss: 10.5435  [33mmemory: 11.38GiB(11.97%)  [34mwps: 213,622  [35mmfu: 2.62%[39m
[rank0]:2024-03-27 14:29:53,060 - root - INFO - [36mstep:  4  [32mloss: 10.3359  [33mmemory: 11.38GiB(11.97%)  [34mwps: 212,856  [35mmfu: 2.61%[39m
[rank0]:2024-03-27 14:29:53,139 - root - INFO - [36mstep:  5  [32mloss: 10.0965  [33mmemory: 11.38GiB(11.97%)  [34mwps: 209,326  [35mmfu: 2.56%[39m
[rank0]:2024-03-27 14:29:53,215 - root - INFO - [36mstep:  6  [32mloss:  9.8806  [33mmemory: 11.38GiB(11.97%)  [34mwps: 216,808  [35mmfu: 2.66%[39m
[rank0]:2024-03-27 14:29:53,292 - root - INFO - [36mstep:  7  [32mloss:  9.6442  [33mmemory: 11.38GiB(11.97%)  [34mwps: 214,874  [35mmfu: 2.63%[39m
[rank0]:2024-03-27 14:29:53,367 - root - INFO - [36mstep:  8  [32mloss:  9.4349  [33mmemory: 11.38GiB(11.97%)  [34mwps: 220,877  [35mmfu: 2.70%[39m
[rank0]:2024-03-27 14:29:53,500 - root - INFO - [36mstep:  9  [32mloss:  9.2674  [33mmemory: 11.38GiB(11.97%)  [34mwps: 123,924  [35mmfu: 1.52%[39m
[rank0]:[rank0]:[W327 14:29:53.248291822 CPUAllocator.cpp:249] Memory block of unknown size was allocated before the profiling started, profiler results will not include the deallocation event
[rank0]:2024-03-27 14:29:53,577 - root - INFO - [36mstep: 10  [32mloss:  9.1404  [33mmemory: 11.38GiB(11.97%)  [34mwps: 214,910  [35mmfu: 2.63%[39m
[rank0]:NCCL version 2.20.5+cuda12.0

=====Integration test: CONFIG_FILE=./train_configs/debug_model_2d.toml NGPU=4 ./run_llama_train.sh=====
+ export USE_LIBUV=1
+ USE_LIBUV=1
+ TRAINER_DIR=/home/gnadathur/local/torchtrain
+ NGPU=4
+ LOG_RANK=0
+ CONFIG_FILE=./train_configs/debug_model_2d.toml
+ torchrun --nproc_per_node=4 --rdzv_endpoint=localhost:5972 --local-ranks-filter 0 --role rank --tee 3 train.py --job.config_file ./train_configs/debug_model_2d.toml
W0327 14:29:58.902000 140021143774208 torch/distributed/run.py:757]
W0327 14:29:58.902000 140021143774208 torch/distributed/run.py:757] *****************************************
W0327 14:29:58.902000 140021143774208 torch/distributed/run.py:757] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
W0327 14:29:58.902000 140021143774208 torch/distributed/run.py:757] *****************************************
[rank0]:2024-03-27 14:30:00,872 - root - INFO - Starting job: LLaMA debug training
[rank0]:2024-03-27 14:30:01,177 - root - WARNING - ENV[TORCH_NCCL_ASYNC_ERROR_HANDLING] = 1 will be overridden to 3 based on job config
[rank0]:2024-03-27 14:30:01,182 - root - INFO - Building 2-D device mesh with ['dp', 'tp'], [2, 2]
[rank0]:2024-03-27 14:30:01,185 - root - INFO - Building sentencepiece tokenizer locally from ./torchtrain/datasets/tokenizer/tokenizer.model
[rank0]:2024-03-27 14:30:01,194 - root - INFO - SentencePieceTokenizer built: #words 32000, BOS ID 1, EOS ID 2
[rank0]:2024-03-27 14:30:01,195 - root - INFO - Preparing alpaca dataset from HuggingFace
[rank0]:2024-03-27 14:30:02,807 - root - INFO - Building llama debugmodel with ModelArgs(dim=256, n_layers=2, n_heads=16, n_kv_heads=None, vocab_size=32000, multiple_of=256, ffn_dim_multiplier=None, norm_eps=1e-05, max_batch_size=32, max_seq_len=32768, depth_init=True)
[rank0]:2024-03-27 14:30:02,818 - root - INFO - [34mModel llama debugmodel [31msize: 18,089,216 total parameters[39m
[rank0]:2024-03-27 14:30:02,819 - root - INFO - GPU capacity: NVIDIA H100 (0) with 95.04GiB memory
[rank0]:2024-03-27 14:30:02,830 - root - INFO - Applied Sequence Parallelism to the model
[rank0]:2024-03-27 14:30:02,975 - root - INFO - Applied selective activation checkpointing to the model
[rank0]:2024-03-27 14:30:02,975 - root - INFO - Applied FSDP to the model
[rank0]:2024-03-27 14:30:03,004 - root - INFO - Model fully initialized via reset_parameters
[rank0]:2024-03-27 14:30:03,004 - root - INFO - Gradient scaling not enabled
[rank0]:2024-03-27 14:30:03,005 - root - INFO - Metrics logging active. Tensorboard logs will be saved at ./outputs/tb/20240327-1430
[rank0]:2024-03-27 14:30:03,642 - root - INFO - Profiling active. Traces will be saved at ./outputs/profiling/traces
[rank0]:/data/users/gnadathur/a/pytorch/torch/utils/checkpoint.py:144: UserWarning: Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. Device state will only be saved for devices of a single device type, and the remaining devices will be ignored. Consequently, if any checkpointed functions involve randomness, this may result in incorrect gradients. (Note that if CUDA devices are among the devices detected, it will be prioritized; otherwise, the first device encountered will be selected.)
[rank0]:  warnings.warn(
[rank0]:2024-03-27 14:30:04,528 - root - INFO - [36mstep:  1  [32mloss: 10.8502  [33mmemory:  5.71GiB(6.01%)  [34mwps: 9,259  [35mmfu: 0.11%[39m
[rank0]:2024-03-27 14:30:04,528 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:00:05
[rank0]:2024-03-27 14:30:04,679 - root - INFO - [36mstep:  2  [32mloss: 10.7671  [33mmemory:  6.69GiB(7.04%)  [34mwps: 54,430  [35mmfu: 0.67%[39m
[rank0]:2024-03-27 14:30:04,773 - root - INFO - [36mstep:  3  [32mloss: 10.6390  [33mmemory:  6.69GiB(7.04%)  [34mwps: 88,457  [35mmfu: 1.08%[39m
[rank0]:2024-03-27 14:30:04,864 - root - INFO - [36mstep:  4  [32mloss: 10.4210  [33mmemory:  6.69GiB(7.04%)  [34mwps: 90,384  [35mmfu: 1.11%[39m
[rank0]:2024-03-27 14:30:04,954 - root - INFO - [36mstep:  5  [32mloss: 10.1648  [33mmemory:  6.69GiB(7.04%)  [34mwps: 93,058  [35mmfu: 1.14%[39m
[rank0]:2024-03-27 14:30:05,067 - root - INFO - [36mstep:  6  [32mloss:  9.9451  [33mmemory:  6.69GiB(7.04%)  [34mwps: 72,642  [35mmfu: 0.89%[39m
[rank0]:2024-03-27 14:30:05,165 - root - INFO - [36mstep:  7  [32mloss:  9.7004  [33mmemory:  6.69GiB(7.04%)  [34mwps: 85,096  [35mmfu: 1.04%[39m
[rank0]:2024-03-27 14:30:05,251 - root - INFO - [36mstep:  8  [32mloss:  9.4422  [33mmemory:  6.69GiB(7.04%)  [34mwps: 95,860  [35mmfu: 1.17%[39m
[rank0]:2024-03-27 14:30:05,399 - root - INFO - [36mstep:  9  [32mloss:  9.2144  [33mmemory:  6.69GiB(7.04%)  [34mwps: 55,837  [35mmfu: 0.68%[39m
[rank0]:[rank0]:[W327 14:30:05.148473462 CPUAllocator.cpp:249] Memory block of unknown size was allocated before the profiling started, profiler results will not include the deallocation event
[rank0]:2024-03-27 14:30:05,496 - root - INFO - [36mstep: 10  [32mloss:  9.1710  [33mmemory:  6.69GiB(7.04%)  [34mwps: 86,136  [35mmfu: 1.05%[39m
[rank0]:NCCL version 2.20.5+cuda12.0
```

Reviewers:

Subscribers:

Tasks:

Tags: