### PR TITLE
remove CI for FSDP2 + fp8 all-gather

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -276,50 +276,6 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--training.enable_float8_linear",
-                ]
-            ],
-            "FSDP2 with original dtype",
-            "float8_fsdp2_orig_all_gather",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.enable_fsdp_float8_all_gather",
-                ]
-            ],
-            "FSDP2 with float8 all-gather",
-            "fsdp2_float8_all_gather",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.enable_fsdp_float8_all_gather",
-                    "--training.precompute_float8_dynamic_scale_for_fsdp",
-                ]
-            ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales",
-            "fsdp2_float8_all_gather_precompute_dynamic_scales",
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--training.enable_float8_linear",
-                    "--training.enable_fsdp_float8_all_gather",
-                    "--training.precompute_float8_dynamic_scale_for_fsdp",
-                    "--training.compile",
-                ]
-            ],
-            "FSDP2 with float8 all-gather and precomputed dynamic scales",
-            "fsdp2_float8_all_gather_precompute_dynamic_scales_compile",
-        ),
-        OverrideDefinitions(
-            [
-                [
                     "--training.data_parallel_type ddp",
                 ]
             ],


### PR DESCRIPTION
per discussion from https://github.com/pytorch/torchtitan/pull/469#issuecomment-2240258083

we are planning BC breaking changes in float8_experimental. remove CI for FSDP2 + fp8 all-gather for now. When public APIs are finalized, we can discuss bringing it back