### PR TITLE
Tags in tj-actions/changed-files are compromised

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,6 +32,6 @@ jobs:
           pre-commit install-hooks
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
       - name: Lint modified files
         run: pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
The tags in tj-actions/changed-files action are compromised and are leaking GitHub secrets in repos using the compromised repo. This pins the action to a known good hash.

https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised