### PR TITLE
missing dependency in pyproject for tyro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     # Miscellaneous
     "tomli>=1.1.0",
     "fsspec"
+    "tyro"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Installing dependencies with pip install editable mode results in ModuleNotFound error. 
Replicating from fresh environment:
```bash
cd $HOME/local/a/pytorch
conda activate $PWD-env
cd ../torchtitan
pip install -e .
LOG_RANK=0,1 NGPU=4 ./run_train.sh
```
error:
```python
*****************************************                                                                         
[rank0]:Traceback (most recent call last):                                                                               
[rank0]:  File "/home/wesleytruong/local/a/pytorch-env/lib/python3.10/runpy.py", line 187, in _run_module_as_main        
[rank0]:    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)                                             
[rank0]:  File "/home/wesleytruong/local/a/pytorch-env/lib/python3.10/runpy.py", line 110, in _get_module_details        
[rank0]:    __import__(pkg_name)                                                                                         
[rank0]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/__init__.py", line 8, in <module>                       
[rank0]:    import torchtitan.components.quantization  # noqa: F401                                                      
[rank0]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/components/quantization/__init__.py", line 17, in <modul
e>                                                                                                                       
[rank0]:    import torchtitan.components.quantization.float8  # noqa: F401                                               
[rank0]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/components/quantization/float8.py", line 12, in <module>
[rank0]:    from torchtitan.config_manager import Float8, JobConfig                                                      
[rank0]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/config_manager.py", line 15, in <module>                
[rank0]:    import tyro                                                                                                  
[rank0]:ModuleNotFoundError: No module named 'tyro'                                                                      
[rank1]:Traceback (most recent call last):                                                                               
[rank1]:  File "/home/wesleytruong/local/a/pytorch-env/lib/python3.10/runpy.py", line 187, in _run_module_as_main        
[rank1]:    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)                                             
[rank1]:  File "/home/wesleytruong/local/a/pytorch-env/lib/python3.10/runpy.py", line 110, in _get_module_details        
[rank1]:    __import__(pkg_name)                                                                                         
[rank1]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/__init__.py", line 8, in <module>                       
[rank1]:    import torchtitan.components.quantization  # noqa: F401                                                      
[rank1]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/components/quantization/__init__.py", line 17, in <modul
e>                                                                                                                       
[rank1]:    import torchtitan.components.quantization.float8  # noqa: F401                                               
[rank1]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/components/quantization/float8.py", line 12, in <module>
[rank1]:    from torchtitan.config_manager import Float8, JobConfig                                                      
[rank1]:  File "/data/users/wesleytruong/a/torchtitan/torchtitan/config_manager.py", line 15, in <module>                
[rank1]:    import tyro                                                                                                  
[rank1]:ModuleNotFoundError: No module named 'tyro'
```