### PR TITLE
RFC for ckpt apis

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -230,12 +230,23 @@ class JobConfig:
             ),
         )
         self.parser.add_argument(
-            "--checkpoint.folder",
+            "--checkpoint.save_folder",
             type=str,
             default="",
             help=(
-                "The folder to store the checkpoints. If this is not specified or "
-                "is an empty string, checkpointing is disabled."
+                "The folder to store the checkpoints in. If this is not specified or "
+                "is an empty string, checkpointing is disabled. If a relative path is given, "
+                "it will be relative to the job.dump_folder.  Absolute paths are also supported."
+            ),
+        )
+        self.parser.add_argument(
+            "--checkpoint.load_folder",
+            type=str,
+            default=None,
+            help=(
+                "The folder to load the checkpoints. Defaults to loading from 'checkpoint.save_folder'. "
+                "The checkpoint with the highest step number in the folder will be loaded. Relative/absolute paths "
+                " follow the same rules as 'checkpoint.save_folder'."
             ),
         )
         self.parser.add_argument(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #226

unsure how to proceed with the apis, but a few nice to haves are

1- specify load path separately from save path: you may want to load a
"golden checkpoint" repeatedly and produce output checkpoints into
isolated output dirs
2- enable/disable loading and saving of ckpts separately: you may want
to use ckpt loading for initialization purposes, but not save ckpts.
You may want to start from scratch, but save ckpts
3- specify a _specific_ ckpt to load, not just the most recent one in a
folder: you may want to test going back to a particular point and
retraining, e.g. to match convergence over a recent period