### PR TITLE
refactor PP auto-split algorithm

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -492,9 +492,10 @@ class JobConfig:
             type=int,
             default=None,
             help="""
-                The number of layers per stage. If specified, the split points will be calculated from
-                the number of layers and pipeline_parallel_degree. If not specified, the layers per stage will
-                be inferred from the model, schedule, and pipeline_parallel_degree.""",
+                The number of layers per (virtual) pipeline stage. If specified, the split points will be
+                calculated from the number of layers and pipeline_parallel_degree. If not specified, the
+                layers per stage will be inferred from the model, schedule, and pipeline_parallel_degree.
+                """,
         )
         self.parser.add_argument(
             "--parallelism.pipeline_parallel_schedule",

--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -26,7 +26,7 @@ __all__ = [
 llama4_configs = {
     "debugmodel": TransformerModelArgs(
         dim=256,
-        n_layers=8,
+        n_layers=6,
         n_heads=16,
         rope_theta=500000,
     ),

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
 
 llama3_configs = {
     "debugmodel": TransformerModelArgs(
-        dim=256, n_layers=8, n_heads=16, rope_theta=500000
+        dim=256, n_layers=6, n_heads=16, rope_theta=500000
     ),
     "8B": TransformerModelArgs(
         dim=4096,

--- a/torchtitan/models/llama3/pipeline_llama.py
+++ b/torchtitan/models/llama3/pipeline_llama.py
@@ -94,9 +94,9 @@ def pipeline_llama_manual_split(
 
     splits = parallelism_config.pipeline_parallel_split_points or generate_split_points(
         parallelism_config.pipeline_parallel_schedule,
-        parallelism_config.pipeline_parallel_layers_per_stage,
         parallel_dims.pp,
         model_config.n_layers,
+        parallelism_config.pipeline_parallel_layers_per_stage,
     )
 
     def _build_stage(


### PR DESCRIPTION
This PR continues the work laid out in https://github.com/pytorch/torchtitan/pull/1041#pullrequestreview-2748308167

There are two cases in the PP auto-split algorithm:
1. `num_layers_per_virtual_stage` is given. In this case, we now require rigid fit of the effective layers (regular layers + weighted input + weighted output) onto pipeline stages and ranks, with several assertions. It is the users' responsibility to figure out the input weight, output weight, and the number of regular layers, so that they can be arranged nicely.
2. `num_layers_per_virtual_stage` is not given. In this case, we by default set each pipeline rank to have 2 virtual stages, and try to distribute all effective layers evenly onto the PP stages. If there are extra layers, we disperse them in the starting stages.

This PR also modifies the debug model to have 6 regular layers, now that input and output weights are default to 1. This will
- help test the case where a PP rank/stage only has the input/output layer
- make testing & development slightly faster