### PR TITLE
[DeepSeek] Let MoEs share Symmetric Memory across layers

### DIFF
--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -37,9 +37,6 @@ def run_full_model(
 
     # Get model configs
     model_args = deepseek_config_registry[model_id]
-    # [Note]: I am making the model smaller for testing / avoiding OOM. If you
-    # have sufficient GPUs for model parallelism, you can remove this line.
-    model_args.num_hidden_layers = 16
 
     # Apply model parallelism
     model_args.ep_size = ep_size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #956
* #989
* __->__ #958
* #954
* #952
* #941

MoEs are executed sequentially across layers, and symmetric memory here is used as temporary buffers. So we can reuse it across layers, instead of creating one per MoE instance. 

(No wonder I hit OOM when running larger models previously)