### PR TITLE
[PP] Ensure loss is visible on console for users

### DIFF
--- a/torchtitan/models/llama/train_configs/debug_model.toml
+++ b/torchtitan/models/llama/train_configs/debug_model.toml
@@ -48,7 +48,7 @@ dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
 
 [experimental]
 context_parallel_degree = 1
-pipeline_parallel_degree = 1
+pipeline_parallel_degree = 8
 enable_async_tensor_parallel = false
 
 [checkpoint]

--- a/torchtitan/models/llama/train_configs/debug_model.toml
+++ b/torchtitan/models/llama/train_configs/debug_model.toml
@@ -48,7 +48,7 @@ dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
 
 [experimental]
 context_parallel_degree = 1
-pipeline_parallel_degree = 8
+pipeline_parallel_degree = 1
 enable_async_tensor_parallel = false
 
 [checkpoint]

--- a/torchtitan/tools/metrics.py
+++ b/torchtitan/tools/metrics.py
@@ -15,7 +15,7 @@ from torch.utils.tensorboard import SummaryWriter
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import device_module, device_type
+from torchtitan.tools.utils import Color, device_module, device_type
 
 # named tuple for passing device memory stats for logging
 DeviceMemStats = namedtuple(
@@ -154,11 +154,13 @@ class WandBLogger(BaseLogger):
             self.wandb.finish()
 
 
-def ensure_pp_loss_visible(parallel_dims: ParallelDims, job_config: JobConfig) -> None:
+def ensure_pp_loss_visible(
+    parallel_dims: ParallelDims, job_config: JobConfig, color: Color
+) -> None:
     """
     Ensures that the loss is visible on the console for pipeline-parallel training.
 
-    For most pipeline-parallel training, the loss is only visible on the last pipeline stage.
+    For pipeline-parallel training, the loss is only visible on the last pipeline stage.
     This function checks if the appropriate rank is included in the LOG_RANK environment
     variable and warns if it's not.
     """
@@ -179,13 +181,8 @@ def ensure_pp_loss_visible(parallel_dims: ParallelDims, job_config: JobConfig) -
 
     if str(loss_visible_rank) not in env_logged_ranks:
         logger.warning(
-            f"Pipeline parallel loss is not visible. Add rank {loss_visible_rank} to LOG_RANK environment variable."
-        )
-        # TODO - this does not work...Add the loss visible rank to the environment variable
-        env_logged_ranks.append(str(loss_visible_rank))
-        os.environ["LOG_RANK"] = ",".join(env_logged_ranks)
-        logger.info(
-            f"Added rank {loss_visible_rank} to LOG_RANK environment variable for pipeline parallel loss visibility."
+            f"{color.red}Pipeline parallel loss is not visible. "
+            f"Add {color.yellow}rank {loss_visible_rank}{color.red} to LOG_RANK environment variable in run_train.sh.{color.reset}"
         )
 
 

--- a/torchtitan/tools/metrics.py
+++ b/torchtitan/tools/metrics.py
@@ -199,7 +199,6 @@ def _get_metrics_rank(
             - Rank 0 for pipeline-parallel 'ZBVZeroBubble' schedule
             - The first rank of the last pipeline stage for other pipeline-parallel schedules
     """
-
     # Early return for non-pipeline-parallel configurations
     if not parallel_dims.pp_enabled:
         return 0

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -271,8 +271,6 @@ def main(job_config: JobConfig):
     time_last_log = time.perf_counter()
     device_memory_monitor.reset_peak_stats()
 
-    # ensure
-
     # train loop
     logger.info(
         f"Training starts at step {train_state.step + 1}, "

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -191,7 +191,7 @@ def main(job_config: JobConfig):
             m.train()
 
         # confirm that user will be able to view loss metrics on the console
-        ensure_pp_loss_visible(parallel_dims, job_config)
+        ensure_pp_loss_visible(parallel_dims, job_config, color)
 
     else:
         # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel


### PR DESCRIPTION
This is similar in spirit to [PR_944](https://github.com/pytorch/torchtitan/pull/944) (cc @lkhphuc)  but takes a slightly different approach.
Problem - users that default turn on PP training will get -1 for their loss.  This is b/c by default, rank 0 is the only one logged.
However, for *most* PP schedules, the loss is output on the last rank.
Thus, users see -1 for loss and it's a bad/confusing experience.

This PR adds a check to review both the current PP schedule (b/c for VBlocks, loss is returned on 0) and if it is a last rank loss schedule, then it checks that the first rank of the last stage is visible in the LOG_RANK environment variable.
If not, it warns the user, using Red for the warning if color is enabled, and highlights the rank they should add in yellow:
<img width="1236" alt="Screenshot 2025-03-07 at 11 51 46 AM" src="https://github.com/user-attachments/assets/02b18870-90bb-4cfb-89c1-3e92d2fb9bfb" />


Note that I attempted to then modify the LOG_RANK to add the missing last rank...but it has no effect.  This is b/c the --log_rank_filter passed into torchrun is fixed and thus the env has no effect.
We can fix this by moving to our own filtering via python log filtering (thanks to @d4l3k for this idea) and then it would auto-update.
The tradeoff is that we have to init distributed first (to understand the ranks) meaning that at launch, there's a bit of delay before the first logging.  From there, then NCCL warnings are not suppressed b/c they are emitted from .cpp file vs torchrun filtering controls that...so we get some additional console spam.   
This PR thus sticks to a simple warning with Red highlight (assuming color is on) and provide the user how to fix.
