### PR TITLE
set max_seq_len before training to make it align with input data

### DIFF
--- a/train.py
+++ b/train.py
@@ -166,8 +166,11 @@ def main(job_config: JobConfig):
     # build model (using meta init)
     model_cls = model_name_to_cls[model_name]
     model_config = models_config[model_name][job_config.model.flavor]
+    # set the model configs from training inputs:
+    # 1. norm type to decide which norm layer to use
+    # 2. vocab size from tokenizer
+    # 3. max_seq_len base on inputs
     model_config.norm_type = job_config.model.norm_type
-    # set vocab size from tokenizer and max_seq_len base on inputs
     model_config.vocab_size = tokenizer.n_words
     model_config.max_seq_len = job_config.training.seq_len
 


### PR DESCRIPTION
as titled, we need to set this to get the accurate seq_length set from the dataloader config. This would ensure the max_seq_len always correct so that rope init would be always correct

<img width="946" alt="Screenshot 2024-04-17 at 1 00 29 PM" src="https://github.com/pytorch/torchtitan/assets/9443650/39942187-cf37-4cef-b380-644a1a9b9d35">


