### PR TITLE
Add emulate in float8 and relative checks

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,6 +1,5 @@
 torchdata >= 0.8.0
 datasets >= 3.6.0
-ao >= 0.12.0
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard
 tiktoken
@@ -9,3 +8,4 @@ tabulate
 wandb
 fsspec
 tyro
+torchao

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -8,4 +8,3 @@ tabulate
 wandb
 fsspec
 tyro
-torchao

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,5 +1,6 @@
 torchdata >= 0.8.0
 datasets >= 3.6.0
+ao >= 1.0.1
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard
 tiktoken

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,6 +1,6 @@
 torchdata >= 0.8.0
 datasets >= 3.6.0
-ao >= 1.0.1
+ao >= 0.12.0
 tomli >= 1.1.0 ; python_version < "3.11"
 tensorboard
 tiktoken

--- a/.github/workflows/integration_test_8gpu.yaml
+++ b/.github/workflows/integration_test_8gpu.yaml
@@ -38,5 +38,7 @@ jobs:
 
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
 
+        USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
+
         mkdir artifacts-to-be-uploaded
         python ./tests/integration_tests.py artifacts-to-be-uploaded --ngpu 8

--- a/.github/workflows/integration_test_8gpu.yaml
+++ b/.github/workflows/integration_test_8gpu.yaml
@@ -38,7 +38,7 @@ jobs:
 
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
 
-        USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
+        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu126
 
         mkdir artifacts-to-be-uploaded
         python ./tests/integration_tests.py artifacts-to-be-uploaded --ngpu 8

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -26,6 +26,6 @@ jobs:
 
         pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
 
-        pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
+        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
 
         pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -25,6 +25,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
-        pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv
 
         pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
+
+        pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -27,4 +27,4 @@ jobs:
         pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv
 
-        python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -26,3 +26,5 @@ jobs:
 
         pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv
+
+        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu126

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -27,4 +27,4 @@ jobs:
         pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv
 
-        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu126
+        python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -11,7 +11,7 @@ USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
 
 For float8 with tensorwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --float8.force_recompute_fp8_weight_in_bwd --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --float8.force_recompute_fp8_weight_in_bwd --training.compile
 ```
 * `--model.converters="float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
@@ -21,7 +21,7 @@ CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_train.sh --model.converters="
 
 For float8 with rowwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.recipe_name rowwise --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.recipe_name rowwise --training.compile
 ```
 * `--model.converters="float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
 * `--float8.recipe_name="rowwise"`: use the rowwise scaling recipe for higher accuracy compared to tensorwise scaling

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -17,7 +17,6 @@ CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_train.sh --model.converters="
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
 * `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
 * `--float8.force_recompute_fp8_weight_in_bwd` (optional): force recomputation of fp8 weights during backward pass, preventing unsharded fp8 weights from being saved for backward.
-* `--float8.emulate` (optional): emulate float8 traning with older hardware in eager mode.
 * `--training.compile` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For float8 with rowwise scaling, launch training job with the following command (or alternatively set configs in toml files)

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -17,6 +17,7 @@ CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_train.sh --model.converters="
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
 * `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
 * `--float8.force_recompute_fp8_weight_in_bwd` (optional): force recomputation of fp8 weights during backward pass, preventing unsharded fp8 weights from being saved for backward.
+* `--float8.emulate` (optional): emulate float8 traning with older hardware in eager mode.
 * `--training.compile` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For float8 with rowwise scaling, launch training job with the following command (or alternatively set configs in toml files)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -48,19 +48,6 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--model.converters float8",
