### PR TITLE
[SimpleFSDP] Add mixed precision training support

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -5,10 +5,8 @@ This folder includes an experimental frontend implementation for [SimpleFSDP: Si
 ### Enable SimpleFSDP Training
 
 ```bash
-CONFIG_FILE="./torchtitan/models/llama/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --training.compile --training.mixed_precision_param float32
+CONFIG_FILE="./torchtitan/models/llama/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --training.compile
 ```
-
-Note: The mixed precision training support is on-going. We set `training.mixed_precision_param` to `float32` for now and will remove it once the integration is completed.
 
 ### Composability Support
 
@@ -18,7 +16,7 @@ Some of the features require the updates from PyTorch, with which we are working
 | :--------: | :--------: |
 |Meta Initialization| ✅ |
 |Activation Checkpointing| ✅ |
-|Mixed Precision Training| 🚧 |
+|Mixed Precision Training| ✅ |
 |Tensor Parallelism| 🚧 |
 |Context Parallelism| ✅ |
 |Pipeline Parallelism| ✅ |

--- a/torchtitan/experiments/simple_fsdp/simple_fsdp.py
+++ b/torchtitan/experiments/simple_fsdp/simple_fsdp.py
@@ -96,12 +96,10 @@ class ReplicateComputation(torch.nn.Module):
             )
 
             # the actuall FSDP all-gather on dp_mesh
-            # TODO(ruisizhang123): enable mixed-precision training here
-            # add the forward_dtype and backward_dtype back after landing changes in PyTorch DTensor
             replicated_dtensor = sharded_dtensor.redistribute(
                 placements=self.compute_placements,
-                # forward_dtype=self.param_dtype,
-                # backward_dtype=self.reduce_dtype,
+                forward_dtype=self.param_dtype,
+                backward_dtype=self.reduce_dtype,
             )
 
             # re-wrap 1D all-gathered DTensor on dp_mesh to 1D DTensor on tp_mesh
@@ -115,8 +113,8 @@ class ReplicateComputation(torch.nn.Module):
         else:
             output = x.redistribute(
                 placements=self.compute_placements,
-                # forward_dtype=self.param_dtype,
-                # backward_dtype=self.reduce_dtype,
+                forward_dtype=self.param_dtype,
+                backward_dtype=self.reduce_dtype,
             ).to_local(grad_placements=self.grad_placements)
 
         return output


### PR DESCRIPTION
This PR adds mixed precision training support for SimpleFSDP, together with this change from PyTorch: https://github.com/pytorch/pytorch/pull/150740. 

**(This is a placeholder for now, and shall be merged only after the PyTorch pr is landed.)** 


#### Convergence on debug model

The loss curves are all benchmarked with `training.seed = 42` on 4 GPUs.

- Fully Shard Mode (['dp_shard'], [4]): FSDP2 and SimpleFSDP's losses are perfectly matched
<img width="2234" alt="Screenshot 2025-04-05 at 4 06 04 PM" src="https://github.com/user-attachments/assets/e0ec66f2-948f-43e2-8d88-20243fbaccfc" />


- Hybrid Shard Mode (['dp_replicate', 'dp_shard'], [2, 2]): FSDP2 and SimpleFSDP's losses are similar

<img width="977" alt="Screenshot 2025-04-07 at 6 15 04 PM" src="https://github.com/user-attachments/assets/81c14637-e0a7-42aa-9b2e-c7092a287ea0" />


The end-to-end SimpleFSDP mixed precision training integration has been proved to work properly in the PR from this fork: https://github.com/tianyu-l/pytorch_intern24/pull/20.