### PR TITLE
Add support of DDP and experimental CompiledAutograd

### DIFF
--- a/estimation.py
+++ b/estimation.py
@@ -67,7 +67,7 @@ def estimate_memory(job_config: JobConfig):
         pp=job_config.experimental.pipeline_parallel_degree,
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
-        dp_type=job_config.experimental.data_parallel_type,
+        dp_type=job_config.training.data_parallel_type,
     )
 
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")

--- a/test_runner.py
+++ b/test_runner.py
@@ -277,11 +277,10 @@ def build_test_list():
             [
                 [
                     "--training.data_parallel_type ddp",
-                    "--experimental.enable_compiled_autograd",
                 ]
             ],
-            "CompiledDDP",
-            "compiled_ddp",
+            "DDP",
+            "ddp",
             ngpu=4,
         ),
     ]

--- a/test_runner.py
+++ b/test_runner.py
@@ -276,15 +276,13 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--training.tensor_parallel_degree 1",
-                    "--training.data_parallel_degree 8",
-                    "--experimental.data_parallel_type ddp",
+                    "--training.data_parallel_type ddp",
                     "--experimental.enable_compiled_autograd",
                 ]
             ],
             "CompiledDDP",
             "compiled_ddp",
-            ngpu=8,
+            ngpu=4,
         ),
     ]
     return integration_tests_flavors

--- a/test_runner.py
+++ b/test_runner.py
@@ -276,7 +276,6 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-<<<<<<< HEAD
                     "--training.enable_float8_linear",
                 ]
             ],

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -313,7 +313,7 @@ class JobConfig:
             """,
         )
         self.parser.add_argument(
-            "--experimental.data_parallel_type",
+            "--training.data_parallel_type",
             type=str,
             default="fsdp",
             help="Data parallelism type. TorchTitan currently supports FSDP and DDP.",

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -313,6 +313,17 @@ class JobConfig:
             """,
         )
         self.parser.add_argument(
+            "--experimental.data_parallel_type",
+            type=str,
+            default="fsdp",
+            help="Data parallelism type. TorchTitan currently supports FSDP and DDP.",
+        )
+        self.parser.add_argument(
+            "--experimental.enable_compiled_autograd",
+            action="store_true",
+            help="Enable CompiledAutograd to compile the backward.",
+        )
+        self.parser.add_argument(
             "--training.mixed_precision_param",
             type=str,
             default="bfloat16",

--- a/torchtitan/parallelisms/__init__.py
+++ b/torchtitan/parallelisms/__init__.py
@@ -28,8 +28,10 @@ class ParallelDims:
     pp: int
     world_size: int
     enable_loss_parallel: bool
+    dp_type: str
 
     def __post_init__(self):
+        self.dp_type = self.dp_type.lower()
         self._validate()
 
     def _validate(self):
@@ -42,6 +44,7 @@ class ParallelDims:
         assert (
             dp * tp * pp == self.world_size
         ), f"Invalid parallel dims: dp({dp}) * tp({tp}) * pp({pp}) != WORLD_SIZE({self.world_size})"
+        assert self.dp_type in ("fsdp", "ddp")
 
     def build_mesh(self, device_type):
         dims = []

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -495,7 +495,7 @@ def apply_ddp(model, world_mesh, parallel_dims, job_config: JobConfig):
         raise RuntimeError("DDP has not supported > 1D parallelism.")
 
     if job_config.training.compile:
-        if job_config.experimental.compiled_autograd:
+        if job_config.experimental.enable_compiled_autograd:
             torch._dynamo.config.optimize_ddp = (
                 "python_reducer_without_compiled_forward"
             )

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -12,9 +12,9 @@ from collections import defaultdict
 from typing import Dict, Tuple
 
 import torch
+from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
 
 from torch.distributed._composable.replicate import replicate
-from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed._tensor import Replicate, Shard
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,
@@ -493,7 +493,9 @@ def apply_ddp(model, world_mesh, parallel_dims, job_config: JobConfig):
 
     if job_config.training.compile:
         if job_config.experimental.compiled_autograd:
-            torch._dynamo.config.optimize_ddp = "python_reducer_without_compiled_forward"
+            torch._dynamo.config.optimize_ddp = (
+                "python_reducer_without_compiled_forward"
+            )
         else:
             torch._dynamo.config.optimize_ddp = "ddp_optimizer"
 

--- a/train.py
+++ b/train.py
@@ -135,6 +135,20 @@ def build_optimizers(model_parts, job_config: JobConfig):
     return OptimizersContainer([_build_optimizer(model) for model in model_parts])
 
 
+def get_train_context(enable_loss_parallel: bool, enable_compiled_autograd: bool):
+    @contextlib.contextmanager
+    def context():
+        with contextlib.ExitStack() as stack:
+            if enable_loss_parallel:
+                stack.enter_context(loss_parallel())
+            if enable_compiled_autograd:
+                stack.enter_context(torch._dynamo.utils.maybe_enable_compiled_autograd(True))
+
+            yield
+
+    return context
+
+
 # Enable debug tracing on failure: https://pytorch.org/docs/stable/elastic/errors.html
 @record
 def main(job_config: JobConfig):
@@ -157,6 +171,7 @@ def main(job_config: JobConfig):
         pp=job_config.experimental.pipeline_parallel_degree,
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
+        dp_type=job_config.experimental.data_parallel_type,
     )
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     torch.cuda.set_device(device)
@@ -191,9 +206,9 @@ def main(job_config: JobConfig):
         dp_rank,
     )
 
