### PR TITLE
[Cleanup] Remove libuv from run_llama_train.sh

### DIFF
--- a/create_seed_checkpoint.sh
+++ b/create_seed_checkpoint.sh
@@ -18,7 +18,6 @@
 
 set -ex
 
-export USE_LIBUV=1
 TRAINER_DIR=${1:-/home/$USER/local/torchtitan}
 NGPU=1
 LOG_RANK=0

--- a/multinode_trainer.slurm
+++ b/multinode_trainer.slurm
@@ -53,7 +53,6 @@ export NCCL_SOCKET_IFNAME="eth0,en,eth,em,bond"
 export NCCL_BUFFSIZE=2097152
 #export TORCH_DIST_INIT_BARRIER=1
 export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
-#export USE_LIBUV=1
 CONFIG_FILE=${CONFIG_FILE:-"./train_configs/llama2_13b.toml"}
 
 dcgmi profile --pause

--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -7,9 +7,6 @@
 
 set -ex
 
-# libUV is a scalable backend for TCPStore which is used in processGroup
-# rendezvous. This is the recommended backend for distributed training.
-export USE_LIBUV=1
 TRAINER_DIR=${TRAINER_DIR:-/home/$USER/local/torchtitan}
 
 # use envs as local overrides for convenience


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #456
* #455
* #454
* __->__ #453

libuv is now enabled by default.

we can proably do without the educational blurb there, and don't need
the env either since the default has landed.