### PR TITLE
Decouple seed from deterministic

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -394,8 +394,7 @@ class JobConfig:
         )
         self.parser.add_argument(
             "--training.deterministic",
-            type=bool,
-            default=False,
+            action="store_true",
             help="Enable the use of deterministic algorithms (can decrease performance)",
         )
         # checkpointing configs

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -392,6 +392,12 @@ class JobConfig:
             default=None,
             help="Implement reproducibility by setting a Python, PyTorch and CUDA seed",
         )
+        self.parser.add_argument(
+            "--training.deterministic",
+            type=bool,
+            default=False,
+            help="Enable the use of deterministic algorithms (can decrease performance)",
+        )
         # checkpointing configs
         self.parser.add_argument(
             "--checkpoint.enable_checkpoint",

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -52,18 +52,19 @@ def _warn_overwrite_env(env, val):
     os.environ[env] = val
 
 
-def set_determinism(seed: Optional[int]) -> None:
+def set_determinism(seed: Optional[int], deterministic: bool) -> None:
     """
     Set Python, PyTorch, CUDA seeds and cudnn settings for reproducibility
     """
     if seed is not None:
         # CPU and GPU determinism
         torch.manual_seed(seed)
+        # set Python seed
+        os.environ["PYTHONHASHSEED"] = str(seed)
+    if deterministic:
         # set deterministic cudnn algorithms
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-        # set Python seed
-        os.environ["PYTHONHASHSEED"] = str(seed)
         torch.use_deterministic_algorithms(True)
         # env var for deterministic CuBLAS
         # https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html

--- a/train.py
+++ b/train.py
@@ -42,14 +42,10 @@ def main(job_config: JobConfig):
     # take control of garbage collection to avoid stragglers
     gc_handler = utils.GarbageCollection(gc_freq=job_config.training.gc_freq)
 
-    # set determinisism, use seed == None to skip deterministic training
-    utils.set_determinism(job_config.training.seed)
-    if job_config.training.seed is None:
-        logger.info("Deterministic training off")
-    else:
-        logger.info(
-            f"Deterministic training on. Using seed: {job_config.training.seed}"
-        )
+    logger.info(
+        f"Deterministic training: {job_config.training.deterministic}. Using seed: {job_config.training.seed}"
+    )
+    utils.set_determinism(job_config.training.seed, job_config.training.deterministic)
 
     # init distributed
     world_size = int(os.environ["WORLD_SIZE"])


### PR DESCRIPTION
Using determinstic algorithms impacts performance.

Seeding can still be useful without deterministic, for instance to shuffle the data.

This PR proposes separating them instead of using `seed is not None` as a proxy