### PR TITLE
[DeepSeek] Remove support of EP=1 case

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model_config.py
+++ b/torchtitan/experiments/deepseek_v3/model_config.py
@@ -142,6 +142,7 @@ class ModelArgs:
     pad_token_id = None
     # Added for symmetric memory
     max_seq_len: int = 4096
+    dtype: str = "bfloat16"
     # Added for pipeline parallel
     num_stages: int = 1
     stage_idx: int = 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #956
* #989
* #958
* __->__ #954
* #952
* #941

For simplicity, removing code path support EP=1 (less related to this repo's purpose).