### PR TITLE
Checkpoint unittest fix

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -292,6 +292,7 @@ class TestCheckpointManager(unittest.TestCase):
         f = manager.async_future
         f.result.assert_not_called()
 
+    @mock.patch("torch.cuda.Stream")
     @mock.patch("torchtitan.components.checkpoint.dist.new_group")
     @mock.patch(
         "torchtitan.components.checkpoint.get_model_state_dict",

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -322,11 +322,15 @@ class CheckpointManager:
         self.close()
 
     def close(self):
-        if self.enable_checkpoint:
-            if self.mp and self.mp.is_alive():
+        if hasattr(self, "enable_checkpoint") and self.enable_checkpoint:
+            if hasattr(self, "mp") and self.mp and self.mp.is_alive():
                 self.mp_queue_send.put(Terminate())
                 self.mp.join()
-            if self.purge_thread and self.purge_thread.is_alive():
+            if (
+                hasattr(self, "purge_thread")
+                and self.purge_thread
+                and self.purge_thread.is_alive()
+            ):
                 self.purge_queue.put(Terminate())
                 self.purge_thread.join()
 


### PR DESCRIPTION
The unittest is not compatible with the latest PyTorch. This PR fixes it.