### PR TITLE
Add 1 sec delay to rank 0 cleanup

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 import contextlib
 import gc
 import os
+import time
 
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -386,6 +387,10 @@ def main(job_config: JobConfig):
                     timeout=timedelta(seconds=job_config.comm.train_timeout_seconds),
                     world_mesh=world_mesh,
                 )
+
+    if torch.distributed.get_rank() == 0:
+        logger.info("Sleeping for 1 second for others ranks to complete ")
+        time.sleep(1)
 
     metric_logger.close()
     logger.info("Training completed.")


### PR DESCRIPTION
Add the delay as a short term workaround the TCPStore cleanup sync issue (https://github.com/pytorch/pytorch/issues/123969)
Test:
 Ran `TORCH_NCCL_ABORT_IN_DESTROY_PG=1 CONFIG_FILE=./train_configs/debug_model.toml NGPU=4 LOG_RANK=0,1,2,3 ./run_llama_train.sh --checkpoint.folder ./test_runner_checkpoint_full_checkpoint` 10 times w/o failure.