### PR TITLE
[BE] Set up Code owners for main components and exclude experiment folder 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-/torchtitan @tianyu-l @wconstable @fegin @wwwjn
+/torchtitan @tianyu-l @wconstab @fegin @wwwjn
 
 # Exclude the experiments directory by adding a pattern without owners
 /torchtitan/experiments/*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# This is a CODEOWNERS file.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+/torchtitan @tianyu-l @wconstable @fegin @wwwjn
+
+# Exclude the experiments directory by adding a pattern without owners
+/torchtitan/experiments/*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-/torchtitan @tianyu-l @wconstab @fegin @wwwjn
+* @tianyu-l @fegin @wwwjn
 
 # Exclude the experiments directory by adding a pattern without owners
-/torchtitan/experiments/*
+/torchtitan/experiments/


### PR DESCRIPTION
As we discussed offline, set up a coder owner for the main components in TorchTitan, to ensure the code stability and provide light-weight protection. Next step is to set "protected branches" rule to require >= 1 code owner approval. 

Exclude experiment folder from code owner mechanism for fast iteration. 