### PR TITLE
Modifying memory estimation options and minor changes

### DIFF
--- a/estimation.py
+++ b/estimation.py
@@ -49,7 +49,7 @@ def estimate_memory(job_config: JobConfig):
     # fake tensor doesn't work with fused rmsnorm
     if (
         job_config.model.norm_type == "fused_rmsnorm"
-        and job_config.memory_estimation.fake_mode_only
+        and not job_config.memory_estimation.disable_fake_mode
     ):
         logger.info(
             "Fused RMSNorm is not supported yet under fake estimation mode. "
@@ -111,7 +111,7 @@ def estimate_memory(job_config: JobConfig):
     model_config.vocab_size = tokenizer.n_words
     model_config.max_seq_len = job_config.training.seq_len
 
-    with FakeTensorMode() if job_config.memory_estimation.fake_mode_only else contextlib.nullcontext():
+    with FakeTensorMode() if not job_config.memory_estimation.disable_fake_mode else contextlib.nullcontext():
 
         logger.info(
             f"Building {model_name} {job_config.model.flavor} with {model_config}"
@@ -202,7 +202,7 @@ def estimate_memory(job_config: JobConfig):
             f" {peak_reserved / gib} GiB | num_retries: {num_retries}"
         )
         print(f"Tracker Max: {tracker_peak / gib} GiB")
-        if not job_config.memory_estimation.fake_mode_only and peak_active > 0:
+        if job_config.memory_estimation.disable_fake_mode and peak_active > 0:
             print(f"Tracker Accuracy: {tracker_peak/peak_active}")
         gc.enable()
 

--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -31,7 +31,7 @@ if [ $# -ne 0 ]; then
 fi
 
 # Check if --estimate.memory=True is in the arguments
-if echo "$overrides" | grep -q -- "--estimate.memory=True"; then
+if echo "$overrides" | grep -q -- "--memory_estimation.enabled"; then
     # Calculate WORLD_SIZE as the product of NGPU and NNODES
     # Export WORLD_SIZE and LOCAL_RANK
     export WORLD_SIZE=$((NGPU * NNODES))

--- a/test_runner.py
+++ b/test_runner.py
@@ -267,12 +267,11 @@ def build_test_list():
             [
                 [
                     "--memory_estimation.enabled",
-                    "--memory_estimation.fake_mode_only",
                 ]
             ],
             "FSDP2 Memory Tracking and Estimation",
             "fsdp2_mem_tracker",
-            ngpu=8,
+            ngpu=4,
         ),
     ]
     return integration_tests_flavors

--- a/test_runner.py
+++ b/test_runner.py
@@ -265,11 +265,14 @@ def build_test_list():
         ),
         OverrideDefinitions(
             [
-                ["--estimate.memory=True", "--estimate.mode=real"],
+                [
+                    "--memory_estimation.enabled",
+                    "--memory_estimation.fake_mode_only",
+                ]
             ],
             "FSDP2 Memory Tracking and Estimation",
             "fsdp2_mem_tracker",
-            ngpu=4,
+            ngpu=8,
         ),
     ]
     return integration_tests_flavors

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -488,8 +488,9 @@ class JobConfig:
         )
 
         self.parser.add_argument(
-            "--memory_estimation.fake_mode_only",
+            "--memory_estimation.disable_fake_mode",
             help="Whether to estimate memory under FakeTensorMode",
+            default=False,
             action="store_true",
         )
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -480,18 +480,17 @@ class JobConfig:
             help="Flight recorder ring buffer size, >0 means recording by default, 0 means disabled",
         )
 
-        # estimation mode settings
+        # memory estimation settings
         self.parser.add_argument(
-            "--estimate.memory",
+            "--memory_estimation.enabled",
             help="Whether to estimate memory usage for FSDP",
-            default=False,
+            action="store_true",
         )
 
         self.parser.add_argument(
-            "--estimate.mode",
-            type=str,
-            default="fake",
-            help="Mode of estimation to use ['fake', 'real']",
+            "--memory_estimation.fake_mode_only",
+            help="Whether to estimate memory under FakeTensorMode",
+            action="store_true",
         )
 
     def parse_args(self, args_list: list = sys.argv[1:]):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #435
* #426 
* #425 

As per suggestions from @tianyu-l in #425, the config options are now:
`./run_llama_train.sh --memory_estimation.enabled --memory_estimation.disable_fake_mode`

`FakeTensorMode` is enabled by default. User needs to use the config option `--memory_estimation.disable_fake_mode` to disable it explicitly.