### PR TITLE
[PP] fix CI

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -141,19 +141,6 @@ def build_test_list():
                 [
                     "--checkpoint.enable_checkpoint",
                     "--experimental.pipeline_parallel_degree 4",
-                    "--experimental.pipeline_parallel_schedule FlexibleInterleaved1F1B",
-                ],
-            ],
-            "PP looped flexible 1F1B test",
-            "pp_looped_flexible_1f1b",
-            requires_seed_checkpoint=True,
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--experimental.pipeline_parallel_degree 4",
                     "--experimental.pipeline_parallel_schedule InterleavedZeroBubble",
                 ],
             ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #621

There is a test in CI that is using `ScheduleFlexibleInterleaved1F1B` which was removed in https://github.com/pytorch/pytorch/pull/137783. So removing that test to fix CI.

Separately I noticed we are not using the `pipeline_parallel_microbatches` config correctly, so i am looking into that
