### PR TITLE
Add force_recompute_fp8_weight_in_bwd when FSDP

### DIFF
--- a/torchtitan/float8.py
+++ b/torchtitan/float8.py
@@ -54,6 +54,7 @@ class Float8Handler:
         )
         self.config = Float8LinearConfig(
             enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
+            force_recompute_fp8_weight_in_bwd=parallel_dims.dp_shard_enabled
         )
 
         self.enabled = True


### PR DESCRIPTION
Turns on force_recompute_fp8_weight_in_bwd if we're in FSDP, to silence the warning noted in #821 