### PR TITLE
fix lr scheduling by checkpointing scheduler

### DIFF
--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -64,6 +64,7 @@ class CheckpointManager:
         self,
         model: nn.Module,
         optimizer: torch.optim.Optimizer,
+        lr_scheduler: torch.optim.lr_scheduler.LRScheduler,
         states: Dict[str, Any],
         job_config: JobConfig,
     ) -> None:
@@ -76,6 +77,7 @@ class CheckpointManager:
                 {
                     "model": ModelWrapper(model),
                     "optimizer": OptimizerWrapper(model, optimizer),
+                    "lr_scheduler": lr_scheduler,
                 }
             )
 

--- a/train.py
+++ b/train.py
@@ -239,6 +239,7 @@ def main(job_config: JobConfig):
     checkpoint = CheckpointManager(
         model=model,
         optimizer=optimizer,
+        lr_scheduler=scheduler,
         states={"train_state": train_state},
         job_config=job_config,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #275

If not checkpointed, lr scheduler's step always starts from 0 after loading checkpoint, which is wrong.