### PR TITLE
remove .item() per iter

### DIFF
--- a/train.py
+++ b/train.py
@@ -151,9 +151,7 @@ def main(job_config: JobConfig):
 
     # loss_parallel enables dispatching to efficient loss operators
     loss_parallel_ctx = (
-        loss_parallel
-        if parallel_dims.loss_parallel_enabled
-        else contextlib.nullcontext
+        loss_parallel if parallel_dims.loss_parallel_enabled else contextlib.nullcontext
     )
 
     # loss fn can be shared by pipeline-parallel or non-pp execution


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #206

only do cpu/gpu sync on the logging iteration

also fixing a minor bug recently introduced