### PR TITLE
simplify embedding + first transformer block TP

### DIFF
--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -160,6 +160,7 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
             {
                 "tok_embeddings": RowwiseParallel(
                     input_layouts=Replicate(),
+                    output_layouts=Shard(1),
                 ),
                 "output": col_parallel_strategy(
                     input_layouts=Shard(1),
@@ -167,11 +168,6 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
                     use_local_output=not loss_parallel,
                 ),
                 "norm": SequenceParallel(),
-                "layers.0": PrepareModuleInput(
-                    input_layouts=(Replicate(), None),
-                    desired_input_layouts=(Shard(1), None),
-                    use_local_output=True,
-                ),
             },
         )
 

--- a/train_configs/llama3_8b.toml
+++ b/train_configs/llama3_8b.toml
@@ -36,7 +36,7 @@ tensor_parallel_degree = 1
 pipeline_parallel_degree = 1
 fp8_linear = ""
 compile = false
-dataset = "c4_mini"
+dataset = "c4"
 
 [checkpoint]
 enable_checkpoint = false

--- a/train_configs/llama3_8b.toml
+++ b/train_configs/llama3_8b.toml
@@ -36,7 +36,7 @@ tensor_parallel_degree = 1
 pipeline_parallel_degree = 1
 fp8_linear = ""
 compile = false
-dataset = "c4"
+dataset = "c4_mini"
 
 [checkpoint]
 enable_checkpoint = false


### PR DESCRIPTION
as titled, we can directly specify the rowwise parallel embedding output layouts be shard on sequence dim, so that we don't need the first layer prepare input.

Switching to output_layouts = Shard(1) would also trigger reduce_scatter instead of allreduce for embedding layer, which could give some small perf wins