### PR TITLE
[SimpleFSDP] Add tensor parallel support

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -5,7 +5,7 @@ This folder includes an experimental frontend implementation for [SimpleFSDP: Si
 ### Enable SimpleFSDP Training
 
 ```bash
-CONFIG_FILE="./torchtitan/models/llama/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --training.compile
 ```
 
 ### Composability Support
@@ -17,11 +17,11 @@ Some of the features require the updates from PyTorch, with which we are working
 |Meta Initialization| ✅ |
 |Activation Checkpointing| ✅ |
 |Mixed Precision Training| ✅ |
-|Tensor Parallelism| 🚧 |
+|Tensor Parallelism| ✅ |
 |Context Parallelism| ✅ |
 |Pipeline Parallelism| ✅ |
 |Distributed Checkpointing| 🚧 |
-|Float8 Training| ❌ |
+|Float8 Training| 🚧 |
 
 
 ### Citation

--- a/torchtitan/experiments/simple_fsdp/parallelize_llama.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize_llama.py
@@ -11,7 +11,7 @@ from torch.distributed import DeviceMesh
 
 from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
-from torchtitan.models.llama3.parallelize_llama import apply_ac
+from torchtitan.models.llama3.parallelize_llama import apply_ac, apply_tp
 from torchtitan.tools.logging import logger
 
 from .simple_fsdp import data_parallel, MixedPrecisionPolicy
@@ -30,32 +30,32 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
-    # TODO(ruisizhang123): Add support for TP (on-going)
-    # if parallel_dims.tp_enabled:
-    #     if (
-    #         job_config.parallelism.enable_async_tensor_parallel
-    #         and not job_config.training.compile
-    #     ):
-    #         raise RuntimeError("Async TP requires --training.compile")
+    if parallel_dims.tp_enabled:
+        if (
+            job_config.parallelism.enable_async_tensor_parallel
+            and not job_config.training.compile
+        ):
+            raise RuntimeError("Async TP requires --training.compile")
 
-    #     enable_float8_linear = "float8" in job_config.model.converters
-    #     float8_is_rowwise = job_config.float8.recipe_name in (
-    #         "rowwise",
-    #         "rowwise_with_gw_hp",
-    #     )
+        enable_float8_linear = "float8" in job_config.model.converters
+        float8_is_rowwise = job_config.float8.recipe_name in (
+            "rowwise",
+            "rowwise_with_gw_hp",
+        )
 
-    #     # For now, float8 all-gather with TP is only supported for tensorwise
-    #     # float8 scaling recipes. For rowwise recipes, we use regular TP and
-    #     # all-gather happens in high precision.
-    #     enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
+        # For now, float8 all-gather with TP is only supported for tensorwise
+        # float8 scaling recipes. For rowwise recipes, we use regular TP and
+        # all-gather happens in high precision.
+        enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
 
-    #     apply_tp(
-    #         model,
-    #         world_mesh["tp"],
-    #         loss_parallel=parallel_dims.loss_parallel_enabled,
-    #         enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
-    #         enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
-    #     )
+        tp_mesh = world_mesh["tp"]
+        apply_tp(
+            model,
+            world_mesh["tp"],
+            loss_parallel=parallel_dims.loss_parallel_enabled,
+            enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+            enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
+        )
 
     if job_config.activation_checkpoint.mode != "none":
         apply_ac(model, job_config.activation_checkpoint)
@@ -88,6 +88,7 @@ def parallelize_llama(
             mode=dp_mode,
             ac_mode=job_config.activation_checkpoint.mode,
             mp_policy=mp_policy,
+            tp_mesh=tp_mesh if parallel_dims.tp_enabled else None,
         )
         logger.info("Applied Data Parallel (dp mode=%s) to the model", dp_mode)
 


### PR DESCRIPTION
This PR adds tensor parallel (TP) support for SimpleFSDP, together with [this pr](https://github.com/pytorch/pytorch/pull/152286) from PyTorch.

**(This is a placeholder for now, and shall be merged only after the PyTorch pr is landed.)**

**Profile Trace & Convergence on debug model:**

<img width="1578" alt="Screenshot 2025-04-27 at 3 48 35 PM" src="https://github.com/user-attachments/assets/42d36eb7-51c1-4f60-aa2e-20b58d8c491b" />


<img width="1369" alt="Screenshot 2025-04-27 at 3 31 46 PM" src="https://github.com/user-attachments/assets/79e25f88-9e8a-4fe2-b7c9-a7e9747d19a4" />


The loss curves are all benchmarked with `training.seed = 42` on 4 GPUs.

The end-to-end SimpleFSDP TP integration has been proved to work in the PR from this fork: https://github.com/tianyu-l/pytorch_intern24/pull/25. Per the discussion with Tianyu, the new PyTorch PR has add `_StridedShard` following FSDP2 to be compatible with distributed checkpointing. The newly benchmarked results demonstrated it works properly. 