### PR TITLE
support 3rd-party backend

### DIFF
--- a/torchtitan/__init__.py
+++ b/torchtitan/__init__.py
@@ -1,0 +1,4 @@
+from torch._utils import _get_available_device_type, _get_device_module
+
+DEVICE_TYPE = _get_available_device_type()
+DEVICE_MODULE = _get_device_module(DEVICE_TYPE)

--- a/torchtitan/__init__.py
+++ b/torchtitan/__init__.py
@@ -1,4 +1,0 @@
-from torch._utils import _get_available_device_type, _get_device_module
-
-DEVICE_TYPE = _get_available_device_type()
-DEVICE_MODULE = _get_device_module(DEVICE_TYPE)

--- a/torchtitan/metrics.py
+++ b/torchtitan/metrics.py
@@ -11,14 +11,15 @@ from typing import Any, Dict, Optional
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
-from torchtitan import DEVICE_TYPE, DEVICE_MODULE
 from torchtitan.config_manager import JobConfig
 from torchtitan.logging import logger
 from torchtitan.parallelisms import ParallelDims
+from torchtitan.utils import device_module, device_type
 
-# named tuple for passing GPU memory stats for logging
-MemStats = namedtuple(
-    "MemStats",
+
+# named tuple for passing device memory stats for logging
+DeviceMemStats = namedtuple(
+    "DeviceMemStats",
     [
         "max_active_gib",
         "max_active_pct",
@@ -29,19 +30,19 @@ MemStats = namedtuple(
     ],
 )
 
-class MemoryMonitor:
-    def __init__(self, device: str = f"{DEVICE_TYPE}:0"):
+
+class DeviceMemoryMonitor:
+    def __init__(self, device: str = f"{device_type}:0"):
         self.device = torch.device(device)  # device object
-        self.device_name = DEVICE_MODULE.get_device_name(self.device)
-        self.device_index = DEVICE_MODULE.current_device()
-        self.device_capacity = DEVICE_MODULE.get_device_properties(
+        self.device_name = device_module.get_device_name(self.device)
+        self.device_index = device_module.current_device()
+        self.device_capacity = device_module.get_device_properties(
             self.device
         ).total_memory
         self.device_capacity_gib = self._to_gib(self.device_capacity)
 
-
-        DEVICE_MODULE.reset_peak_memory_stats()
-        DEVICE_MODULE.empty_cache()
+        device_module.reset_peak_memory_stats()
+        device_module.empty_cache()
 
     def _to_gib(self, memory_in_bytes):
         # NOTE: GiB (gibibyte) is 1024, vs GB is 1000
@@ -53,25 +54,27 @@ class MemoryMonitor:
         return 100 * memory / self.device_capacity
 
     def get_peak_stats(self):
-        mem_info = DEVICE_MODULE.memory_stats(self.device)
+        device_info = device_module.memory_stats(self.device)
 
-        max_active = mem_info["active_bytes.all.peak"]
+        max_active = device_info["active_bytes.all.peak"]
         max_active_gib = self._to_gib(max_active)
         max_active_pct = self._to_pct(max_active)
 
-        max_reserved = mem_info["reserved_bytes.all.peak"]
+        max_reserved = device_info["reserved_bytes.all.peak"]
         max_reserved_gib = self._to_gib(max_reserved)
         max_reserved_pct = self._to_pct(max_reserved)
 
-        num_retries = mem_info["num_alloc_retries"]
-        num_ooms = mem_info["num_ooms"]
+        num_retries = device_info["num_alloc_retries"]
+        num_ooms = device_info["num_ooms"]
 
         if num_retries > 0:
-            logger.warning(f"{num_retries} {DEVICE_TYPE} memory allocation retries.")
+            logger.warning(
+                f"{num_retries} {device_type.upper} memory allocation retries."
+            )
         if num_ooms > 0:
-            logger.warning(f"{num_ooms} {DEVICE_TYPE} OOM errors thrown.")
+            logger.warning(f"{num_ooms} {device_type.upper} OOM errors thrown.")
 
-        return MemStats(
+        return DeviceMemStats(
             max_active_gib,
             max_active_pct,
             max_reserved_gib,
@@ -81,17 +84,17 @@ class MemoryMonitor:
         )
 
     def reset_peak_stats(self):
-        DEVICE_MODULE.reset_peak_memory_stats()
+        device_module.reset_peak_memory_stats()
 
 
-def build_memory_monitor():
-    memory_monitor = MemoryMonitor(DEVICE_TYPE)
+def build_device_memory_monitor():
+    device_memory_monitor = DeviceMemoryMonitor(device_type)
     logger.info(
-        f"{DEVICE_TYPE.upper} capacity: {memory_monitor.device_name} ({memory_monitor.device_index}) "
-        f"with {memory_monitor.device_capacity_gib:.2f}GiB memory"
+        f"{device_type.upper} capacity: {device_memory_monitor.device_name} ({device_memory_monitor.device_index}) "
+        f"with {device_memory_monitor.device_capacity_gib:.2f}GiB memory"
     )
 
-    return memory_monitor
+    return device_memory_monitor
 
 
 class MetricLogger:

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -16,8 +16,7 @@ import triton.language as tl
 
 from torch.distributed._tensor import Partial, Replicate, Shard
 from torch.distributed._tensor.experimental import local_map
-
-from torchtitan import DEVICE_MODULE
+from torchtitan.utils import device_module, device_type
 
 
 def build_norm(norm_type: str, dim: int, eps: float = 1e-6):
@@ -287,7 +286,7 @@ class TritonFusedRMSNorm(torch.autograd.Function):
         M, N = dy.shape
         dx = torch.empty_like(x)
 
-        sm_count = DEVICE_MODULE.get_device_properties(x.device).multi_processor_count
+        sm_count = device_module.get_device_properties(x.device).multi_processor_count
         _dw = torch.empty((sm_count, N), dtype=torch.float32, device=weight.device)
 
         max_size = 65536 // x.element_size()

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -16,7 +16,7 @@ import triton.language as tl
 
 from torch.distributed._tensor import Partial, Replicate, Shard
 from torch.distributed._tensor.experimental import local_map
-from torchtitan.utils import device_module, device_type
+from torchtitan.utils import device_module
 
 
 def build_norm(norm_type: str, dim: int, eps: float = 1e-6):

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -17,6 +17,8 @@ import triton.language as tl
 from torch.distributed._tensor import Partial, Replicate, Shard
 from torch.distributed._tensor.experimental import local_map
 
+from torchtitan import DEVICE_MODULE
+
 
 def build_norm(norm_type: str, dim: int, eps: float = 1e-6):
     """
@@ -285,7 +287,7 @@ class TritonFusedRMSNorm(torch.autograd.Function):
         M, N = dy.shape
         dx = torch.empty_like(x)
 
-        sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
+        sm_count = DEVICE_MODULE.get_device_properties(x.device).multi_processor_count
         _dw = torch.empty((sm_count, N), dtype=torch.float32, device=weight.device)
 
         max_size = 65536 // x.element_size()

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -16,8 +16,8 @@ from typing import Generator, Iterable, List, Optional, Set, Union
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
-from torch._utils import _get_available_device_type, _get_device_module
 from torch import distributed as dist
+from torch._utils import _get_available_device_type, _get_device_module
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torchtitan.logging import logger

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -15,18 +15,29 @@ from typing import Generator, List, Optional, Set, Union
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
+from torch._utils import _get_available_device_type, _get_device_module
 from torch.distributed.device_mesh import DeviceMesh
-from torchtitan import DEVICE_TYPE, DEVICE_MODULE
 from torchtitan.logging import logger
 
 
+def get_device_info():
+    device_type = _get_available_device_type()
+    if device_type == None:
+        device_type = "cuda"  # default device_type: cuda
+    device_module = _get_device_module(device_type)  # default device_module:torch.cuda
+    return device_type, device_module
+
+
+device_type, device_module = get_device_info()
+
+
 def dist_max(x: Union[int, float], mesh: DeviceMesh) -> float:
-    tensor = torch.tensor(x).to(DEVICE_TYPE)
+    tensor = torch.tensor(x).to(device_type)
     return funcol.all_reduce(tensor, reduceOp=c10d.ReduceOp.MAX.name, group=mesh).item()
 
 
 def dist_mean(x: Union[int, float], mesh: DeviceMesh) -> float:
-    tensor = torch.tensor(x).to(DEVICE_TYPE)
+    tensor = torch.tensor(x).to(device_type)
     return funcol.all_reduce(tensor, reduceOp=c10d.ReduceOp.AVG.name, group=mesh).item()
 
 
@@ -72,8 +83,8 @@ def set_pg_timeouts(timeout, world_mesh):
     # otherwise, some ranks may issue collectives with the new/shorter timeout and
     # those may time out, before other ranks have finished with initialization done
     # under the old/slow timeout.
-    torch.distributed.barrier(device_ids=[DEVICE_MODULE.current_device()])
-    DEVICE_MODULE.synchronize()
+    torch.distributed.barrier(device_ids=[device_module.current_device()])
+    device_module.synchronize()
 
     groups = [world_mesh.get_group(mesh_dim) for mesh_dim in range(world_mesh.ndim)]
 

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -22,7 +22,7 @@ from torchtitan.logging import logger
 
 def get_device_info():
     device_type = _get_available_device_type()
-    if device_type == None:
+    if device_type is None:
         device_type = "cuda"  # default device_type: cuda
     device_module = _get_device_module(device_type)  # default device_module:torch.cuda
     return device_type, device_module

--- a/train.py
+++ b/train.py
@@ -12,13 +12,13 @@ import torch
 
 from torch.distributed.elastic.multiprocessing.errors import record
 
-from torchtitan import utils
+from torchtitan import utils, DEVICE_TYPE, DEVICE_MODULE
 from torchtitan.checkpoint import CheckpointManager, TrainState
 from torchtitan.config_manager import JobConfig
 from torchtitan.datasets import build_hf_data_loader, build_tokenizer
 from torchtitan.float8 import Float8Handler
 from torchtitan.logging import init_logger, logger
-from torchtitan.metrics import build_gpu_memory_monitor, build_metric_logger
+from torchtitan.metrics import build_memory_monitor, build_metric_logger
 from torchtitan.models import model_name_to_cls, model_name_to_tokenizer, models_config
 from torchtitan.optimizer import build_lr_schedulers, build_optimizers
 from torchtitan.parallelisms import (
@@ -61,16 +61,16 @@ def main(job_config: JobConfig):
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
     )
-    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
-    torch.cuda.set_device(device)
+    device = torch.device(f"{DEVICE_TYPE}:{int(os.environ['LOCAL_RANK'])}")
+    DEVICE_MODULE.set_device(device)
     utils.init_distributed(job_config)
     # initialize GPU memory monitor and get peak flops for MFU calculation
-    gpu_memory_monitor = build_gpu_memory_monitor()
-    gpu_peak_flops = utils.get_peak_flops(gpu_memory_monitor.device_name)
+    memory_monitor = build_memory_monitor()
+    gpu_peak_flops = utils.get_peak_flops(memory_monitor.device_name)
     logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
 
     # build meshes
-    world_mesh = parallel_dims.build_mesh(device_type="cuda")
+    world_mesh = parallel_dims.build_mesh(device_type=DEVICE_TYPE)
     if parallel_dims.dp_enabled:
         dp_mesh = world_mesh["dp"]
         dp_degree, dp_rank = dp_mesh.size(), dp_mesh.get_local_rank()
@@ -144,9 +144,9 @@ def main(job_config: JobConfig):
         buffer_device = None
     elif job_config.training.enable_cpu_offload:
         init_device = "cpu"
-        buffer_device = "cuda"
+        buffer_device = f"{DEVICE_TYPE}"
     else:
-        init_device = "cuda"
+        init_device = f"{DEVICE_TYPE}"
         buffer_device = None
 
     # apply parallelisms and initialization
@@ -174,11 +174,11 @@ def main(job_config: JobConfig):
 
         model_parts = [model]
 
-    gpu_mem_stats = gpu_memory_monitor.get_peak_stats()
+    device_mem_stats = memory_monitor.get_peak_stats()
     logger.info(
-        f"GPU memory usage for model: "
-        f"{gpu_mem_stats.max_reserved_gib:.2f}GiB"
-        f"({gpu_mem_stats.max_reserved_pct:.2f}%)"
+        f"{DEVICE_TYPE.upper} memory usage for model: "
+        f"{device_mem_stats.max_reserved_gib:.2f}GiB"
+        f"({device_mem_stats.max_reserved_pct:.2f}%)"
     )
 
     # build optimizer after applying parallelisms to the model
@@ -239,7 +239,7 @@ def main(job_config: JobConfig):
     ntokens_since_last_log = 0
     data_loading_times = []
     time_last_log = time.perf_counter()
-    gpu_memory_monitor.reset_peak_stats()
+    memory_monitor.reset_peak_stats()
 
     checkpoint.reset()
 
@@ -268,8 +268,8 @@ def main(job_config: JobConfig):
             ntokens_since_last_log += labels.numel()
             data_loading_times.append(time.perf_counter() - data_load_start)
 
-            input_ids = input_ids.cuda()
-            labels = labels.cuda()
+            input_ids = input_ids.to(DEVICE_TYPE)
+            labels = labels.to(DEVICE_TYPE)
             optimizers.zero_grad()
 
             # apply context parallelism if cp is enabled
@@ -368,7 +368,7 @@ def main(job_config: JobConfig):
                 time_data_loading = sum(data_loading_times) / len(data_loading_times)
                 time_data_loading_pct = 100 * sum(data_loading_times) / time_delta
 
-                gpu_mem_stats = gpu_memory_monitor.get_peak_stats()
+                device_mem_stats = memory_monitor.get_peak_stats()
 
                 metrics = {
                     "loss_metrics/global_avg_loss": global_avg_loss,
@@ -378,20 +378,20 @@ def main(job_config: JobConfig):
                     "time_metrics/end_to_end(s)": time_end_to_end,
                     "time_metrics/data_loading(s)": time_data_loading,
                     "time_metrics/data_loading(%)": time_data_loading_pct,
-                    "memory/max_active(GiB)": gpu_mem_stats.max_active_gib,
-                    "memory/max_active(%)": gpu_mem_stats.max_active_pct,
-                    "memory/max_reserved(GiB)": gpu_mem_stats.max_reserved_gib,
-                    "memory/max_reserved(%)": gpu_mem_stats.max_reserved_pct,
-                    "memory/num_alloc_retries": gpu_mem_stats.num_alloc_retries,
-                    "memory/num_ooms": gpu_mem_stats.num_ooms,
+                    "memory/max_active(GiB)": device_mem_stats.max_active_gib,
+                    "memory/max_active(%)": device_mem_stats.max_active_pct,
+                    "memory/max_reserved(GiB)": device_mem_stats.max_reserved_gib,
+                    "memory/max_reserved(%)": device_mem_stats.max_reserved_pct,
+                    "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
+                    "memory/num_ooms": device_mem_stats.num_ooms,
                 }
                 metric_logger.log(metrics, step=train_state.step)
 
                 logger.info(
                     f"{color.cyan}step: {train_state.step:2}  "
                     f"{color.green}loss: {global_avg_loss:7.4f}  "
-                    f"{color.yellow}memory: {gpu_mem_stats.max_reserved_gib:5.2f}GiB"
-                    f"({gpu_mem_stats.max_reserved_pct:.2f}%)  "
+                    f"{color.yellow}memory: {device_mem_stats.max_reserved_gib:5.2f}GiB"
+                    f"({device_mem_stats.max_reserved_pct:.2f}%)  "
                     f"{color.blue}wps: {round(wps):,}  "
                     f"{color.magenta}mfu: {mfu:.2f}%{color.reset}"
                 )
@@ -400,7 +400,7 @@ def main(job_config: JobConfig):
                 ntokens_since_last_log = 0
                 data_loading_times.clear()
                 time_last_log = time.perf_counter()
-                gpu_memory_monitor.reset_peak_stats()
+                memory_monitor.reset_peak_stats()
 
             checkpoint.save(
                 train_state.step, force=(train_state.step == job_config.training.steps)

--- a/train.py
+++ b/train.py
@@ -145,7 +145,7 @@ def main(job_config: JobConfig):
         buffer_device = None
     elif job_config.training.enable_cpu_offload:
         init_device = "cpu"
-        buffer_device = f"{device_type}"
+        buffer_device = device_type
     else:
         init_device = f"{device_type}"
         buffer_device = None

--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ from torchtitan.parallelisms import (
     ParallelDims,
 )
 from torchtitan.profiling import maybe_enable_memory_snapshot, maybe_enable_profiling
-from torchtitan.utils import device_module, device_type, clip_grad_norm_
+from torchtitan.utils import clip_grad_norm_, device_module, device_type
 
 
 # Enable debug tracing on failure: https://pytorch.org/docs/stable/elastic/errors.html

--- a/train.py
+++ b/train.py
@@ -12,13 +12,13 @@ import torch
 
 from torch.distributed.elastic.multiprocessing.errors import record
 
-from torchtitan import utils, DEVICE_TYPE, DEVICE_MODULE
+from torchtitan import utils
 from torchtitan.checkpoint import CheckpointManager, TrainState
 from torchtitan.config_manager import JobConfig
 from torchtitan.datasets import build_hf_data_loader, build_tokenizer
 from torchtitan.float8 import Float8Handler
 from torchtitan.logging import init_logger, logger
-from torchtitan.metrics import build_memory_monitor, build_metric_logger
+from torchtitan.metrics import build_device_memory_monitor, build_metric_logger
 from torchtitan.models import model_name_to_cls, model_name_to_tokenizer, models_config
 from torchtitan.optimizer import build_lr_schedulers, build_optimizers
 from torchtitan.parallelisms import (
@@ -27,6 +27,7 @@ from torchtitan.parallelisms import (
     ParallelDims,
 )
 from torchtitan.profiling import maybe_enable_memory_snapshot, maybe_enable_profiling
+from torchtitan.utils import device_module, device_type
 
 
 # Enable debug tracing on failure: https://pytorch.org/docs/stable/elastic/errors.html
@@ -61,16 +62,16 @@ def main(job_config: JobConfig):
         world_size=world_size,
         enable_loss_parallel=job_config.training.enable_loss_parallel,
     )
-    device = torch.device(f"{DEVICE_TYPE}:{int(os.environ['LOCAL_RANK'])}")
-    DEVICE_MODULE.set_device(device)
+    device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+    device_module.set_device(device)
     utils.init_distributed(job_config)
-    # initialize GPU memory monitor and get peak flops for MFU calculation
-    memory_monitor = build_memory_monitor()
-    gpu_peak_flops = utils.get_peak_flops(memory_monitor.device_name)
+    # initialize device memory monitor and get peak flops for MFU calculation
+    device_memory_monitor = build_device_memory_monitor()
+    gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
     logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
 
     # build meshes
-    world_mesh = parallel_dims.build_mesh(device_type=DEVICE_TYPE)
+    world_mesh = parallel_dims.build_mesh(device_type=device_type)
     if parallel_dims.dp_enabled:
         dp_mesh = world_mesh["dp"]
         dp_degree, dp_rank = dp_mesh.size(), dp_mesh.get_local_rank()
@@ -144,9 +145,9 @@ def main(job_config: JobConfig):
         buffer_device = None
     elif job_config.training.enable_cpu_offload:
         init_device = "cpu"
-        buffer_device = f"{DEVICE_TYPE}"
+        buffer_device = f"{device_type}"
     else:
-        init_device = f"{DEVICE_TYPE}"
+        init_device = f"{device_type}"
         buffer_device = None
 
     # apply parallelisms and initialization
@@ -174,9 +175,9 @@ def main(job_config: JobConfig):
 
         model_parts = [model]
 
-    device_mem_stats = memory_monitor.get_peak_stats()
+    device_mem_stats = device_memory_monitor.get_peak_stats()
     logger.info(
-        f"{DEVICE_TYPE.upper} memory usage for model: "
+        f"{device_type.upper} memory usage for model: "
         f"{device_mem_stats.max_reserved_gib:.2f}GiB"
         f"({device_mem_stats.max_reserved_pct:.2f}%)"
     )
@@ -239,7 +240,7 @@ def main(job_config: JobConfig):
     ntokens_since_last_log = 0
     data_loading_times = []
     time_last_log = time.perf_counter()
-    memory_monitor.reset_peak_stats()
+    device_memory_monitor.reset_peak_stats()
 
     checkpoint.reset()
 
@@ -268,8 +269,8 @@ def main(job_config: JobConfig):
             ntokens_since_last_log += labels.numel()
             data_loading_times.append(time.perf_counter() - data_load_start)
 
-            input_ids = input_ids.to(DEVICE_TYPE)
-            labels = labels.to(DEVICE_TYPE)
+            input_ids = input_ids.to(device_type)
+            labels = labels.to(device_type)
             optimizers.zero_grad()
 
             # apply context parallelism if cp is enabled
@@ -368,7 +369,7 @@ def main(job_config: JobConfig):
                 time_data_loading = sum(data_loading_times) / len(data_loading_times)
                 time_data_loading_pct = 100 * sum(data_loading_times) / time_delta
 
-                device_mem_stats = memory_monitor.get_peak_stats()
+                device_mem_stats = device_memory_monitor.get_peak_stats()
 
                 metrics = {
                     "loss_metrics/global_avg_loss": global_avg_loss,
@@ -400,7 +401,7 @@ def main(job_config: JobConfig):
                 ntokens_since_last_log = 0
                 data_loading_times.clear()
                 time_last_log = time.perf_counter()
-                memory_monitor.reset_peak_stats()
+                device_memory_monitor.reset_peak_stats()
 
             checkpoint.save(
                 train_state.step, force=(train_state.step == job_config.training.steps)

--- a/train.py
+++ b/train.py
@@ -147,7 +147,7 @@ def main(job_config: JobConfig):
         init_device = "cpu"
         buffer_device = device_type
     else:
-        init_device = f"{device_type}"
+        init_device = device_type
         buffer_device = None
 
     # apply parallelisms and initialization


### PR DESCRIPTION

register for example:

```python
# register DEVICE_TYPE
c10::register_privateuse1_backend("npu")
torch.utils.rename_privateuse1_backend("npu")
# register DEVICE_MODULE
torch._register_device_module('npu', torch_npu.npu)
```



ussage:

"torch.cuda" should be replaced by "DEVICE_MODULE"
".cuda()" should be replaced by ".to(device=DEVICE_TYPE)"