### PR TITLE
Add checkpoint load step

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -49,7 +49,8 @@ export_dtype = "bfloat16"
 enable_checkpoint = true
 folder = "checkpoint"
 interval_type = "steps"
-interval = 5
+interval = 10
+load_step = 5
 model_weights_only = true
 export_dtype = "bfloat16"
 ```

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -480,7 +480,12 @@ class JobConfig:
                 0 is the default value.
             """,
         )
-
+        self.parser.add_argument(
+            "--checkpoint.load_step",
+            type=int,
+            default=0,
+            help="Load the checkpoint at the specified step. If 0, load the latest checkpoint.",
+        )
         # activation checkpointing configs
         self.parser.add_argument(
             "--activation_checkpoint.mode",

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -483,8 +483,8 @@ class JobConfig:
         self.parser.add_argument(
             "--checkpoint.load_step",
             type=int,
-            default=0,
-            help="Load the checkpoint at the specified step. If 0, load the latest checkpoint.",
+            default=-1,
+            help="Load the checkpoint at the specified step. If -1, load the latest checkpoint.",
         )
         # activation checkpointing configs
         self.parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -206,7 +206,7 @@ def main(job_config: JobConfig):
         logger.info("Created seed checkpoint")
         return
 
-    checkpoint_loaded = checkpoint.load()
+    checkpoint_loaded = checkpoint.load(step=job_config.checkpoint.load_step)
 
     if parallel_dims.pp_enabled and not checkpoint_loaded:
         # TODO: fix this by allowing each rank to set their own seed


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchtitan/issues/662

followed @fegin advice to test this and indeed things are working https://gist.github.com/msaroufim/2925b3f17b631bf370a49f185b6e169d

```
[checkpoint]
enable_checkpoint = true
folder = "checkpoint"
interval_type = "steps"
interval = 10
model_weights_only = false
export_dtype = "float32"
async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
load_step = 10
```

