### PR TITLE
add L40s gpu type for MFU calcs

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -103,6 +103,10 @@ def get_peak_flops(device_name: str) -> int:
         # Standard EU mode (i.e. 448 max compute units): 298.2 TFLOPS (BF16)
         max_comp_units = torch.xpu.get_device_properties("xpu").max_compute_units
         return 512 * max_comp_units * 1300 * 10**6
+    elif "l40s" in device_name:
+        # data from: "https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413"
+        return 362e12
+
     else:  # for other GPU types, assume A100
         logger.warning(f"Peak flops undefined for: {device_name}, fallback to A100")
         return 312e12


### PR DESCRIPTION
This PR:
adds L40s as a valid gpu type for get_peak_flops in order to properly calculate MFU. We are currently using L40's for some FT work. 

