### PR TITLE
[DeepSeek] Enable data parallel

### DIFF
--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# torchrun --standalone --nproc-per-node 4 run.py
+# torchrun --standalone --nproc-per-node 8 run.py
 import torch
 import torch.distributed as dist
 from checkpoint import load_weights_from_hf
@@ -12,7 +12,8 @@ from model import DeepseekForCausalLM
 from model_config import deepseek_config_registry
 
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.pipelining import PipelineStage, Schedule1F1B
 
 
 # Use DeepSeek-V2-Lite as a proxy
@@ -36,6 +37,9 @@ def run_full_model(
 
     # Get model configs
     model_args = deepseek_config_registry[model_id]
+    # [Note]: I am making the model smaller for testing / avoiding OOM. If you
+    # have sufficient GPUs for model parallelism, you can remove this line.
+    model_args.num_hidden_layers = 16
 
     # Apply model parallelism
     model_args.ep_size = ep_size
@@ -50,6 +54,25 @@ def run_full_model(
     # Load weights
     load_weights_from_hf(model, model_id, device)
     model.train()
+
+    # Apply data parallelism
+    fsdp_mesh = mesh["fsdp"]
+    hsdp_mesh = mesh["ep", "fsdp"]
+    # Using `reshard_after_forward=False` to implement Zero-2, i.e. sharding the
+    # optimizer (Zero-1) and gradients (Zero-2), but not the model weights.
+    # Reason: the MoE is "sparsely activated" compared to the dense model, thus
+    # it will be ineconomical re-gather the weights.
+    for layer in model.model.layers.values():
+        # Apply FSDP to experts
+        if hasattr(layer.mlp, "experts"):
+            for expert in layer.mlp.experts.values():
+                fully_shard(expert, mesh=fsdp_mesh, reshard_after_forward=False)
+        # Apply HSDP to other parts such as attention, layernorm, because they
+        # are doing DDP on EP dimension
+        fully_shard(layer, mesh=hsdp_mesh, reshard_after_forward=False)
+
+    # Apply HSDP on root model (lm_head, embeddings, etc)
+    fully_shard(model, mesh=hsdp_mesh, reshard_after_forward=False)
 
     # Example inputs
     bs = 2
@@ -74,7 +97,7 @@ def run_full_model(
         # Create pipeline schedule
         microbatches = 2
         losses = []
-        pp_schedule = ScheduleGPipe(stage, microbatches, loss_fn=loss_fn)
+        pp_schedule = Schedule1F1B(stage, microbatches, loss_fn=loss_fn)
 
         if pp_rank == 0:
             y = pp_schedule.step(x)
@@ -96,7 +119,7 @@ def run_full_model(
 
 
 if __name__ == "__main__":
-    mesh = dist.init_device_mesh("cuda", (2, 2), mesh_dim_names=("pp", "ep"))
+    mesh = dist.init_device_mesh("cuda", (2, 2, 2), mesh_dim_names=("pp", "ep", "fsdp"))
 
     run_full_model(mesh)
 


### PR DESCRIPTION
Reland #956

This PR adds FSDP on the Expert modules. Since before this we are already doing a DP-to-EP shuffle between the Attention and the Experts, we applies HSDP on the Attention, with the replicate dimension being the same as the EP dimension.

In particular, we are using Zero-2 sharding which shards optimizer and gradients, and not sharding the weights, to avoid the expensive re-gather of MoE.