### PR TITLE
Switch RMSNorm implementation to native PyTorch version

### DIFF
--- a/torchtitan/models/llama_multimodal/model.py
+++ b/torchtitan/models/llama_multimodal/model.py
@@ -38,9 +38,7 @@ class ModelArgs:
     is_causal: bool = True
 
     # decoder part
-    decoder_embed_dim: int = (
-        4096  # This is for linear projection to convert the output of encoder to decoder
-    )
+    decoder_embed_dim: int = 4096  # This is for linear projection to convert the output of encoder to decoder
     fusion_interval: int = 1  # This is the interval of layers that are used for fusion
     num_special_tokens: int = 2  # This is the number of special tokens in the tokenizer
     decoder_num_layers: int = 16

--- a/torchtitan/models/llama_multimodal/model.py
+++ b/torchtitan/models/llama_multimodal/model.py
@@ -1136,8 +1136,8 @@ class CrossAttention(nn.Module):
             model_args.decoder_embed_dim,
             bias=False,
         )
-        self.q_norm = nn.RMSNorm(dim=self.head_dim, eps=1e-05)
-        self.k_norm = nn.RMSNorm(dim=self.head_dim, eps=1e-05)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=1e-05)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=1e-05)
 
     def init_weights(self, init_std: float):
         for linear in (self.wq, self.wk, self.wv):
@@ -1190,14 +1190,14 @@ class DecoderTransformerSelfAttnBlock(nn.Module):
     ):
         super().__init__()
         self.attn = SelfAttention(model_args)
-        self.ln_attn = nn.RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
+        self.ln_attn = nn.RMSNorm(model_args.decoder_embed_dim, eps=1e-5)
         self.mlp = FeedForwardForDecoder(
             dim=model_args.decoder_embed_dim,
             hidden_dim=4 * model_args.decoder_embed_dim,
             multiple_of=model_args.multiple_of,
             ffn_dim_multiplier=model_args.ffn_dim_multiplier,
         )
-        self.ln_mlp = nn.RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
+        self.ln_mlp = nn.RMSNorm(model_args.decoder_embed_dim, eps=1e-5)
 
     def forward(
         self,
@@ -1218,14 +1218,14 @@ class DecoderTransformerCrossAttnBlock(nn.Module):
     ):
         super().__init__()
         self.attn = CrossAttention(model_args)
-        self.ln_attn = nn.RMSNorm(dim=model_args.decoder_embed_dim)
+        self.ln_attn = nn.RMSNorm(model_args.decoder_embed_dim)
         self.mlp = FeedForward(
             dim=model_args.decoder_embed_dim,
             hidden_dim=4 * model_args.decoder_embed_dim,
             multiple_of=model_args.multiple_of,
             ffn_dim_multiplier=model_args.ffn_dim_multiplier,
         )
-        self.ln_mlp = nn.RMSNorm(dim=model_args.decoder_embed_dim)
+        self.ln_mlp = nn.RMSNorm(model_args.decoder_embed_dim)
         self.attn_scale = TanhGate()
         self.mlp_scale = TanhGate()
 

--- a/torchtitan/models/llama_multimodal/model.py
+++ b/torchtitan/models/llama_multimodal/model.py
@@ -15,8 +15,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from torchtitan.models.norms import RMSNorm
-
 
 @dataclass
 class ModelArgs:
@@ -40,7 +38,9 @@ class ModelArgs:
     is_causal: bool = True
 
     # decoder part
-    decoder_embed_dim: int = 4096  # This is for linear projection to convert the output of encoder to decoder
+    decoder_embed_dim: int = (
+        4096  # This is for linear projection to convert the output of encoder to decoder
+    )
     fusion_interval: int = 1  # This is the interval of layers that are used for fusion
     num_special_tokens: int = 2  # This is the number of special tokens in the tokenizer
     decoder_num_layers: int = 16
@@ -1136,8 +1136,8 @@ class CrossAttention(nn.Module):
             model_args.decoder_embed_dim,
             bias=False,
         )
-        self.q_norm = RMSNorm(dim=self.head_dim, eps=1e-05)
-        self.k_norm = RMSNorm(dim=self.head_dim, eps=1e-05)
+        self.q_norm = nn.RMSNorm(dim=self.head_dim, eps=1e-05)
+        self.k_norm = nn.RMSNorm(dim=self.head_dim, eps=1e-05)
 
     def init_weights(self, init_std: float):
         for linear in (self.wq, self.wk, self.wv):
@@ -1190,14 +1190,14 @@ class DecoderTransformerSelfAttnBlock(nn.Module):
     ):
         super().__init__()
         self.attn = SelfAttention(model_args)
-        self.ln_attn = RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
+        self.ln_attn = nn.RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
         self.mlp = FeedForwardForDecoder(
             dim=model_args.decoder_embed_dim,
             hidden_dim=4 * model_args.decoder_embed_dim,
             multiple_of=model_args.multiple_of,
             ffn_dim_multiplier=model_args.ffn_dim_multiplier,
         )
