### PR TITLE
Adding support for collate_fn parameter in ParallelAwareDataloader class

### DIFF
--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -58,7 +58,6 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         self.dp_world_size = dp_world_size
         self.dp_rank = dp_rank
         self.batch_size = batch_size
-        self.collate_fn = collate_fn
         super().__init__(dataset, batch_size, collate_fn=collate_fn)
         self._rank_id = f"dp_rank_{dp_rank}"
 

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -6,9 +6,9 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from collections.abc import Callable
 import pickle
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, Optional
 
 from torch.distributed.checkpoint.stateful import Stateful
@@ -53,7 +53,7 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         dp_rank: int,
         dp_world_size: int,
         batch_size: int,
-        collate_fn:Optional[Callable]=None,
+        collate_fn: Optional[Callable] = None,
     ):
         self.dp_world_size = dp_world_size
         self.dp_rank = dp_rank

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset
 from torchdata.stateful_dataloader import StatefulDataLoader
+from torchtitan.tools.logging import logger
 
 
 class BaseDataLoader(Stateful, ABC):

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -6,9 +6,10 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
+from collections.abc import Callable
 import pickle
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset
@@ -39,6 +40,7 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         dp_rank: Data parallelism rank for this dataloader.
         dp_world_size: The world size of the data parallelism.
         batch_size: The batch size to use for each iteration.
+        collate_fn: Optional function to collate samples in a batch.
     """
 
     dp_rank: int
@@ -51,11 +53,13 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         dp_rank: int,
         dp_world_size: int,
         batch_size: int,
+        collate_fn:Optional[Callable]=None,
     ):
         self.dp_world_size = dp_world_size
         self.dp_rank = dp_rank
         self.batch_size = batch_size
-        super().__init__(dataset, batch_size)
+        self.collate_fn = collate_fn
+        super().__init__(dataset, batch_size, collate_fn=collate_fn)
         self._rank_id = f"dp_rank_{dp_rank}"
 
     def state_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
Currently there is no provision to provide a custom collate function to the dataloader in torchtitan. This PR aims to address that.

For example, if users are having multimodal datasets, they might want to collate the data in a specific way. They can't use the provided `build_hf_dataloader` function from `hf_dataset.py` today  because the `ParallelAwareDataloader` class inside it does not take a `collate_fn` parameter. 

We can solve this by simply accepting a `collate_fn` parameter in the `__init__` of the `ParallelAwareDataloader` class. This class is inheriting from `StatefulDataLoader` where the collate function is already supported! All that we have to do is to accept this parameter and pass it while calling the init of the base class from ParallelAwareDataloader.

An example usage after this change would be:

```
def build_hf_dataloader(
    dp_world_size: int,
    dp_rank: int,
    tokenizer: Tokenizer,
    job_config: JobConfig,
    infinite: bool = True,
) -> ParallelAwareDataloader:
    """Build a data loader for HuggingFace datasets."""
    dataset_name = job_config.training.dataset
    dataset_path = job_config.training.dataset_path
    batch_size = job_config.training.batch_size
    seq_len = job_config.training.seq_len

    hf_ds = HuggingFaceDataset(
        dataset_name=dataset_name,
        dataset_path=dataset_path,
        tokenizer=tokenizer,
        seq_len=seq_len,
        dp_rank=dp_rank,
        dp_world_size=dp_world_size,
        infinite=infinite,
    )
    # from <my data utils> import custom_collate_fn
    return ParallelAwareDataloader(
        dataset=hf_ds,
        dp_rank=dp_rank,
        dp_world_size=dp_world_size,
        batch_size=batch_size,
        collate_fn=custom_collate_fn 
    )
    ```
