### PR TITLE
[GroupGemm] Fix output dimension of M*G kernel

### DIFF
--- a/torchtitan/experiments/kernels/triton_mg_group_gemm/torchao_pr/tma_autotuning.py
+++ b/torchtitan/experiments/kernels/triton_mg_group_gemm/torchao_pr/tma_autotuning.py
@@ -144,6 +144,7 @@ class TmaDescriptorHelper:
 
 
 # ======  Autotuning utilities ======
+ALIGN_SIZE_M = 64
 
 _NV_CONFIGS = [
     triton.Config(
@@ -156,7 +157,7 @@ _NV_CONFIGS = [
         num_warps=num_warps,
         num_ctas=num_ctas,
     )
-    for block_size_m in [64, 128]
+    for block_size_m in [ALIGN_SIZE_M, ]
     for block_size_n in [64, 128, 256]
     for block_size_k in [64, 128, 256]
     for num_stages in [3, 4]


### PR DESCRIPTION
Previously the output dimension is `n*G`, but we want only `n`.
Also added alignment requirement for the grouped input, i.e. each element in `m_sizes` must be divisible by the alignment size.
The impl today has alignment of 64, which is a bit big. We should drive it down. (TODO @lessw2020 )