### PR TITLE
Redefine lr_scheduler behavior

### DIFF
--- a/tests/unit_tests/test_lr_scheduler.py
+++ b/tests/unit_tests/test_lr_scheduler.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
 import unittest
 from unittest.mock import MagicMock
 

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -155,12 +155,16 @@ def build_lr_schedulers(
             # linear warmup
             # 0-indexed step, hence + 1 adjustments
             current_step += 1
+            assert (
+                warmup_steps != 0
+            ), "warmup_steps must not be zero to reach this branch"
             curr_adjustment = float(current_step / warmup_steps)
-        elif current_step < warmup_stable_steps or decay_steps == 0:
+        elif current_step < warmup_stable_steps:
             curr_adjustment = 1.0
         else:
             # 0-indexed step, hence + 1 adjustments
             current_step += 1
+            assert decay_steps != 0, "decay_steps must not be zero to reach this branch"
             progress = float(current_step - warmup_stable_steps) / decay_steps
 
             if lr_decay_type == "linear":


### PR DESCRIPTION
## Context

The current warmup-stable-decay lr_scheduler behavior is not intuitive. For example, in `debug_model.toml`, the configurattion is: 
```
[lr_scheduler]
warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
decay_type = "linear"
lr_min = 0.0
```
So we are expected warmup_steps =2, decay steps=8, total steps=10.

And we got the curret learning rate (blue line) There are 2 issues:
1. The max learning rate is not reaching 1 (expected max lr = 1 since we are calculating ratio here). 
2. Intuitively, the user would expect to see learning rate increase by 0.5 (suppose max_lr = 1) each step during warm up stage, and decrease by 1/8 each step during decay stage. But in blue line, the lr is increasing by 1/3, and decreasing by 1/9, which is counter-intuitive. 

Thus we propose a standard lr_scheduler behavior, which aligns with user's intuitive and the meaning of the parameter names. (the red line)
![learning_rate_schedule](https://github.com/user-attachments/assets/1c2be9e0-6043-4310-b09f-9b06a024abf9)

## Standard lr_scheduler behavior
- Warm up stage:  LR increase by 1/{warmup_steps}
- Stable stage: Length of  stable stage = total_train_step + 1 - warmup_stage - decay_stage. We manually add one step to stable stage (so we have a fake step 11), which is preventing if decay is enabled the step 10 learning rate drops to 0. 
- Decay stage:   LR decrease by 1/{decay_steps}


