### PR TITLE
add float8 support

### DIFF
--- a/torchtitan/experiments/auto_parallel/parallelize_llama.py
+++ b/torchtitan/experiments/auto_parallel/parallelize_llama.py
@@ -53,6 +53,14 @@ def parallelize_llama(
     assert parallel_dims.cp_enabled is False, "CP not supported yet"
     assert parallel_dims.pp_enabled is False, "PP not supported yet"
 
+    # TODO: there are multiple float8 recipes, this just hardcodes one
+    enable_float8_linear = "float8" in job_config.model.converters
+    if enable_float8_linear:
+        import copy
+        from torchao.float8.float8_linear_utils import convert_to_float8_training
+        from torchao.float8.config import Float8LinearConfig
+        model = convert_to_float8_training(copy.deepcopy(model), config=Float8LinearConfig())
+
     # bail out
     # model = model_fn()
     # return model


### PR DESCRIPTION
repro command:
```
CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" ./run_train.sh --model.name llama3_auto_parallel --parallelism.tensor_parallel_degree 4 --model.converters="float8"
```

my integration uses an existing float8 util that just replaces any linear layers in the user model with `Float8Linear` layers.

**The good news**

we don't actually need special subclass handling in autoparallel yet! The model weights are stored in high precision and gets quantized dynamically during the forward, so we have no subclass params in the state dict. After talking to Driss/Daniel, this is true for **both** float8 compute, and float8 allgathers

**The bad news**

The first thing that breaks is that _scaled_mm raises an error because it rquires its second arg to be column-major, and autoparallel accidentally makes all intermediate tensors contiguous during FlopCounter estimation. fix here: 