### PR TITLE
[FT] Change the integration from using ManagedDeviceMesh to set_all_r…

### DIFF
--- a/torchtitan/components/ft.py
+++ b/torchtitan/components/ft.py
@@ -12,6 +12,7 @@ from typing import Optional
 import torch
 import torch.distributed._functional_collectives as funcol
 from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.distributed_c10d import ReduceOp
 from torch.distributed.tensor import DTensor
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
@@ -34,6 +35,7 @@ class FTManager:
         self._manager = manager
         self.group_size = group_size
         self.replica_id = replica_id
+        self.replicate_pg = None
 
     @property
     def enabled(self) -> bool:
@@ -47,6 +49,25 @@ class FTManager:
     def get_dp_info(self, dp_degree: int, dp_rank: int) -> tuple[int, int]:
         return dp_degree * self.group_size, dp_degree * self.replica_id + dp_rank
 
+    def build_pg(self) -> None:
+        self.replicate_pg = ft.process_group.ManagedProcessGroup(self._manager)
+        self.replicate_pg.register("dp_replicate")
+
+    def set_all_reduce_hook(self, model_parts: list[torch.nn.Module]) -> None:
+        def all_reduce_hook(output):
+            torch.distributed.all_reduce(
+                output,
+                group=self.replicate_pg,
+                op=ReduceOp.AVG,
+            )
+
+        def apply_set_all_reduce_hook(m):
+            if hasattr(m, "set_all_reduce_hook"):
+                m.set_all_reduce_hook(all_reduce_hook)
+
+        for part in model_parts:
+            part.apply(apply_set_all_reduce_hook)
+
 
 def init_ft_manager(job: JobConfig) -> FTManager:
     """Initialize the FT manager if TorchFT is enabled.
@@ -55,7 +76,7 @@ def init_ft_manager(job: JobConfig) -> FTManager:
         job (JobConfig): The job configuration.
 
     Returns:
-        Optional[ft.Manager]: The FT manager if TorchFT is enabled, otherwise None.
+        FTManager: A wrapper around TorchFT.Manager
     """
     if not job.fault_tolerance.enable:
         return FTManager(None)
@@ -66,7 +87,7 @@ def init_ft_manager(job: JobConfig) -> FTManager:
     if job.fault_tolerance.min_replica_size < 1:
         raise ValueError("At least one FT replica is required.")
 
