### PR TITLE
Add check for `seq_len%tensor_parallel_degree==0` for parallelized Llama

### DIFF
--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -47,7 +47,7 @@ def parallelize_llama(
     """
 
     if parallel_dims.tp_enabled:
-        assert job_config.training.seq_len % parallel_dims.tp == 0, (
+        assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
             f"Sequence length {job_config.training.seq_len} must be divisible by "
             f"tensor parallel degree {parallel_dims.tp} because of numerical "
             f"issue in the computation of complex numbers with DTensors. "
@@ -111,6 +111,10 @@ def parallelize_llama(
 
         if parallel_dims.cp_enabled:
             logger.info("Applied Context Parallel to the model")
+            assert job_config.training.seq_len % parallel_dims.cp == 0, (
+                f"Sequence length {job_config.training.seq_len} must be divisible by "
+                f"context parallel degree {parallel_dims.cp}."
+            )
 
         if job_config.training.enable_cpu_offload:
             logger.info("Applied CPU Offloading to the model")

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -45,16 +45,16 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
-    assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
-        f"""
-        Sequence length {job_config.training.seq_len} must be divisible by both TP degree 
-        ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
-        TP currently cannot handle uneven seq_len because we set `use_local_output=True` 
-        (to use plain Tensors), which was because the bug in computation of complex 
-        numbers with DTensors when setting `use_local_output=False`. 
-        See https://github.com/pytorch/pytorch/issues/130646 and 
-        https://github.com/pytorch/torchtitan/issues/1306 for details.
-        """
+  # TODO: TP currently cannot handle uneven seq_len because we set `use_local_output=True` 
+  # (to use plain Tensors), which was because of the bug in computation of complex 
+  # numbers with DTensors when setting `use_local_output=False`. 
+  # See https://github.com/pytorch/pytorch/issues/130646 and 
+  # https://github.com/pytorch/torchtitan/issues/1306 for details.
+  assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
+      f"""
+      Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree 
+      ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
+      """
     )
 
     if parallel_dims.tp_enabled:

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -45,17 +45,17 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
-  # TODO: TP currently cannot handle uneven seq_len because we set `use_local_output=True` 
-  # (to use plain Tensors), which was because of the bug in computation of complex 
-  # numbers with DTensors when setting `use_local_output=False`. 
-  # See https://github.com/pytorch/pytorch/issues/130646 and 
-  # https://github.com/pytorch/torchtitan/issues/1306 for details.
-  assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
-      f"""
-      Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree 
-      ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
-      """
-    )
+    # TODO: TP currently cannot handle uneven seq_len because we set `use_local_output=True`
+    # (to use plain Tensors), which was because of the bug in computation of complex
+    # numbers with DTensors when setting `use_local_output=False`.
+    # See https://github.com/pytorch/pytorch/issues/130646 and
+    # https://github.com/pytorch/torchtitan/issues/1306 for details.
+    assert (
+        job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0
+    ), f"""
+        Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
+        """
 
     if parallel_dims.tp_enabled:
         if (

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -47,8 +47,9 @@ def parallelize_llama(
     """
 
     if parallel_dims.tp_enabled:
-        assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
-            f"Sequence length {job_config.training.seq_len} must be divisible by "
+        assert job_config.training.seq_len / parallel_dims.cp % parallel_dims.tp == 0, (
+            f"Sequence length {job_config.training.seq_len} seen by the model "
+            f"during forward pass (seq_len / cp) must be divisible by "
             f"tensor parallel degree {parallel_dims.tp} because of numerical "
             f"issue in the computation of complex numbers with DTensors. "
             f"See https://github.com/pytorch/pytorch/issues/130646 and "

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -111,11 +111,11 @@ def parallelize_llama(
             logger.info("Applied FSDP to the model")
 
         if parallel_dims.cp_enabled:
-            logger.info("Applied Context Parallel to the model")
             assert job_config.training.seq_len % parallel_dims.cp == 0, (
                 f"Sequence length {job_config.training.seq_len} must be divisible by "
                 f"context parallel degree {parallel_dims.cp}."
             )
+            logger.info("Applied Context Parallel to the model")
 
         if job_config.training.enable_cpu_offload:
             logger.info("Applied CPU Offloading to the model")

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -47,6 +47,13 @@ def parallelize_llama(
     """
 
     if parallel_dims.tp_enabled:
+        assert job_config.training.seq_len % parallel_dims.tp == 0, (
+            f"Sequence length {job_config.training.seq_len} must be divisible by "
+            f"tensor parallel degree {parallel_dims.tp} because of numerical "
+            f"issue in the computation of complex numbers with DTensors. "
+            f"See https://github.com/pytorch/pytorch/issues/130646 and "
+            f"https://github.com/pytorch/torchtitan/issues/1306 for details. "
+        )
         if (
             job_config.parallelism.enable_async_tensor_parallel
             and not job_config.training.compile

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -47,7 +47,7 @@ def parallelize_llama(
     """
     assert job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0, (
         f"""
-        Sequence length {job_config.training.seq_len} must be divisible by TP degree 
+        Sequence length {job_config.training.seq_len} must be divisible by both TP degree 
         ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
         TP currently cannot handle uneven seq_len because we set `use_local_output=True` 
         (to use plain Tensors), which was because the bug in computation of complex 


### PR DESCRIPTION
Mitigates #1306 

Following discussions in #1306, the `seq_len%tensor_parallel_degree==0` seems to be a necessary condition for the tp Llama3 model to work (since it is a workaround of [this](https://github.com/pytorch/pytorch/issues/130646) numerical issue in pytorch Dtensors of complex numbers.

This PR makes this requirements explicit.