### PR TITLE
Dimdi y/extendable checkpointing

### DIFF
--- a/tests/unit_tests/test_checkpoint_manager.py
+++ b/tests/unit_tests/test_checkpoint_manager.py
@@ -1,0 +1,230 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Generator
+
+import pytest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.checkpoint.stateful import Stateful
+
+from torchtitan.checkpoint import CheckpointManager
+from torchtitan.config_manager import JobConfig
+
+
+class ModelDummy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(1, 1)
+        self.layer.weight = nn.Parameter(torch.ones(1, 1))
+
+    def forward(self, x):
+        return self.layer(x)
+
+
+class StatefulDummy(Stateful):
+    def __init__(self, state: Dict[str, Any]):
+        self.state = state
+
+    def state_dict(self):
+        return self.state
+
+    # simulate SchedulersContainer
+    def get_lr_scheduler_state(self):
+        return {"lr_scheduler": self}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        assert set(state_dict.keys()) == set(self.state.keys())
+        for k, v in state_dict.items():
+            self.state[k] = v
+
+    def __repr__(self) -> str:
+        return f"StatefulDummy({self.state})"
+
+
+class TestCheckpointManager:
+    @pytest.fixture
+    def job_config(self, tmp_path: Path) -> JobConfig:
+        config = JobConfig()
+        config.parse_args(["--job.config_file", "./train_configs/debug_model.toml"])
+
+        config.job.dump_folder = os.path.join(str(tmp_path), "output")
+        config.checkpoint.enable_checkpoint = True
+        config.checkpoint.async_mode = "disabled"
+        config.checkpoint.folder = "checkpoint"
+        config.checkpoint.interval_type = "steps"
+
+        return config
+
+    @pytest.fixture
+    def initial_state(self) -> Dict[str, Any]:
+        return dict(
+            dataloader=StatefulDummy({"dataloader": 1}),
+            # need cuda here because async checkpointing works incorrectly on CPU
+            # https://github.com/pytorch/pytorch/issues/144657
+            model_parts=ModelDummy().cuda(),
+            optimizers=StatefulDummy({"optimizer": 1}),
+            lr_schedulers=StatefulDummy({"lr_schedulers": 1}),
+        )
+
+    @pytest.fixture
+    def process_group(self, tmp_path) -> Generator[None, None, None]:
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "12345"
+        os.environ["LOCAL_RANK"] = "0"
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        dist.init_process_group()
+        yield None
+        dist.destroy_process_group(None)
+
+    def _set_state_values(self, state, value):
+        for part in state.values():
+            if isinstance(part, StatefulDummy):
+                for key in part.state.keys():
+                    part.state[key] = value
+            elif isinstance(part, ModelDummy):
+                with torch.no_grad():
+                    state["model_parts"].layer.weight.fill_(value)
+            else:
+                raise ValueError(
+                    f"expected StatefulDummy or ModelDummy, got {type(part)}"
+                )
+
+    def _check_state_values(self, state, value):
+        for part in state.values():
+            if isinstance(part, StatefulDummy):
+                for key in part.state.keys():
+                    assert part.state[key] == value, f"expected 1 for {key} state"
+            elif isinstance(part, ModelDummy):
+                assert state["model_parts"].layer.weight.data[0, 0] == value
+            else:
+                raise ValueError(
+                    f"expected StatefulDummy or ModelDummy, got {type(part)}"
+                )
+
+    def test_saveload(
+        self,
+        initial_state: Dict[str, Any],
+        job_config: JobConfig,
+        process_group: None,
+    ):
+        state = initial_state
+
+        manager = CheckpointManager(
+            **state,
+            states={},
+            job_config=job_config,
+        )
+
+        # nothing saved yet, nothing to load
+        assert not manager.load()
+
+        self._set_state_values(state, 10)
+        manager.save(10)
+        self._set_state_values(state, 11)
+
+        # should load step 10
+        assert manager.load()
+        self._check_state_values(state, 10)
+
+    def test_loading_last_checkpoint(
+        self,
+        initial_state: Dict[str, Any],
+        job_config: JobConfig,
+        process_group: None,
+    ):
+        state = initial_state
+
+        manager = CheckpointManager(
+            **state,
+            states={},
+            job_config=job_config,
+        )
+
+        # nothing saved yet, nothing to load
+        assert not manager.load()
+
+        for step in [20, 30, 200, 400]:
+            self._set_state_values(state, step)
+            manager.save(step)
+
+        # corrupt checkpoint 400
+        os.remove(os.path.join(manager._create_checkpoint_id(400), ".metadata"))
+
+        # no step passed means last successful checkpoint
+        assert manager.load()
+        self._check_state_values(state, 200)
+
+        # if an existing step passed, load it
+        assert manager.load(30)
+        self._check_state_values(state, 30)
+
+        # if a corrupted step passed, don't load
+        assert not manager.load(400)
+        self._check_state_values(state, 30)
+
+        # if a non-existant step passed, don't load
+        assert not manager.load(300)
+        self._check_state_values(state, 30)
+
+    def test_keep_latest_k(
+        self,
+        initial_state: Dict[str, Any],
+        job_config: JobConfig,
+        process_group: None,
+    ):
+        state = initial_state
+
+        job_config.checkpoint.keep_latest_k = 3
+        manager = CheckpointManager(
+            **state,
+            states={},
+            job_config=job_config,
+        )
+
+        steps = [0, 10, 20, 30, 40, 50]
+
+        for i, step in enumerate(steps):
+            self._set_state_values(state, step)
+            manager.save(step)
+
+            found = sorted(os.listdir(manager.folder))
+
+            expected_steps_left = steps[: i + 1][-job_config.checkpoint.keep_latest_k :]
+            assert found == [f"step-{step}" for step in expected_steps_left]
+
+    @pytest.mark.parametrize("async_mode", ["async", "async_with_pinned_mem"])
+    def test_async_modes(
+        self,
+        initial_state: Dict[str, Any],
+        job_config: JobConfig,
+        process_group: None,
+        async_mode: str,
+    ):
+        state = initial_state
+
+        job_config.checkpoint.async_mode = async_mode
+        manager = CheckpointManager(
+            **state,
+            states={},
+            job_config=job_config,
+        )
+
+        steps = [10, 20, 30, 40, 50]
+        for step in steps:
+            manager.maybe_wait_for_staging()
+            self._set_state_values(state, step)
+            # force on the last step to ensure the last checkpoint is written
+            manager.save(step, force=step == 50)
+
+        for step in steps:
+            assert manager.load(step)
+            self._check_state_values(state, step)

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -449,7 +449,10 @@ class CheckpointManager:
         return os.path.isfile(metadata_probe)
 
     def _discover_checkpointed_steps(self) -> List[int]:
