### PR TITLE
[CI] add a test to guard on torch.compile+SAC+TP

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -94,6 +94,19 @@ def build_test_list():
             "2D compile",
             "2d_compile",
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.compile",
+                    "--parallelism.tensor_parallel_degree 4",
+                    "--activation_checkpoint.mode selective",
+                    "--activation_checkpoint.selective_ac_option op",
+                ],
+            ],
+            "2D compile with selective op AC",
+            "2d_compile_sac_op",
+            ngpu=8,
+        ),
         # TODO: re-enable this test once the async TP issue is fixed
         # OverrideDefinitions(
         #     [


### PR DESCRIPTION
referring to https://github.com/pytorch/torchtitan/issues/1185

on 8 GPUs, DP2 TP4 

torch.compile + selective op AC + TP:
got failure
```
File "/data/users/lty/pytorch/torch/_ops.py", line 1317, in __getattr__
      raise AttributeError(
  AttributeError: '_OpNamespace' 'symm_mem' object has no attribute 'fused_all_gather_matmul'
```
**Note**: DP4 TP2 works.