### PR TITLE
Fix lr scheduler

### DIFF
--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -140,20 +140,26 @@ def build_lr_schedulers(
 
         If `lr_min` is specified, the decay range is scaled from 1 to `lr_min`
         to ensure the learning rate does not drop below this minimum value.
+
+        NOTE: Since this is called before the step is taken, passing `current_step` returns the lr for the next step.
         """
+
         warmup_stable_steps = warmup_steps + stable_steps
+        if current_step >= warmup_stable_steps + decay_steps:
+            # edge case, this is the lr for the step which would take place after max_steps, which is undefined
+            current_step = warmup_stable_steps + decay_steps
         # if we are in the warmup phase, return the warmup progress
         # if warmup_steps is 0, we will go to the next phase
         if current_step < warmup_steps:
             # linear warmup
-            return float(current_step / warmup_steps)
+            return float((current_step + 1) / (warmup_steps + 1))
 
         # if we are in the stable phase or there is no decay, return 1.0
         if current_step < warmup_stable_steps or decay_steps == 0:
             return 1.0
 
         # if we are in the decay phase, calculate the decay progress
-        progress = float(current_step - warmup_stable_steps) / decay_steps
+        progress = float((current_step + 1) - warmup_stable_steps) / (decay_steps + 1)
 
         if lr_decay_type == "linear":
             curr_adjustment = 1 - progress


### PR DESCRIPTION
Addresses #1213, whose root cause was an arithmetic error in the lr scheduler.

The lr_scheduler adds 1 to the current step, which is not necessary and causes several errors in the lr steps.

Also took the chance to slightly simplify the logic (in my opinion) using early returns, as well as explicitly dealing with the edge case where decay_ratio is 0.

Copying over the reasoning I shared in #1213 

Lets set an example scenario where our lr schedule has warmup_steps of 5 and a target lr of 0.0008.
We would expect the lr to increase in each step by `0.0008/5 = 0.00016`. However, what happens is below:

```
[rank0]:[titan] 2025-06-04 14:42:54,945 - root - INFO - Step 1 lr: 0.00013333333333333334
[rank0]:[titan] 2025-06-04 14:42:54,946 - root - INFO - step:  1  loss:  1.7905  memory: 19.94GiB(42.08%)  tps: 519,779  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:42:54,946 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-06-04 14:42:55,316 - root - INFO - Step 2 lr: 0.0002666666666666667
[rank0]:[titan] 2025-06-04 14:42:55,316 - root - INFO - step:  2  loss:  1.9953  memory: 20.45GiB(43.17%)  tps: 2,121,432  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:42:55,686 - root - INFO - Step 3 lr: 0.0004
[rank0]:[titan] 2025-06-04 14:42:55,686 - root - INFO - step:  3  loss:  1.7081  memory: 20.45GiB(43.17%)  tps: 2,125,984  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:42:56,079 - root - INFO - Step 4 lr: 0.0005333333333333334
[rank0]:[titan] 2025-06-04 14:42:56,079 - root - INFO - step:  4  loss:  1.6267  memory: 20.45GiB(43.17%)  tps: 2,004,664  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:42:56,476 - root - INFO - Step 5 lr: 0.0008
[rank0]:[titan] 2025-06-04 14:42:56,477 - root - INFO - step:  5  loss:  1.5076  memory: 20.45GiB(43.17%)  tps: 1,977,805  tflops: 0.00  mfu: 0.00%
```

This is clearly wrong, as the lr is increasing by 0.00013 except for the last step, which increases by more to make up the difference.

We can easily resolve this by removing the assumptions in the comments `# 0-indexed step, hence + 1 adjustments`.
Making those changes, we get the desired behaviour of:


```
[rank0]:[titan] 2025-06-04 14:46:48,496 - root - INFO - Step 1 lr: 0.00016
[rank0]:[titan] 2025-06-04 14:46:48,497 - root - INFO - step:  1  loss:  1.8309  memory: 19.94GiB(42.08%)  tps: 512,095  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:46:48,497 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-06-04 14:46:48,867 - root - INFO - Step 2 lr: 0.00032
[rank0]:[titan] 2025-06-04 14:46:48,867 - root - INFO - step:  2  loss:  1.9606  memory: 20.45GiB(43.17%)  tps: 2,124,707  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:46:49,233 - root - INFO - Step 3 lr: 0.00048
[rank0]:[titan] 2025-06-04 14:46:49,233 - root - INFO - step:  3  loss:  1.6091  memory: 20.45GiB(43.17%)  tps: 2,147,417  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:46:49,640 - root - INFO - Step 4 lr: 0.00064
[rank0]:[titan] 2025-06-04 14:46:49,641 - root - INFO - step:  4  loss:  1.4623  memory: 20.45GiB(43.17%)  tps: 1,931,065  tflops: 0.00  mfu: 0.00%
[rank0]:[titan] 2025-06-04 14:46:50,039 - root - INFO - Step 5 lr: 0.0008
[rank0]:[titan] 2025-06-04 14:46:50,040 - root - INFO - step:  5  loss:  1.6065  memory: 20.45GiB(43.17%)  tps: 1,971,288  tflops: 0.00  mfu: 0.00%
```

This same behaviour was causing the bug I described in #1213 . It was making it so, in the final step, we were going 1 over the max_steps expected, and thus setting the multiplicative lr adjustment factor to 0.
