### PR TITLE
Fix the performance number for 405B

### DIFF
--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -136,16 +136,20 @@ def get_num_flop_per_token(num_params: int, model_config, seq_len) -> int:
 
 # hardcoded BF16 type peak flops for NVIDIA A100 and H100 GPU
 def get_peak_flops(device_name: str) -> int:
-    # Run the lspci command and capture the output
-    result = subprocess.run(["lspci"], stdout=subprocess.PIPE, text=True)
-    # Filter the output for lines containing both "NVIDIA" and "H100"
-    filtered_lines = [
-        line
-        for line in result.stdout.splitlines()
-        if "NVIDIA" in line and "H100" in line
-    ]
-    # Join all filtered lines into a single string
-    combined_output = " ".join(filtered_lines)
+    try:
+        # Run the lspci command and capture the output
+        result = subprocess.run(["lspci"], stdout=subprocess.PIPE, text=True)
+        # Filter the output for lines containing both "NVIDIA" and "H100"
+        filtered_lines = [
+            line
+            for line in result.stdout.splitlines()
+            if "NVIDIA" in line and "H100" in line
+        ]
+        # Join all filtered lines into a single string
+        combined_output = " ".join(filtered_lines)
+    except Exception as e:
+        logger.warning(f"Error running lspci: {e}")
+        combined_output = None
     device_name = combined_output or device_name
     if "A100" in device_name:
         # data from https://www.nvidia.com/en-us/data-center/a100/

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -148,7 +148,7 @@ def get_peak_flops(device_name: str) -> int:
         # Join all filtered lines into a single string
         combined_output = " ".join(filtered_lines)
     except Exception as e:
-        logger.warning(f"Error running lspci: {e}")
+        logger.warning(f"Error running lspci: {e}, fallback to use device_name")
         combined_output = None
     device_name = combined_output or device_name
     if "A100" in device_name:


### PR DESCRIPTION
The lspci command is part of the `pciutils` package, which provides tools for listing and querying PCI devices. But somehow `pciutils` is not installed in CI machines. This PR is to first unblock CI failure and then we can see if we want to make `pciutils` a requirement for Titan.