### PR TITLE
dist_utils: set extra process group default to None

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -49,7 +49,9 @@ def _dist_reduce(
 
 
 def dist_max(
-    x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
+    x: torch.Tensor,
+    mesh: DeviceMesh,
+    extra_pg: dist.ProcessGroup | None = None,
 ) -> float:
     return _dist_reduce(
         x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, extra_pg=extra_pg
@@ -57,7 +59,9 @@ def dist_max(
 
 
 def dist_mean(
-    x: torch.Tensor, mesh: DeviceMesh, extra_pg: dist.ProcessGroup | None
+    x: torch.Tensor,
+    mesh: DeviceMesh,
+    extra_pg: dist.ProcessGroup | None = None,
 ) -> float:
     return _dist_reduce(
         x, reduceOp=c10d.ReduceOp.AVG.name, mesh=mesh, extra_pg=extra_pg


### PR DESCRIPTION
Recently introduced 'extra_pg' in distributed utils does not provide a default. 
Set default to None like the underlying `dist_reduce`.

This is to avoid breaking forks that currently uses `dist_mean` or `dist_max`.