### PR TITLE
uniformly use skip for both (map-style) Dataset and IterableDataset

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,6 +1,6 @@
 torch >= 2.3.0
 torchdata >= 0.8.0
-datasets >= 2.19.0
+datasets >= 2.21.0
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard
 sentencepiece


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #521

The support of `skip` on "an `IterableDataset` obtained from `split_dataset_by_node`" has landed in https://github.com/huggingface/datasets/pull/6965 and released in https://github.com/huggingface/datasets/releases/tag/2.21.0

For previous discussions see
https://discuss.huggingface.co/t/skip-not-implemented-for-iterabledataset-after-split-dataset-by-node/91450

I manually did a unit-test on the c4 dataset (as an `IterableDataset`) by replacing https://github.com/pytorch/torchtitan/blob/main/test/datasets/test_checkpoint.py#L14