### PR TITLE
Update fsdp.md

### DIFF
--- a/docs/fsdp.md
+++ b/docs/fsdp.md
@@ -106,7 +106,7 @@ fully_shard(model)
 for tensor in itertools.chain(model.parameters(), model.buffers()):
     assert tensor.device == torch.device("meta")
 # Allocate buffers and sharded parameters on GPU
-model.to_empty("cuda")
+model.to_empty(device="cuda")
 # Run user-defined initializers
 model.init_weights() # or `model.apply(init_weights)`
 ```


### PR DESCRIPTION
`torch.nn.Module.to_empty` takes keyword only arg of "device" according to https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.to_empty