### PR TITLE
apply less heavy profiling

### DIFF
--- a/torchtitan/profiling.py
+++ b/torchtitan/profiling.py
@@ -53,7 +53,9 @@ def maybe_enable_profiling(config: JobConfig, *pos_args, **kwargs):
 
         warmup, active = WARMUP, 1
         wait = profile_freq - (active + warmup)
-        assert wait >= 0, "profile_freq must be greater than or equal to warmup + active"
+        assert (
+            wait >= 0
+        ), "profile_freq must be greater than or equal to warmup + active"
         with torch.profiler.profile(
             activities=[
                 torch.profiler.ProfilerActivity.CPU,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #270

While I try to mitigate #266 by inserting a barrier in the dump step, this PR simplifies profiling to only provide minimal stats, thus making it less heavy.
