### PR TITLE
[Checkpointing] Force to save a checkpoint at step 1 if checkpoint is enabled

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -610,6 +610,11 @@ class CheckpointManager:
         if not self.enable_checkpoint:
             return False
 
+        # Force saving a checkpoint at step 1 to fail fast if checkpointer is
+        # compatible with the cluster.
+        if curr_step == 1:
+            return True
+
         if force:
             return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Fail fast if checkpointer is not compatible with the system.