### PR TITLE
add utils.set_determinism for reproducibility

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -357,7 +357,12 @@ class JobConfig:
             default=50,
             help="Python garbage control scheduling interval, in steps",
         )
-
+        self.parser.add_argument(
+            "--training.seed",
+            type=int,
+            default=2024,
+            help="Implement reproducibility by setting a Python, PyTorch and CUDA seed",
+        )
         # checkpointing configs
         self.parser.add_argument(
             "--checkpoint.enable_checkpoint",

--- a/train.py
+++ b/train.py
@@ -56,6 +56,10 @@ def main(job_config: JobConfig):
     # take control of garbage collection to avoid stragglers
     gc_handler = utils.GarbageCollection(gc_freq=job_config.training.gc_freq)
 
+    # set determinisism, use seed == 1 to skip random seed setting
+    utils.set_determinism(job_config)
+    logger.info(f"Using seed: {job_config.training.seed}")
+
     # init distributed
     world_size = int(os.environ["WORLD_SIZE"])
     parallel_dims = ParallelDims(

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -30,6 +30,7 @@ name = "AdamW"
 lr = 8e-4
 
 [training]
+seed = 1  # use 1 avoid determinism
 batch_size = 8
 seq_len = 2048
 warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
@@ -59,4 +60,4 @@ mode = 'selective'  # ['none', 'selective', 'full']
 selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
 [float8]
-enable_float8_linear = false
+enable_float8_linear = true


### PR DESCRIPTION
This PR:
1 - adds a set_determinism function to set seed for Python, PyTorch, CUDA and deterministic settings for cudnn.
2 - if seed ==1, then no deterministic settings are used.  This may be important as turning off cuDnn benchmarking to ensure determinism, can also negatively impact perf.

This lack of determinism negatively impacted work with AWS where we ended up with variations in loss curves while running fp8 for our joint blog that appeared to be from fp8 but are instead likely due to not having determinism in titan. 

Testing - I ran multiple small runs with 7B while rotating between three seeds and saw consistent ending loss points matching to the respective seeds.  

This PR does not set per worker aspects for the dataloader since we do not shuffle atm...but that could become a future source of randomness that will need to be set if we shuffle in the future.