### PR TITLE
Keeping SDPA happy, else hits following exceptions

### DIFF
--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -30,7 +30,7 @@ llama4_configs = {
         n_heads=16,
         rope_theta=500000,
         every_n_layers_nope=4,
-        fixed_attn_block_size=256,
+        #fixed_attn_block_size=256,
     ),
     "17bx16e": TransformerModelArgs(
         dim=5120,

--- a/torchtitan/experiments/llama4/model/args.py
+++ b/torchtitan/experiments/llama4/model/args.py
@@ -45,7 +45,8 @@ class TransformerModelArgs(BaseModelArgs):
     # only attend to the tokens within the same block regardless how long is the
     # sequence.
     every_n_layers_nope: int | None = None
-    fixed_attn_block_size: int = 8192
+    #fixed_attn_block_size: int = 8192
+    fixed_attn_block_size: int | None = None
 
     # MoE args
     moe_enabled: bool = True
@@ -62,6 +63,7 @@ class TransformerModelArgs(BaseModelArgs):
         self.norm_type = job_config.model.norm_type
         self.vocab_size = tokenizer.n_words
         self.max_seq_len = job_config.training.seq_len
+        self.attn_mask_type = job_config.model.attn_mask_type
         self.use_flex_attn = job_config.model.use_flex_attn
         if self.use_grouped_mm and not has_cuda_capability(9, 0):
             logger.warning(


### PR DESCRIPTION
def build_attention(
    use_flex_attn: bool, attn_mask_type: str, fixed_block_size: int | None = None
):
    if use_flex_attn:
        return FlexAttention(attn_mask_type, fixed_block_size)
    else:
        if fixed_block_size is not None:
            raise ValueError(
                f"TorchTitan with SDPA currently does not support fixed_block_size. {fixed_block_size} "
            )
        if attn_mask_type != "causal":
            raise ValueError(
                f"TorchTitan with SDPA currently only supports causal mask, but was {attn_mask_type}"
            )
        return ScaledDotProductAttention(attn_mask_type)