### PR TITLE
Fix: update expert_bias buffer in-place to preserve it in checkpoint

### DIFF
--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -237,7 +237,7 @@ class MoE(nn.Module):
             self.tokens_per_expert.mean() - self.tokens_per_expert
         )
         expert_bias_delta = expert_bias_delta - expert_bias_delta.mean()
-        self.expert_bias = self.expert_bias + expert_bias_delta
+        self.expert_bias.add_(expert_bias_delta)
 
         self.tokens_per_expert.zero_()
 


### PR DESCRIPTION
 This PR fixes an issue I previously reported in [this bug report](https://github.com/pytorch/torchtitan/issues/1222).

#### Problem

When training LLaMA 4 with the MoE architecture, the `expert_bias` buffer was being correctly updated during runtime. However, the saved checkpoints consistently stored all-zero tensors for this parameter. The root cause was in the `_update_expert_bias()` method, where the buffer was reassigned like this:

```python
self.expert_bias = self.expert_bias + expert_bias_delta
```

This out-of-place update breaks checkpointer's original reference to the registered buffer. As a result, the checkpointer no longer tracks updates to `expert_bias`, and the saved checkpoints only reflect its initial (zero) state before the first out-of-place update.

#### Solution

The update should be done in-place:

```python
self.expert_bias.add_(expert_bias_delta)
```