### PR TITLE
ensure logging ranks are visible to titan

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -11,7 +11,7 @@ set -ex
 # e.g.
 # LOG_RANK=0,1 NGPU=4 ./run_train.sh
 NGPU=${NGPU:-"8"}
-LOG_RANK=${LOG_RANK:-0}
+export LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama/train_configs/debug_model.toml"}
 
 overrides=""


### PR DESCRIPTION
This PR ensures that the current logging environment is visible inside of titan.  This way checks like PP logging visible can operate successfully by matching the logged ranks are also valid for showing the PP loss.

Testing:
a - run with 1F1B without valid loss rank (4 in this case), verify warning fires
b - run with 1F1B with valid loss rank, ensure no warning displayed
c - run with one and multiple ranks, verify export has no effect on actual rank logging (same as before). 

