### PR TITLE
Fix ZeroDivisionError when decay_steps=0

### DIFF
--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -142,11 +142,10 @@ def build_lr_schedulers(
         to ensure the learning rate does not drop below this minimum value.
         """
         warmup_stable_steps = warmup_steps + stable_steps
-        if current_step < warmup_steps:
+        if current_step <= warmup_steps:
             # linear warmup
-            # 0-indexed step, hence + 1 adjustments
-            current_step += 1
-            curr_adjustment = float(current_step / (warmup_steps + 1))
+            # 1-indexed step
+            curr_adjustment = float(current_step / warmup_steps)
         elif current_step <= warmup_stable_steps:
             curr_adjustment = 1.0
         else:

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -149,6 +149,7 @@ def build_lr_schedulers(
         elif current_step <= warmup_stable_steps:
             curr_adjustment = 1.0
         else:
+            assert decay_steps != 0, "decay_steps must be greater than 0"
             progress = float(current_step - warmup_stable_steps) / decay_steps
 
             if lr_decay_type == "linear":

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -147,7 +147,7 @@ def build_lr_schedulers(
             # 0-indexed step, hence + 1 adjustments
             current_step += 1
             curr_adjustment = float(current_step / (warmup_steps + 1))
-        elif current_step < warmup_stable_steps:
+        elif current_step <= warmup_stable_steps:
             curr_adjustment = 1.0
         else:
             progress = float(current_step - warmup_stable_steps) / decay_steps

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -142,15 +142,17 @@ def build_lr_schedulers(
         to ensure the learning rate does not drop below this minimum value.
         """
         warmup_stable_steps = warmup_steps + stable_steps
-        if current_step <= warmup_steps:
+        if current_step < warmup_steps:
             # linear warmup
-            # 1-indexed step
-            curr_adjustment = float(current_step / warmup_steps)
-        elif current_step <= warmup_stable_steps:
+            # 0-indexed step, hence + 1 adjustments
+            current_step += 1
+            curr_adjustment = float(current_step / (warmup_steps + 1))
+        elif current_step < warmup_stable_steps:
             curr_adjustment = 1.0
         else:
-            assert decay_steps != 0, "decay_steps must be greater than 0"
-            progress = float(current_step - warmup_stable_steps) / decay_steps
+            # 0-indexed step, hence + 1 adjustments
+            current_step += 1
+            progress = float(current_step - warmup_stable_steps) / (decay_steps + 1)
 
             if lr_decay_type == "linear":
                 curr_adjustment = 1 - progress


### PR DESCRIPTION
When `decay_steps=0`, a ZeroDivisionError occurs.

Example:

Given parameters:
- decay_steps=0
- warmup_steps=5
- training_steps=10

Then:
- warmup_stable_steps=warmup_steps+stable_steps=10
- current_step ranges from 1 to 10

With the original code, when `current_step` equals `warmup_stable_steps`, we fall through to the `else` branch, which triggers a ZeroDivisionError due to `decay_steps` being 0.

```python
if current_step < warmup_steps:
    # linear warmup
    # 0-indexed step, hence + 1 adjustments
    current_step += 1
    curr_adjustment = float(current_step / (warmup_steps + 1))
elif current_step < warmup_stable_steps:
    curr_adjustment = 1.0
else:
    progress = float(current_step - warmup_stable_steps) / decay_steps

    if lr_decay_type == "linear":
        curr_adjustment = 1 - progress
    elif lr_decay_type == "sqrt":
        curr_adjustment = 1 - math.sqrt(progress)
    elif lr_decay_type == "cosine":
        curr_adjustment = 0.5 * (1.0 + math.cos(math.pi * progress))
    curr_adjustment = lr_min + (1 - lr_min) * curr_adjustment
```

This PR changes `current_step < warmup_stable_steps` to `current_step <= warmup_stable_steps` to better handle the boundary case and prevent the ZeroDivisionError when `decay_steps=0`.