### PR TITLE
fix simple_fsdp logic when CP is used

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -20,10 +20,10 @@ Some of the features require the updates from PyTorch, with which we are working
 |Activation Checkpointing| ✅ |
 |Mixed Precision Training| 🚧 |
 |Tensor Parallelism| 🚧 |
-|Context Parallelism| ✅ |
+|Context Parallelism| 🚧 |
 |Pipeline Parallelism| ✅ |
-|Distributed Checkpointing|  🚧 |
-|Float8 Training| ❌|
+|Distributed Checkpointing| 🚧 |
+|Float8 Training| ❌ |
 
 
 ### Citation


### PR DESCRIPTION
I observed that
1. When CP is used without other data parallel (`dp_replicate` / `dp_shard`), it works fine with and without torch.compile
2. When CP is combined with any other data parallel, it only works without torch.compile. It would fail under compile, with error info like "_UnboundLocalError: cannot access local variable 'buf899' where it is not associated with a value_"

So I'm marking CP as "to be fixed".