### PR TITLE
[float8] Make module filter function for float8 training configurable

### DIFF
--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -121,7 +121,9 @@ class Float8Converter(ModelConverter):
         assert isinstance(mod, nn.Linear)
 
         # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
-        dims_multiples_of_16 = mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
+        dims_multiples_of_16 = (
+            mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
+        )
 
         # If the fqn matches any filtered fqn, then we should not convert this module.
         is_filtered_fqn = any(filtered_fqn in fqn for filtered_fqn in self.filter_fqns)

--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -117,8 +117,9 @@ class Float8Converter(ModelConverter):
             f"{self.config.enable_fsdp_float8_all_gather}"
         )
 
-    def _module_filter_fn(self, mod, fqn):
-        assert isinstance(mod, nn.Linear)
+    def _module_filter_fn(self, mod: nn.Module, fqn: str) -> bool:
+        if not isinstance(mod, nn.Linear):
+            return False
 
         # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
         dims_multiples_of_16 = (

--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -57,6 +57,7 @@ class Float8Converter(ModelConverter):
             return
 
         self.enabled = True
+        self.filter_fqns = float8_config.filter_fqns
 
         if float8_config.recipe_name is not None:
             assert (
@@ -109,12 +110,23 @@ class Float8Converter(ModelConverter):
         convert_to_float8_training(
             model,
             config=self.config,
-            module_filter_fn=lambda mod, fqn: fqn != "output",
+            module_filter_fn=self._module_filter_fn,
         )
         logger.info(
             "Swapped to Float8Linear layers with enable_fsdp_float8_all_gather="
             f"{self.config.enable_fsdp_float8_all_gather}"
         )
+
+    def _module_filter_fn(self, mod, fqn):
+        assert isinstance(mod, nn.Linear)
+
+        # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
+        dims_multiples_of_16 = mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
+
+        # If the fqn matches any filtered fqn, then we should not convert this module.
+        is_filtered_fqn = any(filtered_fqn in fqn for filtered_fqn in self.filter_fqns)
+
+        return dims_multiples_of_16 and not is_filtered_fqn
 
     def precompute_float8_dynamic_scale_for_fsdp(
         self, model: nn.Module | list[nn.Module]

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -699,7 +699,7 @@ class JobConfig:
             default=[],
             nargs="+",
             help="""
-            Comma-separated list of fully qualified names of modules to skip applying float8 training to. 
+            Comma-separated list of fully qualified names of modules to skip applying float8 training to.
             nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
             Example: --float8.module_filter_fqns "attention.wq,attention.wk,attention.wv,output"
             """,

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -693,6 +693,17 @@ class JobConfig:
             `tensorwise`, `rowwise` and `rowwise_with_gw_hp`.
             """,
         )
+        self.parser.add_argument(
+            "--float8.filter_fqns",
+            type=string_list,
+            default=[],
+            nargs="+",
+            help="""
+            Comma-separated list of fully qualified names of modules to skip applying float8 training to. 
+            nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
+            Example: --float8.module_filter_fqns "attention.wq,attention.wk,attention.wv,output"
+            """,
+        )
 
         # communications library settings
         self.parser.add_argument(

--- a/torchtitan/models/llama/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_405b.toml
@@ -60,3 +60,4 @@ mode = 'full' # ['none', 'selective', 'full']
 [float8]
 enable_fsdp_float8_all_gather = true
 precompute_float8_dynamic_scale_for_fsdp = true
+filter_fqns = ["output"]

--- a/torchtitan/models/llama/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_70b.toml
@@ -59,3 +59,4 @@ mode = 'full'
 [float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]

--- a/torchtitan/models/llama/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_8b.toml
@@ -60,3 +60,4 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 [float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
+target_fqns = ["output"]

--- a/torchtitan/models/llama/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama/train_configs/llama3_8b.toml
@@ -60,4 +60,4 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 [float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
-target_fqns = ["output"]
+filter_fqns = ["output"]


### PR DESCRIPTION
## Summary

Fixes #1043 

- Adds `--float8.filter_fqns` argument, which accepts a comma-separated list of FQNs. Defaults to empty list.
- When float8 training is enabled, any nn.Linear which has dim sizes divisible by 16 and whose FQN does not appear in the `filter_fqns` list, will be module-swapped for a Float8Linear layer.

## Test plan
- Manual testing the following cases:
    - Single FQN via command line: `--float8.filter_fqns "output"` - [logged module definition](https://www.internalfb.com/phabricator/paste/view/P1778127918)
    - Multiple FQNs via command line: `--float8.filter_fqns "output,attention.wq"` - [logged module defintion](https://www.internalfb.com/phabricator/paste/view/P1778128848)
    - Single FQN via toml ("output"): [logged module defintion](https://www.internalfb.com/phabricator/paste/view/P1778129382)
    - Multiple FQNs via toml ("output", "feed_forward.w1"): [logged module definition](https://www.internalfb.com/phabricator/paste/view/P1778134498)