### PR TITLE
update llama4 debug_model to use group gemm with AdamW again

### DIFF
--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -26,14 +26,12 @@ tokenizer_path = "./tests/assets/test_tiktoken.model"
 # converters = ["float8"]
 
 [optimizer]
-# TODO: currently grouped mm in MoE doesn't work with AdamW, need to investigate
-# name = "AdamW"
-name = "Adam"
+name = "AdamW"
 lr = 4e-3
 eps = 1e-15
 
 [lr_scheduler]
-warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+warmup_steps = 200  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
 decay_type = "linear"
 lr_min = 0.1
@@ -42,7 +40,7 @@ lr_min = 0.1
 batch_size = 8
 seq_len = 2048
 max_norm = 1.0  # grad norm clipping
-steps = 10
+steps = 1000
 compile = false
 dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
 

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -31,7 +31,7 @@ lr = 4e-3
 eps = 1e-15
 
 [lr_scheduler]
-warmup_steps = 200  # lr scheduler warm up, normally 20% of the train steps
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
 decay_type = "linear"
 lr_min = 0.1
@@ -40,7 +40,7 @@ lr_min = 0.1
 batch_size = 8
 seq_len = 2048
 max_norm = 1.0  # grad norm clipping
-steps = 1000
+steps = 10
 compile = false
 dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
 


### PR DESCRIPTION
this PR updates the debug_toml for llama4 as we no longer need to use Adam for group gemm.
The core issue regarding hangs with group gemm was resolved already (https://github.com/pytorch/torchtitan/pull/1166). 
Thus, we can remove the todo and go back to AdamW as default. 

Testing:
verified 1K run with AdamW works as expected, no hangs as before. 