### PR TITLE
Exclude embedding params by module class

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -52,7 +52,9 @@ class GarbageCollection:
 def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
-        num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
+        num_params -= sum(
+            m.num_parameters() for m in model.children() if isinstance(m, nn.Embedding)
+        )
     return num_params
 
 


### PR DESCRIPTION
### What does this PR do?

This PR enhances the method for counting embedding layers, making it more versatile and compatible with various model architectures, especially in HF-format.

#### Changes
Replace the Llama-specific embedding count:
```py
num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
```
by a more generic approach

```py
num_params -= sum(
    m.num_parameters() for m in model.children() if isinstance(m, nn.Embedding)
)
```



