### PR TITLE
whole_model for fp8 

### DIFF
--- a/train.py
+++ b/train.py
@@ -217,7 +217,7 @@ def main(job_config: JobConfig):
 
     # apply fp8 linear module swap
     if job_config.training.fp8_linear:
-        build_fp8_linear(model, job_config)
+        build_fp8_linear(whole_model, job_config)
 
     # log model size
     model_param_count = get_num_params(whole_model)


### PR DESCRIPTION
train.py renamed `model` to `whole_model` https://github.com/pytorch/torchtitan/pull/406

fp8 still use `model` thus report error on `model not defined`. this PR fixed it

`build_fp8_linear(whole_model, job_config)`