### PR TITLE
[Do not review] Activation offloading

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -242,6 +242,12 @@ class JobConfig:
             help="Whether to apply loss parallel when sequence parallel is enabled",
         )
         self.parser.add_argument(
+            "--experimental.offload_activations",
+            default=False,
+            action="store_true",
+            help="Whether to offload activations",
+        )
+        self.parser.add_argument(
             "--experimental.enable_async_tensor_parallel",
             default=False,
             action="store_true",

--- a/torchtitan/parallelisms/offload_utils.py
+++ b/torchtitan/parallelisms/offload_utils.py
@@ -66,6 +66,11 @@ class offload_to_cpu(saved_tensors_hooks):
     :meth:`copy_h2d_async` to issue the H2D copy as async before the compute
     with which to overlap has been issued. When the activation is used in
     backward, we will wait for that H2D copy without user intervention.
+
+    The D2H and H2D copies always used pinned memory, so the user should take
+    care to ensure sufficient CPU RAM to be pinned. Otherwise the program can
+    become slow or freeze. The first few iterations will be much slower due to
+    repeated ``cudaHostAlloc`` calls to warmup the CPU caching allocator.
     """
 
     def __init__(self, offload_stream: torch.cuda.Stream):

--- a/torchtitan/parallelisms/offload_utils.py
+++ b/torchtitan/parallelisms/offload_utils.py
@@ -1,0 +1,131 @@
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from torch.autograd.graph import saved_tensors_hooks
+
+
+HandleKey = Tuple[torch.device, torch.Tensor]
+
+
+class Handle:
+    def __init__(
+        self,
+        device_tensor: torch.Tensor,
+        offload_stream: torch.cuda.Stream,
+    ):
+        if not torch.is_tensor(device_tensor):
+            raise ValueError(f"Expect stensor but got {device_tensor}")
+        self.device_tensor: Optional[torch.Tensor] = device_tensor
+        self.cpu_tensor: Optional[torch.Tensor] = None
+        self.offload_stream = offload_stream
+        self.d2h_event: Optional[torch.cuda.Event] = None
+        self.h2d_event: Optional[torch.cuda.Event] = None
+        self.device: torch.device = device_tensor.device
+
+    def copy_d2h_async(self) -> None:
+        current_stream = torch.cuda.current_stream()
+        self.offload_stream.wait_stream(current_stream)
+        with torch.cuda.stream(self.offload_stream):
+            self.cpu_tensor = self.device_tensor.to(
+                torch.device("cpu"), non_blocking=True
+            )
+            self.d2h_event = self.offload_stream.record_event()
+
+    def copy_h2d_async(self) -> None:
+        if self.device_tensor is not None:
+            return
+        assert self.cpu_tensor is not None
+        self.device_tensor = torch.empty_like(self.cpu_tensor, device=self.device)
+        self.offload_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self.offload_stream):
+            self.device_tensor.copy_(self.cpu_tensor, non_blocking=True)
+            self.h2d_event = self.offload_stream.record_event()
+
+    def wait_for_d2h(self):
+        if self.d2h_event:
+            torch.cuda.current_stream().wait_event(self.d2h_event)
+        self.device_tensor = None
+
+    def wait_for_h2d(self):
+        if self.h2d_event:
+            torch.cuda.current_stream().wait_event(self.h2d_event)
+        self.cpu_tensor = None
+
+
+class offload_to_cpu(saved_tensors_hooks):
+    """
+    This represents a saved tensors hooks context that offloads activations to
+    CPU in forward and un-offloads them from CPU in backward.
+
+    In forward, the D2H copy is always async. Device memory is freed when the
+    user calls :meth:`wait_for_d2h`, which should be done after the compute
+    with which to overlap has been issued.
+
+    In backward, the H2D copy defaults to sync. However, the user may call
+    :meth:`copy_h2d_async` to issue the H2D copy as async before the compute
+    with which to overlap has been issued. When the activation is used in
+    backward, we will wait for that H2D copy without user intervention.
+    """
+
+    def __init__(self, offload_stream: torch.cuda.Stream):
+        self.handle_key_to_handle: Dict[HandleKey, Handle] = {}
+
+        def pack_to_cpu(tensor: torch.Tensor):
+            if tensor.device.type == "cpu":
+                return (tensor.device, tensor)
+
+            device_tensor = tensor
+            del tensor
+            # TODO: Need a way to decide whether to offload this tensor or not
+            # that might need to be a function of the op constructing this
+            # tensor, pipeline parallel rank, etc.
+            if device_tensor.numel() < (14336 * 8192):  # (FFN dim * seq_len) for 8B
+                return (device_tensor.device, device_tensor)
+
+            handle = Handle(device_tensor, offload_stream)
+            handle.copy_d2h_async()
+
+            assert handle.cpu_tensor is not None
+            handle_key = (device_tensor.device, handle.cpu_tensor)
+            self.handle_key_to_handle[handle_key] = handle
+
+            return handle_key
+
+        def unpack_from_cpu(handle_key: HandleKey):
+            device, tensor = handle_key
+            if tensor.device == device:
+                return tensor
+
+            assert tensor.device == torch.device("cpu"), f"{tensor.device}"
+            cpu_tensor = tensor
+            del tensor
+
+            handle = self.handle_key_to_handle.get(handle_key, None)
+            if handle is None:
+                raise RuntimeError(f"Handle missing for {handle_key}")
+
+            handle.wait_for_h2d()
+            if handle.device_tensor is not None:
+                device_tensor = handle.device_tensor
+                handle.device_tensor = None
+                return device_tensor
+
+            # Fallback to non-overlapped H2D copy
+            device_tensor = cpu_tensor.to(device, non_blocking=True)
+            assert handle.cpu_tensor is None
+            return device_tensor
+
+        super().__init__(pack_to_cpu, unpack_from_cpu)
+
+    def wait_for_d2h(self):
+        for handle in self.handle_key_to_handle.values():
+            handle.wait_for_d2h()
+
+    def copy_h2d_async(self):
+        for handle in self.handle_key_to_handle.values():
+            handle.copy_h2d_async()
+
+    def __enter__(self):
+        super().__enter__()
+        return self

--- a/torchtitan/profiling.py
+++ b/torchtitan/profiling.py
@@ -14,7 +14,7 @@ from torchtitan.config_manager import JobConfig
 from torchtitan.logging_utils import logger
 
 # the number of warmup steps before the active step in each profiling cycle
-WARMUP = 3
+WARMUP = 1
 
 # how much memory allocation/free ops to record in memory snapshots
 MEMORY_SNAPSHOT_MAX_ENTRIES = 100000


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #467

**Current UX**
- We use a `saved_tensors_hooks` context manager, which should be wrapped around `module.forward`. The context lets us override pack and unpack hooks that are called when saving an activation for backward and using an activation in backward, respectively. See the [tutorial](https://pytorch.org/tutorials/intermediate/autograd_saved_tensors_hooks_tutorial.html) for more info.
- We expose two main methods for the user from the context: `wait_for_d2h` and `copy_h2d_async`.
    - By default, the D2H copies for offloading are async and use pinned memory. The user must call `wait_for_d2h` to wait on the D2H copies and free the device memory. This should be done after the compute to overlap with has been issued.
    - By default, the H2D copies are sync. The user must call `copy_h2d_async` to prefetch the H2D copies as async. This should be done before the compute to overlap with has been issued.
    - We show an example of this in `apply_ac` in `parallelize_llama.py` using module hooks.
- Together, this means that by default, no GPU memory is saved and that H2D copies are sync. Only by calling the `wait_for_d2h` method can we save GPU memory, and only by calling `copy_h2d_async` methods can we overlap H2D in backward.

**Known Problems**
- **!** Conflict with `split_with_sizes_copy`'s H2D copy (specific to FSDP2):
    - FSDP2's all-gather copy-out uses `split_with_sizes_copy`, which first issues a mini-H2D copy to send metadata needed for the main copy.
    - When the CPU issue order is `copy_h2d_async` for layer `i-1` -> `split_with_sizes_copy` for layer `i` -> layer `i` backward compute, the mini-H2D copy for `split_with_sizes_copy` for layer `i` can get serialized to run _after_ the `copy_h2d_async` for layer `i-1` H2D copies even though they are running in different streams. This prevents the `copy_h2d_async` for layer `i-1` to overlap with layer `i` backward compute.
    - For now, this can be worked around with `reshard_after_forward=False`.
    - Trick/hack from @yifuwang : sleep 1 ms in the `offload_stream` before un-offloading (https://fburl.com/perfdoctor/ms47gqvp) --> allows prioritizing the `split_with_sizes_copy` H2D copy
    - The CPU issue order of `copy_h2d_async` for layer `i-1` -> `split_with_sizes_copy` for layer `i` -> layer `i` backward compute comes from running the `copy_h2d_async` for layer `i-1` using a module full pre-backward hook.
- **!** If the user offloads too many activations, the program can become slow and/or freeze. Further, the first few iterations are slow due to `cudaHostAlloc` calls warming up the CPU caching allocator. This might be brittle if other parts of the program (e.g. checkpointing) also use pinned memory. If we do not `gc.collect()` every iteration, the pinned memory does not seem to be freed, so the allocator does not reuse it in subsequent iterations.
- **!** We do not have a good way to apply a predicate to decide which activation tensors to offload. With the pack hook API, we only see the tensor, not any other information like which op constructed the tensor.

**Examples**
- Llama3-8B: DP=8, local batch size 1, sequence length 8192, no AC, `reshard_after_forward=False`:
    - Trace: https://fburl.com/perfdoctor/r1yf0lqf
    - Reserved memory: 65.67GiB(69.10%)
    - WPS: 5,294  MFU: 31.00%
- Llama3-8B: DP=8, local batch size 1, sequence length 8192, no AC, `reshard_after_forward=True`:
    - Trace: https://fburl.com/perfdoctor/qbhr98az
    - Reserved memory: 54.01GiB(56.83%)
    - WPS: 4,085  MFU: 23.92% (mainly because H2Ds in backward are not overlapped)
    - If we use @yifuwang's trick, we can get WPS: 5,073, MFU: 29.70% without changing reserved memory
- Baseline Llama3-8B: DP=8, local batch size 1, sequence length 8192, no AC, `reshard_after_forward=True`:
    - Reserved memory: 78.38GiB(82.48%)
    - WPS: 6,341  MFU: 37.13%