### PR TITLE
Always ignore freqs_cis

### DIFF
--- a/scripts/convert_llama_to_dcp.py
+++ b/scripts/convert_llama_to_dcp.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import torch
 import torch.distributed.checkpoint as DCP
-from torchtitan.models.llama.model import precompute_freqs_cis
 from torchtitan.tools.logging import init_logger, logger
 
 
@@ -122,13 +121,6 @@ def convert_llama_weights(input_dir, output_dir, max_seq_len: int):
         )
         for i in range(len(shards)):
             del shards[i]["output.weight"]
-
-    # NOTE: precompute freqs_cis because must be persisted by default in torchtitan
-    state_dict["freqs_cis"] = precompute_freqs_cis(
-        dims_per_head,
-        max_seq_len,
-        params.get("rope_theta", 500000),
-    )
 
     logger.info(f"Writing to DCP at '{output_dir}'")
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -24,8 +24,8 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torchtitan.components.checkpoint import excluded_parameters_for_model_only
 from torchtitan.components.metrics import build_device_memory_monitor
-
 from torchtitan.config_manager import ConfigManager
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.protocols.train_spec import get_train_spec
@@ -142,6 +142,8 @@ def test_generate(
     model.eval()
 
     state_dict = {"model": model.state_dict()}
+    for k in excluded_parameters_for_model_only:
+        state_dict["model"].pop(k, None)
 
     # Checkpoint Loading
     begin = time.monotonic()

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -534,6 +534,64 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2.close()
 
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    def test_excluded_parameters_not_saved(self, mock_save, mock_rank):
+        """
+        Test that freqs_cis and other excluded parameters are not saved in the checkpoint.
+        """
+
+        # Create a fake model with freqs_cis and other parameters
+        class FakeModelWithFreqsCis(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(2, 2))
+                self.bias = nn.Parameter(torch.randn(2))
+                # Register freqs_cis as a buffer (common pattern in transformer models)
+                self.register_buffer("freqs_cis", torch.randn(10, 5))
+                self.other_param = nn.Parameter(torch.randn(3, 3))
+
+        fake_model = FakeModelWithFreqsCis()
+
+        # Use the existing fake_save method
+        mock_save.side_effect = self.fake_save
+
+        cfg = self.job_config.checkpoint
+        cfg.keep_latest_k = 0  # Disable purging
+
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=[fake_model],
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            job_config=self.job_config,
+            ft_manager=self.ft_manager,
+        )
+
+        # Save the checkpoint
+        manager.save(curr_step=1)
+
+        # Verify that dcp.save was called
+        self.assertEqual(mock_save.call_count, 1)
+
+        # Load the saved state dict from disk to verify exclusions
+        checkpoint_path = os.path.join(self.test_folder, "step-1", "state_dict.pt")
+        saved_data = torch.load(checkpoint_path, weights_only=False)
+
+        # Get the model state dict that was saved
+        model_state_dict = saved_data[MODEL]
+
+        # Verify that freqs_cis is NOT in the saved state dict
+        self.assertNotIn("freqs_cis", model_state_dict)
+
+        # Verify that other parameters ARE in the saved state dict
+        self.assertIn("weight", model_state_dict)
+        self.assertIn("bias", model_state_dict)
+        self.assertIn("other_param", model_state_dict)
+
+        manager.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -49,6 +49,12 @@ class AsyncMode(str, enum.Enum):
     ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
 
 
+# For now, we will manually pop the freqs_cis buffer, as we made this permanent
+# temporarily and we don't want to include it in the exported state_dict.
+# Context: https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama3/model.py#L404
+excluded_parameters_for_model_only = {"freqs_cis"}
+
+
 class ModelWrapper(Stateful):
     def __init__(self, model: nn.Module | list[nn.Module]) -> None:
         self.model = [model] if isinstance(model, nn.Module) else model
@@ -84,12 +90,6 @@ class Terminate:
 
 class SaveDone:
     pass
-
-
-# For now, we will manually pop the freqs_cis buffer, as we made this permanent
-# temporarily and we don't want to include it in the exported state_dict.
-# Context: https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama3/model.py#L404
-excluded_parameters_for_model_only = {"freqs_cis"}
 
 
 @torch.no_grad()

--- a/torchtitan/experiments/llama4/scripts/convert_hf_to_dcp_with_gpus.py
+++ b/torchtitan/experiments/llama4/scripts/convert_hf_to_dcp_with_gpus.py
@@ -497,11 +497,6 @@ if __name__ == "__main__":
             size += v.numel() * v.element_size()
         logger.info(f"Total size of the model: {size / 1e9:.2f} GB")
 
-        # Do not support PP yet, we will need to iterate over the PP dimension and
-        # extract the corresponding state_dict and device_mesh.
-        if "freqs_cis" in state_dict:
-            state_dict.pop("freqs_cis")
-
         # Our tokenizer is not up-to-date yet.
         tok_embeddings_weight = state_dict.pop("tok_embeddings.weight")
         output_weight = state_dict.pop("output.weight")
@@ -531,8 +526,6 @@ if __name__ == "__main__":
             dist.barrier()
             logger.info(f"Verifies state_dict {time.time() - begin}.")
         else:
-            # oh, this is pretty bad, when can we get rid of the freqs_cis issue?
-            state_dict["freqs_cis"] = None
             trainer.checkpointer.states[MODEL] = DummyModel(state_dict)
             trainer.checkpointer.last_save_model_weights_only = True
             trainer.checkpointer.export_dtype = next(iter(state_dict.values())).dtype

--- a/torchtitan/experiments/llama4/scripts/convert_meta_to_dcp_with_gpus.py
+++ b/torchtitan/experiments/llama4/scripts/convert_meta_to_dcp_with_gpus.py
@@ -498,11 +498,6 @@ if __name__ == "__main__":
             size += v.numel() * v.element_size()
         logger.info(f"Total size of the model: {size / 1e9:.2f} GB")
 
-        # Do not support PP yet, we will need to iterate over the PP dimension and
-        # extract the corresponding state_dict and device_mesh.
-        if "freq_cis" in state_dict:
-            state_dict.pop("freqs_cis")
-
         state_dict = CheckpointConverter(
             process_group=trainer.world_mesh.get_group(),
             path=config.checkpoint.convert_path,
@@ -526,8 +521,6 @@ if __name__ == "__main__":
             dist.barrier()
             logger.info(f"Verifies state_dict {time.time() - begin}.")
         else:
-            # oh, this is pretty bad, when can we get rid of the freqs_cis issue?
-            state_dict["freqs_cis"] = None
             trainer.checkpointer.states[MODEL] = DummyModel(state_dict)
             trainer.checkpointer.last_save_model_weights_only = True
             trainer.checkpointer.export_dtype = next(iter(state_dict.values())).dtype


### PR DESCRIPTION
We should always ignore freq_cis and other parameters in excluded_parameters_for_model_only to avoid confusion.

TODO: Is this going to break PP with seed checkpoint?