### PR TITLE
Use torch generic workflow for CI, add ssh, artifacts

### DIFF
--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -17,7 +17,7 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       # This image is faster to clone than the default, but it lacks CC needed by triton
-      # (1m25s vs 2m37s)
+      # (1m25s vs 2m37s).
       docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
@@ -32,6 +32,3 @@ jobs:
         python -m pip install -r dev-requirements.txt
         mkdir artifacts-to-be-uploaded
         python ./test_runner.py artifacts-to-be-uploaded
-  # upload-coverage:
-  #     - name: Upload Coverage to Codecov
-  #       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -13,7 +13,7 @@ jobs:
       runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "11.6"
-      repository: "https://github.com/pytorch/torchtitan"
+      repository: "pytorch/torchtitan"
       script: |
         pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py
-        mv outputs/* artifacts-to-be-uploaded/
+        mv outputs artifacts-to-be-uploaded
 # TODO the below were not ported over to the 'generic workflow' - do they matter?
 
 # defaults:

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -16,7 +16,7 @@ jobs:
       runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
-      docker-image: "nvidia/cuda:12.4.1-runtime-ubuntu22.04"
+      docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
@@ -25,8 +25,6 @@ jobs:
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py
         mv outputs artifacts-to-be-uploaded
-
-# TODO the below were not ported over to the 'generic workflow' - do they matter?
-
-#       - name: Upload Coverage to Codecov
-#         uses: codecov/codecov-action@v3
+  upload-coverage:
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -20,8 +20,8 @@ jobs:
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
+        pip config --user set global.progress_bar off
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
-        echo "installed torch!"
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -20,8 +20,8 @@ jobs:
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
-        python -m pip uninstall torch
-        python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+        python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+        echo "installed torch!"
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -16,7 +16,8 @@ jobs:
       runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
-      docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
+      # This image is faster to clone than the default, but it lacks CC needed by triton
+      # docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -16,6 +16,7 @@ jobs:
       runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
+      docker-image: "nvidia/cuda:12.4.1-runtime-ubuntu22.04"
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
@@ -24,11 +25,8 @@ jobs:
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py
         mv outputs artifacts-to-be-uploaded
+
 # TODO the below were not ported over to the 'generic workflow' - do they matter?
 
-# defaults:
-#   run:
-#     shell: bash -l -eo pipefail {0}
-# ---
 #       - name: Upload Coverage to Codecov
 #         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -20,7 +20,8 @@ jobs:
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
-        pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+        python -m pip uninstall torch
+        python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -1,10 +1,13 @@
 name: 4 GPU Unit Test
 
-
 on:
   push:
     branches: [ main ]
   pull_request:
+
+concurrency:
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:
@@ -12,47 +15,20 @@ jobs:
     with:
       runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
-      gpu-arch-version: "11.6"
+      gpu-arch-version: "12.1"
       repository: "pytorch/torchtitan"
+      upload-artifact: "outputs"
       script: |
         pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py
-
-
-# concurrency:
-#   group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
-#   cancel-in-progress: true
+        mv outputs/* artifacts-to-be-uploaded/
+# TODO the below were not ported over to the 'generic workflow' - do they matter?
 
 # defaults:
 #   run:
 #     shell: bash -l -eo pipefail {0}
-
-# jobs:
-#   unit_tests_4gpu:
-#     runs-on: linux.g5.12xlarge.nvidia.gpu
-#     strategy:
-#       matrix:
-#         python-version: ['3.10']
-#     steps:
-#       - name: Check out repo
-#         uses: actions/checkout@v3
-#       - name: Setup conda env
-#         uses: conda-incubator/setup-miniconda@v2
-#         with:
-#           auto-update-conda: true
-#           miniconda-version: "latest"
-#           activate-environment: test
-#           python-version: ${{ matrix.python-version }}
-#       - name: Update pip
-#         run: python -m pip install --upgrade pip
-#       - name: Install dependencies
-#         run: |
-#           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
-#           python -m pip install -r requirements.txt
-#           python -m pip install -r dev-requirements.txt
-#       - name: Run test_runner.py
-#         run: python ./test_runner.py
+# ---
 #       - name: Upload Coverage to Codecov
 #         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -30,8 +30,8 @@ jobs:
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
-        python ./test_runner.py
-        mv outputs artifacts-to-be-uploaded
+        mkdir artifacts-to-be-uploaded
+        python ./test_runner.py artifacts-to-be-uploaded
   # upload-coverage:
   #     - name: Upload Coverage to Codecov
   #       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -1,42 +1,58 @@
 name: 4 GPU Unit Test
 
+
 on:
   push:
     branches: [ main ]
   pull_request:
 
-concurrency:
-  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
-  cancel-in-progress: true
-
-defaults:
-  run:
-    shell: bash -l -eo pipefail {0}
-
 jobs:
-  unit_tests_4gpu:
-    runs-on: linux.g5.12xlarge.nvidia.gpu
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: |
-          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
-          python -m pip install -r requirements.txt
-          python -m pip install -r dev-requirements.txt
-      - name: Run test_runner.py
-        run: python ./test_runner.py
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+  build-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.g5.12xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "11.6"
+      repository: "https://github.com/pytorch/torchtitan"
+      script: |
+        pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+        python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
+        python ./test_runner.py
+
+
+# concurrency:
+#   group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+#   cancel-in-progress: true
+
+# defaults:
+#   run:
+#     shell: bash -l -eo pipefail {0}
+
+# jobs:
+#   unit_tests_4gpu:
+#     runs-on: linux.g5.12xlarge.nvidia.gpu
+#     strategy:
+#       matrix:
+#         python-version: ['3.10']
+#     steps:
+#       - name: Check out repo
+#         uses: actions/checkout@v3
+#       - name: Setup conda env
+#         uses: conda-incubator/setup-miniconda@v2
+#         with:
+#           auto-update-conda: true
+#           miniconda-version: "latest"
+#           activate-environment: test
+#           python-version: ${{ matrix.python-version }}
+#       - name: Update pip
+#         run: python -m pip install --upgrade pip
+#       - name: Install dependencies
+#         run: |
+#           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+#           python -m pip install -r requirements.txt
+#           python -m pip install -r dev-requirements.txt
+#       - name: Run test_runner.py
+#         run: python ./test_runner.py
+#       - name: Upload Coverage to Codecov
+#         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -25,6 +25,6 @@ jobs:
         python -m pip install -r dev-requirements.txt
         python ./test_runner.py
         mv outputs artifacts-to-be-uploaded
-  upload-coverage:
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+  # upload-coverage:
+  #     - name: Upload Coverage to Codecov
+  #       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_4gpu.yaml
+++ b/.github/workflows/unit_test_4gpu.yaml
@@ -17,11 +17,16 @@ jobs:
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       # This image is faster to clone than the default, but it lacks CC needed by triton
-      # docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
+      # (1m25s vs 2m37s)
+      docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
       repository: "pytorch/torchtitan"
       upload-artifact: "outputs"
       script: |
+        conda install -y -q git clang clangxx
+        export CC=clang
+        export CXX=clangxx
         pip config --user set global.progress_bar off
+        pip install --upgrade pip
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -21,6 +21,6 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         pytest test --cov=. --cov-report=xml --durations=20 -vv
-  upload-coverage:
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+  # upload-coverage:
+  #     - name: Upload Coverage to Codecov
+  #       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -15,7 +15,6 @@ jobs:
     with:
       docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
       repository: "pytorch/torchtitan"
-      upload-artifact: "outputs"
       script: |
         pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
         python -m pip install -r requirements.txt

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -9,34 +9,18 @@ concurrency:
   group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash -l -eo pipefail {0}
-
 jobs:
-  cpu_unit_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: |
-          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
-          python -m pip install -r requirements.txt
-          python -m pip install -r dev-requirements.txt
-      - name: Run unit tests with coverage
-        run: pytest test --cov=. --cov-report=xml --durations=20 -vv
+  build-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
+      repository: "pytorch/torchtitan"
+      upload-artifact: "outputs"
+      script: |
+        pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
+        python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
+        pytest test --cov=. --cov-report=xml --durations=20 -vv
+  upload-coverage:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -20,6 +20,3 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
         pytest test --cov=. --cov-report=xml --durations=20 -vv
-  # upload-coverage:
-  #     - name: Upload Coverage to Codecov
-  #       uses: codecov/codecov-action@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch >= 2.2.0.dev
+pytorch-triton
 datasets
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch >= 2.2.0.dev
-pytorch-triton
 datasets
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #318
* __->__ #325

This moves over to using the standard pytorch CI job template.  ([doc](https://github.com/pytorch/test-infra/wiki/Writing-generic-CI-jobs)).

The general advantages should be that we can more easily add features or options in a maintained way.  A specific reason is becuase I was not able to ssh-debug on our old CI and @seemethere mentioned that the 'generic workflow' is where the CI SSH support lives.

**SSH**
Use ssh just like pytorch/pytorch CI:
<img width="1470" alt="image" src="https://github.com/pytorch/torchtitan/assets/4984825/86819d9d-5288-4795-88b7-63961334b3ba">


**Artifacts Uploading**
The job.dump_folder for each test is uniquely named and bundled into an `outputs.zip` which can be downloaded from github actions UI:
<img width="1565" alt="image" src="https://github.com/pytorch/torchtitan/assets/4984825/b637e61e-97bb-4943-9144-024bc7df600e">
* profiles
* checkpoints
* flight recorder comm_dumps (if any hang happened during CI)

To implement the artifacts upload, the following changes are made to test_runner.py
* job.dump_folder is set to a unique subfolder for each test, so test outputs don't overwrite each other
* the root for job.dump_folder is `artifacts-to-be-uploaded`
* the 'default' configuration gets tested explicitly with its own dump_dir specified

