### PR TITLE
Document behavior of booleans for parser

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -9,7 +9,7 @@ CONFIG_FILE="./train_configs/debug_model.toml" ./run_train.sh --profiling.enable
 	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
 	+ Regular snapshots (taken every `profiling.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
 
-You cab find the saved pickle files in your output folder.
+You can find the saved pickle files in your output folder.
 To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).
 
 ## Overriding Boolean Flags from `.toml` via CLI

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -14,14 +14,21 @@ To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/m
 
 ## Overriding Boolean Flags from `.toml` via CLI
 
-If a boolean is set to `true` in a `.toml` config file and you want to override it from the command line, use the following syntax:
+Boolean flags are treated as **actions**. To disable a flag from the command line, use the `--no` prefix.
+
+For example, given the following in your `.toml` file:
+
+```toml
+[profiling]
+enable_memory_snapshot = true
+
+```
+You can override it at runtime via CLI with:
 
 ```bash
 --profiling.no_enable_memory_snapshot
 --profiling.no-enable-memory-snapshot  # Equivalent
 ```
-
-Boolean flags are treated as **actions**; to disable them, use the `--no` prefix.
 
 > Note: `--enable_memory_snapshot=False` will **not** work. Use `--no_enable_memory_snapshot` instead.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -12,6 +12,40 @@ CONFIG_FILE="./train_configs/debug_model.toml" ./run_train.sh --profiling.enable
 You cab find the saved pickle files in your output folder.
 To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).
 
+## Overriding Boolean Flags from `.toml` via CLI
+
+If a boolean is set to `true` in a `.toml` config file and you want to override it from the command line, use the following syntax:
+
+```bash
+--profiling.no_enable_memory_snapshot
+--profiling.no-enable-memory-snapshot  # Equivalent
+```
+
+Boolean flags are treated as **actions**; to disable them, use the `--no` prefix.
+
+> Note: `--enable_memory_snapshot=False` will **not** work. Use `--no_enable_memory_snapshot` instead.
+
+## Debugging Config Values
+
+To inspect how configuration values are interpreted—including those from `.toml` files and CLI overrides—run the config manager directly:
+
+```bash
+python -m torchtitan.config_manager [your cli args...]
+```
+
+For example,
+
+```bash
+python -m torchtitan.config_manager --job.config_file ./torchtitan/models/llama3/train_configs/llama3_8b.toml --profiling.enable_memory_snapshot
+```
+
+To list all available CLI flags and usage:
+
+```bash
+python -m torchtitan.config_manager --help
+```
+
+This will print a structured configuration to `stdout`, allowing you to verify that overrides are being applied correctly.
 
 ## Troubleshooting jobs that timeout
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -739,3 +739,25 @@ class ConfigManager:
                 is_instance=lambda instance: all(isinstance(i, str) for i in instance),
                 str_from_instance=lambda instance: [",".join(instance)],
             )
+
+
+if __name__ == "__main__":
+    # -----------------------------------------------------------------------------
+    # Run this module directly to debug or inspect configuration parsing.
+    #
+    # Examples:
+    #   Show help message:
+    #     > python -m torchtitan.config_manager --help
+    #
+    #   Parse and print a config with CLI arguments:
+    #     > python -m torchtitan.config_manager --profiling.enable_memory_snapshot
+    #
+    # -----------------------------------------------------------------------------
+
+    from rich import print as rprint
+    from rich.pretty import Pretty
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args()
+
+    rprint(Pretty(config))


### PR DESCRIPTION
Updated parser treats booleans as 'actions' by default. Updated docs to reflect this change + included entry point for print/stdout of config values for debugging

re #1176 