-        """List steps that have their corresponding directories created
+        """List steps that have their corresponding directories created.
+
+        Failed checkpoints are also returned here,
+        existance of .metadata should be checked separately
 
         Can be overriden for compatibility with custom storage_reader/storage_writer
         """

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import dataclass, field
 from io import BytesIO
 from multiprocessing import get_context
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -25,6 +25,7 @@ from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
 )
 from torch.distributed.checkpoint.stateful import Stateful
+from torch.distributed.checkpoint.storage import StorageReader, StorageWriter
 from torch.utils.data import DataLoader
 from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
 from torchtitan.logging import init_logger, logger
@@ -105,7 +106,7 @@ class SaveDone:
     pass
 
 
-def checkpoint_mp(recv, send):
+def checkpoint_mp(recv, send, storage_writer):
     init_logger()
     os.environ["MASTER_PORT"] = str(int(os.environ["MASTER_PORT"]) + 2)
     os.environ["TORCHELASTIC_USE_AGENT_STORE"] = "False"
@@ -124,7 +125,11 @@ def checkpoint_mp(recv, send):
             assert isinstance(obj, tuple)
             begin = time.monotonic()
             state, checkpoint_id = obj
-            dcp.save(state, checkpoint_id=checkpoint_id)
+            dcp.save(
+                state,
+                checkpoint_id=checkpoint_id,
+                storage_writer=storage_writer,
+            )
             logger.info(
                 "Finish saving the checkpoint in the background process in "
                 f"{time.monotonic() - begin:.2f} seconds."
@@ -143,6 +148,8 @@ class CheckpointManager:
         lr_schedulers: SchedulersContainer,
         states: Dict[str, Any],
         job_config: JobConfig,
+        storage_reader: Optional[StorageReader] = None,
+        storage_writer: Optional[StorageWriter] = None,
     ) -> None:
         ckpt_config = job_config.checkpoint
         self.enable_checkpoint = ckpt_config.enable_checkpoint
@@ -187,7 +194,9 @@ class CheckpointManager:
         )
         self.states.update(lr_schedulers.get_lr_scheduler_state())
 
-        self.folder = os.path.join(job_config.job.dump_folder, ckpt_config.folder)
+        self.folder = self._get_folder_from_job_config(job_config)
+        self.storage_reader = storage_reader
+        self.storage_writer = storage_writer
         self.interval_type = (
             IntervalType.SECONDS
             if ckpt_config.interval_type == "seconds"
@@ -219,6 +228,7 @@ class CheckpointManager:
                 args=(
                     self.mp_queue_send,
                     self.mp_queue_recv,
+                    self.storage_writer,
                 ),
                 daemon=True,
             )
@@ -234,6 +244,16 @@ class CheckpointManager:
             f"Checkpointing active. Checkpoints will be loaded from and saved to {self.folder}"
         )
 
+    def _get_folder_from_job_config(self, job_config: JobConfig) -> str:
+        """Construct self.folder from job config.
+
+        Can be overriden for compatibility with custom storage_reader/storage_writer
+        """
+        return os.path.join(
+            job_config.job.dump_folder,
+            job_config.checkpoint.folder,
+        )
+
     def __del__(self):
         if self.enable_checkpoint and self.mp and self.mp.is_alive():
             self.mp_queue_send.put(Terminate())
@@ -243,6 +263,11 @@ class CheckpointManager:
         self.begin_time = time.monotonic()
 
     def _create_checkpoint_id(self, step: int) -> str:
+        """Convert step to checkpoint id acceptable by dcp.save
+
+        Can be overriden for compatibility with custom storage_reader/storage_writer
+        """
+
         return os.path.join(self.folder, f"step-{step}")
 
     def _save_last_step(self, curr_step: int) -> None:
@@ -274,7 +299,11 @@ class CheckpointManager:
         else:
             logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
 
-        dcp.save(self.states, checkpoint_id=self._create_checkpoint_id(curr_step))
+        dcp.save(
+            self.states,
+            checkpoint_id=self._create_checkpoint_id(curr_step),
+            storage_writer=self.storage_writer,
+        )
         self.reset()
 
     def _should_save(self, curr_step: int, force: bool = False) -> bool:
@@ -369,10 +398,17 @@ class CheckpointManager:
             self._async_with_pinned_memory(checkpoint_id)
         elif self.async_mode == AsyncMode.ASYNC:
             self.async_future = dcp.async_save(
-                self.states, checkpoint_id=checkpoint_id, process_group=self.pg
+                self.states,
+                checkpoint_id=checkpoint_id,
+                process_group=self.pg,
+                storage_writer=self.storage_writer,
             )
         else:
-            dcp.save(self.states, checkpoint_id=checkpoint_id)
+            dcp.save(
+                self.states,
+                checkpoint_id=checkpoint_id,
+                storage_writer=self.storage_writer,
+            )
         self.reset()
         self._purge_stale_checkpoints()
 
@@ -402,24 +438,53 @@ class CheckpointManager:
             sync_func()
             self.staging = False
 
+    def _check_checkpoint_exitsts(self, step: int) -> bool:
+        """Check if a checkpoint has been fully written for the corresponding step
+
+        Can be overriden for compatibility with custom storage_reader/storage_writer
+        """
+
+        checkpoint_id = self._create_checkpoint_id(step)
+        metadata_probe = os.path.join(checkpoint_id, ".metadata")
+        return os.path.isfile(metadata_probe)
+
+    def _discover_checkpointed_steps(self) -> List[int]:
+        """List steps that have their corresponding directories created
+
+        Can be overriden for compatibility with custom storage_reader/storage_writer
+        """
+        if not os.path.isdir(self.folder):
+            return []
+
+        discovered_steps = []
+        for filename in os.listdir(self.folder):
+            match = re.search(r"step-(\d+)", filename)
+            if not match:
+                continue
+            step = int(match.group(1))
+            discovered_steps.append(step)
+        if not discovered_steps:
+            return None
+        return discovered_steps
+
+    def _find_last_saved_step(self) -> Optional[int]:
+        all_steps = self._discover_checkpointed_steps()
+        fully_written_steps = list(filter(self._check_checkpoint_exitsts, all_steps))
+
+        return max(fully_written_steps, default=None)
+
     def load(self, step: int = -1) -> bool:
         if not self.enable_checkpoint:
             return False
-        if not os.path.isdir(self.folder):
-            return False
-        if step != -1 and not os.path.isdir(self._create_checkpoint_id(step)):
-            return False
 
         if step == -1:
-            step_counts = []
-            for filename in os.listdir(self.folder):
-                match = re.search(r"step-(\d+)", filename)
-                metadata_probe = os.path.join(self.folder, filename, ".metadata")
-                if match and os.path.isfile(metadata_probe):
-                    step_counts.append(int(match.group(1)))
-            if not step_counts:
+            last_step = self._find_last_saved_step()
+            if last_step is None:
                 return False
-            step = max(step_counts)
+            step = last_step
+
+        if not self._check_checkpoint_exitsts(step):
+            return False
 
         # We won't have optimizer states to load, if we are loading a seed checkpoint
         states = {"model": self.states["model"]} if step == 0 else self.states
@@ -437,6 +502,7 @@ class CheckpointManager:
         dcp.load(
             states,
             checkpoint_id=self._create_checkpoint_id(step),
+            storage_reader=self.storage_reader,
         )
         logger.info(
             f"Finished loading the checkpoint in {time.monotonic() - begin:.2f} seconds."
@@ -448,11 +514,10 @@ class CheckpointManager:
 
     def _purge_stale_checkpoints(self):
         if self.keep_latest_k > 0:
-            discovered_checkpoints = []
-            for filename in os.listdir(self.folder):
-                match = re.search(r"step-(\d+)", filename)
-                path = os.path.join(self.folder, filename)
-                discovered_checkpoints.append((int(match.group(1)), path))
+            discovered_checkpoints = [
+                (step, self._create_checkpoint_id(step))
+                for step in self._discover_checkpointed_steps()
+            ]
 
             discovered_checkpoints.sort()
             to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]


### PR DESCRIPTION
The goal of this PR is to make using custom `torch.distributed.checkpoint.storage.StorageReader/StorageWriter`s with torchtitan easier.
For example, using `S3StorageWriter` from [s3-connector-for-pytorch](https://github.com/awslabs/s3-connector-for-pytorch/#distributed-checkpoints) would allow storing checkpoints in AWS S3.

Two changes needed to be made to allow this:
1. Allow passing `storage_reader` and `storage_writer` into the `CheckpointManager`.
2. Isolate the usage of `os.path` module under overridable methods (as this logic is specific to the default `torch.distributed.checkpoint.filesystem.FileSystemReader/FileSystemWriter`).

I also added basic tests for CheckpointManager to make sure I didn't break the original behavior