### PR TITLE
[BE] Lr schduler flatten

### DIFF
--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -177,8 +177,7 @@ class CheckpointManager:
             TODO: This is currently unsolved and needs a fix.
         """
         self.states = states
-        for scheduler in lr_schedulers.schedulers:
-            print("sample: ", scheduler)
+
         self.states.update(
             {
                 "model": ModelWrapper(model_parts),
@@ -187,7 +186,6 @@ class CheckpointManager:
                 "lr_scheduler": lr_schedulers,
             }
         )
-        # self.states.update(lr_schedulers.get_lr_scheduler_state())
 
         self.folder = os.path.join(job_config.job.dump_folder, ckpt_config.folder)
         self.interval_type = (

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -177,15 +177,17 @@ class CheckpointManager:
             TODO: This is currently unsolved and needs a fix.
         """
         self.states = states
-
+        for scheduler in lr_schedulers.schedulers:
+            print("sample: ", scheduler)
         self.states.update(
             {
                 "model": ModelWrapper(model_parts),
                 "optimizer": optimizers,
                 "dataloader": dataloader,
+                "lr_scheduler": lr_schedulers,
             }
         )
-        self.states.update(lr_schedulers.get_lr_scheduler_state())
+        # self.states.update(lr_schedulers.get_lr_scheduler_state())
 
         self.folder = os.path.join(job_config.job.dump_folder, ckpt_config.folder)
         self.interval_type = (

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -182,7 +182,7 @@ class SchedulersContainer(Stateful):
     def state_dict(self) -> Dict[str, Any]:
         state_dict = {}
         for idx, lr_scheduler in enumerate(self.schedulers):
-            state_dict[f"lr_scheduler_{idx}"] = lr_scheduler
+            state_dict[f"lr_scheduler_{idx}"] = lr_scheduler.state_dict()
         return state_dict
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -189,8 +189,8 @@ class SchedulersContainer(Stateful):
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         # Load the same state_dict for all schedulers
-        for idx in range(len(self.schedulers)):
-            self.schedulers[idx].load_state_dict(state_dict)
+        for scheduler in self.schedulers:
+            scheduler.load_state_dict(state_dict)
 
 
 def build_lr_schedulers(optimizers, job_config: JobConfig) -> SchedulersContainer:

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -180,14 +180,17 @@ class SchedulersContainer(Stateful):
             scheduler.step()
 
     def state_dict(self) -> Dict[str, Any]:
-        state_dict = {}
-        for idx, lr_scheduler in enumerate(self.schedulers):
-            state_dict[f"lr_scheduler_{idx}"] = lr_scheduler.state_dict()
-        return state_dict
+        # Right now we have lr_scheduler with the same state_dict for all optimizers,
+        # so we can just save one.
+        assert (
+            len(self.schedulers) > 0
+        ), "Must have at least one scheduler to save state_dict"
+        return self.schedulers[0].state_dict()
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        # Load the same state_dict for all schedulers
         for idx in range(len(self.schedulers)):
-            self.schedulers[idx].load_state_dict(state_dict[f"lr_scheduler_{idx}"])
+            self.schedulers[idx].load_state_dict(state_dict)
 
 
 def build_lr_schedulers(optimizers, job_config: JobConfig) -> SchedulersContainer:

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -179,17 +179,6 @@ class SchedulersContainer:
         for scheduler in self.schedulers:
             scheduler.step()
 
-    def get_lr_scheduler_state(self) -> Dict[str, Any]:
-        state_dict = {}
-        if len(self.schedulers) == 1:
-            state_dict["lr_scheduler"] = self.schedulers[0]
-        else:
-            # For now, pipeline-parallel with looped schedules does not support resharding for lr_scheduler.
-            # It should only support saving and loading a distributed checkpoint with the same number of pp ranks
-            for idx, lr_scheduler in enumerate(self.schedulers):
-                state_dict[f"lr_scheduler_{idx}"] = lr_scheduler
-        return state_dict
-
 
 def build_lr_schedulers(optimizers, job_config: JobConfig) -> SchedulersContainer:
     warmup_steps = int(job_config.training.warmup_steps)

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -180,8 +180,7 @@ class SchedulersContainer(Stateful):
             scheduler.step()
 
     def state_dict(self) -> Dict[str, Any]:
-        # Right now we have lr_scheduler with the same state_dict for all optimizers,
-        # so we can just save one.
+        # We have lr_scheduler with the same state_dict for all optimizers, so can just save one.
         assert (
             len(self.schedulers) > 0
         ), "Must have at least one scheduler to save state_dict"


### PR DESCRIPTION
Currently, lr_scheduler is stored differently as optimizer, model and data_loader, with keys to be "lr_scheduler_0", "lr_scheduler_1", ... stored in the state
This PR aims to flatten lr_shceduler so that all the schedulers would be stored as a list of state_dict under self.state['lr_scheduler'], which is consistent with optimizer

Here we have the assumption that all the optimziers have the same lr_scheduler, thus only to save a single lr_scheduler's state_dict and load it to all the schedulers works here.

The lr_scheduler has the state_dict like:
`{'base_lrs': [0.0003], 'last_epoch': 1, 'verbose': False, '_step_count': 2, '_get_lr_called_within_step': False, '_last_lr': [2.985074626865671e-06], 'lr_lambdas': [{}]}`

The PR is tested by 2 parts:
1. test lr_scheduler value before and after checkpoint, resharding with degree changes on tp and pp.
[dp=2, tp=4, pp=1] -> [dp=2, tp=1, pp=4]
[dp=2, tp=1, pp=4] -> [dp=2, tp=4, pp=1]
date_loader does not support resharding right now.

logs:
[dp=2, tp=4, pp=1] 
step 5 before saving to checkpoint:
[{'lr': 8.955223880597014e-06, ...}]

step 10 after loading from checkpoint and reshard to [dp=2, tp=2, pp=2]:
[{'lr': 1.6417910447761194e-05, ...}, {'lr': 1.6417910447761194e-05, ...}]

[dp=8, tp=1, pp=1]
step 5 without checkpoint:
[{'lr': 8.955223880597014e-06, ...}]
step 10 without checkpoint:
[{'lr': 1.6417910447761194e-05, ...}]

2. Memory trace:
Before the flatten, rerun llama3_8b.toml from step 5 to step 10:
<img width="1166" alt="Screenshot 2025-01-16 at 2 40 03 PM" src="https://github.com/user-attachments/assets/d3e84d63-30be-4604-823b-68bd217498a0" />

After the flatten, rerun llama3_8b.toml from step 5 to step 10:
<img width="1166" alt="Screenshot 2025-01-16 at 2 40 21 PM" src="https://github.com/user-attachments/assets/b6ed68ae-2dbf-400a-b723-06eae6740ade" />
