### PR TITLE
Add option to exclude low flop mms from every-other-mm sac policy

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -489,8 +489,8 @@ class ActivationCheckpoint:
     selective_op_ac_mm_flops_threshold: int = 0
     """
     When selective_ac_option is 'op', this threshold is used to determine whether to
-    save a given mm, e.g. 1e5 means every other mm is saved, excluding mm with
-    flops < 1e5.
+    save a given mm, e.g. 1e5 means excluding mms flops < 1e5, and then saving
+    every other mm from the remaining mms.
     """
 
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -489,11 +489,8 @@ class ActivationCheckpoint:
     selective_op_ac_mm_flops_threshold: int = 0
     """
     When selective_ac_option is 'op', this threshold is used to determine whether to
-    apply save a given mm.
-
-    For example:
-    - 0 means no threshold; every other mm is saved
-    - 1e5 means every other mm is saved, excluding mm with flops > 1e5.
+    save a given mm, e.g. 1e5 means every other mm is saved, excluding mm with
+    flops < 1e5.
     """
 
 

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -486,6 +486,15 @@ class ActivationCheckpoint:
     Selective activation checkpointing options ['int', 'op'].
     'int' (e.g., 2) for every nth layer, or 'op' for op level ac.
     """
+    selective_op_ac_mm_flops_threshold: int = 0
+    """
+    When selective_ac_option is 'op', this threshold is used to determine whether to
+    apply save a given mm.
+
+    For example:
+    - 0 means no threshold; every other mm is saved
+    - 1e5 means every other mm is saved, excluding mm with flops > 1e5.
+    """
 
 
 @dataclass

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -486,6 +486,7 @@ class ActivationCheckpoint:
     Selective activation checkpointing options ['int', 'op'].
     'int' (e.g., 2) for every nth layer, or 'op' for op level ac.
     """
+
     selective_op_ac_mm_flops_threshold: int = 0
     """
     When selective_ac_option is 'op', this threshold is used to determine whether to
@@ -493,6 +494,11 @@ class ActivationCheckpoint:
     every other mm from the remaining mms.
     """
 
+    log_mm_flops: bool = False
+    """
+    Whether to log the distribution of mm flops. This can be useful for determining
+    the appropriate threshold for selective_op_ac_mm_flops_threshold.
+    """
 
 @dataclass
 class Float8:

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -63,8 +63,10 @@ export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = "none"  # ["none", "selective", "full"]
-selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+selective_op_ac_mm_flops_threshold = 0 # checking if everything is recomputed
+log_mm_flops = true
 
 [float8]
 enable_fsdp_float8_all_gather = false

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -8,6 +8,8 @@
 # training techniques (e.g. activation checkpointing and compile) to the Llama model.
 
 from collections import defaultdict
+from decimal import Decimal
+import functools
 
 import torch
 import torch.nn as nn
@@ -237,6 +239,28 @@ _save_list = {
 }
 
 
+def _format_mm_flops_table(entries):
+    header = ("MM Shape", "FLOPs", "Count")
+    rows = [header] + [(k[0], k[1], str(v)) for k, v in entries.items()]
+    col0 = max(len(r[0]) for r in rows)
+    col1 = max(len(r[1]) for r in rows)
+    col2 = max(len(r[2]) for r in rows)
+    lines = [
+        f"| {'MM Shape'.ljust(col0)} | {'FLOPs'.ljust(col1)} | {'Count'.ljust(col2)} |",
+        f"| {'-' * col0} | {'-' * col1} | {'-' * col2} |",
+    ]
+    for s, fl, cnt in rows[1:]:
+        lines.append(f"| {s.ljust(col0)} | {fl.ljust(col1)} | {cnt.ljust(col2)} |")
+    return "\n".join(lines)
+
+
+def _wrap_with_disable_early_stop(fn):
+    def inner(*args, **kwargs):
+        with torch.utils.checkpoint.set_checkpoint_early_stop(False):
+            return fn(*args, **kwargs)
+    return inner
+
+
 def _apply_ac_to_transformer_block(module: nn.Module, ac_config):
     valid_ac_modes = ("full", "selective")
     if ac_config.mode not in valid_ac_modes:
@@ -264,21 +288,38 @@ def _apply_ac_to_transformer_block(module: nn.Module, ac_config):
         def _get_custom_policy(meta):
             def _custom_policy(ctx, func, *args, **kwargs):
                 mode = "recompute" if ctx.is_recompute else "forward"
+
+                mm_count_key_filtered = f"{mode}_mm_count_filtered"
                 mm_count_key = f"{mode}_mm_count"
 
                 if func == torch.ops.aten.mm.default:
