### PR TITLE
Removed setting global flag for `swap_tensors` since not needed anymore

### DIFF
--- a/train.py
+++ b/train.py
@@ -197,7 +197,7 @@ def main(job_config: JobConfig):
     model = models_parallelize_fns[model_name](
         model, world_mesh, parallel_dims, job_config
     )
-    # allocate sharded model on GPU and initialize weights
+    # allocate sharded model on GPU and initialize weights via DTensor
     model.to_empty(device="cuda")
     model.init_weights()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #175

https://github.com/pytorch/pytorch/pull/122755 is in nightlies. We can remove the global flag now.