### PR TITLE
upgrade generate_permute_indices with faster kernel (parallelized)

### DIFF
--- a/torchtitan/experiments/kernels/moe/indices.py
+++ b/torchtitan/experiments/kernels/moe/indices.py
@@ -12,64 +12,96 @@ import triton.language as tl
 __all__ = ["generate_permute_indices"]
 
 
+# parallelized kernel
 @triton.jit
-def fill_indices_kernel(
-    tokens_per_expert_group_ptr,  # *Pointer* to first input vector.
-    start_index_values_ptr,  # *Pointer* to second input vector.
-    write_offsets_ptr,  # *Pointer* to third input vector.
-    output_ptr,  # *Pointer* to output vector.
-    experts_per_rank,  # Number of experts per rank.
-    num_ranks,  # Number of expert ranks.
+def _fill_indices_kernel(
+    tokens_per_expert_group_ptr,
+    start_index_values_ptr,
+    write_offsets_ptr,
+    output_ptr,
+    experts_per_rank: tl.constexpr,
+    num_ranks: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # Number of threads per block
 ):
-    # There are multiple 'programs' processing different data. We identify which program
-    # we are here:
-    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
-    # The total number of programs in the launch grid.
+    pid = tl.program_id(axis=0)
     num_programs = tl.num_programs(axis=0)
-    # We map the programs (blocks) to the experts.
-    for expert_id in tl.range(pid, experts_per_rank, step=num_programs):
-        # Read this expert's write offset.
+
+    # map programs (blocks) to the experts and loop (grid stride) if needed
+    for expert_id in range(pid, experts_per_rank, num_programs):
+
+        # read this experts write offset
         write_offset = tl.load(write_offsets_ptr + expert_id)
-        # Loop over the ranks.
-        for r in tl.range(num_ranks):
-            # Slot in the tokens_per_expert_group array.
+
+        # loop over all ranks
+        for r in range(num_ranks):
+            # index into tokens_per_expert_group array
             i = r * experts_per_rank + expert_id
+
+            # load start index and number of tokens for this expert-rank pair
             start_index = tl.load(start_index_values_ptr + i)
             length = tl.load(tokens_per_expert_group_ptr + i)
-            # Write the indices.
-            for l in tl.range(length):
-                val = start_index + l
-                tl.store(output_ptr + write_offset + l, val)
+
+            # each thread in block processes tokens in parallel
+            offsets = tl.arange(0, BLOCK_SIZE)
+
+            # tokens are processed in chunks of BLOCK_SIZE
+            for chunk_start in range(0, length, BLOCK_SIZE):
+                chunk_offsets = chunk_start + offsets
+
+                # mask valid indices
+                mask = chunk_offsets < length
+
+                values = start_index + chunk_offsets
+
+                # destination
+                dest_indices = write_offset + chunk_offsets
+
+                # store
+                tl.store(output_ptr + dest_indices, values, mask=mask)
+
+            # update write offset for next rank
             write_offset += length
 
 
-def fill_indices(
+# ==============
+# wrapper
+# ==============
+
+
+def fill_indices_wrapper(
     tokens_per_expert_group: torch.Tensor,
     start_index_values: torch.Tensor,
     write_offsets: torch.Tensor,
     experts_per_rank: int,
     num_ranks: int,
     max_len: int,
+    block_size: int = 128,
+    max_blocks: int = 1024,  # cap on total number of blocks to launch
 ):
-    # We need to preallocate the output.
+    # preallocate output
     permuted_indices = torch.full(
         (max_len,), -1, dtype=torch.int32, device=tokens_per_expert_group.device
     )
-    # Analogous to CUDA launch grids. It can be either Tuple[int], or Callable(metaparameters) -> Tuple[int].
-    # In this case, we use a 1D grid where the size is the number of blocks (TODO: bump this value).
-    grid = lambda meta: (1,)
-    #  Each torch.tensor object is implicitly converted into a pointer to its first element.
-    fill_indices_kernel[grid](
+
+    # write offsets is per local expert...
+    num_blocks = min(experts_per_rank, max_blocks)
+    # grid = one block per expert unless capped and then we loop...
+    grid = (num_blocks,)
+
+    # launch kernel
+    _fill_indices_kernel[grid](
         tokens_per_expert_group,
         start_index_values,
         write_offsets,
         permuted_indices,
         experts_per_rank,
         num_ranks,
+        BLOCK_SIZE=block_size,
     )
     return permuted_indices
 
 
+# reference
 def fill_indices_cpu(
     tokens_per_expert_group: torch.Tensor,
     start_index_values: torch.Tensor,
@@ -78,21 +110,31 @@ def fill_indices_cpu(
     num_ranks: int,
     max_len: int,
 ):
-    # We need to preallocate the output.
-    permuted_indices = torch.full((max_len,), -1, dtype=torch.int32)
+    # We need to preallocate the output - we ignore device and force it on cpu
+    # device = tokens_per_expert_group.device
+    permuted_indices = torch.full(
+        (max_len,),
+        -1,
+        dtype=torch.int32,
+    )  # device=device)
     # Fill the permuted indices
     # For each local expert
     for e in range(experts_per_rank):
-        write_start = write_offsets[e]
+        write_start = write_offsets[e].item()
         # For each remote rank
         for r in range(num_ranks):
             i = r * experts_per_rank + e
-            start_index = start_index_values[i]
-            length = tokens_per_expert_group[i]
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
             # Fill in the indices
-            permuted_indices[write_start : write_start + length] = torch.arange(
-                start_index, start_index + length
-            )
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                permuted_indices[write_start:end_idx] = torch.arange(
+                    start_index,
+                    start_index + (end_idx - write_start),
+                    dtype=torch.int32,
+                    # device=device,
+                )
             write_start += length
     return permuted_indices
 
@@ -105,60 +147,68 @@ def generate_permute_indices(
     alignment: int,
     use_cpu: bool = False,
 ):
-    # Prepare permutation indices and the number of tokens for each expert.  The
-    # permutation indices are the indices of the tokens for each expert.  The
-    # number of tokens for each expert is the sum of the number of tokens for
-    # such experts from all ranks. This number is aligned to the provided
-    # alignment requirement (usually comes from group gemm).
+    """
+    Prepare permutation indices and the number of tokens for each expert.
 
-    # Args:
-    #     tokens_per_expert_group: number of tokens for each expert from all ranks.
-    #     experts_per_rank: number of experts per rank.
-    #     num_ranks: number of ranks.
-    #     max_len: maximum length of the output index vector. If greater than
-    #     total number of tokens, the remaining indices are set to -1.
-    #     alignment: alignment for each returned element in `m_sizes`.
-    #     use_cpu: whether to use cpu or gpu.
-    # Returns:
-    #     permuted_indices: permutation indices.
-    #     m_sizes: number of tokens for each expert.
+    Args:
+        tokens_per_expert_group: number of tokens for each expert from all ranks.
+        experts_per_rank: number of experts per rank.
+        num_ranks: number of ranks.
+        max_len: maximum length of the output index vector.
+        alignment: alignment for each returned element in `m_sizes`.
+        use_cpu: whether to use CPU implementation.
+        use_optimized: whether to use optimized Triton implementation.
+        block_size: block size for optimized implementation.
 
-    # `tokens_per_expert_group` is of shape (num_ranks * experts_per_rank,), for example:
-    # From: |       rank 0      |       rank 1      |
-    # To:   | E0 | E1 | E2 | E3 | E0 | E1 | E2 | E3 |
-    #       |  4 |  2 |  1 |  3 |  1 |  2 |  3 |  4 |
-
-    # Prefix sum to get the start index value of each expert
+    Returns:
+        permuted_indices: permutation indices.
+        m_sizes: number of tokens for each expert.
+    """
+    # prefix sum to get start index of each expert (parallel scan kernel in future?)
     start_index_values = (
         torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
     )
-    # Chunk sizes for each expert
+
+    # chunk sizes for each expert
     chunk_size_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
-    # Align the chunk sizes to the given alignment
+
+    # align the chunk sizes (cdiv)
     m_sizes = ((chunk_size_per_expert + alignment - 1) // alignment * alignment).to(
         torch.int32
     )
-    # Perform another prefix sum to get the write offset of each expert in `permuted_indices`
+
+    # additional prefix sum to get write offset of each expert in permuted_indices
+    # write offsets is per local expert, not global
     m_offsets = torch.cumsum(m_sizes, 0)
     write_offsets = m_offsets - m_sizes
-    # Select the method to fill the permuted indices
-    fill_fn = fill_indices_cpu if use_cpu else fill_indices
-    # Fill the permuted indices
-    permuted_indices = fill_fn(
-        tokens_per_expert_group,
-        start_index_values,
-        write_offsets,
-        experts_per_rank,
-        num_ranks,
-        max_len,
-    )
+
+    # Select the implementation to use
+    if use_cpu:
+        permuted_indices = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+    else:
+        permuted_indices = fill_indices_wrapper(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+
     return permuted_indices, m_sizes, m_offsets.to(torch.int32)
 
 
 # Below is for testing only
 
 
-def test():
+def simple_test():
     device = torch.device("cuda", 0)
     experts_per_rank = 4
     num_ranks = 4
@@ -168,11 +218,11 @@ def test():
     max_len = 128
     alignment = 32
     # Use the GPU kernel
-    permuted_indices_gpu, m_sizes, _ = generate_permute_indices(
+    permuted_indices_gpu, m_sizes = generate_permute_indices(
         tokens_per_expert_group, experts_per_rank, num_ranks, max_len, alignment
     )
     # Use the CPU method
-    permuted_indices_cpu, _, _ = generate_permute_indices(
+    permuted_indices_cpu, _ = generate_permute_indices(
         tokens_per_expert_group,
         experts_per_rank,
         num_ranks,
@@ -181,16 +231,18 @@ def test():
         use_cpu=True,
     )
     # Check that the results are the same
+
     assert torch.equal(permuted_indices_gpu.cpu(), permuted_indices_cpu)
     assert torch.equal(
         torch.remainder(m_sizes, alignment),
         torch.zeros(experts_per_rank, device=device),
     )
     # Print the results
-    print(permuted_indices_gpu)
-    print(m_sizes)
+    print(f"{permuted_indices_gpu=}, \n{permuted_indices_cpu=}")
+    print(f"{m_sizes=}")
     print("Success")
+    return True  # assert would have failed meaning getting here is success.
 
 
 if __name__ == "__main__":
-    test()
+    simple_test()

--- a/torchtitan/experiments/kernels/moe/indices.py
+++ b/torchtitan/experiments/kernels/moe/indices.py
@@ -218,11 +218,11 @@ def simple_test():
     max_len = 128
     alignment = 32
     # Use the GPU kernel
-    permuted_indices_gpu, m_sizes = generate_permute_indices(
+    permuted_indices_gpu, m_sizes, _ = generate_permute_indices(
         tokens_per_expert_group, experts_per_rank, num_ranks, max_len, alignment
     )
     # Use the CPU method
-    permuted_indices_cpu, _ = generate_permute_indices(
+    permuted_indices_cpu, m_sizes, _ = generate_permute_indices(
         tokens_per_expert_group,
         experts_per_rank,
         num_ranks,

--- a/torchtitan/experiments/kernels/moe/unit_tests/permute_indices_testing.py
+++ b/torchtitan/experiments/kernels/moe/unit_tests/permute_indices_testing.py
@@ -1,0 +1,423 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from typing import Tuple
+
+import numpy as np
+import torch
+
+try:
+    from torchtitan.experiments.kernels.moe.indices import fill_indices_wrapper
+
+except ImportError:
+    print("unable to import required function(s) from indices.py...")
+    raise
+
+
+def fill_indices_cpu(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+):
+    """CPU implementation for reference."""
+    # We need to preallocate the output
+    device = tokens_per_expert_group.device
+    permuted_indices = torch.full((max_len,), -1, dtype=torch.int32, device=device)
+    # Fill the permuted indices
+    # For each local expert
+    for e in range(experts_per_rank):
+        write_start = write_offsets[e].item()
+        # For each remote rank
+        for r in range(num_ranks):
+            i = r * experts_per_rank + e
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
+            # Fill in the indices
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                # Add this check to prevent empty ranges
+                if write_start < end_idx:
+                    permuted_indices[write_start:end_idx] = torch.arange(
+                        start_index,
+                        start_index + (end_idx - write_start),
+                        dtype=torch.int32,
+                        device=device,
+                    )
+            write_start += length
+    return permuted_indices
+
+
+class TestOptimizedKernel(unittest.TestCase):
+    """Test cases for the permute Triton kernel."""
+
+    def setUp(self):
+        """Set up common test parameters."""
+        # Check if GPU is available
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if self.device.type == "cpu":
+            self.skipTest("WARNING:  No GPU available, skipping Triton kernel tests")
+
+        # Set random seed for reproducible tests
+        torch.manual_seed(2020)
+        np.random.seed(2020)
+
+        # Total experts to test
+        self.total_experts = 256
+
+    def create_test_data(
+        self,
+        experts_per_rank: int,
+        num_ranks: int,
+        token_range: Tuple[int, int] = (1, 16),
+        alignment: int = 32,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """Create test data"""
+        # Create token counts
+        tokens_per_expert_group = torch.randint(
+            token_range[0],
+            token_range[1] + 1,
+            (num_ranks * experts_per_rank,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Calc start indices
+        start_index_values = (
+            torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
+        )
+
+        # Calcu chunk sizes
+        chunk_size_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+        m_sizes = ((chunk_size_per_expert + alignment - 1) // alignment * alignment).to(
+            torch.int32
+        )
+
+        # Calc write offsets
+        write_offsets = torch.cumsum(m_sizes, 0) - m_sizes
+
+        # Calcu max_len
+        total_tokens = tokens_per_expert_group.sum().item()
+        max_len = total_tokens * 2  # Give some extra space
+
+        return tokens_per_expert_group, start_index_values, write_offsets, max_len
+
+    def test_fixed_total_experts_varying_ranks(self):
+        """Test with 256 total experts (deepseek v3) distributed across different numbers of ranks."""
+        # Test with different rank configurations
+        rank_configs = [1, 2, 4, 8, 16, 32, 64, 128]
+
+        for num_ranks in rank_configs:
+            # Calculate experts per rank to maintain fixed total experts
+            experts_per_rank = self.total_experts // num_ranks
+
+            # Skip if experts_per_rank is less than 1
+            if experts_per_rank < 1:
+                continue
+
+            # Actual total experts (may differ slightly due to integer division)
+            actual_total_experts = experts_per_rank * num_ranks
+
+            with self.subTest(
+                f"ranks={num_ranks}, experts_per_rank={experts_per_rank}, total={actual_total_experts}"
+            ):
+                print(
+                    f"Testing {experts_per_rank} experts per rank across {num_ranks} ranks (total: {actual_total_experts})"
+                )
+
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(experts_per_rank, num_ranks)
+
+                # Run CPU implementation
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Triton kernel output does not match CPU implementation for "
+                    f"{experts_per_rank} experts per rank, {num_ranks} ranks",
+                )
+
+                # Check that all valid positions match
+                valid_positions = cpu_result != -1
+                if valid_positions.sum() > 0:
+                    valid_cpu = cpu_result[valid_positions]
+                    valid_optimized = optimized_result[valid_positions]
+                    self.assertTrue(
+                        torch.equal(valid_cpu, valid_optimized),
+                        f"Mismatch in valid positions for {experts_per_rank} experts per rank, {num_ranks} ranks",
+                    )
+
+    def test_different_block_sizes_with_fixed_experts(self):
+        """Test different block sizes with fixed total experts."""
+        # Use a moderate rank configuration
+        num_ranks = 8
+        experts_per_rank = self.total_experts // num_ranks  # 32 experts per rank
+
+        (
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            max_len,
+        ) = self.create_test_data(experts_per_rank, num_ranks)
+
+        # Run CPU implementation for reference
+        cpu_result = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+
+        # Test different block sizes
+        block_sizes = [32, 64, 128, 256, 512]
+        for block_size in block_sizes:
+            with self.subTest(f"block_size={block_size}"):
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=block_size,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Block size {block_size} produces incorrect results",
+                )
+
+    def test_edge_cases_with_fixed_experts(self):
+        """Test edge cases with configurations that maintain fixed total experts."""
+        # For fixed total experts = 256
+        # Test with different token ranges
+        token_ranges = [(1, 1), (0, 0), (16, 16), (1, 32)]
+
+        num_ranks = 8
+        experts_per_rank = self.total_experts // num_ranks  # 32 experts per rank
+
+        for token_range in token_ranges:
+            with self.subTest(f"token_range={token_range}"):
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(experts_per_rank, num_ranks, token_range)
+
+                # Run CPU implementation
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Triton kernel failed for token range {token_range}",
+                )
+
+    def test_max_blocks_with_large_experts(self):
+        """Test cases where the number of experts exceeds the maximum number of blocks.
+
+        This test verifies that the kernel correctly processes all experts even when
+        the number of experts is significantly larger than the maximum blocks allowed,
+        forcing multiple experts to be processed by each block.
+        """
+        # Test configurations where experts greatly exceed max_blocks
+        test_configs = [
+            {
+                "experts_per_rank": 512,
+                "num_ranks": 4,
+                "max_blocks": 64,
+            },  # 8 experts per block
+            {
+                "experts_per_rank": 1024,
+                "num_ranks": 2,
+                "max_blocks": 32,
+            },  # 32 experts per block
+            {
+                "experts_per_rank": 2048,
+                "num_ranks": 1,
+                "max_blocks": 16,
+            },  # 128 experts per block
+        ]
+
+        for config in test_configs:
+            experts_per_rank = config["experts_per_rank"]
+            num_ranks = config["num_ranks"]
+            max_blocks = config["max_blocks"]
+
+            # Calculate experts per block for reporting
+            experts_per_block = (experts_per_rank + max_blocks - 1) // max_blocks
+
+            with self.subTest(
+                f"experts_per_rank={experts_per_rank}, num_ranks={num_ranks}, "
+                f"max_blocks={max_blocks}, experts_per_block={experts_per_block}"
+            ):
+                print(
+                    f"Testing with {experts_per_rank} experts per rank, {num_ranks} ranks, "
+                    f"max_blocks={max_blocks} (approx. {experts_per_block} experts per block)"
+                )
+
+                # Create test data
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(
+                    experts_per_rank,
+                    num_ranks,
+                    token_range=(
+                        1,
+                        8,
+                    ),  # Use smaller token range for large expert counts
+                )
+
+                # Run CPU implementation for reference
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation with max_blocks cap
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                    max_blocks=max_blocks,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Triton kernel output doesn't match CPU implementation with max_blocks={max_blocks}",
+                )
+
+                # Additional verification for valid entries
+                valid_positions = cpu_result != -1
+                if valid_positions.sum() > 0:
+                    valid_cpu = cpu_result[valid_positions]
+                    valid_optimized = optimized_result[valid_positions]
+                    self.assertTrue(
+                        torch.equal(valid_cpu, valid_optimized),
+                        f"Mismatch in valid positions with max_blocks={max_blocks}",
+                    )
+
+    def test_extreme_max_blocks_limit(self):
+        """Test with extremely small max_blocks limits to stress-test the looping mechanism."""
+        # Use moderately large number of experts
+        experts_per_rank = 256
+        num_ranks = 4
+
+        # Test with extremely small max_blocks values
+        max_blocks_values = [8, 4, 2, 1]  # Test down to just a single block
+
+        for max_blocks in max_blocks_values:
+            experts_per_block = (experts_per_rank + max_blocks - 1) // max_blocks
+
+            with self.subTest(
+                f"experts_per_rank={experts_per_rank}, max_blocks={max_blocks}, "
+                f"experts_per_block={experts_per_block}"
+            ):
+                print(
+                    f"Testing extreme case with {experts_per_rank} experts per rank, "
+                    f"max_blocks={max_blocks} (approx. {experts_per_block} experts per block)"
+                )
+
+                # Create test data
+                (
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    max_len,
+                ) = self.create_test_data(experts_per_rank, num_ranks)
+
+                # Run CPU implementation for reference
+                cpu_result = fill_indices_cpu(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                )
+
+                # Run optimized implementation with extremely limited max_blocks
+                optimized_result = fill_indices_wrapper(
+                    tokens_per_expert_group,
+                    start_index_values,
+                    write_offsets,
+                    experts_per_rank,
+                    num_ranks,
+                    max_len,
+                    block_size=128,
+                    max_blocks=max_blocks,
+                )
+
+                # Verify results match
+                self.assertTrue(
+                    torch.equal(cpu_result, optimized_result),
+                    f"Triton kernel failed with extreme max_blocks limit of {max_blocks}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -246,7 +246,7 @@ class MoE(nn.Module):
             ALIGN_SIZE_M = 16
 
             with torch.no_grad():
-                permuted_indices, m_sizes, m_offsets = generate_permute_indices(
+                permuted_indices, m_sizes, _ = generate_permute_indices(
                     num_local_tokens_per_expert,
                     self.experts.num_experts,
                     1,

--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -246,7 +246,7 @@ class MoE(nn.Module):
             ALIGN_SIZE_M = 16
 
             with torch.no_grad():
-                permuted_indices, m_sizes = generate_permute_indices(
+                permuted_indices, m_sizes, m_offsets = generate_permute_indices(
                     num_local_tokens_per_expert,
                     self.experts.num_experts,
                     1,


### PR DESCRIPTION
This PR updates both llama4 and DeepSeekv3 to use the faster parallelized kernel for generate_permute_indices. 
This also adds a unit test for the core kernel in generate_permute_indices.

~~~

Summary for fixed total experts (256), where we mimic various DeepSeek experts across a number of ranks:
Ranks | Experts/Rank | Original (ms) | Optimized (ms) | Block Size | Speedup | Correct
------------------------------------------------------------------------------------------
    1 |          256 |        0.241 |        0.020 |        128 |   11.95x |       1
    4 |           64 |        0.222 |        0.020 |        128 |   10.97x |       1
   16 |           16 |        0.221 |        0.021 |        128 |   10.40x |       1
   32 |            8 |        0.224 |        0.025 |         64 |    8.81x |       1
   64 |            4 |        0.225 |        0.037 |        128 |    6.01x |       1
  128 |            2 |        0.217 |        0.051 |        128 |    4.26x |       1
  ~~~
  
  Testing:
  Verified Llama4 working with new kernel 
  Verified DeepSeekv2 inference working with new kernel
  Verified unit tests passing
  
  