### PR TITLE
Set `record_shapes=True` for profiler

### DIFF
--- a/torchtitan/profiling.py
+++ b/torchtitan/profiling.py
@@ -68,6 +68,7 @@ def maybe_enable_profiling(config: JobConfig, *, global_step: int = 0):
             ],
             schedule=torch.profiler.schedule(wait=wait, warmup=warmup, active=active),
             on_trace_ready=trace_handler,
+            record_shapes=True,
         ) as torch_profiler:
             torch_profiler.step_num = global_step
             yield torch_profiler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #419

`record_shapes=True` should have negligible extra runtime overhead and does not bloat the trace file. We should set it since it helps understanding traces.