### PR TITLE
Correct self reference in Trainer

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -390,7 +390,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     def train(self):
         job_config = self.job_config
 
-        trainer.checkpointer.load(step=job_config.checkpoint.load_step)
+        self.checkpointer.load(step=job_config.checkpoint.load_step)
         logger.info(f"Training starts at step {self.step + 1}.")
 
         with maybe_enable_profiling(


### PR DESCRIPTION
Fixed a bug where the `Trainer.train` method was incorrectly using `trainer` instead of `self`.

When `train.py` is executed and the `if __name__ == "__main__": ...` block runs, the global variable `trainer` is identical to `self`, so execution proceeds without issues.

However, when we import and run `Trainer` from other files, the `trainer` variable doesn't exist, causing an error. This PR fixes that issue.
