### PR TITLE
[Flux] Add script to download autoencoder before training 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ wandb
 
 torchtitan/datasets/**/*.model
 assets/**/*.model
+torchtitan/experiments/**/assets/*
 
 # temp files
 *.log

--- a/torchtitan/experiments/flux/README.md
+++ b/torchtitan/experiments/flux/README.md
@@ -3,10 +3,16 @@
 ## Overview
 
 ## Usage
+First, download the autoencoder model from HuggingFace with your own access token:
+```bash
+python torchtitan/experiments/flux/scripts/download_autoencoder.py --repo_id black-forest-labs/FLUX.1-dev --ae_path ae.safetensors --hf_token <your_access_token>
 
-Run the following command to train the model:
 ```
-    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True torchrun --nproc_per_node=1 torchtitan/experiments/flux/train.py --job.config_file torchtitan/experiments/flux/train_configs/debug_model.toml
+This step will download the autoencoder model from HuggingFace and save it to the `assets/autoencoder/ae.safetensors` file.
+
+Run the following command to train the model on a single GPU:
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True torchrun --nproc_per_node=1 torchtitan/experiments/flux/train.py --job.config_file torchtitan/experiments/flux/train_configs/debug_model.toml
 
 ```
 

--- a/torchtitan/experiments/flux/README.md
+++ b/torchtitan/experiments/flux/README.md
@@ -6,14 +6,12 @@
 First, download the autoencoder model from HuggingFace with your own access token:
 ```bash
 python torchtitan/experiments/flux/scripts/download_autoencoder.py --repo_id black-forest-labs/FLUX.1-dev --ae_path ae.safetensors --hf_token <your_access_token>
-
 ```
-This step will download the autoencoder model from HuggingFace and save it to the `assets/autoencoder/ae.safetensors` file.
+This step will download the autoencoder model from HuggingFace and save it to the `torchtitan/experiments/flux/assets/autoencoder/ae.safetensors` file.
 
 Run the following command to train the model on a single GPU:
 ```bash
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True torchrun --nproc_per_node=1 torchtitan/experiments/flux/train.py --job.config_file torchtitan/experiments/flux/train_configs/debug_model.toml
-
 ```
 
 ## TODO

--- a/torchtitan/experiments/flux/model/autoencoder.py
+++ b/torchtitan/experiments/flux/model/autoencoder.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 
 import torch
 from einops import rearrange
-from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file as load_sft
 from torch import nn, Tensor
 
@@ -356,11 +355,8 @@ class AutoEncoder(nn.Module):
 def load_ae(
     ckpt_path: str,
     autoencoder_params: AutoEncoderParams,
-    repo_id: str = "black-forest-labs/FLUX.1-dev",
-    repo_ae: str = "ae.safetensors",
     device: str | torch.device = "cuda",
     dtype=torch.bfloat16,
-    hf_download: bool = True,
 ) -> AutoEncoder:
     """
     Load the autoencoder from the given model name.
@@ -370,17 +366,15 @@ def load_ae(
     Returns:
         AutoEncoder: The loaded autoencoder.
     """
-    if (
-        not os.path.exists(ckpt_path)
-        and repo_id is not None
-        and repo_ae is not None
-        and hf_download
-    ):
-        hf_hub_download(repo_id, repo_ae, local_dir=ckpt_path)
     # Loading the autoencoder
     print("Init AE")
     with torch.device(device):
         ae = AutoEncoder(autoencoder_params)
+
+    if not os.path.exists(ckpt_path):
+        raise ValueError(
+            f"Autoencoder path {ckpt_path} does not exist. Please download it first."
+        )
 
     if ckpt_path is not None:
         sd = load_sft(ckpt_path, device=str(device))

--- a/torchtitan/experiments/flux/scripts/download_autoencoder.py
+++ b/torchtitan/experiments/flux/scripts/download_autoencoder.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from requests.exceptions import HTTPError
+
+
+def hf_download(
+    repo_id: str, file_path: str, local_dir: str, hf_token: Optional[str] = None
+) -> None:
+    from huggingface_hub import hf_hub_download
+
+    try:
+        hf_hub_download(
+            repo_id=repo_id,
+            filename=file_path,
+            local_dir=local_dir,
+            local_dir_use_symlinks=False,
+            token=hf_token,
+        )
+    except HTTPError as e:
+        if e.response.status_code == 401:
+            print(
+                "You need to pass a valid `--hf_token=...` to download private checkpoints."
+            )
+        else:
+            raise e
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Download tokenizer from HuggingFace.")
+    parser.add_argument(
+        "--repo_id",
+        type=str,
+        default="black-forest-labs/FLUX.1-dev",
+        help="Repository ID to download from. default to Flux-dev model",
+    )
+    parser.add_argument(
+        "--ae_path",
+        type=str,
+        default="ae.safetensors",
+        help="the autoencoder path relative to repo_id",
+    )
+    parser.add_argument(
+        "--hf_token", type=str, default=None, help="HuggingFace API token"
+    )
+    parser.add_argument(
+        "--local_dir",
+        type=str,
+        default="assets/autoencoder/",
+        help="local directory to save the autoencoder",
+    )
+
+    args = parser.parse_args()
+    hf_download(args.repo_id, args.ae_path, args.local_dir, args.hf_token)

--- a/torchtitan/experiments/flux/scripts/download_autoencoder.py
+++ b/torchtitan/experiments/flux/scripts/download_autoencoder.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--local_dir",
         type=str,
-        default="assets/autoencoder/",
+        default="torchtitan/experiments/flux/assets/autoencoder/",
         help="local directory to save the autoencoder",
     )
 

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -39,8 +39,8 @@ class FluxTrainer(Trainer):
         self.autoencoder = load_ae(
             job_config.encoder.auto_encoder_path,
             model_config.autoencoder_params,
-            "cpu",
-            self._dtype,
+            device="cpu",
+            dtype=self._dtype,
         )
         self.clip_encoder = FluxEmbedder(version=job_config.encoder.clip_encoder).to(
             dtype=self._dtype

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -53,7 +53,7 @@ seed = 0
 t5_encoder="google/t5-v1_1-small"
 clip_encoder="openai/clip-vit-large-patch14"
 max_t5_encoding_len=512
-auto_encoder_path="assets/autoencoder/ae.safetensors"
+auto_encoder_path="assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
 [parallelism]
 data_parallel_replicate_degree = 1

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -53,7 +53,7 @@ seed = 0
 t5_encoder="google/t5-v1_1-small"
 clip_encoder="openai/clip-vit-large-patch14"
 max_t5_encoding_len=512
-auto_encoder_path="assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
+auto_encoder_path="torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
 [parallelism]
 data_parallel_replicate_degree = 1


### PR DESCRIPTION
## Context
1. Modify `load_ae()` function signature to use pre-downloaded auto-encoder. 
2. Add script to download autoencoder before training.
3. Add instructions in README.md to fix #1067 

## Test
Train flux debug model on a single GPU with refreshed pycache.