### PR TITLE
remove TORCH_NCCL_AVOID_RECORD_STREAMS env var setting

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -207,11 +207,6 @@ def init_distributed(job_config):
         os.makedirs(dump_dir, exist_ok=True)
         _warn_overwrite_env(TRACE_FILE, f"{dump_dir}/rank_")
 
-    # to mitigate the memory issue that collectives using
-    # async_op=True hold memory longer than they should
-    # such as those in tensor parallelism
-    os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
-
     torch.distributed.init_process_group(
         backend=_get_distributed_backend(job_config),
         timeout=timedelta(seconds=job_config.comm.init_timeout_seconds),


### PR DESCRIPTION
as I'm seeing the following warning
```
Warning: TORCH_NCCL_AVOID_RECORD_STREAMS is the default now, this environment variable is thus deprecated. (function operator())
```
from https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L997