### PR TITLE
turn off dynamic shape for torch.compile

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,7 +230,9 @@ def main(job_config: JobConfig):
                 True
             )
         logger.info("Compiling model with torch.compile")
-        model = torch.compile(model)
+        # Dynamic shape have issues with distributed, turn dynamic off as Transformer
+        # training is static_shape TODO: resolve dynamic shape issue and restore defaults
+        model = torch.compile(model, dynamic=False)
 
     train_state = TrainState()
 

--- a/train_configs/llama3_8b.toml
+++ b/train_configs/llama3_8b.toml
@@ -18,7 +18,7 @@ save_tb_folder = "tb"
 [model]
 name = "llama3"
 flavor = "8B"
-norm_type = "fused_rmsnorm"  # [layernorm / np_layernorm / rmsnorm / fused_rmsnorm]
+norm_type = "rmsnorm"  # [layernorm / np_layernorm / rmsnorm / fused_rmsnorm]
 tokenizer_path = "./torchtitan/datasets/tokenizer/original/tokenizer.model"
 
 [optimizer]


### PR DESCRIPTION
as titled. This could make 1-D and 2-D works with the lastest main build. thanks @bdhirsh for all the fixes!

We should figure out why dynamic shape gets turned on as a follow up