### PR TITLE
Correct CI test name

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -382,7 +382,7 @@ def build_test_list():
                     "--parallelism.context_parallel_degree=2",
                 ]
             ],
-            "HSDP+CP (with dp_shard)",
+            "HSDP+CP (without dp_shard)",
             "hsdp+cp_without_dp_shard",
             ngpu=4,
         ),
@@ -394,7 +394,7 @@ def build_test_list():
                     "--parallelism.context_parallel_degree=2",
                 ]
             ],
-            "HSDP+CP (without dp_shard)",
+            "HSDP+CP (with dp_shard)",
             "hsdp+cp_with_dp_shard",
             ngpu=8,
         ),


### PR DESCRIPTION
As titled, this PR fixes the incorrect test name in CI testing per this previous discussion: https://github.com/pytorch/torchtitan/pull/1231#discussion_r2114360445