### PR TITLE
Hpc setup

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -821,7 +821,6 @@ class JobConfig:
             ]
             func = getattr(module, public_functions[0])
             func(self.parser)
-        )
 
 
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -753,6 +753,20 @@ class JobConfig:
             help="The minimum number of FT replica for each step.",
         )
 
+        # hpc , slurm etc settings
+        self.parser.add_argument(
+            "--hpc.rank_var",
+            type=str,
+            default=None,
+            help="The enviroment var set by launcher ( e.g.  mpirun, mpiexec, ect.) for rank.",
+        )
+        self.parser.add_argument(
+            "--hpc.local_rank_var",
+            type=str,
+            default=None,
+            help="The enviroment var set by launcher ( e.g.  mpirun, mpiexec, ect.) for local rank.",
+        )
+
         self.parser.add_argument(
             "--experimental.custom_import",
             type=str,
@@ -807,6 +821,9 @@ class JobConfig:
             ]
             func = getattr(module, public_functions[0])
             func(self.parser)
+        )
+
+
 
     def to_dict(self):
         return self.args_dict

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -31,6 +31,12 @@ from torchtitan.tools.profiling import (
     maybe_enable_profiling,
 )
 
+def hpc_setup(job_config: JobConfig):
+    if job_config.hpc.rank_var:
+        os.environ['RANK'] = os.getenv(job_config.hpc.rank_var)
+    if job_config.hpc.local_rank_var:
+        os.environ['LOCAL_RANK'] = os.getenv(job_config.hpc.local_rank_var)
+
 
 class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     job_config: JobConfig
@@ -463,6 +469,8 @@ if __name__ == "__main__":
     config = JobConfig()
     config.maybe_add_custom_args()
     config.parse_args()
+    hpc_setup(config)
+
     trainer: Optional[Trainer] = None
 
     try:


### PR DESCRIPTION
HPC type setup ( e.g. mpirun , mpiexec)   currently requires code change in train.py ( or elsewhere) . Adding  couple of optional additional   args ( e.g. rank and local rank) to toml file along with a simple function in train.py removes the need to make those changes. 