### PR TITLE
[Not for land] float8 rowwise on single GPU + nanchecker

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -358,26 +358,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             # Non-PP forward / backward
             with self.train_context(optional_context_parallel_ctx):
-#                with NanInfDetect(do_breakpoint=True):
-                assert len(model_parts) == 1
-                pred = model_parts[0](inputs)
+                with NanInfDetect(do_breakpoint=True):
+                    assert len(model_parts) == 1
+                    pred = model_parts[0](inputs)
 
-                # check for Nans in model output
-                assert not pred.isnan().any(), "model output contains NaN"
-                
-                loss = self.loss_fn(pred, labels)
+                    # check for Nans in model output
+                    assert not pred.isnan().any(), "model output contains NaN"
+                    
+                    loss = self.loss_fn(pred, labels)
 
-                # Check loss is not nan
-                assert not loss.isnan().any(), "loss contains NaN"
+                    # Check loss is not nan
+                    assert not loss.isnan().any(), "loss contains NaN"
 
-                # pred.shape=(bs, seq_len, vocab_size)
-                # need to free to before bwd to avoid peaking memory
-                del pred
-                loss.backward()
+                    # pred.shape=(bs, seq_len, vocab_size)
+                    # need to free to before bwd to avoid peaking memory
+                    del pred
+                    loss.backward()
 
-                # check for NaNs in the gradients
-                for param in model_parts[0].parameters():
-                    assert not param.grad.isnan().any(), "gradients contain NaN after bwd"
+                    # check for NaNs in the gradients
+                    for param in model_parts[0].parameters():
+                        assert not param.grad.isnan().any(), "gradients contain NaN after bwd"
 
         dist_utils.clip_grad_norm_(
             [p for m in model_parts for p in m.parameters()],

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -358,22 +358,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             # Non-PP forward / backward
             with self.train_context(optional_context_parallel_ctx):
-                with NanInfDetect(do_breakpoint=True):
-                    assert len(model_parts) == 1
-                    pred = model_parts[0](inputs)
+#                with NanInfDetect(do_breakpoint=True):
+                assert len(model_parts) == 1
+                pred = model_parts[0](inputs)
 
-                    # check for Nans in model output
-                    assert not pred.isnan().any(), "model output contains NaN"
-                    
-                    loss = self.loss_fn(pred, labels)
-                    # pred.shape=(bs, seq_len, vocab_size)
-                    # need to free to before bwd to avoid peaking memory
-                    del pred
-                    loss.backward()
+                # check for Nans in model output
+                assert not pred.isnan().any(), "model output contains NaN"
+                
+                loss = self.loss_fn(pred, labels)
 
-                    # check for NaNs in the gradients
-                    for param in model_parts[0].parameters():
-                        assert not param.grad.isnan().any(), "gradients contain NaN after bwd"
+                # Check loss is not nan
+                assert not loss.isnan().any(), "loss contains NaN"
+
+                # pred.shape=(bs, seq_len, vocab_size)
+                # need to free to before bwd to avoid peaking memory
+                del pred
+                loss.backward()
+
+                # check for NaNs in the gradients
+                for param in model_parts[0].parameters():
+                    assert not param.grad.isnan().any(), "gradients contain NaN after bwd"
 
         dist_utils.clip_grad_norm_(
             [p for m in model_parts for p in m.parameters()],


### PR DESCRIPTION
sharing my local changes used for debugging float8 training issues on a single GPU.

Changes:
- convert model to bfloat16 (required for float8 GEMMs which must have bfloat16 output dtype w/ rowwise scales)
- use nan checker to throw breakpoint when any intermediate result has nans

`aten._scaled_dot_product_flash_attention` returns nan in the forward pass