### PR TITLE
fix mixed precision for `replicate` / pure DDP

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -332,8 +332,9 @@ class JobConfig:
             default="bfloat16",
             choices=["bfloat16", "float32"],
             help="""
-                torch dtype to use for parameters when applying mixed precision via FSDP.
-                This feature only takes effect when data_parallel_degree > 1
+                torch dtype to use for parameters when applying mixed precision.
+                When data_parallel_degree > 1, this changes FSDP's `param_dtype`.
+                When data_parallel_degree == 1, this enables AMP autocast.
             """,
         )
         self.parser.add_argument(

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -333,8 +333,8 @@ class JobConfig:
             choices=["bfloat16", "float32"],
             help="""
                 torch dtype to use for parameters when applying mixed precision.
-                When data_parallel_degree > 1, this changes FSDP's `param_dtype`.
-                When data_parallel_degree == 1, this enables AMP autocast.
+                When data_parallel_shard_degree > 1, this changes FSDP's `param_dtype`.
+                When data_parallel_shard_degree == 1, this enables AMP autocast.
             """,
         )
         self.parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -289,7 +289,10 @@ def main(job_config: JobConfig):
                 # Non-PP forward / backward
                 with train_context():
                     with contextlib.nullcontext() if parallel_dims.dp_shard_enabled else torch.autocast(
-                        "cuda", dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],
+                        "cuda",
+                        dtype=TORCH_DTYPE_MAP[
+                            job_config.training.mixed_precision_param
+                        ],
                     ):
                         pred = model(input_ids)
                         loss = loss_fn(pred, labels)


### PR DESCRIPTION
Hi. I noticed the following:
1. the keyword `autocast` does not exist in the repository
2. MixedPrecisionConfig is only used in the `fully_shard` codepath
3. the duration of a dummy 1000 step run is a lot longer with DDP than with FSDP

All of the above indicates that, when `dp_shard_enabled` is false, training runs with pure fp32, regardless of the mixed precision config.

This pull request changes the code to use `torch.autocast` in the training forward pass, specifically only when `dp_shard_enabled` is false, to the dtype of `mixed_precision_param`.