### PR TITLE
Re-enable FSDP2 Mem Tracker integration tests

### DIFF
--- a/estimation.py
+++ b/estimation.py
@@ -14,7 +14,6 @@ from torch._guards import active_fake_mode
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed import destroy_process_group
 from torch.distributed._tools.fsdp2_mem_tracker import FSDPMemTracker
-from torch.distributed.tensor.parallel import loss_parallel
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 from torchtitan.config_manager import JobConfig

--- a/test_runner.py
+++ b/test_runner.py
@@ -314,6 +314,8 @@ def run_test(test_flavor: OverrideDefinitions, full_path: str, output_dir: str):
 
     for override_arg in test_flavor.override_args:
         cmd = f"CONFIG_FILE={full_path} NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} ./run_llama_train.sh"
+        if test_name == "fsdp2_mem_tracker":
+            cmd = f"CONFIG_FILE={full_path} NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} ./run_memory_estimation.sh"
         cmd += " " + dump_folder_arg
         cmd += " " + model_flavor_arg
         if override_arg:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #485

When `run_llama_train.sh` was simplified, we moved the launch of memory estimation and tracking to `run_memory_estimation.sh`. But changing the `test_runner.py ` was missed which in-turn caused the integration test to be a no-op. This PR re-enables integration tests for the `FSDP2MemTracker`. 

Also syncs `estimation.py` with `train.py` since it went out of sync due to testing being skipped.