### PR TITLE
[Async TP] Add back reduce_scatter_tensor to save list for per op SAC now that it's supported in core

### DIFF
--- a/torchtitan/models/llama/parallelize_llama.py
+++ b/torchtitan/models/llama/parallelize_llama.py
@@ -227,6 +227,7 @@ _save_list = {
     torch.ops.aten.mm.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
     # for low precision training, it's useful to always save
     # the result of max, since the absolute maximum is
     # used to compute the scaling factor for quantization.


### PR DESCRIPTION
## Summary

In https://github.com/pytorch/pytorch/issues/149876 I found there was a problem with per op SAC, per layer SAC, and no AC because all these settings saved reduce_scatter_tensor for backward but this a problem: it broke the async TP pattern matching which expects reduce scatter node to only have 1 user (wait_tensor), not 2 (wait_tensor and output_node).

In https://github.com/pytorch/pytorch/pull/149946 I addressed this by:

1) Adding new graph patterns to match on which allow reduce_scatter to have 2 users.
2) Updating the subgraph replacement logic to save the "fused matmul reduce scatter" node for backward instead of the reduce scatter node, if it detects the graph is saving reduce_scatter for backward. This allows the original matmul reduce scatter graph to be replaced and erased correctly.

Once https://github.com/pytorch/pytorch/pull/149946 is landed, we can add back reduce_scatter_tensor to the op save list for SAC in torchtitan, and it won't break SAC and no AC anymore 👍 