### PR TITLE
refactor quantization modules

### DIFF
--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.float8 import Float8Converter
+from torchtitan.components.quantization.float8 import Float8Converter
 from torchtitan.config_manager import ConfigManager
 from torchtitan.distributed import ParallelDims
 from torchtitan.protocols.model_converter import (

--- a/torchtitan/__init__.py
+++ b/torchtitan/__init__.py
@@ -3,12 +3,9 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-#
-# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-# Import to register Float8Converter.
-import torchtitan.components.float8  # noqa: F401
-import torchtitan.components.mx  # noqa: F401
+# Import to register quantization modules.
+import torchtitan.components.quantization  # noqa: F401
 
 # Import the built-in models here so that the corresponding register_model_spec()
 # will be called.

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# [Note] Getting the 'torchao' package:
+# This script requires the 'torchao' package to function correctly.
+# Please ensure you have this package installed from the appropriate repository.
+# You can obtain it from https://github.com/pytorch/ao by following the
+# installation instructions.
+
+# Note: Performance
+# The quantization modules are intended to be ran under `torch.compile`` for competitive performance
+
+# Import to register quantization modules as ModelConverter
+import torchtitan.components.quantization.float8  # noqa: F401
+import torchtitan.components.quantization.mx  # noqa: F401

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -4,14 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# [Note] Getting the 'torchao' package:
-# This script requires the 'torchao' package to function correctly.
-# Please ensure you have this package installed from the appropriate repository.
-# You can obtain it from https://github.com/pytorch/ao by following the
-# installation instructions.
-
-# Note: Performance
-# Float8 experimental is intended to be ran under `torch.compile`` for competitive performance
+from functools import partial
 
 import torch
 import torch.nn as nn
@@ -24,6 +17,8 @@ from torchtitan.protocols.model_converter import (
 )
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
+
+from .utils import module_filter_fn
 
 
 class Float8Converter(ModelConverter):
@@ -93,12 +88,6 @@ class Float8Converter(ModelConverter):
             logger.info("Float8 tensorwise scaled training active")
 
     def convert(self, model: nn.Module):
-        return self.convert_to_float8_training(model)
-
-    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
-        return self.precompute_float8_dynamic_scale_for_fsdp(model)
-
-    def convert_to_float8_training(self, model: nn.Module):
         """
         This function converts the linear layers of `model` to `Float8Linear`.
         Note that today, only dynamic tensor scaling (the default) is supported.
@@ -113,30 +102,14 @@ class Float8Converter(ModelConverter):
         convert_to_float8_training(
             model,
             config=self.config,
-            module_filter_fn=self._module_filter_fn,
+            module_filter_fn=partial(module_filter_fn, filter_fqns=self.filter_fqns),
         )
         logger.info(
             "Swapped to Float8Linear layers with enable_fsdp_float8_all_gather="
             f"{self.config.enable_fsdp_float8_all_gather}"
         )
 
-    def _module_filter_fn(self, mod: nn.Module, fqn: str) -> bool:
-        if not isinstance(mod, nn.Linear):
-            return False
-
-        # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
-        dims_multiples_of_16 = (
-            mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
-        )
-
-        # If the fqn matches any filtered fqn, then we should not convert this module.
-        is_filtered_fqn = any(filtered_fqn in fqn for filtered_fqn in self.filter_fqns)
-
-        return dims_multiples_of_16 and not is_filtered_fqn
-
-    def precompute_float8_dynamic_scale_for_fsdp(
-        self, model: nn.Module | list[nn.Module]
-    ):
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
         if not self.enabled:
             return
 

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn as nn
+
+
+def module_filter_fn(mod: nn.Module, fqn: str, filter_fqns: list[str]) -> bool:
+    """
+    Filter function to determine which modules should be converted.
+    For both Float8 and MXFP8, we only convert Linear modules
+    with dimensions divisible by 16 and not matching any filtered FQNs.
+    """
+    if not isinstance(mod, nn.Linear):
+        return False
+
+    # All dims must be divisible by 16 due to float8 tensorcore hardware requirements.
+    dims_multiples_of_16 = (
+        mod.weight.shape[0] % 16 == 0 and mod.weight.shape[1] % 16 == 0
+    )
+
+    # If the fqn matches any filtered fqn, then we should not convert this module.
+    is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
+
+    return dims_multiples_of_16 and not is_filtered_fqn

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -440,12 +440,10 @@ class Float8:
     for backward computation.
     """
 
-    recipe_name: Literal[
-        "tensorwise", "rowwise", "rowwise_with_gw_hp", "mxfp8"
-    ] | None = None
+    recipe_name: Literal["tensorwise", "rowwise", "rowwise_with_gw_hp"] | None = None
     """If specified, creates float8 config from recipe name"""
 
-    filter_fqns: list[str] | str = field(default_factory=list)
+    filter_fqns: list[str] = field(default_factory=list)
     """
     Comma-separated list of fully qualified names of modules to skip applying float8 training to.
     nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
@@ -461,7 +459,7 @@ class MX:
     recipe_name: Literal["mxfp8"] = "mxfp8"
     """If specified, creates float8 config from recipe name"""
 
-    filter_fqns: list[str] | str = field(default_factory=list)
+    filter_fqns: list[str] = field(default_factory=list)
     """
     Comma-separated list of fully qualified names of modules to skip applying mxfloat8 training to.
     nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.


### PR DESCRIPTION
This PR
1. puts `float8.py` and `mx.py` under a `components/quantization` subfolder
2. extract the `module_filter_fn` into a `utils.py` file
3. fix typing of `filter_fqns: list[str] | str` to be just `list[str]`
4. some other cleanups