-                    "--float8.enable_fsdp_float8_all_gather",
-                    "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
-                    "--float8.emulate",
-                ],
-            ],
-            "Float8 emulation test",
-            "float8_emulation",
-        ),
-        OverrideDefinitions(
-            [
-                [
                     "--profiling.enable_profiling",
                     "--metrics.enable_tensorboard",
                 ],
@@ -495,6 +482,19 @@ def build_test_list():
             ],
             "Optional checkpoint",
             "optional_checkpoint",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--model.converters float8",
+                    "--float8.enable_fsdp_float8_all_gather",
+                    "--float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--float8.force_recompute_fp8_weight_in_bwd",
+                    "--float8.emulate",
+                ],
+            ],
+            "Float8 emulation test",
+            "float8_emulation",
         ),
     ]
     return integration_tests_flavors

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -483,6 +483,19 @@ def build_test_list():
             "Optional checkpoint",
             "optional_checkpoint",
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--model.converters float8",
+                    "--float8.enable_fsdp_float8_all_gather",
+                    "--float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--float8.force_recompute_fp8_weight_in_bwd",
+                    "--float8.emulate",
+                ],
+            ],
+            "Float8 emulation test",
+            "float8_emulation",
+        ),
     ]
     return integration_tests_flavors
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -48,6 +48,19 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
+                    "--model.converters float8",
+                    "--float8.enable_fsdp_float8_all_gather",
+                    "--float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--float8.force_recompute_fp8_weight_in_bwd",
+                    "--float8.emulate",
+                ],
+            ],
+            "Float8 emulation test",
+            "float8_emulation",
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--profiling.enable_profiling",
                     "--metrics.enable_tensorboard",
                 ],
@@ -482,19 +495,6 @@ def build_test_list():
             ],
             "Optional checkpoint",
             "optional_checkpoint",
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--model.converters float8",
-                    "--float8.enable_fsdp_float8_all_gather",
-                    "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
-                    "--float8.emulate",
-                ],
-            ],
-            "Float8 emulation test",
-            "float8_emulation",
         ),
     ]
     return integration_tests_flavors

--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -40,6 +40,7 @@ def test_build_model_converters_empty_list():
 def test_build_model_converters_float8_converter():
     config_manager = ConfigManager()
     config = config_manager.parse_args(["--model.converters", "float8"])
+    config = config_manager.parse_args(["--float8.emulate"])
     parallel_dims = build_parallel_dims(config, 1)
 
     model_converters = build_model_converters(config, parallel_dims)

--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -39,8 +39,9 @@ def test_build_model_converters_empty_list():
 
 def test_build_model_converters_float8_converter():
     config_manager = ConfigManager()
-    config = config_manager.parse_args(["--model.converters", "float8"])
-    config = config_manager.parse_args(["--float8.emulate"])
+    config = config_manager.parse_args(
+        ["--model.converters", "float8", "--float8.emulate"]
+    )
     parallel_dims = build_parallel_dims(config, 1)
 
     model_converters = build_model_converters(config, parallel_dims)

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -28,7 +28,7 @@ class Float8Converter(ModelConverter):
         float8_config: Float8 = job_config.float8
         if not has_cuda_capability(8, 9) and not float8_config.emulate:
             logger.warning(
-                "Float8Linear is only supported on SM89 or later hardware. "
+                "Failed to swap to Float8Linear because float8 is only supported on SM89 or later."
                 "To enable support on older hardware, set `Float8.emulate` to True.",
             )
             return

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -26,9 +26,15 @@ class Float8Converter(ModelConverter):
         self.enabled = False
 
         float8_config: Float8 = job_config.float8
-        if not has_cuda_capability(8, 9):
+        if not has_cuda_capability(8, 9) and not float8_config.emulate:
             logger.warning(
-                "Failed to swap to Float8Linear because float8 is only supported on SM89 or later",
+                "Float8Linear is only supported on SM89 or later hardware. "
+                "To enable support on older hardware, set `Float8.emulate` to True.",
+            )
+            return
+        elif float8_config.emulate and job_config.training.compile:
+            logger.warning(
+                "Failed to run on emulate with compile on, please disable compile to allow on emulate.",
             )
             return
         try:

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -29,7 +29,7 @@ class Float8Converter(ModelConverter):
         if not has_cuda_capability(8, 9) and not float8_config.emulate:
             logger.warning(
                 "Failed to swap to Float8Linear because float8 is only supported on SM89 or later."
-                "To enable support on older hardware, set `Float8.emulate` to True.",
+                "To enable support on older hardware, set `float8.emulate` to True.",
             )
             return
         elif float8_config.emulate and job_config.training.compile:

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -26,12 +26,15 @@ class Float8Converter(ModelConverter):
         self.enabled = False
 
         float8_config: Float8 = job_config.float8