+                    meta[mm_count_key] += 1
+
                     m, k = args[0].shape
                     k2, n = args[1].shape
                     assert k == k2
                     flops = m * n * 2 * k
+
+                    if ac_config.log_mm_flops and ctx.is_recompute:
+                        shape_str = f"({m}x{k}) x ({k2}x{n})"
+                        flops_str = f"{Decimal(flops):.2E}"
+                        key = (shape_str, flops_str)
+                        meta[key] += 1
+                        if meta["recompute_mm_count"] == meta["forward_mm_count"]:
+                            table = _format_mm_flops_table({k:v for k,v in meta.items() if "mm_count" not in k})
+                            logger.info("\n%s", table)
+
+                    # Filter out ops below are certain flop threshold. See discussion for why we
+                    # recompute instead of save here:
+                    # https://github.com/pytorch/torchtitan/pull/1372#discussion_r2193722200
                     if flops < ac_config.selective_op_ac_mm_flops_threshold:
                         return CheckpointPolicy.PREFER_RECOMPUTE
 
-                if func == torch.ops.aten.mm.default:
-                    meta[mm_count_key] += 1
+                    meta[mm_count_key_filtered] += 1
+
                 # Saves output of all compute ops, except every second mm
                 to_save = func in _save_list and not (
-                    func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0
+                    func == torch.ops.aten.mm.default and meta[mm_count_key_filtered] % 2 == 0
                 )
                 return (
                     CheckpointPolicy.MUST_SAVE
@@ -292,9 +333,17 @@ def _apply_ac_to_transformer_block(module: nn.Module, ac_config):
             meta = defaultdict(int)
             return create_selective_checkpoint_contexts(_get_custom_policy(meta))
 
+        checkpoint_fn = functools.partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
+        if ac_config.log_mm_flops:
+            # If early-stop is enabled, fewer mm are recomputed than in forward. Disabling
+            # this will slightly alter perf, but allows us to deterministically know when to
+            # log the mm flops table rather than having to spam it for every mm call.
+            checkpoint_fn = _wrap_with_disable_early_stop(checkpoint_fn)
+
         return ptd_checkpoint_wrapper(
             module,
             context_fn=selective_checkpointing_context_fn,
+            checkpoint_fn=checkpoint_fn,
             preserve_rng_state=False,
         )
     elif use_layer_sac:
@@ -314,7 +363,9 @@ def apply_ac(model: nn.Module, ac_config):
         transformer_block = _apply_ac_to_transformer_block(transformer_block, ac_config)
         model.layers.register_module(layer_id, transformer_block)
 
-    logger.info(f"Applied {ac_config.mode} activation checkpointing to the model")
+    logger.info(f"Applied {ac_config.mode} checkpointing to the model")
+    if ac_config.selective_ac_option == "op" and ac_config.log_mm_flops:
+        logger.info("Logging enabled for mm flops.")
 
 
 def apply_compile(model: nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1372

See issue described in https://github.com/pytorch/torchtitan/pull/1182#issuecomment-3047379581 / https://github.com/pytorch/torchtitan/pull/1330#discussion_r2164727536

Manual testing (on llama3 8b):

Without PR: 
[rank0]:[titan] 2025-07-09 09:12:06,021 - root - INFO - step:  1  loss: 12.2236  grad_norm:  4.1079  memory: 69.06GiB(87.27%)  tps: 401  tflops: 23.22  mfu: 7.44%

With `selective_op_ac_mm_flops_threshold=1e50`:
[rank0]:[titan] 2025-07-09 09:09:56,360 - root - INFO - step:  1  loss: 12.2236  grad_norm:  4.1079  memory: 58.42GiB(73.82%)  tps: 389  tflops: 22.52  mfu: 7.22%

With `selective_op_ac_mm_flops_threshold=0`:
[rank0]:[titan] 2025-07-09 09:10:50,693 - root - INFO - step:  1  loss: 12.2236  grad_norm:  4.1079  memory: 69.06GiB(87.27%)  tps: 399  tflops: 23.10  mfu: 7.40%

Manual exclude all mms from being saved:
[rank0]:[titan] 2025-07-09 09:12:56,345 - root - INFO - step:  1  loss: 12.2236  grad_norm:  4.1079  memory: 58.42GiB(73.82%)  tps: 394  tflops: 22.84  mfu: 7.32%

<summary>

Also adds the ability to log the mm shapes/flops:
llama 3 8b
```
[rank0]:| MM Shape                    | FLOPs    | Count |
[rank0]:| --------------------------- | -------- | ----- |
[rank0]:| (8192x4096) x (4096x4096)   | 2.75E+11 | 2     |
[rank0]:| (8192x4096) x (4096x1024)   | 6.87E+10 | 2     |
[rank0]:| (8192x4096) x (4096x14336)  | 9.62E+11 | 2     |
[rank0]:| (8192x14336) x (14336x4096) | 9.62E+11 | 1     |
```

llama 4 debug
```
[rank0]:[titan] 2025-07-10 08:35:02,476 - root - INFO -
[rank0]:| MM Shape                | FLOPs   | Count |
[rank0]:| ----------------------- | ------- | ----- |
[rank0]:| (16384x256) x (256x256) | 2.15E+9 | 4     |
[rank0]:| (16384x256) x (256x8)   | 6.71E+7 | 1     |
[rank0]:| (16x256) x (256x512)    | 4.19E+6 | 10    |
[rank0]:| (16x512) x (512x256)    | 4.19E+6 | 5     |
[rank0]:| (15104x256) x (256x512) | 3.96E+9 | 2     |
[rank0]:| (15104x512) x (512x256) | 3.96E+9 | 1     |
[rank0]:| (352x256) x (256x512)   | 9.23E+7 | 2     |
[rank0]:| (352x512) x (512x256)   | 9.23E+7 | 1     |
[rank0]:| (928x256) x (256x512)   | 2.43E+8 | 2     |
[rank0]:| (928x512) x (512x256)   | 2.43E+8 | 1     |
[rank0]:[titan] 2025-07-10 08:35:02,606 - root - INFO -
[rank0]:| MM Shape                | FLOPs   | Count |
[rank0]:| ----------------------- | ------- | ----- |
[rank0]:| (16384x256) x (256x256) | 2.15E+9 | 4     |
[rank0]:| (16384x256) x (256x8)   | 6.71E+7 | 1     |
[rank0]:| (5696x256) x (256x512)  | 1.49E+9 | 2     |
[rank0]:| (5696x512) x (512x256)  | 1.49E+9 | 1     |
[rank0]:| (192x256) x (256x512)   | 5.03E+7 | 2     |
[rank0]:| (192x512) x (512x256)   | 5.03E+7 | 1     |
[rank0]:| (16x256) x (256x512)    | 4.19E+6 | 6     |
[rank0]:| (16x512) x (512x256)    | 4.19E+6 | 3     |
[rank0]:| (5504x256) x (256x512)  | 1.44E+9 | 2     |
[rank0]:| (5504x512) x (512x256)  | 1.44E+9 | 1     |
[rank0]:| (4976x256) x (256x512)  | 1.30E+9 | 2     |
[rank0]:| (4976x512) x (512x256)  | 1.30E+9 | 1     |
[rank0]:| (32x256) x (256x512)    | 8.39E+6 | 2     |
[rank0]:| (32x512) x (512x256)    | 8.39E+6 | 1     |
[rank0]:[titan] 2025-07-10 08:35:02,736 - root - INFO -
[rank0]:| MM Shape                | FLOPs   | Count |
[rank0]:| ----------------------- | ------- | ----- |
[rank0]:| (16384x256) x (256x256) | 2.15E+9 | 4     |
[rank0]:| (16384x256) x (256x8)   | 6.71E+7 | 1     |
[rank0]:| (1392x256) x (256x512)  | 3.65E+8 | 2     |
[rank0]:| (1392x512) x (512x256)  | 3.65E+8 | 1     |
[rank0]:| (1008x256) x (256x512)  | 2.64E+8 | 2     |
[rank0]:| (1008x512) x (512x256)  | 2.64E+8 | 1     |
[rank0]:| (2960x256) x (256x512)  | 7.76E+8 | 2     |
[rank0]:| (2960x512) x (512x256)  | 7.76E+8 | 1     |
[rank0]:| (400x256) x (256x512)   | 1.05E+8 | 2     |
[rank0]:| (400x512) x (512x256)   | 1.05E+8 | 1     |
[rank0]:| (2336x256) x (256x512)  | 6.12E+8 | 2     |
[rank0]:| (2336x512) x (512x256)  | 6.12E+8 | 1     |
[rank0]:| (4144x256) x (256x512)  | 1.09E+9 | 2     |
[rank0]:| (4144x512) x (512x256)  | 1.09E+9 | 1     |
[rank0]:| (1024x256) x (256x512)  | 2.68E+8 | 2     |
[rank0]:| (1024x512) x (512x256)  | 2.68E+8 | 1     |
[rank0]:| (3168x256) x (256x512)  | 8.30E+8 | 2     |
[rank0]:| (3168x512) x (512x256)  | 8.30E+8 | 1     |
```

