### PR TITLE
Pass the original input to all PP stages

### DIFF
--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -446,7 +446,12 @@ class Transformer(nn.Module, ModelProtocol):
         Perform a forward pass through the Transformer model.
 
         Args:
-            tokens (torch.Tensor): Input token indices.
+            tokens (torch.Tensor): Input token indices if pipeline parallelism is not enabled.
+                If pipeline parallelism is enabled, this will be the input token indices
+                for the ranks on the first pipeline stage. This will be the activation of the
+                previous pipeline stage if the current rank is not on the first stage.
+            input_batch (torch.Tensor): The input batch read from the dataloader.
+                This will always be the input batch regardless of the pipeline stage.
 
         Returns:
             torch.Tensor: Output logits after applying the Transformer model.

--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -441,7 +441,7 @@ class Transformer(nn.Module, ModelProtocol):
             self.model_args.rope_theta,
         )
 
-    def forward(self, tokens: torch.Tensor, input_batch: Optional[torch.Tensor] = None):
+    def forward(self, tokens: torch.Tensor, input_batch: torch.Tensor | None = None):
         """
         Perform a forward pass through the Transformer model.
 

--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -441,7 +441,7 @@ class Transformer(nn.Module, ModelProtocol):
             self.model_args.rope_theta,
         )
 
-    def forward(self, tokens: torch.Tensor):
+    def forward(self, tokens: torch.Tensor, input_batch: torch.Tensor):
         """
         Perform a forward pass through the Transformer model.
 
@@ -452,10 +452,8 @@ class Transformer(nn.Module, ModelProtocol):
             torch.Tensor: Output logits after applying the Transformer model.
 
         """
-        # TODO: We will to change forward() signature to allow tokens to
-        # be always passed in.
         if self.model_args.use_flex_attn:
-            init_attention_mask(tokens, eos_id=self.eos_id)
+            init_attention_mask(input_batch, eos_id=self.eos_id)
 
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -463,7 +463,7 @@ class Transformer(nn.Module, ModelProtocol):
             self.model_args.rope_theta,
         )
 
-    def forward(self, tokens: torch.Tensor):
+    def forward(self, tokens: torch.Tensor, input_batch: torch.Tensor):
         """
         Perform a forward pass through the Transformer model.
 
@@ -474,10 +474,8 @@ class Transformer(nn.Module, ModelProtocol):
             torch.Tensor: Output logits after applying the Transformer model.
 
         """
-        # TODO: We will to change forward() signature to allow tokens to
-        # be always passed in.
         if self.model_args.use_flex_attn:
-            init_attention_mask(tokens, eos_id=self.eos_id)
+            init_attention_mask(input_batch, eos_id=self.eos_id)
 
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -468,7 +468,12 @@ class Transformer(nn.Module, ModelProtocol):
         Perform a forward pass through the Transformer model.
 
         Args:
-            tokens (torch.Tensor): Input token indices.
+            tokens (torch.Tensor): Input token indices if pipeline parallelism is not enabled.
+                If pipeline parallelism is enabled, this will be the input token indices
+                for the ranks on the first pipeline stage. This will be the activation of the
+                previous pipeline stage if the current rank is not on the first stage.
+            input_batch (torch.Tensor): The input batch read from the dataloader.
+                This will always be the input batch regardless of the pipeline stage.
 
         Returns:
             torch.Tensor: Output logits after applying the Transformer model.

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -463,9 +463,7 @@ class Transformer(nn.Module, ModelProtocol):
             self.model_args.rope_theta,
         )
 
-    def forward(
-        self, tokens: torch.Tensor, input_batch: Optioinal[torch.Tensor] = None
-    ):
+    def forward(self, tokens: torch.Tensor, input_batch: torch.Tensor | None = None):
         """
         Perform a forward pass through the Transformer model.
 

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -463,7 +463,9 @@ class Transformer(nn.Module, ModelProtocol):
             self.model_args.rope_theta,
         )
 
-    def forward(self, tokens: torch.Tensor, input_batch: torch.Tensor):
+    def forward(
+        self, tokens: torch.Tensor, input_batch: Optioinal[torch.Tensor] = None
+    ):
         """
         Perform a forward pass through the Transformer model.
 
@@ -474,13 +476,17 @@ class Transformer(nn.Module, ModelProtocol):
                 previous pipeline stage if the current rank is not on the first stage.
             input_batch (torch.Tensor): The input batch read from the dataloader.
                 This will always be the input batch regardless of the pipeline stage.
+                This field is required for non-first PP stages to perform document
+                masking attention (to analyze the boundary of the document).
 
         Returns:
             torch.Tensor: Output logits after applying the Transformer model.
 
         """
         if self.model_args.use_flex_attn:
-            init_attention_mask(input_batch, eos_id=self.eos_id)
+            init_attention_mask(
+                input_batch if input_batch is not None else tokens, eos_id=self.eos_id
+            )
 
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -357,7 +357,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # Non-PP forward / backward
             with self.train_context(optional_context_parallel_ctx):
                 assert len(model_parts) == 1
-                pred = model_parts[0](inputs, input_batch=inputs)
+                pred = model_parts[0](inputs)
                 loss = self.loss_fn(pred, labels)
                 # need to free to before bwd to avoid peaking memory
                 del pred


### PR DESCRIPTION
We need the original tokens to generate the document masks/block causal masks. Since TorchTitan currently let all ranks perform data loading, there will be no performance regressions.

This is required to support document masking attention with PP.