### PR TITLE
remove unnecessary install of torchtitan

### DIFF
--- a/.github/workflows/integration_test_periodic.yaml
+++ b/.github/workflows/integration_test_periodic.yaml
@@ -36,7 +36,6 @@ jobs:
           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
           python -m pip install -r requirements.txt
           python -m pip install -r dev-requirements.txt
-          python -m pip install -e .
       - name: Run test_runner.py
         run: python ./test_runner.py
       - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -36,7 +36,6 @@ jobs:
           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
           python -m pip install -r requirements.txt
           python -m pip install -r dev-requirements.txt
-          python -m pip install -e .
       - name: Run test_runner.py
         run: python ./test_runner.py
       - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -36,7 +36,6 @@ jobs:
           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
           python -m pip install -r requirements.txt
           python -m pip install -r dev-requirements.txt
-          python -m pip install -e .
       - name: Run unit tests with coverage
         run: pytest test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ git clone https://github.com/pytorch/torchtitan
 cd torchtitan
 pip install -r requirements.txt
 pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121 # or cu118
-pip install .
 ```
 
 ### Downloading a tokenizer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #295

we can remove `pip install .` before it's supported / needed.