### PR TITLE
[deepseek][blackwell] add manual looping group gemm to enable base working inference on Blackwell

### DIFF
--- a/torchtitan/experiments/deepseek_v3/generate.py
+++ b/torchtitan/experiments/deepseek_v3/generate.py
@@ -19,9 +19,9 @@ from model import DeepseekForCausalLM
 from model_config import deepseek_config_registry
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
-from transformers import AutoTokenizer
 
 from torchtitan.tools.utils import Color
+from transformers import AutoTokenizer
 
 # Uncomment the model you want to run.
 model_id, mesh_shape = "deepseek-ai/DeepSeek-V2-Lite-Chat", (1, 4)
@@ -224,7 +224,7 @@ def generate(
     tokenizer,
     dist_config,
     messages: list[dict],
-    n_tokens: int = 200,
+    n_tokens: int = 50,
 ):
     rank = dist.get_rank()
     device = dist_config.device


### PR DESCRIPTION
This PR enables deepseek inference to run on Blackwell (B200). 
Currently, torch._grouped_mm is specific to Hopper...thus trying to run on B200 via TorchBF16GroupGEMM yields:
~~~
"Error using torch strategy: torch._grouped_mm is only supported on CUDA devices with compute capability = 9.0"
~~~

thus this PR adds a manual looping group gemm to get ds inference working on Blackwell.  
*Note that you must use Symmetric Memory for the all2all, dist.all2all_single does not yet work on Blackwell. 

Wtih this PR:
<img width="1103" alt="Screenshot 2025-06-07 at 4 20 31 PM" src="https://github.com/user-attachments/assets/0a1b77d7-6423-4c2a-91aa-2f8587cae78a" />

Token per second of 1.21 is not great, but we have moved now from 'not working' to a working inference on B200.  
