### PR TITLE
compile: turn off fullgraph=True to support llama4

### DIFF
--- a/torchtitan/models/llama3/parallelize_llama.py
+++ b/torchtitan/models/llama3/parallelize_llama.py
@@ -312,7 +312,7 @@ def apply_compile(model: nn.Module):
         # will minimize the risk of this being a problem.
         # If it is a problem in practice, we can also try to tweak torchtitan
         # So that we compile the MoE layer and the rest of the transformer block separately.
-        if hasattr(transformer_block, 'moe'):
+        if hasattr(transformer_block, "moe"):
             transformer_block = torch.compile(transformer_block, fullgraph=False)
         else:
             transformer_block = torch.compile(transformer_block, fullgraph=True)


### PR DESCRIPTION
This PR + https://github.com/pytorch/pytorch/pull/153384 is enough to get torchtitan running for me with llama4 and compile
```
CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --training.compile
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1182

