### PR TITLE
[Flux] Implement Initialize weight function for Flux model

### DIFF
--- a/torchtitan/experiments/flux/model/layers.py
+++ b/torchtitan/experiments/flux/model/layers.py
@@ -196,6 +196,10 @@ class DoubleStreamBlock(nn.Module):
         for layer in (self.img_attn, self.img_mod, self.txt_attn, self.txt_mod):
             layer.init_weights()
 
+        # Reset parameters for Normalization layers
+        for norm in (self.txt_norm1, self.txt_norm2, self.img_norm1, self.img_norm2):
+            norm.reset_parameters()
+
     def forward(
         self, img: Tensor, txt: Tensor, vec: Tensor, pe: Tensor
     ) -> tuple[Tensor, Tensor]:
@@ -279,7 +283,8 @@ class SingleStreamBlock(nn.Module):
         for layer in (self.linear1, self.linear2):
             nn.init.xavier_uniform_(layer.weight)
             nn.init.constant_(layer.bias, 0)
-
+        self.norm.init_weights()
+        self.pre_norm.reset_parameters()
         self.modulation.init_weights()
 
     def forward(self, x: Tensor, vec: Tensor, pe: Tensor) -> Tensor:
@@ -315,6 +320,7 @@ class LastLayer(nn.Module):
         nn.init.constant_(self.adaLN_modulation[-1].bias, 0)
         nn.init.constant_(self.linear.weight, 0)
         nn.init.constant_(self.linear.bias, 0)
+        self.norm_final.reset_parameters()
 
     def forward(self, x: Tensor, vec: Tensor) -> Tensor:
         shift, scale = self.adaLN_modulation(vec).chunk(2, dim=1)

--- a/torchtitan/experiments/flux/model/model.py
+++ b/torchtitan/experiments/flux/model/model.py
@@ -122,7 +122,7 @@ class FluxModel(nn.Module, ModelProtocol):
     def init_weights(self, buffer_device=None):
         # Adopted from DiT weight initialization: https://github.com/facebookresearch/DiT/blob/main/models.py#L189
 
-        # Initialize transformer layers, img_in, txt_in
+        # Initialize transformer blocks, img_in (linear layer), txt_in (linear layer)
         def _basic_init(module):
             if isinstance(module, nn.Linear):
                 torch.nn.init.xavier_uniform_(module.weight)
@@ -140,7 +140,7 @@ class FluxModel(nn.Module, ModelProtocol):
             nn.init.normal_(self.guidance_in.in_layer.weight, std=0.02)
             nn.init.normal_(self.guidance_in.out_layer.weight, std=0.02)
 
-        # Zero-out modulation layers in blocks:
+        # Zero-out modulation layers in transformer blocks:
         for block in self.single_blocks:
             nn.init.constant_(block.modulation.lin.weight, 0)
             nn.init.constant_(block.modulation.lin.bias, 0)

--- a/torchtitan/experiments/flux/model/model.py
+++ b/torchtitan/experiments/flux/model/model.py
@@ -120,7 +120,7 @@ class FluxModel(nn.Module, ModelProtocol):
         self.final_layer = LastLayer(self.hidden_size, 1, self.out_channels)
 
     def init_weights(self, buffer_device=None):
-        # Adopted from DiT weight initialization: https://github.com/facebookresearch/DiT/blob/main/models.py#L189
+        # Adapted from DiT weight initialization: https://github.com/facebookresearch/DiT/blob/main/models.py#L189
         # initialize Linear Layers: img_in, txt_in
         nn.init.xavier_uniform_(self.img_in.weight)
         nn.init.constant_(self.img_in.bias, 0)

--- a/torchtitan/experiments/flux/tests/test_generate_image.py
+++ b/torchtitan/experiments/flux/tests/test_generate_image.py
@@ -118,12 +118,16 @@ class TestGenerateImage:
         clip_tokenizer = FluxTokenizer(
             model_path="openai/clip-vit-large-patch14", max_length=77
         )
-        t5_tokenizer = FluxTokenizer(model_path="google/t5-v1_1-small", max_length=512)
-        clip_encoder = FluxEmbedder(version="openai/clip-vit-large-patch14").to(
-            torch_device, dtype=torch.bfloat16
+        t5_tokenizer = FluxTokenizer(model_path="google/t5-v1_1-xxl", max_length=4096)
+        clip_encoder = (
+            FluxEmbedder(version="openai/clip-vit-large-patch14")
+            .to(torch_device, dtype=torch.bfloat16)
+            .eval()
         )
-        t5_encoder = FluxEmbedder(version="google/t5-v1_1-small").to(
-            torch_device, dtype=torch.bfloat16
+        t5_encoder = (
+            FluxEmbedder(version="google/t5-v1_1-xxl")
+            .to(torch_device, dtype=torch.bfloat16)
+            .eval()
         )
 
         rng = torch.Generator(device="cpu")

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -12,7 +12,7 @@ enable_memory_snapshot = false
 save_memory_snapshot_folder = "memory_snapshot"
 
 [metrics]
-log_freq = 100
+log_freq = 10
 disable_color_printing = false
 enable_tensorboard = false
 save_tb_folder = "tb"

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -12,7 +12,7 @@ enable_memory_snapshot = false
 save_memory_snapshot_folder = "memory_snapshot"
 
 [metrics]
-log_freq = 10
+log_freq = 100
 disable_color_printing = false
 enable_tensorboard = false
 save_tb_folder = "tb"


### PR DESCRIPTION
## Context
Implement `init_weights()` function in `model.py`. Adopted from DiT: https://github.com/facebookresearch/DiT/blob/main/models.py#L125


## Test

Train flux-schnell model on 8 H100 GPU

```
[rank0]:[titan] 2025-04-10 13:51:04,539 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-04-10 13:52:24,633 - root - INFO - step: 10  loss:  1.9750  memory: 78.43GiB(82.56%)  tps: 88,370  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 13:53:52,970 - root - INFO - step: 20  loss:  2.3648  memory: 78.43GiB(82.56%)  tps: 89,026  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 13:55:21,283 - root - INFO - step: 30  loss:  2.3314  memory: 78.43GiB(82.56%)  tps: 89,052  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 13:56:49,486 - root - INFO - step: 40  loss:  2.0655  memory: 78.43GiB(82.56%)  tps: 89,163  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 13:57:51,067 - root - WARNING - Low quality image 000000212 is skipped in Flux Dataloader
[rank0]:[titan] 2025-04-10 13:58:09,780 - root - INFO - [GC] Peforming periodical GC collection. 0.03 seconds.
[rank0]:[titan] 2025-04-10 13:58:19,156 - root - INFO - step: 50  loss:  2.3672  memory: 78.43GiB(82.56%)  tps: 87,705  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 13:59:48,336 - root - INFO - step: 60  loss:  2.4141  memory: 78.43GiB(82.56%)  tps: 88,186  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 14:01:16,549 - root - INFO - step: 70  loss:  2.1855  memory: 78.43GiB(82.56%)  tps: 89,154  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 14:02:44,915 - root - INFO - step: 80  loss:  2.1686  memory: 78.43GiB(82.56%)  tps: 88,999  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 14:04:18,518 - root - INFO - step: 90  loss:  2.2813  memory: 78.43GiB(82.56%)  tps: 84,019  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-04-10 14:05:38,536 - root - INFO - [GC] Peforming periodical GC collection. 0.00 seconds.
[rank0]:[titan] 2025-04-10 14:05:47,472 - root - INFO - step: 100  loss:  2.4654  memory: 78.43GiB(82.56%)  tps: 88,411  tflops: 0.00  mfu: 0.00%
```

