### PR TITLE
basic validator implementation

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -513,12 +513,83 @@ def build_test_list():
             [
                 [
                     "--validation.enabled",
-                    "--validation.dataset c4_test",
+                    "--validation.dataset c4_validation",
                 ],
             ],
             "Validation test no parallelism",
             "validation_no_parallel",
             ngpu=1,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--validation.enabled",
+                    "--validation.dataset c4_validation",
+                    "--parallelism.data_parallel_shard_degree=1",
+                    "--parallelism.data_parallel_replicate_degree=4",
+                ]
+            ],
+            "Validation test with DP",
+            "validation_dp",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--validation.enabled",
+                    "--validation.dataset c4_validation",
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=2",
+                ]
+            ],
+            "Validation test with FSDP",
+            "validation_fsdp",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--checkpoint.enable_checkpoint",
+                    "--validation.enabled",
+                    "--validation.dataset c4_validation",
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=2",
+                ]
+            ],
+            "Validation checkpoint test with FSDP",
+            "validation_fsdp_checkpoint",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--validation.enabled",
+                    "--validation.dataset c4_validation",
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=1",
+                    "--parallelism.tensor_parallel_degree=2",
+                    "--parallelism.context_parallel_degree=2",
+                ]
+            ],
+            "Validation test with FSDP, TP, CP",
+            "validation_fsdp_tp_cp",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--checkpoint.enable_checkpoint",
+                    "--validation.enabled",
+                    "--validation.dataset c4_validation",
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.data_parallel_replicate_degree=1",
+                    "--parallelism.tensor_parallel_degree=2",
+                    "--parallelism.context_parallel_degree=2",
+                ]
+            ],
+            "Validation checkpoint test with FSDP, TP, CP",
+            "validation_fsdp_tp_cp_checkpoint",
+            ngpu=8,
         ),
     ]
     return integration_tests_flavors

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -509,6 +509,17 @@ def build_test_list():
             "gradient_accumulation",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--validation.enabled",
+                    "--validation.dataset c4_test",
+                ],
+            ],
+            "Validation test no parallelism",
+            "validation_no_parallel",
+            ngpu=1,
+        ),
     ]
     return integration_tests_flavors
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -513,7 +513,7 @@ def build_test_list():
             [
                 [
                     "--validation.enabled",
-                    "--validation.dataset c4_validation",
+                    "--validation.dataset c4_test",
                 ],
             ],
             "Validation test no parallelism",
@@ -523,35 +523,9 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
-                    "--validation.enabled",
-                    "--validation.dataset c4_validation",
-                    "--parallelism.data_parallel_shard_degree=1",
-                    "--parallelism.data_parallel_replicate_degree=4",
-                ]
-            ],
-            "Validation test with DP",
-            "validation_dp",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--validation.enabled",
-                    "--validation.dataset c4_validation",
-                    "--parallelism.data_parallel_shard_degree=2",
-                    "--parallelism.data_parallel_replicate_degree=2",
-                ]
-            ],
-            "Validation test with FSDP",
-            "validation_fsdp",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
                     "--checkpoint.enable_checkpoint",
                     "--validation.enabled",
-                    "--validation.dataset c4_validation",
+                    "--validation.dataset c4_test",
                     "--parallelism.data_parallel_shard_degree=2",
                     "--parallelism.data_parallel_replicate_degree=2",
                 ]
@@ -559,37 +533,6 @@ def build_test_list():
             "Validation checkpoint test with FSDP",
             "validation_fsdp_checkpoint",
             ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--validation.enabled",
-                    "--validation.dataset c4_validation",
-                    "--parallelism.data_parallel_shard_degree=2",
-                    "--parallelism.data_parallel_replicate_degree=1",
-                    "--parallelism.tensor_parallel_degree=2",
-                    "--parallelism.context_parallel_degree=2",
-                ]
-            ],
-            "Validation test with FSDP, TP, CP",
-            "validation_fsdp_tp_cp",
-            ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--validation.enabled",
-                    "--validation.dataset c4_validation",
-                    "--parallelism.data_parallel_shard_degree=2",
-                    "--parallelism.data_parallel_replicate_degree=1",
-                    "--parallelism.tensor_parallel_degree=2",
-                    "--parallelism.context_parallel_degree=2",
-                ]
-            ],
-            "Validation checkpoint test with FSDP, TP, CP",
-            "validation_fsdp_tp_cp_checkpoint",
-            ngpu=8,
         ),
     ]
     return integration_tests_flavors

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -514,25 +514,14 @@ def build_test_list():
                 [
                     "--validation.enabled",
                     "--validation.dataset c4_test",
+                    "--parallelism.data_parallel_replicate_degree=2",
+                    "--parallelism.tensor_parallel_degree=2",
+                    "--parallelism.context_parallel_degree=2",
                 ],
             ],
