### PR TITLE
update .gitignore to screen out slew of new temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ out
 wandb
 
 torchtitan/datasets/**/*.model
+
+# temp files
+*.log
+error.json
+_remote_module_non_scriptable.py


### PR DESCRIPTION
After updating today, I found a whole slew of various new temp files clogging up my source tab. 
This PR screens these out so that they don't accidentally get added in a PR and keeps your source tab change count correct. 

Example of issue without this PR:
<img width="780" alt="Screenshot 2024-05-23 at 9 21 55 PM" src="https://github.com/pytorch/torchtitan/assets/46302957/41b7061a-41a0-4a95-938b-3fd9292a2f38">

vs with this PR:
<img width="661" alt="Screenshot 2024-05-23 at 10 07 16 PM" src="https://github.com/pytorch/torchtitan/assets/46302957/cccf8c5f-368d-40a8-b10f-f11ca37df2bc">

