### PR TITLE
[Async TP] Don't save reduce scatter output for per op SAC

### DIFF
--- a/torchtitan/models/llama/parallelize_llama.py
+++ b/torchtitan/models/llama/parallelize_llama.py
@@ -221,7 +221,6 @@ _save_list = {
     torch.ops.aten.mm.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
-    torch.ops._c10d_functional.reduce_scatter_tensor.default,
     # for low precision training, it's useful to always save
     # the result of max, since the absolute maximum is
     # used to compute the scaling factor for quantization.


### PR DESCRIPTION
Part of #866

## Summary
- This PR fixes async TP for bf16 and float8 w/ tensorwise scales.
- Support for async TP + float8 w/ rowwise scales requires a different change in pytorch here https://github.com/pytorch/pytorch/pull/149247

## Details
Saving reduces scatter op in per op SAC was breaking the graph pattern matching used implement part of async TP, causing it to "fail silently" - async TP would fail to identify subgraphs to replace with `fused_scaled_mm_reduce_scatter` but continue to run using vanilla TP anyway, unbeknownst to the user.

See root cause analysis here https://github.com/pytorch/torchtitan/issues/866#issuecomment-2725779000

## Test plan
- Confirmed via manual testing with torchtitan + inspecting compile graphs, that the fusion is occurring correctly for bf16 and float8 w/ tensorwise scales.

## Next steps
- Investigate if it's possible to only store the activations of specific reduce-scatter -> wait-tensor ops, since this bug has shown we cannot store them all.