### PR TITLE
remove old torch dependency in requirements.txt

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,4 +1,3 @@
-torch >= 2.2.0.dev
 datasets >= 2.19.0
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -3,7 +3,6 @@
 [job]
 dump_folder = "./outputs"
 description = "Llama 3 debug training"
-# TODO: turn this back on once ci have tokenizer
 use_for_integration_test = true
 
 [profiling]
@@ -50,7 +49,7 @@ interval_type = "steps"
 interval = 5
 model_weights_only = false
 export_dtype = "float32"
-async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
 mode = 'selective'  # ['none', 'selective', 'full']

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -3,6 +3,7 @@
 [job]
 dump_folder = "./outputs"
 description = "Llama 3 debug training"
+# TODO: turn this back on once ci have tokenizer
 use_for_integration_test = true
 
 [profiling]
@@ -49,7 +50,7 @@ interval_type = "steps"
 interval = 5
 model_weights_only = false
 export_dtype = "float32"
-async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
 mode = 'selective'  # ['none', 'selective', 'full']


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #372

`torch 2.2.0.dev` is too stale to be useful.
For CI, since we will install nightly anyway, this avoids storing the old version in the docker image.

update: per @wanchaol's comment, adding 2.3.0 as it's the lastest stable version.

some comments:
1. Putting `2.4.0.dev` there requires `--index-url https://download.pytorch.org/whl/nightly/cu121`. We don't want to specify `cu121` since different people might have different cuda support. However, if we remove that, as @awgu  previously explored, it will try to download everything and then select. So we'd rather let user install latest nightly.
2. Installing a stable `torch` version like 2.3.0 will install `triton`, whereas installing a nightly 2.4.0.dev version will install `pytorch-triton`. This potentially might be the reason which caused CI failure when we remove `torch` dependency in `requirements.txt`.