### PR TITLE
[DO NOT REVIEW] --experimental.fsdp_sharding_on_largest_dim

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -327,6 +327,13 @@ class JobConfig:
             help="Enable CompiledAutograd to compile the backward.",
         )
         self.parser.add_argument(
+            "--experimental.fsdp_sharding_on_largest_dim",
+            action="store_true",
+            help="""
+                sharding on largest dim to reduce padding
+            """,
+        )
+        self.parser.add_argument(
             "--training.mixed_precision_param",
             type=str,
             default="bfloat16",


### PR DESCRIPTION
FSDP2 can shard on largest dim now 
* pytorch PR with extra copy https://github.com/pytorch/pytorch/pull/137496
* pytorch PR without extra copy but big cpu overhead using out_view tricks  https://github.com/pytorch/pytorch/pull/137683

becuase of dim-1, there are 2 extra copies (chunk-cat)
* 1st in all_gather_copy_out
* 2nd in post_backward_reduce

<img width="1172" alt="Screenshot 2024-10-09 at 4 27 33 PM" src="https://github.com/user-attachments/assets/1dbc0e70-b036-4c37-97e2-a9e1adca6250">
