### PR TITLE
[Flux] Refactor argparser to follow new practice, Fix dtype and txt_in layer shape issue

### DIFF
--- a/torchtitan/experiments/flux/flux_argparser.py
+++ b/torchtitan/experiments/flux/flux_argparser.py
@@ -4,75 +4,53 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import argparse
+from dataclasses import dataclass, field
 
 
-def extend_parser(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--training.classifer_free_guidance_prob",
-        type=float,
-        default=0.0,
-        help="Classifier-free guidance with probability p to dropout the text conditioning",
+@dataclass
+class Training:
+    classifer_free_guidance_prob: float = 0.0
+    """Classifier-free guidance with probability p to dropout the text conditioning"""
+    img_size: int = 256
+    """Image width to sample"""
+
+
+@dataclass
+class Encoder:
+    t5_encoder: str = "google/t5-v1_1-small"
+    """T5 encoder to use, HuggingFace model name. This field could be either a local folder path,
+        or a Huggingface repo name."""
+    clip_encoder: str = "openai/clip-vit-large-patch14"
+    """Clip encoder to use, HuggingFace model name. This field could be either a local folder path,
+        or a Huggingface repo name."""
+    autoencoder_path: str = (
+        "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"
     )
-    parser.add_argument(
-        "--training.img_size",
-        type=int,
-        default=256,
-        help="Image width to sample",
-    )
-    parser.add_argument(
-        "--encoder.t5_encoder",
-        type=str,
-        default="google/t5-v1_1-small",
-        help="T5 encoder to use, HuggingFace model name. This field could be either a local folder path, \
-        or a Huggingface repo name.",
-    )
-    parser.add_argument(
-        "--encoder.clip_encoder",
-        type=str,
-        default="openai/clip-vit-large-patch14",
-        help="Clip encoder to use, HuggingFace model name. This field could be either a local folder path, \
-        or a Huggingface repo name.",
-    )
-    parser.add_argument(
-        "--encoder.autoencoder_path",
-        type=str,
-        default="torchtitan/experiments/flux/assets/autoencoder/ae.safetensors",
-        help="Autoencoder checkpoint path to load. This should be a local path referring to a safetensors file.",
-    )
-    parser.add_argument(
-        "--encoder.max_t5_encoding_len",
-        type=int,
-        default=512,
-        help="Maximum length of the T5 encoding.",
-    )
-    # eval configs
-    parser.add_argument(
-        "--eval.enable_classifer_free_guidance",
-        action="store_true",
-        help="Whether to use classifier-free guidance during sampling",
-    )
-    parser.add_argument(
-        "--eval.classifier_free_guidance_scale",
-        type=float,
-        default=5.0,
-        help="Classifier-free guidance scale when sampling",
-    )
-    parser.add_argument(
-        "--eval.denoising_steps",
-        type=int,
-        default=50,
-        help="How many denoising steps to sample when generating an image",
-    )
-    parser.add_argument(
-        "--eval.eval_freq",
-        type=int,
-        default=100,
-        help="Frequency of evaluation/sampling during training",
-    )
-    parser.add_argument(
-        "--eval.save_img_folder",
-        type=str,
-        default="img",
-        help="Directory to save image generated/sampled from the model",
-    )
+    """Autoencoder checkpoint path to load. This should be a local path referring to a safetensors file."""
+    max_t5_encoding_len: int = 512
+    """Maximum length of the T5 encoding."""
+
+
+@dataclass
+class Eval:
+    enable_classifer_free_guidance: bool = False
+    """Whether to use classifier-free guidance during sampling"""
+    classifier_free_guidance_scale: float = 5.0
+    """Classifier-free guidance scale when sampling"""
+    denoising_steps: int = 50
+    """How many denoising steps to sample when generating an image"""
+    eval_freq: int = 100
+    """Frequency of evaluation/sampling during training"""
+    save_img_folder: str = "img"
+    """Directory to save image generated/sampled from the model"""
+
+
+@dataclass
+class JobConfig:
+    """
+    Extend the tyro parser with custom config classe for Flux model.
+    """
+
+    training: Training = field(default_factory=Training)
+    encoder: Encoder = field(default_factory=Encoder)
+    eval: Eval = field(default_factory=Eval)

--- a/torchtitan/experiments/flux/model/model.py
+++ b/torchtitan/experiments/flux/model/model.py
@@ -9,8 +9,6 @@ from dataclasses import dataclass, field
 import torch
 
 from torch import nn, Tensor
-from torchtitan.components.tokenizer import Tokenizer
-from torchtitan.config_manager import JobConfig
 
 from torchtitan.experiments.flux.model.autoencoder import AutoEncoderParams
 from torchtitan.experiments.flux.model.layers import (
@@ -41,10 +39,6 @@ class FluxModelArgs(BaseModelArgs):
     theta: int = 10_000
     qkv_bias: bool = True
     autoencoder_params: AutoEncoderParams = field(default_factory=AutoEncoderParams)
-
-    def update_from_config(self, job_config: JobConfig, tokenizer: Tokenizer) -> None:
-        # context_in_dim is the same as the T5 embedding dimension
-        self.context_in_dim = job_config.encoder.max_t5_encoding_len
 
     def get_nparams_and_flops(self, model: nn.Module, seq_len: int) -> tuple[int, int]:
         # TODO(jianiw): Add the number of flops for the autoencoder

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -92,7 +92,8 @@ class FluxTrainer(Trainer):
         # the major variables that are used in the training loop.
         model_parts = self.model_parts
         assert len(self.model_parts) == 1
-        model = self.model_parts[0]
+        # explicitely convert flux model to be Bfloat16 no matter FSDP is applied or not
+        model = self.model_parts[0].to(self._dtype)
 
         world_mesh = self.world_mesh
         parallel_dims = self.parallel_dims

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import torch
 
-from torchtitan.config_manager import ConfigManager, JobConfig
+from torchtitan.config_manager import ConfigManager, JobConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.experiments.flux.dataset.tokenizer import FluxTokenizer
 from torchtitan.experiments.flux.model.autoencoder import load_ae
@@ -43,9 +43,14 @@ class FluxTrainer(Trainer):
 
         self.preprocess_fn = preprocess_data
         # NOTE: self._dtype is the data type used for encoders (image encoder, T5 text encoder, CLIP text encoder).
-        # We cast the encoders and it's input/output to this dtype.
-        # For Flux model, we use FSDP with mixed precision training.
-        self._dtype = torch.bfloat16
+        # We cast the encoders and it's input/output to this dtype.  If FSDP with mixed precision training is not used,
+        # the dtype for encoders is torch.float32 (default dtype for Flux Model).
+        # Otherwise, we use the same dtype as mixed precision training process.
+        self._dtype = (
+            TORCH_DTYPE_MAP[job_config.training.mixed_precision_param]
+            if self.parallel_dims.dp_shard_enabled
+            else torch.float32
+        )
 
         # load components
         model_config = self.train_spec.config[job_config.model.flavor]
@@ -93,7 +98,7 @@ class FluxTrainer(Trainer):
         model_parts = self.model_parts
         assert len(self.model_parts) == 1
         # explicitely convert flux model to be Bfloat16 no matter FSDP is applied or not
-        model = self.model_parts[0].to(self._dtype)
+        model = self.model_parts[0]
 
         world_mesh = self.world_mesh
         parallel_dims = self.parallel_dims

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -45,7 +45,7 @@ img_size = 256
 [encoder]
 t5_encoder = "google/t5-v1_1-xxl"
 clip_encoder = "openai/clip-vit-large-patch14"
-max_t5_encoding_len = 4096
+max_t5_encoding_len = 256
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
 [eval]

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -44,7 +44,7 @@ img_size = 256
 [encoder]
 t5_encoder = "google/t5-v1_1-xxl"
 clip_encoder = "openai/clip-vit-large-patch14"
-max_t5_encoding_len = 4096
+max_t5_encoding_len = 512
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
 [eval]

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -44,7 +44,7 @@ img_size = 256
 [encoder]
 t5_encoder = "google/t5-v1_1-xxl"
 clip_encoder = "openai/clip-vit-large-patch14"
-max_t5_encoding_len = 4096
+max_t5_encoding_len = 256
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
 [eval]


### PR DESCRIPTION
## What changed?
1. Refactor Flux arg parser to follow #767 new argparse practice
2. Explicitly change dtype for flux model to avoid #1137 (when FSDP is not enabled)
3. Fix txt_in layer shape issue by changing the config of schnell and dev model #1146 


## dtype management in Flux Training 

Without FSDP (fsdp dim = 1) :
- Encoder's dtype = float32, Flux model's dtype = float32

With FSDP enabled:
- Encoder's dtype = bfloat16, Text and Image encodings' dtype=bfloat16
- Flux Model's dtype: sharded params are in fp32, reduce-scatter is in fp32, so gradient updates happen in fp32. dtype when calculation=bfloat16

cc @CarlosGomes98