### PR TITLE
refactor train_spec.loss_fn to build_loss_fn & chunked loss

### DIFF
--- a/scripts/estimate/estimation.py
+++ b/scripts/estimate/estimation.py
@@ -153,13 +153,14 @@ def estimate_memory(job_config: JobConfig):
         fsdp_memtracker = FSDPMemTracker(mod=model, optm=optimizers.optimizers[0])
         fsdp_memtracker.track_inputs(batch)
 
+        loss_fn = train_spec.build_loss_fn(job_config)
         with fsdp_memtracker:
             for iter_idx in range(2):
                 input_ids, labels = batch
                 # train step
                 with train_context():
                     pred = model(input_ids)
-                    loss = train_spec.loss_fn(pred, labels)
+                    loss = loss_fn(pred, labels)
                     del pred
                     loss.backward()
 

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -9,7 +9,7 @@ from functools import partial
 import pytest
 import torch
 import torch.nn as nn
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers, OptimizersContainer
 from torchtitan.config_manager import JobConfig
@@ -62,7 +62,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             build_tokenizer_fn=build_tiktoken_tokenizer,
-            loss_fn=cross_entropy_loss,
+            build_loss_fn=build_cross_entropy_loss,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake")
@@ -83,7 +83,7 @@ class TestTrainSpec:
             build_lr_schedulers_fn=build_lr_schedulers,
             build_dataloader_fn=build_hf_dataloader,
             build_tokenizer_fn=build_tiktoken_tokenizer,
-            loss_fn=cross_entropy_loss,
+            build_loss_fn=build_cross_entropy_loss,
         )
         register_train_spec(spec)
         new_spec = get_train_spec("fake2")

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -4,7 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Callable, TypeAlias
+
 import torch
+
+from torchtitan.config_manager import JobConfig
+from torchtitan.tools.logging import logger
+
+LossFunction: TypeAlias = Callable[[...], torch.Tensor]
 
 
 def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
@@ -14,22 +21,9 @@ def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
     )
 
 
-# TODO: compiling loss function causes CUDA errors, turning off for now
-# compiled_cross_entropy_loss = torch.compile(cross_entropy_loss)
-
-
-def chunked_cross_entropy_loss(
-    logits: torch.Tensor, labels: torch.Tensor, num_output_chunks: int = 8
-) -> torch.Tensor:
-    # Adapted from torchtune
-    # https://github.com/pytorch/torchtune/blob/c3703482bde72e572b535d3f7c43c81e94164ebc/torchtune/modules/loss/ce_chunked_output_loss.py
-
-    labels = [target_chunk for target_chunk in labels.chunk(num_output_chunks, dim=1)]
-    logits = [logit_chunk for logit_chunk in logits.chunk(num_output_chunks, dim=1)]
-
-    # compute one chunk at a time
-    total_loss = 0.0
-    for logits_chunk, labels_chunk in zip(logits, labels):
-        total_loss += cross_entropy_loss(logits_chunk, labels_chunk)
-
-    return total_loss / num_output_chunks
+def build_cross_entropy_loss(job_config: JobConfig):
+    loss_fn = cross_entropy_loss
+    if job_config.training.compile:
+        logger.info("Compiling the loss function with torch.compile")
+        loss_fn = torch.compile(loss_fn)
+    return loss_fn

--- a/torchtitan/experiments/multimodal/__init__.py
+++ b/torchtitan/experiments/multimodal/__init__.py
@@ -6,7 +6,7 @@
 
 from mm_dataset import build_mm_dataloader
 
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.datasets.tokenizer.tiktoken import build_tiktoken_tokenizer
@@ -27,6 +27,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_mm_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
-        loss_fn=cross_entropy_loss,
+        build_loss_fn=build_cross_entropy_loss,
     )
 )

--- a/torchtitan/experiments/simple_fsdp/__init__.py
+++ b/torchtitan/experiments/simple_fsdp/__init__.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
@@ -28,6 +28,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
-        loss_fn=cross_entropy_loss,
+        build_loss_fn=build_cross_entropy_loss,
     )
 )

--- a/torchtitan/models/llama/__init__.py
+++ b/torchtitan/models/llama/__init__.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
@@ -71,6 +71,6 @@ register_train_spec(
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
-        loss_fn=cross_entropy_loss,
+        build_loss_fn=build_cross_entropy_loss,
     )
 )

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -10,10 +10,10 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Type, TypeAlias
 
-import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.loss import LossFunction
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import OptimizersContainer
@@ -59,7 +59,7 @@ OptimizersBuilder: TypeAlias = Callable[
     [list[nn.Module], JobConfig], OptimizersContainer
 ]
 LRSchedulersBuilder: TypeAlias = Callable[[OptimizersContainer], LRSchedulersContainer]
-LossFunction: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+LossFunctionBuilder: TypeAlias = Callable[[...], LossFunction]
 
 
 @dataclass
@@ -75,7 +75,7 @@ class TrainSpec:
     build_lr_schedulers_fn: LRSchedulersBuilder
     build_dataloader_fn: DataLoaderBuilder
     build_tokenizer_fn: TokenizerBuilder
-    loss_fn: LossFunction
+    build_loss_fn: LossFunctionBuilder
     build_metrics_processor_fn: Optional[MetricsProcessorBuilder] = None
 
 


### PR DESCRIPTION
To enable chunked loss, I refactor the `train_spec.loss_fn` to `train_spec.build_loss_fn` as suggested in #996

 Also:
- Unified chunked loss implementation with the `cross_entropy_loss` name, since default is a special case with chunk=1.
Identical loss and memory:

<img width="1257" alt="Screenshot 2025-03-30 at 13 03 44" src="https://github.com/user-attachments/assets/11c07849-2340-4b42-ad5c-d96657ee53b9" />

- Enable compiling the loss function as it's working fine for me, and result in reduction of memory and slightly better througput.

<img width="1275" alt="Screenshot 2025-03-30 at 16 47 00" src="https://github.com/user-attachments/assets/09edaf16-1770-48da-87b2-e4de29e7519c" />

While we only have one type of loss, I create a field for `loss.name` with default to 'cross_entropy' to be fork-friendly anyway.