### PR TITLE
improve TrainSpec and general typing

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import threading
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -50,16 +50,16 @@ class AsyncMode(str, enum.Enum):
 
 
 class ModelWrapper(Stateful):
-    def __init__(self, model: Union[nn.Module, List[nn.Module]]) -> None:
+    def __init__(self, model: nn.Module | list[nn.Module]) -> None:
         self.model = [model] if isinstance(model, nn.Module) else model
         self.cache_state_dict = {
             k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()
         }
 
-    def state_dict(self) -> Dict[str, Any]:
+    def state_dict(self) -> dict[str, Any]:
         return self.cache_state_dict
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         func = functools.partial(
             set_model_state_dict,
             model_state_dict=state_dict,
@@ -207,10 +207,10 @@ class CheckpointManager:
     def __init__(
         self,
         dataloader: DataLoader,
-        model_parts: List[nn.Module],
+        model_parts: list[nn.Module],
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
-        states: Dict[str, Any],
+        states: dict[str, Any],
         job_config: JobConfig,
         ft_manager: FTManager,
     ) -> None:
@@ -517,7 +517,7 @@ class CheckpointManager:
             f"Finished loading the ft checkpoint in {time.monotonic() - begin:.2f} seconds."
         )
 
-    def _states_to_load(self, step: int) -> Dict[str, Any]:
+    def _states_to_load(self, step: int) -> dict[str, Any]:
         """Determines which states to load for the given step.
 
         When checkpointer determines which step of the checkpoint to load, this API is
@@ -606,7 +606,7 @@ class CheckpointManager:
         self._cpu_staging(checkpoint_id)
         self.sending_to_checkpoint_mp = True
 
-    def _cpu_staging(self, checkpoint_id: Optional[str]) -> None:
+    def _cpu_staging(self, checkpoint_id: str | None) -> None:
         """Offload state_dict to CPU memory"""
         state_dict = dcp.state_dict_saver._stateful_to_state_dict(self.states)
         if self.cpu_offload_state_dict is None:

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -9,7 +9,7 @@
 import pickle
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset
@@ -54,7 +54,7 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         dp_rank: int,
         dp_world_size: int,
         batch_size: int,
-        collate_fn: Optional[Callable] = None,
+        collate_fn: Callable | None = None,
     ):
         self.dp_world_size = dp_world_size
         self.dp_rank = dp_rank

--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -13,8 +13,6 @@
 # Note: Performance
 # Float8 experimental is intended to be ran under `torch.compile`` for competitive performance
 
-from typing import List, Union
-
 import torch
 import torch.nn as nn
 
@@ -54,7 +52,7 @@ class Float8Converter(ModelConverter):
         ):
             logger.warning(
                 "Failed to swap to Float8Linear with recipe lookup because the torchao version "
-                + "is too old, please install torchao v0.9.0 or later and try again",
+                "is too old, please install torchao v0.9.0 or later and try again",
             )
             return
 
@@ -93,7 +91,7 @@ class Float8Converter(ModelConverter):
     def convert(self, model: nn.Module):
         return self.convert_to_float8_training(model)
 
-    def post_optimizer_hook(self, model: Union[nn.Module, List[nn.Module]]):
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
         return self.precompute_float8_dynamic_scale_for_fsdp(model)
 
     def convert_to_float8_training(self, model: nn.Module):
@@ -119,7 +117,7 @@ class Float8Converter(ModelConverter):
         )
 
     def precompute_float8_dynamic_scale_for_fsdp(
-        self, model: Union[nn.Module, List[nn.Module]]
+        self, model: nn.Module | list[nn.Module]
     ):
         if not self.enabled:
             return

--- a/torchtitan/components/ft.py
+++ b/torchtitan/components/ft.py
@@ -44,7 +44,7 @@ class FTManager:
         assert self._manager is not None
         return self._manager
 
-    def get_dp_info(self, dp_degree: int, dp_rank: int) -> int:
+    def get_dp_info(self, dp_degree: int, dp_rank: int) -> tuple[int, int]:
         return dp_degree * self.group_size, dp_degree * self.replica_id + dp_rank
 
 
@@ -120,12 +120,11 @@ class FTParallelDims(ParallelDims):
 def ft_dist_reduce(
     x: torch.Tensor, reduceOp: str, mesh: DeviceMesh
 ) -> tuple[torch.Tensor, str, DeviceMesh]:
-    if has_torchft:
-        if isinstance(mesh, ft.process_group._FlattenDeviceMesh):
-            x = funcol.all_reduce(
-                x, reduceOp=reduceOp, group=mesh.managed_mesh.replicate_pg
-            )
-            return x, reduceOp, mesh.managed_mesh.mesh
+    if has_torchft and isinstance(mesh, ft.process_group._FlattenDeviceMesh):
+        x = funcol.all_reduce(
+            x, reduceOp=reduceOp, group=mesh.managed_mesh.replicate_pg
+        )
+        return x, reduceOp, mesh.managed_mesh.mesh
     return x, reduceOp, mesh
 
 

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -11,7 +11,7 @@ import torch
 from torchtitan.config_manager import JobConfig
 from torchtitan.tools.logging import logger
 
-LossFunction: TypeAlias = Callable[[...], torch.Tensor]
+LossFunction: TypeAlias = Callable[..., torch.Tensor]
 
 
 def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -7,7 +7,7 @@
 import copy
 import functools
 import math
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Iterator
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.optim.lr_scheduler import LambdaLR, LRScheduler
@@ -46,7 +46,7 @@ class LRSchedulersContainer(Stateful):
         optimizers (OptimizersContainer): The corresponding optimizers for the lr_schedulers.
     """
 
