### PR TITLE
use Fused AdamW as default

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -268,11 +268,20 @@ def build_test_list():
             [
                 [
                     "--optimizer.name AdamW --optimizer.implementation foreach",
+                ]
+            ],
+            "Foreach Optimizer Test",
+            "optimizer_foreach",
+            ngpu=2,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--optimizer.name AdamW --optimizer.implementation fused",
                 ]
             ],
-            "Fused and Foreach Optimizer Test",
-            "optimizer_fused_and_foreach",
+            "Fused Optimizer Test",
+            "optimizer_fused",
             ngpu=2,
         ),
         OverrideDefinitions(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -277,16 +277,6 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--optimizer.name AdamW --optimizer.implementation fused",
-                ]
-            ],
-            "Fused Optimizer Test",
-            "optimizer_fused",
-            ngpu=2,
-        ),
-        OverrideDefinitions(
-            [
-                [
                     "--training.data_parallel_shard_degree=1",
                     "--training.data_parallel_replicate_degree=4",
                 ]

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -267,11 +267,13 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--optimizer.name Adam --optimizer.fused",
-                    "--optimizer.name AdamW --optimizer.fused",
+                    "--optimizer.name AdamW --optimizer.implementation foreach",
+                    "--optimizer.name AdamW --optimizer.implementation fused",
                 ]
             ],
-            "Fused Optimizer Test",
+            "Fused and Foreach Optimizer Test",
+            "optimizer_fused_and_foreach",
+            ngpu=2,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -210,8 +210,7 @@ def build_optimizers(
 
     fused = optim_implementation == "fused"
     foreach = optim_implementation == "foreach"
-    print(f"Using {optim_implementation} implementation for optimizer")
-    print(f"{foreach=}, {fused=}")
+
     optimizer_kwargs = {
         "lr": lr,
         "betas": (0.9, 0.95),

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -205,6 +205,8 @@ def build_optimizers(
     name = job_config.optimizer.name
     lr = job_config.optimizer.lr
     fused = job_config.optimizer.fused
+    if job_config.optimizer.disable_fused:
+        fused = False
     optimizer_kwargs = {
         "lr": lr,
         "betas": (0.9, 0.95),

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -204,15 +204,20 @@ def build_optimizers(
         )
     name = job_config.optimizer.name
     lr = job_config.optimizer.lr
-    fused = job_config.optimizer.fused
-    if job_config.optimizer.disable_fused:
-        fused = False
+
+    optim_implementation = job_config.optimizer.implementation
+    assert optim_implementation in ["fused", "foreach", "for-loop"]
+
+    fused = optim_implementation == "fused"
+    foreach = optim_implementation == "foreach"
+    print(f"Using {optim_implementation} implementation for optimizer")
+    print(f"{foreach=}, {fused=}")
     optimizer_kwargs = {
         "lr": lr,
         "betas": (0.9, 0.95),
         "weight_decay": 0.1,
         "fused": fused,
-        "foreach": not fused,
+        "foreach": foreach,
     }
 
     return (

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -218,15 +218,17 @@ class JobConfig:
             "--optimizer.lr", type=float, default=8e-4, help="Learning rate to use"
         )
         self.parser.add_argument(
-            "--optimizer.fused",
-            action="store_true",
-            default=True,
-            help="Whether the fused implementation(CUDA only) is used.",
-        )
-        self.parser.add_argument(
-            "--optimizer.disable_fused",
-            action="store_true",
-            help="Whether the fused implementation(CUDA only) is used.",
+            "--optimizer.implementation",
+            type=str,
+            default="fused",
+            choices=["for-loop", "foreach", "fused"],
+            help="""
+            Specify which optimizer implementation to use:
+            - 'fused': Use fused implementation (CUDA only) for best performance.
+            - 'foreach': Use some horizontal fusion of tensors for better performance.
+            - 'for-loop': Use the default implementation for the optimizer (slowest).
+            - more info: https://pytorch.org/docs/stable/optim.html
+            """,
         )
         self.parser.add_argument(
             "--optimizer.early_step_in_backward",

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -220,6 +220,7 @@ class JobConfig:
         self.parser.add_argument(
             "--optimizer.fused",
             action="store_true",
+            default=True,
             help="Whether the fused implementation(CUDA only) is used.",
         )
         self.parser.add_argument(

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -224,6 +224,11 @@ class JobConfig:
             help="Whether the fused implementation(CUDA only) is used.",
         )
         self.parser.add_argument(
+            "--optimizer.disable_fused",
+            action="store_true",
+            help="Whether the fused implementation(CUDA only) is used.",
+        )
+        self.parser.add_argument(
             "--optimizer.early_step_in_backward",
             action="store_true",
             help="""


### PR DESCRIPTION
Currently Titan does not use Fused AdamW as default.
This PR makes Fused the new default.

After investigating current parallelisms using Llama 8B, I found an average speedup of 2.64% as follows:

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Fused AdamW | FSDP, eager | 2.24%
-- | -- | --
8B | FSDP, compile | 1.63%
  | TP | 3.62%
  | AsyncTP | 3.26%
  | CP | 2.97%
(debug model)  | PP | 2.10%
  |   |  
Gains | Average | 2.64%
  | Min | 1.63%
  | Max | 3.62%

Updated to add --optimizer.implementation with ["for-loop", "foreach" and "fused"] support.

Testing:
beyond verifying no issues with all parallelisms above, verified that fused/foreach/ for-loop is being set with the new default config:
~~~
[rank0]:Using foreach implementation for optimizer
[rank0]:foreach=True, fused=False
~~~
~~~
[rank0]:Using for-loop implementation for optimizer
[rank0]:foreach=False, fused=False
~~~
~~~
[rank0]:Using fused implementation for optimizer
[rank0]:foreach=False, fused=True
~~~