### PR TITLE
Make MetricsLogger as a component

### DIFF
--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -24,13 +24,13 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torchtitan.components.metrics import build_device_memory_monitor
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.protocols.train_spec import get_train_spec
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
-from torchtitan.tools.metrics import build_device_memory_monitor
 from torchtitan.tools.utils import device_module, device_type
 
 # support running w/o installing as package

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -86,6 +86,3 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         # We don't have to use pickle as DCP will serialize the state_dict. However, we have to
         # keep this for backward compatibility.
         super().load_state_dict(pickle.loads(state_dict[self._rank_id]))
-
-
-DataLoaderBuilder: TypeAlias = Callable[[...], BaseDataLoader]

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -8,7 +8,7 @@
 
 import pickle
 from abc import ABC, abstractmethod
-from typing import Any, Callable, TypeAlias
+from typing import Any
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -13,10 +13,8 @@ from typing import Any, Dict, Optional
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
-
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
-
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
@@ -251,6 +251,14 @@ def _build_metric_logger(
 
 
 class MetricsLogger:
+    """Metrics logger that logs metrics to TensorBoard or WandB.
+
+    Args:
+        job_config (JobConfig): Job configuration.
+        parallel_dims (ParallelDims): Parallel dimensions.
+        tag (Optional[str]): Tag to use for TensorBoard or WandB. Defaults to None.
+    """
+
     logger: BaseLogger
     parallel_dims: ParallelDims
     job_config: JobConfig
@@ -356,4 +364,13 @@ class MetricsLogger:
 def build_metrics_logger(
     job_config: JobConfig, parallel_dims: ParallelDims, tag: Optional[str] = None
 ) -> MetricsLogger:
+    """Create a metrics logger.
+    Args:
+        job_config (JobConfig): Job configuration.
+        parallel_dims (ParallelDims): Parallel dimensions.
+        tag (Optional[str]): Tag to use for TensorBoard or WandB. Defaults to None.
+
+    Returns:
+        MetricsLogger: A metrics logger.
+    """
     return MetricsLogger(job_config, parallel_dims, tag)

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -248,8 +248,11 @@ def _build_metric_logger(
     return BaseLogger()
 
 
-class MetricsLogger:
-    """Metrics logger that logs metrics to TensorBoard or WandB.
+class MetricsProcessor:
+    """Metrics processor to processes the metrics and log metrics.
+
+    The current MetricsProcessor log some metrics to STDOUT and some metrics to
+    TensorBoard or WandB.
 
     Args:
         job_config (JobConfig): Job configuration.
@@ -299,6 +302,9 @@ class MetricsLogger:
         self.num_flop_per_token = -1
         self.optimizers = None
         self.lr_schedulers = None
+
+    def should_log(self, step: int) -> bool:
+        return step == 1 or step % self.job_config.metrics.log_freq == 0
 
     def log(self, step: int, global_avg_loss: float, global_max_loss: float):
         assert self.num_flop_per_token > 0, "num_flop_per_token must be set"
@@ -359,16 +365,17 @@ class MetricsLogger:
         self.logger.close()
 
 
-def build_metrics_logger(
+def build_metrics_processor(
     job_config: JobConfig, parallel_dims: ParallelDims, tag: Optional[str] = None
-) -> MetricsLogger:
-    """Create a metrics logger.
+) -> MetricsProcessor:
+    """Create a metrics processor.
+
     Args:
         job_config (JobConfig): Job configuration.
         parallel_dims (ParallelDims): Parallel dimensions.
         tag (Optional[str]): Tag to use for TensorBoard or WandB. Defaults to None.
 
     Returns:
-        MetricsLogger: A metrics logger.
+        MetricsProcessor: A metrics processor.
     """
-    return MetricsLogger(job_config, parallel_dims, tag)
+    return MetricsProcessor(job_config, parallel_dims, tag)

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -5,15 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import time
 from collections import namedtuple
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
+from torchtitan.components.optimizer import OptimizersContainer
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
+
+from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 
@@ -181,7 +185,7 @@ def _get_metrics_rank(
     return (world_size // pp_size) * (pp_size - 1)
 
 
-def build_metric_logger(
+def _build_metric_logger(
     job_config: JobConfig, parallel_dims: ParallelDims, tag: Optional[str] = None
 ) -> BaseLogger:
     """
@@ -244,3 +248,110 @@ def build_metric_logger(
 
     logger.debug("No loggers enabled, returning BaseLogger")
     return BaseLogger()
+
+
+class MetricsLogger:
+    logger: BaseLogger
+    parallel_dims: ParallelDims
+    job_config: JobConfig
+    device_memory_monitor: DeviceMemoryMonitor
+    color: utils.Color
+
+    gpu_peak_flops: int
+    ntokens_since_last_log: int
+    data_loading_times: list[float]
+    time_last_log: float
+
+    num_flop_per_token: int
+    optimizers: Optional[OptimizersContainer]
+
+    def __init__(
+        self,
+        job_config: JobConfig,
+        parallel_dims: ParallelDims,
+        tag: Optional[str] = None,
+    ):
+        self.logger = _build_metric_logger(job_config, parallel_dims, tag)
+        self.parallel_dims = parallel_dims
+        self.job_config = job_config
+        self.device_memory_monitor = build_device_memory_monitor()
+        # used for colorful printing
+        self.color = (
+            utils.NoColor if job_config.metrics.disable_color_printing else utils.Color
+        )
+
+        self.gpu_peak_flops = utils.get_peak_flops(
+            self.device_memory_monitor.device_name
+        )
+        self.ntokens_since_last_log = 0
+        self.data_loading_times = []
+        self.time_last_log = time.perf_counter()
+        self.device_memory_monitor.reset_peak_stats()
+
+        # These variables have to be set later as they depend on other components or model.
+        self.num_flop_per_token = -1
+        self.optimizers = None
+
+    def log(self, step: int, global_avg_loss: float, global_max_loss: float):
+        assert self.num_flop_per_token > 0, "num_flop_per_token must be set"
+
+        time_delta = time.perf_counter() - self.time_last_log
+
+        # tokens per second per device, abbreviated as tps
+        tps = self.ntokens_since_last_log / (
+            time_delta * self.parallel_dims.non_data_parallel_size
+        )
+        # model FLOPS utilization
+        # For its definition and calculation, please refer to the PaLM paper:
+        # https://arxiv.org/abs/2204.02311
+        mfu = 100 * self.num_flop_per_token * tps / self.gpu_peak_flops
+        tflops = self.num_flop_per_token * tps / 1e12
+
+        time_end_to_end = time_delta / self.job_config.metrics.log_freq
+        time_data_loading = sum(self.data_loading_times) / len(self.data_loading_times)
+        time_data_loading_pct = 100 * sum(self.data_loading_times) / time_delta
+
+        device_mem_stats = self.device_memory_monitor.get_peak_stats()
+
+        metrics = {
+            "loss_metrics/global_avg_loss": global_avg_loss,
+            "loss_metrics/global_max_loss": global_max_loss,
+            "throughput(tps)": tps,
+            "tflops": tflops,
+            "mfu(%)": mfu,
+            "time_metrics/end_to_end(s)": time_end_to_end,
+            "time_metrics/data_loading(s)": time_data_loading,
+            "time_metrics/data_loading(%)": time_data_loading_pct,
+            "memory/max_active(GiB)": device_mem_stats.max_active_gib,
+            "memory/max_active(%)": device_mem_stats.max_active_pct,
+            "memory/max_reserved(GiB)": device_mem_stats.max_reserved_gib,
+            "memory/max_reserved(%)": device_mem_stats.max_reserved_pct,
+            "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
+            "memory/num_ooms": device_mem_stats.num_ooms,
+        }
+        self.logger.log(metrics, step)
+
+        color = self.color
+        logger.info(
+            f"{color.red}step: {step:2}  "
+            f"{color.green}loss: {global_avg_loss:7.4f}  "
+            f"{color.yellow}memory: {device_mem_stats.max_reserved_gib:5.2f}GiB"
+            f"({device_mem_stats.max_reserved_pct:.2f}%)  "
+            f"{color.blue}tps: {round(tps):,}  "
+            f"{color.cyan}tflops: {tflops:,.2f}  "
+            f"{color.magenta}mfu: {mfu:.2f}%{color.reset}"
+        )
+
+        self.ntokens_since_last_log = 0
+        self.data_loading_times.clear()
+        self.time_last_log = time.perf_counter()
+        self.device_memory_monitor.reset_peak_stats()
+
+    def close(self):
+        self.logger.close()
+
+
+def build_metrics_logger(
+    job_config: JobConfig, parallel_dims: ParallelDims, tag: Optional[str] = None
+) -> MetricsLogger:
+    return MetricsLogger(job_config, parallel_dims, tag)

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -264,6 +264,7 @@ class MetricsLogger:
 
     num_flop_per_token: int
     optimizers: Optional[OptimizersContainer]
+    lr_schedulers: Optional[LRSchedulersContainer]
 
     def __init__(
         self,
@@ -291,6 +292,7 @@ class MetricsLogger:
         # These variables have to be set later as they depend on other components or model.
         self.num_flop_per_token = -1
         self.optimizers = None
+        self.lr_schedulers = None
 
     def log(self, step: int, global_avg_loss: float, global_max_loss: float):
         assert self.num_flop_per_token > 0, "num_flop_per_token must be set"

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -166,13 +166,6 @@ class JobConfig:
             """,
         )
         self.parser.add_argument(
-            "--metrics.disable_logging_from_checkpoint",
-            action="store_true",
-            help="""
-                Whether to log metrics from scratch for each checkpoint load. We have seen this feature
-                leading to nccl watchdog timeout issue when testing with tb. This flag disables it.""",
-        )
-        self.parser.add_argument(
             "--metrics.enable_wandb",
             action="store_true",
             help="Whether to log metrics to Weights & Biases",

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
-from torchtitan.components.metrics import MetricsLogger
+from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.components.tokenizer import Tokenizer
 from torchtitan.config_manager import JobConfig
@@ -43,7 +43,7 @@ class ModelProtocol(Protocol):
 
 
 DataLoaderBuilder: TypeAlias = Callable[[...], BaseDataLoader]
-MetricsLoggerBuilder: TypeAlias = Callable[[...], MetricsLogger]
+MetricsProcessorBuilder: TypeAlias = Callable[[...], MetricsProcessor]
 OptimizersBuilder: TypeAlias = Callable[
     [list[nn.Module], JobConfig], OptimizersContainer
 ]
@@ -65,7 +65,7 @@ class TrainSpec:
     build_dataloader_fn: DataLoaderBuilder
     tokenizer_cls: Type[Tokenizer]
     loss_fn: LossFunction
-    build_metrics_logger_fn: Optional[MetricsLoggerBuilder] = None
+    build_metrics_processor_fn: Optional[MetricsProcessorBuilder] = None
 
 
 _train_specs = {}

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -7,15 +7,15 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 from dataclasses import dataclass
-from typing import Callable, Protocol, Type, TypeAlias, Optional
+from typing import Callable, Optional, Protocol, Type, TypeAlias
 
 import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.metrics import MetricsLogger
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.components.tokenizer import Tokenizer
-from torchtitan.components.metrics import MetricsLogger
 from torchtitan.config_manager import JobConfig
 
 

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -7,14 +7,15 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 from dataclasses import dataclass
-from typing import Callable, Protocol, Type, TypeAlias
+from typing import Callable, Protocol, Type, TypeAlias, Optional
 
 import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
-from torchtitan.components.dataloader import DataLoaderBuilder
+from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.components.tokenizer import Tokenizer
+from torchtitan.components.metrics import MetricsLogger
 from torchtitan.config_manager import JobConfig
 
 
@@ -41,6 +42,8 @@ class ModelProtocol(Protocol):
         ...
 
 
+DataLoaderBuilder: TypeAlias = Callable[[...], BaseDataLoader]
+MetricsLoggerBuilder: TypeAlias = Callable[[...], MetricsLogger]
 OptimizersBuilder: TypeAlias = Callable[
     [list[nn.Module], JobConfig], OptimizersContainer
 ]
@@ -62,9 +65,7 @@ class TrainSpec:
     build_dataloader_fn: DataLoaderBuilder
     tokenizer_cls: Type[Tokenizer]
     loss_fn: LossFunction
-
-    # TODO: Add a FQN convert fn to allow users to load checkpoints from
-    # HuggingFace or other sources that have different FQN conventions.
+    build_metrics_logger_fn: Optional[MetricsLoggerBuilder] = None
 
 
 _train_specs = {}

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -13,7 +13,10 @@ from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.checkpoint import CheckpointManager, TrainState
 from torchtitan.components.ft import FTParallelDims, init_ft_manager
-from torchtitan.components.metrics import build_metrics_processor
+from torchtitan.components.metrics import (
+    build_metrics_processor,
+    ensure_pp_loss_visible,
+)
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 
@@ -25,7 +28,6 @@ from torchtitan.tools.logging import init_logger, logger
 from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
-    ensure_pp_loss_visible,
 )
 
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -21,7 +21,7 @@ from torchtitan.protocols.train_spec import get_train_spec
 
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
-from torchtitan.tools.metrics import build_device_memory_monitor, build_metric_logger
+from torchtitan.components.metrics import build_metrics_logger
 from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
@@ -38,9 +38,6 @@ def main(job_config: JobConfig):
 
     if job_config.job.print_args:
         logger.info(f"Running with args: {job_config.to_dict()}")
-
-    # used for colorful printing
-    color = utils.NoColor if job_config.metrics.disable_color_printing else utils.Color
 
     # take control of garbage collection to avoid stragglers
     gc_handler = utils.GarbageCollection(gc_freq=job_config.training.gc_freq)
@@ -75,10 +72,6 @@ def main(job_config: JobConfig):
             ft_manager=ft_manager,
         )
     dist_utils.init_distributed(job_config)
-    # initialize device memory monitor and get peak flops for MFU calculation
-    device_memory_monitor = build_device_memory_monitor()
-    gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
-    logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
 
     # build meshes
     world_mesh = parallel_dims.build_mesh(device_type=device_type)
@@ -132,9 +125,14 @@ def main(job_config: JobConfig):
     model_converters = build_model_converters(job_config, parallel_dims)
     model_converters.convert(model)
 
+    # metrics logging
+    build_metrics_logger_fn = build_metrics_logger if train_spec.build_metrics_logger_fn is None else traiin_spec.build_metrics_logger_fn
+    metrics_logger = build_metrics_logger_fn(job_config, parallel_dims)
+    color = metrics_logger.color
+
     # log model size
     model_param_count = utils.get_num_params(model)
-    num_flop_per_token = utils.get_num_flop_per_token(
+    metrics_logger.num_flop_per_token = utils.get_num_flop_per_token(
         utils.get_num_params(model, exclude_embedding=True),
         model_config,
         job_config.training.seq_len,
@@ -195,6 +193,10 @@ def main(job_config: JobConfig):
 
         model_parts = [model]
 
+    # initialize device memory monitor and get peak flops for MFU calculation
+    device_memory_monitor = metrics_logger.device_memory_monitor
+    gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
+    logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
     device_mem_stats = device_memory_monitor.get_peak_stats()
     logger.info(
         f"{device_type.upper()} memory usage for model: "
@@ -237,18 +239,10 @@ def main(job_config: JobConfig):
         return
 
     checkpoint.load(step=job_config.checkpoint.load_step)
-    metric_logger = build_metric_logger(job_config, parallel_dims)
 
     # plot losses loaded from checkpoint (if any) to TensorBoard
     # NOTE: Loss info after the last log step before checkpoint saving will not be ploted.
     #       This can be avoided by setting checkpoint.interval to be a multiple of metrics.log_freq
-    if train_state.step > 0 and not job_config.metrics.disable_logging_from_checkpoint:
-        for idx, step in enumerate(train_state.log_steps):
-            metrics = {
-                "loss_metrics/global_avg_loss": train_state.global_avg_losses[idx],
-                "loss_metrics/global_max_loss": train_state.global_max_losses[idx],
-            }
-            metric_logger.log(metrics, step=step)
 
     data_iterator = iter(dataloader)
 
@@ -256,12 +250,6 @@ def main(job_config: JobConfig):
         parallel_dims.loss_parallel_enabled,
         job_config.experimental.enable_compiled_autograd,
     )
-
-    # variables used to keep info for metrics logging
-    ntokens_since_last_log = 0
-    data_loading_times = []
-    time_last_log = time.perf_counter()
-    device_memory_monitor.reset_peak_stats()
 
     # train loop
     logger.info(
@@ -285,8 +273,10 @@ def main(job_config: JobConfig):
             data_load_start = time.perf_counter()
             batch = next(data_iterator)
             input_ids, labels = batch
-            ntokens_since_last_log += labels.numel()
-            data_loading_times.append(time.perf_counter() - data_load_start)
+            metrics_logger.ntokens_since_last_log += labels.numel()
+            metrics_logger.data_loading_times.append(
+                time.perf_counter() - data_load_start
+            )
 
             input_ids = input_ids.to(device_type)
             labels = labels.to(device_type)
@@ -363,61 +353,7 @@ def main(job_config: JobConfig):
                 else:
                     global_avg_loss = global_max_loss = loss.item()
 
-                # update train state
-                train_state.log_steps.append(train_state.step)
-                train_state.global_avg_losses.append(global_avg_loss)
-                train_state.global_max_losses.append(global_max_loss)
-
-                time_delta = time.perf_counter() - time_last_log
-
-                # tokens per second per device, abbreviated as tps
-                tps = ntokens_since_last_log / (
-                    time_delta * parallel_dims.non_data_parallel_size
-                )
-                # model FLOPS utilization
-                # For its definition and calculation, please refer to the PaLM paper:
-                # https://arxiv.org/abs/2204.02311
-                mfu = 100 * num_flop_per_token * tps / gpu_peak_flops
-                tflops = num_flop_per_token * tps / 1e12
-
-                time_end_to_end = time_delta / job_config.metrics.log_freq
-                time_data_loading = sum(data_loading_times) / len(data_loading_times)
-                time_data_loading_pct = 100 * sum(data_loading_times) / time_delta
-
-                device_mem_stats = device_memory_monitor.get_peak_stats()
-
-                metrics = {
-                    "loss_metrics/global_avg_loss": global_avg_loss,
-                    "loss_metrics/global_max_loss": global_max_loss,
-                    "throughput(tps)": tps,
-                    "tflops": tflops,
-                    "mfu(%)": mfu,
-                    "time_metrics/end_to_end(s)": time_end_to_end,
-                    "time_metrics/data_loading(s)": time_data_loading,
-                    "time_metrics/data_loading(%)": time_data_loading_pct,
-                    "memory/max_active(GiB)": device_mem_stats.max_active_gib,
-                    "memory/max_active(%)": device_mem_stats.max_active_pct,
-                    "memory/max_reserved(GiB)": device_mem_stats.max_reserved_gib,
-                    "memory/max_reserved(%)": device_mem_stats.max_reserved_pct,
-                    "memory/num_alloc_retries": device_mem_stats.num_alloc_retries,
-                    "memory/num_ooms": device_mem_stats.num_ooms,
-                }
-                metric_logger.log(metrics, step=train_state.step)
-
-                logger.info(
-                    f"{color.red}step: {train_state.step:2}  "
-                    f"{color.green}loss: {global_avg_loss:7.4f}  "
-                    f"{color.yellow}memory: {device_mem_stats.max_reserved_gib:5.2f}GiB"
-                    f"({device_mem_stats.max_reserved_pct:.2f}%)  "
-                    f"{color.blue}tps: {round(tps):,}  "
-                    f"{color.cyan}tflops: {tflops:,.2f}  "
-                    f"{color.magenta}mfu: {mfu:.2f}%{color.reset}"
-                )
-
-                ntokens_since_last_log = 0
-                data_loading_times.clear()
-                time_last_log = time.perf_counter()
-                device_memory_monitor.reset_peak_stats()
+                metrics_logger.log(train_state.step, global_avg_loss, global_max_loss)
 
             checkpoint.save(
                 train_state.step, force=(train_state.step == job_config.training.steps)
@@ -441,7 +377,7 @@ def main(job_config: JobConfig):
         logger.info("Sleeping 2 seconds for other ranks to complete")
         time.sleep(2)
 
-    metric_logger.close()
+    metrics_logger.close()
     logger.info("Training completed")
 
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -13,6 +13,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.checkpoint import CheckpointManager, TrainState
 from torchtitan.components.ft import FTParallelDims, init_ft_manager
+from torchtitan.components.metrics import build_metrics_logger
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 
@@ -21,7 +22,6 @@ from torchtitan.protocols.train_spec import get_train_spec
 
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
-from torchtitan.components.metrics import build_metrics_logger
 from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
@@ -126,7 +126,11 @@ def main(job_config: JobConfig):
     model_converters.convert(model)
 
     # metrics logging
-    build_metrics_logger_fn = build_metrics_logger if train_spec.build_metrics_logger_fn is None else traiin_spec.build_metrics_logger_fn
+    build_metrics_logger_fn = (
+        build_metrics_logger
+        if train_spec.build_metrics_logger_fn is None
+        else train_spec.build_metrics_logger_fn
+    )
     metrics_logger = build_metrics_logger_fn(job_config, parallel_dims)
     color = metrics_logger.color
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -240,10 +240,6 @@ def main(job_config: JobConfig):
 
     checkpoint.load(step=job_config.checkpoint.load_step)
 
-    # plot losses loaded from checkpoint (if any) to TensorBoard
-    # NOTE: Loss info after the last log step before checkpoint saving will not be ploted.
-    #       This can be avoided by setting checkpoint.interval to be a multiple of metrics.log_freq
-
     data_iterator = iter(dataloader)
 
     train_context = dist_utils.get_train_context(
@@ -340,6 +336,10 @@ def main(job_config: JobConfig):
                 train_state.step == 1
                 or train_state.step % job_config.metrics.log_freq == 0
             ):
+                # NOTE: Loss info after the last log step before checkpoint saving will
+                # not be ploted. This can be avoided by setting checkpoint.interval to
+                # be a multiple of metrics.log_freq
+
                 if (
                     parallel_dims.dp_replicate_enabled
                     or parallel_dims.dp_shard_enabled


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #945

MetricsLogger should be a component as its role is similar to CheckpointManager, which provides some functions and has its own states. More importantly, users may want to customize the metrics. Make it a component and can be customized through TrainSpec.

Change the name of `MetricsLogger` to `MetricsProcessor` as it not only log but also process metrics.