### PR TITLE
Remove the filesystem-path based import

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -746,20 +746,17 @@ class JobConfig:
             help="The minimum number of FT replica for each step.",
         )
 
-        # I'm not particularly fond of this. Users can choose to write their own wrapper
-        # module and import torchtitan training loop and execute it, which look cleaner.
-        # One reason to provide this option is to allow users to use the existing run script.
-        # While the script is pretty trivial now, we may add more logic when integrating
-        # with TorchFT.
-        # This option is subject to change and may be deleted in the future.
         self.parser.add_argument(
             "--experimental.custom_model_path",
             type=str,
             default="",
             help="""
-                This option allows importing an external module from a custom path.
-                Acceptable value can be a file system path to the module (e.g., my_models/model_x),
-                or a dotted import module (e.g., some_package.model_x).
+            This option enables the importation of external modules from custom paths.
+            Currently, it only supports dotted import modules (e.g., some_package.model_x).
+            It is the user's responsibility to ensure that the specified path can be
+            successfully imported. One method to achieve this, you can place your module
+            inside the ``torchtitan/torchtitan`` folder and execute ``pip install -e .`` to
+            make it available for import.
             """,
         )
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -747,11 +747,11 @@ class JobConfig:
         )
 
         self.parser.add_argument(
-            "--experimental.custom_model_path",
+            "--experimental.custom_import",
             type=str,
             default="",
             help="""
-            This option enables the importation of external modules from custom paths.
+            This option enables the importation of external modules.
             Currently, it only supports dotted import modules (e.g., some_package.model_x).
             It is the user's responsibility to ensure that the specified path can be
             successfully imported. One method to achieve this, you can place your module

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -6,6 +6,7 @@
 
 import contextlib
 import math
+import os
 from datetime import timedelta
 from typing import Generator, Iterable, List, Optional, Set, Union
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -6,7 +6,6 @@
 
 import contextlib
 import math
-import os
 from datetime import timedelta
 from typing import Generator, Iterable, List, Optional, Set, Union
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -5,9 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import gc
-import os
 import subprocess
-import sys
 import time
 from dataclasses import dataclass
 from typing import Optional

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import gc
-import importlib
 import os
 import subprocess
 import sys
@@ -164,36 +163,3 @@ def check_if_feature_in_pytorch(
             f"{min_nightly_version}. Please upgrade a newer version to include the "
             f"change in ({pull_request_link}) for correct {feature_name}."
         )
-
-
-def import_module_from_path(path: str):
-    path = os.path.expanduser(path)
-
-    # 1. Check if path is an existing file or directory path.
-    if os.path.exists(path):
-        if not os.path.isdir(path):
-            raise ImportError(f"Path '{path}' is not a directory.")
-        init_file = os.path.join(path, "__init__.py")
-        if os.path.isfile(init_file):
-            return _import_module_from_init(path)
-
-        raise ImportError(
-            f"Directory '{path}' is not a Python package because it does not "
-            "contain an __init__.py file."
-        )
-
-    # 2. If not a valid path, assume it's a dotted module name.
-    return importlib.import_module(path)
-
-
-def _import_module_from_init(path: str):
-    init_file = os.path.join(path, "__init__.py")
-    module_name = os.path.basename(path)
-    spec = importlib.util.spec_from_file_location(module_name, init_file)
-    if spec is None:
-        raise ImportError(f"Could not create spec from '{init_file}'")
-
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib
 import os
 import time
 from datetime import timedelta
@@ -60,7 +61,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         logger.info(f"Starting job: {job_config.job.description}")
 
         if job_config.experimental.custom_model_path:
-            utils.import_module_from_path(job_config.experimental.custom_model_path)
+            importlib.import_module(job_config.experimental.custom_model_path)
 
         if job_config.job.print_args:
             logger.info(f"Running with args: {job_config.to_dict()}")

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -60,8 +60,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         logger.info(f"Starting job: {job_config.job.description}")
 
-        if job_config.experimental.custom_model_path:
-            importlib.import_module(job_config.experimental.custom_model_path)
+        if job_config.experimental.custom_import:
+            importlib.import_module(job_config.experimental.custom_import)
 
         if job_config.job.print_args:
             logger.info(f"Running with args: {job_config.to_dict()}")


### PR DESCRIPTION
While it is convenient to do abosolute path import, it can be error-prune. This is especially true when the program spawns an new process.