### PR TITLE
[SimpleFSDP] Front-end Code and Unit test

### DIFF
--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torchtitan.experiments.simple_fsdp

--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -1,0 +1,40 @@
+## SimpleFSDP
+
+This folder includes an experimental frontend implementation for [SimpleFSDP: Simpler Fully Sharded Data Parallel with torch.compile](https://arxiv.org/abs/2411.00284). SimpleFSDP is a compiler-based Fully Sharded Data Parallel (FSDP) framework, which has a simple implementation for maintenance and composability, allows full computation-communication graph tracing, and brings performance enhancement via compiler backend optimizations.
+
+### Enable SimpleFSDP Training
+
+```bash
+CONFIG_FILE="./torchtitan/models/llama/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --training.compile --training.mixed_precision_param float32
+```
+
+Note: The mixed precision training support is on-going. We set `training.mixed_precision_param` to `float32` for now and will remove it once the integration is completed.
+
+### Composability Support
+
+Some of the features require the updates from PyTorch, with which we are working on providing composability support for the following features:
+
+| Feature | Support |
+| :--------: | :--------: |
+|Meta Initialization| ✅ |
+|Activation Checkpointing| ✅ |
+|Mixed Precision Training| 🚧 |
+|Tensor Parallelism| 🚧 |
+|Context Parallelism| ✅ |
+|Pipeline Parallelism| ✅ |
+|Distributed Checkpointing|  🚧 |
+|Float8 Training| ❌|
+
+
+### Citation
+
+If you find SimpleFSDP useful, please kindly consider citing the following paper:
+
+```latex
+@article{zhang2024simplefsdp,
+  title={SimpleFSDP: Simpler Fully Sharded Data Parallel with torch. compile},
+  author={Zhang, Ruisi and Liu, Tianyu and Feng, Will and Gu, Andrew and Purandare, Sanket and Liang, Wanchao and Massa, Francisco},
+  journal={arXiv preprint arXiv:2411.00284},
+  year={2024}
+}
+```

--- a/torchtitan/experiments/simple_fsdp/__init__.py
+++ b/torchtitan/experiments/simple_fsdp/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.lr_scheduler import build_lr_schedulers
+from torchtitan.components.optimizer import build_optimizers
+from torchtitan.datasets.hf_datasets import build_hf_dataloader
+from torchtitan.datasets.tokenizer.tiktoken import build_tiktoken_tokenizer
+from torchtitan.models.llama import llama3_configs, pipeline_llama
+from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+
+from .model import SimpleFSDPTransformer
+from .parallelize_llama import parallelize_llama
+
+register_train_spec(
+    TrainSpec(
+        name="llama3_simple_fsdp",
+        cls=SimpleFSDPTransformer,
+        config=llama3_configs,
+        parallelize_fn=parallelize_llama,
+        pipelining_fn=pipeline_llama,
+        build_optimizers_fn=build_optimizers,
+        build_lr_schedulers_fn=build_lr_schedulers,
+        build_dataloader_fn=build_hf_dataloader,
+        build_tokenizer_fn=build_tiktoken_tokenizer,
+        loss_fn=cross_entropy_loss,
+    )
+)

--- a/torchtitan/experiments/simple_fsdp/model.py
+++ b/torchtitan/experiments/simple_fsdp/model.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.llama import Transformer, TransformerModelArgs
+from .simple_fsdp import disable_data_parallel
+
+
+class SimpleFSDPTransformer(Transformer):
+    def __init__(self, model_args: TransformerModelArgs):
+        super().__init__(model_args)
+        self.init_weights()
+
+    def init_weights(self, *args, **kwargs):
+        with disable_data_parallel():
+            super().init_weights(*args, **kwargs)

--- a/torchtitan/experiments/simple_fsdp/parallelize_llama.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize_llama.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+
+from torch.distributed import DeviceMesh
+
+from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
+from torchtitan.distributed import ParallelDims
+from torchtitan.models.llama.parallelize_llama import apply_ac
+from torchtitan.tools.logging import logger
+
+from .simple_fsdp import data_parallel, MixedPrecisionPolicy
+
+
+def parallelize_llama(
+    model: nn.Module,
+    world_mesh: DeviceMesh,
+    parallel_dims: ParallelDims,
+    job_config: JobConfig,
+):
+    """
+    Apply activation checkpointing, torch.compile, and simplefsdp to the model.
+
+    NOTE: The passed-in model preferably should be on meta device. Otherwise,
+    the model must fit on GPU or CPU memory.
+    """
+    # TODO(ruisizhang123): Add support for TP (on-going)
+    # if parallel_dims.tp_enabled:
+    #     if (
+    #         job_config.parallelism.enable_async_tensor_parallel
+    #         and not job_config.training.compile
+    #     ):
+    #         raise RuntimeError("Async TP requires --training.compile")
+
+    #     enable_float8_linear = "float8" in job_config.model.converters
+    #     float8_is_rowwise = job_config.float8.recipe_name in (
+    #         "rowwise",
+    #         "rowwise_with_gw_hp",
+    #     )
+
+    #     # For now, float8 all-gather with TP is only supported for tensorwise
+    #     # float8 scaling recipes. For rowwise recipes, we use regular TP and
+    #     # all-gather happens in high precision.
+    #     enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
+
+    #     apply_tp(
+    #         model,
+    #         world_mesh["tp"],
+    #         loss_parallel=parallel_dims.loss_parallel_enabled,
+    #         enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+    #         enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
+    #     )
+
+    if job_config.activation_checkpoint.mode != "none":
+        apply_ac(model, job_config.activation_checkpoint)
+
+    if parallel_dims.dp_shard_enabled or parallel_dims.dp_replicate_enabled:
+        if parallel_dims.dp_replicate_enabled and parallel_dims.dp_shard_enabled:
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
+            fsdp_mode = "hybrid_shard"
+        elif parallel_dims.dp_replicate_enabled:
+            dp_mesh_dim_names = ("dp_replicate",)
+            fsdp_mode = "replicate"
+        else:
+            dp_mesh_dim_names = ("dp_shard_cp",)
+            fsdp_mode = "fully_shard"
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],
+            reduce_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_reduce],
+        )
+
+        model = data_parallel(
+            model,
+            world_mesh[tuple(dp_mesh_dim_names)],
+            mode=fsdp_mode,
+            ac_mode=job_config.activation_checkpoint.mode,
+            mp_policy=mp_policy,
+        )
+        logger.info("Applied SimpleFSDP (fsdp mode=%s) to the model", fsdp_mode)
+
+    if job_config.training.compile:
+        torch._inductor.config.reorder_for_peak_memory = False
+        model = torch.compile(model, fullgraph=True)
+
+    return model

