### PR TITLE
Fixes test_fused_rms_norm.py

### DIFF
--- a/test/test_fused_rms_norm.py
+++ b/test/test_fused_rms_norm.py
@@ -11,7 +11,7 @@ from torch.distributed._tensor import (
     Replicate,
     Shard,
 )
-from torch.distributed._tensor.debug import CommDebugMode
+from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #573
* #518

The import is not correct.