### PR TITLE
Fix MergedJobConfig class to enable printing arguments during training

### DIFF
--- a/tests/unit_tests/test_job_config.py
+++ b/tests/unit_tests/test_job_config.py
@@ -242,6 +242,8 @@ class TestJobConfig(unittest.TestCase):
         )
         assert config.custom_args.how_is_your_day == "bad"
         assert config.model.converters == ["float8", "mxfp"]
+        result = config.to_dict()
+        assert isinstance(result, dict)
 
         # There will be a SystemExit raised by ArgumentParser with exist status 2.
         with self.assertRaisesRegex(SystemExit, "2"):
@@ -280,6 +282,8 @@ class TestJobConfig(unittest.TestCase):
             )
             assert config.custom_args.how_is_your_day == "bad"
             assert config.model.converters == ["float8", "mxfp"]
+            result = config.to_dict()
+            assert isinstance(result, dict)
 
         with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as fp:
             tomli_w.dump(
@@ -303,6 +307,8 @@ class TestJobConfig(unittest.TestCase):
 
             assert config.custom_args.how_is_your_day == "really good"
             assert config.model.converters == ["float8", "mxfp"]
+            result = config.to_dict()
+            assert isinstance(result, dict)
 
 
 if __name__ == "__main__":

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -691,15 +691,7 @@ class ConfigManager:
             if name not in b_map:
                 result.append((name, f.type, field(default_factory=f.type)))
 
-        merged_cls = make_dataclass(f"Merged{base.__name__}", result, bases=(object,))
-
-        # Add to_dict method to the merged class
-        def to_dict(self) -> dict[str, Any]:
-            return asdict(self)
-
-        merged_cls.to_dict = to_dict
-
-        return merged_cls
+        return make_dataclass(f"Merged{base.__name__}", result, bases=(base,))
 
     def _dict_to_dataclass(self, cls, data: dict[str, Any]) -> Any:
         """Convert dictionary to dataclass, handling nested structures."""

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -691,7 +691,15 @@ class ConfigManager:
             if name not in b_map:
                 result.append((name, f.type, field(default_factory=f.type)))
 
-        return make_dataclass(f"Merged{base.__name__}", result, bases=(object,))
+        merged_cls = make_dataclass(f"Merged{base.__name__}", result, bases=(object,))
+
+        # Add to_dict method to the merged class
+        def to_dict(self) -> dict[str, Any]:
+            return asdict(self)
+
+        merged_cls.to_dict = to_dict
+
+        return merged_cls
 
     def _dict_to_dataclass(self, cls, data: dict[str, Any]) -> Any:
         """Convert dictionary to dataclass, handling nested structures."""


### PR DESCRIPTION
## Context

The `MergedJobConfig` class doesn't have method to_dict(), so when the job_config is an instance of `MergeJobConfig`, we will run into the following error when running with `--job.print_args`.
```
AttributeError: 'MergedJobConfig' object has no attribute 'to_dict'
```