### PR TITLE
[ez] Remove legacy float8 enabling flag in 405B toml

### DIFF
--- a/train_configs/llama3_405b.toml
+++ b/train_configs/llama3_405b.toml
@@ -33,7 +33,6 @@ max_norm = 1.0  # grad norm clipping
 steps = 3000
 data_parallel_degree = -1
 tensor_parallel_degree = 8  # 8-way TP
-enable_float8_linear = false
 compile = true
 dataset = "c4"
 


### PR DESCRIPTION
Somehow, when rebasing, the legacy float8 enabling flag stays in the 405B toml. Let's remove it. And this does not affect the perf number we obtained because the old flag is just a no-op after rebase. 