### PR TITLE
bump comm.train_timeout_seconds

### DIFF
--- a/torchtrain/config_manager.py
+++ b/torchtrain/config_manager.py
@@ -265,7 +265,7 @@ class JobConfig:
         self.parser.add_argument(
             "--comm.train_timeout_seconds",
             type=int,
-            default=50,
+            default=100,
             help=(
                 "Timeout for communication operations after the first train step-"
                 "usually a tighter bound than during initialization."


### PR DESCRIPTION
this PR bumps this default config to a larger value, as profiling is pretty heavy step, a default 5 seconds would likely trigger watchdog unintentionally