### PR TITLE
[Feature] Pythonify next_batch

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -295,23 +295,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         device_type = utils.device_type
 
         while True:
-            try:
-                data_load_start = time.perf_counter()
-                batch = next(data_iterator)
-                input_dict, labels = batch
-                self.metrics_processor.ntokens_since_last_log += labels.numel()
-                self.metrics_processor.data_loading_times.append(
-                    time.perf_counter() - data_load_start
-                )
+            data_load_start = time.perf_counter()
+            batch = next(data_iterator)
+            input_dict, labels = batch
+            self.metrics_processor.ntokens_since_last_log += labels.numel()
+            self.metrics_processor.data_loading_times.append(
+                time.perf_counter() - data_load_start
+            )
 
-                # Move tensors to the appropriate device
-                for k, _ in input_dict.items():
-                    input_dict[k] = input_dict[k].to(device_type)
-                labels = labels.to(device_type)
+            # Move tensors to the appropriate device
+            for k, _ in input_dict.items():
+                input_dict[k] = input_dict[k].to(device_type)
+            labels = labels.to(device_type)
 
-                yield input_dict, labels
-            except StopIteration:
-                break
+            yield input_dict, labels
 
     def train_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
         self.optimizers.zero_grad()

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -305,8 +305,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             )
 
             # Move tensors to the appropriate device
-            for k, _ in input_dict.items():
-                input_dict[k] = input_dict[k].to(device_type)
+            for k, v in input_dict.items():
+                if isinstance(v, torch.Tensor):
+                    input_dict[k] = v.to(device_type)
             labels = labels.to(device_type)
 
             yield input_dict, labels

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -15,14 +15,14 @@ from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.components.ft as ft
 import torchtitan.protocols.train_spec as train_spec_module
-
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
 from torchtitan.config_manager import ConfigManager, JobConfig
-from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed import utils as dist_utils
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
@@ -412,12 +412,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 job_config, global_step=self.step
             ) as memory_profiler,
             ft.maybe_semi_sync_training(
-            job_config,
-            ft_manager=self.ft_manager,
-            model=self.model_parts[0],
-            optimizer=self.optimizers,
-            sync_every=job_config.fault_tolerance.sync_steps,
-            )
+                job_config,
+                ft_manager=self.ft_manager,
+                model=self.model_parts[0],
+                optimizer=self.optimizers,
+                sync_every=job_config.fault_tolerance.sync_steps,
+            ),
         ):
             for inputs, labels in self.batch_generator(self.dataloader):
                 if self.step >= job_config.training.steps:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -21,8 +21,7 @@ from torchtitan.components.metrics import (
     ensure_pp_loss_visible,
 )
 from torchtitan.config_manager import ConfigManager, JobConfig
-from torchtitan.distributed import ParallelDims
-from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
@@ -473,12 +472,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert int(os.environ["WORLD_SIZE"]) == 1, (
-                "Must create seed checkpoint using a single device, to disable sharding."
-            )
-            assert config.checkpoint.enable_checkpoint, (
-                "Must enable checkpointing when creating a seed checkpoint."
-            )
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable_checkpoint
+            ), "Must enable checkpointing when creating a seed checkpoint."
             trainer.checkpointer.save(curr_step=0, force=True)
             logger.info("Created seed checkpoint")
         else:


### PR DESCRIPTION
Hey Folks!

I've had a really good time playing with torchtitan so far :) 

Looking into the code, as it stands, the way the data loader is wrapped by `next_batch` is not very pythonic. It makes it very awkward to iterate through the data loader in a pythonic way with `for` or `while`.

This is a PoC of my suggestion to make this more pythonic.

I think this will especially bear fruit in situations where we might want to iterate through a dataset from beginning to end, e.g., for a validation dataset.

To note, this current change might break a few of the models under experimental, which would need to mirror this change in their `train.py`