--- a/torchtitan/experiments/simple_fsdp/simple_fsdp.py
+++ b/torchtitan/experiments/simple_fsdp/simple_fsdp.py
@@ -1,0 +1,194 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from torch.distributed._tensor import (
+    distribute_tensor,
+    DTensor,
+    Partial,
+    Replicate,
+    Shard,
+)
+from torch.utils.checkpoint import (
+    checkpoint,
+    CheckpointPolicy,
+    create_selective_checkpoint_contexts,
+)
+
+
+_active_parametrization = True
+
+
+@contextmanager
+def disable_data_parallel():
+    global _active_parametrization
+    try:
+        _active_parametrization = False
+        yield
+    finally:
+        _active_parametrization = True
+
+
+@dataclass(frozen=True)
+class MixedPrecisionPolicy:
+    param_dtype: Optional[torch.dtype] = None
+    reduce_dtype: Optional[torch.dtype] = None
+
+
+def fsdp_policy():
+    def _fsdp_recomp_policy():
+        def _custom_policy(ctx, func, *args, **kwargs):
+            to_recompute = func in {
+                torch.ops._c10d_functional.all_gather_into_tensor.default,
+                torch.ops._c10d_functional.wait_tensor.default,
+                torch.ops.aten._to_copy.default,  # for dtype cast in FSDP
+            }
+            return (
+                CheckpointPolicy.MUST_RECOMPUTE
+                if to_recompute
+                else CheckpointPolicy.MUST_SAVE
+            )
+
+        return _custom_policy
+
+    return create_selective_checkpoint_contexts(_fsdp_recomp_policy())
+
+
+class ReplicateComputation(torch.nn.Module):
+    def __init__(self, device_mesh, param_sharding, mode, regional_ac, mp_policy):
+        super().__init__()
+        self.device_mesh = device_mesh
+        self.param_sharding = param_sharding
+        self.mode = mode
+        self.compute_placements = [Replicate()] * self.device_mesh.ndim
+        self.grad_placements = [Partial(reduce_op="avg")] * self.device_mesh.ndim
+        self.regional_ac = regional_ac
+        mp_policy = mp_policy or MixedPrecisionPolicy()
+        self.param_dtype = mp_policy.param_dtype
+        self.reduce_dtype = mp_policy.reduce_dtype
+
+    def replicate_compute(self, x):
+        # data parallel runtime replicate parameters and do local compute
+        # the gradients are partial tensors that needs to perform reduction
+        # (i.e. DDP: allreduce, FSDP: reduce_scatter, HSDP: mix of both)
+
+        # NOTE: specifying mixed precision is only available in pytorch_intern24
+        #       https://github.com/tianyu-l/pytorch_intern24/pull/20
+        # support for FSDP + TP (assuming TP shards the inner-most dim)
+        if self.mode == "fully_shard" and x._spec.mesh.ndim == 2:
+            dp_placement, tp_placement = x._spec.placements
+            dp_mesh, tp_mesh = self.device_mesh, x._spec.mesh["tp"]
+
+            # re-wrap 2D DTensor to 1D DTensor on dp_mesh for efficient FSDP all-gather
+            # TODO: we should consider merging this logic into DTensor redistribute API
+            sharded_local_tensor = x.to_local()
+            sharded_dtensor = DTensor.from_local(
+                sharded_local_tensor, dp_mesh, self.param_sharding
+            )
+
+            # the actuall FSDP all-gather on dp_mesh
+            # TODO(ruisizhang123): enable mixed-precision training here
+            # add the forward_dtype and backward_dtype back after landing changes in PyTorch DTensor
+            replicated_dtensor = sharded_dtensor.redistribute(
+                placements=self.compute_placements,
+                # forward_dtype=self.param_dtype,
+                # backward_dtype=self.reduce_dtype,
+            )
+
+            # re-wrap 1D all-gathered DTensor on dp_mesh to 1D DTensor on tp_mesh
+            # TODO: DTensor should support this mesh collasping operation
+            replicated_local_tensor = replicated_dtensor.to_local(
+                grad_placements=self.grad_placements
+            )
+            output = DTensor.from_local(
+                replicated_local_tensor, tp_mesh, (tp_placement,)
+            )
+        else:
+            output = x.redistribute(
+                placements=self.compute_placements,
+                # forward_dtype=self.param_dtype,
+                # backward_dtype=self.reduce_dtype,
+            ).to_local(grad_placements=self.grad_placements)
+
+        return output
+
+    def forward(self, x):
+        global _active_parametrization
+        # This should never be set to true during forward, only outside for model
+        # inspection / debugging / initialization
+        # model initialization can be done now through
+        # with disable_data_parallel():
+        #     model.init_weights()
+        if not _active_parametrization:
+            return x
+
+        if self.regional_ac and self.mode in ("fully_shard", "hybrid_shard"):
+            # apply checkpointing to implement reshard_after_forward
+            output = checkpoint(
+                self.replicate_compute, x, use_reentrant=False, context_fn=fsdp_policy
+            )
+        else:
+            output = self.replicate_compute(x)
+
+        return output
+
+
+def data_parallel(
+    model,
+    device_mesh,
+    mode="replicate",
+    ac_mode: str = "none",
+    mp_policy: Optional[MixedPrecisionPolicy] = None,
+):
+    if mode == "replicate":
+        param_sharding = (Replicate(),)
+    elif mode == "fully_shard":
+        param_sharding = (Shard(0),)
+    elif mode == "hybrid_shard":
+        # replicate inter-host, fully shard intra-host
+        param_sharding = (Replicate(), Shard(0))
+        assert (
+            device_mesh.ndim == 2
+        ), "hybrid sharded data parallel requires 2D DeviceMesh"
+    else:
+        raise ValueError(f"Unsupported mode {mode}")
+
+    modules = list(model.modules())
+
+    # apply regional ac (with fsdp_policy) if no global ac is to be applied
+    regional_ac = ac_mode == "none"
+
+    for mod in modules:
+        params_dict = dict(mod.named_parameters(recurse=False))
+        for p_name, p in params_dict.items():
+            if p is not None and p.numel() > 0:
+                mod.register_parameter(
+                    p_name,
+                    # NOTE: for 2D we need to distribute_tensor a DTensor
+                    #       which requires latest change in pytorch_intern24
+                    #       https://github.com/tianyu-l/pytorch_intern24/pull/25
+                    nn.Parameter(distribute_tensor(p, device_mesh, param_sharding)),
+                )
+                nn.utils.parametrize.register_parametrization(
+                    mod,
+                    p_name,
+                    ReplicateComputation(
+                        device_mesh,
+                        param_sharding,
+                        mode,
+                        regional_ac,
+                        mp_policy=mp_policy,
+                    ),
+                    unsafe=True,
+                )
+
+    return model

