### PR TITLE
ensure reproducible determinsitc numerics

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -360,7 +360,7 @@ class JobConfig:
         self.parser.add_argument(
             "--training.seed",
             type=int,
-            default=42,
+            default=None,
             help="Implement reproducibility by setting a Python, PyTorch and CUDA seed",
         )
         # checkpointing configs

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -360,7 +360,7 @@ class JobConfig:
         self.parser.add_argument(
             "--training.seed",
             type=int,
-            default=None,
+            default=42,
             help="Implement reproducibility by setting a Python, PyTorch and CUDA seed",
         )
         # checkpointing configs

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -50,7 +50,7 @@ def set_determinism(seed: Optional[int]) -> None:
         os.environ["PYTHONHASHSEED"] = str(seed)
         torch.use_deterministic_algorithms(True)
         # env var for deterministic CuBLAS
-        # https://github.com/pytorch/pytorch/blob/18525e185e211b3eab44c67a688e5df8396f6f97/torch/__init__.py#L1300
+        # https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
     else:
         # ensure we turn off deterministic cudnn algorithms

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -48,6 +48,10 @@ def set_determinism(seed: Optional[int]) -> None:
         torch.backends.cudnn.benchmark = False
         # set Python seed
         os.environ["PYTHONHASHSEED"] = str(seed)
+        torch.use_deterministic_algorithms(True)
+        # env var for deterministic CuBLAS
+        # https://github.com/pytorch/pytorch/blob/18525e185e211b3eab44c67a688e5df8396f6f97/torch/__init__.py#L1300
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
     else:
         # ensure we turn off deterministic cudnn algorithms
         torch.backends.cudnn.deterministic = False


### PR DESCRIPTION
resolve https://github.com/pytorch/torchtitan/issues/593

grad norms are quite different if running the same config twice
<img width="407" alt="Screenshot 2024-10-01 at 8 34 40 PM" src="https://github.com/user-attachments/assets/eee9d4b0-f4a3-48ad-85b7-b3b9ee43321a">

grad norms become exactly the same in repeated runs
<img width="419" alt="Screenshot 2024-10-01 at 8 53 19 PM" src="https://github.com/user-attachments/assets/c142f873-474e-43ae-8343-95e0fee8e34c">

