### PR TITLE
update README.md with up-to-date installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ git clone https://github.com/pytorch/torchtitan
 cd torchtitan
 pip install -r requirements.txt
 pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124 --force-reinstall
+pip install -e .
 ```
 
 ### Downloading a tokenizer


### PR DESCRIPTION
Summary:

Seems like we need to install the module after the latest codebase refactors, updating the README.md to match since this is BC breaking.

Test Plan:

```
with-proxy CONFIG_FILE="./torchtitan/models/llama/train_configs/debug_model.toml" ./run_train.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: