### PR TITLE
[llama4] add back max_len arg to generate_permute_indices

### DIFF
--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -295,6 +295,7 @@ class MoE(nn.Module):
                     num_local_tokens_per_expert,
                     self.experts.num_experts,
                     1,
+                    token_indices.shape[0] + self.experts.num_experts * ALIGN_SIZE_M,
                     ALIGN_SIZE_M,
                 )
             token_indices = torch.vstack(


### PR DESCRIPTION
Fixes #1353 

Bug is related to this revert, the arg list changed: https://github.com/pytorch/torchtitan/pull/1340

So need to add this arg back: https://github.com/pytorch/torchtitan/commit/4e31b862d1d161b330b64be5b8db52c46c33ba58

cc @lessw2020 @tianyu-l 