### PR TITLE
[float8] emulate eager mode precision casts for float8 rowwise

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -71,6 +71,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if job_config.job.print_args:
             logger.info(f"Running with args: {job_config.to_dict()}")
 
+        # short-term solution for https://github.com/pytorch/pytorch/issues/150859
+        if job_config.float8.recipe_name == "rowwise":
+            torch._inductor.config.emulate_precision_casts = True
+            logger.debug("Set torch._inductor.config.emulate_precision_casts to True")
+
         # take control of garbage collection to avoid stragglers
         self.gc_handler = utils.GarbageCollection(gc_freq=job_config.training.gc_freq)
 


### PR DESCRIPTION
## Summary
This is a short term solution for #1056 (pytorch core issue tracker: https://github.com/pytorch/pytorch/issues/150859)

For a long term solution, the compiler folks are looking into supporting deterministic recompute of intermediates for AC during the backward pass.

## Test plan
- Manual testing confirmed loss decreases as expected without NaNs (training logs: https://www.internalfb.com/phabricator/paste/view/P1787321079

cc @tianyu-l @lessw2020 