### PR TITLE
Create logging directory in wandb logger

### DIFF
--- a/torchtitan/metrics.py
+++ b/torchtitan/metrics.py
@@ -133,6 +133,9 @@ class WandBLogger(BaseLogger):
         self.wandb = wandb
         self.tag = tag
 
+        # Create logging directory
+        os.makedirs(log_dir, exist_ok=True)
+
         self.wandb.init(
             project="torchtitan",
             dir=log_dir,


### PR DESCRIPTION
The logging directory path was set up but the directory was not created.
In the  case of Wandb Logger, this caused the following:
```
[rank0]:wandb: WARNING Path ./outputs/tb/20250220-1829/wandb/ wasn't writable, using system temp directory.
```
With this addition, the wandb logging is properly set to ``` ./outputs/tb/20250220-1829/wandb```