### PR TITLE
[CP] CP should respect the backends selected by ScaledDotProductionAt…

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -16,7 +16,9 @@ import torch.distributed.distributed_c10d as c10d
 from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
+from torch.nn.attention import SDPBackend
 
+from torchtitan.models.attention import ScaledDotProductAttention
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 
@@ -188,17 +190,10 @@ def get_train_context(
                 )
 
             if cp_context is not None:
-                from torch.nn.attention import sdpa_kernel, SDPBackend
-
-                stack.enter_context(
-                    sdpa_kernel(
-                        [
-                            SDPBackend.FLASH_ATTENTION,
-                            SDPBackend.EFFICIENT_ATTENTION,
-                            SDPBackend.CUDNN_ATTENTION,
-                        ]
-                    )
-                )
+                assert (
+                    ScaledDotProductAttention.backends
+                ), "SDPA backends should not be empty."
+                ScaledDotProductAttention.backends.pop(SDPBackend.MATH)
                 stack.enter_context(cp_context)
 
             yield

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -194,6 +194,9 @@ def get_train_context(
                     ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
                 except ValueError:
                     pass
+                assert (
+                    ScaledDotProductAttention.backends
+                ), "No valid SDPA backends with CP."
                 stack.enter_context(cp_context)
 
             yield

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -190,10 +190,10 @@ def get_train_context(
                 )
 
             if cp_context is not None:
-                assert (
-                    ScaledDotProductAttention.backends
-                ), "SDPA backends should not be empty."
-                ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
+                try:
+                    ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
+                except ValueError:
+                    pass
                 stack.enter_context(cp_context)
 
             yield

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -193,7 +193,7 @@ def get_train_context(
                 assert (
                     ScaledDotProductAttention.backends
                 ), "SDPA backends should not be empty."
-                ScaledDotProductAttention.backends.pop(SDPBackend.MATH)
+                ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
                 stack.enter_context(cp_context)
 
             yield

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -190,10 +190,8 @@ def get_train_context(
                 )
 
             if cp_context is not None:
-                try:
+                if SDPBackend.MATH in ScaledDotProductAttention.backends:
                     ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
-                except ValueError:
-                    pass
                 assert (
                     ScaledDotProductAttention.backends
                 ), "No valid SDPA backends with CP."


### PR DESCRIPTION
Summary:
ScaledDotProductionAttention now has its own SDPBackend selection, https://github.com/pytorch/torchtitan/pull/1209. CP should respect the result from ScaledDotProductionAttention.