### PR TITLE
Only include checkpoints that have .metadata written

### DIFF
--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -341,7 +341,7 @@ class CheckpointManager:
             step_counts = []
             for filename in os.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
-                metadata_probe = os.path.join(self.folder, filename, ".metadata")                
+                metadata_probe = os.path.join(self.folder, filename, ".metadata")
                 if match and os.path.isfile(metadata_probe):
                     step_counts.append(int(match.group(1)))
             if not step_counts:

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -341,7 +341,8 @@ class CheckpointManager:
             step_counts = []
             for filename in os.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
-                if match:
+                metadata_probe = os.path.join(self.folder, filename, ".metadata")                
+                if match and os.path.isfile(metadata_probe):
                     step_counts.append(int(match.group(1)))
             if not step_counts:
                 return False


### PR DESCRIPTION
.metadata may be missing in some checkpoints if some ranks did not checkpoint properly. This PR filters out checkpoints that do not have .metadata in them.