-    pg = ft.ProcessGroupBabyNCCL()
+    pg = ft.ProcessGroupNCCL()
 
     return FTManager(
         ft.Manager(

--- a/torchtitan/components/ft.py
+++ b/torchtitan/components/ft.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import torch
 import torch.distributed._functional_collectives as funcol
+import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.distributed_c10d import ReduceOp
 from torch.distributed.tensor import DTensor
@@ -55,11 +56,7 @@ class FTManager:
 
     def set_all_reduce_hook(self, model_parts: list[torch.nn.Module]) -> None:
         def all_reduce_hook(output):
-            torch.distributed.all_reduce(
-                output,
-                group=self.replicate_pg,
-                op=ReduceOp.AVG,
-            )
+            dist.all_reduce(output, group=self.replicate_pg, op=ReduceOp.AVG)
 
         def apply_set_all_reduce_hook(m):
             if hasattr(m, "set_all_reduce_hook"):

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -51,13 +51,17 @@ def _dist_reduce(
 def dist_max(
     x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
 ) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, extra_pg=pg)
+    return _dist_reduce(
+        x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, extra_pg=extra_pg
+    )
 
 
 def dist_mean(
     x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
 ) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, extra_pg=pg)
+    return _dist_reduce(
+        x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, extra_pg=extra_pg
+    )
 
 
 def set_determinism(

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -17,7 +17,6 @@ from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 
-from torchtitan.components.ft import ft_dist_reduce
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -25,25 +25,39 @@ def _dist_reduce(
     x: torch.Tensor,
     reduceOp: str,
     mesh: DeviceMesh,
-    pg: dist.ProcessGroup | None = None,
+    extra_pg: dist.ProcessGroup | None = None,
 ) -> float:
+    """Perform distributed reduction on a tensor.
+
+    Args:
+        x (torch.Tensor): Input tensor.
+        reduceOp (str): Reduce operation to perform.
+        mesh (DeviceMesh): Device mesh to use for reduction.
+        extra_pg (dist.ProcessGroup, optional): Extra process group to use for reduction.
+            Defaults to None. If provided, this all_reduce will be called for the extra
+            process group, and then the result will be all_reduced for the mesh.
+    """
     if isinstance(x, DTensor):
         # functional collectives do not support DTensor inputs
         x = x.full_tensor()
 
-    if pg is not None:
-        x = funcol.all_reduce(x, reduceOp=reduceOp, group=pg)
+    if extra_pg is not None:
+        x = funcol.all_reduce(x, reduceOp=reduceOp, group=extra_pg)
 
     assert x.numel() == 1  # required by `.item()`
     return funcol.all_reduce(x, reduceOp=reduceOp, group=mesh).item()
 
 
-def dist_max(x: torch.Tensor, mesh: DeviceMesh, pg: dist.ProcessGroup | None) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, pg=pg)
+def dist_max(
+    x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
+) -> float:
+    return _dist_reduce(x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, extra_pg=pg)
 
 
-def dist_mean(x: torch.Tensor, mesh: DeviceMesh, pg: dist.ProcessGroup | None) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, pg=pg)
+def dist_mean(
+    x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
+) -> float:
+    return _dist_reduce(x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, extra_pg=pg)
 
 
 def set_determinism(

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -17,28 +17,34 @@ from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 
-from torchtitan.components.ft import ft_clip_grad_norm_util, ft_dist_reduce
+from torchtitan.components.ft import ft_dist_reduce
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 
 
-def _dist_reduce(x: torch.Tensor, reduceOp: str, mesh: DeviceMesh) -> float:
-    # Remove FT replicate dimension if it exists.
-    x, reduceOp, mesh = ft_dist_reduce(x, reduceOp, mesh)
-
+def _dist_reduce(
+    x: torch.Tensor,
+    reduceOp: str,
+    mesh: DeviceMesh,
+    pg: dist.ProcessGroup | None = None,
+) -> float:
     if isinstance(x, DTensor):
         # functional collectives do not support DTensor inputs
         x = x.full_tensor()
+
+    if pg is not None:
+        x = funcol.all_reduce(x, reduceOp=reduceOp, group=pg)
+
     assert x.numel() == 1  # required by `.item()`
     return funcol.all_reduce(x, reduceOp=reduceOp, group=mesh).item()
 
 
-def dist_max(x: torch.Tensor, mesh: DeviceMesh) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh)
+def dist_max(x: torch.Tensor, mesh: DeviceMesh, pg: dist.ProcessGroup | None) -> float:
+    return _dist_reduce(x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, pg=pg)
 
 
-def dist_mean(x: torch.Tensor, mesh: DeviceMesh) -> float:
-    return _dist_reduce(x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh)
+def dist_mean(x: torch.Tensor, mesh: DeviceMesh, pg: dist.ProcessGroup | None) -> float:
+    return _dist_reduce(x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, pg=pg)
 
 
 def set_determinism(
@@ -290,8 +296,6 @@ def clip_grad_norm_(
         # Will reach here if any non-PP parallelism is used.
         # If only using PP, total_norm will be a local tensor.
 
-        # Remove FT replicate dimension if it exists.
-        total_norm = ft_clip_grad_norm_util(total_norm)
         total_norm = total_norm.full_tensor()
 
     if pp_mesh is not None:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -78,32 +78,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
-        ft_manager = ft.init_ft_manager(job_config)
+        self.ft_manager = ft.init_ft_manager(job_config)
 
         # init distributed
         world_size = int(os.environ["WORLD_SIZE"])
         parallelism_config = job_config.parallelism
-        if not ft_manager.enabled:
-            self.parallel_dims = parallel_dims = ParallelDims(
-                dp_shard=parallelism_config.data_parallel_shard_degree,
-                dp_replicate=parallelism_config.data_parallel_replicate_degree,
-                cp=parallelism_config.context_parallel_degree,
-                tp=parallelism_config.tensor_parallel_degree,
-                pp=parallelism_config.pipeline_parallel_degree,
-                world_size=world_size,
-                enable_loss_parallel=not parallelism_config.disable_loss_parallel,
-            )
-        else:
-            self.parallel_dims = parallel_dims = ft.FTParallelDims(
-                dp_shard=parallelism_config.data_parallel_shard_degree,
-                dp_replicate=parallelism_config.data_parallel_replicate_degree,
-                cp=parallelism_config.context_parallel_degree,
-                tp=parallelism_config.tensor_parallel_degree,
-                pp=parallelism_config.pipeline_parallel_degree,
-                world_size=world_size,
-                enable_loss_parallel=not parallelism_config.disable_loss_parallel,
-                ft_manager=ft_manager,
-            )
+        self.parallel_dims = parallel_dims = ParallelDims(
+            dp_shard=parallelism_config.data_parallel_shard_degree,
+            dp_replicate=parallelism_config.data_parallel_replicate_degree,
+            cp=parallelism_config.context_parallel_degree,
+            tp=parallelism_config.tensor_parallel_degree,
+            pp=parallelism_config.pipeline_parallel_degree,
+            world_size=world_size,
+            enable_loss_parallel=not parallelism_config.disable_loss_parallel,
+        )
         dist_utils.init_distributed(job_config)
 
         # build meshes
@@ -113,6 +101,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             dp_degree, dp_rank = dp_mesh.size(), dp_mesh.get_local_rank()
         else:
             dp_degree, dp_rank = 1, 0
+
+        # If TorchFT is enabled, the dp_rank and dp_degree, which are used for
+        # dataloader must be changed.
+        if self.ft_manager.enabled:
+            self.ft_manager.build_pg()
+            dp_degree, dp_rank = self.ft_manager.get_dp_info(dp_degree, dp_rank)
 
         # Set random seed, and maybe enable deterministic mode
         # (mainly for debugging, expect perf loss).
@@ -130,11 +124,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             if self.train_spec.build_tokenizer_fn is not None
             else None
         )
-
-        # If TorchFT is enabled, the dp_rank and dp_degree, which are used for
-        # dataloader must be changed.
-        if ft_manager.enabled:
-            dp_degree, dp_rank = ft_manager.get_dp_info(dp_degree, dp_rank)
 
         self.dataloader = self.train_spec.build_dataloader_fn(
             dp_world_size=dp_degree,
@@ -241,6 +230,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
             self.model_parts = [model]
 
+        if self.ft_manager.enabled:
+            self.ft_manager.set_all_reduce_hook(self.model_parts)
+
         # initialize device memory monitor and get peak flops for MFU calculation
         device_memory_monitor = self.metrics_processor.device_memory_monitor
         gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
@@ -254,7 +246,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         # build optimizer after applying parallelisms to the model
         self.optimizers = self.train_spec.build_optimizers_fn(
-            self.model_parts, job_config, ft_manager
+            self.model_parts, job_config, self.ft_manager
         )
         self.lr_schedulers = self.train_spec.build_lr_schedulers_fn(
             self.optimizers, job_config
@@ -280,7 +272,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
             job_config=job_config,
-            ft_manager=ft_manager,
+            ft_manager=self.ft_manager,
         )
 
         self.train_context = dist_utils.get_train_context(
@@ -384,11 +376,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             parallel_dims.dp_replicate_enabled
             or parallel_dims.dp_shard_enabled
             or parallel_dims.cp_enabled
+            or self.ft_manager.enabled
         ):
             loss = loss.detach()
+            ft_pg = self.ft_manager.replicate_pg if self.ft_manager.enabled else None
             global_avg_loss, global_max_loss = (
-                dist_utils.dist_mean(loss, world_mesh["dp_cp"]),
-                dist_utils.dist_max(loss, world_mesh["dp_cp"]),
+                dist_utils.dist_mean(loss, world_mesh["dp_cp"], ft_pg),
+                dist_utils.dist_max(loss, world_mesh["dp_cp"], ft_pg),
             )
         else:
             global_avg_loss = global_max_loss = loss.detach().item()

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -78,7 +78,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
-        self.ft_manager = ft.init_ft_manager(job_config)
 
         # init distributed
         world_size = int(os.environ["WORLD_SIZE"])
@@ -102,10 +101,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             dp_degree, dp_rank = 1, 0
 
+        self.ft_manager = ft.init_ft_manager(job_config)
         # If TorchFT is enabled, the dp_rank and dp_degree, which are used for
         # dataloader must be changed.
         if self.ft_manager.enabled:
-            self.ft_manager.build_pg()
             dp_degree, dp_rank = self.ft_manager.get_dp_info(dp_degree, dp_rank)
 
         # Set random seed, and maybe enable deterministic mode


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchtitan/issues/1105

While using `ManagedDeviceMesh` makes the integration code cleaner, `ManagedDeviceMesh` currently suffers from the composability issue with TP due to the limitations of `DeviceMesh`.

This PR changes the integration to using `FSDP.set_all_reduce_hook()`. We will revisit the `ManagedDeviceMesh` once `DeviceMesh` becomes more friendly to the inheritance use cases.