### PR TITLE
Fix ft mesh_dim_names

### DIFF
--- a/torchtitan/components/ft.py
+++ b/torchtitan/components/ft.py
@@ -95,7 +95,7 @@ class FTParallelDims(ParallelDims):
             return ft_init_device_mesh(
                 device_type=device_type,
                 mesh_shape=mesh_shape,
-                mesh_dim_names=mesh_dim_names,
+                mesh_dim_names=tuple(mesh_dim_names),
                 replicate_dim=mesh_dim_names.index("dp_replicate"),
                 manager=self.ft_manager.manager,
             )


### PR DESCRIPTION
https://github.com/pytorch/torchft/pull/155/ hashes `mesh_dim_names` but we are passing in a list which causes 

```
TypeError: unhashable type: 'list'
```
