### PR TITLE
fix: clip_grad_norm_ general usage

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -309,6 +309,11 @@ def clip_grad_norm_(
         Total norm of the parameter gradients (viewed as a single vector).
 
     """
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    else:
+        # prevent generators from being exhausted
+        parameters = list(parameters)
     grads = [p.grad for p in parameters if p.grad is not None]
     total_norm = torch.nn.utils.get_total_norm(
         grads, norm_type, error_if_nonfinite, foreach


### PR DESCRIPTION
Small fix which allows `torchtitan`'s `clip_grad_norm_` to be used analogously to `nn.utils.clip_grad_norm_` more generally.

As written, titan's utility will silently fail if a generator of parameters is passed in, as the generator is exhausted and the empty generator is used in `torch.nn.utils.clip_grads_with_norm_` :

```py
from torchtitan.distributed import ParallelDims, utils as dist_utils

# grads are silently left unchanged!
dist_utils.clip_grad_norm_(model.parameters(), 1.0)

#  works as expected 
dist_utils.clip_grad_norm_(list(model.parameters()), 1.0)
```
Torchtitan itself uses something like the second form, so there are no correctness issues. This PR hopefully prevents silent errors for anyone copy/pasting `clip_grad_norm_` and using it like the first call above.