### PR TITLE
[fused_rmsnorm] Avoid conditional on dynamic stride

### DIFF
--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -220,10 +220,8 @@ class TritonFusedRMSNorm(torch.autograd.Function):
 
         # Flatten input
         x = x.view(-1, x.shape[-1])
-        if x.stride(-1) != 1:
-            x = x.contiguous()
-        if weight.stride(-1) != 1:
-            weight = weight.contiguous()
+        x = x.contiguous()
+        weight = weight.contiguous()
 
         M, N = x.shape
         y = torch.empty_like(x)
@@ -264,8 +262,7 @@ class TritonFusedRMSNorm(torch.autograd.Function):
 
         # Flatten input and output gradients
         dy = dy.view(-1, dy.shape[-1])
-        if dy.stride(-1) != 1:
-            dy = dy.contiguous()
+        dy = dy.contiguous()
 
         M, N = dy.shape
         dx = torch.empty_like(x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #301
* __->__ #300
* #161

The conditional expression forces evaluation of a symbolic quantity,
which is not a problem in eager but prevents tracing/export and blocks
using Pipeline Parallelism via tracing frontend.

Tensor.contiguous operator already handles returning `self` if the
striding of self is already contiguous.

Fixes https://github.com/pytorch/PiPPy/issues/1108