### PR TITLE
Two trivial fixes

### DIFF
--- a/torchtitan/datasets/tokenizer/__init__.py
+++ b/torchtitan/datasets/tokenizer/__init__.py
@@ -18,4 +18,4 @@ def build_tokenizer(tokenizer_type: str, tokenizer_path: str) -> Tokenizer:
     elif tokenizer_type == "tiktoken":
         return TikTokenizer(tokenizer_path)
     else:
-        raise ValueError(f"Unknown tokenizer type: {args.type}")
+        raise ValueError(f"Unknown tokenizer type: {tokenizer_type}")

--- a/torchtitan/parallelisms/parallel_dims.py
+++ b/torchtitan/parallelisms/parallel_dims.py
@@ -54,7 +54,6 @@ class ParallelDims:
         for d, name in zip(
             [self.pp, self.dp_replicate, self.dp_shard, self.tp],
             ["pp", "dp_replicate", "dp_shard", "tp"],
-            strict=True,
         ):
             if d > 1:
                 dims.append(d)


### PR DESCRIPTION
I was reading the framework just out of interest and found two quick fixes.

Especially, the rationale behind removing `strict=True` from `zip` is:
1. It's obvious that both iterables have the same length.
2. `strict=True` was introduced in `zip` in Python 3.10, but `pyproject.toml` specifies `requires-python >= 3.8`.