### PR TITLE
refactor ParallelDims and CheckpointManager

### DIFF
--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -106,14 +106,13 @@ def test_generate(
     # Tokenizer setup
     tokenizer = train_spec.build_tokenizer_fn(config)
 
-    model_cls = train_spec.cls
-    model_args = train_spec.config[config.model.flavor]
+    model_args = train_spec.model_args[config.model.flavor]
     model_args.update_from_config(config, tokenizer)
 
     init_device = "meta" if world_size > 1 else device
     with torch.device(init_device):
         logger.info(f"Init model on init_device: {init_device}")
-        model = model_cls(model_args)
+        model = train_spec.model_cls(model_args)
 
     world_mesh = None
     # Init distributed env
@@ -127,14 +126,12 @@ def test_generate(
             pp=1,
             ep=1,
             world_size=world_size,
-            enable_loss_parallel=False,
         )
-        # Build world mesh for parallelism
-        world_mesh = parallel_dims.build_mesh(device_type=device_type)
+        world_mesh = parallel_dims.world_mesh
 
         # apply_tp (with Sequence Parallel) on unevenly sharded
         # sequences would require https://github.com/pytorch/torchtitan/pull/686
-        apply_tp_minus_sp(model, world_mesh["tp"])
+        apply_tp_minus_sp(model, parallel_dims.world_mesh["tp"])
 
     dist_utils.set_determinism(world_mesh, device, seed, deterministic)
 

--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -23,7 +23,6 @@ def build_parallel_dims(job_config, world_size):
         pp=parallelism_config.pipeline_parallel_degree,
         ep=parallelism_config.expert_parallel_degree,
         world_size=world_size,
-        enable_loss_parallel=not parallelism_config.disable_loss_parallel,
     )
     return parallel_dims
 

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -26,8 +26,8 @@ from torch.distributed.checkpoint.state_dict import (
 )
 from torch.distributed.checkpoint.state_dict_saver import AsyncCheckpointerType
 from torch.distributed.checkpoint.stateful import Stateful
-from torch.utils.data import DataLoader
 
+from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.ft import FTManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -180,17 +180,19 @@ class CheckpointManager:
 
     def __init__(
         self,
-        dataloader: DataLoader,
+        dataloader: BaseDataLoader | None,
         model_parts: list[nn.Module],
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
         job_config: JobConfig,
-        ft_manager: FTManager,
+        ft_manager: FTManager | None = None,
     ) -> None:
         ckpt_config = job_config.checkpoint
         self.enable_checkpoint = ckpt_config.enable_checkpoint
-        self.ft_manager = ft_manager.manager if ft_manager.enabled else None
+        self.ft_manager = (
+            ft_manager.manager if ft_manager and ft_manager.enabled else None
+        )
 
         if self.ft_manager:
             optimizers.init_cache_state_dict()

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -15,7 +15,6 @@ from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
 )
 from torch.distributed.checkpoint.stateful import Stateful
-from torch.distributed.device_mesh import DeviceMesh
 from torch.optim import Optimizer
 
 from torchtitan.components.ft import FTManager, has_torchft
