### PR TITLE
[llama4] Change expert_bias and tokens_per_expert to non-persistent buffer

### DIFF
--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -249,12 +249,10 @@ class MoE(nn.Module):
             self.register_buffer(
                 "expert_bias",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=False,
             )
             self.register_buffer(
                 "tokens_per_expert",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=False,
             )
         else:
             self.expert_bias = None

--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -249,12 +249,12 @@ class MoE(nn.Module):
             self.register_buffer(
                 "expert_bias",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=True,
+                persistent=False,
             )
             self.register_buffer(
                 "tokens_per_expert",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=True,
+                persistent=False,
             )
         else:
             self.expert_bias = None

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -52,7 +52,7 @@ tensor_parallel_degree = 1
 enable_async_tensor_parallel = false
 pipeline_parallel_degree = 1
 context_parallel_degree = 1
-expert_parallel_degree = 1
+expert_parallel_degree = 2
 
 [checkpoint]
 enable_checkpoint = false

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -52,7 +52,7 @@ tensor_parallel_degree = 1
 enable_async_tensor_parallel = false
 pipeline_parallel_degree = 1
 context_parallel_degree = 1
-expert_parallel_degree = 2
+expert_parallel_degree = 1
 
 [checkpoint]
 enable_checkpoint = false

--- a/torchtitan/models/deepseek_v3/model/moe.py
+++ b/torchtitan/models/deepseek_v3/model/moe.py
@@ -290,12 +290,10 @@ class MoE(nn.Module):
             self.register_buffer(
                 "expert_bias",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=True,
             )
             self.register_buffer(
                 "tokens_per_expert",
                 torch.zeros(num_experts, dtype=torch.float32),
-                persistent=True,
             )
         else:
             self.expert_bias = None


### PR DESCRIPTION
As titled. 

Tested on llama4 debugging model (dp=8, ep=2):
<img width="1188" height="226" alt="Screenshot 2025-07-15 at 8 05 12 PM" src="https://github.com/user-attachments/assets/24a1bf87-b038-481e-b40b-96e2123c96fc" />

