### PR TITLE
add model_args as argument to build_metrics_processor_fn in train.py

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -432,5 +432,4 @@ def build_metrics_processor(
     Returns:
         MetricsProcessor: A metrics processor.
     """
-    del model_args  # Currently unused by the default MetricsProcessor
     return MetricsProcessor(job_config, parallel_dims, tag)

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -8,7 +8,7 @@ import os
 import time
 from collections import namedtuple
 from datetime import datetime
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
@@ -19,6 +19,10 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import Color, device_module, device_type
+
+if TYPE_CHECKING:
+    from torchtitan.protocols.train_spec import BaseModelArgs
+
 
 # named tuple for passing device memory stats for logging
 DeviceMemStats = namedtuple(
@@ -414,7 +418,7 @@ class MetricsProcessor:
 def build_metrics_processor(
     job_config: JobConfig,
     parallel_dims: ParallelDims,
-    model_args = None,
+    model_args: "BaseModelArgs | None" = None,
     tag: str | None = None,
 ) -> MetricsProcessor:
     """Create a metrics processor.

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -412,16 +412,21 @@ class MetricsProcessor:
 
 
 def build_metrics_processor(
-    job_config: JobConfig, parallel_dims: ParallelDims, tag: str | None = None
+    job_config: JobConfig,
+    parallel_dims: ParallelDims,
+    model_args = None,
+    tag: str | None = None,
 ) -> MetricsProcessor:
     """Create a metrics processor.
 
     Args:
         job_config (JobConfig): Job configuration.
         parallel_dims (ParallelDims): Parallel dimensions.
-        tag (Optional[str]): Tag to use for TensorBoard or WandB. Defaults to None.
+        model_args (BaseModelArgs | None): Model-specific arguments. Defaults to None.
+        tag (str | None): Tag to use for TensorBoard or WandB. Defaults to None.
 
     Returns:
         MetricsProcessor: A metrics processor.
     """
+    del model_args  # Currently unused by the default MetricsProcessor
     return MetricsProcessor(job_config, parallel_dims, tag)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -153,7 +153,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             if self.train_spec.build_metrics_processor_fn is None
             else self.train_spec.build_metrics_processor_fn
         )
-        self.metrics_processor = build_metrics_processor_fn(job_config, parallel_dims)
+        self.metrics_processor = build_metrics_processor_fn(
+            job_config, parallel_dims, model_args
+        )
         color = self.metrics_processor.color
 
         # calculate model size and flops per token


### PR DESCRIPTION
Just to make the trainer's init a little bit more general and fork friendly.

In our fork, the metrics processor would need some information from the specific model args as well.