-            "Validation test no parallelism",
-            "validation_no_parallel",
-            ngpu=1,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--validation.enabled",
-                    "--validation.dataset c4_test",
-                    "--parallelism.data_parallel_shard_degree=2",
-                    "--parallelism.data_parallel_replicate_degree=2",
-                ]
-            ],
-            "Validation checkpoint test with FSDP",
-            "validation_fsdp_checkpoint",
-            ngpu=4,
+            "Validation test with fsdp, tp, cp",
+            "validation_fsdp_tp_cp",
+            ngpu=8,
         ),
     ]
     return integration_tests_flavors

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -20,7 +20,7 @@ class BaseValidator:
     def __init__(self, job_config: JobConfig):
         self.job_config = job_config
 
-    def validate(self) -> dict[str, float]:
+    def validate(self, model_parts: list[nn.Module]) -> dict[str, float]:
         raise NotImplementedError("validate method not implemented")
 
 
@@ -40,48 +40,59 @@ class Validator(BaseValidator):
     def __init__(
         self,
         job_config: JobConfig,
-        loss_fn: LossFunction,
-        model: nn.Module,
         dp_world_size: int,
         dp_rank: int,
         tokenizer: Tokenizer,
+        loss_fn: LossFunction,
     ):
         self.job_config = job_config
         self.loss_fn = loss_fn
-        self.model = model
         self.validation_dataloader = build_hf_validation_dataloader(
+            job_config=job_config,
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,
             tokenizer=tokenizer,
-            job_config=job_config,
             infinite=False,
         )
 
-    def validate(self) -> dict[str, float]:
+    def should_validate(self, step: int) -> bool:
+        return step % self.job_config.validation.val_freq == 0
+
+    def validate(
+        self,
+        model_parts: list[nn.Module],
+    ) -> dict[str, float]:
         # Set model to eval mode
-        self.model.eval()
+        model = model_parts[0]
+        model.eval()
 
         total_loss = 0.0
         num_batches = 0
         device_type = utils.device_type
+        num_val_steps = 0
 
         with torch.no_grad():
             try:
-                for batch_data, targets in self.validation_dataloader:
-                    input_dict, labels = batch_data, targets
+                for input_dict, labels in self.validation_dataloader:
+
+                    if (
+                        self.job_config.validation.val_steps != -1
+                        and num_val_steps >= self.job_config.validation.val_steps
+                    ):
+                        break
 
                     for k, v in input_dict.items():
-                        if isinstance(v, torch.Tensor):
-                            input_dict[k] = v.to(device_type)
-                    if isinstance(labels, torch.Tensor):
-                        labels = labels.to(device_type)
+                        input_dict[k] = v.to(device_type)
+                    labels = labels.to(device_type)
 
                     inputs = input_dict["input"]
-                    predictions = self.model(inputs)
+                    predictions = model(inputs)
                     loss = self.loss_fn(predictions, labels)
 
                     total_loss += loss.item()
                     num_batches += 1
+
+                    num_val_steps += 1
 
             except StopIteration:
                 logger.info("Validation dataloader exhausted")
@@ -93,29 +104,28 @@ class Validator(BaseValidator):
             average_loss = 0.0
             logger.warning("No validation batches processed")
 
-        # Set model back to train mode
-        self.model.train()
-
         logger.info(
             f"Validation completed. Average loss: {average_loss:.4f} over {num_batches} batches"
         )
