### PR TITLE
[SimpleFSDP] Add CI for SimpleFSDP

### DIFF
--- a/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
+++ b/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
@@ -1,0 +1,46 @@
+name: SimpleFSDP 8 GPU Integration Test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'torchtitan/experiments/simple_fsdp/**'
+  pull_request:
+    paths:
+      - 'torchtitan/experiments/simple_fsdp/**'
+  schedule:
+    # Runs every 6 hours
+    - cron: '0 */6 * * *'
+concurrency:
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+  build-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.g5.48xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      # This image is faster to clone than the default, but it lacks CC needed by triton
+      # (1m25s vs 2m37s).
+      docker-image: torchtitan-ubuntu-20.04-clang12
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      script: |
+        set -eux
+
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        pip config --user set global.progress_bar off
+
+        python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
+
+        mkdir artifacts-to-be-uploaded
+        python -m torchtitan.experiments.simple_fsdp.tests.integration_tests artifacts-to-be-uploaded --ngpu 8

--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -1,5 +1,9 @@
 ## SimpleFSDP
 
+[![integration tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_simple_fsdp.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_simple_fsdp.yaml?query=branch%3Amain)
+[![arXiv](https://img.shields.io/badge/arXiv-2411.00284-b31b1b.svg)](https://arxiv.org/abs/2411.00284)
+
+
 This folder includes an experimental frontend implementation for [SimpleFSDP: Simpler Fully Sharded Data Parallel with torch.compile](https://arxiv.org/abs/2411.00284). SimpleFSDP is a compiler-based Fully Sharded Data Parallel (FSDP) framework, which has a simple implementation for maintenance and composability, allows full computation-communication graph tracing, and brings performance enhancement via compiler backend optimizations.
 
 ### Enable SimpleFSDP Training

--- a/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
+++ b/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
@@ -1,0 +1,289 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import logging
+import os
+import subprocess
+from collections import defaultdict
+
+from tests.integration_tests import OverrideDefinitions
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+def build_test_list():
+    """
+    key is the config file name and value is a list of OverrideDefinitions
+    that is used to generate variations of integration tests based on the
+    same root config file.
+    """
+    integration_tests_flavors = defaultdict(list)
+    integration_tests_flavors["debug_model.toml"] = [
+        OverrideDefinitions(
+            [
+                [],
+            ],
+            "1D",
+            "1d",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--activation_checkpoint.mode selective",
+                    "--activation_checkpoint.selective_ac_option op",
+                ],
+            ],
+            "1D with selective op AC",
+            "1d_sac_op",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--activation_checkpoint.mode full",
+                ],
+            ],
+            "1D with full AC",
+            "1d_full_ac",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "2D",
+            "2d",
+        ),
+        # TODO: re-enable this test once the async TP issue is fixed
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.tensor_parallel_degree 2",
+        #             "--parallelism.enable_async_tensor_parallel",
+        #         ],
+        #     ],
+        #     "2D async TP",
+        #     "2d_asynctp",
+        # ),
+        # TODO: Adds back after DCP is supported by SimpleFSDP
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #         ],
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--training.steps 20",
+        #         ],
+        #     ],
+        #     "Checkpoint Integration Test - Save Load Full Checkpoint",
+        #     "full_checkpoint",
+        # ),
+        OverrideDefinitions(
+            [
+                [
+                    "--checkpoint.enable_checkpoint",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+                [
+                    "--training.steps 20",
+                    "--checkpoint.enable_checkpoint",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "PP+DP+TP 3D test with save/load resume ckpt",
+            "pp_dp_tp",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--parallelism.data_parallel_shard_degree=1",
+                    "--parallelism.data_parallel_replicate_degree=4",
+                ]
+            ],
+            "DDP",
+            "ddp",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=2",
+                ]
+            ],
+            "HSDP",
+            "hsdp",
+            ngpu=4,
+        ),
+        # TODO: Adds back after HSDP+TP & DDP+TP is supported by SimpleFSDP
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.data_parallel_shard_degree=2",
+        #             "--parallelism.data_parallel_replicate_degree=2",
+        #             "--parallelism.tensor_parallel_degree=2",
+        #         ]
+        #     ],
+        #     "HSDP+TP",
+        #     "hsdp+tp",
+        #     ngpu=8,
+        # ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.data_parallel_replicate_degree=2",
+        #             "--parallelism.tensor_parallel_degree=2",
+        #         ]
+        #     ],
+        #     "DDP+TP",
+        #     "ddp+tp",
+        #     ngpu=4,
+        # ),
+        OverrideDefinitions(
+            [
+                [
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=2",
+                    "--parallelism.context_parallel_degree=2",
+                ]
+            ],
+            "HSDP+CP (with dp_shard)",
+            "hsdp+cp_with_dp_shard",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.tensor_parallel_degree=2",
+                    "--parallelism.context_parallel_degree=2",
+                ]
+            ],
+            "FSDP+TP+CP",
+            "fsdp+tp+cp",
+            ngpu=8,
+        ),
+        # TODO: Adds back after DCP is supported by SimpleFSDP
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--training.steps 10",
+        #         ],
+        #         # Save at [dp:4] and load at [dp:2, tp:2]. Note that the dataloader should be
+        #         # excluded during loading to avoid errors caused by mismatched dp_degree.
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--checkpoint.exclude_from_loading lr_scheduler,dataloader,optimizer",
+        #             "--parallelism.tensor_parallel_degree 2",
+        #             "--training.steps 20",
+        #         ],
+        #         # load at [tp:4].
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--checkpoint.exclude_from_loading lr_scheduler,dataloader,optimizer",
+        #             "--parallelism.tensor_parallel_degree 4",
+        #             "--training.steps 30",
+        #         ],
+        #     ],
+        #     "Optional checkpoint",
+        #     "optional_checkpoint",
+        #     ngpu=4,
+        # ),
+    ]
+    return integration_tests_flavors
+
+
+def _run_cmd(cmd):
+    return subprocess.run([cmd], text=True, shell=True)
+
+
+def run_test(test_flavor: OverrideDefinitions, full_path: str, output_dir: str):
+    # run_test supports sequence of tests.
+    test_name = test_flavor.test_name
+    dump_folder_arg = f"--job.dump_folder {output_dir}/{test_name}"
+    all_ranks = ",".join(map(str, range(test_flavor.ngpu)))
+
+    for idx, override_arg in enumerate(test_flavor.override_args):
+        cmd = (
+            f"CONFIG_FILE={full_path} NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} ./run_train.sh "
+            f"--model.name llama3_simple_fsdp --training.compile "
+        )
+        # dump compile trace for debugging purpose
+        cmd = f'TORCH_TRACE="{output_dir}/{test_name}/compile_trace" ' + cmd
+        cmd += " " + dump_folder_arg
+        if override_arg:
+            cmd += " " + " ".join(override_arg)
+        logger.info(
+            f"=====Integration test, flavor : {test_flavor.test_descr}, command : {cmd}====="
+        )
+
+        result = _run_cmd(cmd)
+        logger.info(result.stdout)
+        if result.returncode != 0:
+            raise Exception(
+                f"Integration test failed, flavor : {test_flavor.test_descr}, command : {cmd}"
+            )
+
+
+def run_tests(args):
+    integration_tests_flavors = build_test_list()
+    for config_file in os.listdir(args.config_dir):
+        if config_file.endswith(".toml"):
+            full_path = os.path.join(args.config_dir, config_file)
+            with open(full_path, "rb") as f:
+                config = tomllib.load(f)
+                is_integration_test = config["job"].get(
+                    "use_for_integration_test", False
+                )
+                if is_integration_test:
+                    for test_flavor in integration_tests_flavors[config_file]:
+                        if args.test == "all" or test_flavor.test_name == args.test:
+                            if args.ngpu < test_flavor.ngpu:
+                                logger.info(
+                                    f"Skipping test {test_flavor.test_name} that requires {test_flavor.ngpu} gpus,"
+                                    f" because --ngpu arg is {args.ngpu}"
+                                )
+                            else:
+                                run_test(test_flavor, full_path, args.output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir")
+    parser.add_argument(
+        "--config_dir", default="./torchtitan/models/llama3/train_configs"
+    )
+    parser.add_argument(
+        "--test",
+        default="all",
+        help="test to run, acceptable values: `test_name` in `build_test_list` (default: all)",
+    )
+    parser.add_argument("--ngpu", default=8, type=int)
+    args = parser.parse_args()
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+    if os.listdir(args.output_dir):
+        raise RuntimeError("Please provide an empty output directory.")
+    run_tests(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds CI for SimpleFSDP. It mainly adopted FSDP-related integration tests from this file: https://github.com/pytorch/torchtitan/blob/main/tests/integration_tests.py

A few things to list here:

- Currently, DDP/HSDP + TP (SimpleFSDP's `replicate` and `hybrid_shard` mode) is not supported. I'll add support for them in follow-up PRs.

- DCP + SimpleFSDP failed in `test_generate` test on my end. The output seems to indicate some of the model weights are not correctly checkpointed when resharding from [dp:4] -> [tp:4]. [dp:4] -> [dp:2, tp:2] works out.

```
[rank2]:   File "/home/ruisi/pytorch/torch/distributed/checkpoint/default_planner.py", line 471, in create_default_local_load_plan
[rank2]:     raise RuntimeError(f"Missing key in checkpoint state_dict: {fqn}.")
[rank2]: RuntimeError: Missing key in checkpoint state_dict: model.tok_embeddings.weight.
```