### PR TITLE
Make metrics logging work for pipeline parallelism

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -129,7 +129,11 @@ class JobConfig:
             "--metrics.rank_0_only",
             default=True,
             action="store_true",
-            help="Whether to save TensorBoard metrics only for rank 0 or for all ranks",
+            help="""
+                Whether to save TensorBoard metrics only for rank 0 or for all ranks.
+                When pipeline_parallel_degree is > 1, this option uses the 0th rank of the last stage pipeline group,
+                which is the only stage that computes loss metrics.
+            """,
         )
 
         # model configs

--- a/torchtitan/metrics.py
+++ b/torchtitan/metrics.py
@@ -14,7 +14,6 @@ from torch.utils.tensorboard import SummaryWriter
 from torchtitan.config_manager import JobConfig
 from torchtitan.logging_utils import logger
 
-
 # named tuple for passing GPU memory stats for logging
 GPUMemStats = namedtuple(
     "GPUMemStats",

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -40,10 +40,11 @@ def get_metrics_rank(world_mesh: DeviceMesh, parallel_dims: ParallelDims) -> int
     Returns global rank 0 in non-pipeline-parallel configs, and returns the global
     rank of the 0th rank in the last pipeline stage when pipeline parallelism is enabled.
     """
-    assert (
-        world_mesh.mesh_dim_names[0] == "pp"
-    ), "get_metrics_rank assumes pp is the outer mesh dim"
     if parallel_dims.pp_enabled:
+        assert (
+            world_mesh.mesh_dim_names[0] == "pp"
+        ), "get_metrics_rank assumes pp is the outer mesh dim"
+        pp_mesh = world_mesh["pp"]
         pp_size = pp_mesh.size()
         metrics_log_rank = int((world_mesh.size() // pp_size) * (pp_size - 1))
     else:

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -14,6 +14,7 @@ import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 from torch.distributed.device_mesh import DeviceMesh
 from torchtitan.logging_utils import logger
+from torchtitan.parallelisms import ParallelDims
 
 
 def dist_max(x: Union[int, float], mesh: DeviceMesh) -> float:
@@ -32,6 +33,21 @@ def _warn_overwrite_env(env, val):
             f"ENV[{env}] = {os.environ[env]} will be overridden to {val} based on job config"
         )
     os.environ[env] = val
+
+
+def get_metrics_rank(world_mesh: DeviceMesh, parallel_dims: ParallelDims) -> int:
+    """
+    Returns global rank 0 in non-pipeline-parallel configs, and returns the global
+    rank of the 0th rank in the last pipeline stage when pipeline parallelism is enabled.
+    """
+    assert (
+        world_mesh.mesh_dim_names[0] == "pp"
+    ), "get_metrics_rank assumes pp is the outer mesh dim"
+    if parallel_dims.pp_enabled:
+        pp_size = pp_mesh.size()
+        metrics_log_rank = int((world_mesh.size() // pp_size) * (pp_size - 1))
+    else:
+        metrics_log_rank = 0
 
 
 def set_pg_timeouts(timeout, world_mesh):

--- a/train.py
+++ b/train.py
@@ -244,7 +244,12 @@ def main(job_config: JobConfig):
     optimizer = build_optimizer(model, job_config)
     scheduler = get_lr_scheduler(optimizer, job_config)
 
-    metric_logger = build_metric_logger(job_config)
+    if parallel_dims.pp_enabled:
+        pp_size = pp_mesh.size()
+        metrics_log_rank = int((world_mesh.size() // pp_size) * (pp_size - 1))
+    else:
+        metrics_log_rank = 0
+    metric_logger = build_metric_logger(job_config, metrics_log_rank=metrics_log_rank)
 
     train_state = TrainState()
 

--- a/train.py
+++ b/train.py
@@ -43,6 +43,7 @@ from torchtitan.utils import (
     Color,
     dist_max,
     dist_mean,
+    get_metrics_rank,
     get_num_flop_per_token,
     get_num_params,
     get_peak_flops,
@@ -244,12 +245,9 @@ def main(job_config: JobConfig):
     optimizer = build_optimizer(model, job_config)
     scheduler = get_lr_scheduler(optimizer, job_config)
 
-    if parallel_dims.pp_enabled:
-        pp_size = pp_mesh.size()
-        metrics_log_rank = int((world_mesh.size() // pp_size) * (pp_size - 1))
-    else:
-        metrics_log_rank = 0
-    metric_logger = build_metric_logger(job_config, metrics_log_rank=metrics_log_rank)
+    metric_logger = build_metric_logger(
+        job_config, metrics_log_rank=get_metrics_rank(world_mesh, parallel_dims)
+    )
 
     train_state = TrainState()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #383

Avoid complicating the ux and leave the status quo of 2 user-selectable
behaviors:
 - log from rank 0 (the default)
 - log from all ranks (not the default)

Modify the meaning of 'log from rank 0' to log from rank 0 in
non-pipeline parallel runs, and log from the local rank 0 within the
last pipeline-parallel stage group if pp is enabled.  (note: earlier
pipeline stages still produce some metrics like mfu/memory, but do not
compute loss.)