### PR TITLE
[DeepSeek] Integrate M*G Group Gemm

### DIFF
--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -144,7 +144,7 @@ def create_model(dist_config: DistConfig):
 
 
 @torch.inference_mode()
-def generate(mesh: DeviceMesh, messages: list[dict], n_tokens: int = 10):
+def generate(mesh: DeviceMesh, messages: list[dict], n_tokens: int = 50):
     rank = dist.get_rank()
 
     device_count = torch.cuda.device_count()

--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -144,7 +144,7 @@ def create_model(dist_config: DistConfig):
 
 
 @torch.inference_mode()
-def generate(mesh: DeviceMesh, messages: list[dict], n_tokens: int = 50):
+def generate(mesh: DeviceMesh, messages: list[dict], n_tokens: int = 10):
     rank = dist.get_rank()
 
     device_count = torch.cuda.device_count()

--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -42,6 +42,7 @@ from symm_mem_recipes import OnDeviceAllToAllV
 from torch import nn
 from torch.distributed._functional_collectives import all_to_all_single_autograd
 
+from torchtitan.experiments.kernels.triton_mg_group_gemm.torchao_pr.mg_grouped_gemm import grouped_gemm_backward, grouped_gemm_forward
 
 # Get model parallel subgroup by name:
 # e.g. "pp", "ep", None
@@ -323,6 +324,8 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
 
 
 class MLP(nn.Module):
+    act_fn = nn.SiLU()
+
     def __init__(self, config, hidden_size=None, intermediate_size=None):
         super().__init__()
         self.config = config
@@ -334,7 +337,6 @@ class MLP(nn.Module):
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
-        self.act_fn = nn.SiLU()
 
     def forward(self, x):
         down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
@@ -485,6 +487,16 @@ class MoE(nn.Module):
                 config=config, intermediate_size=intermediate_size
             )
 
+    def combine_experts(self, submod_name):
+        all_weights = []
+        for expert in self.experts.values():
+            lin = expert.get_submodule(submod_name)
+            all_weights.append(lin.weight)
+            lin.weight = None
+
+        concat_weight = torch.cat(all_weights)
+        self.register_parameter(f"{submod_name}_weight", nn.Parameter(concat_weight))
+
     # This function is used to create a symm mem buffer for MoE's. It is for
     # shuffling tokens fully "on-device", as compared to traditional torch
     # all_to_all APIs which requrie a GPU-to-CPU sync of the splits.  If a user
@@ -493,6 +505,12 @@ class MoE(nn.Module):
     def setup_symm_mem(self, dtype: torch.dtype, device: torch.device):
         # Switch shuffle method
         self.shuffle_method = "symm_mem"
+
+        # Combine expert weights
+        print("Combining expert weights for Group GEMM")
+        self.combine_experts("gate_proj")
+        self.combine_experts("up_proj")
+        self.combine_experts("down_proj")
 
         # Assuming worst case, 2x tokens are routed to one EP rank
         overflow = 2
@@ -547,7 +565,12 @@ class MoE(nn.Module):
         # for each token, select top-k experts, and compute the weight for each expert
         topk_idx, topk_weight = self.gate(hidden_states)
         hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-        y = self.moe_forward(hidden_states, topk_idx, topk_weight).view(*orig_shape)
+        if self.shuffle_method == "symm_mem":
+            y = self.moe_on_device(hidden_states, topk_idx, topk_weight)
+        else:  # "torch_all_to_all"
+            y = self.moe_forward(hidden_states, topk_idx, topk_weight)
+
+        y = y.view(*orig_shape)
         if self.config.n_shared_experts is not None:
             y = y + self.shared_experts(identity)
         return y
@@ -660,6 +683,143 @@ class MoE(nn.Module):
                 output_splits.tolist(),
                 self.ep_group,
             )
