### PR TITLE
[Extensions] ensure extension default values from extension toml are used, not base class 

### DIFF
--- a/tests/unit_tests/test_job_config.py
+++ b/tests/unit_tests/test_job_config.py
@@ -281,6 +281,7 @@ class TestJobConfig(unittest.TestCase):
                 ]
             )
             assert config.custom_args.how_is_your_day == "bad"
+            assert config.training.my_custom_steps == 32
             assert config.model.converters == ["float8", "mxfp"]
             result = config.to_dict()
             assert isinstance(result, dict)

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -710,6 +710,10 @@ class ConfigManager:
                 m_type = ConfigManager._merge_configs(f.type, c_map[name].type)
 
                 # Create a default factory that preserves custom defaults
+                # We do this by using a closure to capture both the merged type and custom fields,
+                # ensuring the custom defaults are preserved when creating instances of the merged type.
+                # Previously, we were using a default_factory that would create an instance of the merged type,
+                # but this would not preserve the custom defaults as it would use base class defaults.
                 def make_factory(m_type, c_field):
                     def factory():
                         # Initialize with custom defaults first


### PR DESCRIPTION
This PR:
Ensures that JobConfig extension values are included in the final merged JobConfig, rather than just the custom fields and their values all (incorrectly) set to zero. 
Fix has gone from closure to a one line adjustment (credit @tianyu-l )
Unit testing has been increased to verify and catch any future breaks like this (credit @jaysonfrancis )

Testing - verified all unit tests passing (with added assert for custom field update) and expert parallel extension use case working. 
Example:
~~~
@dataclass
class Parallelism:
    expert_parallel_degree: int = 2
    """ degree to parallelize experts """
~~~
results in 
~~~
parallelism=MergedParallelism(... expert_parallel_degree=0)
~~~
 which is not what is desired. 
 
 With PR:
 ~~~
parallelism=MergedParallelism(... expert_parallel_degree=2)
~~~
    