### PR TITLE
Prepare train.py for model chunks for pipelining

### DIFF
--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -295,15 +295,7 @@ def pipeline_llama_tracer(
     return ((stage,), (model,))
 
 
-def parallelize_llama(model_parts, world_mesh, parallel_dims, job_config: JobConfig):
-    """Apply SPMD parallelisms and activation checkpointing to each model in model_parts"""
-    return [
-        _parallelize_llama(m, world_mesh, parallel_dims, job_config)
-        for m in model_parts
-    ]
-
-
-def _parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
+def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
     """
     Apply SPMD parallelisms and activation checkpointing to the model.
 

--- a/torchtitan/parallelisms/pipelining_utils.py
+++ b/torchtitan/parallelisms/pipelining_utils.py
@@ -7,7 +7,9 @@ from torch.distributed.pipelining import Schedule1F1B, ScheduleGPipe
 from torchtitan.logging_utils import logger
 
 
-def build_pipeline_schedule(job_config, parallel_dims, stage, loss_fn):
+def build_pipeline_schedule(job_config, parallel_dims, stages, loss_fn):
+    assert len(stages) == 1, "Looped schedules not yet supported"
+    stage = stages[0]
     if job_config.experimental.pipeline_parallel_schedule == "1f1b":
         schedule_class = Schedule1F1B
     elif job_config.experimental.pipeline_parallel_schedule == "gpipe":

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -7,7 +7,7 @@
 import os
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, Union
+from typing import Union
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -15,11 +15,6 @@ import torch.distributed.distributed_c10d as c10d
 from torch.distributed.device_mesh import DeviceMesh
 from torchtitan.logging_utils import logger
 from torchtitan.parallelisms import ParallelDims
-
-
-def move_to_empty(model_parts: List[torch.nn.Module], device: torch.device):
-    for model in model_parts:
-        model.to_empty(device="cuda")
 
 
 def dist_max(x: Union[int, float], mesh: DeviceMesh) -> float:

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -7,7 +7,7 @@
 import os
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Union
+from typing import List, Union
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -15,6 +15,11 @@ import torch.distributed.distributed_c10d as c10d
 from torch.distributed.device_mesh import DeviceMesh
 from torchtitan.logging_utils import logger
 from torchtitan.parallelisms import ParallelDims
+
+
+def move_to_empty(model_parts: List[torch.nn.Module], device: torch.device):
+    for model in model_parts:
+        model.to_empty(device="cuda")
 
 
 def dist_max(x: Union[int, float], mesh: DeviceMesh) -> float:

--- a/train.py
+++ b/train.py
@@ -256,7 +256,7 @@ def main(job_config: JobConfig):
 
     init_device = "cpu" if job_config.checkpoint.create_seed_checkpoint else "cuda"
     for model in model_parts:
-        model.to_empty(init_device)
+        model.to_empty(device=init_device)
 
     if parallel_dims.pp_enabled:
         pp_schedule = build_pipeline_schedule(

--- a/train.py
+++ b/train.py
@@ -48,7 +48,6 @@ from torchtitan.utils import (
     get_num_params,
     get_peak_flops,
     init_distributed,
-    move_to_empty,
     NoColor,
     set_pg_timeouts,
 )
@@ -256,7 +255,8 @@ def main(job_config: JobConfig):
     ]
 
     init_device = "cpu" if job_config.checkpoint.create_seed_checkpoint else "cuda"
-    move_to_empty(model_parts, device=init_device)
+    for model in model_parts:
+        model.to_empty(init_device)
 
     if parallel_dims.pp_enabled:
         pp_schedule = build_pipeline_schedule(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #411
* #358
* __->__ #406

When using pipeline parallelism, a common technique  for reducing bubble
size is to use schedules that specify more than one model chunk per
physical rank.  e.g. pp degree 4 could have 8 pipeline stages, and rank
0 could have stage 0 and stage 4.

To generalize this concept without forking too much code in train.py, I
make 'model_parts' a new container that either contains one model for
non-PP or simple PP cases, and contains multiple model parts for complex
PP cases.

In general, this is tractable becuase we treat each model part the same:
we create one optimizer per model part, and one lr scheduler per
optimizer.  We apply spmd and compile individually to each model part.
The general pattern is to loop over the model parts and perform an
action on each part, which also works fine if the list size is 1.

The rest of train.py and optimizer/lr_scheduler changes add syntax sugar
to simplify calling a method on each model part or optimizer part.