### PR TITLE
[mxpf8] Make mxfp8 dim1 cast kernel configurable

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -56,11 +56,20 @@ class MXConverter(ModelConverter):
         self.filter_fqns = mx_job_config.filter_fqns
 
         # Configure MXFP8
-        from torchao.prototype.mx_formats.config import MXLinearConfig
+        from torchao.prototype.mx_formats.config import (
+            MXFP8Dim1CastKernelChoice,
+            MXLinearConfig,
+        )
 
         config = MXLinearConfig.from_recipe_name(NAME_MAP[mx_job_config.recipe_name])
-        config.use_fp8_dim1_cast_triton_kernel = (
-            mx_job_config.use_fp8_dim1_cast_triton_kernel
+
+        dim1_cast_kernel_choice_str = (
+            mx_job_config.mxfp8_dim1_cast_kernel_choice.upper()
+        )
+        config.mxfp8_dim1_cast_kernel_choice = (
+            MXFP8Dim1CastKernelChoice[dim1_cast_kernel_choice_str]
+            if mx_job_config.mxfp8_dim1_cast_kernel_choice != "NONE"
+            else None
         )
         self.config = config
 

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -57,7 +57,7 @@ class MXConverter(ModelConverter):
 
         # Configure MXFP8
         from torchao.prototype.mx_formats.config import (
-            MXFP8Dim1CastKernelChoice,
+            MXFP8CastKernelChoice,
             MXLinearConfig,
         )
 
@@ -67,7 +67,7 @@ class MXConverter(ModelConverter):
             mx_job_config.mxfp8_dim1_cast_kernel_choice.upper()
         )
         config.mxfp8_dim1_cast_kernel_choice = (
-            MXFP8Dim1CastKernelChoice[dim1_cast_kernel_choice_str]
+            MXFP8CastKernelChoice[dim1_cast_kernel_choice_str]
             if mx_job_config.mxfp8_dim1_cast_kernel_choice != "NONE"
             else None
         )

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -523,7 +523,7 @@ class Float8:
 
 @dataclass
 class MX:
-    use_fp8_dim1_cast_triton_kernel: bool = True
+    mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "none"] = "triton"
     """Temp work around for inductor performance gap"""
 
     recipe_name: Literal["mxfp8"] = "mxfp8"


### PR DESCRIPTION
## Summary
- We recently developed a CUDA kernel in torchao to perform mxfp8 casting with scaling along dim1, which is ~1.4x faster than the previous Triton implementation, this results in e2e training speedup of 1.5% - 2.5% with torchtitan Llama3 8b with FSDP=4/8: https://github.com/pytorch/ao/pull/2513
- The integration into torchao is finished (https://github.com/pytorch/ao/pull/2564), so we need to update torchtitan to make the kernel choice for mxfp8 dim1 cast configurable to `"triton"`, `"cuda"`, or `"torch"`. 

## Test plan
- Triton: `NGPU=8 CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --training.steps=100 --model.converters="mx" --mx.recipe_name="mxfp8" --training.compile --mx.mxfp8_dim1_cast_kernel_choice="triton"`
- Cuda: `NGPU=8 CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --training.steps=100 --model.converters="mx" --mx.recipe_name="mxfp8" --training.compile --mx.mxfp8_dim1_cast_kernel_choice="cuda"`