### PR TITLE
[llama4] fix: remove max_len from generate_permute_indices

### DIFF
--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -295,7 +295,6 @@ class MoE(nn.Module):
                     num_local_tokens_per_expert,
                     self.experts.num_experts,
                     1,
-                    token_indices.shape[0] + self.experts.num_experts * ALIGN_SIZE_M,
                     ALIGN_SIZE_M,
                 )
             token_indices = torch.vstack(


### PR DESCRIPTION
https://github.com/pytorch/torchtitan/pull/1254 removes the `max_len` param from `generate_permute_indices` but does not update the llama4 model.

cc @tianyu-l 