### PR TITLE
Fix the incorrect step log for profiler after resuming from a checkpoint

### DIFF
--- a/torchtitan/profiling.py
+++ b/torchtitan/profiling.py
@@ -17,7 +17,7 @@ WARMUP = 3
 
 
 @contextlib.contextmanager
-def maybe_enable_profiling(config: JobConfig, *pos_args, **kwargs):
+def maybe_enable_profiling(config: JobConfig, *, global_step: int = 0):
     # get user defined profiler settings
     enable_profiling = config.profiling.enable_profiling
 
@@ -27,8 +27,7 @@ def maybe_enable_profiling(config: JobConfig, *pos_args, **kwargs):
         trace_dir = os.path.join(dump_dir, save_trace_dir)
         profile_freq = config.profiling.profile_freq
 
-        _global_iter_count = 0
-
+        _global_iter_count = global_step
         rank = torch.distributed.get_rank()
 
         def trace_handler(prof):

--- a/train.py
+++ b/train.py
@@ -260,7 +260,9 @@ def main(job_config: JobConfig):
     data_iterator = iter(data_loader)
 
     logger.info(f"Training starts at step {train_state.step + 1}")
-    with maybe_enable_profiling(job_config) as torch_profiler:
+    with maybe_enable_profiling(
+        job_config, global_step=train_state.step
+    ) as torch_profiler:
         checkpoint.reset()
 
         # variables used to keep info for metrics logging


### PR DESCRIPTION
Summary:
The profiler currently maintains a counter locally and that counter is not synchronized with the checkpointed train step. This PR fixes the issue.