### PR TITLE
Do not destroy if the world did not init

### DIFF
--- a/estimation.py
+++ b/estimation.py
@@ -216,5 +216,5 @@ if __name__ == "__main__":
     try:
         estimate_memory(config)
     finally:
-        if torch.distributed.GroupMember.WORLD is not None:
+        if torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()

--- a/estimation.py
+++ b/estimation.py
@@ -216,4 +216,5 @@ if __name__ == "__main__":
     try:
         estimate_memory(config)
     finally:
-        torch.distributed.destroy_process_group()
+        if torch.distributed.GroupMember.WORLD is not None:
+            torch.distributed.destroy_process_group()


### PR DESCRIPTION
Fixes

```python
2024-10-28 17:20:47,425 - root - INFO - Estimating memory usage...
2024-10-28 17:20:47,426 - root - INFO - Tensor parallelism and pipeline parallelism are not supported yet.
Traceback (most recent call last):
  File "/home/ubuntu/carlos/torchtitan/estimation.py", line 219, in <module>
    torch.distributed.destroy_process_group()
  File "/home/ubuntu/.pyenv/versions/titan/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 2014, in destroy_process_group
    assert pg is not None
AssertionError
```