### PR TITLE
Configure arbitrary frozen modules via config

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -209,6 +209,16 @@ class JobConfig:
                 which can be found here: https://github.com/pytorch/ao
             """,
         )
+        self.parser.add_argument(
+            "--model.frozen_modules",
+            type=string_list,
+            nargs="+",
+            default=[],
+            help="""
+                Comma separated list of modules's FQN to be frozen inside the model. For example:
+                --model.frozen_modules=`tok_embeddings,layers.0.attention`
+            """,
+        )
 
         # optimizer configs
         self.parser.add_argument(

--- a/torchtitan/utils.py
+++ b/torchtitan/utils.py
@@ -272,8 +272,10 @@ def init_distributed(job_config):
     )
 
 
-def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
+def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False, exclude_frozen: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
+    if exclude_frozen:
+        num_params -= sum(p.numel() for p in model.parameters() if not p.requires_grad)
     if exclude_embedding:
         num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
     return num_params

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -27,6 +27,7 @@ norm_type = "rmsnorm"  # layernorm / np_layernorm / rmsnorm
 # test tokenizer.model, for debug purpose only
 tokenizer_path = "./tests/assets/test_tiktoken.model"
 # converters = "float8"
+# frozen_modules = "tok_embeddings,layers.0.attention"
 
 [optimizer]
 name = "AdamW"


### PR DESCRIPTION
I saw there is an issue about this #306 but it has not been implemented yet so I created this PR.

It allow you to specify a list of modules to be frozen via config file or command line, like: `--model.frozen_modules='tok_embeddings,layers.0.attention'`

Also print the number of frozen and trainable parameters during initialization.
- No frozen modules.
![Screenshot 2025-02-20 at 16 36 26](https://github.com/user-attachments/assets/83b9f5c8-13ff-44d7-881f-2ad35445cb99)
- `[model] frozen_modules = 'tok_embeddings,tik_embeddings,layers.0.attention'`
![Screenshot 2025-02-20 at 16 40 45](https://github.com/user-attachments/assets/0119b356-bde8-4594-980b-d163a8bc1fe4)

Hope this help. 