+
+        # Set model back to train mode
+        model.train()
+
         return {"validation_loss": average_loss}
 
 
 def build_validator(
     job_config: JobConfig,
-    loss_fn: LossFunction,
-    model: nn.Module,
     dp_world_size: int,
     dp_rank: int,
     tokenizer: Tokenizer,
+    loss_fn: LossFunction,
 ) -> BaseValidator:
     """Build a simple validator focused on correctness."""
     return Validator(
         job_config=job_config,
-        loss_fn=loss_fn,
-        model=model,
         dp_world_size=dp_world_size,
         dp_rank=dp_rank,
         tokenizer=tokenizer,
+        loss_fn=loss_fn,
     )

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -1,4 +1,8 @@
-import os
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.nn as nn
@@ -21,6 +25,16 @@ class BaseValidator:
 
 
 class Validator(BaseValidator):
+    """
+    Simple validator focused on correctness and integration.
+
+    Args:
+        job_config: Job configuration
+        validation_dataloader: The validation dataloader
+        loss_fn: Loss function to use for validation
+        model: The model to validate (single model, no parallelism)
+    """
+
     validation_dataloader: BaseDataLoader
 
     def __init__(
@@ -32,15 +46,6 @@ class Validator(BaseValidator):
         dp_rank: int,
         tokenizer: Tokenizer,
     ):
-        """
-        Simple validator focused on correctness and integration.
-
-        Args:
-            job_config: Job configuration
-            validation_dataloader: The validation dataloader
-            loss_fn: Loss function to use for validation
-            model: The model to validate (single model, no parallelism)
-        """
         self.job_config = job_config
         self.loss_fn = loss_fn
         self.model = model

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -1,0 +1,116 @@
+import os
+
+import torch
+import torch.nn as nn
+
+from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.loss import LossFunction
+from torchtitan.components.tokenizer import Tokenizer
+from torchtitan.config_manager import JobConfig
+from torchtitan.datasets.hf_datasets import build_hf_validation_dataloader
+from torchtitan.tools import utils
+from torchtitan.tools.logging import logger
+
+
+class BaseValidator:
+    def __init__(self, job_config: JobConfig):
+        self.job_config = job_config
+
+    def validate(self) -> dict[str, float]:
+        raise NotImplementedError("validate method not implemented")
+
+
+class Validator(BaseValidator):
+    validation_dataloader: BaseDataLoader
+
+    def __init__(
+        self,
+        job_config: JobConfig,
+        loss_fn: LossFunction,
+        model: nn.Module,
+        dp_world_size: int,
+        dp_rank: int,
+        tokenizer: Tokenizer,
+    ):
+        """
+        Simple validator focused on correctness and integration.
+
+        Args:
+            job_config: Job configuration
+            validation_dataloader: The validation dataloader
+            loss_fn: Loss function to use for validation
+            model: The model to validate (single model, no parallelism)
+        """
+        self.job_config = job_config
+        self.loss_fn = loss_fn
+        self.model = model
+        self.validation_dataloader = build_hf_validation_dataloader(
+            dp_world_size=dp_world_size,
+            dp_rank=dp_rank,
+            tokenizer=tokenizer,
+            job_config=job_config,
+            infinite=False,
+        )
+
+    def validate(self) -> dict[str, float]:
+        # Set model to eval mode
+        self.model.eval()
+
+        total_loss = 0.0
+        num_batches = 0
+        device_type = utils.device_type
+
+        with torch.no_grad():
+            try:
+                for batch_data, targets in self.validation_dataloader:
+                    input_dict, labels = batch_data, targets
+
+                    for k, v in input_dict.items():
+                        if isinstance(v, torch.Tensor):
+                            input_dict[k] = v.to(device_type)
+                    if isinstance(labels, torch.Tensor):
+                        labels = labels.to(device_type)
+
+                    inputs = input_dict["input"]
+                    predictions = self.model(inputs)
+                    loss = self.loss_fn(predictions, labels)
+
+                    total_loss += loss.item()
+                    num_batches += 1
+
+            except StopIteration:
+                logger.info("Validation dataloader exhausted")
+
+        # Compute average loss
+        if num_batches > 0:
+            average_loss = total_loss / num_batches
+        else:
+            average_loss = 0.0
+            logger.warning("No validation batches processed")
+
+        # Set model back to train mode
+        self.model.train()
+
+        logger.info(
+            f"Validation completed. Average loss: {average_loss:.4f} over {num_batches} batches"
+        )
+        return {"validation_loss": average_loss}
+
+
+def build_validator(
+    job_config: JobConfig,
+    loss_fn: LossFunction,
+    model: nn.Module,
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: Tokenizer,
+) -> BaseValidator:
+    """Build a simple validator focused on correctness."""
+    return Validator(
+        job_config=job_config,
+        loss_fn=loss_fn,
+        model=model,
+        dp_world_size=dp_world_size,
+        dp_rank=dp_rank,
+        tokenizer=tokenizer,
+    )

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -9,7 +9,6 @@ from typing import Generator
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule
-from torch.distributed.tensor import DTensor
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.loss import LossFunction
 from torchtitan.components.tokenizer import Tokenizer

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -666,7 +666,7 @@ class Experimental:
 
 
 @dataclass
