### PR TITLE
Avoid using skip() in hf_datasets

### DIFF
--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -9,15 +9,15 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
+
+from datasets import Dataset, load_dataset
+from datasets.distributed import split_dataset_by_node
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from torchtitan.datasets.tokenizer import Tokenizer
 from torchtitan.logging import logger
-
-from datasets import Dataset, load_dataset
-from datasets.distributed import split_dataset_by_node
 
 
 def _load_c4_dataset(dataset_path: str):

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -99,13 +99,12 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         self._all_tokens: List[int] = []
 
     def _get_data_iter(self):
-        if self._sample_idx == 0:
-            return iter(self._data)
-
         if isinstance(self._data, Dataset) and self._sample_idx == len(self._data):
             return iter([])
 
-        return iter(self._data.skip(self._sample_idx))
+        for _ in range(self._sample_idx):
+            next(iter(self._data))
+        return iter(self._data)
 
     def __iter__(self):
         max_buffer_token_len = 1 + self.seq_len

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -102,10 +102,11 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         if isinstance(self._data, Dataset) and self._sample_idx == len(self._data):
             return iter([])
 
+        it = iter(self._data)
         for _ in range(self._sample_idx):
-            next(iter(self._data))
+            next(it)
 
-        return iter(self._data)
+        return it
 
     def __iter__(self):
         max_buffer_token_len = 1 + self.seq_len

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -104,6 +104,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
 
         for _ in range(self._sample_idx):
             next(iter(self._data))
+
         return iter(self._data)
 
     def __iter__(self):

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -103,6 +103,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
             return iter([])
 
         it = iter(self._data)
+
         for _ in range(self._sample_idx):
             next(it)
 

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -103,10 +103,8 @@ class HuggingFaceDataset(IterableDataset, Stateful):
             return iter([])
 
         it = iter(self._data)
-
         for _ in range(self._sample_idx):
             next(it)
-
         return it
 
     def __iter__(self):


### PR DESCRIPTION
Fix issue https://github.com/pytorch/torchtitan/issues/809

The current `self._data.skip(self._sample_idx)` could not get the correct data for c_4 dataset.
Thus we switch to next() first before the fix is landed.

Test plan:
We reproduce the https://github.com/pytorch/torchtitan/issues/809 by resuming from checkpoint at step 500, then compare the loss curve in 3 conditions:
1. the origin curve running from step 0 to 750
2. the resumed curve keeping .skip()
3. the resumed curve switch to next(), with this PR change
<img width="354" alt="Screenshot 2025-02-12 at 11 19 24 AM" src="https://github.com/user-attachments/assets/0ad38637-a071-4f8c-9c4c-5cfd8699ad93" />


Warning
for c_4 dataset, if we resume from a large enough step, we call next() for `self._sample_idx` times, resuming from checkpoint would be much slower than using .skip()

Next step:
add unit test:
1. test the state_dict check between dcp.save/load and torch.save/load
2. test the difference between next() and .skip() 
