### PR TITLE
[float8 moe training] validate float8 moe parallelism config

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -55,6 +55,18 @@ class Float8Converter(ModelConverter):
         self.filter_fqns = float8_config.filter_fqns
         self.moe_fqns = float8_config.moe_fqns_prototype
 
+        # Validate MoE training prototype limitations.
+        if self.moe_fqns:
+            assert (
+                job_config.parallelism.tensor_parallel_degree == 1
+            ), "Float8 MoE training prototype does not yet support tensor parallelism"
+            assert (
+                job_config.parallelism.pipeline_parallel_degree == 1
+            ), "Float8 MoE training prototype does not yet support pipeline parallelism"
+            assert (
+                job_config.parallelism.context_parallel_degree == 1
+            ), "Float8 MoE training prototype does not yet support context parallelism"
+
         if float8_config.recipe_name is not None:
             assert (
                 not float8_config.enable_fsdp_float8_all_gather


### PR DESCRIPTION
## Summary
Validate only FSDP, HSDP are used for float8 MoE training. TP support is in progress and CP/PP are untested. 2D+ parallelism are untested as well.

## Test plan
- Command: `NGPU=4 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --training.steps=10 --model.converters="float8" --float8.recipe_name="rowwise"  --float8.moe_fqns_prototype="experts"  --parallelism.tensor_parallel_degree=2`
- Error: `AssertionError: Float8 MoE training prototype does not yet support tensor parallelism`