### PR TITLE
by default disable heavy memory profiling

### DIFF
--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -9,7 +9,7 @@ use_for_integration_test = true
 enable_profiling = true
 save_traces_folder = "profile_trace"
 profile_freq = 10
-enable_memory_snapshot = true
+enable_memory_snapshot = false
 save_memory_snapshot_folder = "memory_snapshot"
 
 [metrics]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #430

Currently memory profiler would profile and dump memory snapshots for every single iteration (for details see https://github.com/pytorch/torchtitan/pull/395#pullrequestreview-2121075514). Even for `debug_model`, this costs around 20 seconds. Let's disable it by default, until per `prof_freq` profiling and dumping is enabled (tracked in #422).

