### PR TITLE
Make test_runner use separate logger with default INFO

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -5,13 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import logging
 import os
 import subprocess
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Sequence
 
-from torchtitan.logging_utils import logger
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 try:
     import tomllib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #345
* #344
* __->__ #352

previous change to use logging from torchtitan caused stdout not
to show up.