### PR TITLE
use -m option to run scripts as modules

### DIFF
--- a/.github/workflows/integration_test_8gpu.yaml
+++ b/.github/workflows/integration_test_8gpu.yaml
@@ -38,8 +38,5 @@ jobs:
 
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124
 
-        # install torchtitan to test the files in ./scripts
-        python -m pip install -e .
-
         mkdir artifacts-to-be-uploaded
         python ./tests/integration_tests.py artifacts-to-be-uploaded --ngpu 8

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ cd torchtitan
 pip install -r requirements.txt
 pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124 --force-reinstall
 [For AMD GPU] pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3 --force-reinstall
-pip install -e .
 ```
 
 ### Downloading a tokenizer

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -5,7 +5,7 @@ An example script for converting the original Llama3 checkpoints into the expect
 
 The script expects a path to the original checkpoint files, and a path to an output directory:
 ```bash
-python3 scripts/convert_llama_to_dcp.py <input_dir> <output_dir>
+python -m scripts.convert_llama_to_dcp <input_dir> <output_dir>
 ```
 
 

--- a/run_train.sh
+++ b/run_train.sh
@@ -25,4 +25,4 @@ PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
 TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
-torchtitan/train.py --job.config_file ${CONFIG_FILE} $overrides
+-m torchtitan.train --job.config_file ${CONFIG_FILE} $overrides

--- a/scripts/estimate/run_memory_estimation.sh
+++ b/scripts/estimate/run_memory_estimation.sh
@@ -23,4 +23,4 @@ fi
 # Export WORLD_SIZE and LOCAL_RANK
 export WORLD_SIZE=$((NGPU * NNODES))
 export LOCAL_RANK=0
-python scripts/estimate/estimation.py --job.config_file ${CONFIG_FILE} --memory_estimation.enabled $overrides
+python -m scripts.estimate.estimation --job.config_file ${CONFIG_FILE} --memory_estimation.enabled $overrides

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -33,5 +33,5 @@ PROMPT="What is the meaning of life?" \
 #### View Available Arguments
 
 ```bash
-> python ./scripts/generate/test_generate.py --help
+> python -m scripts.generate.test_generate --help
 ```

--- a/scripts/generate/run_llama_generate.sh
+++ b/scripts/generate/run_llama_generate.sh
@@ -37,7 +37,7 @@ set -x
 torchrun --standalone \
 	--nproc_per_node="${NGPU}" \
 	--local-ranks-filter="${LOG_RANK}" \
-	scripts/generate/test_generate.py \
+	-m scripts.generate.test_generate \
 	--config="${CONFIG_FILE}" \
 	--checkpoint="${CHECKPOINT_DIR}" \
 	--prompt="${PROMPT}" \


### PR DESCRIPTION
Running `python` or `torchrun` with `-m` option helps resolve package structure without the need to do `pip install -e`.

This is suggested by @yzhangcs in https://github.com/pytorch/torchtitan/issues/897#issuecomment-2744951051
> It avoids the potential pitfalls of using `pip install -e .`, which can sometimes lead to inconvenient and hard-to-debug issues, especially when we're making frequent changes to the codebase.