### PR TITLE
Create logging directory

### DIFF
--- a/torchtitan/metrics.py
+++ b/torchtitan/metrics.py
@@ -208,7 +208,10 @@ def build_metric_logger(
         base_log_dir = os.path.join(
             base_log_dir, f"rank_{torch.distributed.get_rank()}"
         )
-
+    
+    # Create logging directory
+    os.makedirs(base_log_dir, exist_ok=True)
+    
     # Create loggers in priority order
     if metrics_config.enable_wandb:
         logger.debug("Attempting to create WandB logger")


### PR DESCRIPTION
The logging directory path was set up but the directory was not created.
In the  case of Wandb Logger, this caused the following:
```
[rank0]:wandb: WARNING Path ./outputs/tb/20250220-1829/wandb/ wasn't writable, using system temp directory.
```
With this addition, the wandb logging is properly set to ``` ./outputs/tb/20250220-1829/wandb```