### PR TITLE
[DO NOT MERGE][example] fold batch and sequence dimensions to accelerate Sequence Parallel

### DIFF
--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -427,6 +427,7 @@ class Transformer(nn.Module):
             torch.Tensor: Output logits after applying the Transformer model.
 
         """
+        bs = tokens.shape[0]
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stage
         # fold batch dimension and sequence dimension for more efficient allgather/reduce_scatter
         if self.tok_embeddings:
@@ -443,7 +444,7 @@ class Transformer(nn.Module):
 
         h = self.norm(h) if self.norm else h
         # unfold batch and sequence dimension
-        h = h.view(-1, seqlen, self.model_args.dim)
+        h = h.view(bs, -1, self.model_args.dim)
         output = self.output(h).float() if self.output else h
         return output
 

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -79,9 +79,7 @@ def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor) -> torch.Ten
     """
     ndim = x.ndim
     assert 0 <= 1 < ndim
-    seqlen = x.shape[1]
-    freqs_cis = freqs_cis[0:seqlen]
-    assert freqs_cis.shape == (seqlen, x.shape[-1])
+    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
     shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
     return freqs_cis.view(*shape)
 
@@ -187,7 +185,10 @@ class Attention(nn.Module):
             torch.Tensor: Output tensor after attention.
 
         """
-        bs, seqlen, _ = x.shape
+        # dim 0 of x is a folded dimension of [bs, seqlen]
+        seqlen, _ = freqs_cis.shape
+        bs_seqlen, _ = x.shape
+        bs = bs_seqlen // seqlen
         xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
         xq = xq.view(bs, seqlen, self.n_heads, self.head_dim)
@@ -209,7 +210,8 @@ class Attention(nn.Module):
         output = output.transpose(
             1, 2
         ).contiguous()  # (bs, seqlen, n_local_heads, head_dim)
-        output = output.view(bs, seqlen, -1)
+        # output stay folded with batch and sequence dimension
+        output = output.view(bs * seqlen, -1)
         return self.wo(output)
 
 
@@ -427,11 +429,19 @@ class Transformer(nn.Module):
         """
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
+        # fold batch dimension and sequence dimension
+        # for more efficient allgather/reduce_scatter
+        h = h.view(-1, self.model_args.dim)
 
+        freqs_cis = self.freqs_cis[0 : self.model_args.max_seq_len]
         for layer in self.layers.values():
-            h = layer(h, self.freqs_cis)
+            h = layer(h, freqs_cis)
 
         h = self.norm(h) if self.norm else h
