### PR TITLE
[deepseek] fix/avoid Expert Parallel device mesh and 'duplicate gpu mapping' error

### DIFF
--- a/torchtitan/experiments/deepseek_v3/train.py
+++ b/torchtitan/experiments/deepseek_v3/train.py
@@ -6,6 +6,7 @@
 
 # torchrun --standalone --nproc-per-node 8 train.py
 # bash run_training.sh
+import os
 
 import torch
 import torch.distributed as dist
@@ -143,6 +144,9 @@ def run_full_model(
 
 
 if __name__ == "__main__":
+    # set device before init_device mesh, otherwise ep will have duplicate device mapping
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+
     mesh = dist.init_device_mesh("cuda", (2, 2, 2), mesh_dim_names=("pp", "ep", "fsdp"))
 
     run_full_model(mesh)


### PR DESCRIPTION
this PR fixes (or at least works around) this issue (https://github.com/pytorch/torchtitan/issues/1224) that has suddenly appeared regarding duplicate gpu mapping and blocking deepseek with expert parallel training.  
This was previously not an issue but has popped up seemingly with the latest NCCL.  

Regardless, change is to ensure we run torch.cuda.set_device before initializing the device mesh. 
That restores deepseek training to as before. 

Testing:
deepseek training now working via train.py vs broken with duplicate gpu error.
