### PR TITLE
Support gradient accumulation

### DIFF
--- a/docs/converging.md
+++ b/docs/converging.md
@@ -12,7 +12,7 @@ This note clarifies the recommended practices to follow when testing the loss co
 
 ## Guidelines
 
-To validate the correctness of a distributed training technique, one should try to **keep the determinism in the input data to minimize the differences it could cause**. To make sure the global batch size and in general #tokens per iteration stay the same, one can fix the local batch size (`training.batch_size`) in the toml config, and at the same time fix the data parallel degree.
+To validate the correctness of a distributed training technique, one should try to **keep the determinism in the input data to minimize the differences it could cause**. To make sure the global batch size and in general #tokens per iteration stay the same, one can fix the local batch size (`training.local_batch_size`) in the toml config, and at the same time fix the data parallel degree.
 
 If the technique is a parallelism (TP/PP/CP/etc)
 - The control set is a 1D FSDP job on `dp` GPUs (or any other verified setups), with a trusted training config (e.g. those under train_configs).
@@ -40,7 +40,7 @@ Results are obtained on 2025/01/21, with the latest `torch`, `torchao`, and `tor
 
 ### Setup
 - Base config: [torchtitan/models/llama3/train_configs/llama3_8b.toml](../torchtitan/models/llama3/train_configs/llama3_8b.toml)
-- `training.batch_size = 4`, which is a minimum for Pipeline Parallel with `pipeline_parallel_degree = 2` and `pipeline_parallel_schedule = "Interleaved1F1B"`
+- `training.local_batch_size = 4`, which is a minimum for Pipeline Parallel with `pipeline_parallel_degree = 2` and `pipeline_parallel_schedule = "Interleaved1F1B"`
 - `training.data_parallel_shard_degree = 8`, resulting in global batch size 32
 - `training.steps = 3000`, `lr_scheduler.warmup_steps = 600`
 

--- a/scripts/estimate/estimation.py
+++ b/scripts/estimate/estimation.py
@@ -130,13 +130,13 @@ def estimate_memory(job_config: JobConfig):
             torch.randint(
                 0,
                 model_args.vocab_size,
-                (job_config.training.batch_size, model_args.max_seq_len),
+                (job_config.training.local_batch_size, model_args.max_seq_len),
                 device="cuda",
             ),
             torch.randint(
                 0,
                 model_args.vocab_size,
-                (job_config.training.batch_size, model_args.max_seq_len),
+                (job_config.training.local_batch_size, model_args.max_seq_len),
                 device="cuda",
             ),
         )

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -494,6 +494,20 @@ def build_test_list():
             "Float8 emulation test",
             "float8_emulation",
         ),
+        OverrideDefinitions(
+            [
+                [
+                    # Default local batch size = 8, and `ngpu=2`, so
+                    # default global batch size = 8 * 2 = 16.
+                    # To achieve 2 gradient accumulation steps, multiply
+                    # default global batch size by 2. 16 * 2 = 32.
+                    "--training.global_batch_size 32",
+                ],
+            ],
+            "Gradient accumulation",
+            "gradient_accumulation",
+            ngpu=2,
+        ),
     ]
     return integration_tests_flavors
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -497,10 +497,11 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    # Default local batch size = 8, and `ngpu=2`, so
-                    # default global batch size = 8 * 2 = 16.
+                    # Local batch size = 8, and `ngpu=2`, so default
+                    # global batch size = 8 * 2 = 16.
                     # To achieve 2 gradient accumulation steps, multiply
                     # default global batch size by 2. 16 * 2 = 32.
+                    "--training.local_batch_size 8",
                     "--training.global_batch_size 32",
                 ],
             ],

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -64,7 +64,7 @@ class TestDatasetCheckpointing(unittest.TestCase):
             [
                 "--training.dataset",
                 dataset_name,
-                "--training.batch_size",
+                "--training.local_batch_size",
                 str(batch_size),
                 "--training.seq_len",
                 str(seq_len),

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -17,6 +17,12 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from torchtitan.tools.logging import logger
 
 
+class DataloaderStopIteration(StopIteration):
+    """An exception that indicates dataloader exhaustion."""
+
+    pass
+
+
 class BaseDataLoader(Stateful, ABC):
     """Base class for all dataloaders.
 

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import functools
 from typing import Callable, TypeAlias
 
 import torch
@@ -27,3 +28,12 @@ def build_cross_entropy_loss(job_config: JobConfig):
         logger.info("Compiling the loss function with torch.compile")
         loss_fn = torch.compile(loss_fn)
     return loss_fn
+
+
+def rescale_accumulated_loss(unwrapped_loss_fn, accumulation_steps):
+    @functools.wraps(unwrapped_loss_fn)
+    def accumulated_loss_fn(*args, **kwargs):
+        loss = unwrapped_loss_fn(*args, **kwargs)
+        return loss / accumulation_steps
+
+    return accumulated_loss_fn

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -31,6 +31,10 @@ def build_cross_entropy_loss(job_config: JobConfig):
 
 
 def rescale_accumulated_loss(unwrapped_loss_fn, accumulation_steps):
+    """Add a mean reduction over `accumulation_steps` to the given
+    `unwrapped_loss_fn`.
+    """
+
     @functools.wraps(unwrapped_loss_fn)
     def accumulated_loss_fn(*args, **kwargs):
         loss = unwrapped_loss_fn(*args, **kwargs)

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -308,7 +308,6 @@ class MetricsProcessor:
     gpu_peak_flops: int
     ntokens_since_last_log: int
     data_loading_times: list[float]
-    accumulated_losses: list[torch.Tensor]
     time_last_log: float
 
     num_flops_per_token: int
@@ -337,7 +336,6 @@ class MetricsProcessor:
         )
         self.ntokens_since_last_log = 0
         self.data_loading_times = []
-        self.accumulated_losses = []
         self.time_last_log = time.perf_counter()
         self.device_memory_monitor.reset_peak_stats()
 

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -308,6 +308,7 @@ class MetricsProcessor:
     gpu_peak_flops: int
     ntokens_since_last_log: int
     data_loading_times: list[float]
+    accumulated_losses: list[torch.Tensor]
     time_last_log: float
 
     num_flops_per_token: int
@@ -336,6 +337,7 @@ class MetricsProcessor:
         )
         self.ntokens_since_last_log = 0
         self.data_loading_times = []
+        self.accumulated_losses = []
         self.time_last_log = time.perf_counter()
         self.device_memory_monitor.reset_peak_stats()
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -192,6 +192,11 @@ class Training:
     batch_size: int = 8
     """Batch size"""
 
+    global_batch_size: int | None = None
+    """
+    Global batch size (defaults to `training.batch_size * data-parallel degree`)
+    """
+
     seq_len: int = 2048
     """Sequence length"""
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -189,12 +189,12 @@ class Training:
     loaded from this path instead of downloaded.
     """
 
-    batch_size: int = 8
-    """Batch size"""
+    local_batch_size: int = 8
+    """Local batch size (i.e., per-device batch size)"""
 
     global_batch_size: int = -1
     """
-    Global batch size (defaults to `training.batch_size * data-parallel degree`)
+    Global batch size (defaults to `training.local_batch_size * data-parallel degree`)
     """
 
     seq_len: int = 2048
@@ -338,7 +338,7 @@ class Parallelism:
     pipeline_parallel_microbatch_size: int = 1
     """
     The size of each pipeline parallel microbatch (default 1).
-    This value is used to compute the total number of microbatches by dividing batch_size with
+    This value is used to compute the total number of microbatches by dividing local batch_size with
     pipeline_parallel_microbatch_size.
     The global training batch size must be evenly divisible by pipeline_parallel_microbatch_size.
     """

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -192,7 +192,7 @@ class Training:
     batch_size: int = 8
     """Batch size"""
 
-    global_batch_size: int | None = None
+    global_batch_size: int = -1
     """
     Global batch size (defaults to `training.batch_size * data-parallel degree`)
     """

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -338,7 +338,7 @@ class Parallelism:
     pipeline_parallel_microbatch_size: int = 1
     """
     The size of each pipeline parallel microbatch (default 1).
-    This value is used to compute the total number of microbatches by dividing local batch_size with
+    This value is used to compute the total number of microbatches by dividing local_batch_size with
     pipeline_parallel_microbatch_size.
     The global training batch size must be evenly divisible by pipeline_parallel_microbatch_size.
     """

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -174,7 +174,7 @@ def build_hf_dataloader(
     """Build a data loader for HuggingFace datasets."""
     dataset_name = job_config.training.dataset
     dataset_path = job_config.training.dataset_path
-    batch_size = job_config.training.batch_size
+    batch_size = job_config.training.local_batch_size
     seq_len = job_config.training.seq_len
 
     hf_ds = HuggingFaceDataset(

--- a/torchtitan/distributed/pipeline.py
+++ b/torchtitan/distributed/pipeline.py
@@ -150,11 +150,11 @@ def build_pipeline_schedule(
 
     looped_schedule = issubclass(schedule_class, PipelineScheduleMulti)
     microbatch_size = job_config.parallelism.pipeline_parallel_microbatch_size
-    batch_size = job_config.training.batch_size
+    batch_size = job_config.training.local_batch_size
     # validate that the batch size is divisible by the microbatch_size otherwise we'll hang or error during training
     if batch_size % microbatch_size != 0:
         raise ValueError(
-            f"Batch size {job_config.training.batch_size} must be divisible by number of microbatches {n_microbatches}. "
+            f"Batch size {job_config.training.local_batch_size} must be divisible by number of microbatches {n_microbatches}. "
             "Update the config arguments for either batch_size or pipeline_parallel_microbatch_size."
         )
     n_microbatches = batch_size // microbatch_size

--- a/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
+++ b/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
@@ -38,7 +38,7 @@ decay_type = "linear"
 lr_min = 0.1
 
 [training]
-batch_size = 2 # 8
+local_batch_size = 2 # 8
 seq_len = 1024 # 2048
 max_norm = 1.0  # grad norm clipping
 steps = 200

--- a/torchtitan/experiments/deepseek_v3/train_ds_real.py
+++ b/torchtitan/experiments/deepseek_v3/train_ds_real.py
@@ -145,7 +145,7 @@ def run_full_model(
     # model.setup_symm_mem(torch.bfloat16, device)
 
     torch.manual_seed(ep_rank)
-    bs = config.training.batch_size  # * microbatches  # 4
+    bs = config.training.local_batch_size  # * microbatches  # 4
     seqlen = config.training.seq_len  # 128
 
     # metrics manager

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -278,7 +278,7 @@ def build_flux_dataloader(
     """Build a data loader for HuggingFace datasets."""
     dataset_name = job_config.training.dataset
     dataset_path = job_config.training.dataset_path
-    batch_size = job_config.training.batch_size
+    batch_size = job_config.training.local_batch_size
 
     t5_tokenizer, clip_tokenizer = build_flux_tokenizer(job_config)
 

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -40,7 +40,7 @@ class TestFluxDataLoader:
                 str(256),
                 "--training.dataset",
                 dataset_name,
-                "--training.batch_size",
+                "--training.local_batch_size",
                 str(batch_size),
                 "--training.seed",
                 "0",

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Optional
+from typing import Iterable, Optional
 
 import torch
 from torch.distributed.fsdp import FSDPModule
@@ -81,7 +81,10 @@ class FluxTrainer(Trainer):
             job_config=job_config,
         )
 
-    def train_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
+    def train_step(
+        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
+    ):
+        input_dict, labels = self.next_batch(data_iterator)
         # generate t5 and clip embeddings
         input_dict["image"] = labels
         input_dict = preprocess_data(

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -149,7 +149,7 @@ class FluxTrainer(Trainer):
     def train_step(
         self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
-        input_dict, labels = self.next_batch(data_iterator)
+        input_dict, labels = next(data_iterator)
 
         self.optimizers.zero_grad()
 

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -83,7 +83,7 @@ class FluxTrainer(Trainer):
 
     def forward_backward_step(
         self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
-    ):
+    ) -> torch.Tensor:
         # generate t5 and clip embeddings
         input_dict["image"] = labels
         input_dict = preprocess_data(

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -33,7 +33,7 @@ warmup_steps = 1  # 10% warmup steps
 decay_ratio = 0.0  # no decay, stay stable during training
 
 [training]
-batch_size = 4
+local_batch_size = 4
 max_norm = 2.0  # grad norm clipping
 steps = 10
 compile = false

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -32,7 +32,7 @@ warmup_steps = 3_000  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.0  # no decay
 
 [training]
-batch_size = 32
+local_batch_size = 32
 max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -32,7 +32,7 @@ warmup_steps = 3_000  # lr scheduler warm up, normally 20% of the train steps
 decay_ratio = 0.0  # no decay
 
 [training]
-batch_size = 64
+local_batch_size = 64
 max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -37,7 +37,7 @@ decay_type = "linear"
 lr_min = 0.1
 
 [training]
-batch_size = 8
+local_batch_size = 8
 seq_len = 2048
 max_norm = 1.0  # grad norm clipping
 steps = 10

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
@@ -30,7 +30,7 @@ warmup_steps = 600
 lr_min = 0.1
 
 [training]
-batch_size = 1
+local_batch_size = 1
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 3000

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
@@ -30,7 +30,7 @@ warmup_steps = 600
 lr_min = 0.1
 
 [training]
-batch_size = 8
+local_batch_size = 8
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 3000

--- a/torchtitan/experiments/multimodal/check_padding_mm.py
+++ b/torchtitan/experiments/multimodal/check_padding_mm.py
@@ -35,7 +35,7 @@ def main(
         [
             "--training.dataset",
             dataset,
-            "--training.batch_size",
+            "--training.local_batch_size",
             str(batch_size),
             "--training.seq_len",
             str(seq_len),

--- a/torchtitan/experiments/multimodal/mm_dataset.py
+++ b/torchtitan/experiments/multimodal/mm_dataset.py
@@ -240,7 +240,7 @@ def build_mm_dataloader(
     """Build a data loader for HuggingFace datasets."""
     dataset_name = job_config.training.dataset
     dataset_path = job_config.training.dataset_path
-    batch_size = job_config.training.batch_size
+    batch_size = job_config.training.local_batch_size
     seq_len = job_config.training.seq_len
     pad_max_tiles = 4  # TODO(tj.solergibert) Add `pad_max_tiles` to JobConfig
     padding_idx = 128004  # TODO(tj.solergibert) Add `padding_idx` to JobConfig

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -39,7 +39,7 @@ decay_type = "linear"
 lr_min = 0.0
 
 [training]
-batch_size = 8
+local_batch_size = 8
 seq_len = 2048
 max_norm = 1.0  # grad norm clipping
 steps = 10

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -30,7 +30,7 @@ eps = 1e-8
 warmup_steps = 600  # lr scheduler warm up, normally 20% of the train steps
 
 [training]
-batch_size = 2
+local_batch_size = 2
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 3000

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -30,7 +30,7 @@ eps = 1e-8
 warmup_steps = 200  # lr scheduler warm up, normally 20% of the train steps
 
 [training]
-batch_size = 8
+local_batch_size = 8
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 1000

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -30,7 +30,7 @@ eps = 1e-8
 warmup_steps = 200  # lr scheduler warm up
 
 [training]
-batch_size = 1
+local_batch_size = 1
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 1000

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -44,6 +44,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     parallel_dims: ParallelDims
     train_spec: train_spec_module.TrainSpec
     world_mesh: torch.distributed.DeviceMesh
+    gradient_accumulation_steps: int
 
     dataloader: train_spec_module.BaseDataLoader
     metrics_processor: train_spec_module.MetricsProcessor

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -364,7 +364,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             raise DataloaderStopIteration() from ex
         return input_dict, labels
 
-    def batch_backward(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
+    def forward_backward_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
         model_parts = self.model_parts
         world_mesh = self.world_mesh
         parallel_dims = self.parallel_dims
@@ -428,7 +428,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         for microbatch in range(self.gradient_accumulation_steps):
             input_dict, labels = self.next_batch(data_iterator)
-            loss = self.batch_backward(input_dict, labels)
+            loss = self.forward_backward_step(input_dict, labels)
             self.metrics_processor.accumulated_losses.append(loss.detach())
 
         dist_utils.clip_grad_norm_(

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -127,21 +127,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         # verify batch sizes
         if job_config.training.global_batch_size < 0:
             job_config.training.global_batch_size = (
-                job_config.training.batch_size * dp_degree
+                job_config.training.local_batch_size * dp_degree
             )
         assert job_config.training.global_batch_size > 0
         assert (
             job_config.training.global_batch_size
-            % (job_config.training.batch_size * dp_degree)
+            % (job_config.training.local_batch_size * dp_degree)
             == 0
         ), (
             f"global batch size must be multiple of local batch size times "
             f"data-parallel degree ({job_config.training.global_batch_size} "
-            f"% ({job_config.training.batch_size} * {dp_degree}) != 0)"
+            f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
         )
 
         self.gradient_accumulation_steps = job_config.training.global_batch_size // (
-            job_config.training.batch_size * dp_degree
+            job_config.training.local_batch_size * dp_degree
         )
         assert self.gradient_accumulation_steps > 0
 
@@ -323,7 +323,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         logger.info(
             "Trainer is initialized with "
-            f"local batch size {job_config.training.batch_size}, "
+            f"local batch size {job_config.training.local_batch_size}, "
             f"global batch size {job_config.training.global_batch_size}, "
             f"gradient accumulation steps {self.gradient_accumulation_steps}, "
             f"sequence length {job_config.training.seq_len}, "

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -34,6 +34,7 @@ from torchtitan.tools.profiling import (
 
 class DataloaderStopIteration(StopIteration):
     """An exception that indicates dataloader exhaustion."""
+
     pass
 
 
@@ -198,7 +199,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # step.
             global_batch_size = job_config.training.local_batch_size * dp_degree
         assert global_batch_size > 0
-        assert global_batch_size % (job_config.training.local_batch_size * dp_degree) == 0, (
+        assert (
+            global_batch_size % (job_config.training.local_batch_size * dp_degree) == 0
+        ), (
             f"global batch size must be multiple of local batch size times "
             f"data-parallel degree ({global_batch_size} "
             f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
@@ -359,7 +362,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             raise DataloaderStopIteration() from ex
         return input_dict, labels
 
-    def forward_backward_step(self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor):
+    def forward_backward_step(
+        self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
+    ):
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
 
@@ -412,7 +417,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         return loss
 
-    def train_step(self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]):
+    def train_step(
+        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
+    ):
         self.optimizers.zero_grad()
 
         # Keep these variables local to shorten the code as these are
@@ -493,7 +500,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 except DataloaderStopIteration:
                     logger.info("Ran out of data; last step was canceled.")
                     break
-                self.checkpointer.save(self.step, force=(self.step == job_config.training.steps))
+                self.checkpointer.save(
+                    self.step, force=(self.step == job_config.training.steps)
+                )
 
                 # signal the profiler that the next profiling step has started
                 if torch_profiler:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -406,6 +406,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 # need to free to before bwd to avoid peaking memory
                 del pred
                 loss.backward()
+
         return loss
 
     def train_step(self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]):

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -359,7 +359,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
     def forward_backward_step(
         self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
-    ):
+    ) -> torch.Tensor:
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -125,22 +125,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.train_spec = train_spec_module.get_train_spec(job_config.model.name)
 
         # verify batch sizes
-        if job_config.training.global_batch_size < 0:
-            job_config.training.global_batch_size = (
-                job_config.training.local_batch_size * dp_degree
-            )
-        assert job_config.training.global_batch_size > 0
-        assert (
-            job_config.training.global_batch_size
-            % (job_config.training.local_batch_size * dp_degree)
-            == 0
-        ), (
+        global_batch_size = job_config.training.global_batch_size
+        if global_batch_size < 0:
+            global_batch_size = job_config.training.local_batch_size * dp_degree
+        assert global_batch_size > 0
+        assert global_batch_size % (job_config.training.local_batch_size * dp_degree) == 0, (
             f"global batch size must be multiple of local batch size times "
-            f"data-parallel degree ({job_config.training.global_batch_size} "
+            f"data-parallel degree ({global_batch_size} "
             f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
         )
 
-        self.gradient_accumulation_steps = job_config.training.global_batch_size // (
+        self.gradient_accumulation_steps = global_batch_size // (
             job_config.training.local_batch_size * dp_degree
         )
         assert self.gradient_accumulation_steps > 0
@@ -318,7 +313,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         logger.info(
             "Trainer is initialized with "
             f"local batch size {job_config.training.local_batch_size}, "
-            f"global batch size {job_config.training.global_batch_size}, "
+            f"global batch size {global_batch_size}, "
             f"gradient accumulation steps {self.gradient_accumulation_steps}, "
             f"sequence length {job_config.training.seq_len}, "
             f"total steps {job_config.training.steps} "

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -494,14 +494,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 self.gc_handler.run(self.step)
                 data_ran_out = self.train_step(data_iterator)
                 if data_ran_out:
-                    logger.info(
-                        "Ran out of data; last step was canceled. "
-                        "Saving final checkpoint and exiting."
-                    )
-                self.checkpointer.save(
-                    self.step,
-                    force=(self.step == job_config.training.steps or data_ran_out),
-                )
+                    logger.info("Ran out of data; last step was canceled.")
+                    break
+                self.checkpointer.save(self.step, force=(self.step == job_config.training.steps))
 
                 # signal the profiler that the next profiling step has started
                 if torch_profiler:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -16,6 +16,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 import torchtitan.components.ft as ft
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.dataloader import DataloaderStopIteration
 from torchtitan.components.loss import rescale_accumulated_loss
 from torchtitan.components.metrics import (
     build_metrics_processor,
@@ -30,12 +31,6 @@ from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
 )
-
-
-class DataloaderStopIteration(StopIteration):
-    """An exception that indicates dataloader exhaustion."""
-
-    pass
 
 
 class Trainer(torch.distributed.checkpoint.stateful.Stateful):

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -493,7 +493,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 try:
                     self.train_step(data_iterator)
                 except DataloaderStopIteration:
-                    logger.info("Ran out of data; last step was canceled.")
+                    logger.warning("Ran out of data; last step was canceled.")
                     break
                 self.checkpointer.save(
                     self.step, force=(self.step == job_config.training.steps)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -127,6 +127,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         # verify batch sizes
         global_batch_size = job_config.training.global_batch_size
         if global_batch_size < 0:
+            # This global batch size results in 1 gradient accumulation
+            # step.
             global_batch_size = job_config.training.local_batch_size * dp_degree
         assert global_batch_size > 0
         assert global_batch_size % (job_config.training.local_batch_size * dp_degree) == 0, (

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -120,7 +120,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.train_spec = train_spec_module.get_train_spec(job_config.model.name)
 
         # verify batch sizes
-        if job_config.training.global_batch_size is None:
+        if job_config.training.global_batch_size < 0:
             job_config.training.global_batch_size = (
                 job_config.training.batch_size * dp_degree
             )


### PR DESCRIPTION
First, the batched backward calculation is refactored into its own function. Then, gradient accumulation is implemented by moving the data iterator inside the `train_step` method and consuming data from it as necessary. I added some extra handling for non-infinite data iterators, but if you dislike that additional complexity, I can remove it to simplify the code.

The feature is enabled by giving an additional `--training.global_batch_size`, which has a sensible default of 1 gradient accumulation step (i.e., no actual accumulation).

@tianyu-l thanks for the ping.