### PR TITLE
Reinitialize ModelWrapper.cache_state_dict because set_model_state_dict has side effects

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -65,6 +65,11 @@ class ModelWrapper(Stateful):
             options=StateDictOptions(strict=False),
         )
         list(map(func, self.model))
+        # `set_model_state_dict()` does change the keys of the input state_dict,
+        # we will need to reinitialize the cache_state_dict.
+        self.cache_state_dict = {
+            k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()
+        }
 
 
 class Terminate:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #972
* __->__ #971
* #970

Summary:
Fixes https://github.com/pytorch/torchtitan/issues/961

`set_model_state_dict` has side effect over the input state_dict keys.

Test Plan:
```
NGPU=4 CONFIG_FILE="torchtitan/models/llama/train_configs/debug_model.toml" ./run_train.sh --training.compile --checkpoint.enable_checkpoint --training.steps=100 --checkpoint.interval=100
```

```
NGPU=4 CONFIG_FILE="torchtitan/models/llama/train_configs/debug_model.toml" ./run_train.sh --training.compile --checkpoint.enable_checkpoint --training.steps=200 --checkpoint.interval=100
```

```
NGPU=4 CONFIG_FILE="torchtitan/models/llama/train_configs/debug_model.toml" ./run_train.sh --training.compile --checkpoint.enable_checkpoint --training.steps=300 --checkpoint.interval=100
```
The last command will fail without this PR