### PR TITLE
Accessible config as dict

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -610,6 +610,9 @@ class JobConfig:
             action="store_true",
         )
 
+    def to_dict(self):
+        return self.args_dict
+
     def parse_args(self, args_list: list = sys.argv[1:]):
         args, cmd_args = self.parse_args_from_command_line(args_list)
         config_file = getattr(args, "job.config_file", None)
@@ -646,6 +649,8 @@ class JobConfig:
         for section, section_args in cmd_args_dict.items():
             for k, v in section_args.items():
                 args_dict[section][k] = v
+
+        self.args_dict = args_dict
 
         for k, v in args_dict.items():
             class_type = type(k.title(), (), v)

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -52,6 +52,7 @@ class JobConfig:
     """
 
     def __init__(self):
+        self.args_dict = None
         # main parser
         self.parser = argparse.ArgumentParser(description="torchtitan arg parser.")
 


### PR DESCRIPTION
Here is a PR to make it *a bit easier* to observe the configuration across different experiments. This is generally useful for MLOps to observe the exact configuration of your training run.

For example, this makes it easier for a user to extend the code and log the config in Weights & Biases:

```
wandb.init(config=job_config.to_dict())
```