### PR TITLE
[Cleanup] Remove unused TRAINER_DIR

### DIFF
--- a/create_seed_checkpoint.sh
+++ b/create_seed_checkpoint.sh
@@ -18,7 +18,6 @@
 
 set -ex
 
-TRAINER_DIR=${1:-/home/$USER/local/torchtitan}
 NGPU=1
 LOG_RANK=0
 CONFIG_FILE=${CONFIG_FILE:-"./train_configs/debug_model.toml"}

--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -12,7 +12,6 @@ set -ex
 # LOG_RANK=0,1 NGPU=4 ./run_llama_train.sh
 NGPU=${NGPU:-"8"}
 NNODES=${NNODES:-"1"}
-TRAINER_DIR=${TRAINER_DIR:-/home/$USER/local/torchtitan}
 LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./train_configs/debug_model.toml"}
 

--- a/run_memory_estimation.sh
+++ b/run_memory_estimation.sh
@@ -12,7 +12,6 @@ set -ex
 # LOG_RANK=0,1 NGPU=4 ./run_llama_train.sh
 NGPU=${NGPU:-"8"}
 NNODES=${NNODES:-"1"}
-TRAINER_DIR=${TRAINER_DIR:-/home/$USER/local/torchtitan}
 LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./train_configs/debug_model.toml"}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #456
* #455
* #454
* #453

This argument seems to be left over from older times- it is not used
anywhere in the codebase.