### PR TITLE
[Optim] Add an option controlling the optimizer eps

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -6,7 +6,6 @@
 
 import copy
 import functools
-
 from typing import Any, Callable, Dict, Generic, List, TypeVar
 
 import torch
@@ -22,7 +21,6 @@ from torch.optim.lr_scheduler import LambdaLR, LRScheduler
 
 from torchtitan.components.ft import FTManager, has_torchft
 from torchtitan.config_manager import JobConfig
-
 
 __all__ = [
     "OptimizersContainer",
@@ -273,6 +271,7 @@ def build_optimizers(
         )
     name = job_config.optimizer.name
     lr = job_config.optimizer.lr
+    eps = job_config.optimizer.eps
 
     optim_implementation = job_config.optimizer.implementation
     assert optim_implementation in ["fused", "foreach", "for-loop"]
@@ -282,6 +281,7 @@ def build_optimizers(
 
     optimizer_kwargs = {
         "lr": lr,
+        "eps": eps,
         "betas": (0.9, 0.95),
         "weight_decay": 0.1,
         "fused": fused,

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -227,6 +227,9 @@ class JobConfig:
             "--optimizer.lr", type=float, default=8e-4, help="Learning rate to use"
         )
         self.parser.add_argument(
+            "--optimizer.eps", type=float, default=1e-8, help="Epsilon value to use"
+        )
+        self.parser.add_argument(
             "--optimizer.implementation",
             type=str,
             default="fused",

--- a/torchtitan/models/llama/train_configs/debug_model.toml
+++ b/torchtitan/models/llama/train_configs/debug_model.toml
@@ -31,6 +31,7 @@ tokenizer_path = "./tests/assets/test_tiktoken.model"
 [optimizer]
 name = "AdamW"
 lr = 8e-4
+eps = 1e-8
 
 [training]
 batch_size = 8

--- a/torchtitan/models/llama/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_405b.toml
@@ -25,6 +25,7 @@ converters = "float8"
 [optimizer]
 name = "AdamW"
 lr = 8e-5
+eps = 1e-8
 
 [training]
 batch_size = 2

--- a/torchtitan/models/llama/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_70b.toml
@@ -25,6 +25,7 @@ tokenizer_path = "./assets/tokenizer/original/tokenizer.model"
 [optimizer]
 name = "AdamW"
 lr = 1.5e-4
+eps = 1e-8
 
 [training]
 batch_size = 8

--- a/torchtitan/models/llama/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_8b.toml
@@ -25,6 +25,7 @@ tokenizer_path = "./assets/tokenizer/original/tokenizer.model"
 [optimizer]
 name = "AdamW"
 lr = 3e-4
+eps = 1e-8
 
 [training]
 batch_size = 1


### PR DESCRIPTION
### What does this PR do?

Add an option into `torchtitan/components/optimizer.py` and config files to allow users to control the epsilon value passed into the optimizer.


### Why is this change necessary?
Some papers suggest that providing users with the flexibility to control the epsilon value is important. This ensures that epsilon does not dominate the updates when gradients become extremely small. The default value of $1^{-8}$ may not always be sufficiently small; in some cases, setting epsilon to $1^{-15}$ or even zero could be more appropriate.

![image](https://github.com/user-attachments/assets/25bfaf27-3006-45a0-b63a-cbf9216f20ef)

See https://arxiv.org/pdf/2412.17743 and https://arxiv.org/abs/2309.14322 for more details.