### PR TITLE
fix float8 delayed scaling configuration

### DIFF
--- a/torchtitan/float8.py
+++ b/torchtitan/float8.py
@@ -60,7 +60,6 @@ class Float8Handler:
             cast_config_input=CastConfig(scaling_type=scaling_type_input),
             cast_config_weight=CastConfig(scaling_type=scaling_type_weight),
             cast_config_grad_output=CastConfig(scaling_type=scaling_type_grad_output),
-            enable_pre_and_post_forward=False,
         )
 
         self.enabled = True
@@ -73,9 +72,9 @@ class Float8Handler:
 
         # for sync_float8_amax_and_scale_history
         self.delayed_scaling = (
-            scaling_type_input == "delayed"
-            or scaling_type_weight == "delayed"
-            or scaling_type_grad_output == "delayed"
+            scaling_type_input is ScalingType.DELAYED
+            or scaling_type_weight is ScalingType.DELAYED
+            or scaling_type_grad_output is ScalingType.DELAYED
         )
         self._sync_float8_amax_and_scale_history = None
         self.compile = job_config.training.compile


### PR DESCRIPTION
Summary:

The float8 delayed scaling configuration was broken for two reasons:
1. the enum value was compared to a string, which would always fail, leading to the amax syncing function to never be called. Fixing by comparing to the right enum value.
2. the `enable_pre_and_post_forward` was set to False, which meant that the initialization path was taken at every iteration, preventing us from ever seeing performance benefits compared to dynamic scaling.

This PR fixes both of the issues above. Note that this fix requires https://github.com/pytorch/ao/pull/1341 to work correctly.

Note that delayed scaling is still not faster than dynamic due to some missing features in inductor, but this PR at least sets us up with a good baseline.

Test Plan:

```
// dynamic scaling on LLaMa 3 8B (baseline)
// wps: 6810
// mem usage: 37.98GiB
with-proxy CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --training.compile

// delayed scaling on LLaMa 3 8B
// wps: 6750
// mem usage: 37.96GiB
with-proxy CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --training.compile --float8.scaling_type_input delayed --float8.scaling_type_weight delayed --float8.scaling_type_grad_output delayed
```

Reviewers:

Subscribers:

Tasks:

Tags: