### PR TITLE
[Metrics] Don't rely on `tensorboard` dep & allow getting project nam…

### DIFF
--- a/torchtitan/tools/metrics.py
+++ b/torchtitan/tools/metrics.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import torch
-from torch.utils.tensorboard import SummaryWriter
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
@@ -110,6 +109,8 @@ class TensorBoardLogger(BaseLogger):
     """Logger implementation for TensorBoard."""
 
     def __init__(self, log_dir: str, tag: Optional[str] = None):
+        from torch.utils.tensorboard import SummaryWriter
+
         self.tag = tag
         self.writer = SummaryWriter(log_dir, max_queue=1000)
         logger.info(f"TensorBoard logging enabled. Logs will be saved at {log_dir}")
@@ -137,7 +138,7 @@ class WandBLogger(BaseLogger):
         os.makedirs(log_dir, exist_ok=True)
 
         self.wandb.init(
-            project="torchtitan",
+            project=os.getenv("WANDB_PROJECT", "torchtitan"),
             dir=log_dir,
         )
         logger.info("WandB logging enabled")


### PR DESCRIPTION
This commit 
1. Move the `tensorboard` imports into class so that it will not raise errors if `tensorboard` not installed.
2. Allow users to obtain `wandb` project name from the env variable `WANDB_PROJECT`, which is defined in their docs.