### PR TITLE
[RFC] Make last_save_model_weights_only default to True

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -329,13 +329,13 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual(mock_save.call_count, 0)
         manager.save(curr_step=2)
         self.assertEqual(mock_save.call_count, 0)
-        manager.save(curr_step=2, force=True)
+        manager.save(curr_step=2, last_step=True)
         self.assertEqual(mock_save.call_count, 1)
         manager.save(curr_step=3)
         self.assertEqual(mock_save.call_count, 2)
         manager.save(curr_step=4)
         self.assertEqual(mock_save.call_count, 2)
-        manager.save(curr_step=4, force=True)
+        manager.save(curr_step=4, last_step=True)
         self.assertEqual(mock_save.call_count, 3)
         manager.close()
 
@@ -358,7 +358,7 @@ class TestCheckpointManager(unittest.TestCase):
             job_config=self.job_config,
             ft_manager=self.ft_manager,
         )
-        manager1.save(curr_step=1, force=True)
+        manager1.save(curr_step=1, last_step=True)
         path1 = os.path.join(self.test_folder, "step-1")
         self.assertTrue(os.path.isdir(path1))
         # Phase 2: initial load from step-1
@@ -383,7 +383,7 @@ class TestCheckpointManager(unittest.TestCase):
         args1, kwargs1 = mock_load.call_args
         self.assertEqual(kwargs1.get("checkpoint_id"), path1)
         # Phase 3: save new step under default folder, then load that
-        manager2.save(curr_step=2, force=True)
+        manager2.save(curr_step=2, last_step=True)
         # Default folder is test_folder, so step-2 under that
         step2_dir = os.path.join(self.test_folder, "step-2")
         self.assertTrue(os.path.isdir(step2_dir))
@@ -419,12 +419,12 @@ class TestCheckpointManager(unittest.TestCase):
         )
 
         # First save schedules async
-        manager.save(curr_step=10, force=False)
+        manager.save(curr_step=10, last_step=False)
         future = manager.async_future
         future.result.assert_not_called()
 
         # Second save should wait
-        manager.save(curr_step=20, force=False)
+        manager.save(curr_step=20, last_step=False)
         future.result.assert_called_once()
 
         # New future created
@@ -462,12 +462,12 @@ class TestCheckpointManager(unittest.TestCase):
 
         # Initially no future
         self.assertIsNone(manager.async_future)
-        manager.save(curr_step=5, force=False)
+        manager.save(curr_step=5, last_step=False)
         self.assertIsNotNone(manager.async_future)
 
         manager.async_future.result.assert_not_called()
         prev_future = manager.async_future
-        manager.save(curr_step=6, force=False)
+        manager.save(curr_step=6, last_step=False)
         prev_future.result.assert_called_once()
         self.assertIsNotNone(manager.async_future)
         manager.async_future.result.assert_not_called()

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -404,13 +404,13 @@ class Checkpoint:
     interval: int = 500
     """Checkpointing interval in steps."""
 
-    last_save_model_weights_only: bool = False
+    last_save_model_weights_only: bool = True
     """
     When last_save_model_weights_only=True, only model weights will be saved at the end of training,
     the last save.  With this, checkpoints can be loaded using `torch.load(..., weights_only=True)`
     after conversion.  When last_save_model_weights_only=False, the full checkpoint will be saved.
     A full checkpoint includes model, optimizer and train_state, which can be used to resume training.
-    The default value is false.
+    The default value is True.
     """
 
     export_dtype: Literal["float16", "bfloat16", "float32"] = "float32"

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
             assert (
                 config.checkpoint.enable_checkpoint
             ), "Must enable checkpointing when creating a seed checkpoint."
-            trainer.checkpointer.save(curr_step=0, force=True)
+            trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:
             trainer.train()

--- a/torchtitan/experiments/llama4/scripts/convert_hf_to_dcp_with_gpus.py
+++ b/torchtitan/experiments/llama4/scripts/convert_hf_to_dcp_with_gpus.py
@@ -536,7 +536,7 @@ if __name__ == "__main__":
             trainer.checkpointer.states[MODEL] = DummyModel(state_dict)
             trainer.checkpointer.last_save_model_weights_only = True
             trainer.checkpointer.export_dtype = next(iter(state_dict.values())).dtype
-            trainer.checkpointer.save(curr_step=0, force=True)
+            trainer.checkpointer.save(curr_step=0, last_step=True)
             time.sleep(2)
     finally:
         pass

--- a/torchtitan/experiments/llama4/scripts/convert_meta_to_dcp_with_gpus.py
+++ b/torchtitan/experiments/llama4/scripts/convert_meta_to_dcp_with_gpus.py
@@ -531,7 +531,7 @@ if __name__ == "__main__":
             trainer.checkpointer.states[MODEL] = DummyModel(state_dict)
             trainer.checkpointer.last_save_model_weights_only = True
             trainer.checkpointer.export_dtype = next(iter(state_dict.values())).dtype
-            trainer.checkpointer.save(curr_step=0, force=True)
+            trainer.checkpointer.save(curr_step=0, last_step=True)
             time.sleep(2)
     finally:
         pass

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -494,7 +494,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                     logger.warning("Ran out of data; last step was canceled.")
                     break
                 self.checkpointer.save(
-                    self.step, force=(self.step == job_config.training.steps)
+                    self.step, last_step=(self.step == job_config.training.steps)
                 )
 
                 # signal the profiler that the next profiling step has started
@@ -547,7 +547,7 @@ if __name__ == "__main__":
             assert (
                 config.checkpoint.enable_checkpoint
             ), "Must enable checkpointing when creating a seed checkpoint."
-            trainer.checkpointer.save(curr_step=0, force=True)
+            trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:
             trainer.train()


### PR DESCRIPTION
This is a BC breaking change but should be the right way to save the last step checkpoint.