### PR TITLE
Make checkpoint purge thread to be a daemon thread

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -280,7 +280,7 @@ class CheckpointManager:
                 )
             self.purge_queue = queue.Queue()
             self.purge_thread = threading.Thread(
-                target=purge_thread, args=(self.purge_queue,)
+                target=purge_thread, args=(self.purge_queue,), daemon=True
             )
             self.purge_thread.start()
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #972
* #971
* #970

Summary:
This avoids potential deadlocks or freezes caused by exceptions on the main thread.

Test Plan:
Add an exception to the main thread.