### PR TITLE
[float8 moe] Support TP

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -60,9 +60,6 @@ class Float8Converter(ModelConverter):
         # Validate MoE training prototype limitations.
         if self.moe_fqns:
             assert (
-                job_config.parallelism.tensor_parallel_degree == 1
-            ), "Float8 MoE training prototype does not yet support tensor parallelism"
-            assert (
                 job_config.parallelism.pipeline_parallel_degree == 1
             ), "Float8 MoE training prototype does not yet support pipeline parallelism"
             assert (


### PR DESCRIPTION
We can remove this assertion, TP support for float8 rowwise MoE training was added in this PR stack: https://github.com/pytorch/ao/pull/2473