### PR TITLE
[FSDP2] fully_shard(reshard_after_forward=False) for root

### DIFF
--- a/torchtitan/models/llama3/parallelize_llama.py
+++ b/torchtitan/models/llama3/parallelize_llama.py
@@ -364,7 +364,9 @@ def apply_fsdp(
             **fsdp_config,
             reshard_after_forward=reshard_after_forward,
         )
-    fully_shard(model, **fsdp_config, reshard_after_forward=not pp_enabled)
+    # keep root unsharded since its parameters will be
+    # used in the backward immediately
+    fully_shard(model, **fsdp_config, reshard_after_forward=False)
 
 
 def apply_ddp(


### PR DESCRIPTION
for root model, we should always set `reshard_after_forward=False` regardless of pp_enabled, because root model parameters will be used in backward immeidately. no need to reshard and all-gather

this is also a future proof PR for pytorch side change https://github.com/pytorch/pytorch/pull/154704

the code is propagated to NeMo, I will follow up on it as well:https://github.com/NVIDIA/NeMo/blob/373288be4bea04ece4ceb189bc7448a0ca02aa97/nemo/lightning/pytorch/strategies/utils.py#L524C7-L524C66