### PR TITLE
[DeepSeek] Move seqlen from model config to `setup_symm_mem`

### DIFF
--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -40,14 +40,17 @@ def create_model(dist_config: DistConfig):
     model_args.ep_size = dist_config.ep_size
     model_args.num_stages = dist_config.pp_size
     model_args.stage_idx = dist_config.pp_rank
-    model_args.max_seq_len = 16384
+    max_seq_len = 16384
 
     with dist_config.device, dist_config.mesh:
         model = DeepseekForCausalLM(model_args)
     load_weights_from_hf(model, model_id, dist_config.device)
     model.eval()
     model.setup_symm_mem(
-        torch.bfloat16, dist_config.device, microbatches=dist_config.pp_size
+        max_seq_len,
+        torch.bfloat16,
+        dist_config.device,
+        microbatches=dist_config.pp_size,
     )
 
     return model, PipelineStage(

--- a/torchtitan/experiments/deepseek_v3/model_config.py
+++ b/torchtitan/experiments/deepseek_v3/model_config.py
@@ -150,9 +150,6 @@ class ModelArgs:
     attention_bias: bool = False
     attention_dropout: float = 0.0
     pad_token_id = None
-    # Added for symmetric memory
-    max_seq_len: int = 4096
-    dtype: str = "bfloat16"
     # Added for pipeline parallel
     num_stages: int = 1
     stage_idx: int = 0

--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -76,14 +76,15 @@ def run_full_model(
 
     # Synthetic setting
     microbatches = pp_size * 2
+    bs = 4  # microbatch size
+    seqlen = 128
 
-    # Use Symmetric Memory for MoE token shuffle.
-    model.setup_symm_mem(torch.bfloat16, device, microbatches)
+    # Use Symmetric Memory for MoE token shuffle. The number of tokens in each
+    # buffer would be microbatch size * seq_len, i.e. flattened.
+    model.setup_symm_mem(bs * seqlen, torch.bfloat16, device, microbatches)
 
     # Example inputs
     torch.manual_seed(ep_rank)
-    bs = 4
-    seqlen = 128
     x = torch.randint(model_args.vocab_size, (microbatches * bs, seqlen), device=device)
     label = torch.rand(microbatches * bs, seqlen, model_args.vocab_size, device=device)
 


### PR DESCRIPTION
Just a UI change. The seqlen is mainly used in setting up symm mem. That's why we move it out of model config.