### PR TITLE
[DSV3] Explicitly convert to bfloat16 when use grouped mm

### DIFF
--- a/torchtitan/models/deepseek_v3/model/model.py
+++ b/torchtitan/models/deepseek_v3/model/model.py
@@ -336,6 +336,10 @@ class DeepSeekV3Model(nn.Module, ModelProtocol):
         self.model_args = model_args
         self.init_weights()
 
+        # Explicitly set dtype to bfloat16 if use_grouped_mm is True
+        if model_args.use_grouped_mm:
+            self.to(dtype=torch.bfloat16)
+
     def init_weights(self, buffer_device: torch.device | None = None) -> None:
         buffer_device = buffer_device or self.freqs_cis.device
         with torch.device(buffer_device):

--- a/torchtitan/models/deepseek_v3/model/moe.py
+++ b/torchtitan/models/deepseek_v3/model/moe.py
@@ -141,12 +141,12 @@ class GroupedExperts(nn.Module):
             assert x.dim() == 3
 
         assert (
-            x.dtype == w1.dtype == w2.dtype == w3.dtype == torch.bfloat16
-        ), "torch._grouped_mm only supports bf16 dtypes"
+            w1.dtype == w2.dtype == w3.dtype == torch.bfloat16
+        ), "torch._grouped_mm only supports bf16 model weight dtypes"
 
-        h = F.silu(torch._grouped_mm(x, w1, offs=offsets))
-        h = h * torch._grouped_mm(x, w3, offs=offsets)
-        out = torch._grouped_mm(h, w2, offs=offsets)
+        h = F.silu(torch._grouped_mm(x.to(torch.bfloat16), w1, offs=offsets))
+        h = h * torch._grouped_mm(x.to(torch.bfloat16), w3, offs=offsets)
+        out = torch._grouped_mm(h, w2, offs=offsets).to(x.dtype)
 
         return out
 


### PR DESCRIPTION
As titled, use grouped mm would assume the MoE module is bf16