### PR TITLE
Add TORCHINDUCTOR_USE_STATIC_CUDA_LAUNCHER for flux run_train.sh

### DIFF
--- a/torchtitan/experiments/flux/run_train.sh
+++ b/torchtitan/experiments/flux/run_train.sh
@@ -13,6 +13,9 @@ set -ex
 NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/experiments/flux/train_configs/debug_model.toml"}
+# Turn off the static cuda launcher used by inductor.
+# It currently does not play well with the torchtitan compile + SAC tests.
+export TORCHINDUCTOR_USE_STATIC_CUDA_LAUNCHER=0
 
 overrides=""
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
Following https://github.com/pytorch/torchtitan/pull/1156, adding TORCHINDUCTOR_USE_STATIC_CUDA_LAUNCHER for flux run_train.sh