### PR TITLE
Fix the paramterization of simple fsdp

### DIFF
--- a/torchtitan/experiments/simple_fsdp/simple_fsdp.py
+++ b/torchtitan/experiments/simple_fsdp/simple_fsdp.py
@@ -135,7 +135,9 @@ def _register_parametrization(
     get_model_state_dict func in torchtitan's torchtitan/components/checkpoint.py.
     """
     param_name_to_property = {
-        param_name: property(lambda self, pn=param_name: parametrization(self._parameters[pn]))
+        param_name: property(
+            lambda self, pn=param_name: parametrization(self._parameters[pn])
+        )
         for param_name in param_names
     }
     module_cls = type(

--- a/torchtitan/experiments/simple_fsdp/simple_fsdp.py
+++ b/torchtitan/experiments/simple_fsdp/simple_fsdp.py
@@ -135,7 +135,7 @@ def _register_parametrization(
     get_model_state_dict func in torchtitan's torchtitan/components/checkpoint.py.
     """
     param_name_to_property = {
-        param_name: property(lambda self: parametrization(self._parameters[param_name]))
+        param_name: property(lambda self, pn=param_name: parametrization(self._parameters[pn]))
         for param_name in param_names
     }
     module_cls = type(


### PR DESCRIPTION
Some regression since https://github.com/pytorch/torchtitan/pull/1273

The issue is python closure could not capture the param name correctly unless you pass it as a input to the lambda function.