### PR TITLE
fix simple fsdp readme

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -20,7 +20,7 @@ Some of the features require the updates from PyTorch, with which we are working
 |Activation Checkpointing| ✅ |
 |Mixed Precision Training| 🚧 |
 |Tensor Parallelism| 🚧 |
-|Context Parallelism| 🚧 |
+|Context Parallelism| ✅ |
 |Pipeline Parallelism| ✅ |
 |Distributed Checkpointing| 🚧 |
 |Float8 Training| ❌ |


### PR DESCRIPTION
This is following up on https://github.com/pytorch/torchtitan/pull/1011

Previously CP didn't work on my end because I was accidentally using an old version of pytorch, which had a mismatch to triton version. It works for me now.

I'll add CI later.