### PR TITLE
add float8 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ If your gpu count per node is not 8, adjust:
 
 in the SBATCH command section.
 
+## Enable Float8 Training on H100s
+
+Install latest [TorchAO](https://github.com/pytorch/ao/tree/main/torchao/float8) so we can import float8 dtype
+```
+USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
+```
+
+Launch training job with following command
+```
+CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp
+```
+* `--float8.enable_float8_linear`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
+* `--float8.precompute_float8_dynamic_scale_for_fsdp` [optional]: communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameters.
+
+For scaling strategy, we are supporting tensor-wise scaling with dynamic scales. We are actively working on tensor-wise saling with delayed scales. We are also exploring row-wise sclaing
+
+For parallelsims, we are supporting FSDP float8 all-gather. We are actively working on float8 all-gather in TP.
+
 ## License
 
 This code is made available under [BSD 3 license](./LICENSE). However you may have other legal obligations that govern your use of other content, such as the terms of service for third-party models, data, etc.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently we showcase pre-training **Llama 3 and Llama 2** LLMs of various sizes
 6. Learning rate scheduler, meta init, Optional Fused RMSNorm
 7. All options easily configured via [toml files](train_configs/)
 8. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine tuning
+9. [Float8 support](docs/float8.md)
 
 We report our [Performance](docs/performance.md) verified on 64 A100 GPUs
 
@@ -50,11 +51,10 @@ We report our [Performance](docs/performance.md) verified on 64 A100 GPUs
 ### Coming soon
 
 1. Async checkpointing
-2. Float8 support
-3. Context Parallel
-4. 3D Pipeline Parallel
-5. `torch.compile` support
-6. Scalable data loading solution
+2. Context Parallel
+3. 3D Pipeline Parallel
+4. `torch.compile` support
+5. Scalable data loading solution
 
 
 ## Installation
@@ -134,25 +134,6 @@ If your gpu count per node is not 8, adjust:
 ```#SBATCH --gpus-per-task```
 
 in the SBATCH command section.
-
-## Enable Float8 Training on H100s
-
-Install latest [TorchAO](https://github.com/pytorch/ao/tree/main/torchao/float8) so we can import float8 dtype
-```
-USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
-```
-
-Launch training job with following command
-```
-CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp
-```
-* `--float8.enable_float8_linear`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
-* `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
-* `--float8.precompute_float8_dynamic_scale_for_fsdp` [optional]: communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameters.
-
-For scaling strategy, we are supporting tensor-wise scaling with dynamic scales. We are actively working on tensor-wise saling with delayed scales. We are also exploring row-wise sclaing
-
-For parallelsims, we are supporting FSDP float8 all-gather. We are actively working on float8 all-gather in TP.
 
 ## License
 

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -13,6 +13,6 @@ CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enabl
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
 * `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
 
-For parallelisms, we support optional float8 all-gather for FSDP. We are actively working on float8 all-gather in TP.
+For parallelisms, we support optional float8 all-gather for FSDP. We are actively working on float8 all-gather for TP.
 
 For scaling strategy, we currently support tensor-wise scaling with dynamic scales, and are actively working on tensor-wise scaling with delayed scales. Row-wise scaling is under exploration.

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -13,6 +13,6 @@ CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enabl
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
 * `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
 
-For parallelisms, we support optional float8 all-gather for FSDP. We are actively working on float8 all-gather for TP.
+For parallelisms, we support float8 all-gather for FSDP (optional) and for TP (by default for `Float8Linear`).
 
 For scaling strategy, we currently support tensor-wise scaling with dynamic scales, and are actively working on tensor-wise scaling with delayed scales. Row-wise scaling is under exploration.

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -1,0 +1,18 @@
+## Enable Float8 Training on H100s
+
+Please install latest [TorchAO](https://github.com/pytorch/ao/tree/main/torchao/float8) to support float8 dtype
+```
+USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
+```
+
+Launch training job with the following command (or alternatively set configs in toml files)
+```
+CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp
+```
+* `--float8.enable_float8_linear`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
+* `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
+
+For parallelisms, we support optional float8 all-gather for FSDP. We are actively working on float8 all-gather in TP.
+
+For scaling strategy, we currently support tensor-wise scaling with dynamic scales, and are actively working on tensor-wise scaling with delayed scales. Row-wise scaling is under exploration.


### PR DESCRIPTION
add float8 link in README so we can redirect people from dev-discuss post to torchtitan repo


README looks like this after rendering
<img width="518" alt="Screenshot 2024-08-06 at 5 42 10 PM" src="https://github.com/user-attachments/assets/50af99d7-93be-459a-89d7-8c08b8fb95d4">

float8.md looks like this
<img width="563" alt="Screenshot 2024-08-06 at 5 04 17 PM" src="https://github.com/user-attachments/assets/06d30aad-4133-4cec-9037-cfcf155b45c4">

I tried the command locally and traces are looking good
<img width="726" alt="Screenshot 2024-08-06 at 5 00 00 PM" src="https://github.com/user-attachments/assets/bdfa3d7e-efe1-4009-92a1-0f5c310013fb">
