### PR TITLE
[DeepSeek] Potential memory bug for noaux_tc?

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -417,7 +417,7 @@ class MoEGate(nn.Module):
                 ~score_mask.bool(), 0.0
             )  # [n, e]
             _, topk_idx = torch.topk(tmp_scores, k=self.top_k, dim=-1, sorted=False)
-            topk_weight = scores.gather(1, topk_idx)
+            topk_weight = scores.detach().gather(1, topk_idx)
         elif self.topk_method == "greedy":
             topk_weight, topk_idx = torch.topk(
                 scores, k=self.top_k, dim=-1, sorted=False


### PR DESCRIPTION
This is more of a question since I'm not sure if what I'm doing is valid. However, I noticed that `noaux_tc` uses a lot of memory for DSV3. Specifically, the first step suceeded but the run OOMs on the second step -- this is surprising since we use a constant sequence length and if the first step succeeds, in theory the rest should as well.

Do we need some `torch.no_grad()` calls when computing the topk indicies similar to what we do in `moe_forward()`? Adding `detach()` to the `scores` like this PR does fixed the OOM and the training curves / grad norms look ~identical for a small run I tried, but I'm sure what I'm doing is valid.

<img width="890" alt="Screenshot 2025-03-28 at 2 43 02 PM" src="https://github.com/user-attachments/assets/3161aaca-cb24-4cf2-9b50-1535a02ca004" />

cc @kwen2501 @lessw2020 
