### PR TITLE
Use expandable segments in `run_llama_train.sh`

### DIFF
--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -19,6 +19,7 @@ if [ $# -ne 0 ]; then
     overrides="$*"
 fi
 
+PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
 train.py --job.config_file ${CONFIG_FILE} $overrides


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #643
* #645

nice to default to this because users may not know to pass this env var
PyTorch will try to default in the future, but there are still some unsupported cases internally