### PR TITLE
Remove unnecessary .to() inside model forward

### DIFF
--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -423,7 +423,6 @@ class Transformer(nn.Module):
         """
         _bsz, seqlen = tokens.shape
         h = self.tok_embeddings(tokens)
-        self.freqs_cis = self.freqs_cis.to(h.device)
         freqs_cis = self.freqs_cis[0:seqlen]
 
         for layer in self.layers:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #161
* __->__ #298

This appears to be a holdover from a previous way the initialization
worked.

freqs_cis should already be on gpu device after initialization.

See [this conversation](https://github.com/pytorch/torchtitan/pull/161/files#r1588516210) for reference.