### PR TITLE
Add a prefix to titan logs

### DIFF
--- a/torchtitan/logging.py
+++ b/torchtitan/logging.py
@@ -16,7 +16,7 @@ def init_logger():
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        "[titan] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     ch.setFormatter(formatter)
     logger.addHandler(ch)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #860

As title, Sometimes, we have logs from different modules and components. Adding a prefix will give us a way to grep titan related logs.

<img width="457" alt="image" src="https://github.com/user-attachments/assets/5a61bc5c-8b2e-483b-a1ab-926418bbc5a6" />
