### PR TITLE
Add script to convert pickled Llama weights to DCP

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -1,4 +1,16 @@
-# How to Convert a torchtitan Checkpoint for Use in torchtune
+## How to convert a Llama3 checkpoint for use in torchtitan
+
+If you want to continue training from an existing model checkpoint, the checkpoint must be in the DCP format expected by the checkpoint manager.
+An example script for converting the original Llama3 checkpoints into the expected DCP format can be found in `scripts/convert_llama_to_dcp.py`.
+
+The script expects a path to the original checkpoint files, and a path to an output directory:
+```bash
+python3 scripts/convert_llama_to_dcp.py <input_dir> <output_dir>
+```
+
+
+
+## How to Convert a torchtitan Checkpoint for Use in torchtune
 
 This guide will walk you through the steps required to convert a checkpoint from torchtitan so that it can be loaded into torchtune.
 

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -1,0 +1,21 @@
+import argparse
+from pathlib import Path
+
+import torch
+import torch.distributed.checkpoint as DCP
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert Llama weights to DCP format.")
+    parser.add_argument(
+        "input_dir", type=Path, help="Input directory with original Llama weights."
+    )
+    parser.add_argument("output_dir", type=Path, help="Output directory for DCP.")
+    args = parser.parse_args()
+
+    loaded = torch.load(
+        args.input_dir / "consolidated.00.pth", map_location="cpu", weights_only=True
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    storage_writer = DCP.filesystem.FileSystemWriter(args.output_dir)
+    DCP.save({"model": loaded}, storage_writer=storage_writer)

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -1,9 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import argparse
 import json
 from pathlib import Path
 
 import torch
 import torch.distributed.checkpoint as DCP
+
+from torchtitan.logging import init_logger, logger
+
 
 @torch.inference_mode()
 def convert_llama_weights(input_dir, output_dir):
@@ -15,44 +24,90 @@ def convert_llama_weights(input_dir, output_dir):
     dims_per_head = dim // n_heads
 
     checkpoint_list = sorted([file for file in input_dir.rglob("*.pth")])
-    print(f"Loading from these files: {checkpoint_list}.")
-    shards = [torch.load(ckpt, map_location="cpu", weights_only=True) for ckpt in checkpoint_list]
-
-    n_heads_per_shard = n_heads // len(shards)
-    num_key_value_heads = params["n_kv_heads"]
-    n_kv_heads_per_shard = num_key_value_heads // len(shards)
-    key_value_dim = dims_per_head * num_key_value_heads
+    logger.info(
+        f"Loading original Llama weights from {[ckpt.name for ckpt in checkpoint_list]}"
+    )
+    shards = [
+        torch.load(ckpt, map_location="cpu", weights_only=True, mmap=True)
+        for ckpt in checkpoint_list
+    ]
 
     if len(shards) == 1:
         state_dict = shards[0]
-    else: # sharded
+    else:  # sharded
         state_dict = {}
+        n_heads_per_shard = n_heads // len(shards)
+        num_key_value_heads = params["n_kv_heads"]
+        n_kv_heads_per_shard = num_key_value_heads // len(shards)
+        key_value_dim = dims_per_head * num_key_value_heads
         for layer in range(n_layers):
-            state_dict[f"layers.{layer}.attention_norm.weight"] = shards[0][f"layers.{layer}.attention_norm.weight"].clone() # replicated
-            state_dict[f"layers.{layer}.ffn_norm.weight"] = shards[0][f"layers.{layer}.ffn_norm.weight"].clone() # replicated
+            state_dict[f"layers.{layer}.attention_norm.weight"] = shards[0][
+                f"layers.{layer}.attention_norm.weight"
+            ]
+            state_dict[f"layers.{layer}.ffn_norm.weight"] = shards[0][
+                f"layers.{layer}.ffn_norm.weight"
+            ]
 
-            for wn, nh in [("wq", n_heads_per_shard), 
-                           ("wk", n_kv_heads_per_shard), 
-                           ("wv", n_kv_heads_per_shard)]:
+            for wn, nh in [
+                ("wq", n_heads_per_shard),
+                ("wk", n_kv_heads_per_shard),
+                ("wv", n_kv_heads_per_shard),
+            ]:
                 state_dict[f"layers.{layer}.attention.{wn}.weight"] = torch.cat(
-                    [shards[i][f"layers.{layer}.attention.{wn}.weight"].view(nh, dims_per_head, dim) for i in range(len(shards))], dim=0
+                    [
+                        shards[i][f"layers.{layer}.attention.{wn}.weight"].view(
+                            nh, dims_per_head, dim
+                        )
+                        for i in range(len(shards))
+                    ],
+                    dim=0,
                 ).reshape(nh * len(shards) * dims_per_head, dim)
 
-            state_dict[f"layers.{layer}.attention.wo.weight"] = torch.cat([shards[i][f"layers.{layer}.attention.wo.weight"] for i in range(len(shards))], dim=1)
-            state_dict[f"layers.{layer}.feed_forward.w1.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w1.weight"] for i in range(len(shards))], dim=0)
-            state_dict[f"layers.{layer}.feed_forward.w2.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w2.weight"] for i in range(len(shards))], dim=1)
-            state_dict[f"layers.{layer}.feed_forward.w3.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w3.weight"] for i in range(len(shards))], dim=0)
+            state_dict[f"layers.{layer}.attention.wo.weight"] = torch.cat(
+                [
+                    shards[i][f"layers.{layer}.attention.wo.weight"]
+                    for i in range(len(shards))
+                ],
+                dim=1,
+            )
+            state_dict[f"layers.{layer}.feed_forward.w1.weight"] = torch.cat(
+                [
+                    shards[i][f"layers.{layer}.feed_forward.w1.weight"]
+                    for i in range(len(shards))
+                ],
+                dim=0,
+            )
+            state_dict[f"layers.{layer}.feed_forward.w2.weight"] = torch.cat(
+                [
+                    shards[i][f"layers.{layer}.feed_forward.w2.weight"]
+                    for i in range(len(shards))
+                ],
+                dim=1,
+            )
+            state_dict[f"layers.{layer}.feed_forward.w3.weight"] = torch.cat(
+                [
+                    shards[i][f"layers.{layer}.feed_forward.w3.weight"]
+                    for i in range(len(shards))
+                ],
+                dim=0,
+            )
 
         state_dict["norm.weight"] = shards[0]["norm.weight"]
