### PR TITLE
Do GC collect after dcp.save and dcp.load

### DIFF
--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -6,7 +6,6 @@
 
 import enum
 import functools
-import gc
 import os
 import re
 import shutil

--- a/torchtitan/checkpoint.py
+++ b/torchtitan/checkpoint.py
@@ -464,7 +464,7 @@ class CheckpointManager:
         # bugfix from above: restore the original stateful objects,
         # whose states were already updated in-place by dcp.load()
         states.update(original_stateful_states)
-        gc.collect(1)
+        GarbageCollection.collect("GC collection for checkpoint loading.")
         return True
 
     def _purge_stale_checkpoints(self):

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -163,11 +163,16 @@ class GarbageCollection:
         assert gc_freq > 0, "gc_freq must be a positive integer"
         self.gc_freq = gc_freq
         gc.disable()
-        gc.collect(1)
+        self.collect("Initial GC collection.")
 
     def run(self, step_count):
         if step_count > 1 and step_count % self.gc_freq == 0:
-            gc.collect(1)
+            self.collect("Peforming periodical GC collection.")
+
+    @staticmethod
+    def collect(reason: str):
+        logger.info(reason)
+        gc.collect(1)
 
 
 TRACE_BUFFER_SIZE = "TORCH_NCCL_TRACE_BUFFER_SIZE"


### PR DESCRIPTION
We disable auto gc and manually perform GC every 50 steps. This can cause issues when checkpointing frequence is smaller than GC frequency.

This PR change checkpoint manager to call GC when a save or load happens.