### PR TITLE
Adding `loss_fn` to `TrainSpec` model datastructure.

### DIFF
--- a/scripts/estimate/estimation.py
+++ b/scripts/estimate/estimation.py
@@ -89,12 +89,6 @@ def estimate_memory(job_config: JobConfig):
         job_config.experimental.enable_compiled_autograd,
     )
 
-    # loss fn can be shared by pipeline-parallel or non-pp execution
-    def loss_fn(pred, labels):
-        return torch.nn.functional.cross_entropy(
-            pred.flatten(0, 1).float(), labels.flatten(0, 1)
-        )
-
     # build model (using meta init)
     model_cls = train_spec.cls
     model_config = train_spec.config[job_config.model.flavor]
@@ -159,7 +153,7 @@ def estimate_memory(job_config: JobConfig):
                 # train step
                 with train_context():
                     pred = model(input_ids)
-                    loss = loss_fn(pred, labels)
+                    loss = train_spec.loss_fn(pred, labels)
                     del pred
                     loss.backward()
 

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -12,7 +12,11 @@ import torch.nn as nn
 from torchtitan.config_manager import JobConfig
 from torchtitan.datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer import TikTokenizer
-from torchtitan.models.llama import parallelize_llama, pipeline_llama
+from torchtitan.models.llama import (
+    loss_cross_entropy,
+    parallelize_llama,
+    pipeline_llama,
+)
 from torchtitan.optimizer import (
     build_lr_schedulers,
     build_optimizers,
@@ -64,6 +68,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
+            loss_fn=loss_cross_entropy,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake")
@@ -84,6 +89,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
+            loss_fn=loss_cross_entropy,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake2")

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -12,11 +12,8 @@ import torch.nn as nn
 from torchtitan.config_manager import JobConfig
 from torchtitan.datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer import TikTokenizer
-from torchtitan.models.llama import (
-    loss_cross_entropy,
-    parallelize_llama,
-    pipeline_llama,
-)
+from torchtitan.loss import cross_entropy_loss
+from torchtitan.models.llama import parallelize_llama, pipeline_llama
 from torchtitan.optimizer import (
     build_lr_schedulers,
     build_optimizers,
@@ -68,7 +65,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
-            loss_fn=loss_cross_entropy,
+            loss_fn=cross_entropy_loss,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake")
@@ -89,7 +86,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
-            loss_fn=loss_cross_entropy,
+            loss_fn=cross_entropy_loss,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake2")

--- a/torchtitan/loss.py
+++ b/torchtitan/loss.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+def cross_entropy_loss(pred, labels):
+    """Common cross-entropy loss function for Transformer models training."""
+    return torch.nn.functional.cross_entropy(
+        pred.flatten(0, 1).float(), labels.flatten(0, 1)
+    )
+
+
+# TODO: compiling loss function causes CUDA errors, turning off for now
+# cross_entropy_loss = torch.compile(cross_entropy_loss)

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -8,11 +8,8 @@
 
 from torchtitan.datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer import TikTokenizer
-from torchtitan.models.llama.model import (
-    loss_cross_entropy,
-    Transformer,
-    TransformerModelArgs,
-)
+from torchtitan.loss import cross_entropy_loss
+from torchtitan.models.llama.model import Transformer, TransformerModelArgs
 from torchtitan.optimizer import build_lr_schedulers, build_optimizers
 from torchtitan.train_spec import register_train_spec, TrainSpec
 
@@ -73,6 +70,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         tokenizer_cls=TikTokenizer,
-        loss_fn=loss_cross_entropy,
+        loss_fn=cross_entropy_loss,
     )
 )

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -8,7 +8,11 @@
 
 from torchtitan.datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer import TikTokenizer
-from torchtitan.models.llama.model import Transformer, TransformerModelArgs
+from torchtitan.models.llama.model import (
+    loss_cross_entropy,
+    Transformer,
+    TransformerModelArgs,
+)
 from torchtitan.optimizer import build_lr_schedulers, build_optimizers
 from torchtitan.train_spec import register_train_spec, TrainSpec
 
@@ -69,5 +73,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         tokenizer_cls=TikTokenizer,
+        loss_fn=loss_cross_entropy,
     )
 )

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -460,10 +460,3 @@ class Transformer(nn.Module, ModelProtocol):
 
         """
         return cls(model_args)
-
-
-def loss_cross_entropy(pred, labels):
-    """Common cross-entropy loss function for Transformer models training."""
-    return torch.nn.functional.cross_entropy(
-        pred.flatten(0, 1).float(), labels.flatten(0, 1)
-    )

--- a/torchtitan/models/llama/model.py
+++ b/torchtitan/models/llama/model.py
@@ -460,3 +460,10 @@ class Transformer(nn.Module, ModelProtocol):
 
         """
         return cls(model_args)
+
+
+def loss_cross_entropy(pred, labels):
+    """Common cross-entropy loss function for Transformer models training."""
+    return torch.nn.functional.cross_entropy(
+        pred.flatten(0, 1).float(), labels.flatten(0, 1)
+    )

--- a/torchtitan/train_spec.py
+++ b/torchtitan/train_spec.py
@@ -9,6 +9,7 @@
 from dataclasses import dataclass
 from typing import Callable, Protocol, Type, TypeAlias
 
+import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 
@@ -48,6 +49,7 @@ OptimizerBuilderWrapper: TypeAlias = Callable[
     [list[nn.Module], JobConfig, OptimizersContainer], OptimizersContainer
 ]
 LRSchedulersBuilder: TypeAlias = Callable[[OptimizersContainer], LRSchedulersContainer]
+LossFn: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 @dataclass
@@ -63,6 +65,7 @@ class TrainSpec:
     build_lr_schedulers_fn: LRSchedulersBuilder
     build_dataloader_fn: DataLoaderBuilder
     tokenizer_cls: Type[Tokenizer]
+    loss_fn: LossFn
 
     # TODO: Add a FQN convert fn to allow users to load checkpoints from
     # HuggingFace or other sources that have different FQN conventions.

--- a/torchtitan/train_spec.py
+++ b/torchtitan/train_spec.py
@@ -49,7 +49,7 @@ OptimizerBuilderWrapper: TypeAlias = Callable[
     [list[nn.Module], JobConfig, OptimizersContainer], OptimizersContainer
 ]
 LRSchedulersBuilder: TypeAlias = Callable[[OptimizersContainer], LRSchedulersContainer]
-LossFn: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+LossFunction: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 @dataclass
@@ -65,7 +65,7 @@ class TrainSpec:
     build_lr_schedulers_fn: LRSchedulersBuilder
     build_dataloader_fn: DataLoaderBuilder
     tokenizer_cls: Type[Tokenizer]
-    loss_fn: LossFn
+    loss_fn: LossFunction
 
     # TODO: Add a FQN convert fn to allow users to load checkpoints from
     # HuggingFace or other sources that have different FQN conventions.

--- a/train.py
+++ b/train.py
@@ -123,11 +123,7 @@ def main(job_config: JobConfig):
     )
 
     # loss function to be shared by Pipeline Parallel and SPMD training
-    def loss_fn(pred, labels):
-        return torch.nn.functional.cross_entropy(
-            pred.flatten(0, 1).float(), labels.flatten(0, 1)
-        )
-
+    loss_fn = train_spec.loss_fn
     # TODO: compiling loss function causes CUDA errors, turning off for now
     # if job_config.training.compile:
     #     loss_fn = torch.compile(loss_fn)


### PR DESCRIPTION
Allowing for more flexibility in the training by adapting the loss function (e.g. label smoothing, auxilary loss term, ...).