--- a/torchtitan/experiments/simple_fsdp/tests/__init__.py
+++ b/torchtitan/experiments/simple_fsdp/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
+++ b/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import copy
+
+import torch
+from torch.distributed._composable.fsdp import fully_shard
+
+from torch.testing._internal.common_fsdp import FSDPTest
+
+from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.simple_fsdp.simple_fsdp import data_parallel
+
+
+class TestSimpleFSDP(FSDPTest):
+    def init_test(self):
+        self.optimizer = torch.optim.Adam
+        self.loss_fn = cross_entropy_loss
+        data_parallel_shard_degree = -1
+        if self.mode == "replicate":
+            self.dp_mesh_dim_names = ("dp_replicate",)
+            data_parallel_replicate_degree = self.world_size
+        elif self.mode == "fully_shard":
+            self.dp_mesh_dim_names = ("dp_shard_cp",)
+            data_parallel_replicate_degree = 1
+        elif self.mode == "hybrid_shard":
+            self.dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
+            data_parallel_replicate_degree = self.world_size // 2
+        else:
+            raise ValueError(f"Unsupported mode {mode}")
+
+        self.parallel_dims = ParallelDims(
+            dp_shard=data_parallel_shard_degree,
+            dp_replicate=data_parallel_replicate_degree,
+            cp=1,
+            tp=1,
+            pp=1,
+            world_size=self.world_size,
+            enable_loss_parallel=True,
+        )
+        self.device_mesh = self.parallel_dims.build_mesh(device_type="cuda")
+
+    def get_input(self):
+        inputs = torch.randn(8, 8).cuda()
+        labels = torch.randn(8, 8).cuda()
+        model = torch.nn.Linear(8, 8)
+        return model, inputs, labels
+
+    def run_fsdp2(self, model, inputs, labels, epoch=20):
+        fully_shard(model, mesh=self.device_mesh[tuple(self.dp_mesh_dim_names)])
+        optim = self.optimizer(model.parameters(), lr=1e-4)
+        losses = []
+        for _ in range(epoch):
+            optim.zero_grad()
+            out = model(inputs)
+            loss = self.loss_fn(out, labels)
+            loss.backward()
+            optim.step()
+            losses.append(loss)
+        return losses
+
+    def run_simple_fsdp(self, model, inputs, labels, epoch=20):
+        model = data_parallel(
+            model,
+            device_mesh=self.device_mesh[tuple(self.dp_mesh_dim_names)],
+            mode=self.mode,
+        )
+        optim = self.optimizer(model.parameters(), lr=1e-4)
+        losses = []
+        for _ in range(epoch):
+            optim.zero_grad()
+            out = model(inputs)
+            loss = self.loss_fn(out, labels)
+            loss.backward()
+            optim.step()
+            losses.append(loss)
+        return losses
+
+    def test_replicate_convergence(self):
+        # unit test for replicate mode
+        self.mode = "replicate"
+        self.init_test()
+        model, inputs, labels = self.get_input()
+
+        fsdp2_losses = self.run_fsdp2(copy.deepcopy(model), inputs, labels)
+        simple_fsdp_replicate_losses = self.run_simple_fsdp(
+            copy.deepcopy(model), inputs, labels
+        )
+
+        for fsdp2_loss, simple_fsdp_replicate_loss in zip(
+            fsdp2_losses, simple_fsdp_replicate_losses
+        ):
+            assert torch.allclose(fsdp2_loss, simple_fsdp_replicate_loss)
+
+    def test_fullyshard_convergence(self):
+        # unit test for fully_shard mode
+        self.mode = "fully_shard"
+        self.init_test()
+        model, inputs, labels = self.get_input()
+
+        fsdp2_losses = self.run_fsdp2(copy.deepcopy(model), inputs, labels)
+        simple_fsdp_fullyshard_losses = self.run_simple_fsdp(
+            copy.deepcopy(model), inputs, labels
+        )
+
+        for fsdp2_loss, simple_fsdp_fullyshard_loss in zip(
+            fsdp2_losses, simple_fsdp_fullyshard_losses
+        ):
+            assert torch.allclose(fsdp2_loss, simple_fsdp_fullyshard_loss)
+
+    def test_hybridshard_convergence(self):
+        # unit test for hybrid_shard mode
+        self.mode = "hybrid_shard"
+        self.init_test()
+        model, inputs, labels = self.get_input()
+
+        fsdp2_losses = self.run_fsdp2(copy.deepcopy(model), inputs, labels)
+        simple_fsdp_hybridshard_losses = self.run_simple_fsdp(
+            copy.deepcopy(model), inputs, labels
+        )
+
+        for fsdp2_loss, simple_fsdp_hybridshard_loss in zip(
+            fsdp2_losses, simple_fsdp_hybridshard_losses
+        ):
+            assert torch.allclose(fsdp2_loss, simple_fsdp_hybridshard_loss)


