### PR TITLE
[Flux] Fix broken symbolic link

### DIFF
--- a/torchtitan/experiments/flux/requirements-flux.txt
+++ b/torchtitan/experiments/flux/requirements-flux.txt
@@ -1,1 +1,1 @@
-.ci/docker/requirements-flux.txt
+../../../.ci/docker/requirements-flux.txt


### PR DESCRIPTION
The correct symbolic link should use the relative path regrading current "requirements-flux.txt" file location, not the torchtitan project path