### PR TITLE
[cp] add option to choose kv shards rotation method

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -316,7 +316,7 @@ def build_test_list():
                 ]
             ],
             "CP (allgather)",
-            "cp allgather",
+            "cp_allgather",
             ngpu=4,
         ),
         OverrideDefinitions(
@@ -327,7 +327,7 @@ def build_test_list():
                 ]
             ],
             "CP (alltoall)",
-            "cp alltoall",
+            "cp_alltoall",
             ngpu=4,
         ),
         OverrideDefinitions(

--- a/test_runner.py
+++ b/test_runner.py
@@ -312,10 +312,22 @@ def build_test_list():
             [
                 [
                     "--experimental.context_parallel_degree=4",
+                    "--experimental.context_parallel_rotate_method='allgather'",
                 ]
             ],
-            "CP",
-            "cp",
+            "CP (allgather)",
+            "cp allgather",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--experimental.context_parallel_degree=4",
+                    "--experimental.context_parallel_rotate_method='alltoall'",
+                ]
+            ],
+            "CP (alltoall)",
+            "cp alltoall",
             ngpu=4,
         ),
         OverrideDefinitions(

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -365,6 +365,20 @@ class JobConfig:
             help="Context parallelism degree. 1 means disabled.",
         )
         self.parser.add_argument(
+            "--experimental.context_parallel_rotate_method",
+            type=str,
+            default="allgather",
+            help="""
+                The collective to use in context parallel SDPA for kv shards exchange.
+
+                'allgather' means to all-gather all kv shards on ranks,
+
+                'alltoall' means to all-to-all shuffle the kv shards.
+
+                The default value is 'allgather'.
+            """,
+        )
+        self.parser.add_argument(
             "--training.mixed_precision_param",
             type=str,
             default="bfloat16",

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -371,7 +371,7 @@ class JobConfig:
             help="""
                 The collective to use in context parallel SDPA for kv shards exchange.
 
-                'allgather' means to all-gather all kv shards on ranks,
+                'allgather' means to all-gather all kv shards on ranks after the first sub-SDPA computation,
 
                 'alltoall' means to all-to-all shuffle the kv shards.
 

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -166,15 +166,18 @@ def create_context_parallel_ctx(
     cp_buffers: List[torch.Tensor],
     cp_seq_dims: List[int],
     cp_no_restore_buffers: Set[torch.Tensor],
+    cp_rotate_method: str,
 ):
     try:
         from torch.distributed.tensor.experimental import context_parallel
+        from torch.distributed.tensor.experimental._attention import set_rotate_method
     except ImportError:
         print(
             f"PyTorch version {torch.__version__} does not include the experimental "
             "Context Parallel API. Please update to a newer version."
         )
 
+    set_rotate_method(cp_rotate_method)
     return context_parallel(
         cp_mesh,
         buffers=cp_buffers,

--- a/train.py
+++ b/train.py
@@ -264,6 +264,7 @@ def main(job_config: JobConfig):
                     cp_buffers=[input_ids, labels, model.freqs_cis],
                     cp_seq_dims=[1, 1, 0],
                     cp_no_restore_buffers={input_ids, labels},
+                    cp_rotate_method=job_config.experimental.context_parallel_rotate_method,
                 )
                 if parallel_dims.cp_enabled
                 else None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #728

**Summary**
https://github.com/pytorch/pytorch/pull/142093 adds a new API that allows user to choose a rotater method for RingAttention between "allgather" and "alltoall". This PR adds a new config in torchtitan for this feature along with test covering it.

**Test**
CI