### PR TITLE
Avoid perform trainer.train() for seed checkpoint creation case

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -135,7 +135,9 @@ def create_context_parallel_ctx(
     )
 
 
-def get_train_context(enable_loss_parallel: bool, enable_compiled_autograd: bool):
+def get_train_context(
+    enable_loss_parallel: bool, enable_compiled_autograd: bool
+) -> Generator[None, None, None]:
     @contextlib.contextmanager
     def context(cp_context: Optional[Generator[None, None, None]] = None):
         with contextlib.ExitStack() as stack:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -8,7 +8,7 @@ import importlib
 import os
 import time
 from datetime import timedelta
-from typing import Any, Iterable, Optional
+from typing import Any, Generator, Iterable, Optional
 
 import torch
 
@@ -43,6 +43,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     dataloader: train_spec_module.BaseDataLoader
     metrics_processor: train_spec_module.MetricsProcessor
     checkpointer: CheckpointManager
+    train_context: Generator[None, None, None]
 
     model_parts: list[torch.nn.Module]
     optimizers: train_spec_module.OptimizersContainer
@@ -276,32 +277,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             ft_manager=ft_manager,
         )
 
-        if job_config.checkpoint.create_seed_checkpoint:
-            assert (
-                world_size == 1
-            ), "Must create seed checkpoint using a single device, to disable sharding"
-            assert (
-                job_config.checkpoint.enable_checkpoint
-            ), "Must enable checkpointing when creating a seed checkpoint"
-            self.checkpointer.save(curr_step=0, force=True)
-            logger.info("Created seed checkpoint")
-            return
-
-        self.checkpointer.load(step=job_config.checkpoint.load_step)
-
         self.train_context = dist_utils.get_train_context(
             parallel_dims.loss_parallel_enabled,
             parallelism_config.enable_compiled_autograd,
         )
 
         logger.info(
-            "Trainer initialized. "
-            f"Training starts at step {self.step + 1}, "
-            f"with local batch size {job_config.training.batch_size}, "
+            "Trainer is initialized with "
+            f"local batch size {job_config.training.batch_size}, "
             f"global batch size {job_config.training.batch_size * dp_degree}, "
             f"sequence length {job_config.training.seq_len}, "
             f"total steps {job_config.training.steps} "
-            f"(warmup {job_config.lr_scheduler.warmup_steps})"
+            f"(warmup {job_config.lr_scheduler.warmup_steps})."
         )
 
     def next_batch(self, data_iterator: Iterable) -> tuple[torch.Tensor, torch.Tensor]:
@@ -401,6 +388,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
     @record
     def train(self):
+        logger.info("Training starts at step {self.step + 1}.")
+
         job_config = self.job_config
         with maybe_enable_profiling(
             job_config, global_step=self.step
@@ -460,7 +449,19 @@ if __name__ == "__main__":
 
     try:
         trainer = Trainer(config)
-        trainer.train()
+
+        if config.checkpoint.create_seed_checkpoint:
+            assert int(
+                os.environ["WORLD_SIZE"]
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable_checkpoint
+            ), "Must enable checkpointing when creating a seed checkpoint."
+            trainer.checkpointer.save(curr_step=0, force=True)
+            logger.info("Created seed checkpoint")
+        else:
+            trainer.checkpointer.load(step=config.checkpoint.load_step)
+            trainer.train()
     finally:
         if trainer:
             trainer.close()

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -388,9 +388,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
     @record
     def train(self):
+        job_config = self.job_config
+
+        trainer.checkpointer.load(step=job_config.checkpoint.load_step)
         logger.info("Training starts at step {self.step + 1}.")
 
-        job_config = self.job_config
         with maybe_enable_profiling(
             job_config, global_step=self.step
         ) as torch_profiler, maybe_enable_memory_snapshot(
@@ -460,7 +462,6 @@ if __name__ == "__main__":
             trainer.checkpointer.save(curr_step=0, force=True)
             logger.info("Created seed checkpoint")
         else:
-            trainer.checkpointer.load(step=config.checkpoint.load_step)
             trainer.train()
     finally:
         if trainer:


### PR DESCRIPTION
This pull request splits the `Trainer.__init__()` method to separate necessary initializations from actions that require an initialized trainer. The main() function now handles these actions, which currently include seed checkpoint creation and training step.

This modification resolves the current seed checkpoint failure and enables the implementation of future actions that are not part of the training process.