### PR TITLE
2 small fixes: more robust Embedding params count & ModelProtocol typing issue.

### DIFF
--- a/torchtitan/train_spec.py
+++ b/torchtitan/train_spec.py
@@ -36,8 +36,8 @@ class ModelProtocol(Protocol):
     required by the TorchTitan trainer.
     """
 
-    @staticmethod
-    def from_model_args(args: BaseModelArgs) -> nn.Module:
+    @classmethod
+    def from_model_args(cls, args: BaseModelArgs) -> nn.Module:
         ...
 
 

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -275,7 +275,7 @@ def init_distributed(job_config):
 def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
-        num_params -= sum(p.numel() for p  in model.tok_embeddings.parameters())
+        num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
     return num_params
 
 

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -275,7 +275,7 @@ def init_distributed(job_config):
 def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
-        num_params -= model.tok_embeddings.weight.numel()
+        num_params -= sum(p.numel() for p  in model.tok_embeddings.parameters())
     return num_params
 
 


### PR DESCRIPTION
Hi, thanks for sharing this great repo.

I just have some small fixes while working on my fork that I think would make sense to send back here as 

1. Make the Embedding parameters count more robust. We now use the same looping logic `p.numel() for p in model.parameters()` as above, instead of accessing the module's weight directly. It would help if models have nested Embedding modules for trainable and frozen embeddings.
2.Fix typing issue in the ModelProtocol where from_model_args should be a classmethod and takes cls as fist arg, since we will return the model via cls(model_args).