### PR TITLE
[fix] fix bug in loading seed checkpoint

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -457,7 +457,7 @@ class CheckpointManager:
 
         logger.info(f"Loading the checkpoint at step {step}.")
         begin = time.monotonic()
-        states = self._states_to_load(checkpoint_id)
+        states = self._states_to_load(step)
         dcp.load(states, checkpoint_id=checkpoint_id)
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(


### PR DESCRIPTION
Hi, thanks for sharing this great repo.

I just have a small fix while working on my fork that I think would make sense to send back here as:

The `_states_to_load` function expects an integer as input, but the `load` function passes `checkpoint_id` (a string/path-type value) when invoking it. As a result, `_states_to_load` returns **all states** (including the model, optimizer, dataloader, etc.). Since the dataloader's state contains `dp_rank`, and the seed checkpoint was created with `world_size` fixed to 1, errors occur during training when loading this seed checkpoint in a multi-machine environment (where `world_size > 1`). This inconsistency in distributed training parameters triggers compatibility issues.

```python
    # https://github.com/pytorch/torchtitan/blob/main/torchtitan/components/checkpoint.py#L559-L581
    def _states_to_load(self, step: int) -> Dict[str, Any]:
        """Determines which states to load for the given step.

        When checkpointer determines which step of the checkpoint to load, this API is
        used to determine which states to load based on the step.

        Args:
            step (int): The step to load the checkpoint for.

        Returns:
            Dict[str, Any]: The states to load for the given step.
        """
        # For the first step, we will only load the model weights.
        states = {MODEL: self.states[MODEL]} if step == 0 else self.states
        ......

    # https://github.com/pytorch/torchtitan/blob/main/torchtitan/components/checkpoint.py#L429-L466
    def load(self, step: int = -1) -> bool:
        """Load the checkpoint for the given step.

        This function will load the checkpoint for the given step. If ``step`` is -1, it
        will load the latest checkpoint. If the checkpoint does not exist, it will return
        False and load nothing.

        Args:
            step (int, optional): The step to load the checkpoint for. Defaults to -1.

        Returns:
            bool: Whether the checkpoint was loaded successfully.
        """

        ......
        checkpoint_id = self._create_checkpoint_id(step)
        states = self._states_to_load(checkpoint_id)  # !!! should be step here
        dcp.load(states, checkpoint_id=checkpoint_id)
        ......
``` 