@@ -244,7 +243,6 @@ def build_optimizers(
     model_parts: list[nn.Module],
     job_config: JobConfig,
     parallel_dims: ParallelDims,
-    world_mesh: DeviceMesh,
     ft_manager: FTManager,
 ) -> OptimizersContainer:
     """Create a OptimizersContainer for the given model parts and job config.

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -7,16 +7,14 @@
 
 import json
 
-import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Union
 
 from tokenizers import AddedToken, Tokenizer
 from torchtitan.config_manager import JobConfig
+from torchtitan.tools.logging import logger
 from typing_extensions import override
-
-logger = logging.getLogger(__name__)
 
 
 class BaseTokenizer(ABC):

--- a/torchtitan/experiments/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/deepseek_v3/__init__.py
@@ -42,8 +42,8 @@ deepseek_configs = {
 register_train_spec(
     TrainSpec(
         name="deepseek3",
-        cls=DeepseekForCausalLM,
-        config=deepseek_configs,
+        model_cls=DeepseekForCausalLM,
+        model_args=deepseek_configs,
         parallelize_fn=parallelize_deepseek,
         pipelining_fn=pipeline_llama,
         build_optimizers_fn=build_optimizers,

--- a/torchtitan/experiments/deepseek_v3/train_ds_real.py
+++ b/torchtitan/experiments/deepseek_v3/train_ds_real.py
@@ -155,8 +155,8 @@ def run_full_model(
         pp=pp_size,
         cp=1,
         tp=1,
+        ep=1,
         world_size=world_mesh.size(),
-        enable_loss_parallel=False,
     )
 
     metrics_processor = build_metrics_processor(
@@ -180,7 +180,7 @@ def run_full_model(
     loss_fn = cross_entropy_loss  # torch.nn.functional.cross_entropy
 
     ft_manager = ft.init_ft_manager(config)
-    optimizer = build_optimizers([model], config, ft_manager)
+    optimizer = build_optimizers([model], config, proxy_parallel_dims, ft_manager)
 
     lr_scheduler = build_lr_schedulers(optimizer, config)
 

--- a/torchtitan/experiments/flux/__init__.py
+++ b/torchtitan/experiments/flux/__init__.py
@@ -108,8 +108,8 @@ flux_configs = {
 register_train_spec(
     TrainSpec(
         name="flux",
-        cls=FluxModel,
-        config=flux_configs,
+        model_cls=FluxModel,
+        model_args=flux_configs,
         parallelize_fn=parallelize_flux,
         pipelining_fn=None,
         build_optimizers_fn=build_optimizers,

--- a/torchtitan/experiments/flux/infra/parallelize.py
+++ b/torchtitan/experiments/flux/infra/parallelize.py
@@ -21,7 +21,6 @@ from torchtitan.tools.logging import logger
 
 def parallelize_flux(
     model: nn.Module,
-    world_mesh: DeviceMesh,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
@@ -36,7 +35,7 @@ def parallelize_flux(
 
         apply_fsdp(
             model,
-            world_mesh[tuple(dp_mesh_dim_names)],
+            parallel_dims.world_mesh[tuple(dp_mesh_dim_names)],
             param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],
             reduce_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_reduce],
             cpu_offload=job_config.training.enable_cpu_offload,
@@ -117,7 +116,6 @@ def apply_ac(model: nn.Module, ac_config):
 def parallelize_encoders(
     t5_model: nn.Module,
     clip_model: nn.Module,
-    world_mesh: DeviceMesh,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
@@ -132,7 +130,7 @@ def parallelize_encoders(
             reduce_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_reduce],
         )
         fsdp_config = {
-            "mesh": world_mesh[tuple(dp_mesh_dim_names)],
+            "mesh": parallel_dims.world_mesh[tuple(dp_mesh_dim_names)],
             "mp_policy": mp_policy,
         }
         if job_config.training.enable_cpu_offload:

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -36,7 +36,7 @@ class FluxTrainer(Trainer):
         # (mainly for debugging, expect perf loss).
         # For Flux model, we need distinct seed across FSDP ranks to ensure we randomly dropout prompts info in dataloader
         dist_utils.set_determinism(
-            self.world_mesh,
+            self.parallel_dims.world_mesh,
             self.device,
             job_config.training.seed,
             job_config.training.deterministic,
@@ -54,11 +54,11 @@ class FluxTrainer(Trainer):
         )
 
         # load components
-        model_config = self.train_spec.config[job_config.model.flavor]
+        model_args = self.train_spec.model_args[job_config.model.flavor]
 
         self.autoencoder = load_ae(
             job_config.encoder.autoencoder_path,
-            model_config.autoencoder_params,
+            model_args.autoencoder_params,
             device=self.device,
             dtype=self._dtype,
             random_init=job_config.training.test_mode,
@@ -77,7 +77,6 @@ class FluxTrainer(Trainer):
         self.t5_encoder, self.clip_encoder = parallelize_encoders(
             t5_model=self.t5_encoder,
             clip_model=self.clip_encoder,
-            world_mesh=self.world_mesh,
             parallel_dims=self.parallel_dims,
             job_config=job_config,
         )

--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -94,8 +94,8 @@ llama4_configs = {
 register_train_spec(
     TrainSpec(
         name="llama4",
-        cls=Transformer,
-        config=llama4_configs,
+        model_cls=Transformer,
+        model_args=llama4_configs,
         parallelize_fn=parallelize_llama,
         pipelining_fn=pipeline_llama,
         build_optimizers_fn=build_llama4_optimizers,

--- a/torchtitan/experiments/multimodal/__init__.py
+++ b/torchtitan/experiments/multimodal/__init__.py
@@ -24,8 +24,8 @@ llama4_mm_configs = {
 register_train_spec(
     TrainSpec(
         name="llama4_multimodal",
-        cls=MultimodalDecoder,
-        config=llama4_mm_configs,
+        model_cls=MultimodalDecoder,
+        model_args=llama4_mm_configs,
         parallelize_fn=parallelize_llama,
         pipelining_fn=pipeline_llama,
         build_optimizers_fn=build_optimizers,

--- a/torchtitan/experiments/simple_fsdp/__init__.py
+++ b/torchtitan/experiments/simple_fsdp/__init__.py
@@ -20,8 +20,8 @@ from .parallelize import parallelize_llama
 register_train_spec(
     TrainSpec(
         name="llama3_simple_fsdp",
-        cls=SimpleFSDPTransformer,
-        config=llama3_configs,
+        model_cls=SimpleFSDPTransformer,
+        model_args=llama3_configs,
         parallelize_fn=parallelize_llama,
         pipelining_fn=pipeline_llama,
         build_optimizers_fn=build_optimizers,

--- a/torchtitan/experiments/simple_fsdp/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize.py
@@ -7,8 +7,6 @@
 import torch
 import torch.nn as nn
 
-from torch.distributed import DeviceMesh
-
 from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
 from torchtitan.models.llama3.infra.parallelize import apply_ac, apply_tp
@@ -19,7 +17,6 @@ from .simple_fsdp import data_parallel, MixedPrecisionPolicy
 
 def parallelize_llama(
     model: nn.Module,
-    world_mesh: DeviceMesh,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
@@ -30,6 +27,16 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
+    # TODO: TP currently cannot handle uneven seq_len because we set
+    #       `use_local_output=True` to use plain Tensors for legacy reasons.
+    #       Need to revisit this.
+    assert (
+        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
+        Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
+        """
+
     if parallel_dims.tp_enabled:
         if (
             job_config.parallelism.enable_async_tensor_parallel
@@ -48,11 +55,11 @@ def parallelize_llama(
         # all-gather happens in high precision.
         enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
 
-        tp_mesh = world_mesh["tp"]
+        tp_mesh = parallel_dims.world_mesh["tp"]
         apply_tp(
             model,
-            world_mesh["tp"],
-            loss_parallel=parallel_dims.loss_parallel_enabled,
+            tp_mesh,
+            loss_parallel=not job_config.parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
             enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
         )
@@ -84,7 +91,7 @@ def parallelize_llama(
 
         model = data_parallel(
             model,
-            world_mesh[tuple(dp_mesh_dim_names)],
+            parallel_dims.world_mesh[tuple(dp_mesh_dim_names)],
             mode=dp_mode,
             ac_mode=job_config.activation_checkpoint.mode,
             mp_policy=mp_policy,

--- a/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
+++ b/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
@@ -38,10 +38,10 @@ class TestSimpleFSDP(FSDPTest):
             cp=1,
             tp=1,
             pp=1,
+            ep=1,
             world_size=self.world_size,
-            enable_loss_parallel=True,
         )
-        self.device_mesh = self.parallel_dims.build_mesh(device_type="cuda")
+        self.device_mesh = self.parallel_dims.world_mesh
 
     def get_input(self):
         inputs = torch.randn(8, 8).cuda()

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -113,8 +113,8 @@ deepseekv3_configs = {
 register_train_spec(
     TrainSpec(
         name="deepseek_v3",
-        cls=DeepSeekV3Model,
-        config=deepseekv3_configs,
+        model_cls=DeepSeekV3Model,
+        model_args=deepseekv3_configs,
         parallelize_fn=parallelize_deepseekv3,
         pipelining_fn=None,
         build_optimizers_fn=build_llama4_optimizers,  # use optimizer hooks to update expert weights

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -26,10 +26,20 @@ from torchtitan.tools.logging import logger
 # Adapted from llama4/infra/parallelize.py
 def parallelize_deepseekv3(
     model: nn.Module,
-    world_mesh: DeviceMesh,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
+    world_mesh = parallel_dims.world_mesh
+    # TODO: TP currently cannot handle uneven seq_len because we set
+    #       `use_local_output=True` to use plain Tensors for legacy reasons.
+    #       Need to revisit this.
+    assert (
+        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
+        Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
+        """
+
     if parallel_dims.tp_enabled:
         if job_config.parallelism.enable_async_tensor_parallel:
             # TODO(jianiw): This branch needs to be tested and enabled
@@ -54,7 +64,7 @@ def parallelize_deepseekv3(
         apply_non_moe_tp(
             model,
             world_mesh["tp"],
-            loss_parallel=parallel_dims.loss_parallel_enabled,
+            loss_parallel=not job_config.parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=False,
             enable_async_tp=False,
         )

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -73,8 +73,8 @@ llama3_configs = {
 register_train_spec(
     TrainSpec(
         name="llama3",
-        cls=Transformer,
-        config=llama3_configs,
+        model_cls=Transformer,
+        model_args=llama3_configs,
         parallelize_fn=parallelize_llama,
         pipelining_fn=pipeline_llama,
         build_optimizers_fn=build_optimizers,

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -34,7 +34,6 @@ from torchtitan.tools.logging import logger
 
 def parallelize_llama(
     model: nn.Module,
-    world_mesh: DeviceMesh,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ):
@@ -45,16 +44,15 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
-    # TODO: TP currently cannot handle uneven seq_len because we set `use_local_output=True`
-    # (to use plain Tensors), which was because of the bug in computation of complex
-    # numbers with DTensors when setting `use_local_output=False`.
-    # See https://github.com/pytorch/pytorch/issues/130646 and
-    # https://github.com/pytorch/torchtitan/issues/1306 for details.
+    world_mesh = parallel_dims.world_mesh
+    # TODO: TP currently cannot handle uneven seq_len because we set
+    #       `use_local_output=True` to use plain Tensors for legacy reasons.
+    #       Need to revisit this.
     assert (
-        job_config.training.seq_len % (parallel_dims.tp * parallel_dims.cp) == 0
+        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
     ), f"""
         Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
-        ({parallel_dims.tp}) and CP degree ({parallel_dims.cp}).
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
     if parallel_dims.tp_enabled:
@@ -78,7 +76,7 @@ def parallelize_llama(
         apply_tp(
             model,
             world_mesh["tp"],
-            loss_parallel=parallel_dims.loss_parallel_enabled,
+            loss_parallel=not job_config.parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
             enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
         )

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -23,10 +23,8 @@ def has_cuda_capability(major: int, minor: int) -> bool:
     )
 
 
-def get_device_info():
-    device_type = _get_available_device_type()
-    if device_type is None:
-        device_type = "cuda"  # default device_type: cuda
+def get_device_info() -> tuple[str, torch.device]:
+    device_type = _get_available_device_type() or "cuda"
     device_module = _get_device_module(device_type)  # default device_module:torch.cuda
     return device_type, device_module
 


### PR DESCRIPTION
This PR does the following:
1. move `world_mesh` into `ParallelDims`, as they have a close relationship
2. move `enable_loss_parallel` out of `ParallelDims` constructor
3. add a convenient property `seq_len_divisor` to `ParallelDims`
4. set `dataloader` and `ft_manager` as optional in `CheckpointManager`
5. some minor improvements on typing and code organization