-        state_dict["tok_embeddings.weight"] = torch.cat([shards[i]["tok_embeddings.weight"] for i in range(len(shards))], dim=0)
-        state_dict["output.weight"] = torch.cat([shards[i]["output.weight"] for i in range(len(shards))], dim=0)
+        state_dict["tok_embeddings.weight"] = torch.cat(
+            [shards[i]["tok_embeddings.weight"] for i in range(len(shards))], dim=0
+        )
+        state_dict["output.weight"] = torch.cat(
+            [shards[i]["output.weight"] for i in range(len(shards))], dim=0
+        )
 
-    print("Writing to DCP...")
+    logger.info("Writing to DCP...")
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    storage_writer = DCP.filesystem.FileSystemWriter(output_dir)
+    storage_writer = DCP.filesystem.FileSystemWriter(output_dir, thread_count=8)
     DCP.save({"model": state_dict}, storage_writer=storage_writer)
 
+
 if __name__ == "__main__":
+    init_logger()
     parser = argparse.ArgumentParser(description="Convert Llama weights to DCP format.")
     parser.add_argument(
         "input_dir", type=Path, help="Input directory with original Llama weights."

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -100,7 +100,7 @@ def convert_llama_weights(input_dir, output_dir):
             [shards[i]["output.weight"] for i in range(len(shards))], dim=0
         )
 
-    logger.info("Writing to DCP...")
+    logger.info(f"Writing to DCP at {output_dir}")
     args.output_dir.mkdir(parents=True, exist_ok=True)
     storage_writer = DCP.filesystem.FileSystemWriter(output_dir, thread_count=8)
     DCP.save({"model": state_dict}, storage_writer=storage_writer)

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -124,12 +124,12 @@ def convert_llama_weights(input_dir, output_dir, max_seq_len: int):
         for i in range(len(shards)):
             del shards[i]["output.weight"]
 