-        if not has_cuda_capability(8, 9) and not float8_config.emulate:
-            logger.warning(
+        if has_cuda_capability(8, 9) or (
+            float8_config.emulate and not job_config.training.compile
+        ):
+            pass
+        else:
+            raise ValueError(
                 "Failed to swap to Float8Linear because float8 is only supported on SM89 or later."
-                "To enable support on older hardware, set `float8.emulate` to True.",
+                "To enable testing on older hardware, set `float8.emulate` to True in eager mode.",
             )
-            return
         try:
             from torchao.float8 import Float8LinearConfig
         except ImportError as e:

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -85,6 +85,7 @@ class Float8Converter(ModelConverter):
             self.config = Float8LinearConfig(
                 enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
                 force_recompute_fp8_weight_in_bwd=float8_config.force_recompute_fp8_weight_in_bwd,
+                emulate=float8_config.emulate,
             )
             # for precompute_float8_dynamic_scale_for_fsdp
             self.precompute_scale = (

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -32,11 +32,6 @@ class Float8Converter(ModelConverter):
                 "To enable support on older hardware, set `float8.emulate` to True.",
             )
             return
-        elif float8_config.emulate and job_config.training.compile:
-            logger.warning(
-                "Failed to run on emulate with compile on, please disable compile to allow on emulate.",
-            )
-            return
         try:
             from torchao.float8 import Float8LinearConfig
         except ImportError as e:

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -453,7 +453,7 @@ class Float8:
     emulate: bool = False
     """
     If True, emulation is used instead of hardware accelerated gemm. This is for test purpose only,
-    as the current CI does have sm_90 capability, required by Float8.
+    as the current CI does not have sm_89 capability, required by Float8.
     Not compatible with torch.compile.
     """
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -452,8 +452,8 @@ class Float8:
 
     emulate: bool = False
     """
-    Whether to run on earlier hardware in CI test. 
-    torch.compile with float8 dtypes is not going to work on older hardware, so the emulation can 
+    Whether to run on earlier hardware in CI test.
+    torch.compile with float8 dtypes is not going to work on older hardware, so the emulation can
     only be used in eager mode.
     """
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -452,9 +452,9 @@ class Float8:
 
     emulate: bool = False
     """
-    Whether to run on earlier hardware in CI test.
-    torch.compile with float8 dtypes is not going to work on older hardware, so the emulation can
-    only be used in eager mode.
+    If True, emulation is used instead of hardware accelerated gemm. This is for test purpose only, 
+    as the current CI does have sm_90 capability, required by Float8.
+    Not compatible with torch.compile.
     """
 
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -452,7 +452,7 @@ class Float8:
 
     emulate: bool = False
     """
-    If True, emulation is used instead of hardware accelerated gemm. This is for test purpose only, 
+    If True, emulation is used instead of hardware accelerated gemm. This is for test purpose only,
     as the current CI does have sm_90 capability, required by Float8.
     Not compatible with torch.compile.
     """

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -450,6 +450,13 @@ class Float8:
     Example: --float8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
     """
 
+    emulate: bool = False
+    """
+    Whether to run on earlier hardware in CI test. 
+    torch.compile with float8 dtypes is not going to work on older hardware, so the emulation can 
+    only be used in eager mode.
+    """
+
 
 @dataclass
 class MX:


### PR DESCRIPTION
Add [emulate](https://github.com/pytorch/ao/blob/554cb60c750e6ef31bbcafec74bb76a4578902da/torchao/float8/config.py#L193) in float8, to enable test on older hardware.

Change relative warnings

Test result:
Test locally on 8 H100 server.
`CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --float8.force_recompute_fp8_weight_in_bwd`
<img width="1127" alt="Screenshot 2025-05-21 at 2 38 39 PM" src="https://github.com/user-attachments/assets/c15fcabb-d7cd-4c96-8ff4-9fe5a2bc5246" />


`CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --float8.force_recompute_fp8_weight_in_bwd --float8.emulate`
<img width="1127" alt="Screenshot 2025-05-21 at 2 39 01 PM" src="https://github.com/user-attachments/assets/9227c839-fbe6-45d0-a919-6b62ac66863a" />
