### PR TITLE
[llama4][auxiliary-loss-free load balancing] update expert_bias without backward hooks

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -361,6 +361,9 @@ class Parallelism:
     The default value is 'allgather'.
     """
 
+    enable_tp2ep: bool = False
+    """Whether to use expert parallelism instead of tensor parallelism for shared experts."""
+
 
 @dataclass
 class Checkpoint:

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -25,6 +25,7 @@ class ParallelDims:
     pp: int
     world_size: int
     enable_loss_parallel: bool
+    enable_tp2ep: bool
 
     def __post_init__(self):
         self._validate()
@@ -81,17 +82,23 @@ class ParallelDims:
         dp_shard_cp_mesh_dim_names = []
         # Mesh for loss all-reduce
         dp_cp_mesh_dim_names = []
+        dp_cp_tp2ep_mesh_dim_names = []
 
         if self.dp_replicate_enabled:
             dp_mesh_dim_names.append("dp_replicate")
             dp_cp_mesh_dim_names.append("dp_replicate")
+            dp_cp_tp2ep_mesh_dim_names.append("dp_replicate")
         if self.dp_shard_enabled:
             dp_mesh_dim_names.append("dp_shard")
             dp_shard_cp_mesh_dim_names.append("dp_shard")
             dp_cp_mesh_dim_names.append("dp_shard")
+            dp_cp_tp2ep_mesh_dim_names.append("dp_shard")
         if self.cp_enabled:
             dp_shard_cp_mesh_dim_names.append("cp")
             dp_cp_mesh_dim_names.append("cp")
+            dp_cp_tp2ep_mesh_dim_names.append("cp")
+        if self.tp_enabled and self.enable_tp2ep:
+            dp_cp_tp2ep_mesh_dim_names.append("tp")
 
         if dp_mesh_dim_names != []:
             mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
@@ -101,6 +108,8 @@ class ParallelDims:
             )
         if dp_cp_mesh_dim_names != []:
             mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
+        if dp_cp_tp2ep_mesh_dim_names != []:
+            mesh[tuple(dp_cp_tp2ep_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp_tp2ep")
 
         return mesh
 

--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -12,7 +12,7 @@ from torchtitan.datasets.tokenizer.tiktoken import build_tiktoken_tokenizer
 from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
 
-from .infra.parallelize_llama import parallelize_llama
+from .infra.parallelize_llama import parallelize_llama, update_router_expert_bias
 from .model.args import TransformerModelArgs
 from .model.model import Transformer
 
@@ -103,5 +103,5 @@ register_train_spec(
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
-    )
-)
+        finalize_model_grads_func=update_router_expert_bias,
+    ))

--- a/torchtitan/experiments/llama4/infra/parallelize_llama.py
+++ b/torchtitan/experiments/llama4/infra/parallelize_llama.py
@@ -171,7 +171,7 @@ def get_updated_expert_bias(
     """
 
     with torch.no_grad():
-        # All Reduce Across TPxCPxDP group
+        # All Reduce Across DPxCPxTP2EP group
         if reduce_mesh is not None:
             torch.distributed.all_reduce(
                 tokens_per_expert,

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -13,6 +13,7 @@ from typing import Protocol, TypeAlias
 
 import torch
 import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 
 from torchtitan.components.dataloader import BaseDataLoader
@@ -74,6 +75,7 @@ LRSchedulersBuilder: TypeAlias = Callable[
     [OptimizersContainer, JobConfig], LRSchedulersContainer
 ]
 LossFunctionBuilder: TypeAlias = Callable[..., LossFunction]
+FinalizeModelGradsFunc: TypeAlias = Callable[[nn.Module, DeviceMesh], None]
 
 
 @dataclass
@@ -89,6 +91,7 @@ class TrainSpec:
     build_tokenizer_fn: TokenizerBuilder | None
     build_loss_fn: LossFunctionBuilder
     build_metrics_processor_fn: MetricsProcessorBuilder | None = None
+    finalize_model_grads_func: FinalizeModelGradsFunc | None = None
 
 
 _train_specs = {}


### PR DESCRIPTION
Changes:

* Introduce a `finalize_model_grads_func` attribute in TrainSpec.
* Set `finalize_model_grads_func` to `update_router_expert_bias` for MoE models.
* `finalize_model_grads_func` is called **AFTER** gradient accumulation steps.
* `enable_tp2ep` is reserved for https://github.com/pytorch/torchtitan/pull/1269

Reasons:

* Friendly for torch.compile and activation checkpointing.
* The original implementation updates `expert_bias` on each microbatches during gradient accumulation.

cc @tianyu-l 
