### PR TITLE
[llama4] add auxiliary-loss-free load balancing to MoE token routing

### DIFF
--- a/torchtitan/experiments/llama4/README.md
+++ b/torchtitan/experiments/llama4/README.md
@@ -1,7 +1,10 @@
 **The Llama 4 folder is still under development.**
 
+#### Issue tracking
+https://github.com/pytorch/torchtitan/issues/1118
+
 #### Available features
-- Llama 4 model definition (text-only), including the MoE architecture with token-choice routing using efficient bfloat16 Grouped MM kernels
+- Llama 4 model (text-only), including a token-choice MoE architecture with efficient bfloat16 Grouped MM kernels and auxiliary-loss-free load balancing
 - FSDP, TP, PP, CP support
 - DCP checkpoint conversion scripts
 
@@ -13,17 +16,15 @@ python scripts/download_tokenizer.py --repo_id meta-llama/Llama-4-Scout-17B-16E 
 
 #### To be added
 - Modeling
-    - iRoPE implementation
-    - load balance loss for token-choice MoE
     - alternative expert-choice MoE
     - multimodal support
 - Parallelism
-    - Context Parallel support for FlexAttention, iRoPE, and multimodal inputs
+    - Context Parallel support for FlexAttention and multimodal inputs
     - Expert Parallel support
 - torch.compile
     - for MoE layers
 - Quantization
-    - efficient float8 GroupedGEMM kernels (from torchao)
+    - efficient float8 Grouped MM kernels (from torchao)
 - Testing
     - perfomance and loss converging tests
     - CI integration

--- a/torchtitan/experiments/llama4/model/args.py
+++ b/torchtitan/experiments/llama4/model/args.py
@@ -56,6 +56,7 @@ class TransformerModelArgs(BaseModelArgs):
     # token-choice
     top_k: int = 1
     use_grouped_mm: bool = True  # grouped mm or for-loop for the experts computation
+    load_balance_coeff: float | None = 1e-3
 
     def update_from_config(self, job_config: JobConfig, tokenizer: Tokenizer) -> None:
         self.vocab_size = tokenizer.n_words

--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -341,12 +341,12 @@ class TransformerBlock(nn.Module):
             out = h + self.feed_forward(self.ffn_norm(h))
         return out
 
-    def init_weights(self):
+    def init_weights(self, buffer_device: torch.device):
         for norm in (self.attention_norm, self.ffn_norm):
             norm.reset_parameters()
         self.attention.init_weights(self.weight_init_std)
         if self.moe_enabled:
-            self.moe.init_weights(self.weight_init_std)
+            self.moe.init_weights(self.weight_init_std, buffer_device)
         else:
             self.feed_forward.init_weights(self.weight_init_std)
 
@@ -417,7 +417,7 @@ class Transformer(nn.Module, ModelProtocol):
             nn.init.normal_(self.tok_embeddings.weight)
         for layer in self.layers.values():
             if layer is not None:
-                layer.init_weights()
+                layer.init_weights(buffer_device=buffer_device)
         if self.norm is not None:
             self.norm.reset_parameters()
         final_out_std = self.model_args.dim**-0.5

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -8,7 +8,6 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 import torch.nn.functional as F
@@ -25,10 +24,10 @@ class TransformerModelArgs(BaseModelArgs):
     dim: int = 4096
     n_layers: int = 32
     n_heads: int = 32
-    n_kv_heads: Optional[int] = None
+    n_kv_heads: int | None = None
     vocab_size: int = -1  # defined later by tokenizer
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-    ffn_dim_multiplier: Optional[float] = None
+    ffn_dim_multiplier: float | None = None
     norm_eps: float = 1e-5
     rope_theta: float = 10000
 
@@ -93,7 +92,7 @@ def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Te
     Args:
         dim (int): Dimension of the frequency tensor.
         end (int): End index for precomputing frequencies.
-        theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
+        theta (float | None): Scaling factor for frequency computation. Defaults to 10000.0.
 
     Returns:
         torch.Tensor: Precomputed frequency tensor with complex exponentials.
@@ -271,7 +270,7 @@ class FeedForward(nn.Module):
         dim (int): Input dimension.
         hidden_dim (int): Hidden dimension of the feedforward layer.
         multiple_of (int): Value to ensure hidden dimension is a multiple of this value.
-        ffn_dim_multiplier (Optional[float]): Custom multiplier for hidden dimension. Defaults to None.
+        ffn_dim_multiplier (float | None): Custom multiplier for hidden dimension. Defaults to None.
 
     Attributes:
         w1 (Linear): Linear transformation for the first layer.
@@ -285,7 +284,7 @@ class FeedForward(nn.Module):
         dim: int,
         hidden_dim: int,
         multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
+        ffn_dim_multiplier: float | None,
     ):
         super().__init__()
         hidden_dim = int(2 * hidden_dim / 3)
@@ -419,7 +418,7 @@ class Transformer(nn.Module, ModelProtocol):
 
     def init_weights(
         self,
-        buffer_device: Optional[torch.device] = None,
+        buffer_device: torch.device | None = None,
     ):
         """
         [Note: On ``init_weights`` vs. ``reset_parameters``]

--- a/torchtitan/models/llama3/parallelize_llama.py
+++ b/torchtitan/models/llama3/parallelize_llama.py
@@ -175,7 +175,7 @@ def apply_tp(
     # NOTE: At the cost of model code change, we can accelerate Sequence Parallel
     #       by folding (and unfolding) the batch dimension and the sequence dimension.
     #       Examples can be found at https://github.com/pytorch/torchtitan/pull/437
-    for layer_id, transformer_block in model.layers.items():
+    for transformer_block in model.layers.values():
         layer_plan = {
             "attention_norm": SequenceParallel(),
             "attention": prepare_module_input(


### PR DESCRIPTION
There are two issues in this solution:
1. Communication (sync tokens per expert across all DP ranks) happens on the default stream. Maybe need to arrange it on FSDP/DDP comm stream.
2. The communication is blocking experts bias update, thus always exposed.

We need to evaluate if 2 is a problem to performance. 1 is OK if 2 is acceptable.