### PR TITLE
Improved `repeat_kv` eager perf

### DIFF
--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -121,7 +121,7 @@ def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
     if n_rep == 1:
         return x
     return (
-        x[:, :, :, None, :]
+        torch.unsqueeze(x, dim=3)
         .expand(bs, slen, n_kv_heads, n_rep, head_dim)
         .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #418

**Overview**
This PR replaces `x[:, :, :, None, :]` with `torch.unsqueeze(x, dim=3)` to avoid unnecessary device copies and fill kernels in backward (namely, 4 fills and 4 copies with shape `(bs, seq_len, n_kv_heads, head_dim)`).

**Traces**
Existing forward (CPU):
<img width="1060" alt="Screenshot 2024-06-24 at 3 33 24 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/f7a407a6-dfaf-4193-aaba-a3f4cde54632">
Existing backward (CPU):
<img width="1134" alt="Screenshot 2024-06-24 at 3 34 48 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/9a980ec7-309e-4282-b304-830731ffaaea">
Existing backward (GPU):
<img width="768" alt="Screenshot 2024-06-24 at 3 35 40 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/139e2172-c2b9-4681-81f0-c12a8e93a274">

Each `aten::slice` in forward leads to a `SliceBackward0`, which is `aten::zeros` -> `aten::copy_`. 

New forward (CPU):
<img width="1368" alt="Screenshot 2024-06-24 at 3 39 25 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/02e6ba67-0674-4f88-a78f-b8f763df29f7">
New backward (CPU):
<img width="981" alt="Screenshot 2024-06-24 at 3 37 34 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/8b5b3fff-9a01-45d6-9fb5-5d62093d3347">
New backward (GPU): has no more fill kernels and device copies
<img width="489" alt="Screenshot 2024-06-24 at 3 38 51 PM" src="https://github.com/pytorch/torchtitan/assets/31054793/41ca4250-9007-4daf-ba47-6760e9d8afbc">

**Test Plan**
- Add `torch.manual_seed(0)` and `torch.use_deterministic_algorithms(True, warn_only=False)` at the beginning of `main` in `train.py`
- `CUBLAS_WORKSPACE_CONFIG=:4096:8 CONFIG_FILE=train_configs/llama3_8b.toml ./run_llama_train.sh` with DP=8, batch size 1, and no AC
- Baseline: P1441095581
- New: P1441096211
- Losses and memory usage match; WPS increased by 0.2-0.3% for this setup (but may be more significant with larger batch size)



