### PR TITLE
Make encoder params contiguous before fsdp

### DIFF
--- a/torchtitan/experiments/flux/sampling.py
+++ b/torchtitan/experiments/flux/sampling.py
@@ -220,7 +220,7 @@ def save_image(
 ):
     print(f"Saving {output_dir}/{name}")
     if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
     output_name = os.path.join(output_dir, name)
     # bring into PIL format and save
     x = x.clamp(-1, 1)


### PR DESCRIPTION
For a 8-gpu run with `./torchtitan/experiments/flux/run_train.sh`, I got
```
[rank0]:[rank0]:   File "/shared/home/cheng/projects/torchtitan/torchtitan/experiments/flux/train.py", line 73, in __init__
[rank0]:[rank0]:     self.t5_encoder, self.clip_encoder = parallelize_encoders(
[rank0]:[rank0]:   File "/shared/home/cheng/projects/torchtitan/torchtitan/experiments/flux/parallelize_flux.py", line 149, in parallelize_encoders
[rank0]:[rank0]:     fully_shard(block, **fsdp_config)
[rank0]:[rank0]:   File "/shared/home/cheng/.venv/lib/python3.10/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param.py", line 266, in _init_sharded_param
[rank0]:[rank0]:     raise NotImplementedError(
[rank0]:[rank0]: NotImplementedError: FSDP does not support non-contiguous parameters yet: param.shape=torch.Size([4096, 4096]) param.stride()=(1, 4096)
```
This PR adds a make_contiguous helper function that iterates through all parameters in a module and makes them contiguous if they aren't already.

Then the scripts runs. 