### PR TITLE
checkpoint folder by model name and flavor

### DIFF
--- a/scripts/generate/run_llama_generate.sh
+++ b/scripts/generate/run_llama_generate.sh
@@ -13,7 +13,7 @@ set -e
 NGPU=${NGPU:-"1"}
 LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama/train_configs/debug_model.toml"}
-CHECKPOINT_DIR=${CHECKPOINT_DIR:-"./outputs/checkpoint/"}
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-"./outputs/checkpoint/llama3_debugmodel/"}
 PROMPT=${PROMPT:-""}
 
 overrides=()

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -485,7 +485,7 @@ def run_test(test_flavor: OverrideDefinitions, full_path: str, output_dir: str):
         if test_name == "test_generate" and idx == 1:
             cmd = (
                 f"CONFIG_FILE={full_path} NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} "
-                f"CHECKPOINT_DIR={output_dir}/{test_name}/checkpoint/step-10 "
+                f"CHECKPOINT_DIR={output_dir}/{test_name}/checkpoint/llama3_{test_flavor.model_flavor}/step-10 "
                 "PROMPT='What is the meaning of life?' "
                 f"./scripts/generate/run_llama_generate.sh --out > {output_dir}/{test_name}/generated_output.json"
             )

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -308,7 +308,11 @@ class CheckpointManager:
         self.cpu_offload_state_dict = None
         self.staging_stream = torch.cuda.Stream() if self.enable_staging else None
 
-        self.folder = os.path.join(job_config.job.dump_folder, ckpt_config.folder)
+        self.folder = os.path.join(
+            job_config.job.dump_folder,
+            ckpt_config.folder,
+            f"{job_config.model.name}_{job_config.model.flavor}",
+        )
         self.interval = ckpt_config.interval
         async_mode = ckpt_config.async_mode.lower()
         if async_mode == AsyncMode.ASYNC or self.ft_manager:


### PR DESCRIPTION
When training different models, checkpointing loads from the folder:
"job_config.job.dump_folder / ckpt_config.folder"
If the user does not explicitly change the default folders in the config, the CheckpointManager will attempt to save/load models from the same path. This leads to mismatch errors.
I suggest here to impose some structure at least by model name and flavor.
Another alternative is to classify by datetime as in here
https://github.com/pytorch/torchtitan/blob/82afc842e303e49d1a137fc7ea48291a57f72d5d/torchtitan/tools/metrics.py#L207C23-L207C88

However, this might not be in line with the way you see the checkpoint structure, in which case you can ignore this PR.