### PR TITLE
[deepseek] remove unset root logger from HF AutoTokenizer to avoid dupe logging

### DIFF
--- a/torchtitan/experiments/deepseek_v3/tokenizers/hf_tokenizer.py
+++ b/torchtitan/experiments/deepseek_v3/tokenizers/hf_tokenizer.py
@@ -4,8 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 from torchtitan.tools.logging import logger
 from transformers import AutoTokenizer
+
+
+# HF AutoTokenizer will instantiate a root level logger, which will cause
+# duplicate logs. We need to disable their root logger to avoid this.
+def remove_notset_root_handlers():
+    """
+    Remove handlers with level NOTSET from root logger.
+    Titan's logger is set, and thus we can differentiate between these.
+    """
+    for handler in logger.handlers[:]:
+        if handler.level == logging.NOTSET:
+            logger.removeHandler(handler)
 
 
 class TokenizerWrapper:

--- a/torchtitan/experiments/deepseek_v3/train_ds_real.py
+++ b/torchtitan/experiments/deepseek_v3/train_ds_real.py
@@ -37,7 +37,10 @@ from torchtitan.experiments.deepseek_v3.infra.parallelize_deepseek import (
 
 from torchtitan.experiments.deepseek_v3.model_config import deepseek_config_registry
 
-from torchtitan.experiments.deepseek_v3.tokenizers.hf_tokenizer import get_hf_tokenizer
+from torchtitan.experiments.deepseek_v3.tokenizers.hf_tokenizer import (
+    get_hf_tokenizer,
+    remove_notset_root_handlers,
+)
 
 # from torchtitan.experiments.deepseek_v3.train_configs.custom_args import JobConfig
 from torchtitan.tools import utils
@@ -239,6 +242,10 @@ if __name__ == "__main__":
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
     init_logger()
+    # we do this to remove a root logger that is added by HF
+    # otherwise we get duplicate logs
+    remove_notset_root_handlers()
+
     config_manager = ConfigManager()
     config = config_manager.parse_args()
 


### PR DESCRIPTION
This PR adds an additional function in the hf_tokenizer file, remove_notset_root_handlers. 
This eliminates the duplicate logging that otherwise happens when importing HF's AutoTokenizer and avoids touching the titan.logging code per my earlier PR.  

without PR - when running ds, we can see two root level loggers are present (vs only one is present if you run from titan main which does not use HF tokenizers):
~~~
 ROOT LOGGER HANDLERS
[rank0]:------------------------------
[rank0]:Handler 1:
[rank0]:    Type: StreamHandler
[rank0]:    Level: NOTSET (0)
[rank0]:    Stream: <stderr>
[rank0]:    Formatter:
[rank0]:      Format: %(levelname)s:%(name)s:%(message)s
[rank0]:      Date Format: None
[rank0]:      Style: <logging.PercentStyle object at 0x7fca6eaabdd0>
[rank0]:    Filters: None
[rank0]:
[rank0]:Handler 2:
[rank0]:    Type: StreamHandler
[rank0]:    Level: INFO (20)
[rank0]:    Stream: <stderr>
[rank0]:    Formatter:
[rank0]:      Format: [titan] %(asctime)s - %(name)s - %(levelname)s - %(message)s
[rank0]:      Date Format: None
[rank0]:      Style: <logging.PercentStyle object at 0x7fcdaa087d10>
[rank0]:    Filters: None
~~~

which yields duplicate logging as shown below:
<img width="1142" alt="Screenshot 2025-05-30 at 4 53 59 PM" src="https://github.com/user-attachments/assets/2324b683-d647-4232-9a37-193985dc389f" />


With PR, we are back to only titan filtered logging and no duplication:

<img width="1142" alt="Screenshot 2025-05-30 at 4 58 31 PM" src="https://github.com/user-attachments/assets/9222ce3d-2aac-450a-8207-789b705949be" />

