### PR TITLE
Exclude embedding params by module class

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -49,10 +49,13 @@ class GarbageCollection:
         logger.info("[GC] %s %.2f seconds.", reason, time.monotonic() - begin)
 
 
-def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
+def get_num_params(model: nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
-        num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
+        num_params -= sum(
+            sum(p.numel() for p in m.parameters())
+            for m in model.children() if isinstance(m, nn.Embedding)
+        )
     return num_params
 
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -49,7 +49,7 @@ class GarbageCollection:
         logger.info("[GC] %s %.2f seconds.", reason, time.monotonic() - begin)
 
 
-def get_num_params(model: nn.Module, exclude_embedding: bool = False) -> int:
+def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
         num_params -= sum(

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+import torch.nn as nn
 from torch._utils import _get_available_device_type, _get_device_module
 
 from torchtitan.tools.logging import logger
@@ -49,12 +50,13 @@ class GarbageCollection:
         logger.info("[GC] %s %.2f seconds.", reason, time.monotonic() - begin)
 
 
-def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> int:
+def get_num_params(model: nn.Module, exclude_embedding: bool = False) -> int:
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
         num_params -= sum(
             sum(p.numel() for p in m.parameters())
-            for m in model.children() if isinstance(m, nn.Embedding)
+            for m in model.children()
+            if isinstance(m, nn.Embedding)
         )
     return num_params
 


### PR DESCRIPTION
### What does this PR do?

This PR enhances the method for counting embedding layers, making it more versatile and compatible with various model architectures, especially in HF-format.

### Changes
Replace the Llama-specific embedding count:
```py
num_params -= sum(p.numel() for p in model.tok_embeddings.parameters())
```
by a more generic way

```py
num_params -= sum(
    sum(p.numel() for p in m.parameters())
    for m in model.children() if isinstance(m, nn.Embedding)
)
```
