### PR TITLE
Stream subprocess stdout

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -415,13 +415,7 @@ def build_test_list():
 
 
 def _run_cmd(cmd):
-    return subprocess.run(
-        [cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        shell=True,
-    )
+    return subprocess.run([cmd], text=True, shell=True)
 
 
 def run_test(test_flavor: OverrideDefinitions, full_path: str, output_dir: str):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #784
* __->__ #783

The integration tests do not output to terminal unless the process exits, which is a problem I hit when I had a hanging test and there was no output.

Due to setting `stdout=subprocess.PIPE`, this captures the standard output of the subprocess. The output is only printed after the process exits. If we dont set stdout `stdout=None`, then standard output is not captured; it is inherited from the parent process which is just the terminal and prints out normally.