+
+        output_tokens = torch.empty_like(returned_tokens)
+        output_tokens[idxs] = returned_tokens
+        final_out = (
+            output_tokens.view(*topk_ids.shape, -1)
+            .type(topk_weight.dtype)
+            .mul_(topk_weight.unsqueeze(dim=-1))
+            .sum(dim=1)
+            .type(returned_tokens.dtype)
+        )
+        return final_out
+
+
+    def moe_on_device(self, x, topk_ids, topk_weight):
+        # This part sorts the token indices so that tokens routed to the same expert reside consecutively.
+        # An implication is that tokens to the same "expert group" (i.e., device) are also consecutive.
+        # Since this is an "aritificial" index creation (final outcome being
+        # `idxs`), we don't need gradients here.
+        with torch.no_grad():
+            # [seq_len, n_routed_experts]
+            cnts = topk_ids.new_zeros((topk_ids.shape[0], self.config.n_routed_experts))
+            # Fill 1 to the selected experts
+            cnts.scatter_(1, topk_ids, 1)
+            tokens_per_expert = cnts.sum(dim=0)
+            # Token indices for each expert
+            idxs = topk_ids.view(-1).argsort()
+            sorted_tokens_shape = idxs.shape + x.shape[1:]
+
+        sorted_tokens = x[idxs // topk_ids.shape[1]]
+        assert sorted_tokens.shape == sorted_tokens_shape
+
+        # This part exchange the information about the number of tokens send and
+        # received by each expert. We can understand this information as "side
+        # band", which is not part of the actual data. Thus no gradient is
+        # needed.
+        with torch.no_grad():
+            # Sum the tokens over local experts, then we get tokens per EP rank,
+            # which is the input splits
+            tokens_per_expert_group = tokens_per_expert.new_empty(
+                tokens_per_expert.shape[0]
+            )
+            dist.all_to_all_single(
+                tokens_per_expert_group, tokens_per_expert, group=self.ep_group
+            )
+            input_splits = tokens_per_expert.view(self.ep_size, -1).sum(dim=1)
+
+        # Move input to the `token_send_buf` symm mem
+        token_send_buf = self.get_send_buf()
+        token_send_buf[: idxs.shape[0]].copy_(sorted_tokens)
+        # Note: `out=` avoids copy, but it is not differentiable
+        # torch.index_select(x, 0, idxs // topk_ids.shape[1], out=self.token_send_buf[: idxs.shape[0]])
+        token_gather_buf, output_splits = OnDeviceAllToAllV.apply(
+            token_send_buf,
+            input_splits,
+            self.ep_group,
+        )
+
+        # We need to permute the received tokens so that tokens for the same expert are contiguous.
+        # This part prepares a 1D tensor `permuted_indices` for such permutation.
+        # TODO: write a kernel for this part
+        with torch.no_grad():
+            # Prefix sum to get the start indices
+            offsets = torch.cumsum(tokens_per_expert_group, 0)
+            offsets = offsets.tolist()
+            # Create indices chunk by chunk
+            indices = [
+                torch.arange(0 if i == 0 else offsets[i-1], offsets[i]) for i in range(len(offsets))
+            ]
+            permuted_indices = []
+            m_sizes = []
+            # Alignment for token group sizes to be compatible with group GEMM
+            # TODO: to be decreased to 16 or 8
+            ALIGNMENT = 128
+            # Pad -1 (last element) to each chunk so that they meet the alignment requirement
+            pad_pos = -1
+            # For each local expert
+            for e in range(self.experts_per_rank):
+                len_for_e = 0
+                indices_for_e = []
+                # For each remote rank
+                for r in range(self.ep_size):
+                    i = r * self.experts_per_rank + e
+                    # Append the real index chunks
+                    indices_for_e.append(indices[i])
+                    assert indices[i].shape[0] == tokens_per_expert_group[i]
+                    len_for_e += tokens_per_expert_group[i]
+                # Prepare padding
+                fill_len = (ALIGNMENT - len_for_e % ALIGNMENT) % ALIGNMENT
+                fill = torch.full((fill_len,), pad_pos, dtype=torch.int32)
+                indices_for_e.append(fill)
+                # The group's token length is the sum of the real tokens and the padding
+                m_sizes.append(len_for_e + fill_len)
+                permuted_indices.append(torch.cat(indices_for_e))
+
+            permuted_indices = torch.cat(permuted_indices)
+            m_sizes = torch.tensor(m_sizes, dtype=torch.int32, device=topk_ids.device)
+
+        # Permute the received tokens so that tokens for the same expert are contiguous.
+        contig_tokens = token_gather_buf[permuted_indices]
+
+        # Run the first grouped GEMM
+        w1 = self.get_parameter("gate_proj_weight")
+        gate_proj = grouped_gemm_forward(
+            contig_tokens, w1, m_sizes
+        )
+
+        # Run the second grouped GEMM
+        w3 = self.get_parameter("up_proj_weight")
+        up_proj = grouped_gemm_forward(
+            contig_tokens, w3, m_sizes
+        )
+
+        # Apply activation
+        hidden_outputs = MLP.act_fn(gate_proj) * up_proj
+
+        # Run the third grouped GEMM
+        w2 = self.get_parameter("down_proj_weight")
+        hidden_outputs = grouped_gemm_forward(
+            hidden_outputs, w2, m_sizes
+        )
+
+        # Prepare buffer for tokens processed by experts
+        # Take necessary space from `token_gather_buf` symm mem because we are
+        # going to send them out after expert processing
+        processed_tokens = self.get_gather_buf()
+
+        # Move into Symmetric Memory for the return shuffle
+        processed_tokens[permuted_indices] = hidden_outputs
+
+        # Now shuffle the tokens back to their original owner, i.e. EP to DP shuffle.
+        # The input/output splits are just a reverse of the previous shuffle.
+        token_return_buf, _ = OnDeviceAllToAllV.apply(
+            processed_tokens,
+            output_splits,
+            self.ep_group,
+        )
+        returned_tokens = token_return_buf[: sorted_tokens_shape[0]]
 
         output_tokens = torch.empty_like(returned_tokens)
         output_tokens[idxs] = returned_tokens

--- a/torchtitan/experiments/deepseek_v3/run.py
+++ b/torchtitan/experiments/deepseek_v3/run.py
@@ -78,7 +78,9 @@ def run_full_model(
     microbatches = pp_size * 2
 
     # Use Symmetric Memory for MoE token shuffle.
-    model.setup_symm_mem(torch.bfloat16, device)
+    # TODO: we are rewriting `moe_on_device` function. `setup_symm_mem` is
+    # currently supported for forward only. See `generate.py`.
+    # model.setup_symm_mem(torch.bfloat16, device)
 
     # Example inputs
     torch.manual_seed(ep_rank)


### PR DESCRIPTION
### Summary
Integrating the M*G Group GEMM kernel by @lessw2020 in #967. This kernel requires tokens for the same expert to reside together. So we need to permute the received tokens before the GEMM.

We also need to make sure each token group's length (i.e. `m_sizes`) meet the alignment requirement of the Group GEMM. This requires padding some unused index (like `-1`) into the permutation indices.

With this integration, we remove a few CPU sync points in the original program, for example, getting the `received` length, and slicing the chunk of tokens for each expert.

And most obviously, we removed the for loop needed to perform matmul for all local experts.

### TODO
The generation of permutation indices are in CPU right now. We should write a kernel for it.

### Test
```
$ torchrun --standalone --nproc-per-node 4 generate.py
Combining expert weights for Group GEMM
Combining expert weights for Group GEMM
Combining expert weights for Group GEMM
......

Output: You are a helpful assistant.
User: What is 2+2?

Assistant: 2 + 2 equals 4.
```