### PR TITLE
[FT] Fix the async_wait is not appropriately called

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -300,7 +300,7 @@ class TestCheckpointManager(unittest.TestCase):
     @mock.patch(
         "torchtitan.components.checkpoint.dcp.async_save", side_effect=fake_async_save
     )
-    def test_async_save_calls_async_wait(self, *_):
+    def test_ft_async_save_calls_async_wait(self, *_):
         """
         Test that in async mode (AsyncMode.ASYNC), calling save() twice correctly waits
         on the previous async future via _async_wait().

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -292,6 +292,46 @@ class TestCheckpointManager(unittest.TestCase):
         f = manager.async_future
         f.result.assert_not_called()
 
+    @mock.patch("torchtitan.components.checkpoint.dist.new_group")
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=fake_get_model_state_dict,
+    )
+    @mock.patch(
+        "torchtitan.components.checkpoint.dcp.async_save", side_effect=fake_async_save
+    )
+    def test_async_save_calls_async_wait(self, *_):
+        """
+        Test that in async mode (AsyncMode.ASYNC), calling save() twice correctly waits
+        on the previous async future via _async_wait().
+        """
+        # Set async_mode to "async" in the job configuration.
+        job_config = DummyJobConfig(job=self.dummy_job)
+        job_config.checkpoint.async_mode = "disabled"
+        ft_manager = mock.Mock()
+        ft_manager.enabled = True
+        manager = CheckpointManager(
+            dummy_dataloader,
+            dummy_model_parts,
+            dummy_optimizers,
+            dummy_lr_schedulers,
+            {"trainer": self.trainer_state},
+            job_config,
+            ft_manager,
+        )
+        # First save: should schedule an async save.
+        self.assertTrue(manager.async_future is None)
+        manager.save(curr_step=5, force=False)
+        self.assertTrue(manager.async_future is not None)
+        manager.async_future.result.assert_not_called()
+
+        # Keep the previous future as it will be waited and replaced.
+        async_future = manager.async_future
+        manager.save(curr_step=6, force=False)
+        async_future.result.assert_called_once()
+        self.assertTrue(manager.async_future is not None)
+        manager.async_future.result.assert_not_called()
+
     def _checkpoint_id(self, step):
         checkpoint_id = os.path.join(self.checkpoint_folder, f"step-{step}")
         state_file = os.path.join(checkpoint_id, "state.pt")

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -292,11 +292,11 @@ class CheckpointManager:
         self.exclude_from_loading = ckpt_config.exclude_from_loading
 
         self.mp = None
+        self.async_future = None
         if async_mode == AsyncMode.DISABLED:
             self.async_mode = AsyncMode.DISABLED
         elif async_mode == AsyncMode.ASYNC:
             self.async_mode = AsyncMode.ASYNC
-            self.async_future = None
         elif async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             self.async_mode = AsyncMode.ASYNC_WITH_PINNED_MEM
             ctx = mp.get_context("spawn")
@@ -598,9 +598,15 @@ class CheckpointManager:
             if not self.mp.is_alive():
                 raise RuntimeError("The checkpoint background process is dead.")
             _ = self.mp_queue_recv.get()
-        elif self.async_mode == AsyncMode.ASYNC:
+        elif self.async_mode == AsyncMode.ASYNC or self.ft_manager is not None:
             if self.async_future is not None:
                 self.async_future.result()
+                self.async_future = None
+        elif self.async_future is not None:
+            raise RuntimeError(
+                "self.async_future is not None, but self.async_mode is not enabled "
+                "and fault tolerance is not active."
+            )
 
     def _async_with_pinned_memory(self, checkpoint_id: str) -> None:
         self._cpu_staging(checkpoint_id)


### PR DESCRIPTION
Summary:
Currently, if aynsc_mode is not set to async, async_wait won't actually wait for the future even if the future is not None. This is not correct as with TorchFT, DCP.async_save() will be called every iteration to save the dataloader state.

This PR fixes the issue.

Test Plan:
CI