-        # NOTE: precompute freqs_cis because must be persisted by default in torchtitan
-        state_dict["freqs_cis"] = precompute_freqs_cis(
-            dims_per_head,
-            max_seq_len,
-            params.get("rope_theta", 500000),
-        )
+    # NOTE: precompute freqs_cis because must be persisted by default in torchtitan
+    state_dict["freqs_cis"] = precompute_freqs_cis(
+        dims_per_head,
+        max_seq_len,
+        params.get("rope_theta", 500000),
+    )
 
     logger.info(f"Writing to DCP at '{output_dir}'")
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -1,8 +1,56 @@
 import argparse
+import json
 from pathlib import Path
 
 import torch
 import torch.distributed.checkpoint as DCP
+
+@torch.inference_mode()
+def convert_llama_weights(input_dir, output_dir):
+    with open(args.input_dir / "params.json", "r") as f:
+        params = json.load(f)
+    n_layers = params["n_layers"]
+    n_heads = params["n_heads"]
+    dim = params["dim"]
+    dims_per_head = dim // n_heads
+
+    checkpoint_list = sorted([file for file in input_dir.rglob("*.pth")])
+    print(f"Loading from these files: {checkpoint_list}.")
+    shards = [torch.load(ckpt, map_location="cpu", weights_only=True) for ckpt in checkpoint_list]
+
+    n_heads_per_shard = n_heads // len(shards)
+    num_key_value_heads = params["n_kv_heads"]
+    n_kv_heads_per_shard = num_key_value_heads // len(shards)
+    key_value_dim = dims_per_head * num_key_value_heads
+
+    if len(shards) == 1:
+        state_dict = shards[0]
+    else: # sharded
+        state_dict = {}
+        for layer in range(n_layers):
+            state_dict[f"layers.{layer}.attention_norm.weight"] = shards[0][f"layers.{layer}.attention_norm.weight"].clone() # replicated
+            state_dict[f"layers.{layer}.ffn_norm.weight"] = shards[0][f"layers.{layer}.ffn_norm.weight"].clone() # replicated
+
+            for wn, nh in [("wq", n_heads_per_shard), 
+                           ("wk", n_kv_heads_per_shard), 
+                           ("wv", n_kv_heads_per_shard)]:
+                state_dict[f"layers.{layer}.attention.{wn}.weight"] = torch.cat(
+                    [shards[i][f"layers.{layer}.attention.{wn}.weight"].view(nh, dims_per_head, dim) for i in range(len(shards))], dim=0
+                ).reshape(nh * len(shards) * dims_per_head, dim)
+
+            state_dict[f"layers.{layer}.attention.wo.weight"] = torch.cat([shards[i][f"layers.{layer}.attention.wo.weight"] for i in range(len(shards))], dim=1)
+            state_dict[f"layers.{layer}.feed_forward.w1.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w1.weight"] for i in range(len(shards))], dim=0)
+            state_dict[f"layers.{layer}.feed_forward.w2.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w2.weight"] for i in range(len(shards))], dim=1)
+            state_dict[f"layers.{layer}.feed_forward.w3.weight"] = torch.cat([shards[i][f"layers.{layer}.feed_forward.w3.weight"] for i in range(len(shards))], dim=0)
+
+        state_dict["norm.weight"] = shards[0]["norm.weight"]
+        state_dict["tok_embeddings.weight"] = torch.cat([shards[i]["tok_embeddings.weight"] for i in range(len(shards))], dim=0)
+        state_dict["output.weight"] = torch.cat([shards[i]["output.weight"] for i in range(len(shards))], dim=0)
+
+    print("Writing to DCP...")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    storage_writer = DCP.filesystem.FileSystemWriter(output_dir)
+    DCP.save({"model": state_dict}, storage_writer=storage_writer)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert Llama weights to DCP format.")
@@ -12,10 +60,4 @@ if __name__ == "__main__":
     parser.add_argument("output_dir", type=Path, help="Output directory for DCP.")
     args = parser.parse_args()
 
