### PR TITLE
[DeepSeek][Kernels] add on device, parallelized permute_indices kernel

### DIFF
--- a/torchtitan/experiments/deepseek_v3/moe_kernels.py
+++ b/torchtitan/experiments/deepseek_v3/moe_kernels.py
@@ -1,0 +1,307 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+# parallelized kernel
+@triton.jit
+def _fill_indices_kernel(
+    tokens_per_expert_group_ptr,
+    start_index_values_ptr,
+    write_offsets_ptr,
+    output_ptr,
+    experts_per_rank,
+    num_ranks,
+    BLOCK_SIZE: tl.constexpr,  # Number of threads per block
+):
+    pid = tl.program_id(axis=0)
+
+    # each program handles one expert
+    expert_id = pid
+
+    # only process if valid expert
+    if expert_id < experts_per_rank:
+        # read this experts write offset
+        write_offset = tl.load(write_offsets_ptr + expert_id)
+
+        # loop over all ranks
+        for r in range(num_ranks):
+            # index into tokens_per_expert_group array
+            i = r * experts_per_rank + expert_id
+
+            # load start index and number of tokens for this expert-rank pair
+            start_index = tl.load(start_index_values_ptr + i)
+            length = tl.load(tokens_per_expert_group_ptr + i)
+
+            # each thread in block processes tokens in parallel
+            offsets = tl.arange(0, BLOCK_SIZE)
+
+            # tokens are processed in chunks of BLOCK_SIZE
+            for chunk_start in range(0, length, BLOCK_SIZE):
+                chunk_offsets = chunk_start + offsets
+
+                # mask valid indices
+                mask = chunk_offsets < length
+
+                values = start_index + chunk_offsets
+
+                # destination
+                dest_indices = write_offset + chunk_offsets
+
+                # store
+                tl.store(output_ptr + dest_indices, values, mask=mask)
+
+            # update write offset for next rank
+            write_offset += length
+
+
+# ==============
+# wrapper
+# ==============
+
+
+def fill_indices_wrapper(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    block_size: int = 128,
+):
+    # preallocate output
+    permuted_indices = torch.full(
+        (max_len,), -1, dtype=torch.int32, device=tokens_per_expert_group.device
+    )
+
+    # grid = one block per expert
+    grid = (experts_per_rank,)
+
+    # launch kernel
+    _fill_indices_kernel[grid](
+        tokens_per_expert_group,
+        start_index_values,
+        write_offsets,
+        permuted_indices,
+        experts_per_rank,
+        num_ranks,
+        BLOCK_SIZE=block_size,
+    )
+    return permuted_indices
+
+
+# reference
+def fill_indices_cpu(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+):
+    # We need to preallocate the output
+    device = tokens_per_expert_group.device
+    permuted_indices = torch.full((max_len,), -1, dtype=torch.int32, device=device)
+    # Fill the permuted indices
+    # For each local expert
+    for e in range(experts_per_rank):
+        write_start = write_offsets[e].item()
+        # For each remote rank
+        for r in range(num_ranks):
+            i = r * experts_per_rank + e
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
+            # Fill in the indices
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                permuted_indices[write_start:end_idx] = torch.arange(
+                    start_index,
+                    start_index + (end_idx - write_start),
+                    dtype=torch.int32,
+                    device=device,
+                )
+            write_start += length
+    return permuted_indices
+
+
+def generate_permute_indices(
+    tokens_per_expert_group: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    alignment: int,
+    use_cpu: bool = False,
+    block_size: int = 128,
+):
+    """
+    Prepare permutation indices and the number of tokens for each expert.
+
+    Args:
+        tokens_per_expert_group: number of tokens for each expert from all ranks.
+        experts_per_rank: number of experts per rank.
+        num_ranks: number of ranks.
+        max_len: maximum length of the output index vector.
+        alignment: alignment for each returned element in `m_sizes`.
+        use_cpu: whether to use CPU implementation.
+        use_optimized: whether to use optimized Triton implementation.
+        block_size: block size for optimized implementation.
+
+    Returns:
+        permuted_indices: permutation indices.
+        m_sizes: number of tokens for each expert.
+    """
+    # prefix sum to get start index of each expert (parallel scan kernel in future?)
+    start_index_values = (
+        torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
+    )
+
+    # chunk sizes for each expert
+    chunk_size_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+
+    # align the chunk sizes (cdiv)
+    m_sizes = ((chunk_size_per_expert + alignment - 1) // alignment * alignment).to(
+        torch.int32
+    )
+
+    # additional prefix sum to get write offset of each expert in permuted_indices
+    write_offsets = torch.cumsum(m_sizes, 0) - m_sizes
+
+    # Select the implementation to use
+    if use_cpu:
+        permuted_indices = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+    else:
+        permuted_indices = fill_indices_wrapper(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+            block_size=block_size,
+        )
+
+    return permuted_indices, m_sizes
+
+
+def verify_correctness(
+    experts_per_rank: int = 8,
+    num_ranks: int = 8,
+    token_range: Tuple[int, int] = (1, 32),
+    max_len_factor: int = 4,
+    alignment: int = 32,
+    seed: int = 2020,
+):
+    torch.manual_seed(seed)
+
+    # original sequential kernel
+    from indices import generate_permute_indices as original_permute_indices
+
+    # generate test data
+    # Create test data
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokens_per_expert_group = torch.randint(
+        token_range[0],
+        token_range[1] + 1,
+        (num_ranks * experts_per_rank,),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    # Calculate max_len based on token counts
+    total_tokens = tokens_per_expert_group.sum().item()
+    max_len = total_tokens * max_len_factor
+
+    # Generate permutation indices using different implementations
+    cpu_indices, cpu_sizes = generate_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=True,
+    )
+
+    original_indices, original_sizes = original_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=False,
+    )
+
+    optimized_indices, optimized_sizes = generate_permute_indices(
+        tokens_per_expert_group,
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=False,
+    )
+
+    # Check if results match
+    cpu_original_match = torch.equal(cpu_indices, original_indices)
+    cpu_optimized_match = torch.equal(cpu_indices, optimized_indices)
+    orig_optimized_match = torch.equal(original_indices, optimized_indices)
+
+    sizes_match = torch.equal(cpu_sizes, original_sizes) and torch.equal(
+        cpu_sizes, optimized_sizes
+    )
+
+    all_match = (
+        cpu_original_match
+        and cpu_optimized_match
+        and orig_optimized_match
+        and sizes_match
+    )
+
+    if not all_match:
+        print(
+            f"Correctness test failed for experts_per_rank={experts_per_rank}, num_ranks={num_ranks}"
+        )
+        if not cpu_original_match:
+            print("  CPU vs Original mismatch")
+        if not cpu_optimized_match:
+            print("  CPU vs Optimized mismatch")
+        if not orig_optimized_match:
+            print("  Original vs Optimized mismatch")
+        if not sizes_match:
+            print("  Sizes mismatch")
+
+        # Find first mismatch (if results don't match)
+        if not orig_optimized_match:
+            mismatch_indices = (original_indices != optimized_indices).nonzero(
+                as_tuple=True
+            )[0]
+            if len(mismatch_indices) > 0:
+                first_mismatch = mismatch_indices[0].item()
+                print(
+                    f"  First mismatch at index {first_mismatch}: "
+                    f"Original={original_indices[first_mismatch].item()}, "
+                    f"Optimized={optimized_indices[first_mismatch].item()}"
+                )
+    print(f"{optimized_indices=}")
+    return all_match
+
+
+if __name__ == "__main__":
+    res = verify_correctness()
+    if res:
+        print(f"Success - results match reference!")
+    else:
+        print(f"Warning:  see details above - results do not match reference!")

