### PR TITLE
Move eval to main train loop and consolidate FLUX train_step

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ To accelerate contributions to and innovations around torchtitan, we are hosting
 7. DDP and HSDP
 8. [TorchFT](https://github.com/pytorch/torchft) integration
 9. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries) and support for [custom datasets](docs/datasets.md)
-10. Flexible learning rate scheduler (warmup-stable-decay)
-11. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
-12. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
-13. All options easily configured via [toml files](torchtitan/models/llama3/train_configs/)
-14. [Helper scripts](scripts/) to
+10. Gradient accumulation, enabled by giving an additional `--training.global_batch_size` argument in configuration
+11. Flexible learning rate scheduler (warmup-stable-decay)
+12. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
+13. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
+14. All options easily configured via [toml files](torchtitan/models/llama3/train_configs/)
+15. [Helper scripts](scripts/) to
     - download tokenizers from Hugging Face
     - convert original Llama 3 checkpoints into the expected DCP format
     - estimate FSDP/HSDP memory usage without materializing the model

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -158,7 +158,6 @@ class FluxTrainer(Trainer):
 
         t5_tokenizer, clip_tokenizer = build_flux_tokenizer(self.job_config)
 
-        prompt = "A photo of a cat"
         image = generate_image(
             device=self.device,
             dtype=self._dtype,

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -462,11 +462,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         self.metrics_processor.log(self.step, global_avg_loss, global_max_loss)
 
-    def eval_step(self):
-        """Evaluates the model on the validation dataset.
-        Currently is not implemented and this is a placeholder."""
-        return
-
     @record
     def train(self):
         job_config = self.job_config
@@ -496,9 +491,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 except DataloaderStopIteration:
                     logger.warning("Ran out of data; last step was canceled.")
                     break
-
-                self.eval_step()
-
                 self.checkpointer.save(
                     self.step, force=(self.step == job_config.training.steps)
                 )

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -462,6 +462,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         self.metrics_processor.log(self.step, global_avg_loss, global_max_loss)
 
+    def eval_step(self):
+        """Evaluates the model on the validation dataset.
+        Currently is not implemented and this is a placeholder."""
+        return
+
     @record
     def train(self):
         job_config = self.job_config
@@ -491,6 +496,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 except DataloaderStopIteration:
                     logger.warning("Ran out of data; last step was canceled.")
                     break
+
+                self.eval_step()
+
                 self.checkpointer.save(
                     self.step, force=(self.step == job_config.training.steps)
                 )


### PR DESCRIPTION
After #1238 landed, we could consolidate FLUX train_step() to reuse the main trainer's `train_step` function, by removing the `eval_step()`.

We will replace eval_step() to be a `Validator` in the future to perform various validation methods.