### PR TITLE
Fix missing f-string in logging

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -391,7 +391,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         job_config = self.job_config
 
         trainer.checkpointer.load(step=job_config.checkpoint.load_step)
-        logger.info("Training starts at step {self.step + 1}.")
+        logger.info(f"Training starts at step {self.step + 1}.")
 
         with maybe_enable_profiling(
             job_config, global_step=self.step


### PR DESCRIPTION
### Summary

I noticed this log line when running a torchtitan training run, which seemed to indicate a missing f-string:

`Training starts at step {self.step + 1}.`

I took a look at the code and it does seem to be a case of accidentally using a string literal instead of f-string, so I fixed it.