### PR TITLE
[FSDP2] add bfloat16 into training.mixed_precision_reduce

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -352,7 +352,7 @@ class JobConfig:
             "--training.mixed_precision_reduce",
             type=str,
             default="float32",
-            choices=["float32"],
+            choices=["bfloat16", "float32"],
             help="""
                 torch dtype to use for reductions when applying mixed precision via FSDP.
                 This feature only takes effect when data_parallel_shard_degree > 1


### PR DESCRIPTION
Fix https://github.com/pytorch/torchtitan/issues/1027
Add choice of "bfloat16" to allow users more choices in mixed_precision_reduce.
"bfloat16" in `mixed_precision_reduce might` might affect the performance as it's mixed_precision at gradient, we keep "float32" as default but add one more choice

mixed_precision_param = "bfloat16", mixed_precision_reduce = "float32"
<img width="1053" alt="Screenshot 2025-03-28 at 2 27 00 PM" src="https://github.com/user-attachments/assets/39e38d50-a612-4bdf-a6e1-6c1f7a4b071a" />


mixed_precision_param = "bfloat16", mixed_precision_reduce = "bfloat16"
<img width="1053" alt="Screenshot 2025-03-28 at 2 27 07 PM" src="https://github.com/user-attachments/assets/336032e0-505f-47b2-a18a-a5ed950afc8c" />

