### PR TITLE
Log `grad_norm`

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -431,7 +431,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             loss = self.forward_backward_step(input_dict, labels)
             accumulated_losses.append(loss.detach())
 
-        dist_utils.clip_grad_norm_(
+        grad_norm = dist_utils.clip_grad_norm_(
             [p for m in self.model_parts for p in m.parameters()],
             self.job_config.training.max_norm,
             foreach=True,
@@ -463,7 +463,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             global_avg_loss = global_max_loss = loss.detach().item()
 
-        self.metrics_processor.log(self.step, global_avg_loss, global_max_loss)
+        self.metrics_processor.log(
+            self.step,
+            global_avg_loss,
+            global_max_loss,
+            extra_metrics={"grad_norm": grad_norm},
+        )
 
     @record
     def train(self):


### PR DESCRIPTION
Since the `grad_norm` is always computed anyway and might provide useful insight into the training dynamics I don't see a reason not to log it.

`grad_norm` could also be logged to the output [here](https://github.com/pytorch/torchtitan/blob/main/torchtitan/components/metrics.py#L400-L408), let me know if I should add that.