### PR TITLE
Use general way to access and update submodules

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -132,6 +132,7 @@ def build_test_list(args):
             [
                 [
                     "--checkpoint.enable_checkpoint",
+                    f"--job.dump_folder {args.output_dir}/pp_dp_tracer/",
                     "--training.data_parallel_degree 2",
                     "--experimental.pipeline_parallel_degree 2",
                     "--experimental.pipeline_parallel_split_points layers.1",
@@ -141,7 +142,6 @@ def build_test_list(args):
                 ],
             ],
             "PP tracer frontend 2D PP+DP test",
-            "pp_dp_tracer",
             requires_seed_checkpoint=True,
             ngpu=4,
         ),

--- a/test_runner.py
+++ b/test_runner.py
@@ -132,7 +132,6 @@ def build_test_list(args):
             [
                 [
                     "--checkpoint.enable_checkpoint",
-                    f"--job.dump_folder {args.output_dir}/pp_dp_tracer/",
                     "--training.data_parallel_degree 2",
                     "--experimental.pipeline_parallel_degree 2",
                     "--experimental.pipeline_parallel_split_points layers.1",
@@ -142,6 +141,7 @@ def build_test_list(args):
                 ],
             ],
             "PP tracer frontend 2D PP+DP test",
+            "pp_dp_tracer",
             requires_seed_checkpoint=True,
             ngpu=4,
         ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #362
* __->__ #371

This PR fixes the issue mentioned [here](https://github.com/pytorch/pytorch/pull/126653#issuecomment-2130504712):
"Module object has no attributed items."

The reason is, a split `ModuleDict` is no longer a `ModuleDict`.

It would be more generally applicable if we use `named_children()` and `register_module()` to access and update submodules.