### PR TITLE
[BE][doc] add memory_profiler to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
-13. [Memory profier](docs/memory_profiler.md) dump memory snapshots.
+13. [Memory profier](docs/memory_profiler.md) dump memory snapshots
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ You may want to see how the model is defined or how parallelism techniques are a
 3. Selective layer and operator activation checkpointing
 4. Distributed checkpointing (including async checkpointing)
 5. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries)
-6. Loss, GPU memory, tokens-per-second, and MFU displayed and logged via [TensorBoard](#tensorboard)
+6. Loss, GPU memory, tokens-per-second, and MFU displayed and logged via [TensorBoard](#tensorboard), dump [memory snapshots](docs/memory_profiler.md)
 7. Learning rate scheduler, meta-init, optional Fused RMSNorm
 8. [Float8](https://discuss.pytorch.org/t/distributed-w-torchtitan-enabling-float8-all-gather-in-fsdp2/209323) support ([how-to](docs/float8.md))
 9. `torch.compile` support
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
-13. [Memory profier](docs/memory_profiler.md) dump memory snapshots
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
-13. CPU/GPU profiling, [memory profiling](docs/memory_profiler.md), [flight recorder](#debugging)
+13. Debugging tools including CPU/GPU profiling, [memory profiling](docs/memory_profiler.md), [Flight Recorder](#debugging), etc.
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ You may want to see how the model is defined or how parallelism techniques are a
 3. Selective layer and operator activation checkpointing
 4. Distributed checkpointing (including async checkpointing)
 5. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries)
-6. Loss, GPU memory, tokens-per-second, and MFU displayed and logged via [TensorBoard](#tensorboard), dump [memory snapshots](docs/memory_profiler.md)
+6. Loss, GPU memory, tokens-per-second, and MFU displayed and logged via [TensorBoard](#tensorboard)
 7. Learning rate scheduler, meta-init, optional Fused RMSNorm
 8. [Float8](https://discuss.pytorch.org/t/distributed-w-torchtitan-enabling-float8-all-gather-in-fsdp2/209323) support ([how-to](docs/float8.md))
 9. `torch.compile` support
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
+13. CPU/GPU profiling, [memory profiling](docs/memory_profiler.md), flight recorder(#debugging)
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
-13. CPU/GPU profiling, [memory profiling](docs/memory_profiler.md), flight recorder(#debugging)
+13. CPU/GPU profiling, [memory profiling](docs/memory_profiler.md), [flight recorder](#debugging)
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 10. DDP and HSDP
 11. All options easily configured via [toml files](train_configs/)
 12. [Interoperable checkpoints](docs/checkpoint.md) which can be loaded directly into [`torchtune`](https://github.com/pytorch/torchtune) for fine-tuning
+13. [Memory profier](docs/memory_profiler.md) dump memory snapshots.
 
 We report our [Performance](docs/performance.md) verified on 64/128 GPUs.
 

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -9,5 +9,5 @@ CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.
 	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
 	+ Regular snapshots (taken every `profiling.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
 
-Once you have dumped the memory profiler, you will find the saved pickle files in your output folder.
+You cab find the saved pickle files in your output folder.
 To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -2,12 +2,12 @@
 
 Launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder output_folder
+CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder memory_snapshot
 ```
-* `--profiling.enable_memory_snapshot`: enable memory snapshot
-* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default under your output folder to be `./outputs/memory_snapshot`.
-	+ If in case of OOMs, output folder is `memory_snapshot/iteration_x_exit`.
-	+ If regularly according to `profile_freq`, output folder is `memory_snapshot/iteration_x`.
+* `--profiling.enable_memory_snapshot`: to enable memory profiling
+* `--profiling.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`./outputs/memory_snapshot/` by default)
+	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
+	+ Regular snapshots (taken every `profiling.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
 
 Once you have dumped the memory profiler, you will find the saved pickle files in your output folder.
-To visualize the snapshot file, you can utilize the `memory_viz` tool, by either dragging and dropping the snapshot into your browser or generating its HTML file, following the [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).
+To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -8,3 +8,6 @@ CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.
 * `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default to be `memory_snapshot`.
 	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
 	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.
+
+Once you have dumped the memory profiler, you will find the saved pickle files in your output folder.
+To visualize the snapshot file, you can utilize the `memory_viz` tool, by either dragging and dropping the snapshot into your browser or generating its HTML file, following the [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -6,8 +6,8 @@ CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.
 ```
 * `--profiling.enable_memory_snapshot`: enable memory snapshot
 * `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default under your output folder to be `./outputs/memory_snapshot`.
-	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
-	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.
+	+ If in case of OOMs, output folder is `memory_snapshot/iteration_x_exit`.
+	+ If regularly according to `profile_freq`, output folder is `memory_snapshot/iteration_x`.
 
 Once you have dumped the memory profiler, you will find the saved pickle files in your output folder.
 To visualize the snapshot file, you can utilize the `memory_viz` tool, by either dragging and dropping the snapshot into your browser or generating its HTML file, following the [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -5,6 +5,6 @@ Launch training job with the following command (or alternatively set configs in 
 CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder output_folder
 ```
 * `--profiling.enable_memory_snapshot`: enable memory snapshot
-* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output foloder, default to be `memory_snapshot`.
+* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default to be `memory_snapshot`.
 	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
 	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -5,7 +5,7 @@ Launch training job with the following command (or alternatively set configs in 
 CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder output_folder
 ```
 * `--profiling.enable_memory_snapshot`: enable memory snapshot
-* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default to be `memory_snapshot`.
+* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default to be `./outputs/memory_snapshot`.
 	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
 	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.
 

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -5,7 +5,7 @@ Launch training job with the following command (or alternatively set configs in 
 CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder output_folder
 ```
 * `--profiling.enable_memory_snapshot`: enable memory snapshot
-* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default to be `./outputs/memory_snapshot`.
+* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output folder, default under your output folder to be `./outputs/memory_snapshot`.
 	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
 	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.
 

--- a/docs/memory_profiler.md
+++ b/docs/memory_profiler.md
@@ -1,0 +1,10 @@
+## Enable Memory Profiling
+
+Launch training job with the following command (or alternatively set configs in toml files)
+```
+CONFIG_FILE="./train_configs/debug_model.toml" ./run_llama_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder output_folder
+```
+* `--profiling.enable_memory_snapshot`: enable memory snapshot
+* `--profiling.save_memory_snapshot_folder`: dump memory snapshots in to output foloder, default to be `memory_snapshot`.
+	+ If in case of OOMs. output folder is `memory_snapshot/iteration_x_exit`.
+	+ If regularly according to `profile_freq`. output folder is `memory_snapshot/iteration_x`.


### PR DESCRIPTION
Add [memory_profiler](https://github.com/pytorch/torchtitan/pull/395) to README, explain how to use memory profiler with `--profiling.enable_memory_snapshot` and `--profiling.save_memory_snapshot_folder`