-    # loss_parallel enables dispatching to efficient loss operators
-    loss_parallel_ctx = (
-        loss_parallel if parallel_dims.loss_parallel_enabled else contextlib.nullcontext
+    train_context = get_train_context(
+        parallel_dims.loss_parallel_enabled,
+        job_config.experimental.enable_compiled_autograd
     )
 
     # loss fn can be shared by pipeline-parallel or non-pp execution
@@ -362,7 +377,7 @@ def main(job_config: JobConfig):
                 # pipeline parallel forward / backward inside step() call
                 is_last_stage = pp_mesh.get_local_rank() == pp_mesh.size() - 1
 
-                with loss_parallel_ctx():
+                with train_context():
                     if pp_mesh.get_local_rank() == 0:
                         pp_schedule.step(input_ids)
                     elif is_last_stage:
@@ -379,7 +394,7 @@ def main(job_config: JobConfig):
                 )
             else:
                 # Non-PP forward / backward
-                with loss_parallel_ctx():
+                with train_context():
                     pred = model(input_ids)
                     loss = loss_fn(pred, labels)
                     # pred.shape=(bs, seq_len, vocab_size)

--- a/train.py
+++ b/train.py
@@ -142,7 +142,9 @@ def get_train_context(enable_loss_parallel: bool, enable_compiled_autograd: bool
             if enable_loss_parallel:
                 stack.enter_context(loss_parallel())
             if enable_compiled_autograd:
-                stack.enter_context(torch._dynamo.utils.maybe_enable_compiled_autograd(True))
+                stack.enter_context(
+                    torch._dynamo.utils.maybe_enable_compiled_autograd(True)
+                )
 
             yield
 
@@ -208,7 +210,7 @@ def main(job_config: JobConfig):
 
     train_context = get_train_context(
         parallel_dims.loss_parallel_enabled,
-        job_config.experimental.enable_compiled_autograd
+        job_config.experimental.enable_compiled_autograd,
     )
 
     # loss fn can be shared by pipeline-parallel or non-pp execution

--- a/train.py
+++ b/train.py
@@ -173,7 +173,7 @@ def main(job_config: JobConfig):
         pp=job_config.experimental.pipeline_parallel_degree,
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
-        dp_type=job_config.experimental.data_parallel_type,
+        dp_type=job_config.training.data_parallel_type,
     )
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     torch.cuda.set_device(device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #432

Summary:
Address the comments in https://github.com/pytorch/torchtitan/pull/319 and resubmit the PR to fit the current code base.

Test Plan:
```
CONFIG_FILE=./train_configs/debug_model.toml ./run_llama_train.sh --comm.train_timeout_seconds=3600   --training.tensor_parallel_degree=1 --training.data_parallel_degree=8 --experimental.data_parallel_type=ddp --training.steps=1000 --metrics.log_freq=10 --profiling.profile_freq=1000
```

**DDP tensorboard log**
<img width="835" alt="Screenshot 2024-07-18 at 9 42 43 AM" src="https://github.com/user-attachments/assets/5103b724-6ba4-41aa-a03f-686dfe677678">
<img width="414" alt="Screenshot 2024-07-18 at 9 43 03 AM" src="https://github.com/user-attachments/assets/bae08ce5-a130-46a9-992d-76d04f65cf63">

**FSDP tensorboard log**
<img width="834" alt="Screenshot 2024-07-18 at 9 44 36 AM" src="https://github.com/user-attachments/assets/69ea6453-b1c1-4ec4-a37e-64280e9befd1">
<img width="407" alt="Screenshot 2024-07-18 at 9 45 46 AM" src="https://github.com/user-attachments/assets/6eba8b13-aed8-4b75-bbe3-d0825503a2de">