-class Validator:
+class Validation:
     enabled: bool = False
     """Enable validation to default run validation after each training loop"""
 
@@ -707,7 +707,7 @@ class JobConfig:
     memory_estimation: MemoryEstimation = field(default_factory=MemoryEstimation)
     fault_tolerance: FaultTolerance = field(default_factory=FaultTolerance)
     experimental: Experimental = field(default_factory=Experimental)
-    validation: Validator = field(default_factory=Validator)
+    validation: Validation = field(default_factory=Validation)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -666,6 +666,24 @@ class Experimental:
 
 
 @dataclass
+class Validator:
+    enabled: bool = False
+    """Enable validation to default run validation after each training loop"""
+
+    dataset: str = "c4_test"
+    """Dataset to use for validation"""
+
+    dataset_path: str | None = None
+    """Path to dataset to use for validation"""
+
+    local_batch_size: int = 8
+    """Batch size for validation"""
+
+    seq_len: int = 2048
+    """Sequence length for validation"""
+
+
+@dataclass
 class JobConfig:
     """
     Default container for training configuration.
@@ -689,6 +707,7 @@ class JobConfig:
     memory_estimation: MemoryEstimation = field(default_factory=MemoryEstimation)
     fault_tolerance: FaultTolerance = field(default_factory=FaultTolerance)
     experimental: Experimental = field(default_factory=Experimental)
+    validation: Validator = field(default_factory=Validator)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -682,11 +682,16 @@ class Validation:
     seq_len: int = 2048
     """Sequence length for validation"""
 
-    val_freq: int = 1
+    freq: int = 10
     """Frequency of validation"""
 
-    val_steps: int = -1
-    """Number of validation steps, -1 means all steps"""
+    steps: int = -1
+    """Number of steps to take in the validation set, -1 means consuming all the data in the validation dataset"""
+
+    def __post_init__(self):
+        assert (
+            self.steps > 0 or self.steps == -1
+        ), "validation steps must be positive or -1"
 
 
 @dataclass

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -670,7 +670,7 @@ class Validation:
     enabled: bool = False
     """Enable validation to default run validation after each training loop"""
 
-    dataset: str = "c4_test"
+    dataset: str = "c4_validation"
     """Dataset to use for validation"""
 
     dataset_path: str | None = None
@@ -681,6 +681,12 @@ class Validation:
 
     seq_len: int = 2048
     """Sequence length for validation"""
+
+    val_freq: int = 1
+    """Frequency of validation"""
+
+    val_steps: int = -1
+    """Number of validation steps, -1 means all steps"""
 
 
 @dataclass

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -207,7 +207,7 @@ def build_hf_validation_dataloader(
     job_config: JobConfig,
     infinite: bool = True,
 ) -> ParallelAwareDataloader:
-    """Build a data loader for HuggingFace datasets."""
+    """Build a validation data loader for HuggingFace datasets."""
     dataset_name = job_config.validation.dataset
     dataset_path = job_config.validation.dataset_path
     batch_size = job_config.validation.local_batch_size

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -49,11 +49,13 @@ DATASETS = {
         loader=lambda path: load_dataset(path, split="train"),
         text_processor=_process_c4_text,
     ),
-    # "c4_validation": DatasetConfig(
-    #     path="tests/assets/c4_test",
-    #     loader=lambda path: load_dataset(path, split="validation"),
-    #     text_processor=_process_c4_text,
-    # ),
+    "c4_validation": DatasetConfig(
+        path="allenai/c4",
+        loader=lambda path: load_dataset(
+            path, name="en", split="validation", streaming=True
+        ),
+        text_processor=_process_c4_text,
+    ),
 }
 
 

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -49,6 +49,11 @@ DATASETS = {
         loader=lambda path: load_dataset(path, split="train"),
         text_processor=_process_c4_text,
     ),
+    # "c4_validation": DatasetConfig(
+    #     path="tests/assets/c4_test",
+    #     loader=lambda path: load_dataset(path, split="validation"),
+    #     text_processor=_process_c4_text,
+    # ),
 }
 
 
@@ -176,6 +181,37 @@ def build_hf_dataloader(
     dataset_path = job_config.training.dataset_path
     batch_size = job_config.training.local_batch_size
     seq_len = job_config.training.seq_len
+
+    hf_ds = HuggingFaceDataset(
+        dataset_name=dataset_name,
+        dataset_path=dataset_path,
+        tokenizer=tokenizer,
+        seq_len=seq_len,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        infinite=infinite,
+    )
+
+    return ParallelAwareDataloader(
+        dataset=hf_ds,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        batch_size=batch_size,
+    )
+
+
+def build_hf_validation_dataloader(
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: Tokenizer,
+    job_config: JobConfig,
+    infinite: bool = True,
+) -> ParallelAwareDataloader:
+    """Build a data loader for HuggingFace datasets."""
+    dataset_name = job_config.validation.dataset
+    dataset_path = job_config.validation.dataset_path
+    batch_size = job_config.validation.local_batch_size
+    seq_len = job_config.validation.seq_len
 
     hf_ds = HuggingFaceDataset(
         dataset_name=dataset_name,

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -9,6 +9,7 @@
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
+from torchtitan.components.validate import build_validator
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.datasets.tokenizer.tiktoken import build_tiktoken_tokenizer
 from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
@@ -81,5 +82,6 @@ register_train_spec(
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_tiktoken_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
+        build_validator_fn=build_validator,
     )
 )

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -54,6 +54,7 @@ tensor_parallel_degree = 1
 enable_async_tensor_parallel = false
 pipeline_parallel_degree = 1
 context_parallel_degree = 1
+disable_loss_parallel = true
 
 [checkpoint]
 enable_checkpoint = false
@@ -71,3 +72,7 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
+
+[validation]
+enabled = false
+dataset = "c4_test"

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -74,5 +74,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
-dataset = "c4_test"
+enabled = true
+dataset = "c4_validation"
+val_freq = 5
+val_steps = 10

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -54,7 +54,6 @@ tensor_parallel_degree = 1
 enable_async_tensor_parallel = false
 pipeline_parallel_degree = 1
 context_parallel_degree = 1
-disable_loss_parallel = true
 
 [checkpoint]
 enable_checkpoint = false
@@ -76,5 +75,5 @@ filter_fqns = ["output"]
 [validation]
 enabled = false
 dataset = "c4_validation"
-val_freq = 5
-val_steps = 10
+freq = 5
+steps = 10

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -74,7 +74,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = true
+enabled = false
 dataset = "c4_validation"
 val_freq = 5
 val_steps = 10

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -23,6 +23,7 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.components.tokenizer import Tokenizer
+from torchtitan.components.validate import BaseValidator
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed import ParallelDims
 
@@ -80,6 +81,7 @@ LRSchedulersBuilder: TypeAlias = Callable[
     [OptimizersContainer, JobConfig], LRSchedulersContainer
 ]
 LossFunctionBuilder: TypeAlias = Callable[..., LossFunction]
+ValidatorBuilder: TypeAlias = Callable[..., BaseValidator]
 
 
 @dataclass
@@ -94,6 +96,7 @@ class TrainSpec:
     build_dataloader_fn: DataLoaderBuilder
     build_tokenizer_fn: TokenizerBuilder | None
     build_loss_fn: LossFunctionBuilder
+    build_validator_fn: ValidatorBuilder | None = None
     build_metrics_processor_fn: MetricsProcessorBuilder | None = None
 
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -11,10 +11,10 @@ from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
 import torch
+from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.components.ft as ft
 import torchtitan.protocols.train_spec as train_spec_module
-from torch.distributed.elastic.multiprocessing.errors import record
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.dataloader import DataloaderStopIteration
 from torchtitan.components.loss import rescale_accumulated_loss

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -219,7 +219,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if parallel_dims.pp_enabled:
             if not self.train_spec.pipelining_fn:
                 raise RuntimeError(
-                    f"pipeline parallel is enabled but {self.train_spec.name} "
+                    f"Pipeline parallel is enabled but {self.train_spec.name} "
                     f"does not support pipelining"
                 )
 
@@ -336,7 +336,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 tokenizer=tokenizer,
                 parallel_dims=parallel_dims,
                 world_mesh=world_mesh,
-                loss_fn=self.loss_fn,
+                loss_fn=self.train_spec.build_loss_fn(job_config),
+                validation_context=self.train_context,
+                maybe_enable_amp=self.maybe_enable_amp,
             )
 
         logger.info(
@@ -525,7 +527,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                     self.job_config.validation.enabled
                     and self.validator.should_validate(self.step)
                 ):
-                    validation_metrics = self.validator.validate(self.model_parts)
+                    self.validator.validate(self.model_parts)
 
                 self.checkpointer.save(
                     self.step, last_step=(self.step == job_config.training.steps)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -11,10 +11,10 @@ from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
 import torch
-from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.components.ft as ft
 import torchtitan.protocols.train_spec as train_spec_module
+from torch.distributed.elastic.multiprocessing.errors import record
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.dataloader import DataloaderStopIteration
 from torchtitan.components.loss import rescale_accumulated_loss
@@ -330,15 +330,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             and job_config.validation.dataset
         ):
 
-            model = (
-                self.model_parts[0]
-                if len(self.model_parts) == 1
-                else self.model_parts[0]
-            )
             self.validator = self.train_spec.build_validator_fn(
                 job_config=job_config,
                 loss_fn=self.loss_fn,
-                model=model,
+                model=self.model_parts[0],
                 dp_world_size=dp_degree,
                 dp_rank=dp_rank,
                 tokenizer=tokenizer,

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -219,7 +219,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if parallel_dims.pp_enabled:
             if not self.train_spec.pipelining_fn:
                 raise RuntimeError(
-                    f"Pipeline parallel is enabled but {self.train_spec.name} "
+                    f"Pipeline Parallel is enabled but {self.train_spec.name} "
                     f"does not support pipelining"
                 )
 


### PR DESCRIPTION
Update PR Summary:
Implements a validator that can be easily plugged into the training loop and configured from the job specific config file.
Changes:
- Created validation section in job_config with enabled, dataset, freq, and steps fields
- Created a builder function for validator in train_spec
- Created a separate builder function for validation dataset in hf_dataset.py
- Created validator class
  - Validator class initializes a build_validation_hf_loader but leaves this dataloader function unexposed to the train_spec
  - Validator class supports ddp, fsdp, cp, and tp (but not pp yet)
- Integrated validation call into training loop
- Creates an integration test to test parallelization

Updated tests training the same base model weights from a seed checkpoint:

| FSDP=2 | FSDP=2,TP=4 |
| --- | --- |
| <img width="978" alt="Screenshot 2025-07-09 at 4 33 53 PM" src="https://github.com/user-attachments/assets/a1fa9fa7-df2f-4302-aa4a-d556a5699ba9" /> | <img width="978" alt="Screenshot 2025-07-09 at 4 33 53 PM" src="https://github.com/user-attachments/assets/a1fa9fa7-df2f-4302-aa4a-d556a5699ba9" /> |

| FSDP=2,CP=4 | FSDP=2,TP=2,CP=2 |
| --- | --- |
| <img width="972" alt="Screenshot 2025-07-09 at 4 39 35 PM" src="https://github.com/user-attachments/assets/56d62841-5841-4969-85b1-803705892465" /> | <img width="970" alt="Screenshot 2025-07-09 at 4 28 57 PM" src="https://github.com/user-attachments/assets/f7d33fa8-ca2c-48f1-931c-8d4c017a47ce" /> |
