### PR TITLE
[BE][doc]Update fsdp readme, GradScaler enabled for FSDP2

### DIFF
--- a/docs/fsdp.md
+++ b/docs/fsdp.md
@@ -79,7 +79,7 @@ def fully_shard(
 | `optim.state_dict()`: local state dict | `optim.state_dict()`: sharded state dict (no communication) |
 | `summon_full_params()` | use `DTensor` APIs like `full_tensor()` |
 | `FSDP.clip_grad_norm_()` | `nn.utils.clip_grad_norm_()` |
-| `ShardedGradScaler` | not yet supported |
+| `ShardedGradScaler` | `amp.grad_scaler.GradScaler` |
 
 
 ## Meta-Device Initialization


### PR DESCRIPTION
Grad scaler is based on DTensor at FSDP2, its APIs [accept DTensor input](https://github.com/pytorch/pytorch/pull/132816) now