### PR TITLE
remove old torch dependency in requirements.txt

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,4 +1,3 @@
-torch >= 2.3.0
 torchdata >= 0.8.0
 datasets >= 2.19.0
 tomli >= 1.1.0 ; python_version < "3.11"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #523

This has been discussed earlier -- let's remove official torch dependency in `requirements.txt` because
- it likely won't be useful, user will need a recent nightly anyway
- depending on nightly in `requirements.txt` is not ideal, e.g. (1) we cannot specify device type so packages for every device will be downloaded, which could be unnecessarily big; (2) the latest nightly may not work anyway because of new changes in torch