### PR TITLE
[float8] keep model.output as `nn.Linear` (high precision, not fp8)

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -350,8 +350,7 @@ def build_test_list():
                     "--training.enable_float8_linear",
                     "--training.enable_fsdp_float8_all_gather",
                     "--training.precompute_float8_dynamic_scale_for_fsdp",
-                    "--training.data_parallel_degree 1",
-                    "--training.tensor_parallel_degree 4",
+                    "--training.tensor_parallel_degree 2",
                 ]
             ],
             "2D FSDP2 + TP with float8 all-gather and precomputed dynamic scales, eager mode",
@@ -364,8 +363,7 @@ def build_test_list():
                     "--training.enable_float8_linear",
                     "--training.enable_fsdp_float8_all_gather",
                     "--training.precompute_float8_dynamic_scale_for_fsdp",
-                    "--training.data_parallel_degree 1",
-                    "--training.tensor_parallel_degree 4",
+                    "--training.tensor_parallel_degree 2",
                     "--training.compile",
                 ]
             ],

--- a/test_runner.py
+++ b/test_runner.py
@@ -302,8 +302,9 @@ def build_test_list():
                     "--training.precompute_float8_dynamic_scale_for_fsdp",
                 ]
             ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales",
+            "FSDP2 with float8 all-gather and precomputed dynamic scales, eager mode",
             "fsdp2_float8_all_gather_precompute_dynamic_scales",