-    loaded = torch.load(
-        args.input_dir / "consolidated.00.pth", map_location="cpu", weights_only=True
-    )
-
-    args.output_dir.mkdir(parents=True, exist_ok=True)
-    storage_writer = DCP.filesystem.FileSystemWriter(args.output_dir)
-    DCP.save({"model": loaded}, storage_writer=storage_writer)
+    convert_llama_weights(args.input_dir, args.output_dir)

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -44,9 +44,13 @@ def convert_llama_weights(input_dir, output_dir):
             state_dict[f"layers.{layer}.attention_norm.weight"] = shards[0][
                 f"layers.{layer}.attention_norm.weight"
             ]
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.attention_norm.weight"]
             state_dict[f"layers.{layer}.ffn_norm.weight"] = shards[0][
                 f"layers.{layer}.ffn_norm.weight"
             ]
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.ffn_norm.weight"]
 
             for wn, nh in [
                 ("wq", n_heads_per_shard),
@@ -62,6 +66,8 @@ def convert_llama_weights(input_dir, output_dir):
                     ],
                     dim=0,
                 ).reshape(nh * len(shards) * dims_per_head, dim)
+                for i in range(len(shards)):
+                    del shards[i][f"layers.{layer}.attention.{wn}.weight"]
 
             state_dict[f"layers.{layer}.attention.wo.weight"] = torch.cat(
                 [
@@ -70,6 +76,9 @@ def convert_llama_weights(input_dir, output_dir):
                 ],
                 dim=1,
             )
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.attention.wo.weight"]
+
             state_dict[f"layers.{layer}.feed_forward.w1.weight"] = torch.cat(
                 [
                     shards[i][f"layers.{layer}.feed_forward.w1.weight"]
@@ -77,6 +86,9 @@ def convert_llama_weights(input_dir, output_dir):
                 ],
                 dim=0,
             )
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.feed_forward.w1.weight"]
+
             state_dict[f"layers.{layer}.feed_forward.w2.weight"] = torch.cat(
                 [
                     shards[i][f"layers.{layer}.feed_forward.w2.weight"]
@@ -84,6 +96,9 @@ def convert_llama_weights(input_dir, output_dir):
                 ],
                 dim=1,
             )
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.feed_forward.w2.weight"]
+
             state_dict[f"layers.{layer}.feed_forward.w3.weight"] = torch.cat(
                 [
                     shards[i][f"layers.{layer}.feed_forward.w3.weight"]
@@ -91,14 +106,22 @@ def convert_llama_weights(input_dir, output_dir):
                 ],
                 dim=0,
             )
+            for i in range(len(shards)):
+                del shards[i][f"layers.{layer}.feed_forward.w3.weight"]
 
         state_dict["norm.weight"] = shards[0]["norm.weight"]
+        for i in range(len(shards)):
+            del shards[i]["norm.weight"]
         state_dict["tok_embeddings.weight"] = torch.cat(
             [shards[i]["tok_embeddings.weight"] for i in range(len(shards))], dim=0
         )
+        for i in range(len(shards)):
+            del shards[i]["tok_embeddings.weight"]
         state_dict["output.weight"] = torch.cat(
             [shards[i]["output.weight"] for i in range(len(shards))], dim=0
         )
+        for i in range(len(shards)):
+            del shards[i]["output.weight"]
 
     logger.info(f"Writing to DCP at {output_dir}")
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -16,7 +16,7 @@ from torchtitan.logging import init_logger, logger
 
 @torch.inference_mode()
 def convert_llama_weights(input_dir, output_dir):
-    with open(args.input_dir / "params.json", "r") as f:
+    with open(input_dir / "params.json", "r") as f:
         params = json.load(f)
     n_layers = params["n_layers"]
     n_heads = params["n_heads"]
@@ -123,8 +123,8 @@ def convert_llama_weights(input_dir, output_dir):
         for i in range(len(shards)):
             del shards[i]["output.weight"]
 
-    logger.info(f"Writing to DCP at {output_dir}")
-    args.output_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Writing to DCP at '{output_dir}'")
+    output_dir.mkdir(parents=True, exist_ok=True)
     storage_writer = DCP.filesystem.FileSystemWriter(output_dir, thread_count=8)
     DCP.save({"model": state_dict}, storage_writer=storage_writer)
 


### PR DESCRIPTION
Closes #305. 

Just wanted to get this out here quickly. 
The script is very simple since the weights are already in the completely correct format, names and everything. All of the complexity is avoided by not using HF, and so I believe that any functionality relating to HF should be located on their side. However, I do have a DCP -> HF export script which might be useful for some people, in case HF does not have/add one.

I'll be happy to add any needed documentation or tests.