### PR TITLE
QOL: add CLI option to print model after conversion to stdout

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -210,6 +210,14 @@ class JobConfig:
                 which can be found here: https://github.com/pytorch/ao
             """,
         )
+        self.parser.add_argument(
+            "--model.print_after_conversion",
+            action="store_true",
+            help="""
+            If true, model definition will be printed to stdout after all model
+            converters have been applied.
+            """,
+        )
 
         # optimizer configs
         self.parser.add_argument(

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.tools.logging import logger
 
 
 class ModelConverter(Protocol):
@@ -63,10 +64,13 @@ class ModelConvertersContainer(ModelConverter):
         self.converters = [
             mh_cls(job_config, parallel_dims) for mh_cls in converter_classes
         ]
+        self.print_after_conversion = job_config.model.print_after_conversion
 
     def convert(self, model: nn.Module):
         for mh in self.converters:
             mh.convert(model)
+        if self.print_after_conversion:
+            logger.info(f"Model definion after conversion:\n\n{model}\n\n")
 
     def post_optimizer_hook(self, model: Union[nn.Module, List[nn.Module]]):
         for mh in self.converters:


### PR DESCRIPTION
Summary:

I want to do this literally every time I use float8 in titan, let's make it reusable!

```
with-proxy CONFIG_FILE="./torchtitan/models/llama/train_configs/debug_model.toml" ./run_train.sh --model.converters float8 --model.print_after_conversion
```

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: