### PR TITLE
Add pipeline parallel to DeepSeek

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -42,8 +42,6 @@ import torch.utils.checkpoint
 from attn_mask_utils import _prepare_4d_causal_attention_mask
 from symm_mem_recipes import on_device_all_to_all_v
 from torch import nn
-from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 from torch.nn import CrossEntropyLoss
 
 
@@ -1360,6 +1358,13 @@ class DeepseekV3ForCausalLM(torch.nn.Module):
         return reordered_past
 
 
+# Start of testing part
+# torchrun --standalone --nproc-per-node 4 model.py
+
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
+
+
 # Run full model
 def run_full_model(
     mesh: DeviceMesh,
@@ -1416,7 +1421,6 @@ def run_full_model(
         print(y.shape)
 
 
-# torchrun --standalone --nproc-per-node 4 model.py
 if __name__ == "__main__":
     mesh = dist.init_device_mesh("cuda", (2, 2), mesh_dim_names=("pp", "ep"))
 

--- a/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
+++ b/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
@@ -129,14 +129,15 @@ def on_device_all_to_all_v(
     BLOCKS_PER_REMOTE_RANK=8,
     UNROLL_FACTOR: int = 8,
     BLOCK_SIZE: int = 16384,
+    group: dist.ProcessGroup = dist.group.WORLD,
 ):
     assert output.dim() == 2, f"{output.shape}"
     assert input.dim() == 2, f"{input.shape}"
     assert output.shape[1] == input.shape[1]
 
     dim = output.shape[1]
-    input_hdl = symm_mem.rendezvous(input, group=dist.group.WORLD)
-    split_sizes_hdl = symm_mem.rendezvous(split_sizes, group=dist.group.WORLD)
+    input_hdl = symm_mem.rendezvous(input, group=group)
+    split_sizes_hdl = symm_mem.rendezvous(split_sizes, group=group)
 
     num_blocks = input_hdl.world_size * BLOCKS_PER_REMOTE_RANK
     kernel = on_device_all_to_all_v_kernel[(num_blocks, 1, 1)](


### PR DESCRIPTION
This PR treats PP and EP as the two most important model parallel degrees of DeepSeek.
When creating the model on each rank, the rank's PP and EP info are recognized, and we only create the relevant parts.

That is, we employ this flavor of model creation:
```
    # Instantiate model
    with mesh:
        model = DeepseekV3Model(model_args)
```
where `mesh` carries the model parallel information.

This is similar to how `torchchat` creates "model chunks" in case of PP.

Test:
`$ torchrun --standalone --nproc-per-node 4 model.py`