### PR TITLE
Add periodic integration test with signal

### DIFF
--- a/.github/workflows/integration_test_periodic.yaml
+++ b/.github/workflows/integration_test_periodic.yaml
@@ -1,0 +1,43 @@
+name: GPU Integration Test
+
+on:
+  schedule:
+    # Runs hourly
+    - cron: '0 * * * *'
+
+concurrency:
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+  unit_tests_4gpu:
+    runs-on: linux.g5.12xlarge.nvidia.gpu
+    strategy:
+      matrix:
+        python-version: ['3.10']
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+          python -m pip install -r requirements.txt
+          python -m pip install -r dev-requirements.txt
+          python -m pip install -e .
+      - name: Run test_runner.py
+        run: python ./test_runner.py
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GPU Integration Test](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_periodic.yaml/badge.svg)
+![GPU Integration Test](https://github.com/pytorch/torchtitan/actions/workflows/unit_test_4gpu.yaml/badge.svg)
 
 # torchtitan
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GPU Integration Test](https://github.com/pytorch/torchtitan/actions/workflows/unit_test_4gpu.yaml/badge.svg)
+[![GPU Integration Test](https://github.com/pytorch/torchtitan/actions/workflows/unit_test_4gpu.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/unit_test_4gpu.yaml)
 
 # torchtitan
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![GPU Integration Test](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_periodic.yaml/badge.svg)
+
 # torchtitan
 
 `torchtitan` is currently in a pre-release state and under extensive development.


### PR DESCRIPTION
Runs the integration test hourly and updates signal badge. Tested on existing integration test. I will update the badge with periodic test signal once workflow has landed in this PR. 
<img width="516" alt="Screenshot 2024-04-30 at 6 12 00 PM" src="https://github.com/pytorch/torchtitan/assets/1779702/8adaab3d-df18-483d-a39f-5af316b7edbc">
