### PR TITLE
fix MI250X peak FLOPS

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -113,9 +113,9 @@ def get_peak_flops(device_name: str) -> int:
         # MI300X data from https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html
         # MI325X data from https://www.amd.com/en/products/accelerators/instinct/mi300/mi325x.html
         return 1300e12
-    elif "MI250" in device_name:
+    elif "MI250X" in device_name:
         # data from https://www.amd.com/en/products/accelerators/instinct/mi200/mi250.html
-        return 362e12
+        return 191.5e12
     else:  # for other GPU types, assume A100
         logger.warning(f"Peak flops undefined for: {device_name}, fallback to A100")
         return 312e12

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -114,7 +114,7 @@ def get_peak_flops(device_name: str) -> int:
         # MI325X data from https://www.amd.com/en/products/accelerators/instinct/mi300/mi325x.html
         return 1300e12
     elif "MI250X" in device_name:
-        # data from https://www.amd.com/en/products/accelerators/instinct/mi200/mi250.html
+        # data from https://www.amd.com/en/products/accelerators/instinct/mi200/mi250x.html (per GCD)
         return 191.5e12
     else:  # for other GPU types, assume A100
         logger.warning(f"Peak flops undefined for: {device_name}, fallback to A100")


### PR DESCRIPTION
replaces MI250 with MI250X, fixes the peak FLOPS value (since MI250X is a dual-chip GPU, FLOPS should be calculated per GCD).