-        self.ln_mlp = RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
+        self.ln_mlp = nn.RMSNorm(dim=model_args.decoder_embed_dim, eps=1e-5)
 
     def forward(
         self,
@@ -1218,14 +1218,14 @@ class DecoderTransformerCrossAttnBlock(nn.Module):
     ):
         super().__init__()
         self.attn = CrossAttention(model_args)
-        self.ln_attn = RMSNorm(dim=model_args.decoder_embed_dim)
+        self.ln_attn = nn.RMSNorm(dim=model_args.decoder_embed_dim)
         self.mlp = FeedForward(
             dim=model_args.decoder_embed_dim,
             hidden_dim=4 * model_args.decoder_embed_dim,
             multiple_of=model_args.multiple_of,
             ffn_dim_multiplier=model_args.ffn_dim_multiplier,
         )
-        self.ln_mlp = RMSNorm(dim=model_args.decoder_embed_dim)
+        self.ln_mlp = nn.RMSNorm(dim=model_args.decoder_embed_dim)
         self.attn_scale = TanhGate()
         self.mlp_scale = TanhGate()
 
@@ -1413,7 +1413,7 @@ class MultimodalDecoder(nn.Module):
             model_args.num_special_tokens,
             model_args.decoder_embed_dim,
         )
-        self.norm = RMSNorm(model_args.decoder_embed_dim, eps=1e-05)
+        self.norm = nn.RMSNorm(model_args.decoder_embed_dim, eps=1e-05)
         self.output = nn.Linear(
             model_args.decoder_embed_dim, model_args.vocab_size, bias=False
         )

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
 import torch.nn as nn
 
 
@@ -31,36 +30,6 @@ def build_norm(norm_type: str, dim: int, eps: float = 1e-6):
     elif norm_type == "np_layernorm":
         return nn.LayerNorm(dim, eps=eps, elementwise_affine=False, bias=False)
     elif norm_type == "rmsnorm":
-        return RMSNorm(dim, eps=eps)
+        return nn.RMSNorm(dim, eps=eps, elementwise_affine=False)
     else:
         raise NotImplementedError(f"Unknown norm_type: '{norm_type}'")
-
-
-class RMSNorm(nn.Module):
-    """
-    Initialize the RMSNorm normalization layer.
-
-    Args:
-        dim (int): The dimension of the input tensor.
-        eps (float, optional): A small value added to the denominator for numerical stability. Default is 1e-6.
-
-    Attributes:
-        eps (float): A small value added to the denominator for numerical stability.
-        weight (nn.Parameter): Learnable scaling parameter.
-
-    """
-
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
-
-    def _norm(self, x: torch.Tensor):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
-
-    def forward(self, x: torch.Tensor):
-        output = self._norm(x.float()).type_as(x)
-        return output * self.weight
-
-    def reset_parameters(self):
-        torch.nn.init.ones_(self.weight)  # type: ignore

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -30,6 +30,6 @@ def build_norm(norm_type: str, dim: int, eps: float = 1e-6):
     elif norm_type == "np_layernorm":
         return nn.LayerNorm(dim, eps=eps, elementwise_affine=False, bias=False)
     elif norm_type == "rmsnorm":
-        return nn.RMSNorm(dim, eps=eps, elementwise_affine=False)
+        return nn.RMSNorm(dim, eps=eps)
     else:
         raise NotImplementedError(f"Unknown norm_type: '{norm_type}'")


### PR DESCRIPTION
## Description
1. Switch RMSNorm implementation to native PyTorch version
2. Remove torchtitan local RMSNorm implementation


## Test Plan

### Performance metrics 
Test by training llama_8b model after switching to native nn.RMSNorm  (training.seed = 0, deterministic=true):
   - Before the change:  memory: 49.58GiB(52.20%)  tps: 5,233
   - After the change:  memory: 49.66GiB(52.28%)  tps: 5,173

### Numerics 
Test by training llama_8b model after switching to native nn.RMSNorm  (training.seed = 0, deterministic=true): 
- Loss:
  - Before the change: blue line
  - After the change:  orange line
  - The blue line and orange line is not exactly identical. From @tianyu-l 's comment: Before the change, the downcast from FP32 to BF16 happens before the final output * self.weight whereas in pytorch kernel, the downcast happens after the final matmul .
  
<img width="1138" alt="Screenshot 2025-03-19 at 9 05 53 PM" src="https://github.com/user-attachments/assets/c167b3ad-1ccf-4083-8871-3d1b618c78b9" />



### Profiling of nn.RMSNorm
Test by training debug_model after switching to native nn.RMSNorm:
- Before the change: <img width="1487" alt="Screenshot 2025-03-19 at 5 02 27 PM" src="https://github.com/user-attachments/assets/2ae0e84a-b1fa-42af-afa0-6e6a52264ede" />

- After the change:<img width="1487" alt="Screenshot 2025-03-19 at 9 10 22 PM" src="https://github.com/user-attachments/assets/e665bf54-bc5c-4bda-9652-c78b1ae0ec59" />

- Note: `Aten::to` is explicitly changing the precision 