+            ngpu=4,
         ),
         OverrideDefinitions(
             [
@@ -314,8 +315,63 @@ def build_test_list():
                     "--training.compile",
                 ]
             ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales",
+            "FSDP2 with float8 all-gather and precomputed dynamic scales, compile mode",
             "fsdp2_float8_all_gather_precompute_dynamic_scales_compile",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.enable_float8_linear",
+                    "--training.data_parallel_degree 1",
+                    "--training.tensor_parallel_degree 4",
+                ]
+            ],
+            "1D TP with float8 all-gather, eager mode",
+            "tp_float8_all_gather",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.enable_float8_linear",
+                    "--training.data_parallel_degree 1",
+                    "--training.tensor_parallel_degree 4",
+                    "--training.compile",
+                ]
+            ],
+            "1D TP with float8 all-gather, compile mode",
+            "tp_float8_all_gather_compile",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.enable_float8_linear",
+                    "--training.enable_fsdp_float8_all_gather",
+                    "--training.precompute_float8_dynamic_scale_for_fsdp",
+                    "--training.data_parallel_degree 1",
+                    "--training.tensor_parallel_degree 4",
+                ]
+            ],
+            "2D FSDP2 + TP with float8 all-gather and precomputed dynamic scales, eager mode",
+            "fsdp2_tp_float8_all_gather_precompute_dynamic_scales",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.enable_float8_linear",
+                    "--training.enable_fsdp_float8_all_gather",
+                    "--training.precompute_float8_dynamic_scale_for_fsdp",
+                    "--training.data_parallel_degree 1",
+                    "--training.tensor_parallel_degree 4",
+                    "--training.compile",
+                ]
+            ],
+            "2D FSDP2 + TP with float8 all-gather and precomputed dynamic scales, compile mode",
+            "fsdp2_tp_float8_all_gather_precompute_dynamic_scales_compile",
+            ngpu=4,
         ),
         OverrideDefinitions(
             [

--- a/test_runner.py
+++ b/test_runner.py
@@ -302,9 +302,8 @@ def build_test_list():
                     "--training.precompute_float8_dynamic_scale_for_fsdp",
                 ]
             ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales, eager mode",
+            "FSDP2 with float8 all-gather and precomputed dynamic scales",
             "fsdp2_float8_all_gather_precompute_dynamic_scales",
-            ngpu=4,
         ),
         OverrideDefinitions(
             [
@@ -315,61 +314,8 @@ def build_test_list():
                     "--training.compile",
                 ]
             ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales, compile mode",
+            "FSDP2 with float8 all-gather and precomputed dynamic scales",
             "fsdp2_float8_all_gather_precompute_dynamic_scales_compile",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.data_parallel_degree 1",
-                    "--training.tensor_parallel_degree 4",
-                ]
-            ],
-            "1D TP with float8 all-gather, eager mode",
-            "tp_float8_all_gather",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.data_parallel_degree 1",
-                    "--training.tensor_parallel_degree 4",
-                    "--training.compile",
-                ]
-            ],
-            "1D TP with float8 all-gather, compile mode",
-            "tp_float8_all_gather_compile",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.enable_fsdp_float8_all_gather",
-                    "--training.precompute_float8_dynamic_scale_for_fsdp",
-                    "--training.tensor_parallel_degree 2",
-                ]
-            ],
-            "2D FSDP2 + TP with float8 all-gather and precomputed dynamic scales, eager mode",
-            "fsdp2_tp_float8_all_gather_precompute_dynamic_scales",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.enable_fsdp_float8_all_gather",
-                    "--training.precompute_float8_dynamic_scale_for_fsdp",
-                    "--training.tensor_parallel_degree 2",
-                    "--training.compile",
-                ]
-            ],
-            "2D FSDP2 + TP with float8 all-gather and precomputed dynamic scales, compile mode",
-            "fsdp2_tp_float8_all_gather_precompute_dynamic_scales_compile",
-            ngpu=4,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/float8_linear.py
+++ b/torchtitan/float8_linear.py
@@ -74,7 +74,9 @@ def maybe_build_fp8_linear(
         )
         with set_enable_fsdp_float8_all_gather(enable_fsdp_float8_all_gather):
             swap_linear_with_float8_linear(
-                model, scaling_type_w=TensorScalingType.DYNAMIC
+                model,
+                scaling_type_w=TensorScalingType.DYNAMIC,
+                skip_fqn_list=["output"],
             )
         logger.info(
             f"Swapped to Float8Linear layers with {enable_fsdp_float8_all_gather=}"


### PR DESCRIPTION
**keep model.output as nn.Linear**: it's a common practice to NOT apply fp8 on final output layer
* specify `skip_fqn_list` in swapping
* when applying TP to model.output, use plain `ColwiseParallel` instead of `Float8ColwiseParallel`

credit to @awgu, we do not need tokentizer vacab size to be divisible by 16 https://github.com/pytorch/torchtitan/issues/461

1D TP + float8 all-gather, eager mode: `CONFIG_FILE="./train_configs/debug_model.toml" NGPU=4 ./run_llama_train.sh --training.enable_float8_linear --training.data_parallel_degree 1 --training.tensor_parallel_degree 4`

1D TP + float8 all-gather, compile mode: `CONFIG_FILE="./train_configs/debug_model.toml" NGPU=4 ./run_llama_train.sh --training.enable_float8_linear --training.data_parallel_degree 1 --training.tensor_parallel_degree 4 --training.compile`

2D FSDP2 + TP + float8 all-gather, eager mode: `CONFIG_FILE="./train_configs/debug_model.toml" NGPU=4 ./run_llama_train.sh --training.enable_float8_linear --training.enable_fsdp_float8_all_gather --training.precompute_float8_dynamic_scale_for_fsdp --training.tensor_parallel_degree 2`

2D FSDP2 + TP + float8 all-gather, eager mode: `CONFIG_FILE="./train_configs/debug_model.toml" NGPU=4 ./run_llama_train.sh --training.enable_float8_linear --training.enable_fsdp_float8_all_gather --training.precompute_float8_dynamic_scale_for_fsdp --training.tensor_parallel_degree 2 --training.compile`

1D TP + float8 all-gather trace: see float8 and all-gather in the trace
<img width="1611" alt="Screenshot 2024-07-19 at 1 16 59 PM" src="https://github.com/user-attachments/assets/9a95dfd9-40e0-4133-b2bb-e22ddf5b8472">

2D + float8 all-gather trace: see float8 and FSDP collectives and TP collectives
<img width="1038" alt="Screenshot 2024-07-19 at 1 29 59 PM" src="https://github.com/user-attachments/assets/6a34bcaa-bcae-402b-9994-cc892554fec7">


