### PR TITLE
require python>=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "torchtitan"
 description = "A native-PyTorch library for large scale LLM training"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
     { name = "PyTorch Team", email = "packages@pytorch.org" },


### PR DESCRIPTION
Either we require python>=3.10, or we delete TypeAlias imports in the 2 occurrences present in the code base.