### PR TITLE
Move output `.float()` to loss fn and compile it if compiling

### DIFF
--- a/docs/composability.md
+++ b/docs/composability.md
@@ -19,3 +19,6 @@ Initializing the pipeline-parallel model is challenging becuase we assume the mo
 For now, we sidestep all these problems with a simple but brutal solution: Initialize the whole model on some CPU instance, save a checkpoint file, and then lean on Distributed Checkpointing's "load" functionality to initialize the FQNs that are present on a given PP stage after stage creation.  For future work, we consider adding a more elaborate initialization scheme to `torch.pipelining`.
 
 One issue with seed checkpoints is that we rely on initializing _every_ model state from the checkpoint, which means the model can't have any non-persistent buffers, or else we have to specially initialize those in [train.py](../train.py) after pipeline splitting.  `freqs_cis` was originally a non-persistent buffer, and we changed this to persistent in order to load it from the seed checkpoint.
+
+## On upcasting the final output to fp32
+We intentionally upcast the final output tensor to fp32 inside the loss function rather in the `Transformer.forward()` so that forward and backward casts can be fused with the loss forward and backward respectively when we `torch.compile()` the loss function. This can improve both throughput and memory usage.

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -262,7 +262,7 @@ class JobConfig:
         self.parser.add_argument(
             "--training.enable_loss_parallel",
             default=True,
-            action="store_false",
+            action="store_true",
             help="Whether to apply loss parallel when sequence parallel is enabled",
         )
         self.parser.add_argument(

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -262,7 +262,7 @@ class JobConfig:
         self.parser.add_argument(
             "--training.enable_loss_parallel",
             default=True,
-            action="store_true",
+            action="store_false",
             help="Whether to apply loss parallel when sequence parallel is enabled",
         )
         self.parser.add_argument(

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -438,7 +438,7 @@ class Transformer(nn.Module):
             h = layer(h, self.freqs_cis)
 
         h = self.norm(h) if self.norm else h
-        output = self.output(h).float() if self.output else h
+        output = self.output(h) if self.output else h
         return output
 
     @classmethod

--- a/train.py
+++ b/train.py
@@ -146,8 +146,11 @@ def main(job_config: JobConfig):
     # loss function to be shared by Pipeline Parallel and SPMD training
     def loss_fn(pred, labels):
         return torch.nn.functional.cross_entropy(
-            pred.flatten(0, 1), labels.flatten(0, 1)
+            pred.flatten(0, 1).float(), labels.flatten(0, 1)
         )
+
+    if job_config.training.compile:
+        loss_fn = torch.compile(loss_fn)
 
     # apply parallelisms and initialization
     if parallel_dims.pp_enabled:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #643
* #645
* __->__ #642


cc: @tianyu-l I checked that TP=2, DP=4 with compile looks okay:
```
[rank0]:2024-10-22 08:04:37,873 - root - INFO - Training starts at step 1, with local batch size 1, global batch size 4, sequence length 8192, total steps 1000 (warmup 200)
[rank0]:/data/users/andgu/pytorch/torch/_inductor/lowering.py:1759: UserWarning: Torchinductor does not support code generation for complex operators. Performance may be worse than eager.
[rank0]:  warnings.warn(
[rank0]:/data/users/andgu/pytorch/torch/autograd/graph.py:825: UserWarning: cuDNN SDPA backward got grad_output.strides() != output.strides(), attempting to materialize a grad_output with matching strides... (Triggered internally at /data/users/andgu/pytorch/aten/src/ATen/native/cudnn/MHA.cpp:674.)
[rank0]:  return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank0]:2024-10-22 08:04:53,798 - root - INFO - step:  1  loss: 12.2442  memory: 36.95GiB(38.89%)  wps: 257  mfu: 1.51%
[rank0]:2024-10-22 08:04:53,799 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[rank0]:[W1022 08:04:53.745741040 ProcessGroupNCCL.cpp:4268] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
[rank0]:2024-10-22 08:05:01,119 - root - INFO - step:  2  loss: 12.0802  memory: 44.53GiB(46.87%)  wps: 560  mfu: 3.28%
[rank0]:2024-10-22 08:05:01,824 - root - INFO - step:  3  loss: 11.7657  memory: 44.53GiB(46.87%)  wps: 5,807  mfu: 34.01%
[rank0]:2024-10-22 08:05:02,529 - root - INFO - step:  4  loss: 11.2496  memory: 44.53GiB(46.87%)  wps: 5,822  mfu: 34.09%
[rank0]:2024-10-22 08:05:03,237 - root - INFO - step:  5  loss: 10.8570  memory: 44.53GiB(46.87%)  wps: 5,788  mfu: 33.89%
[rank0]:2024-10-22 08:05:03,943 - root - INFO - step:  6  loss: 10.6067  memory: 44.53GiB(46.87%)  wps: 5,804  mfu: 33.99%
[rank0]:2024-10-22 08:05:04,648 - root - INFO - step:  7  loss: 10.2545  memory: 44.53GiB(46.87%)  wps: 5,811  mfu: 34.03%
[rank0]:2024-10-22 08:05:05,357 - root - INFO - step:  8  loss: 10.4116  memory: 44.53GiB(46.87%)  wps: 5,785  mfu: 33.88%
[rank0]:2024-10-22 08:05:06,063 - root - INFO - step:  9  loss: 10.0731  memory: 44.53GiB(46.87%)  wps: 5,807  mfu: 34.01%
[rank0]:2024-10-22 08:05:06,770 - root - INFO - step: 10  loss:  9.9586  memory: 44.53GiB(46.87%)  wps: 5,795  mfu: 33.94%
[rank0]:2024-10-22 08:05:07,477 - root - INFO - step: 11  loss:  9.8314  memory: 44.53GiB(46.87%)  wps: 5,803  mfu: 33.98%
[rank0]:2024-10-22 08:05:08,184 - root - INFO - step: 12  loss:  9.4902  memory: 44.53GiB(46.87%)  wps: 5,794  mfu: 33.93%
[rank0]:2024-10-22 08:05:08,894 - root - INFO - step: 13  loss:  9.2467  memory: 44.53GiB(46.87%)  wps: 5,772  mfu: 33.80%
[rank0]:2024-10-22 08:05:09,599 - root - INFO - step: 14  loss:  9.0352  memory: 44.53GiB(46.87%)  wps: 5,818  mfu: 34.07%
[rank0]:2024-10-22 08:05:10,311 - root - INFO - step: 15  loss:  9.0176  memory: 44.53GiB(46.87%)  wps: 5,754  mfu: 33.69%
[rank0]:2024-10-22 08:05:11,017 - root - INFO - step: 16  loss:  8.9939  memory: 44.53GiB(46.87%)  wps: 5,807  mfu: 34.00%
[rank0]:2024-10-22 08:05:11,724 - root - INFO - step: 17  loss:  8.7929  memory: 44.53GiB(46.87%)  wps: 5,805  mfu: 33.99%
[rank0]:2024-10-22 08:05:12,432 - root - INFO - step: 18  loss:  8.7480  memory: 44.53GiB(46.87%)  wps: 5,786  mfu: 33.88%
[rank0]:2024-10-22 08:05:13,139 - root - INFO - step: 19  loss:  8.7208  memory: 44.53GiB(46.87%)  wps: 5,799  mfu: 33.96%
[rank0]:2024-10-22 08:05:13,845 - root - INFO - step: 20  loss:  8.5405  memory: 44.53GiB(46.87%)  wps: 5,806  mfu: 34.00%
[rank0]:2024-10-22 08:05:14,550 - root - INFO - step: 21  loss:  8.5574  memory: 44.53GiB(46.87%)  wps: 5,810  mfu: 34.02%
[rank0]:2024-10-22 08:05:15,256 - root - INFO - step: 22  loss:  8.2595  memory: 44.53GiB(46.87%)  wps: 5,809  mfu: 34.02%
[rank0]:2024-10-22 08:05:15,965 - root - INFO - step: 23  loss:  8.5042  memory: 44.53GiB(46.87%)  wps: 5,784  mfu: 33.87%
[rank0]:2024-10-22 08:05:16,670 - root - INFO - step: 24  loss:  8.0777  memory: 44.53GiB(46.87%)  wps: 5,818  mfu: 34.07%
[rank0]:2024-10-22 08:05:17,378 - root - INFO - step: 25  loss:  8.0765  memory: 44.53GiB(46.87%)  wps: 5,787  mfu: 33.89%
[rank0]:2024-10-22 08:05:18,086 - root - INFO - step: 26  loss:  7.9639  memory: 44.53GiB(46.87%)  wps: 5,790  mfu: 33.90%
[rank0]:2024-10-22 08:05:18,791 - root - INFO - step: 27  loss:  8.0070  memory: 44.53GiB(46.87%)  wps: 5,816  mfu: 34.06%
[rank0]:2024-10-22 08:05:19,497 - root - INFO - step: 28  loss:  7.9313  memory: 44.53GiB(46.87%)  wps: 5,807  mfu: 34.01%
[rank0]:2024-10-22 08:05:20,202 - root - INFO - step: 29  loss:  7.6236  memory: 44.53GiB(46.87%)  wps: 5,807  mfu: 34.01%
[rank0]:2024-10-22 08:05:20,207 - root - WARNING - Dataset c4_test is being re-looped
```