### PR DESCRIPTION
This PR adds front-end code of SimpleFSDP and integrated with TorchTitan's training. 

#### Composability tracker:

| Feature | Support |
| :--------: | :--------: |
|Meta Initialization| ✅ |
|Activation Checkpointing| ✅ |
|Mixed Precision Training| 🚧 |
|Tensor Parallelism| 🚧 |
|Context Parallelism| ✅ |
|Pipeline Parallelism| ✅ |
|Distributed Checkpointing|  🚧 |
|Float8 Training| ❌| 

#### Convergence on debug model

The loss curves are all benchmarked with `training.mixed_precision_param = float32` (SimpleFSDP's MPT integration is on-going) and `training.seed = 42` on 4 GPU.

- Fully Shard Mode (['dp_shard'], [4]): FSDP2 and SimpleFSDP's losses are perfectly matched

<img width="1329" alt="Screenshot 2025-03-20 at 10 31 22 PM" src="https://github.com/user-attachments/assets/11ba78f4-5ac1-4949-9b34-ea5cf07c374f" />

- Replicate Mode (['dp_replicate'], [4]): FSDP2 and SimpleFSDP's losses are almost the same.

<img width="1332" alt="Screenshot 2025-03-20 at 10 37 34 PM" src="https://github.com/user-attachments/assets/a50b9370-322f-4299-8fab-557b879543e8" />


**Note that the FSDP optimizations (reordering and bucketing) are not included. Thus, users won't be expected  to see the throughputs/memory numbers reported in [SimpleFSDP paper](https://arxiv.org/abs/2411.00284) only with front-end code in this pr.**