### PR TITLE
Added support to run torchtitan tests on ROCm.

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -12,15 +12,29 @@ shift
 
 echo "Building ${IMAGE_NAME} Docker image"
 
+# set operating system
 OS=ubuntu
-OS_VERSION=20.04
-CLANG_VERSION=""
-PYTHON_VERSION=3.11
-MINICONDA_VERSION=24.3.0-0
+
+# set Dockerfile
+DOCKERFILE="${OS}/Dockerfile"
+if [[ "$IMAGE_NAME" == *cuda* ]]; then
+  DOCKERFILE="${OS}-cuda/Dockerfile"
+elif [[ "$IMAGE_NAME" == *rocm* ]]; then
+  DOCKERFILE="${OS}-rocm/Dockerfile"
+fi
 
 case "${IMAGE_NAME}" in
   torchtitan-ubuntu-20.04-clang12)
+    OS_VERSION=20.04
     CLANG_VERSION=12
+    PYTHON_VERSION=3.11
+    MINICONDA_VERSION=24.3.0-0
+    ;;
+  torchtitan-rocm-pytorch-nightly-ubuntu-22.04-clang19-py3)
+    OS_VERSION=22.04
+    CLANG_VERSION=19
+    PYTHON_VERSION=3.10
+    MINICONDA_VERSION=25.3.1-0
     ;;
   *)
     echo "Invalid image name ${IMAGE_NAME}"
@@ -34,7 +48,7 @@ docker build \
   --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
   --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" \
   --build-arg "MINICONDA_VERSION=${MINICONDA_VERSION}" \
-  --shm-size=1g \
-  -f "${OS}"/Dockerfile \
+  -f $(dirname ${DOCKERFILE})/Dockerfile \
   "$@" \
   .
+

--- a/.ci/docker/ubuntu-cuda/Dockerfile
+++ b/.ci/docker/ubuntu-cuda/Dockerfile
@@ -1,0 +1,41 @@
+ARG OS_VERSION
+
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu${OS_VERSION}
+
+ARG OS_VERSION
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install common dependencies
+COPY ./common/install_base.sh install_base.sh
+RUN bash ./install_base.sh && rm install_base.sh
+
+# Install clang
+ARG CLANG_VERSION
+COPY ./common/install_clang.sh install_clang.sh
+RUN bash ./install_clang.sh && rm install_clang.sh
+
+# Install gcc
+ARG GCC_VERSION
+COPY ./common/install_gcc.sh install_gcc.sh
+RUN bash ./install_gcc.sh && rm install_gcc.sh
+
+# Setup user
+COPY ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+# Install conda and other dependencies
+ARG MINICONDA_VERSION
+ARG PYTHON_VERSION
+ENV PYTHON_VERSION=$PYTHON_VERSION
+ENV PATH /opt/conda/envs/py_$PYTHON_VERSION/bin:/opt/conda/bin:$PATH
+COPY requirements-dev.txt /opt/conda/
+COPY requirements.txt /opt/conda/
+COPY requirements-flux.txt /opt/conda/
+COPY conda-env-ci.txt /opt/conda/
+COPY ./common/install_conda.sh install_conda.sh
+COPY ./common/utils.sh utils.sh
+RUN bash ./install_conda.sh && rm install_conda.sh utils.sh /opt/conda/requirements-dev.txt /opt/conda/requirements.txt /opt/conda/requirements-flux.txt /opt/conda/conda-env-ci.txt
+
+USER ci-user
+CMD ["bash"]

--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -1,0 +1,16 @@
+# base image
+FROM rocm/pytorch-nightly:latest
+
+# args
+ARG OS_VERSION
+ARG CLANG_VERSION
+ARG GCC_VERSION
+ARG MINICONDA_VERSION
+ARG PYTHON_VERSION
+
+# install dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r ./requirements.txt
+
+CMD ["bash"]
+


### PR DESCRIPTION
In this PR, I have added support for running torchtitan tests on ROCm. Once the rocm CI for torchtitan is functional, we can run the torchtitan unit tests on ROCm. The current work in this PR is preliminary and I'll be adding more changes to it. 