### PR TITLE
[DeepSeek] all-to-all-v kernel writes out `output_splits`

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -604,11 +604,11 @@ class MoE(nn.Module):
             ).sum(dim=0)
             gatherd_idxs = np.zeros(shape=(gathered_tokens.shape[0],), dtype=np.int32)
             s = 0
-            for i, k in enumerate(tokens_per_expert_group.cpu().numpy()):
+            for i, k in enumerate(tokens_per_expert_group.tolist()):
                 gatherd_idxs[s : s + k] = i % self.experts_per_rank
                 s += k
             gatherd_idxs = gatherd_idxs.argsort()
-            tokens_per_expert = tokens_per_expert_post_gather.cpu().numpy()
+            tokens_per_expert = tokens_per_expert_post_gather.tolist()
 
         sorted_tokens = gathered_tokens[gatherd_idxs]
 

--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -604,10 +604,12 @@ class MoE(nn.Module):
             ).sum(dim=0)
             gatherd_idxs = np.zeros(shape=(gathered_tokens.shape[0],), dtype=np.int32)
             s = 0
+            # TODO: remove `tolist()`
             for i, k in enumerate(tokens_per_expert_group.tolist()):
                 gatherd_idxs[s : s + k] = i % self.experts_per_rank
                 s += k
             gatherd_idxs = gatherd_idxs.argsort()
+            # TODO: remove `tolist()`
             tokens_per_expert = tokens_per_expert_post_gather.tolist()
 
         sorted_tokens = gathered_tokens[gatherd_idxs]

--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -46,43 +46,58 @@ def run_full_model(
     # Instantiate model
     with device, mesh:
         model = DeepseekForCausalLM(model_args)
-        model.eval()
 
     # Load weights
     load_weights_from_hf(model, model_id, device)
+    model.train()
 
     # Example inputs
     bs = 2
-    microbatches = 2
     seqlen = 128
     x = torch.randint(model_args.vocab_size, (bs, seqlen), device=device)
+    label = torch.rand(bs, seqlen, model_args.vocab_size, device=device)
 
-    # Create pipeline stage
-    stage = PipelineStage(
-        model,
-        pp_rank,
-        pp_size,
-        device,
-        group=pp_mesh.get_group(),
-    )
+    # Create loss function
+    loss_fn = torch.nn.functional.cross_entropy
 
-    # Create pipeline schedule
-    pp_schedule = ScheduleGPipe(stage, microbatches)
+    # Run forward and backward
+    if pp_size > 1:
+        # Create pipeline stage
+        stage = PipelineStage(
+            model,
+            pp_rank,
+            pp_size,
+            device,
+            group=pp_mesh.get_group(),
+        )
 
-    # Run forward
-    if pp_rank == 0:
-        y = pp_schedule.step(x)
+        # Create pipeline schedule
+        microbatches = 2
+        losses = []
+        pp_schedule = ScheduleGPipe(stage, microbatches, loss_fn=loss_fn)
+
+        if pp_rank == 0:
+            y = pp_schedule.step(x)
+        elif pp_rank == pp_size - 1:
+            y = pp_schedule.step(target=label, losses=losses)
+            loss = torch.mean(torch.stack(losses))
+        else:
+            pp_schedule.step()
     else:
-        y = pp_schedule.step()
+        y = model(x)
+        loss = loss_fn(y, label)
+        loss.backward()
 
     if pp_rank == pp_size - 1:
-        print(y.shape)
+        print(f"logits: {y.shape}")
+        print(f"{loss=}")
+
+    print("Backward done")
 
 
 if __name__ == "__main__":
     mesh = dist.init_device_mesh("cuda", (2, 2), mesh_dim_names=("pp", "ep"))
 
-    with torch.no_grad():
-        run_full_model(mesh)
+    run_full_model(mesh)
 
     dist.destroy_process_group()

--- a/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
+++ b/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
@@ -178,11 +178,17 @@ class OnDeviceAllToAllV(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        # TODO: autograd requires tensors not be modified a second time, this
+        # conflicts with our wish of sharing the symm mem across layers and/or
+        # PP microbatches.
+        return NotImplementedError(
+            "OnDeviceAllToAllV backward is not ready, please use it for inference only"
+        )
         grad_output_splits = ctx.saved_tensors
         grad_input_splits = torch.empty_like(grad_output_splits)
         grad_input = grad_output.new_empty(*ctx.input_shape)
         _on_device_all_to_all_v(
-            grad_input, grad_input_splits, grad_output, grad_output_splits, group=group
+            grad_input, grad_input_splits, grad_output, grad_output_splits, group=ctx.group
         )
         return None, None, grad_input, None, None
 

--- a/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
+++ b/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
@@ -188,7 +188,11 @@ class OnDeviceAllToAllV(torch.autograd.Function):
         grad_input_splits = torch.empty_like(grad_output_splits)
         grad_input = grad_output.new_empty(*ctx.input_shape)
         _on_device_all_to_all_v(
-            grad_input, grad_input_splits, grad_output, grad_output_splits, group=ctx.group
+            grad_input,
+            grad_input_splits,
+            grad_output,
+            grad_output_splits,
+            group=ctx.group,
         )
         return None, None, grad_input, None, None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #956
* #989
* #958
* #954
* #952
* __->__ #941

This PR contains three changes:
    
    1. all-to-all-v kernel writes out `output_splits` instead of total received
    (so that we can use the split info as `input_splits` in the second shuffle or backward)
    
    2. Add backward for all_to_all_v (WIP)
      
    3. Move parts of the model out of `no_grad()`

ghstack-source-id: 8e0dda40b4dc9206343a020c42e8cd8c5741f860
Pull Request resolved: https://github.com/pytorch/torchtitan/pull/941
    
Test
```
$ torchrun --standalone --nproc-per-node 4 run.py
...
logits: torch.Size([2, 128, 102400])
logits: torch.Size([2, 128, 102400])
loss=tensor(510.3908, device='cuda:2', grad_fn=<MeanBackward0>)
loss=tensor(506.3376, device='cuda:3', grad_fn=<MeanBackward0>)
Backward done
Backward done
Backward done
Backward done
```

cc @yifuwang @ngimel