### PR TITLE
[Flux] Enable checkpointing

### DIFF
--- a/torchtitan/experiments/flux/README.md
+++ b/torchtitan/experiments/flux/README.md
@@ -17,6 +17,11 @@ Run the following command to train the model on a single GPU:
 
 ```
 
+If you want to train with other model config, run the following command:
+```bash
+CONFIG_FILE="./torchtitan/experiments/flux/train_configs/flux_schnell_model.toml" ./torchtitan/experiments/flux/run_train.sh
+```
+
 ## Supported Features
 - Parallelism: The model supports FSDP, HSDP for training on multiple GPUs.
 - Activation checkpointing: The model uses activation checkpointing to reduce memory usage during training.

--- a/torchtitan/experiments/flux/README.md
+++ b/torchtitan/experiments/flux/README.md
@@ -25,10 +25,15 @@ CONFIG_FILE="./torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
 ## Supported Features
 - Parallelism: The model supports FSDP, HSDP for training on multiple GPUs.
 - Activation checkpointing: The model uses activation checkpointing to reduce memory usage during training.
+- Distributed checkpointing and loading.
+    - Notes on the current checkpointing implementation: Currently we need to enable `reshard_after_forward=True` before eval
+    process, and set it back to `False` after eval process. The reason is that eval step only runs forward, but not backward,
+    so FSDP reshard_after_forward plan would interfere with how parameters look like for the potential subsequent checkpointing step.
+
 
 
 ## TODO
 - [ ] More parallesim support (Tensor Parallelism, Context Parallelism, etc)
-- [ ] Support for distributed checkpointing and loading
 - [ ] Implement the num_flops_per_token calculation in get_nparams_and_flops() function
 - [ ] Implement test cases in CI for FLUX model. Adding more unit tests for FLUX model (eg, unit test for preprocessor, etc)
+- [ ] Checkpointing followup: Merge resharding strategy in `flux/trainer.py` to `parallel_flux.py`

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -58,8 +58,9 @@ def _process_cc12m_image(
     if resized_img.mode != "RGB":
         resized_img = resized_img.convert("RGB")
 
+    # Normalize the image to [-1, 1]
     np_img = np.array(resized_img).transpose((2, 0, 1))
-    tensor_img = torch.tensor(np_img).float() / 255.0
+    tensor_img = torch.tensor(np_img).float() / 255.0 * 2.0 - 1.0
 
     # NOTE: The following commented code is an alternative way
     # img_transform = transforms.Compose(

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -110,8 +110,7 @@ class TextToImageDatasetConfig:
 
 DATASETS = {
     "cc12m-wds": TextToImageDatasetConfig(
-        # path="pixparse/cc12m-wds",
-        path="torchtitan/experiments/flux/dataset/cc12m-wds",
+        path="pixparse/cc12m-wds",
         loader=lambda path: load_dataset(path, split="train", streaming=True),
         data_processor=_cc12m_wds_data_processor,
     ),

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -110,7 +110,8 @@ class TextToImageDatasetConfig:
 
 DATASETS = {
     "cc12m-wds": TextToImageDatasetConfig(
-        path="pixparse/cc12m-wds",
+        # path="pixparse/cc12m-wds",
+        path="torchtitan/experiments/flux/dataset/cc12m-wds",
         loader=lambda path: load_dataset(path, split="train", streaming=True),
         data_processor=_cc12m_wds_data_processor,
     ),

--- a/torchtitan/experiments/flux/parallelize_flux.py
+++ b/torchtitan/experiments/flux/parallelize_flux.py
@@ -28,13 +28,11 @@ def parallelize_flux(
     if job_config.activation_checkpoint.mode != "none":
         apply_ac(model, job_config.activation_checkpoint)
 
-    if (
-        parallel_dims.dp_shard_enabled or parallel_dims.dp_replicate_enabled
-    ):  # apply FSDP or HSDP
+    if parallel_dims.dp_shard_enabled:  # apply FSDP or HSDP
         if parallel_dims.dp_replicate_enabled:
-            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard")
         else:
-            dp_mesh_dim_names = ("dp_shard_cp",)
+            dp_mesh_dim_names = ("dp_shard",)
 
         apply_fsdp(
             model,
@@ -122,13 +120,11 @@ def parallelize_encoders(
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
-    if (
-        parallel_dims.dp_shard_enabled or parallel_dims.dp_replicate_enabled
-    ):  # apply FSDP or HSDP
+    if parallel_dims.dp_shard_enabled:  # apply FSDP or HSDP
         if parallel_dims.dp_replicate_enabled:
-            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard")
         else:
-            dp_mesh_dim_names = ("dp_shard_cp",)
+            dp_mesh_dim_names = ("dp_shard",)
 
         mp_policy = MixedPrecisionPolicy(
             param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],

--- a/torchtitan/experiments/flux/parallelize_flux.py
+++ b/torchtitan/experiments/flux/parallelize_flux.py
@@ -28,11 +28,13 @@ def parallelize_flux(
     if job_config.activation_checkpoint.mode != "none":
         apply_ac(model, job_config.activation_checkpoint)
 
-    if parallel_dims.dp_shard_enabled:  # apply FSDP or HSDP
+    if (
+        parallel_dims.dp_shard_enabled or parallel_dims.dp_replicate_enabled
+    ):  # apply FSDP or HSDP
         if parallel_dims.dp_replicate_enabled:
-            dp_mesh_dim_names = ("dp_replicate", "dp_shard")
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
         else:
-            dp_mesh_dim_names = ("dp_shard",)
+            dp_mesh_dim_names = ("dp_shard_cp",)
 
         apply_fsdp(
             model,
@@ -120,11 +122,13 @@ def parallelize_encoders(
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
-    if parallel_dims.dp_shard_enabled:  # apply FSDP or HSDP
+    if (
+        parallel_dims.dp_shard_enabled or parallel_dims.dp_replicate_enabled
+    ):  # apply FSDP or HSDP
         if parallel_dims.dp_replicate_enabled:
-            dp_mesh_dim_names = ("dp_replicate", "dp_shard")
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
         else:
-            dp_mesh_dim_names = ("dp_shard",)
+            dp_mesh_dim_names = ("dp_shard_cp",)
 
         mp_policy = MixedPrecisionPolicy(
             param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -115,10 +115,6 @@ class FluxTrainer(Trainer):
             sigmas = timesteps.view(-1, 1, 1, 1)
             latents = (1 - sigmas) * labels + sigmas * noise
 
-        logger.info(
-            f"Generated info for step {self.step} is : {noise.sum().item()}, timestep: {timesteps.sum().item()}, labels: {labels.sum().item()}"
-        )
-
         bsz, _, latent_height, latent_width = latents.shape
 
         POSITION_DIM = 3  # constant for Flux flow model

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -80,6 +80,7 @@ class FluxTrainer(Trainer):
 
     def train_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
         if self.step == 6:
+            logger.info("Set deterministic mode for debugging at step 6")
             dist_utils.set_determinism(
                 self.world_mesh,
                 self.device,
@@ -123,6 +124,10 @@ class FluxTrainer(Trainer):
             timesteps = torch.rand((bsz,)).to(labels)
             sigmas = timesteps.view(-1, 1, 1, 1)
             latents = (1 - sigmas) * labels + sigmas * noise
+
+        logger.info(
+            f"Generated info for step {self.step} is : {noise.sum().item()}, timestep: {timesteps.sum().item()}, labels: {labels.sum().item()}"
+        )
 
         bsz, _, latent_height, latent_width = latents.shape
 

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -79,16 +79,6 @@ class FluxTrainer(Trainer):
         )
 
     def train_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
-        if self.step == 6:
-            logger.info("Set deterministic mode for debugging at step 6")
-            dist_utils.set_determinism(
-                self.world_mesh,
-                self.device,
-                self.job_config.training.seed,
-                self.job_config.training.deterministic,
-                distinct_seed_mesh_dim="dp_shard",
-            )
-
         # generate t5 and clip embeddings
         input_dict["image"] = labels
         input_dict = self.preprocess_fn(

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 disable_color_printing = false
-enable_tensorboard = true
+enable_tensorboard = false
 save_tb_folder = "tb"
 enable_wandb = false
 
@@ -41,8 +41,6 @@ compile = false
 dataset = "cc12m-wds"
 classifer_free_guidance_prob = 0.1
 img_size = 256
-deterministic = true
-seed = 0
 
 [encoder]
 t5_encoder = "google/t5-v1_1-xxl"

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -15,7 +15,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 disable_color_printing = false
-enable_tensorboard = false
+enable_tensorboard = true
 save_tb_folder = "tb"
 enable_wandb = false
 
@@ -41,6 +41,8 @@ compile = false
 dataset = "cc12m-wds"
 classifer_free_guidance_prob = 0.1
 img_size = 256
+deterministic = true
+seed = 0
 
 [encoder]
 t5_encoder = "google/t5-v1_1-xxl"
@@ -64,3 +66,11 @@ custom_args_module = "torchtitan.experiments.flux.flux_argparser"
 
 [activation_checkpoint]
 mode = "full"
+
+[checkpoint]
+enable_checkpoint = true
+folder = "checkpoint_debug"
+interval = 5
+model_weights_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -74,3 +74,4 @@ interval = 5
 model_weights_only = false
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+load_step = 5

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -68,10 +68,9 @@ custom_args_module = "torchtitan.experiments.flux.flux_argparser"
 mode = "full"
 
 [checkpoint]
-enable_checkpoint = true
-folder = "checkpoint_debug"
+enable_checkpoint = false
+folder = "checkpoint"
 interval = 5
 model_weights_only = false
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
-load_step = 5

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -63,3 +63,11 @@ custom_args_module = "torchtitan.experiments.flux.flux_argparser"
 
 [activation_checkpoint]
 mode = "full"
+
+[checkpoint]
+enable_checkpoint = false
+folder = "checkpoint"
+interval = 10_000
+model_weights_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -28,14 +28,14 @@ lr = 1e-4
 eps = 1e-8
 
 [lr_scheduler]
-warmup_steps = 30_000  # lr scheduler warm up, normally 20% of the train steps
+warmup_steps = 3_000  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.0  # no decay
 
 [training]
 batch_size = 4
 seq_len = 512
 max_norm = 1.0  # grad norm clipping
-steps = 300_000
+steps = 30_000
 compile = false
 dataset = "cc12m-wds"
 classifer_free_guidance_prob = 0.1
@@ -67,7 +67,7 @@ mode = "full"
 [checkpoint]
 enable_checkpoint = false
 folder = "checkpoint"
-interval = 10_000
+interval = 1_000
 model_weights_only = false
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -63,3 +63,11 @@ custom_args_module = "torchtitan.experiments.flux.flux_argparser"
 
 [activation_checkpoint]
 mode = "full"
+
+[checkpoint]
+enable_checkpoint = true
+folder = "checkpoint"
+interval = 100
+model_weights_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -28,14 +28,14 @@ lr = 1e-4
 eps = 1e-8
 
 [lr_scheduler]
-warmup_steps = 30_000  # lr scheduler warm up, normally 20% of the train steps
+warmup_steps = 3_000  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.0  # no decay
 
 [training]
 batch_size = 4
 seq_len = 512
 max_norm = 1.0  # grad norm clipping
-steps = 300_000
+steps = 30_000
 compile = false
 dataset = "cc12m-wds"
 classifer_free_guidance_prob = 0.1
@@ -65,9 +65,9 @@ custom_args_module = "torchtitan.experiments.flux.flux_argparser"
 mode = "full"
 
 [checkpoint]
-enable_checkpoint = true
+enable_checkpoint = false
 folder = "checkpoint"
-interval = 100
+interval = 1_000
 model_weights_only = false
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]


### PR DESCRIPTION
## Context:
1. Change flux-dev / flux-schnell model training to be ~30000 step based on current MAST training results
2. Enable checkpointing. We enabled final_layer reshard_after_forward to solve issue described [here](https://github.com/pytorch/torchtitan/pull/1167#discussion_r2075967381)

## Test
If we run following 2 runs, the training loss curve should be identical with `deterministic = True`:
1. Without checkpoint save and load, total step=10
2. Save checkpoint at step 5, and load checkpoint at step 5, continue training

Currently issue #1194 makes the training loss not strictly identical. To exclude the influence of #1194, we reset the seeds (by calling `set_deterministic()` at the beginning of step 6. Then the checkpoint save/load makes the training loss identical.

<img width="1675" alt="Screenshot 2025-05-14 at 2 06 23 PM" src="https://github.com/user-attachments/assets/22882b71-378c-44fa-bd48-8a8f238aa1b0" />

