### PR TITLE
remove PP tracer

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -227,20 +227,6 @@ def build_test_list():
                     "--checkpoint.enable_checkpoint",
                     "--experimental.pipeline_parallel_degree 2",
                     "--experimental.pipeline_parallel_split_points layers.4",
-                    "--experimental.pipeline_parallel_split_mode tracer",
-                ],
-            ],
-            "PP tracer frontend test",
-            "pp_tracer",
-            requires_seed_checkpoint=True,
-            ngpu=2,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--experimental.pipeline_parallel_degree 2",
-                    "--experimental.pipeline_parallel_split_points layers.4",
                     "--training.data_parallel_degree 2",
                     "--training.tensor_parallel_degree 2",
                 ],

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -270,7 +270,7 @@ class JobConfig:
                 the third containing layers.2 and all the remaining layers.
 
                 Note: fully-automated splitting may be enabled in the future,
-                but currently the split points must be specified manually for both manual and tracer.""",
+                but currently the split points must be specified manually.""",
         )
         self.parser.add_argument(
             "--experimental.pipeline_parallel_schedule",
@@ -284,21 +284,6 @@ class JobConfig:
 
                 Looped schedules (e.g. interleaved_1f1b) require specifying pipeline_paralle_degree = number of ranks,
                 and split_points = number of stages - 1""",
-        )
-        self.parser.add_argument(
-            "--experimental.pipeline_parallel_split_mode",
-            type=str,
-            choices=["manual", "tracer"],
-            default="manual",
-            help="""
-                Specify the split method (e.g. the Pipeline Parallelism Front End)
-
-                "manual" means each rank will construct an nn.Module with the appropriate layers and .forward
-                implementation manually, and then wrap it in a PipelineStage.
-
-                "tracer" means the full model will be initialized (via meta device) and then traced into a graph,
-                split via the provided split points, unflattened into an nn.Module,
-                and finally wrapped in a PipelineStage.  tracer frontend is currently more experimental.""",
         )
         self.parser.add_argument(
             "--experimental.pipeline_parallel_microbatches",

--- a/torchtitan/parallelisms/pipeline_llama.py
+++ b/torchtitan/parallelisms/pipeline_llama.py
@@ -12,7 +12,7 @@ from typing import Callable, Union
 import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
-from torch.distributed.pipelining import pipeline, PipelineStage, SplitPoint
+from torch.distributed.pipelining import PipelineStage
 
 from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
 from torchtitan.logging import logger
@@ -36,20 +36,9 @@ def pipeline_llama(
     model_config: ModelArgs,
     loss_fn: Callable[..., torch.Tensor],
 ):
-    split_mode = job_config.experimental.pipeline_parallel_split_mode
-    valid_split_modes = ("manual", "tracer")
-    if split_mode not in valid_split_modes:
-        raise ValueError(
-            f"Invalid split mode: {split_mode}. Valid split modes: {valid_split_modes}"
-        )
-    if split_mode == "manual":
-        stages, models = pipeline_llama_manual(
-            model, pp_mesh, parallel_dims, job_config, device, model_config
-        )
-    elif split_mode == "tracer":
-        stages, models = pipeline_llama_tracer(
-            model, pp_mesh, parallel_dims, job_config, device, model_config
-        )
+    stages, models = pipeline_llama_manual(
+        model, pp_mesh, parallel_dims, job_config, device, model_config
+    )
 
     pp_schedule = build_pipeline_schedule(job_config, stages, loss_fn)
 
@@ -172,58 +161,4 @@ def pipeline_llama_manual(
         )
         stages.append(stage)
         models.append(model_chunk)
-    return stages, models
-
-
-def pipeline_llama_tracer(
-    model: nn.Module,
-    pp_mesh: DeviceMesh,
-    parallel_dims: ParallelDims,
-    job_config: JobConfig,
-    device: DeviceType,
-    model_config: ModelArgs,
-):
-    if job_config.model.norm_type == "fused_rmsnorm":
-        # TODO(whc) - torch._dynamo.exc.Unsupported: Illegal getattr
-        # invocation stride in strict mode from `if dy.stride(-1) != 1:` in
-        # fused_rmsnorm
-        raise NotImplementedError(
-            "fused_rmsnorm is not compatible with Pipeline Tracer yet. "
-            "Please use rmsnorm or layernorm."
-        )
-    if _mixed_precision_dtype(job_config, parallel_dims) != torch.float32:
-        raise NotImplementedError(
-            "Pipeline tracer does not work with FSDP mixed precision yet. "
-            "To work around, set mixed_precision_param to float32."
-        )
-
-    pp_rank = pp_mesh.get_local_rank()
-    pp_size = pp_mesh.size()
-    microbatches = (
-        job_config.experimental.pipeline_parallel_microbatches or parallel_dims.pp
-    )
-    (input,) = _llama_trace_input(job_config, model_config, device=device)
-    stage_idx = pp_rank
-    split_spec = {
-        layer_name: SplitPoint.BEGINNING
-        for layer_name in job_config.experimental.pipeline_parallel_split_points
-    }
-    num_stages = len(split_spec) + 1
-    pipe = pipeline(
-        model,
-        mb_args=(input.chunk(microbatches)[0],),
-        split_spec=split_spec,
-    )
-
-    stages = []
-    models = []
-    for stage_idx in stage_ids_this_rank(pp_rank, pp_size, num_stages, style="loop"):
-        models.append(pipe.get_stage_module(stage_idx))
-        stages.append(
-            pipe.build_stage(
-                stage_idx,
-                device=device,
-                group=pp_mesh.get_group(),
-            )
-        )
     return stages, models

--- a/torchtitan/parallelisms/pipeline_llama.py
+++ b/torchtitan/parallelisms/pipeline_llama.py
@@ -36,7 +36,7 @@ def pipeline_llama(
     model_config: ModelArgs,
     loss_fn: Callable[..., torch.Tensor],
 ):
-    stages, models = pipeline_llama_manual(
+    stages, models = pipeline_llama_manual_split(
         model, pp_mesh, parallel_dims, job_config, device, model_config
     )
 
@@ -62,7 +62,7 @@ def _mixed_precision_dtype(
     return TORCH_DTYPE_MAP[mp_arg] if parallel_dims.dp_enabled else default
 
 
-def pipeline_llama_manual(
+def pipeline_llama_manual_split(
     whole_model: nn.Module,
     pp_mesh: DeviceMesh,
     parallel_dims: ParallelDims,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #555

Discussed with @wconstab and @kwen2501 , it seems PP tracer has two limitations right now:
1. It doesn't support `init_weights`, thus requiring a seed checkpoint to do init, which is something we probably will deprecate soon after we have the init support for manual splitting.
2. It doesn't support mixed precision training, as the tracer requires that the model being traced be consistent with the model during forward.

We came to the conclusion to remove PP tracer for now, to have a clean version of torchtitan.