### PR TITLE
[EZ] Add logs for some basic training params so that we can verify in…

### DIFF
--- a/train.py
+++ b/train.py
@@ -232,7 +232,12 @@ def main(job_config: JobConfig):
     model_config.max_seq_len = job_config.training.seq_len
 
     logger.info(f"Building {model_name} {job_config.model.flavor} with {model_config}")
-    logger.info(f"Detailed training config local batch_size: {job_config.training.batch_size}, seq_len: {job_config.training.seq_len}, total_steps: {job_config.training.steps}({job_config.training.warmup_steps}), activation_checkpoint: {job_config.activation_checkpoint.mode}")
+    logger.info(
+        f"Detailed training config, local_batch_size: {job_config.training.batch_size}, "
+        f"seq_len: {job_config.training.seq_len}, "
+        f"total_steps: {job_config.training.steps}({job_config.training.warmup_steps}), "
+        f"activation_checkpoint: {job_config.activation_checkpoint.mode}"
+    )
     with torch.device("meta"):
         whole_model = model_cls.from_model_args(model_config)
 

--- a/train.py
+++ b/train.py
@@ -232,12 +232,6 @@ def main(job_config: JobConfig):
     model_config.max_seq_len = job_config.training.seq_len
 
     logger.info(f"Building {model_name} {job_config.model.flavor} with {model_config}")
-    logger.info(
-        f"Detailed training config, local_batch_size: {job_config.training.batch_size}, "
-        f"seq_len: {job_config.training.seq_len}, "
-        f"total_steps: {job_config.training.steps}({job_config.training.warmup_steps}), "
-        f"activation_checkpoint: {job_config.activation_checkpoint.mode}"
-    )
     with torch.device("meta"):
         whole_model = model_cls.from_model_args(model_config)
 
@@ -361,7 +355,12 @@ def main(job_config: JobConfig):
     gpu_memory_monitor.reset_peak_stats()
 
     # train loop
-    logger.info(f"Training starts at step {train_state.step + 1}")
+    logger.info(
+        f"Training starts at step {train_state.step + 1}, "
+        f"with local batch size: {job_config.training.batch_size}, "
+        f"sequence length: {job_config.training.seq_len}, "
+        f"total steps: {job_config.training.steps}({job_config.training.warmup_steps}), "
+    )
     with maybe_enable_profiling(
         job_config, global_step=train_state.step
     ) as torch_profiler, maybe_enable_memory_snapshot(

--- a/train.py
+++ b/train.py
@@ -232,6 +232,7 @@ def main(job_config: JobConfig):
     model_config.max_seq_len = job_config.training.seq_len
 
     logger.info(f"Building {model_name} {job_config.model.flavor} with {model_config}")
+    logger.info(f"Detailed training config local batch_size: {job_config.training.batch_size}, seq_len: {job_config.training.seq_len}, total_steps: {job_config.training.steps}({job_config.training.warmup_steps}), activation_checkpoint: {job_config.activation_checkpoint.mode}")
     with torch.device("meta"):
         whole_model = model_cls.from_model_args(model_config)
 


### PR DESCRIPTION
As title, while testing on 405B model, I found that we need to somehow need the logs for some training params. So added some here. Tested locally and the logging is shown as in the screenshot:


<img width="900" alt="image" src="https://github.com/user-attachments/assets/b94e34f5-3e88-4c5f-94ed-75f50dde9786">

