### PR TITLE
[Do not review] Add Github workflow to build and publish wheel to PyTorch Index nightly

### DIFF
--- a/.github/scripts/update_version.sh
+++ b/.github/scripts/update_version.sh
@@ -1,0 +1,7 @@
+python_file="assets/version.txt"
+if [[ -n "$BUILD_VERSION" ]]; then
+    echo "$BUILD_VERSION" > "$python_file"
+else
+    echo "Error: BUILD_VERSION environment variable is not set or empty."
+    exit 1
+fi

--- a/.github/workflows/build_whl_and_publish.yaml
+++ b/.github/workflows/build_whl_and_publish.yaml
@@ -1,0 +1,40 @@
+name: Build nightly wheels and publish to PyTorch Index
+
+on:
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    if: github.repository_owner == 'pytorch'
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: enable
+      with-rocm: enable
+      build-python-only: enable
+  build:
+    needs: generate-matrix
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    strategy:
+      fail-fast: false
+    with:
+      repository: pytorch/torchtitan
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      package-name: torchtitan
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: .github/scripts/update_version.sh
+      trigger-event: ${{ github.event_name }}
+      build-platform: 'python-build-package'


### PR DESCRIPTION
### Overview

The purpose of this PR is to enable nightly builds of the TorchTitan library that will be made available on the PyTorch Index, thus enabling quick prototyping for downstream users.

### Changes

* Added a workflow file based on PyTorch's [test-infra]() that generates the build matrix and does the push
* Added a pre-build script that correctly sets the version. This is needed b/c nightly versions include the date in order to differentiate them from each new build

### Testing

Coming soon, need trigger to land first in `test-infra`