### PR TITLE
[RFC] Add lr into metric logging and also rename the loss name

### DIFF
--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -27,6 +27,7 @@ from torchtitan.protocols.train_spec import (
     register_train_spec,
     TrainSpec,
 )
+from torchtitan.tools.metrics import metric_processor
 
 
 class FakeModel(ModelProtocol):
@@ -66,6 +67,7 @@ class TestTrainSpec:
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
             loss_fn=cross_entropy_loss,
+            metric_processor_fn=metric_processor,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake")
@@ -87,6 +89,7 @@ class TestTrainSpec:
             build_dataloader_fn=build_hf_dataloader,
             tokenizer_cls=TikTokenizer,
             loss_fn=cross_entropy_loss,
+            metric_processor_fn=metric_processor,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake2")

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -11,6 +11,7 @@ from torchtitan.components.optimizer import build_lr_schedulers, build_optimizer
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer import TikTokenizer
 from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.tools.metrics import metric_processor
 
 from .model import Transformer, TransformerModelArgs
 from .parallelize_llama import parallelize_llama
@@ -71,5 +72,6 @@ register_train_spec(
         build_dataloader_fn=build_hf_dataloader,
         tokenizer_cls=TikTokenizer,
         loss_fn=cross_entropy_loss,
+        metric_processor_fn=metric_processor,
     )
 )

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -7,7 +7,7 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 from dataclasses import dataclass
-from typing import Callable, Protocol, Type, TypeAlias
+from typing import Any, Callable, Dict, Protocol, Type, TypeAlias
 
 import torch
 import torch.nn as nn
@@ -62,6 +62,7 @@ class TrainSpec:
     build_dataloader_fn: DataLoaderBuilder
     tokenizer_cls: Type[Tokenizer]
     loss_fn: LossFunction
+    metric_processor_fn: Callable[Dict[str, Any], Dict[str, Any]]
 
     # TODO: Add a FQN convert fn to allow users to load checkpoints from
     # HuggingFace or other sources that have different FQN conventions.

--- a/torchtitan/tools/metrics.py
+++ b/torchtitan/tools/metrics.py
@@ -96,6 +96,11 @@ def build_device_memory_monitor():
     return device_memory_monitor
 
 
+def metric_processor(metrics: Dict[str, Any]):
+    # by default no processing.
+    return metrics
+
+
 class BaseLogger:
     """Logger that does nothing, used when logging is disabled."""
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -245,9 +245,10 @@ def main(job_config: JobConfig):
     if train_state.step > 0 and not job_config.metrics.disable_logging_from_checkpoint:
         for idx, step in enumerate(train_state.log_steps):
             metrics = {
-                "train/avg_loss_AVG": train_state.global_avg_losses[idx],
-                "train/max_loss_MAX": train_state.global_max_losses[idx],
+                "loss_metrics/global_avg_loss": train_state.global_avg_losses[idx],
+                "loss_metrics/global_max_loss": train_state.global_max_losses[idx],
             }
+            metrics = train_spec.metric_processor_fn(metrics)
             metric_logger.log(metrics, step=step)
 
     data_iterator = iter(dataloader)
@@ -396,8 +397,8 @@ def main(job_config: JobConfig):
                 )
 
                 metrics = {
-                    "train/avg_loss_AVG": global_avg_loss,
-                    "train/max_loss_MAX": global_max_loss,
+                    "loss_metrics/global_avg_loss": global_avg_loss,
+                    "loss_metrics/global_max_loss": global_max_loss,
                     "optim/lr": curr_lr,
                     "throughput(tps)": tps,
                     "tflops": tflops,
@@ -412,6 +413,7 @@ def main(job_config: JobConfig):
                     "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
                     "memory/num_ooms": device_mem_stats.num_ooms,
                 }
+                metrics = train_spec.metric_processor_fn(metrics)
                 metric_logger.log(metrics, step=train_state.step)
 
                 logger.info(

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -245,8 +245,8 @@ def main(job_config: JobConfig):
     if train_state.step > 0 and not job_config.metrics.disable_logging_from_checkpoint:
         for idx, step in enumerate(train_state.log_steps):
             metrics = {
-                "loss_metrics/global_avg_loss": train_state.global_avg_losses[idx],
-                "loss_metrics/global_max_loss": train_state.global_max_losses[idx],
+                "train/avg_loss_AVG": train_state.global_avg_losses[idx],
+                "train/max_loss_MAX": train_state.global_max_losses[idx],
             }
             metric_logger.log(metrics, step=step)
 
@@ -385,10 +385,20 @@ def main(job_config: JobConfig):
                 time_data_loading_pct = 100 * sum(data_loading_times) / time_delta
 
                 device_mem_stats = device_memory_monitor.get_peak_stats()
+                curr_lr = float(
+                    max(
+                        [
+                            pgroup["lr"]
+                            for opim in optimizers.optimizers
+                            for pgroup in opim.param_groups
+                        ]
+                    )
+                )
 
                 metrics = {
-                    "loss_metrics/global_avg_loss": global_avg_loss,
-                    "loss_metrics/global_max_loss": global_max_loss,
+                    "train/avg_loss_AVG": global_avg_loss,
+                    "train/max_loss_MAX": global_max_loss,
+                    "optim/lr": curr_lr,
                     "throughput(tps)": tps,
                     "tflops": tflops,
                     "mfu(%)": mfu,


### PR DESCRIPTION
During some experiments we realized that we need to log lr into metrics so that we can ensure things are correct.

somehow the name of loss does not match with the run we want to compare. So I am wondering if we can build a metric update util so that we can set and change it for different workload?

For example changing from loss_metrics/global_avg_loss to train/avg_loss_AVG