### PR TITLE
[prototype] Expert Parallel

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -349,6 +349,13 @@ class JobConfig:
             help="Context parallelism degree. 1 means disabled.",
         )
         self.parser.add_argument(
+            "--experimental.expert_parallel_mode",
+            type=str,
+            default="none",
+            choices=["none", "tp", "tp2ep", "dp2ep"],
+            help="Expert Parallel mode",
+        )
+        self.parser.add_argument(
             "--training.mixed_precision_param",
             type=str,
             default="bfloat16",

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -14,7 +14,6 @@ from typing import Optional, Tuple
 import torch
 import torch.nn.functional as F
 from torch import nn
-
 from torchtitan.models.norms import build_norm
 
 

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -14,6 +14,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn.functional as F
 from torch import nn
+
 from torchtitan.models.norms import build_norm
 
 
@@ -34,6 +35,13 @@ class ModelArgs:
     # `False`, each uses the total number of transformer blocks
     depth_init: bool = True
     norm_type: str = "rmsnorm"
+
+    # MoE args
+    enable_moe: bool = True
+    num_experts: int = 8
+    capacity_factor: float = 1.0
+    use_shared_expert: bool = True
+    auto_scale_hidden_dim: bool = True
 
 
 def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
@@ -284,12 +292,55 @@ class TransformerBlock(nn.Module):
         self.n_heads = model_args.n_heads
         self.dim = model_args.dim
         self.attention = Attention(model_args)
-        self.feed_forward = FeedForward(
-            dim=model_args.dim,
-            hidden_dim=4 * model_args.dim,
-            multiple_of=model_args.multiple_of,
-            ffn_dim_multiplier=model_args.ffn_dim_multiplier,
-        )
+        self.enable_moe = model_args.enable_moe
+
+        if not self.enable_moe:
+            self.feed_forward = FeedForward(
+                dim=model_args.dim,
+                hidden_dim=4 * model_args.dim,
+                multiple_of=model_args.multiple_of,
+                ffn_dim_multiplier=model_args.ffn_dim_multiplier,
+            )
+        else:
+            from torchtitan.models.llama.moe_layers import (
+                ExpertChoiceTopKRouter,
+                GroupedExperts,
+                MoE,
+            )
+
+            hidden_dim_denom = 1
+            if model_args.auto_scale_hidden_dim:
+                hidden_dim_denom = model_args.capacity_factor + int(
+                    model_args.use_shared_expert
+                )
+
+            dim = model_args.dim
+            hidden_dim = 4 * model_args.dim
+            hidden_dim = int(2 * hidden_dim / 3)
+            if model_args.ffn_dim_multiplier is not None:
+                hidden_dim = int(model_args.ffn_dim_multiplier * hidden_dim)
+            if model_args.auto_scale_hidden_dim:
+                hidden_dim = int(hidden_dim / hidden_dim_denom)
+            hidden_dim += -hidden_dim % model_args.multiple_of
+
+            num_experts = model_args.num_experts
+            self.moe = MoE(
+                experts=GroupedExperts(
+                    dim_in=dim, dim_out=hidden_dim, num_experts=num_experts
+                ),
+                router=ExpertChoiceTopKRouter(
+                    gate=nn.Linear(dim, num_experts, bias=False),
+                    dim=dim,
+                    num_experts=num_experts,
+                    capacity_factor=model_args.capacity_factor,
+                ),
+                shared_expert=(
+                    GroupedExperts(dim_in=dim, dim_out=hidden_dim, num_experts=1)
+                    if model_args.use_shared_expert
+                    else None
+                ),
+            )
+
         self.layer_id = layer_id
         self.num_layers = model_args.n_layers
 
@@ -322,14 +373,20 @@ class TransformerBlock(nn.Module):
 
         """
         h = x + self.attention(self.attention_norm(x), freqs_cis)
-        out = h + self.feed_forward(self.ffn_norm(h))
+        if not self.enable_moe:
+            out = h + self.feed_forward(self.ffn_norm(h))
+        else:
+            out = h + self.moe(self.ffn_norm(h))
         return out
 
     def init_weights(self):
         for norm in (self.attention_norm, self.ffn_norm):
             norm.reset_parameters()
         self.attention.init_weights(self.weight_init_std)
-        self.feed_forward.init_weights(self.weight_init_std)
+        if not self.enable_moe:
+            self.feed_forward.init_weights(self.weight_init_std)
+        else:
+            self.moe.init_weights(self.weight_init_std)
 
 
 class Transformer(nn.Module):

--- a/torchtitan/models/llama/moe_layers.py
+++ b/torchtitan/models/llama/moe_layers.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, NamedTuple, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class GroupedExperts(nn.Module):
+    """This class implements the grouped experts layer used in Mixture of Experts. Each expert
+    is a variant of the Gated Linear Units network. See more details in https://arxiv.org/pdf/2002.05202.
+
+    Args:
+        dim_in (int): Input dimension.
+        dim_out (int): Output dimension.
+        num_experts (int): Number of experts in this grouped experts layer. Default is 1.
+        swiglu (bool): Whether to use gated linear unit. Default is True.
+        activation (nn.Module): Activation function to use. Default is F.silu.
+    """
+
+    def __init__(
+        self,
+        *,
+        dim_in: int,
+        dim_out: int,
+        num_experts: int = 1,
+        swiglu: bool = True,
+        activation: Callable = F.silu,
+    ):
+        super().__init__()
+        self.dim_in = dim_in
+        self.num_experts = num_experts
+        self.gate_proj = nn.Parameter(torch.empty(num_experts, dim_in, dim_out))
+        self.down_proj = nn.Parameter(torch.empty(num_experts, dim_out, dim_in))
+        if swiglu:
+            self.up_proj = nn.Parameter(torch.empty(num_experts, dim_in, dim_out))
+            self.act_fn = F.silu
+        else:
+            self.up_proj = None
+            self.act_fn = activation
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x (torch.Tensor): with shape (num_experts, tokens_per_expert, dim_in) for Expert Choice(EC).
+
+        Returns:
+            torch.Tensor: with shape (num_experts, tokens_per_expert, dim_in) for Expert Choice(EC).
+        """
+        # Expert Choice(EC) forward
+        # x shape (num_experts, tokens_per_expert, dim_in)
+        h = self.act_fn(torch.bmm(x, self.gate_proj))
+        if self.up_proj is not None:
+            h = h * torch.bmm(x, self.up_proj)
+        # out shape (num_experts, tokens_per_expert, dim_out)
+        out = torch.bmm(h, self.down_proj)
+        return out
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.gate_proj, mean=0.0, std=0.02)
+        if self.up_proj is not None:
+            nn.init.trunc_normal_(self.up_proj, mean=0.0, std=init_std)
+        nn.init.trunc_normal_(self.down_proj, mean=0.0, std=init_std)
+
+
+class RouterOutput(NamedTuple):
+    """Router output for Expert Choice routing.
+
+    routed_input (torch.Tensor): tokens grouped together by experts indices with shape
+        ``(num_experts*tokens_per_expert, dim)`` for Expert Choice.
+    token_indices (torch.Tensor): token indices for routed_input with shape
+        ``(num_experts*tokens_per_expert, dim)`` for Expert Choice.
+    """
+
+    routed_input: torch.Tensor
+    token_indices: torch.Tensor
+
+
+class ExpertChoiceTopKRouter(nn.Module):
+    """This class implements experts choice routing. Each experts will select it's top K tokens based on
+        the router scores. Refer to more details in https://arxiv.org/abs/2202.09368
+
+    Args:
+        gate (nn.Module): Gate module to calculate the scores, typically nn.Linear(dim, num_experts).
+        dim (int): Dimension of input tokens.
+        num_experts (int): Number of experts in each moe layer.
+        capacity_factor (float): Capacity factor determines how many tokens each expert can choose.
+            expert capacity = (number of tokens * capacity factor) / number of experts.
+        use_sigmoid (bool): Whether to use sigmoid or softmax for router scores. Default is False.
+    """
+
+    def __init__(
+        self,
+        *,
+        gate: nn.Module,
+        dim: int,
+        num_experts: int,
+        capacity_factor: float,
+        use_sigmoid: bool = True,
+    ):
+        super().__init__()
+        self.gate = gate
+        self.dim = dim
+        self.num_experts = num_experts
+        self.capacity_factor = capacity_factor
+        self.use_sigmoid = use_sigmoid
+
+    def forward(self, x: torch.Tensor) -> RouterOutput:
+        """
+        Args:
+            x (torch.Tensor): Input tensor with shape ``(bs*slen, dim)``.
+
+        Returns:
+            routed_input (torch.Tensor): input tokens grouped together by experts indices with shape
+                ``(num_experts*tokens_per_expert, dim)``.
+            token_indices (torch.Tensor): token indices for routed_input. Shape ``(num_experts*tokens_per_expert,)``.
+        """
+        # scores shape (num_experts, bs*slen)
+        scores = self.gate(x).transpose(0, 1)
+        # By default, we perform sigmoid and softmax in float32 to avoid loss explosion.
+        if self.use_sigmoid:
+            scores = torch.sigmoid(scores.to(torch.float32)).to(x.dtype)
+        else:
+            scores = F.softmax(scores.to(torch.float32), dim=0).to(x.dtype)
+        tokens_per_expert = int(x.shape[0] * self.capacity_factor / self.num_experts)
+        tokens_per_expert += -tokens_per_expert % 8
+        # Take the smaller of tokens_per_expert and the number of tokens
+        tokens_per_expert = min(tokens_per_expert, x.shape[0])
+
+        # top_scores shape (num_experts, tokens_per_expert)
+        top_scores, selected_token_indices = torch.topk(
+            scores, k=tokens_per_expert, dim=1
+        )
+
+        # token_indices shape (num_experts*tokens_per_expert, dim)
+        token_indices = selected_token_indices.reshape(-1, 1).expand(-1, self.dim)
+        # routed_input shape (num_experts*tokens_per_expert, dim)
+        routed_input = torch.gather(x, dim=0, index=token_indices)
+        routed_input = routed_input * top_scores.reshape(-1, 1)
+        return RouterOutput(
+            routed_input,
+            token_indices,
+        )
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.gate.weight, mean=0.0, std=init_std)
+
+
+class MoE(nn.Module):
+    """This class implements the moe layer which is Mixture of Experts. Mixture of Experts
+    typically consists of a set of expert networks, alongside with a router, which directs input tokens
+    to the appropriate experts. See more details in https://arxiv.org/pdf/2407.06204.
+
+    Args:
+        experts (nn.Module): experts module.
+        router (nn.Module): router module.
+        shared_expert (Optional[nn.Module]): shared expert module. Default is None.
+    """
+
+    def __init__(
+        self,
+        *,
+        experts: nn.Module,
+        router: nn.Module,
+        shared_expert: Optional[nn.Module] = None,
+    ):
+        super().__init__()
+        self.experts = experts
+        self.router = router
+        self.shared_expert = shared_expert
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x (torch.Tensor): Input tensor with shape ``(bz, slen, dim)``.
+
+        Returns:
+            out (torch.Tensor): Output tensor with shape ``(bz, slen, dim)``.
+        """
+        bz, slen, dim = x.shape
+        # routed_input shape (num_experts*tokens_per_expert, dim) for EC
+        routed_input, token_indices = self.router(x.reshape(bz * slen, dim))
+
+        # routed_input shape (num_experts, tokens_per_expert, dim_in)
+        routed_input = routed_input.reshape(self.router.num_experts, -1, dim)
+        # routed_output shape (num_experts, tokens_per_expert, dim_out)
+        routed_output = self.experts(routed_input)
+        # routed_output shape (num_experts*tokens_per_expert, dim_out)
+        routed_output = routed_output.reshape(-1, dim)
+
+        # shared expert
+        if self.shared_expert is not None:
+            out = self.shared_expert(x.reshape(1, bz * slen, dim)).reshape(
+                bz * slen, dim
+            )
+        else:
+            out = torch.zeros_like(x.reshape(bz * slen, dim))
+
+        # add experts output
+        # doing in in place might be faster
+        out = out.scatter_add(dim=0, index=token_indices, src=routed_output)
+        out = out.reshape(bz, slen, dim)
+        return out
+
+    def init_weights(self, init_std: float):
+        self.experts.init_weights(init_std)
+        self.router.init_weights(init_std)
+        if self.shared_expert is not None:
+            self.shared_expert.init_weights(init_std)

--- a/torchtitan/parallelisms/expert_parallel.py
+++ b/torchtitan/parallelisms/expert_parallel.py
@@ -1,0 +1,410 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# mypy: allow-untyped-defs
+# Copyright (c) Meta Platforms, Inc. and affiliates
+from functools import partial
+from typing import Any, Dict, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import (
+    DeviceMesh,
+    distribute_module,
+    distribute_tensor,
+    DTensor,
+    Partial,
+    Replicate,
+    Shard,
+)
+from torch.distributed.tensor.parallel import ParallelStyle
+from torch.distributed.tensor.placement_types import Placement
+
+
+# This is similar to PrepareModuleInput and PrepareModuleOutput,
+# but applies them simultaneously.
+class PrepareModuleInputOutput(ParallelStyle):
+    def __init__(
+        self,
+        *,
+        input_layouts: Optional[Union[Placement, Tuple[Optional[Placement]]]] = None,
+        desired_input_layouts: Optional[
+            Union[Placement, Tuple[Optional[Placement]]]
+        ] = None,
+        input_kwarg_layouts: Optional[Dict[str, Placement]] = None,
+        desired_input_kwarg_layouts: Optional[Dict[str, Placement]] = None,
+        use_local_input: bool = False,
+        output_layouts: Union[Placement, Tuple[Placement]],
+        desired_output_layouts: Union[Placement, Tuple[Placement]],
+        use_local_output: bool = True,
+    ):
+        # for input
+        self.input_layouts = (
+            (input_layouts,) if isinstance(input_layouts, Placement) else input_layouts
+        )
+        self.desired_input_layouts = (
+            (desired_input_layouts,)
+            if isinstance(desired_input_layouts, Placement)
+            else desired_input_layouts
+        )
+        self.use_local_input = use_local_input
+        if self.input_layouts is not None:
+            assert (
+                self.desired_input_layouts is not None
+            ), "desired module inputs should not be None!"
+            assert len(self.input_layouts) == len(
+                self.desired_input_layouts
+            ), "input_layouts and desired_input_layouts should have same length!"
+        self.with_kwargs = input_kwarg_layouts is not None
+        self.input_kwarg_layouts = input_kwarg_layouts or {}
+        self.desired_input_kwarg_layouts = desired_input_kwarg_layouts or {}
+        if self.with_kwargs:
+            assert len(self.input_kwarg_layouts) == len(
+                self.desired_input_kwarg_layouts
+            ), "input_kwarg_layouts and desired_input_kwarg_layouts should have same length!"
+
+        # for output
+        self.output_layouts = (
+            (output_layouts,)
+            if isinstance(output_layouts, Placement)
+            else output_layouts
+        )
+        self.desired_output_layouts = (
+            (desired_output_layouts,)
+            if isinstance(desired_output_layouts, Placement)
+            else desired_output_layouts
+        )
+        self.use_local_output = use_local_output
+        assert len(self.output_layouts) == len(
+            self.desired_output_layouts
+        ), "output_layouts and desired_output_layouts should have same length!"
+
+    def _prepare_input_arg(
+        self,
+        input: Any,
+        mesh: DeviceMesh,
+        input_layout: Optional[Placement],
+        desired_layout: Optional[Placement],
+    ):
+        if input_layout is not None:
+            if isinstance(input, DTensor):
+                # TODO: re-enable the check once we fix the compile path
+                # assert inp.placements[0] == input_layout
+                dt_inp = input
+            else:
+                assert isinstance(
+                    input, torch.Tensor
+                ), "expecting input to be a torch.Tensor!"
+                dt_inp = DTensor.from_local(
+                    input, mesh, (input_layout,), run_check=False
+                )
+
+            if desired_layout is not None and input_layout != desired_layout:
+                dt_inp = dt_inp.redistribute(placements=(desired_layout,))
+
+            return dt_inp.to_local() if self.use_local_input else dt_inp
+        else:
+            return input
+
+    def _prepare_input_fn(self, inputs, device_mesh):
+        if self.input_layouts is None:
+            return inputs
+        prepared_inputs = []
+        if not isinstance(inputs, tuple):
+            inputs = (inputs,)
+        if len(inputs) != len(self.input_layouts):
+            raise ValueError("module inputs and input_layouts should have same length!")
+
+        assert (
+            self.desired_input_layouts is not None
+        ), "desired module inputs should not be None!"
+        for inp, input_layout, desired_layout in zip(
+            inputs, self.input_layouts, self.desired_input_layouts
+        ):
+            prepared_inputs.append(
+                self._prepare_input_arg(inp, device_mesh, input_layout, desired_layout)
+            )
+        return tuple(prepared_inputs)
+
+    def _prepare_input_kwarg_fn(self, inputs, kwarg_inputs, device_mesh):
+        prepared_arg_inputs = self._prepare_input_fn(inputs, device_mesh)
+        prepared_kwarg_inputs = {}
+        for kwarg_key in kwarg_inputs.keys():
+            kwarg_val = kwarg_inputs[kwarg_key]
+            input_layout = self.input_kwarg_layouts.get(kwarg_key)
+            desired_input_layout = self.desired_input_kwarg_layouts.get(kwarg_key)
+
+            prepared_kwarg_inputs[kwarg_key] = self._prepare_input_arg(
+                kwarg_val, device_mesh, input_layout, desired_input_layout
+            )
+
+        return (prepared_arg_inputs, prepared_kwarg_inputs)
+
+    def _prepare_out_fn(self, outputs, device_mesh):
+        prepared_outputs = []
+        if not isinstance(outputs, tuple):
+            outputs = (outputs,)
+        if len(outputs) != len(self.output_layouts):
+            raise ValueError(
+                "module outputs and output_layouts should have same length!"
+            )
+        for out, out_layout, desired_out_layout in zip(
+            outputs, self.output_layouts, self.desired_output_layouts
+        ):
+            if out_layout is not None:
+                if isinstance(out, DTensor):
+                    # TODO: re-enable the check once we fix the compile path
+                    # assert out.placements[0] == out_layout
+                    dt_out = out
+                else:
+                    dt_out = DTensor.from_local(
+                        out, device_mesh, (out_layout,), run_check=False
+                    )
+
+                if out_layout != desired_out_layout:
+                    dt_out = dt_out.redistribute(placements=(desired_out_layout,))
+                prepared_outputs.append(
+                    dt_out.to_local() if self.use_local_output else dt_out
+                )
+            else:
+                prepared_outputs.append(out)
+        if len(prepared_outputs) == 1:
+            return prepared_outputs[0]
+        else:
+            return tuple(prepared_outputs)
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        # for input
+        if self.with_kwargs:
+            module.register_forward_pre_hook(
+                lambda _, inputs, kwargs: self._prepare_input_kwarg_fn(
+                    inputs, kwargs, device_mesh
+                ),
+                with_kwargs=True,
+            )  # type: ignore[misc]
+        else:
+            module.register_forward_pre_hook(
+                lambda _, inputs: self._prepare_input_fn(inputs, device_mesh)
+            )  # type: ignore[misc, call-arg]
+
+        # for output
+        module.register_forward_hook(
+            lambda _, inputs, outputs: self._prepare_out_fn(outputs, device_mesh)
+        )  # type: ignore[misc, call-arg]
+
+        return module
+
+
+# normal TP on the expert, output is Partial
+# TODO: using low-level API for now, may need to formulate into a high-level API
+def _apply_tp_to_expert(module, device_mesh):
+    module.register_parameter(
+        "gate_proj",
+        nn.Parameter(distribute_tensor(module.gate_proj, device_mesh, [Shard(2)])),
+    )  # Column-wise sharding
+    module.register_parameter(
+        "down_proj",
+        nn.Parameter(distribute_tensor(module.down_proj, device_mesh, [Shard(1)])),
+    )  # Row-wise sharding
+    module.register_parameter(
+        "up_proj",
+        nn.Parameter(distribute_tensor(module.up_proj, device_mesh, [Shard(2)])),
+    )  # Column-wise sharding
+
+
+class ExpertParallel(ParallelStyle):
+    def __init__(
+        self,
+        *,
+        input_layouts: Optional[Placement] = None,
+        output_layouts: Optional[Placement] = None,
+        use_local_output: bool = False,
+    ):
+        super().__init__()
+        self.input_layouts = (input_layouts or Shard(0),)
+        self.output_layouts = (output_layouts or Shard(0),)
+        self.desired_input_layouts = (Shard(0),)
+        self.use_local_output = use_local_output
+
+    @staticmethod
+    def _prepare_input_fn(
+        input_layouts, desired_input_layouts, mod, inputs, device_mesh
+    ):
+        # TODO: figure out dynamo support for instance method and switch this to instance method
+
+        # annotate module input placements/sharding with input_layouts
+        input_tensor = inputs[0]
+        if not isinstance(input_tensor, DTensor):
+            input_tensor = DTensor.from_local(
+                input_tensor, device_mesh, input_layouts, run_check=False
+            )
+
+        if input_layouts != desired_input_layouts:
+            input_tensor = input_tensor.redistribute(
+                placements=desired_input_layouts, async_op=True
+            )
+        return input_tensor
+
+    def _partition_fn(self, name, module, device_mesh):
+        # shard on the expert dimension
+        for name, param in module.named_parameters(recurse=False):
+            dist_param = nn.Parameter(distribute_tensor(param, device_mesh, [Shard(0)]))
+            module.register_parameter(name, dist_param)
+
+    @staticmethod
+    def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
+        # outputs is a shard on last dimension DTensor, i.e. Shard(-1)
+        if outputs.placements != output_layouts:
+            outputs = outputs.redistribute(placements=output_layouts, async_op=True)
+        # back to local tensor
+        return outputs.to_local() if use_local_output else outputs
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            self._partition_fn,
+            partial(
+                self._prepare_input_fn, self.input_layouts, self.desired_input_layouts
+            ),
+            partial(
+                self._prepare_output_fn, self.output_layouts, self.use_local_output
+            ),
+        )
+
+
+# This class is for dp2ep with TP (without TP we can just use ExpertParallel)
+class ExpertTensorParallel(ParallelStyle):
+    def __init__(
+        self,
+        *,
+        sp_dim=2,
+    ):
+        super().__init__()
+        # NOTE: sp_dim can be 1 or 2 in (num_experts, tokens_per_expert, dim)
+        #       but sp_dim = 1 may create difficulty for the a2a(ep)
+        self.sp_dim = sp_dim
+
+    @staticmethod
+    def _prepare_input_fn(sp_dim, mod, inputs, device_mesh):
+        input_tensor = inputs[0]
+
+        # NOTE: this is to convert the input 1D DTensor on the TP mesh to torch.Tensor
+        if isinstance(input_tensor, DTensor):
+            input_tensor = input_tensor.to_local()
+
+        input_tensor = DTensor.from_local(
+            input_tensor, device_mesh, (Shard(1), Shard(0))
+        )
+        # a2a(tp)
+        input_tensor = input_tensor.redistribute(placements=(Shard(1), Shard(sp_dim)))
+        # a2a(ep)
+        input_tensor = input_tensor.redistribute(placements=(Shard(0), Shard(sp_dim)))
+        # ag(tp)
+        input_tensor = input_tensor.redistribute(placements=(Shard(0), Replicate()))
+
+        # TODO: below is an ad hoc fix when _partition_fn results in 1D sharded param
+        input_tensor = input_tensor.to_local()
+        input_tensor = DTensor.from_local(
+            input_tensor, device_mesh["tp"], (Replicate(),)
+        )
+
+        return input_tensor
+
+    def _partition_fn(self, name, module, device_mesh):
+        # NOTE: the following code should work when FSDP is applied on the non-expert modules.
+        # module.register_parameter(
+        #     "gate_proj",
+        #     nn.Parameter(
+        #         distribute_tensor(module.gate_proj, device_mesh, [Shard(0), Shard(2)])
+        #     ),
+        # )  # Column-wise sharding
+        # module.register_parameter(
+        #     "down_proj",
+        #     nn.Parameter(
+        #         distribute_tensor(module.down_proj, device_mesh, [Shard(0), Shard(1)])
+        #     ),
+        # )  # Row-wise sharding
+        # module.register_parameter(
+        #     "up_proj",
+        #     nn.Parameter(
+        #         distribute_tensor(module.up_proj, device_mesh, [Shard(0), Shard(2)])
+        #     ),
+        # )  # Column-wise sharding
+
+        # NOTE: the following code works when FSDP is not applied.
+        # TODO: the above 2D sharding (only on experts) causes optimizer foreach to fail
+        # TODO: apply FSDP on the non-expert params should resolve the issue
+        module.register_parameter(
+            "gate_proj",
+            nn.Parameter(
+                DTensor.from_local(
+                    (
+                        distribute_tensor(
+                            module.gate_proj, device_mesh, [Shard(0), Shard(2)]
+                        ).to_local()
+                    ),
+                    device_mesh["tp"],
+                    (Shard(2),),
+                )
+            ),
+        )  # Column-wise sharding
+        module.register_parameter(
+            "down_proj",
+            nn.Parameter(
+                DTensor.from_local(
+                    (
+                        distribute_tensor(
+                            module.down_proj, device_mesh, [Shard(0), Shard(1)]
+                        ).to_local()
+                    ),
+                    device_mesh["tp"],
+                    (Shard(1),),
+                )
+            ),
+        )  # Row-wise sharding
+        module.register_parameter(
+            "up_proj",
+            nn.Parameter(
+                DTensor.from_local(
+                    (
+                        distribute_tensor(
+                            module.up_proj, device_mesh, [Shard(0), Shard(2)]
+                        ).to_local()
+                    ),
+                    device_mesh["tp"],
+                    (Shard(2),),
+                )
+            ),
+        )  # Column-wise sharding
+
+    @staticmethod
+    def _prepare_output_fn(sp_dim, mod, outputs, device_mesh):
+        # outputs of placements (Shard(0), Partial())
+
+        # TODO: below is an ad hoc fix when _partition_fn results in 1D sharded param
+        outputs = outputs.to_local()
+        outputs = DTensor.from_local(outputs, device_mesh, (Shard(0), Partial()))
+
+        # rs(tp)
+        outputs = outputs.redistribute(placements=(Shard(0), Shard(sp_dim)))
+        # a2a(ep)
+        outputs = outputs.redistribute(placements=(Shard(1), Shard(sp_dim)))
+        # a2a(tp)
+        outputs = outputs.redistribute(placements=(Shard(1), Shard(0)))
+
+        # NOTE: this is to cast output back to the TP mesh, so
+        # it can work with the output from the shared expert
+        outputs = DTensor.from_local(outputs.to_local(), device_mesh["tp"], (Shard(0),))
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return distribute_module(
+            module,
+            device_mesh,
+            self._partition_fn,
+            partial(self._prepare_input_fn, self.sp_dim),
+            partial(self._prepare_output_fn, self.sp_dim),
+        )

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -354,22 +354,8 @@ def apply_ep(
                 parallelize_module(
                     module=transformer_block.moe.experts,
                     device_mesh=dp_tp_mesh,
-                    parallelize_plan=ExpertTensorParallel(sp_dim=2),
+                    parallelize_plan=ExpertTensorParallel(),
                 )
-
-                from torch.distributed._composable.contract import (
-                    REGISTRY_KEY,
-                    RegistryItem,
-                )
-
-                def ignore_module_for_fully_shard(module: nn.Module):
-                    default_registry = {}
-                    registry = module.__dict__.setdefault(
-                        REGISTRY_KEY, default_registry
-                    )
-                    registry.setdefault("fully_shard", RegistryItem())
-
-                ignore_module_for_fully_shard(transformer_block.moe.experts)
 
                 if transformer_block.moe.shared_expert is not None:
                     _apply_tp_to_expert(transformer_block.moe.shared_expert, tp_mesh)

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -8,6 +8,7 @@
 # training techniques (e.g. activation checkpointing and compile) to the Llama model.
 
 from collections import defaultdict
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -64,6 +65,19 @@ def parallelize_llama(
             enable_float8=job_config.float8.enable_float8_linear,
             enable_async_tp=job_config.experimental.enable_async_tensor_parallel,
         )
+
+    ep_mode = job_config.experimental.expert_parallel_mode
+    apply_ep(
+        model,
+        ep_mode=ep_mode,
+        dp_mesh=world_mesh["dp"] if parallel_dims.dp_shard_enabled else None,
+        tp_mesh=world_mesh["tp"] if parallel_dims.tp_enabled else None,
+        dp_tp_mesh=(
+            world_mesh["dp", "tp"]
+            if parallel_dims.dp_shard_enabled and parallel_dims.tp_enabled
+            else None
+        ),
+    )
 
     if job_config.activation_checkpoint.mode != "none":
         apply_ac(model, job_config.activation_checkpoint)
@@ -228,6 +242,139 @@ def apply_tp(
         f"Applied {'Float8 ' if enable_float8 else ''}{'Async ' if enable_async_tp else ''}"
         "Tensor Parallelism to the model"
     )
+
+
+def apply_ep(
+    model: nn.Module,
+    ep_mode: str,
+    dp_mesh: Optional[DeviceMesh] = None,
+    tp_mesh: Optional[DeviceMesh] = None,
+    dp_tp_mesh: Optional[DeviceMesh] = None,
+):
+    from torch.distributed.tensor import Partial
+    from torchtitan.parallelisms.expert_parallel import (
+        _apply_tp_to_expert,
+        ExpertParallel,
+        ExpertTensorParallel,
+        PrepareModuleInputOutput,
+    )
+
+    for _, transformer_block in model.layers.items():
+        if ep_mode == "tp":
+            assert tp_mesh is not None
+            moe_plan = {
+                # input / output sharding on the seqlen dim
+                "moe": PrepareModuleInputOutput(
+                    input_layouts=(Shard(1),),
+                    desired_input_layouts=(Replicate(),),
+                    output_layouts=(Partial(),),
+                    desired_output_layouts=(Shard(1),),
+                ),
+                # Router Parallel, sharding on the expert dim
+                "moe.router.gate": ColwiseParallel(use_local_output=False),
+                # input / output sharding on the expert dim
+                "moe.experts": PrepareModuleInputOutput(
+                    input_layouts=(Shard(0),),
+                    desired_input_layouts=(Replicate(),),
+                    output_layouts=(Partial(),),
+                    desired_output_layouts=(Shard(0),),
+                    use_local_output=False,
+                ),
+            }
+            parallelize_module(
+                module=transformer_block,
+                device_mesh=tp_mesh,
+                parallelize_plan=moe_plan,
+            )
+
+            _apply_tp_to_expert(transformer_block.moe.experts, tp_mesh)
+            if transformer_block.moe.shared_expert is not None:
+                _apply_tp_to_expert(transformer_block.moe.shared_expert, tp_mesh)
+
+        elif ep_mode == "tp2ep":
+            assert tp_mesh is not None
+            moe_plan = {
+                # input / output sharding on the seqlen dim
+                "moe": PrepareModuleInputOutput(
+                    input_layouts=(Shard(1),),
+                    desired_input_layouts=(Replicate(),),
+                    output_layouts=(Partial(),),
+                    desired_output_layouts=(Shard(1),),
+                ),
+                # Router Parallel, sharding on the expert dim
+                "moe.router.gate": ColwiseParallel(use_local_output=False),
+                # input / output replicated
+                "moe.experts": ExpertParallel(),
+            }
+            parallelize_module(
+                module=transformer_block,
+                device_mesh=tp_mesh,
+                parallelize_plan=moe_plan,
+            )
+
+            if transformer_block.moe.shared_expert is not None:
+                _apply_tp_to_expert(transformer_block.moe.shared_expert, tp_mesh)
+
+        elif ep_mode == "dp2ep":
+            if not tp_mesh:
+                assert dp_mesh is not None
+                parallelize_module(
+                    module=transformer_block.moe.experts,
+                    device_mesh=dp_mesh,
+                    # input / output sharding on the tokens dim
+                    parallelize_plan=ExpertParallel(
+                        input_layouts=Shard(1),
+                        output_layouts=Shard(1),
+                        use_local_output=True,
+                    ),
+                )
+
+            else:  # dp2ep with TP
+                assert dp_tp_mesh is not None
+                moe_plan = {
+                    # input / output sharding on the seqlen dim
+                    "moe": PrepareModuleInputOutput(
+                        input_layouts=(Shard(1),),
+                        desired_input_layouts=(Replicate(),),
+                        # use_local_input=True,
+                        output_layouts=(Partial(),),
+                        desired_output_layouts=(Shard(1),),
+                    ),
+                    # Router Parallel, sharding on the expert dim
+                    # NOTE: need to use_local_output=False to be aware of shape
+                    #       during expert input tensor reshape
+                    "moe.router.gate": ColwiseParallel(use_local_output=False),
+                }
+                parallelize_module(
+                    module=transformer_block,
+                    device_mesh=tp_mesh,
+                    parallelize_plan=moe_plan,
+                )
+
+                parallelize_module(
+                    module=transformer_block.moe.experts,
+                    device_mesh=dp_tp_mesh,
+                    parallelize_plan=ExpertTensorParallel(sp_dim=2),
+                )
+
+                from torch.distributed._composable.contract import (
+                    REGISTRY_KEY,
+                    RegistryItem,
+                )
+
+                def ignore_module_for_fully_shard(module: nn.Module):
+                    default_registry = {}
+                    registry = module.__dict__.setdefault(
+                        REGISTRY_KEY, default_registry
+                    )
+                    registry.setdefault("fully_shard", RegistryItem())
+
+                ignore_module_for_fully_shard(transformer_block.moe.experts)
+
+                if transformer_block.moe.shared_expert is not None:
+                    _apply_tp_to_expert(transformer_block.moe.shared_expert, tp_mesh)
+
+    logger.info(f"Applied {ep_mode} Expert Parallelism to the model")
 
 
 # for selective op activation checkpointing

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -6,7 +6,7 @@ description = "Llama 3 debug training"
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = false
+enable_profiling = true
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = false
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 enable_color_printing = true
-enable_tensorboard = false
+enable_tensorboard = true
 save_tb_folder = "tb"
 
 [model]
@@ -58,7 +58,7 @@ async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
 mode = 'none'  # ['none', 'selective', 'full']
-selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
 [float8]
 enable_float8_linear = false

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -6,7 +6,7 @@ description = "Llama 3 debug training"
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = true
+enable_profiling = false
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = false
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 enable_color_printing = true
-enable_tensorboard = true
+enable_tensorboard = false
 save_tb_folder = "tb"
 
 [model]
@@ -45,6 +45,7 @@ dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
 context_parallel_degree = 1
 pipeline_parallel_degree = 1
 enable_async_tensor_parallel = false
+expert_parallel_mode = "dp2ep"
 
 [checkpoint]
 enable_checkpoint = false
@@ -56,8 +57,8 @@ export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = 'selective'  # ['none', 'selective', 'full']
-selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+mode = 'none'  # ['none', 'selective', 'full']
+selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
 [float8]
 enable_float8_linear = false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #714

The expert-choice MoE implementation is mostly from torchtune: https://github.com/pytorch/torchtune/pull/1902
The PR requires (ad hoc) changes to pytorch: https://github.com/pytorch/pytorch/pull/141937

Issue tracking:
- [ ] [dp2ep] how to apply FSDP only to the non-MoE modules? (for now need to comment out `fully_shard`)
- [ ] [dp2ep] `shard_dim_alltoall` not robust (especially during backward with more than 1D)
- [ ] [tp2ep] backward efficiency may not optimized (e.g. right now `aten.scatter.src` only supports [replicate](https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/_ops/_tensor_ops.py#L368) sharding prop)
- [ ] [tp2ep] using DTensor (e.g. in "tp2ep"), the backward `aten.scatter.src` requires `_allow_implicit_replication` (maybe because in backward some tensor is not generated as DTensor)
- [ ] some other issues tracked in https://github.com/pytorch/pytorch/pull/141937
- [ ] `torch.compile` fails on `torch.topk`

Haven't worked on
- softmax scoring instead of sigmoid (can be done similarly, would incur extra communications)
- part of DP (e.g. CP) to EP

Not considering
- shared expert overlapping
- token-choice MoE