### PR TITLE
[EZ][405B] Use scientific notation for 405B model lr

### DIFF
--- a/train_configs/llama3_405b.toml
+++ b/train_configs/llama3_405b.toml
@@ -23,7 +23,7 @@ tokenizer_path = "./torchtitan/datasets/tokenizer/original/tokenizer.model"
 
 [optimizer]
 name = "AdamW"
-lr = 0.8e-4
+lr = 8e-5
 
 [training]
 batch_size = 2


### PR DESCRIPTION
As title, use `8e-5` rather than `0.8e-4`.