### PR TITLE
[not for land] enable torchao's mxfp8 training recipe

### DIFF
--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -105,6 +105,15 @@ class Float8Converter(ModelConverter):
         if not self.enabled:
             return
 
+        from torchao.prototype.mx_formats.mx_linear import swap_linear_with_mx_linear
+        from torchao.prototype.mx_formats.config import MXLinearConfig
+
+        config = MXLinearConfig.from_recipe_name("mxfp8_cublas")
+        config.use_fp8_dim1_cast_triton_kernel = True
+
+        swap_linear_with_mx_linear(model, config=config, filter_fn=lambda mod, fqn: fqn != "output")
+        return
+
         from torchao.float8 import convert_to_float8_training
 
         # Mutates the model inplace replacing instances of nn.Linear with Float8Linear


### PR DESCRIPTION
Summary:

Not for land - just testing for now. We'll have to clean this up significantly once we are closer to landable state in titan.

Test Plan:

```
with-proxy CONFIG_FILE="./torchtitan/models/llama/train_configs/llama3_8b.toml" ./run_train.sh --model.print_after_conversion --training.compile --training.steps 50 --model.converters float8
```

Reviewers:

Subscribers:

Tasks:

Tags: