### PR TITLE
Update pipelining import after change on pytorch

### DIFF
--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -19,7 +19,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointImpl,
 )
 from torch.distributed.pipelining import pipeline, SplitPoint
-from torch.distributed.pipelining._PipelineStage import (
+from torch.distributed.pipelining.PipelineStage import (
     _PipelineStage,
     ManualPipelineStage,
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #344
* __->__ #356

APIs conform to the pytorch rules.  This PR should be able to land
safely after tonight's nightly pytorch build which includes the above
PR.