--- a/torchtitan/experiments/deepseek_v3/moe_kernels.py
+++ b/torchtitan/experiments/deepseek_v3/moe_kernels.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
-
 import torch
 import triton
 import triton.language as tl

--- a/torchtitan/experiments/deepseek_v3/moe_kernels.py
+++ b/torchtitan/experiments/deepseek_v3/moe_kernels.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple
+from typing import Tuple
 
 import torch
 import triton
@@ -302,6 +302,6 @@ def verify_correctness(
 if __name__ == "__main__":
     res = verify_correctness()
     if res:
-        print(f"Success - results match reference!")
+        print("Success - results match reference!")
     else:
-        print(f"Warning:  see details above - results do not match reference!")
+        print("Warning:  see details above - results do not match reference!")

--- a/torchtitan/experiments/deepseek_v3/moe_kernels.py
+++ b/torchtitan/experiments/deepseek_v3/moe_kernels.py
@@ -147,6 +147,7 @@ def generate_permute_indices(
     alignment: int,
     use_cpu: bool = False,
     block_size: int = 128,
+    max_blocks: int = 1024,
 ):
     """
     Prepare permutation indices and the number of tokens for each expert.

--- a/torchtitan/experiments/deepseek_v3/moe_kernels.py
+++ b/torchtitan/experiments/deepseek_v3/moe_kernels.py
@@ -146,8 +146,6 @@ def generate_permute_indices(
     max_len: int,
     alignment: int,
     use_cpu: bool = False,
-    block_size: int = 128,
-    max_blocks: int = 1024,
 ):
     """
     Prepare permutation indices and the number of tokens for each expert.
@@ -201,7 +199,6 @@ def generate_permute_indices(
             experts_per_rank,
             num_ranks,
             max_len,
-            block_size=block_size,
         )
 
     return permuted_indices, m_sizes

--- a/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
+++ b/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 
 try:
-    from moe_kernels import fill_indices_wrapper, generate_permute_indices
+    from moe_kernels import fill_indices_wrapper
 
 except ImportError:
     print("unable to import required function(s) from moe_kernels.py...")

--- a/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
+++ b/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
@@ -132,9 +132,12 @@ class TestOptimizedKernel(unittest.TestCase):
                     f"Testing {experts_per_rank} experts per rank across {num_ranks} ranks (total: {actual_total_experts})"
                 )
 
