### PR TITLE
Workaround for pytorch/pytorch#138575 distributed checkpoint loading bug

### DIFF
--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -471,7 +471,7 @@ class CheckpointManager:
         states = {"model": self.states["model"]} if step == 0 else self.states
         # PyTorch bug: (pytorch/pytorch#138575)
         # dcp.load() replaces the values of stateful elements in `states` with new objects
-        # from loading the checkpointm, in addition to updating the states of the original
+        # from loading the checkpoint, in addition to updating the states of the original
         # objects from `states` in-place. This is a problem because the state_dict no longer
         # refers to the objects being used in the train loop, meaning any future checkpoints
         # will not include updates to these objects (such as updated optimizer states, etc.)

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -475,7 +475,9 @@ class CheckpointManager:
         # objects from `states` in-place. This is a problem because the state_dict no longer
         # refers to the objects being used in the train loop, meaning any future checkpoints
         # will not include updates to these objects (such as updated optimizer states, etc.)
-        original_stateful_states = {k: v for k, v in states.items() if isinstance(v, Stateful)}
+        original_stateful_states = {
+            k: v for k, v in states.items() if isinstance(v, Stateful)
+        }
         logger.info(f"Loading the checkpoint at step {step}.")
         begin = time.monotonic()
         dcp.load(


### PR DESCRIPTION
Upstream PyTorch has a bug (pytorch/pytorch#138575) with `dcp.load()` that causes the objects pointed to by `state_dict` to diverge from the objects in use by the train loop. Specifically, torch is supposed to update in-place the Stateful elements in `state_dict`, however it also replaces the references in `state_dict` with the newly loaded object, resulting in the CheckpointManager instance having a stale trainstate/optimizer/etc.

This causes an issue when attempting to load a model from a checkpoint and subsequently save the checkpoint -- the loaded trainstate/optimizer/etc are saved instead of the current values. As a result, if a training run is pre-empted and resumed twice, the results are subtly wrong.

Until pytorch/pytorch#138575 is merged, this should work around the issue.

From @karan-dalal and I, thanks for all the work on TorchTitan! We're glad to be able to contribute back upstream in return!