-    schedulers: List[LRScheduler]
+    schedulers: list[LRScheduler]
 
     def __init__(self, optimizers: OptimizersContainer, lr_lambda: Callable) -> None:
         assert (
@@ -55,7 +55,7 @@ class LRSchedulersContainer(Stateful):
 
         self.schedulers = [LambdaLR(optimizer, lr_lambda) for optimizer in optimizers]
 
-    def __iter__(self) -> LRScheduler:
+    def __iter__(self) -> Iterator[LRScheduler]:
         return iter(self.schedulers)
 
     def __len__(self) -> int:
@@ -65,13 +65,13 @@ class LRSchedulersContainer(Stateful):
         for scheduler in self.schedulers:
             scheduler.step()
 
-    def state_dict(self) -> Dict[str, Any]:
+    def state_dict(self) -> dict[str, Any]:
         # While there may be multiple schedulers, we only save the first one because
         # the state_dict is the same for all. See the limitations section in the
         # docstring.
         return self.schedulers[0].state_dict()
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         # Load the same state_dict for all schedulers. The key value we're concerned
         # within ``LRScheduler.state_dict()`` is ``last_epoch``, which is an integer
         # that is immutable. As long as ``training.steps`` and ``lr_scheduler.warmup_steps``

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -7,7 +7,6 @@
 import os
 
 from abc import ABC, abstractmethod
-from typing import List
 
 
 class Tokenizer(ABC):
@@ -20,7 +19,7 @@ class Tokenizer(ABC):
         self._n_words = 8
 
     @abstractmethod
-    def encode(self, *args, **kwargs) -> List[int]:
+    def encode(self, *args, **kwargs) -> list[int]:
         ...
 
     @abstractmethod

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import torch
 
@@ -53,7 +53,7 @@ DATASETS = {
 
 
 def _validate_dataset(
-    dataset_name: str, dataset_path: str = None
+    dataset_name: str, dataset_path: str | None = None
 ) -> tuple[str, Callable, Callable]:
     """Validate dataset name and path."""
     if dataset_name not in DATASETS:
@@ -72,7 +72,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
     def __init__(
         self,
         dataset_name: str,
-        dataset_path: Optional[str],
+        dataset_path: str | None,
         tokenizer: Tokenizer,
         seq_len: int = 2048,
         dp_rank: int = 0,

--- a/torchtitan/datasets/tokenizer/tiktoken.py
+++ b/torchtitan/datasets/tokenizer/tiktoken.py
@@ -8,19 +8,9 @@
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
 import os
+from collections.abc import Collection, Iterator, Sequence, Set as AbstractSet
 from pathlib import Path
-from typing import (
-    AbstractSet,
-    cast,
-    Collection,
-    Dict,
-    Iterator,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import cast, Literal
 
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
@@ -38,7 +28,7 @@ class TikTokenizer(Tokenizer):
         model_path (str): The path to the Tiktoken model file.
     """
 
-    special_tokens: Dict[str, int]
+    special_tokens: dict[str, int]
 
     num_reserved_special_tokens = 256
 
@@ -94,9 +84,9 @@ class TikTokenizer(Tokenizer):
         *,
         bos: bool,
         eos: bool,
-        allowed_special: Optional[Union[Literal["all"], AbstractSet[str]]] = None,
-        disallowed_special: Optional[Union[Literal["all"], Collection[str]]] = None,
-    ) -> List[int]:
+        allowed_special: Literal["all"] | AbstractSet[str] | None = None,
+        disallowed_special: Literal["all"] | Collection[str] | None = None,
+    ) -> list[int]:
         """
         Encodes a string into a list of token IDs.
 
@@ -138,7 +128,7 @@ class TikTokenizer(Tokenizer):
                 s[i : i + TIKTOKEN_MAX_ENCODE_CHARS], MAX_NO_WHITESPACES_CHARS
             )
         )
-        t: List[int] = []
+        t: list[int] = []
         for substr in substrs:
             t.extend(
                 self.model.encode(
@@ -164,7 +154,7 @@ class TikTokenizer(Tokenizer):
             str: The decoded string.
         """
         # Typecast is safe here. Tiktoken doesn't do anything list-related with the sequence.
-        return self.model.decode(cast(List[int], t))
+        return self.model.decode(cast(list[int], t))
 
     @staticmethod
     def _split_whitespaces_or_nonwhitespaces(

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Callable
 
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
@@ -71,7 +71,6 @@ class ParallelDims:
         init_device_mesh_fn: Callable,
     ) -> DeviceMesh:
         logger.info(f"Building {len(dims)}-D device mesh with {names}, {dims}")
-        names = tuple(names)
         mesh = init_device_mesh_fn(device_type, dims, mesh_dim_names=names)
 
         # Create all the submesh here to ensure all required process groups are

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -7,8 +7,8 @@
 import contextlib
 import math
 import os
+from collections.abc import Generator, Iterable
 from datetime import timedelta
-from typing import Generator, Iterable, List, Optional, Set, Union
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -42,9 +42,9 @@ def dist_mean(x: torch.Tensor, mesh: DeviceMesh) -> float:
 
 
 def set_determinism(
-    world_mesh: Optional[DeviceMesh],
+    world_mesh: DeviceMesh | None,
     device: torch.device,
-    seed: Optional[int] = None,
+    seed: int | None = None,
     deterministic: bool = False,
 ) -> None:
     """
@@ -112,9 +112,9 @@ def set_determinism(
 
 def create_context_parallel_ctx(
     cp_mesh: DeviceMesh,
-    cp_buffers: List[torch.Tensor],
-    cp_seq_dims: List[int],
-    cp_no_restore_buffers: Set[torch.Tensor],
+    cp_buffers: list[torch.Tensor],
+    cp_seq_dims: list[int],
+    cp_no_restore_buffers: set[torch.Tensor],
     cp_rotate_method: str,
 ):
     try:
@@ -139,7 +139,7 @@ def get_train_context(
     enable_loss_parallel: bool, enable_compiled_autograd: bool
 ) -> Generator[None, None, None]:
     @contextlib.contextmanager
-    def context(cp_context: Optional[Generator[None, None, None]] = None):
+    def context(cp_context: Generator[None, None, None] | None = None):
         with contextlib.ExitStack() as stack:
             if enable_loss_parallel:
                 stack.enter_context(torch.distributed.tensor.parallel.loss_parallel())
@@ -178,7 +178,7 @@ def init_distributed(job_config):
 
     def _get_distributed_backend(job_config):
         backend = "nccl"
-        if device_type in torch.distributed.Backend.default_device_backend_map.keys():
+        if device_type in torch.distributed.Backend.default_device_backend_map:
             backend = torch.distributed.Backend.default_device_backend_map.get(
                 device_type
             )
@@ -247,12 +247,12 @@ def set_pg_timeouts(timeout, world_mesh):
 
 @torch.no_grad()
 def clip_grad_norm_(
-    parameters: Union[torch.Tensor, Iterable[torch.Tensor]],
+    parameters: torch.Tensor | Iterable[torch.Tensor],
     max_norm: float,
     norm_type: float = 2.0,
     error_if_nonfinite: bool = False,
-    foreach: Optional[bool] = None,
-    pp_mesh: Optional[DeviceMesh] = None,
+    foreach: bool | None = None,
+    pp_mesh: DeviceMesh | None = None,
 ) -> torch.Tensor:
     """
     Clip the gradient norm of an iterable of parameters.

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -7,18 +7,24 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 from abc import abstractmethod
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Callable, Optional, Protocol, Type, TypeAlias
+from typing import Protocol, TypeAlias
 
+import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
+
 from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.ft import FTManager
 from torchtitan.components.loss import LossFunction
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.components.tokenizer import Tokenizer
 from torchtitan.config_manager import JobConfig
+
+DeviceType = int | str | torch.device
 
 
 @dataclass
@@ -54,31 +60,35 @@ class ModelProtocol(Protocol):
         ...
 
 
-DataLoaderBuilder: TypeAlias = Callable[[...], BaseDataLoader]
-TokenizerBuilder: TypeAlias = Callable[[...], Tokenizer]
-MetricsProcessorBuilder: TypeAlias = Callable[[...], MetricsProcessor]
-OptimizersBuilder: TypeAlias = Callable[
-    [list[nn.Module], JobConfig], OptimizersContainer
+ParallelizeFunction: TypeAlias = Callable[..., nn.Module]
+PipeliningFunction: TypeAlias = Callable[
+    ..., tuple[_PipelineSchedule, list[nn.Module], bool, bool]
 ]
-LRSchedulersBuilder: TypeAlias = Callable[[OptimizersContainer], LRSchedulersContainer]
-LossFunctionBuilder: TypeAlias = Callable[[...], LossFunction]
+DataLoaderBuilder: TypeAlias = Callable[..., BaseDataLoader]
+TokenizerBuilder: TypeAlias = Callable[..., Tokenizer]
+MetricsProcessorBuilder: TypeAlias = Callable[..., MetricsProcessor]
+OptimizersBuilder: TypeAlias = Callable[
+    [list[nn.Module], JobConfig, FTManager], OptimizersContainer
+]
+LRSchedulersBuilder: TypeAlias = Callable[
+    [OptimizersContainer, JobConfig], LRSchedulersContainer
+]
+LossFunctionBuilder: TypeAlias = Callable[..., LossFunction]
 
 
 @dataclass
 class TrainSpec:
     name: str
-    cls: Type[nn.Module]
-    config: dict[str, BaseModelArgs]
-    parallelize_fn: Callable[[nn.Module], nn.Module]
-    pipelining_fn: Optional[
-        Callable[[nn.Module], tuple[_PipelineSchedule, list[nn.Module], bool, bool]]
-    ]
+    cls: type[nn.Module]
+    config: Mapping[str, BaseModelArgs]
+    parallelize_fn: ParallelizeFunction
+    pipelining_fn: PipeliningFunction | None
     build_optimizers_fn: OptimizersBuilder
     build_lr_schedulers_fn: LRSchedulersBuilder
     build_dataloader_fn: DataLoaderBuilder
     build_tokenizer_fn: TokenizerBuilder
     build_loss_fn: LossFunctionBuilder
-    build_metrics_processor_fn: Optional[MetricsProcessorBuilder] = None
+    build_metrics_processor_fn: MetricsProcessorBuilder | None = None
 
 
 _train_specs = {}


### PR DESCRIPTION
My LSP (based)pyright gives lots of error about signatures mismatches so I tried to fix them up.

Before:
![Screenshot 2025-04-03 at 09 48 49](https://github.com/user-attachments/assets/432c5bd7-367e-4075-8757-71220a16e007)

After:
![Screenshot 2025-04-03 at 09 47 50](https://github.com/user-attachments/assets/2b8f3316-bd84-41c4-85ac-d7d9f7ac9063)

The only linter error left is at the pipelining function, where currently it is declared to take "BaseModelArgs", but the actual passed in value is of subtype "TransformerModelArgs" etc. I haven't found a clean way to declare it yet.

- Also fixes some other inconsistences in return type, redundant nested if etc.
- Also since the pyproject.toml requires python >=3.10, I also upgrades other typing to be more modern such as "Dict -> dict" etc.

The fixes are not exhaustive and I can followup more in this PR or another PR if you like.
But if it conflicts with some Meta's internal tool etc, feel free to close.