### PR TITLE
[DeepSeek] update moe_forward to sort_tokens api update

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -593,7 +593,6 @@ class MoE(nn.Module):
         (
             sorted_tokens,
             token_indices,
-            sorted_tokens_shape,
             tokens_per_expert,
         ) = self.sort_tokens(x, topk_ids, topk_weight)
 
@@ -681,7 +680,7 @@ class MoE(nn.Module):
                 output_splits,
                 self.ep_group,
             )
-            returned_tokens = token_return_buf[: sorted_tokens_shape[0]]
+            returned_tokens = token_return_buf[: sorted_tokens.shape[0]]
         else:  # "torch_all_to_all"
             returned_tokens = all_to_all_single_autograd(
                 processed_tokens,


### PR DESCRIPTION
This PR corrects a last minute change in the sort_tokens function.  
moe_on_device was updated to reflect it but moe_forward was missing the change. 

Note - I missed this b/c I only ran testing for inference.  
Ran training loop to verify this is fully working. 