### PR TITLE
[DeepSeek] Re-enable backward for on-device all_to_all_v

### DIFF
--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -132,7 +132,7 @@ def create_model(dist_config: DistConfig):
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
     model.eval()
-    model.setup_symm_mem(torch.bfloat16, dist_config.device)
+    model.setup_symm_mem(torch.bfloat16, dist_config.device, microbatches=dist_config.pp_size)
 
     return model, PipelineStage(
         model,

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -131,7 +131,8 @@ def create_model(dist_config: DistConfig):
     with dist_config.device, dist_config.mesh:
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
-    model.train()
+    model.eval()
+    model.setup_symm_mem(torch.bfloat16, dist_config.device, shared=True)
 
     return model, PipelineStage(
         model,

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -132,7 +132,9 @@ def create_model(dist_config: DistConfig):
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
     model.eval()
-    model.setup_symm_mem(torch.bfloat16, dist_config.device, microbatches=dist_config.pp_size)
+    model.setup_symm_mem(
+        torch.bfloat16, dist_config.device, microbatches=dist_config.pp_size
+    )
 
     return model, PipelineStage(
         model,

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -132,7 +132,7 @@ def create_model(dist_config: DistConfig):
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
     model.eval()
-    model.setup_symm_mem(torch.bfloat16, dist_config.device, shared=True)
+    model.setup_symm_mem(torch.bfloat16, dist_config.device)
 
     return model, PipelineStage(
         model,

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -143,6 +143,7 @@ def create_model(dist_config: DistConfig):
     )
 
 
+@torch.inference_mode()
 def generate(mesh: DeviceMesh, messages: list[dict], n_tokens: int = 50):
     rank = dist.get_rank()
 

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -132,9 +132,7 @@ def create_model(dist_config: DistConfig):
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
     model.eval()
-    model.setup_symm_mem(
-        torch.bfloat16, dist_config.device, microbatches=dist_config.pp_size
-    )
+    model.setup_symm_mem(torch.bfloat16, dist_config.device)
 
     return model, PipelineStage(
         model,

--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -27,7 +27,7 @@
 # limitations under the License.
 """ PyTorch DeepSeek model."""
 import math
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -452,8 +452,8 @@ class MoE(nn.Module):
     shuffle_method = "torch_all_to_all"
 
     # Symmetric memory buffers shared by all MoE instances across layers
-    token_send_buf: Optional[torch.Tensor] = []
-    token_gather_buf: Optional[torch.Tensor] = []
+    token_send_buf: Optional[List[torch.Tensor]] = []
+    token_gather_buf: Optional[List[torch.Tensor]] = []
 
     def __init__(self, config):
         super().__init__()

--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -535,10 +535,12 @@ class MoE(nn.Module):
         # backward through the graph a second time. To avoid this, we detach the
         # buffer from the graph. `detach()` returns a new tensor, which shares
         # the same storage with the original one.
+        self.token_send_buf.grad = None
         return self.token_send_buf.detach()
 
     def get_gather_buf(self):
         # See [Why detach?] in `get_send_buf`
+        self.token_gather_buf.grad = None
         return self.token_gather_buf.detach()
 
     def forward(self, hidden_states):

--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -494,11 +494,6 @@ class MoE(nn.Module):
     # all_to_all APIs which requrie a GPU-to-CPU sync of the splits.  If a user
     # calls this function, the `shuffle_method` would switch from
     # `torch_all_to_all` to `symm_mem`.
-
-    # Status: supports inference. For training, this is disabled for now. Reason
-    # is that autograd requires tensors not be modified a second time, this
-    # conflicts with our wish of sharing the symm mem across layers and/or
-    # PP microbatches.
     def setup_symm_mem(
         self, dtype: torch.dtype, device: torch.device, microbatches: int
     ):
@@ -513,16 +508,6 @@ class MoE(nn.Module):
         self.gather_buf_len = (
             self.config.max_seq_len * self.num_experts_per_tok * overflow
         )
-        # # Splits are not shared across layers, because autograd needs to save
-        # # them for backward.
-        # # Number of tokens to send to EP peers, aka. input splits
-        # self.input_splits = symm_mem.empty(
-        #     self.ep_size, dtype=torch.int64, device=device
-        # )
-        # # Number of tokens to receive from EP peers, aka. output splits
-        # self.output_splits = symm_mem.empty(
-        #     self.ep_size, dtype=torch.int64, device=device
-        # )
 
         # Symmetric memory buffers are shared by all MoE instances across
         # layers, we only need to initialize them once

--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -85,7 +85,7 @@ def run_full_model(
 
     # Use Symmetric Memory for MoE token shuffle. Do not share across layers,
     # because shuffle outputs are saved by autograd for backward.
-    model.setup_symm_mem(torch.bfloat16, device, shared=True)
+    model.setup_symm_mem(torch.bfloat16, device)
 
     # Run forward and backward
     if pp_size > 1:

--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -78,7 +78,7 @@ def run_full_model(
     microbatches = pp_size * 2
 
     # Use Symmetric Memory for MoE token shuffle.
-    model.setup_symm_mem(torch.bfloat16, device, microbatches)
+    model.setup_symm_mem(torch.bfloat16, device)
 
     # Example inputs
     torch.manual_seed(ep_rank)

--- a/torchtitan/experiments/deepseek_v3/symm_mem_recipes/__init__.py
+++ b/torchtitan/experiments/deepseek_v3/symm_mem_recipes/__init__.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .triton_on_device_all_to_all_v import on_device_all_to_all_v
+from .triton_on_device_all_to_all_v import OnDeviceAllToAllV
 
 __all__ = [
-    "on_device_all_to_all_v",
+    "OnDeviceAllToAllV",
 ]

--- a/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
+++ b/torchtitan/experiments/deepseek_v3/symm_mem_recipes/triton_on_device_all_to_all_v.py
@@ -187,7 +187,6 @@ class OnDeviceAllToAllV(torch.autograd.Function):
             if OnDeviceAllToAllV.max_output_shape is None
             else max(OnDeviceAllToAllV.max_output_shape, output.shape)
         )
-        print(f"FWD: {output_splits=}")
         return output
 
     @staticmethod
@@ -209,7 +208,6 @@ class OnDeviceAllToAllV(torch.autograd.Function):
 
         # Size info
         (grad_output_splits,) = ctx.saved_tensors
-        print(f"BWD: {grad_output_splits=}")
         grad_input_splits = torch.empty_like(grad_output_splits)  # unused
         grad_input = grad_output.new_empty(*ctx.input_shape)
 


### PR DESCRIPTION
A couple changes compared to previous try in #941:
- Make `OnDeviceAllToAllV` in functional form (easier to form autograd graph).
- Move symm-mem based splits buffer inside `OnDeviceAllToAllV` (this part does not need gradients). This would introduce a small copy from normal split tensor to this symm-mem backed split tensor, but since this copy is very small (of `ep_size`), so we should be able to tolerate it, and reduce outside dependency.
- Create different symm mem space for data buffers of different micro-batches (from pipeline parallel), because autograd does not allow them to step on each other's toes.

Test:
`torchrun --standalone --nproc-per-node 8 run.py`
Using traditional `torch_all_to_all`:
```
loss=tensor(681.1560, device='cuda:4', grad_fn=<MeanBackward0>)
loss=tensor(681.1560, device='cuda:5', grad_fn=<MeanBackward0>)
loss=tensor(688.9081, device='cuda:7', grad_fn=<MeanBackward0>)
loss=tensor(688.9081, device='cuda:6', grad_fn=<MeanBackward0>)
torch.linalg.norm(param.grad)=DTensor(local_tensor=104.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=136.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=104.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=136.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
```
Using symm mem all_to_all_v:
```
loss=tensor(688.9081, device='cuda:7', grad_fn=<MeanBackward0>)
loss=tensor(688.9081, device='cuda:6', grad_fn=<MeanBackward0>)
loss=tensor(681.1560, device='cuda:5', grad_fn=<MeanBackward0>)
loss=tensor(681.1560, device='cuda:4', grad_fn=<MeanBackward0>)
torch.linalg.norm(param.grad)=DTensor(local_tensor=104.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=136.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=136.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
torch.linalg.norm(param.grad)=DTensor(local_tensor=104.0, device_mesh=DeviceMesh('cuda', [[0, 1], [2, 3]], mesh_dim_names=('ep', 'fsdp')), placements=(Replicate(), _NormPartial(reduce_op='sum', norm_type=2.0)))
```