### PR TITLE
Add mxfp8 path

### DIFF
--- a/torchtitan/__init__.py
+++ b/torchtitan/__init__.py
@@ -8,6 +8,7 @@
 
 # Import to register Float8Converter.
 import torchtitan.components.float8  # noqa: F401
+import torchtitan.components.mx  # noqa: F401
 
 # Import the built-in models here so that the corresponding register_model_spec()
 # will be called.

--- a/torchtitan/components/float8.py
+++ b/torchtitan/components/float8.py
@@ -16,7 +16,7 @@
 import torch
 import torch.nn as nn
 
-from torchtitan.config_manager import JobConfig
+from torchtitan.config_manager import Float8, JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.protocols.model_converter import (
     ModelConverter,
@@ -30,7 +30,7 @@ class Float8Converter(ModelConverter):
     def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
         self.enabled = False
 
-        float8_config = job_config.float8
+        float8_config: Float8 = job_config.float8
         if not has_cuda_capability(8, 9):
             logger.warning(
                 "Failed to swap to Float8Linear because float8 is only supported on SM89 or later",

--- a/torchtitan/components/mx.py
+++ b/torchtitan/components/mx.py
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# [Note] Getting the 'torchao' package:
+# This script requires the 'torchao' package to function correctly.
+# Please ensure you have this package installed from the appropriate repository.
+# You can obtain it from https://github.com/pytorch/ao by following the
+# installation instructions.
+
+# Note: Performance
+# The MX component is intended to be run under `torch.compile`` for competitive performance
+
+from importlib.metadata import version
+from importlib.util import find_spec
+from typing import Any, List
+
+import torch.nn as nn
+
+from torchtitan.config_manager import JobConfig, MX
+from torchtitan.distributed import ParallelDims
+from torchtitan.protocols.model_converter import (
+    ModelConverter,
+    register_model_converter,
+)
+from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import has_cuda_capability
+
+# Maps titan recipe names to torchao mx recipe names
+NAME_MAP = {"mxfp8": "mxfp8_cublas"}
+
+
+class MXConverter(ModelConverter):
+    """Converts the linear layers of `model` to `MXLinear`."""
+
+    enabled: bool
+    filter_fqns: List[str] | str
+    mx_config: Any  # MXLinearConfig type when imported
+
+    def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
+        # Ensure minimum torchao versions
+        torchao_spec = find_spec("torchao")
+        if torchao_spec is None:
+            raise ImportError(
+                "torchao is not installed. Please install it to use MXFP8 linear layers."
+            )
+        torchao_version = version("torchao")
+        mxfp8_min_version = "0.11.0"
+        if torchao_version < mxfp8_min_version:
+            raise ImportError(
+                f"torchao version {torchao_version} is too old, please install torchao {mxfp8_min_version} or later and try again"
+            )
+
+        # Can be removed if we enable the emulated versions
+        assert has_cuda_capability(
+            10, 0
+        ), "MXFP8 is only supported on SM100 or architectures"
+
+        self.enabled = True
+        mx_job_config: MX = job_config.mx
+        self.filter_fqns = mx_job_config.filter_fqns
+
+        # Configure MXFP8
+        from torchao.prototype.mx_formats.config import MXLinearConfig
+
+        config = MXLinearConfig.from_recipe_name(NAME_MAP[mx_job_config.recipe_name])
+        config.use_fp8_dim1_cast_triton_kernel = (
+            mx_job_config.use_fp8_dim1_cast_triton_kernel
+        )
+        self.config = config
+
+        logger.info(f"Float8 training active with recipe {mx_job_config.recipe_name}")
+
+    def convert(self, model: nn.Module):
+        """
+        Converts the linear layers of `model` to `MXLinear`.
+        Note that today, only dynamic tensor scaling (the default) is supported.
+        This will mutate the model inplace.
+        """
+        if not self.enabled:
+            return
+
+        from torchao.prototype.mx_formats.config import MXLinearConfig
+        from torchao.quantization import quantize_
+
+        assert isinstance(self.config, MXLinearConfig)
+        quantize_(model, config=self.config, filter_fn=self._module_filter_fn)
+        logger.info("Swapped to MXLinear layers")
+
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
+        """
+        MXFP8 doesn't require any post-optimizer hooks at the moment
+        """
+        return
+
+    def _module_filter_fn(self, mod: nn.Module, fqn: str) -> bool:
+        """
+        Filter function to determine which modules should be converted.
+        For MXFP8, we only convert Linear modules with dimensions divisible by 16
+        and not matching any filtered FQNs.
+        """
+        if not isinstance(mod, nn.Linear):
+            return False
+
+        # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
+        dims_multiples_of_16 = (
+            mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
+        )
+
+        # If the fqn matches any filtered fqn, then we should not convert this module.
+        is_filtered_fqn = any(filtered_fqn in fqn for filtered_fqn in self.filter_fqns)
+
+        return dims_multiples_of_16 and not is_filtered_fqn
+
+
+register_model_converter(MXConverter, "mx")

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -440,7 +440,9 @@ class Float8:
     for backward computation.
     """
 
-    recipe_name: Literal["tensorwise", "rowwise", "rowwise_with_gw_hp"] | None = None
+    recipe_name: Literal[
+        "tensorwise", "rowwise", "rowwise_with_gw_hp", "mxfp8"
+    ] | None = None
     """If specified, creates float8 config from recipe name"""
 
     filter_fqns: list[str] | str = field(default_factory=list)
@@ -448,6 +450,22 @@ class Float8:
     Comma-separated list of fully qualified names of modules to skip applying float8 training to.
     nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
     Example: --float8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
+    """
+
+
+@dataclass
+class MX:
+    use_fp8_dim1_cast_triton_kernel: bool = True
+    """Temp work around for inductor performance gap"""
+
+    recipe_name: Literal["mxfp8"] = "mxfp8"
+    """If specified, creates float8 config from recipe name"""
+
+    filter_fqns: list[str] | str = field(default_factory=list)
+    """
+    Comma-separated list of fully qualified names of modules to skip applying mxfloat8 training to.
+    nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
+    Example: --MXFloat8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
     """
 
 
@@ -552,6 +570,7 @@ class JobConfig:
         default_factory=ActivationCheckpoint
     )
     float8: Float8 = field(default_factory=Float8)
+    mx: MX = field(default_factory=MX)
     comm: Comm = field(default_factory=Comm)
     memory_estimation: MemoryEstimation = field(default_factory=MemoryEstimation)
     fault_tolerance: FaultTolerance = field(default_factory=FaultTolerance)


### PR DESCRIPTION
Stacked PRs:
 * #1196
 * __->__#1190


--- --- ---

Add mxfp8 path

```Shell
with-proxy CONFIG_FILE="torchtitan/models/llama3/train_configs/llama3_8b.toml " ./run_train.sh --model.print_after_conversion --training.compile --training.steps 50 --model.converters mx --mx.recipe_name "mxfp8"
```

## Review highlight
I wish we could do Polls in PRs  but bike shed all the names and whether we should add a separate configmanger from float8 section and JobConfig entry

As well here is a version that encodes all of it into recipe name: https://github.com/pytorch/torchtitan/pull/1189

Logs:


``` Shell
[rank0]:/home/drisspg/.conda/envs/nightly/lib/python3.12/site-packages/torch/_inductor/lowering.py:1881: UserWarning: Torchinductor does not support code generation for complex operators. Performance may be worse than eager.
[rank0]:  warnings.warn(
[rank0]:[titan] 2025-05-13 18:27:58,957 - root - INFO - step:  1  loss: 12.2382  memory: 30.54GiB(17.12%)  tps: 691  tflops: 40.00  mfu: 12.82%
[rank0]:[titan] 2025-05-13 18:27:58,957 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-05-13 18:28:05,743 - root - INFO - step: 10  loss:  9.8639  memory: 38.04GiB(21.32%)  tps: 10,866  tflops: 629.32  mfu: 201.71%
[rank0]:[titan] 2025-05-13 18:28:13,048 - root - INFO - step: 20  loss:  8.3960  memory: 38.04GiB(21.32%)  tps: 11,215  tflops: 649.50  mfu: 208.17%
[rank0]:[titan] 2025-05-13 18:28:20,337 - root - INFO - step: 30  loss:  7.7323  memory: 38.04GiB(21.32%)  tps: 11,241  tflops: 651.01  mfu: 208.66%
[rank0]:[titan] 2025-05-13 18:28:27,637 - root - INFO - step: 40  loss:  7.3134  memory: 38.04GiB(21.32%)  tps: 11,223  tflops: 649.96  mfu: 208.32%
[rank0]:[titan] 2025-05-13 18:28:34,172 - root - INFO - [GC] Peforming periodical GC collection. 0.04 seconds.
[rank0]:[titan] 2025-05-13 18:28:34,993 - root - INFO - step: 50  loss:  7.0908  memory: 38.04GiB(21.32%)  tps: 11,138  tflops: 645.03  mfu: 206.74%
[rank0]:[titan] 2025-05-13 18:28:34,993 - root - INFO - Sleeping 2 seconds for other ranks to complete
[rank0]:[titan] 2025-05-13 18:28:36,994 - root - INFO - Training completed
[rank0]:[titan] 2025-05-13 18:28:39,313 - root - INFO - Process group destroyed.
```