### PR TITLE
remove folding and unfolding of batch dim and sequence dim in model.py

### DIFF
--- a/torchtrain/models/llama/model.py
+++ b/torchtrain/models/llama/model.py
@@ -226,10 +226,7 @@ class Attention(nn.Module):
             torch.Tensor: Output tensor after attention.
 
         """
-        seqlen, _ = freqs_cis.shape
-        bs_seqlen, _ = x.shape
-        bsz = bs_seqlen // seqlen
-
+        bsz, seqlen, _ = x.shape
         xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
         xq = xq.view(bsz, seqlen, self.n_heads, self.head_dim)
@@ -255,8 +252,7 @@ class Attention(nn.Module):
         output = output.transpose(
             1, 2
         ).contiguous()  # (bs, seqlen, n_local_heads, head_dim)
-        # output stay folded with batch and sequence dimension
-        output = output.view(bsz * seqlen, -1)
+        output = output.view(bsz, seqlen, -1)
         return self.wo(output)
 
 
@@ -487,17 +483,9 @@ class Transformer(nn.Module):
 
         """
         h, freqs_cis = self.embeddings(tokens)
-        # fold batch and sequence dimension for more efficient allgather/reduce_scatter
-        h = h.view(-1, self.model_args.dim)
-
         for layer in self.layers:
             h = layer(h, freqs_cis)
-
         h = self.norm(h)
-        # unfold batch and sequence dimension
-        bsz = tokens.shape[0]
-        bs_seqlen = h.shape[0]
-        h = h.view(bsz, bs_seqlen // bsz, self.model_args.dim)
         output = self.output(h).float()
         return output
 

--- a/torchtrain/parallelisms/parallelize_llama.py
+++ b/torchtrain/parallelisms/parallelize_llama.py
@@ -153,7 +153,7 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
                     input_layouts=Replicate(),
                 ),
                 "output": col_parallel_strategy(
-                    input_layouts=Shard(0),
+                    input_layouts=Shard(1),
                     output_layouts=(
                         Shard(-1)
                         if parallel_dims.loss_parallel_enabled
@@ -161,10 +161,10 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
                     ),
                     use_local_output=not parallel_dims.loss_parallel_enabled,
                 ),
-                "norm": SequenceParallel(sequence_dim=0),
+                "norm": SequenceParallel(),
                 "layers.0": PrepareModuleInput(
                     input_layouts=(Replicate(), None),
-                    desired_input_layouts=(Shard(0), None),
+                    desired_input_layouts=(Shard(1), None),
                     use_local_output=True,
                 ),
             },
@@ -174,22 +174,22 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
         for layer_id, transformer_block in enumerate(model.layers):
             layer_plan = {
                 "attention": PrepareModuleInput(
-                    input_layouts=(Shard(0), None),
+                    input_layouts=(Shard(1), None),
                     desired_input_layouts=(Replicate(), None),
                 ),
                 "attention.wq": col_parallel_strategy(),
                 "attention.wk": col_parallel_strategy(),
                 "attention.wv": col_parallel_strategy(),
-                "attention.wo": row_parallel_strategy(output_layouts=Shard(0)),
-                "attention_norm": SequenceParallel(sequence_dim=0),
+                "attention.wo": row_parallel_strategy(output_layouts=Shard(1)),
+                "attention_norm": SequenceParallel(),
                 "feed_forward": PrepareModuleInput(
-                    input_layouts=(Shard(0),),
+                    input_layouts=(Shard(1),),
                     desired_input_layouts=(Replicate(),),
                 ),
                 "feed_forward.w1": col_parallel_strategy(),
-                "feed_forward.w2": row_parallel_strategy(output_layouts=Shard(0)),
+                "feed_forward.w2": row_parallel_strategy(output_layouts=Shard(1)),
                 "feed_forward.w3": col_parallel_strategy(),
-                "ffn_norm": SequenceParallel(sequence_dim=0),
+                "ffn_norm": SequenceParallel(),
             }
 
             # Adjust attention module to use the local number of heads


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #190

Local experiments show that this does not slow down training. Actually it brings slight memory saving and speedup.
Experiment setup: devgpu, dp-degree=2, tp-degree=4, llama-13b, full AC

Before:
<img width="733" alt="Screenshot 2024-04-03 at 3 46 15 PM" src="https://github.com/pytorch/torchtrain/assets/150487191/5f8564cf-7812-4243-beb2-f75483780e6a">

After this PR:
<img width="726" alt="Screenshot 2024-04-03 at 4 01 01 PM" src="https://github.com/pytorch/torchtrain/assets/150487191/aa8fc6bc-ff74-42dc-9c82-ef701ccdae5b">
