### PR TITLE
Minimal reproduce of error when saving state dict after looping

### DIFF
--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -31,8 +31,7 @@ class BaseDataLoader(Stateful, ABC):
     """
 
     @abstractmethod
-    def __iter__(self):
-        ...
+    def __iter__(self): ...
 
 
 class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):

--- a/torchtitan/experiments/flux/sampling.py
+++ b/torchtitan/experiments/flux/sampling.py
@@ -101,7 +101,7 @@ def generate_image(
 
     batch = preprocess_data(
         device=device,
-        dtype=torch.bfloat16,
+        dtype=torch.float32,
         autoencoder=None,
         clip_encoder=clip_encoder,
         t5_encoder=t5_encoder,

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -14,12 +14,12 @@ class TestFluxDataLoader:
     def test_load_dataset(self):
         # The test checks for the correct tensor shapes during the first num_steps
         # The next num_steps ensure the loaded from checkpoint dataloader generates tokens and labels correctly
-        for world_size in [2, 4]:
+        for world_size in [1]:
             for rank in range(world_size):
-                dataset_name = "cc12m-test"
-                batch_size = 4
+                dataset_name = "cc12m-test-iterable"
+                batch_size = 33
 
-                num_steps = 10
+                num_steps = 1
 
                 path = "torchtitan.experiments.flux.job_config"
                 config_manager = ConfigManager()

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -8,14 +8,12 @@ import torch
 
 from torchtitan.config_manager import ConfigManager
 from torchtitan.experiments.flux.dataset.flux_dataset import build_flux_dataloader
-from torchtitan.tools.profiling import (
-    maybe_enable_memory_snapshot,
-    maybe_enable_profiling,
-)
 
 
 class TestFluxDataLoader:
     def test_load_dataset(self):
+        # The test checks for the correct tensor shapes during the first num_steps
+        # The next num_steps ensure the loaded from checkpoint dataloader generates tokens and labels correctly
         for world_size in [2, 4]:
             for rank in range(world_size):
                 dataset_name = "cc12m-test"
@@ -39,76 +37,65 @@ class TestFluxDataLoader:
                         "--training.classifer_free_guidance_prob",
                         "0.447",
                         "--encoder.t5_encoder",
-                        "google/t5-v1_1-small",
+                        "google/t5-v1_1-xxl",
                         "--encoder.clip_encoder",
                         "openai/clip-vit-large-patch14",
-                        "--encoder.max_t5_encoding_len",
-                        "512",
+                        # "--encoder.max_t5_encoding_len",
+                        # "512",
                     ]
                 )
 
-                with maybe_enable_profiling(
-                    config, global_step=0
-                ) as torch_profiler, maybe_enable_memory_snapshot(
-                    config, global_step=0
-                ) as memory_profiler:
-                    dl = build_flux_dataloader(
-                        dp_world_size=world_size,
-                        dp_rank=rank,
-                        job_config=config,
-                        tokenizer=None,
-                        infinite=True,
+                dl = build_flux_dataloader(
+                    dp_world_size=world_size,
+                    dp_rank=rank,
+                    job_config=config,
+                    tokenizer=None,
+                    infinite=True,
+                )
+
+                it = iter(dl)
+
+                for i in range(0, num_steps):
+                    input_data, labels = next(it)
+
+                    assert len(input_data) == 2  # (clip_encodings, t5_encodings)
+                    assert labels.shape == (batch_size, 3, 256, 256)
+                    assert input_data["clip_tokens"].shape == (
+                        batch_size,
+                        1,
+                        77,
+                    )
+                    assert input_data["t5_tokens"].shape == (
+                        batch_size,
+                        1,
+                        256,
                     )
 
-                    it = iter(dl)
+                state = dl.state_dict()
 
-                    for i in range(0, num_steps):
-                        input_data, labels = next(it)
-                        if torch_profiler:
-                            torch_profiler.step()
-                        if memory_profiler:
-                            memory_profiler.step()
+                # Create new dataloader, restore checkpoint, and check if next data yielded is the same as above
+                dl_resumed = build_flux_dataloader(
+                    dp_world_size=world_size,
+                    dp_rank=rank,
+                    job_config=config,
+                    tokenizer=None,
+                    infinite=True,
+                )
+                dl_resumed.load_state_dict(state)
+                it_resumed = iter(dl_resumed)
 
-                        assert len(input_data) == 2  # (clip_encodings, t5_encodings)
-                        assert labels.shape == (batch_size, 3, 256, 256)
-                        # assert input_data["clip_tokens"].shape[0] == batch_size
-                        # assert input_data["t5_tokens"].shape == (batch_size, 512, 512)
+                for i in range(num_steps):
+                    # Set torch manual seed before each dataloader iteration to ensure consistent randomness
+                    # across dataloaders for testing purposes.
+                    torch.manual_seed(i)
+                    expected_input_ids, expected_labels = next(it)
+                    torch.manual_seed(i)
+                    input_ids, labels = next(it_resumed)
 
-                    state = dl.state_dict()
-
-                    # Create new dataloader, restore checkpoint, and check if next data yielded is the same as above
-                    dl_resumed = build_flux_dataloader(
-                        dp_world_size=world_size,
-                        dp_rank=rank,
-                        job_config=config,
-                        tokenizer=None,
-                        infinite=True,
+                    assert torch.equal(
+                        input_ids["clip_tokens"], expected_input_ids["clip_tokens"]
                     )
-                    dl_resumed.load_state_dict(state)
-                    it_resumed = iter(dl_resumed)
-
-                    for i in range(num_steps):
-                        # Set torch manual seed before each dataloader iteration to ensure consistent randomness
-                        # across dataloaders for testing purposes.
-                        torch.manual_seed(i)
-                        expected_input_ids, expected_labels = next(it)
-                        torch.manual_seed(i)
-                        input_ids, labels = next(it_resumed)
-
-                        if torch_profiler:
-                            torch_profiler.step()
-                        if memory_profiler:
-                            memory_profiler.step()
-
-                        assert torch.equal(
-                            input_ids["clip_tokens"], expected_input_ids["clip_tokens"]
-                        )
-                        assert torch.equal(
-                            input_ids["t5_tokens"], expected_input_ids["t5_tokens"]
-                        )
-                        assert torch.equal(labels, expected_labels)
-
-                    if torch_profiler:
-                        torch_profiler.step()
-                    if memory_profiler:
-                        memory_profiler.step(exit_ctx=True)
+                    assert torch.equal(
+                        input_ids["t5_tokens"], expected_input_ids["t5_tokens"]
+                    )
+                    assert torch.equal(labels, expected_labels)

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
 from torchtitan.config_manager import ConfigManager
 from torchtitan.experiments.flux.dataset.flux_dataset import build_flux_dataloader
 from torchtitan.tools.profiling import (
@@ -31,13 +32,6 @@ class TestFluxDataLoader:
         config = config_manager.parse_args(
             [
                 f"--experimental.custom_args_module={path}",
-                # Profiling options
-                # "--profiling.enable_profiling",
-                # "--profiling.profile_freq",
-                # "5",
-                # "--profiling.enable_memory_snapshot",
-                # "--profiling.save_memory_snapshot_folder",
-                # "memory_snapshot_flux",
                 "--training.img_size",
                 str(256),
                 "--training.dataset",
@@ -110,13 +104,6 @@ class TestFluxDataLoader:
                 config = config_manager.parse_args(
                     [
                         f"--experimental.custom_args_module={path}",
-                        # Profiling options
-                        # "--profiling.enable_profiling",
-                        # "--profiling.profile_freq",
-                        # "5",
-                        # "--profiling.enable_memory_snapshot",
-                        # "--profiling.save_memory_snapshot_folder",
-                        # "memory_snapshot_flux",
                         "--training.img_size",
                         str(256),
                         "--training.dataset",
@@ -125,8 +112,6 @@ class TestFluxDataLoader:
                         str(batch_size),
                         "--training.seed",
                         "0",
-                        "--training.classifer_free_guidance_prob",
-                        "0.447",
                         "--encoder.t5_encoder",
                         "google/t5-v1_1-small",
                         "--encoder.clip_encoder",
@@ -148,6 +133,7 @@ class TestFluxDataLoader:
                 it_resumed = iter(dl_resumed)
 
                 for i in range(50):
+                    # Call torch_manual seed before each dataloader's it to ensure randomness in each dataloader is same for testing
                     torch.manual_seed(i)
                     expected_input_ids, expected_labels = next(it)
                     torch.manual_seed(i)

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -22,7 +22,7 @@ enable_wandb = false
 [model]
 name = "flux"
 flavor = "flux-debug"
-
+tokenizer_path = "./tests/assets/test_tiktoken.model"
 [optimizer]
 name = "AdamW"
 lr = 8e-4
@@ -33,6 +33,7 @@ warmup_steps = 1  # 10% warmup steps
 decay_ratio = 0.0  # no decay, stay stable during training
 
 [training]
+test_mode = true
 local_batch_size = 4
 max_norm = 2.0  # grad norm clipping
 steps = 10
@@ -42,8 +43,8 @@ classifer_free_guidance_prob = 0.447
 img_size = 256
 
 [encoder]
-t5_encoder = "google/t5-v1_1-xxl"
-clip_encoder = "openai/clip-vit-large-patch14"
+t5_encoder = "/data/users/wesleytruong/a/torchtitan/torchtitan/experiments/flux/tests/assets/t5-v1_1-xxl"  # T5 encoder to use for text
+clip_encoder = "/data/users/wesleytruong/a/torchtitan/torchtitan/experiments/flux/tests/assets/clip-vit-large-patch14"
 max_t5_encoding_len = 256
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
@@ -65,7 +66,7 @@ custom_args_module = "torchtitan.experiments.flux.job_config"
 mode = "full"
 
 [checkpoint]
-enable_checkpoint = false
+enable_checkpoint = true
 folder = "checkpoint"
 interval = 10
 last_save_model_weights_only = false


### PR DESCRIPTION
When looping iterable dataset, state dict is not being saved correctly as shown by:
```
save state dict:  {'examples_iterable': {'examples_iterable': {'shard_idx': 0, 'shard_example_idx': 8, 'type': 'ArrowExamplesIterable'}, 'previous_state': {'shard_idx': 0, 'shard_example_idx': 0, 'type': 'ArrowExamplesIterable'}, 'batch_idx': 1, 'num_chunks_since_previous_state': 1, 'cropped_chunk_length': 0, 'type': 'RebatchedArrowExamplesIterable'}, 'epoch': 1}
load state dict:  {'examples_iterable': {'examples_iterable': {'shard_idx': 0, 'shard_example_idx': 0, 'type': 'ArrowExamplesIterable'}, 'previous_state': None, 'batch_idx': 0, 'num_chunks_since_previous_state': 0, 'cropped_chunk_length': 0, 'type': 'RebatchedArrowExamplesIterable'}, 'epoch': 0}
```
The error can be reproduced when switching between batch sizes of less than and greater than 32.