### PR TITLE
[FLUX] independently drop t5 and clip tokens for classifier free guidance 

### DIFF
--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -249,6 +249,7 @@ class FluxDataset(IterableDataset, Stateful):
             if dropout_prob > 0.0:
                 if torch.rand(1).item() < dropout_prob:
                     sample_dict["t5_tokens"] = self._t5_empty_token
+                if torch.rand(1).item() < dropout_prob:
                     sample_dict["clip_tokens"] = self._clip_empty_token
 
             self._sample_idx += 1

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass, field
 @dataclass
 class Training:
     classifer_free_guidance_prob: float = 0.0
-    """Classifier-free guidance with probability `p` to dropout each text encoding independently. 
-    If `n` text encoders are used, the unconditional model is trained in `p ^ n` of all steps. 
+    """Classifier-free guidance with probability `p` to dropout each text encoding independently.
+    If `n` text encoders are used, the unconditional model is trained in `p ^ n` of all steps.
     For example, if `n = 2` and `p = 0.447`, the unconditional model is trained in 20% of all steps"""
     img_size: int = 256
     """Image width to sample"""

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass, field
 @dataclass
 class Training:
     classifer_free_guidance_prob: float = 0.0
-    """Classifier-free guidance with probability p to dropout the text conditioning"""
+    """Classifier-free guidance with probability `p` to dropout each text encoding independently. 
+    If `n` text encoders are used, the unconditional model is trained in `p ^ n` of all steps. 
+    For example, if `n = 2` and `p = 0.447`, the unconditional model is trained in 20% of all steps"""
     img_size: int = 256
     """Image width to sample"""
     test_mode: bool = False

--- a/torchtitan/experiments/flux/tests/test_generate_image.py
+++ b/torchtitan/experiments/flux/tests/test_generate_image.py
@@ -47,7 +47,7 @@ class TestGenerateImage:
                 "--training.seed",
                 "0",
                 "--training.classifer_free_guidance_prob",
-                "0.1",
+                "0.447",
                 "--encoder.t5_encoder",
                 "google/t5-v1_1-base",
                 "--encoder.clip_encoder",

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -45,7 +45,7 @@ class TestFluxDataLoader:
                 "--training.seed",
                 "0",
                 "--training.classifer_free_guidance_prob",
-                "0.1=447",
+                "0.447",
                 "--encoder.t5_encoder",
                 "google/t5-v1_1-small",
                 "--encoder.clip_encoder",

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -45,7 +45,7 @@ class TestFluxDataLoader:
                 "--training.seed",
                 "0",
                 "--training.classifer_free_guidance_prob",
-                "0.1",
+                "0.1=447",
                 "--encoder.t5_encoder",
                 "google/t5-v1_1-small",
                 "--encoder.clip_encoder",

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -38,7 +38,7 @@ max_norm = 2.0  # grad norm clipping
 steps = 10
 compile = false
 dataset = "cc12m-test"
-classifer_free_guidance_prob = 0.1
+classifer_free_guidance_prob = 0.316
 img_size = 256
 
 [encoder]

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -38,7 +38,7 @@ max_norm = 2.0  # grad norm clipping
 steps = 10
 compile = false
 dataset = "cc12m-test"
-classifer_free_guidance_prob = 0.316
+classifer_free_guidance_prob = 0.447
 img_size = 256
 
 [encoder]

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -37,7 +37,7 @@ max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false
 dataset = "cc12m-wds"
-classifer_free_guidance_prob = 0.1
+classifer_free_guidance_prob = 0.316
 img_size = 256
 
 [encoder]

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -37,7 +37,7 @@ max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false
 dataset = "cc12m-wds"
-classifer_free_guidance_prob = 0.316
+classifer_free_guidance_prob = 0.447
 img_size = 256
 
 [encoder]

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -37,7 +37,7 @@ max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false
 dataset = "cc12m-wds"
-classifer_free_guidance_prob = 0.1
+classifer_free_guidance_prob = 0.316
 img_size = 256
 
 [encoder]

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -37,7 +37,7 @@ max_norm = 1.0  # grad norm clipping
 steps = 30_000
 compile = false
 dataset = "cc12m-wds"
-classifer_free_guidance_prob = 0.316
+classifer_free_guidance_prob = 0.447
 img_size = 256
 
 [encoder]


### PR DESCRIPTION
In the SD3 paper, independently drop each tokenzier's result for classifier free guidance in trainnig.
> For unconditional diffusion guidance (Ho & Salimans, 2022), we set the outputs of each of the three text encoders independently to zero with a probability of 46.4%, such that we roughly train an unconditional model in 10% of all steps.

Thanks @tianyu-l  for identifying this issue!