### PR TITLE
Enable FlexAttention for llama model

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -299,6 +299,18 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
+                    "--parallelism.data_parallel_shard_degree=4",
+                    "--activation_checkpoint.mode='full'",
+                    "--model.use_flex_attn",
+                ]
+            ],
+            "FSDP+FLEX_ATTN",
+            "fsdp+flex_attn",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--parallelism.context_parallel_degree=4",
                     "--parallelism.context_parallel_rotate_method='allgather'",
                 ]

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -194,6 +194,11 @@ class JobConfig:
             help="Type of layer normalization to use [layernorm, np_layernorm, rmsnorm]",
         )
         self.parser.add_argument(
+            "--model.use_flex_attn",
+            action="store_true",
+            help="Whether to use Flex Attention.",
+        )
+        self.parser.add_argument(
             "--model.tokenizer_path",
             type=str,
             default="./assets/tokenizer/original/tokenizer.model",

--- a/torchtitan/models/llama/parallelize_llama.py
+++ b/torchtitan/models/llama/parallelize_llama.py
@@ -73,6 +73,14 @@ def parallelize_llama(
         )
 
     if job_config.activation_checkpoint.mode != "none":
+        if (
+            job_config.activation_checkpoint.mode == "selective"
+            and job_config.model.use_flex_attn
+        ):
+            raise ValueError(
+                "FlexAttention is not compatible with selective AC yet. "
+                "See https://github.com/pytorch/pytorch/issues/147879"
+            )
         apply_ac(model, job_config.activation_checkpoint)
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -147,6 +147,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         model_config.norm_type = job_config.model.norm_type
         model_config.vocab_size = tokenizer.n_words
         model_config.max_seq_len = job_config.training.seq_len
+        model_config.use_flex_attn = job_config.model.use_flex_attn
 
         logger.info(
             f"Building {self.train_spec.name} {job_config.model.flavor} with {model_config}"


### PR DESCRIPTION
Summary: This PR enables using FlexAttention for llama model.

Differential Revision: D70186496

SDPA
```
[rank2]:[titan] 2025-03-20 00:15:44,653 - root - INFO - step: 20  loss:  8.4828  memory: 36.06GiB(45.56%)  tps: 2,546  tflops: 147.44  mfu: 47.26%
```
FlexAttention
```
[rank0]:[titan] 2025-03-20 00:38:14,024 - root - INFO - step: 20  loss:  8.4238  memory: 36.06GiB(45.56%)  tps: 2,168  tflops: 125.53  mfu: 40.23%
```
FlexAttention + max auto tune without cuda graph
```
[rank0]:[titan] 2025-03-20 00:33:37,008 - root - INFO - step: 20  loss:  8.5293  memory: 36.75GiB(46.43%)  tps: 2,421  tflops: 140.20  mfu: 44.94%
```