### PR TITLE
Change the function signature in trainer to support flexible inputs 

### DIFF
--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -31,7 +31,7 @@ class TestDatasetCheckpointing:
         dl.load_state_dict(state)
         input_ids, labels = next(iter(dl))
 
-        assert torch.equal(input_ids, expected_input_ids)
+        assert torch.equal(input_ids["input"], expected_input_ids["input"])
         assert torch.equal(labels, expected_labels)
 
     def _build_dataloader(self, dataset_name, batch_size, seq_len, world_size, rank):

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -124,7 +124,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
                     self._all_tokens = self._all_tokens[max_buffer_token_len:]
                     input = x[:-1]
                     label = x[1:]
-                    yield input, label
+                    yield {"input": input}, label
 
             if not self.infinite:
                 logger.warning(f"Dataset {self.dataset_name} has run out of data")

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -56,8 +56,7 @@ class ModelProtocol(Protocol):
     """
 
     @classmethod
-    def from_model_args(cls, args: BaseModelArgs) -> nn.Module:
-        ...
+    def from_model_args(cls, args: BaseModelArgs) -> nn.Module: ...
 
 
 ParallelizeFunction: TypeAlias = Callable[..., nn.Module]

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -56,7 +56,8 @@ class ModelProtocol(Protocol):
     """
 
     @classmethod
-    def from_model_args(cls, args: BaseModelArgs) -> nn.Module: ...
+    def from_model_args(cls, args: BaseModelArgs) -> nn.Module:
+        ...
 
 
 ParallelizeFunction: TypeAlias = Callable[..., nn.Module]

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -12,10 +12,10 @@ from typing import Any, Generator, Iterable, Optional
 
 import torch
 
+from torch.distributed.elastic.multiprocessing.errors import record
+
 import torchtitan.components.ft as ft
 import torchtitan.protocols.train_spec as train_spec_module
-
-from torch.distributed.elastic.multiprocessing.errors import record
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.metrics import (
     build_metrics_processor,


### PR DESCRIPTION
## Context

1. Change `inputs` from `Tensor` to `dict[str, Tensor]`, which could support multiple inputs. The default dictionary key is "input" if there's only one item in the dict.
2. Change  Dataloader ouptuts to match the new format

If a model has multiple input Tensor, rewrite `train_step()` function in trainer to handle multiple inputs.

## Tests
Tested on training with Llama 8b model
![Screenshot 2025-04-01 at 10 57 51 AM](https://github.com/user-attachments/assets/289b2689-48af-42ab-93b2-261fcff3d1bb)