-                tokens_per_expert_group, start_index_values, write_offsets, max_len = (
-                    self.create_test_data(experts_per_rank, num_ranks)
-                )
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(experts_per_rank, num_ranks)
 
                 # Run CPU implementation
                 cpu_result = fill_indices_cpu(
@@ -180,9 +183,12 @@ class TestOptimizedKernel(unittest.TestCase):
         num_ranks = 8
         experts_per_rank = self.total_experts // num_ranks  # 32 experts per rank
 
-        tokens_per_expert_group, start_index_values, write_offsets, max_len = (
-            self.create_test_data(experts_per_rank, num_ranks)
-        )
+        (
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            max_len,
+        ) = self.create_test_data(experts_per_rank, num_ranks)
 
         # Run CPU implementation for reference
         cpu_result = fill_indices_cpu(
@@ -225,9 +231,12 @@ class TestOptimizedKernel(unittest.TestCase):
 
         for token_range in token_ranges:
             with self.subTest(f"token_range={token_range}"):
-                tokens_per_expert_group, start_index_values, write_offsets, max_len = (
-                    self.create_test_data(experts_per_rank, num_ranks, token_range)
-                )
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(experts_per_rank, num_ranks, token_range)
 
                 # Run CPU implementation
                 cpu_result = fill_indices_cpu(

--- a/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
+++ b/torchtitan/experiments/deepseek_v3/unit_testing/permute_indices_testing.py
@@ -1,0 +1,261 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from typing import Tuple
+
+import numpy as np
+import torch
+
+try:
+    from moe_kernels import fill_indices_wrapper, generate_permute_indices
+
+except ImportError:
+    print("unable to import required function from moe_kernels.py...")
+    raise
+
+
+def fill_indices_cpu(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+):
+    """CPU implementation for reference."""
+    # We need to preallocate the output
+    device = tokens_per_expert_group.device
+    permuted_indices = torch.full((max_len,), -1, dtype=torch.int32, device=device)
+    # Fill the permuted indices
+    # For each local expert
+    for e in range(experts_per_rank):
+        write_start = write_offsets[e].item()
+        # For each remote rank
+        for r in range(num_ranks):
+            i = r * experts_per_rank + e
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
+            # Fill in the indices
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                # Add this check to prevent empty ranges
+                if write_start < end_idx:
+                    permuted_indices[write_start:end_idx] = torch.arange(
+                        start_index,
+                        start_index + (end_idx - write_start),
+                        dtype=torch.int32,
+                        device=device,
+                    )
+            write_start += length
+    return permuted_indices
+
+
+class TestOptimizedKernel(unittest.TestCase):
+    """Test cases for the optimized Triton kernel."""
+
+    def setUp(self):
+        """Set up common test parameters."""
+        # Check if GPU is available
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if self.device.type == "cpu":
+            self.skipTest("No GPU available, skipping Triton kernel tests")
+
+        # Set random seed for reproducible tests
+        torch.manual_seed(2020)
+        np.random.seed(2020)
+
+        # Total experts to test
+        self.total_experts = 256
+
+    def create_test_data(
+        self,
+        experts_per_rank: int,
+        num_ranks: int,
+        token_range: Tuple[int, int] = (1, 16),
+        alignment: int = 32,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """Create test data with given parameters."""
+        # Create token counts
+        tokens_per_expert_group = torch.randint(
+            token_range[0],
+            token_range[1] + 1,
+            (num_ranks * experts_per_rank,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Calculate start indices
+        start_index_values = (
+            torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
+        )
+
+        # Calculate chunk sizes
+        chunk_size_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+        m_sizes = ((chunk_size_per_expert + alignment - 1) // alignment * alignment).to(
+            torch.int32
+        )
+
+        # Calculate write offsets
+        write_offsets = torch.cumsum(m_sizes, 0) - m_sizes
+
+        # Calculate max_len
+        total_tokens = tokens_per_expert_group.sum().item()
+        max_len = total_tokens * 2  # Give some extra space
+
+        return tokens_per_expert_group, start_index_values, write_offsets, max_len
+
+    def test_fixed_total_experts_varying_ranks(self):
+        """Test with 256 total experts distributed across different numbers of ranks."""
+        # Test with different rank configurations
+        rank_configs = [1, 2, 4, 8, 16, 32, 64, 128]
+
+        for num_ranks in rank_configs:
+            # Calculate experts per rank to maintain fixed total experts
+            experts_per_rank = self.total_experts // num_ranks
+
+            # Skip if experts_per_rank is less than 1
+            if experts_per_rank < 1:
+                continue
+
+            # Actual total experts (may differ slightly due to integer division)
+            actual_total_experts = experts_per_rank * num_ranks
+
+            with self.subTest(
+                f"ranks={num_ranks}, experts_per_rank={experts_per_rank}, total={actual_total_experts}"
+            ):
+                print(
+                    f"Testing {experts_per_rank} experts per rank across {num_ranks} ranks (total: {actual_total_experts})"
+                )
+
+                tokens_per_expert_group, start_index_values, write_offsets, max_len = (
+                    self.create_test_data(experts_per_rank, num_ranks)
+                )
+
+                # Run CPU implementation
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Optimized kernel output does not match CPU implementation for "
+                    f"{experts_per_rank} experts per rank, {num_ranks} ranks",
+                )
+
+                # Check that all valid positions match
+                valid_positions = cpu_result != -1
+                if valid_positions.sum() > 0:
+                    valid_cpu = cpu_result[valid_positions]
+                    valid_optimized = optimized_result[valid_positions]
+                    self.assertTrue(
+                        torch.equal(valid_cpu, valid_optimized),
+                        f"Mismatch in valid positions for {experts_per_rank} experts per rank, {num_ranks} ranks",
+                    )
+
+    def test_different_block_sizes_with_fixed_experts(self):
+        """Test different block sizes with fixed total experts."""
+        # Use a moderate rank configuration
+        num_ranks = 8
+        experts_per_rank = self.total_experts // num_ranks  # 32 experts per rank
+
+        tokens_per_expert_group, start_index_values, write_offsets, max_len = (
+            self.create_test_data(experts_per_rank, num_ranks)
+        )
+
+        # Run CPU implementation for reference
+        cpu_result = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+
+        # Test different block sizes
+        block_sizes = [32, 64, 128, 256, 512]
+        for block_size in block_sizes:
+            with self.subTest(f"block_size={block_size}"):
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=block_size,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Block size {block_size} produces incorrect results",
+                )
+
+    def test_edge_cases_with_fixed_experts(self):
+        """Test edge cases with configurations that maintain fixed total experts."""
+        # For fixed total experts = 256
+        # Test with different token ranges
+        token_ranges = [(1, 1), (0, 0), (16, 16), (1, 32)]
+
+        num_ranks = 8
+        experts_per_rank = self.total_experts // num_ranks  # 32 experts per rank
+
+        for token_range in token_ranges:
+            with self.subTest(f"token_range={token_range}"):
+                tokens_per_expert_group, start_index_values, write_offsets, max_len = (
+                    self.create_test_data(experts_per_rank, num_ranks, token_range)
+                )
+
+                # Run CPU implementation
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Optimized kernel failed for token range {token_range}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates the original Triton kernel in indices.py (https://github.com/pytorch/torchtitan/pull/1062) to move it to a more parallelized and vectorized implementation to better support larger runs.  
This provides roughly an 8.7x perf improvement for 256 experts. 

This kernel functionally achieves the same as before:
Prepare permutation indices and the number of tokens for each expert with any required alignment, where alignment is driven by the group gemm requirement. 
* The permutation indices are the indices of the tokens for each expert. 
* The number of tokens for each expert is the sum of the number of tokens for
such experts from all ranks. 

However, this kernel improves the parallelization by assigning one block to each expert, and threads in each block process the tokens in chunks, all while using vectorized loads and stores.   
This results in the performance improvement while yielding the same indices.

Testing:
~~~
python moe_kernels.py
  ~~~

(runs simple verification using cpu, previous kernel and new optimized kernel)

Benchmark of performance improvement using fixed 256 experts across various world sizes
~~~

Summary for fixed total experts (256), where we mimic various DeepSeek experts across a number of ranks:
Ranks | Experts/Rank | Original (ms) | Optimized (ms) | Block Size | Speedup | Correct
------------------------------------------------------------------------------------------
    1 |          256 |        0.241 |        0.020 |        128 |   11.95x |       1
    4 |           64 |        0.222 |        0.020 |        128 |   10.97x |       1
   16 |           16 |        0.221 |        0.021 |        128 |   10.40x |       1
   32 |            8 |        0.224 |        0.025 |         64 |    8.81x |       1
   64 |            4 |        0.225 |        0.037 |        128 |    6.01x |       1
  128 |            2 |        0.217 |        0.051 |        128 |    4.26x |       1
  ~~~

added unit testing: 
~~~
..Testing 256 experts per rank across 1 ranks (total: 256)
Testing 128 experts per rank across 2 ranks (total: 256)
Testing 64 experts per rank across 4 ranks (total: 256)
Testing 32 experts per rank across 8 ranks (total: 256)
Testing 16 experts per rank across 16 ranks (total: 256)
Testing 8 experts per rank across 32 ranks (total: 256)
Testing 4 experts per rank across 64 ranks (total: 256)
Testing 2 experts per rank across 128 ranks (total: 256)
.
----------------------------------------------------------------------
Ran 3 tests in 1.104s

OK
~~~