### PR TITLE
Control 'deterministic' mode separately from rng seed

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -371,7 +371,13 @@ class JobConfig:
             "--training.seed",
             type=int,
             default=None,
-            help="Implement reproducibility by setting a Python, PyTorch and CUDA seed",
+            help="Choose the base RNG seed used for training",
+        )
+        self.parser.add_argument(
+            "--training.deterministic",
+            type=bool,
+            default=False,
+            help="Use deterministic algorithms wherever possible, may be slower",
         )
         # checkpointing configs
         self.parser.add_argument(

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -80,22 +80,24 @@ def manual_seed(
     torch.distributed.tensor._random.manual_seed(seed)
 
 
-def set_determinism(seed: Optional[int]) -> None:
+def set_determinism(deterministic: bool, seed: Optional[int] = None) -> None:
     """
     Set Python, PyTorch, CUDA seeds and cudnn settings for reproducibility
     """
+
     if seed is not None:
         # CPU and GPU determinism
         torch.manual_seed(seed)
         # set deterministic cudnn algorithms
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
         # set Python seed
         os.environ["PYTHONHASHSEED"] = str(seed)
-    else:
-        # ensure we turn off deterministic cudnn algorithms
-        torch.backends.cudnn.deterministic = False
-        torch.backends.cudnn.benchmark = True
+
+    if deterministic:
+        logger.info(
+            f"Deterministic training enabled (expect perf degradation). Using seed: {seed}"
+        )
+    torch.backends.cudnn.deterministic = deterministic
+    torch.backends.cudnn.benchmark = not deterministic
 
 
 def set_pg_timeouts(timeout, world_mesh):

--- a/train.py
+++ b/train.py
@@ -42,14 +42,8 @@ def main(job_config: JobConfig):
     # take control of garbage collection to avoid stragglers
     gc_handler = utils.GarbageCollection(gc_freq=job_config.training.gc_freq)
 
-    # set determinisism, use seed == None to skip deterministic training
-    utils.set_determinism(job_config.training.seed)
-    if job_config.training.seed is None:
-        logger.info("Deterministic training off")
-    else:
-        logger.info(
-            f"Deterministic training on. Using seed: {job_config.training.seed}"
-        )
+    # Enable deterministic mode (mainly for debugging, expect perf loss)
+    utils.set_determinism(job_config.training.deterministic, job_config.training.seed)
 
     # init distributed
     world_size = int(os.environ["WORLD_SIZE"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #691
* __->__ #690
* #689

The use case for 'deterministic' mode may be more for debugging, while
users may want to control RNG seeds used for real runs.