### PR TITLE
chunked cross entropy loss to reduce peak memory

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -82,5 +82,5 @@ A seed checkpoint does initialization of the model on a single CPU, and can be l
 To create a seed checkpoint, use the same model config as you use for training.
 e.g.
 ```bash
-NGPU=1 CONFIG=<path_to_model_config> ./run_train.sh --checkpoint.enable_checkpoint --checkpoint.create_seed_checkpoint --training.data_parallel_replicate_degree 1 --training.data_parallel_shard_degree 1 --training.tensor_parallel_degree 1 --experimental.pipeline_parallel_degree 1 --experimental.context_parallel_degree 1
+NGPU=1 CONFIG=<path_to_model_config> ./run_train.sh --checkpoint.enable_checkpoint --checkpoint.create_seed_checkpoint --parallelism.data_parallel_replicate_degree 1 --parallelism.data_parallel_shard_degree 1 --parallelism.tensor_parallel_degree 1 --parallelism.pipeline_parallel_degree 1 --parallelism.context_parallel_degree 1
 ```

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -16,3 +16,20 @@ def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
 
 # TODO: compiling loss function causes CUDA errors, turning off for now
 # compiled_cross_entropy_loss = torch.compile(cross_entropy_loss)
+
+
+def chunked_cross_entropy_loss(
+    logits: torch.Tensor, labels: torch.Tensor, num_output_chunks: int = 8
+) -> torch.Tensor:
+    # Adapted from torchtune
+    # https://github.com/pytorch/torchtune/blob/c3703482bde72e572b535d3f7c43c81e94164ebc/torchtune/modules/loss/ce_chunked_output_loss.py
+
+    labels = [target_chunk for target_chunk in labels.chunk(num_output_chunks, dim=1)]
+    logits = [logit_chunk for logit_chunk in logits.chunk(num_output_chunks, dim=1)]
+
+    # compute one chunk at a time
+    total_loss = 0.0
+    for logits_chunk, labels_chunk in zip(logits, labels):
+        total_loss += cross_entropy_loss(logits_chunk, labels_chunk)
+
+    return total_loss / num_output_chunks

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from torchtitan.components.loss import chunked_cross_entropy_loss
+from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
@@ -71,6 +71,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
-        loss_fn=chunked_cross_entropy_loss,
+        loss_fn=cross_entropy_loss,
     )
 )

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import chunked_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
@@ -71,6 +71,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
-        loss_fn=cross_entropy_loss,
+        loss_fn=chunked_cross_entropy_loss,
     )
 )


### PR DESCRIPTION
Noticed that in the memory snapshot when running the Llama3-8B models, the cross entropy loss is causing huge spikes in peak memory: 
<img width="474" alt="image" src="https://github.com/user-attachments/assets/31ea0f9a-7734-4454-90e5-e3a4ed0b5db3" />

Replace the cross entropy loss function with a chunked version can help reduce peak memory by 7GiB without affecting training throughput. This is inspired by the torchtune [implementation](https://github.com/pytorch/torchtune/blob/c3703482bde72e572b535d3f7c43c81e94164ebc/torchtune/modules/loss/ce_chunked_output_loss.py#L13).

**Baseline run**
```
...
[rank0]:[titan] 2025-03-20 08:19:11,539 - root - INFO - step: 30  loss:  7.7158  memory: 49.58GiB(52.20%)  tps: 5,966  tflops: 345.53  mfu: 34.94%
[rank0]:[titan] 2025-03-20 08:19:25,291 - root - INFO - step: 40  loss:  7.3677  memory: 49.58GiB(52.20%)  tps: 5,957  tflops: 345.01  mfu: 34.88%
[rank0]:[titan] 2025-03-20 08:19:39,040 - root - INFO - step: 50  loss:  7.0890  memory: 49.58GiB(52.20%)  tps: 5,959  tflops: 345.10  mfu: 34.89%
[rank0]:[titan] 2025-03-20 08:19:52,794 - root - INFO - step: 60  loss:  6.8336  memory: 49.58GiB(52.20%)  tps: 5,957  tflops: 344.99  mfu: 34.88%
...
```

**With the changes**
```
...
[rank0]:[titan] 2025-03-20 08:29:30,780 - root - INFO - step: 30  loss:  7.7423  memory: 42.26GiB(44.49%)  tps: 5,957  tflops: 345.01  mfu: 34.89%
[rank0]:[titan] 2025-03-20 08:29:44,554 - root - INFO - step: 40  loss:  7.3368  memory: 42.26GiB(44.49%)  tps: 5,948  tflops: 344.49  mfu: 34.83%
[rank0]:[titan] 2025-03-20 08:29:58,318 - root - INFO - step: 50  loss:  7.0574  memory: 42.26GiB(44.49%)  tps: 5,953  tflops: 344.74  mfu: 34.86%
[rank0]:[titan] 2025-03-20 08:30:12,080 - root - INFO - step: 60  loss:  6.8472  memory: 42.26GiB(44.49%)  tps: 5,953  tflops: 344.79  mfu: 34.86%
...
```

**cc**: @lessw2020 @weifengpy @wconstab @yf225 