### PR TITLE
[CI] Only run integration test when PR's base branch is main 

### DIFF
--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
+    branches: [ main ]
     paths-ignore:
       - 'torchtitan/experiments/**'
   schedule:


### PR DESCRIPTION
As titled, to save some H100 resource and avoid long waiting, only run integration test when PR's base branch is main.

No need to run H100 tests on PRs like #1330  