+        # unfold batch and sequence dimension
+        bs = tokens.shape[0]
+        bs_seqlen = h.shape[0]
+        h = h.view(bs, bs_seqlen // bs, self.model_args.dim)
         output = self.output(h).float() if self.output else h
         return output
 

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -439,9 +439,8 @@ class Transformer(nn.Module):
 
         h = self.norm(h) if self.norm else h
         # unfold batch and sequence dimension
-        bs = tokens.shape[0]
-        bs_seqlen = h.shape[0]
-        h = h.view(bs, bs_seqlen // bs, self.model_args.dim)
+        bs, seqlen = tokens.shape
+        h = h.view(bs, seqlen, self.model_args.dim)
         output = self.output(h).float() if self.output else h
         return output
 

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -221,8 +221,8 @@ def _rms_norm_bwd_kernel_sm(
 class TritonFusedRMSNorm(torch.autograd.Function):
     @partial(
         local_map,
-        out_placements=[Shard(1)],
-        in_placements=(None, [Shard(1)], [Replicate()], None),
+        out_placements=[Shard(0)],
+        in_placements=(None, [Shard(0)], [Replicate()], None),
     )
     @staticmethod
     def forward(ctx, x, weight, eps):
@@ -268,8 +268,8 @@ class TritonFusedRMSNorm(torch.autograd.Function):
 
     @partial(
         local_map,
-        out_placements=([Shard(1)], [Partial()], None),
-        in_placements=(None, [Shard(1)]),
+        out_placements=([Shard(0)], [Partial()], None),
+        in_placements=(None, [Shard(0)]),
     )
     @staticmethod
     def backward(ctx, dy):

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -350,6 +350,7 @@ def apply_tp(model, world_mesh, parallel_dims, job_config: JobConfig):
         {
             "tok_embeddings": RowwiseParallel(
                 input_layouts=Replicate(),
+                output_layouts=Shard(0),
             ),
             "output": col_parallel_strategy(
                 input_layouts=Shard(0),
@@ -357,11 +358,6 @@ def apply_tp(model, world_mesh, parallel_dims, job_config: JobConfig):
                 use_local_output=not loss_parallel,
             ),
             "norm": SequenceParallel(sequence_dim=0),
-            "layers.0": PrepareModuleInput(
-                input_layouts=(Replicate(), None),
-                desired_input_layouts=(Shard(0), None),
-                use_local_output=True,
-            ),
         },
     )
 

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -350,7 +350,6 @@ def apply_tp(model, world_mesh, parallel_dims, job_config: JobConfig):
         {
             "tok_embeddings": RowwiseParallel(
                 input_layouts=Replicate(),
-                output_layouts=Shard(0),
             ),
             "output": col_parallel_strategy(
                 input_layouts=Shard(0),
@@ -358,6 +357,11 @@ def apply_tp(model, world_mesh, parallel_dims, job_config: JobConfig):
                 use_local_output=not loss_parallel,
             ),
             "norm": SequenceParallel(sequence_dim=0),
+            "layers.0": PrepareModuleInput(
+                input_layouts=(Replicate(), None),
+                desired_input_layouts=(Shard(0), None),
+                use_local_output=True,
+            ),
         },
     )
 

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -6,7 +6,7 @@ description = "Llama 3 debug training"
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = false
+enable_profiling = true
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = false
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 enable_color_printing = true
-enable_tensorboard = false
+enable_tensorboard = true
 save_tb_folder = "tb"
 
 [model]
@@ -36,7 +36,7 @@ warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
 max_norm = 1.0  # grad norm clipping
 steps = 10
 data_parallel_degree = -1
-tensor_parallel_degree = 4
+tensor_parallel_degree = 1
 fp8_linear = ""
 compile = false
 dataset = "c4_mini"  # supported datasets: c4_mini (45K), c4 (177M)

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -6,7 +6,7 @@ description = "Llama 3 debug training"
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = true
+enable_profiling = false
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = false
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 enable_color_printing = true
-enable_tensorboard = true
+enable_tensorboard = false
 save_tb_folder = "tb"
 
 [model]
@@ -36,7 +36,7 @@ warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
 max_norm = 1.0  # grad norm clipping
 steps = 10
 data_parallel_degree = -1
-tensor_parallel_degree = 1
+tensor_parallel_degree = 4
 fp8_linear = ""
 compile = false
 dataset = "c4_mini"  # supported datasets: c4_mini (45K), c4 (177M)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #437

Note: This PR is for showcasing purpose only and is almost a reverse of #190.

At the cost of model code change, we can obtain better Sequence Parallel performance. Without folding and unfolding,  all-gather and reduce-scatter are performed on dim 1 (sequence dim) instead of dim 0 (folded dim), which incurs an extra `aten.cat` after each collective.

Stats from @awgu:
> for 8k seq len, batch size 1 on H100, these two cats take about 0.18 ms out of 3 ms of FFN compute (6%)

Experiment on 8-layer `debug_model`
before:
<img width="1023" alt="image" src="https://github.com/pytorch/torchtitan/assets/150487191/04e5ea4b-fa9e-48e5-92be-582841cb2796">
after:
<img width="1023" alt="image" src="https://github.com/pytorch/torchtitan/assets/150487191/38c39506-462d-485a-a16c-48770a28edb0">