### PR TITLE
[BE] refactor get peak flops for easier updates / readability

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -103,6 +103,7 @@ def get_peak_flops(device_name: str) -> int:
 
     # Check for Intel PVC
     if "Data Center GPU Max 1550" in device_name:
+        # data from https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/intel-xe-gpu-architecture.html
         # Full EU mode (i.e. 512 max compute units): 340.8 TFLOPS (BF16)
         # Standard EU mode (i.e. 448 max compute units): 298.2 TFLOPS (BF16)
         max_comp_units = torch.xpu.get_device_properties("xpu").max_compute_units

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -64,9 +64,9 @@ def get_peak_flops(device_name: str) -> int:
     # Tuple of tuples mapping device names to their BF16 peak flops and source URL
     device_flops = (
         ("A100", 312e12, "https://www.nvidia.com/en-us/data-center/a100/"),
-        ("H100", 989e12, "https://www.nvidia.com/en-us/data-center/h100/"),
         ("H100 NVL", 835e12, "https://www.nvidia.com/en-us/data-center/h100/"),
         ("H100 PCIe", 756e12, "https://www.nvidia.com/en-us/data-center/h100/"),
+        ("H100", 989e12, "https://www.nvidia.com/en-us/data-center/h100/"),
         ("H200", 989e12, "https://www.nvidia.com/en-us/data-center/h200/"),
         (
             "B200",

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -107,9 +107,8 @@ def get_peak_flops(device_name: str) -> int:
         return 512 * max_comp_units * 1300 * 10**6
 
     # Return the peak flops for the known device or log a warning and assume A100
-    for key, (flops, url) in device_flops.items():
+    for key, (flops, _) in device_flops.items():
         if key in device_name:
-            logger.info(f"Using peak flops from {url}")
             return flops
 
     logger.warning(f"Peak flops undefined for: {device_name}, falling back to A100")

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -69,16 +69,16 @@ def get_peak_flops(device_name: str) -> int:
             "flops": 312e12,
             "source": "https://www.nvidia.com/en-us/data-center/a100/",
         },
-        "h100": {
-            "flops": 989e12,
-            "source": "https://www.nvidia.com/en-us/data-center/h100/",
-        },
         "h100 nvl": {
             "flops": 835e12,
             "source": "https://www.nvidia.com/en-us/data-center/h100/",
         },
         "h100 pcie": {
             "flops": 756e12,
+            "source": "https://www.nvidia.com/en-us/data-center/h100/",
+        },
+        "h100": {
+            "flops": 989e12,
             "source": "https://www.nvidia.com/en-us/data-center/h100/",
         },
         "h200": {

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -103,6 +103,8 @@ def get_peak_flops(device_name: str) -> int:
 
     # Check for Intel PVC
     if "Data Center GPU Max 1550" in device_name:
+        # Full EU mode (i.e. 512 max compute units): 340.8 TFLOPS (BF16)
+        # Standard EU mode (i.e. 448 max compute units): 298.2 TFLOPS (BF16)
         max_comp_units = torch.xpu.get_device_properties("xpu").max_compute_units
         return 512 * max_comp_units * 1300 * 10**6
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -89,9 +89,9 @@ def get_peak_flops(device_name: str) -> int:
             "flops": 4.5e15,
             "source": "https://nvdam.widen.net/s/wwnsxrhm2w/blackwell-datasheet-3384703",
         },
-        "l40s": {
-            "flops": 362e12,
-            "source": "https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413",
+        "mi250x": {
+            "flops": 191.5e12,
+            "source": "https://www.amd.com/en/products/accelerators/instinct/mi200/mi250x.html",
         },
         "mi300x": {
             "flops": 1300e12,
@@ -100,10 +100,6 @@ def get_peak_flops(device_name: str) -> int:
         "mi325x": {
             "flops": 1300e12,
             "source": "https://www.amd.com/en/products/accelerators/instinct/mi300/mi325x.html",
-        },
-        "mi250x": {
-            "flops": 191.5e12,
-            "source": "https://www.amd.com/en/products/accelerators/instinct/mi200/mi250x.html",
         },
     }
 


### PR DESCRIPTION
This PR:
refactors the get_peak_flops from a long if/elif stream,  to instead use a device_flops dictionary, with the peak flops and source URL cleanly housed.

This makes the code much easier to read in terms of seeing what GPU's are present and supported, and should make future updates much cleaner as you only have to make an entry to the dictionary.

Testing:
verified on B200, H100