### PR TITLE
Fix FT allreduce bug

### DIFF
--- a/torchtitan/components/ft.py
+++ b/torchtitan/components/ft.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import ContextManager, Optional, TYPE_CHECKING, Union
 
 import torch
-import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule
 from torch.distributed.device_mesh import DeviceMesh
@@ -59,7 +58,7 @@ class FTManager:
 
     def set_all_reduce_hook(self, model_parts: list[torch.nn.Module]) -> None:
         def all_reduce_hook(output):
-            dist.all_reduce(output, group=self.replicate_pg, op=ReduceOp.AVG)
+            self.replicate_pg.allreduce(output, opts=ReduceOp.AVG)
 
         def apply_set_all_reduce_hook(m):
             if isinstance(m, FSDPModule):


### PR DESCRIPTION
I was seeing this log / commit failure when using FT: `should_commit=False enough_replicas=True, errored='NoneType' object has no attribute 'wait’`

![Pasted Graphic](https://github.com/user-attachments/assets/fbba95a4-942e-4e3c-aba0-2e31a048600c)

It was coming from an FSDP hook which was calling `dist.allreduce()` the regular c10d collective now returns `None` which causes the error above. Instead we should be using `self.replicate_pg.allreduce(output, opts=ReduceOp.AVG)`. I think we could also achieve the same thing with `manager.allreduce(output)`, so I'm not sure if the `ManagedProcessGroup` is needed. Would appreciate any thoughts @fegin @d4l3k 