### PR TITLE
[WIP][Kernels] Add Quack (Cutlass 4.0) RMSNorm 

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -12,7 +12,7 @@ set -ex
 # LOG_RANK=0,1 NGPU=4 ./run_train.sh
 NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
-CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama3/train_configs/debug_model.toml"}
+CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama3/train_configs/llama3_8b.toml"}
 
 overrides=""
 if [ $# -ne 0 ]; then

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -9,7 +9,30 @@
 
 import torch
 import torch.nn.functional as F
+
+from quack.rmsnorm import QuackRMSNorm
 from torch import nn
+
+# Global toggle to switch between nn.RMSNorm and QuackRMSNorm
+USE_QUACK_RMSNORM = False
+
+
+def get_rmsnorm(dim, eps):
+    """
+    Returns either nn.RMSNorm or QuackRMSNorm based on the global toggle.
+
+    Args:
+        dim (int): The dimension of the input tensor
+        eps (float): The epsilon value for numerical stability
+
+    Returns:
+        nn.Module: The RMSNorm implementation to use
+    """
+    if USE_QUACK_RMSNORM:
+        return QuackRMSNorm(dim, eps=eps)
+    else:
+        return nn.RMSNorm(dim, eps=eps)
+
 
 from torchtitan.models.attention import build_attention, init_attention_mask
 from torchtitan.protocols.train_spec import ModelProtocol
@@ -273,8 +296,8 @@ class TransformerBlock(nn.Module):
             multiple_of=model_args.multiple_of,
             ffn_dim_multiplier=model_args.ffn_dim_multiplier,
         )
-        self.attention_norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
-        self.ffn_norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
+        self.attention_norm = get_rmsnorm(model_args.dim, model_args.norm_eps)
+        self.ffn_norm = get_rmsnorm(model_args.dim, model_args.norm_eps)
 
         if model_args.depth_init:
             self.weight_init_std = 0.02 / (2 * (layer_id + 1)) ** 0.5
@@ -348,7 +371,7 @@ class Transformer(nn.Module, ModelProtocol):
         self.layers = torch.nn.ModuleDict()
         for layer_id in range(model_args.n_layers):
             self.layers[str(layer_id)] = TransformerBlock(layer_id, model_args)
-        self.norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
+        self.norm = get_rmsnorm(model_args.dim, model_args.norm_eps)
         self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
         self.init_weights()
 

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -14,7 +14,7 @@ from quack.rmsnorm import QuackRMSNorm
 from torch import nn
 
 # Global toggle to switch between nn.RMSNorm and QuackRMSNorm
-USE_QUACK_RMSNORM = False
+USE_QUACK_RMSNORM = True
 
 
 def get_rmsnorm(dim, eps):

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -6,13 +6,13 @@ dump_folder = "./outputs"
 description = "Llama 3 8B training"
 
 [profiling]
-enable_profiling = true
+enable_profiling = false
 save_traces_folder = "profile_trace"
 profile_freq = 100
 
 [metrics]
-log_freq = 10
-enable_tensorboard = true
+log_freq = 1
+enable_tensorboard = false
 save_tb_folder = "tb"
 
 [model]
@@ -33,7 +33,7 @@ warmup_steps = 200  # lr scheduler warm up
 local_batch_size = 1
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
-steps = 1000
+steps = 20
 compile = false
 dataset = "c4"
 
@@ -53,7 +53,7 @@ export_dtype = "float32"
 async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = "selective"  # ["none", "selective", "full"]
+mode = "none"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
 [float8]

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -34,7 +34,7 @@ local_batch_size = 1
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 20
-compile = false
+compile = true
 dataset = "c4"
 
 [parallelism]


### PR DESCRIPTION
This is an exploratory PR to test out speedups from running the new Quack RMSNorm from Tri Dao, written in Cutlass 4.0 and showing faster than torch.compile results.

This requires my Quack RMSNorm PR here atm to support bf16:
https://github.com/Dao-AILab/quack/pull/16/

In addition:
pip install quack-kernels

Current simple testing with Titan and Llama3-8B on 8 * B200:
<img width="373" height="82" alt="Screenshot 2025-07-15 at 4 06 37 PM" src="https://github.com/user-attachments/assets/4da385e5-162b-4bca-9b96-839086b03e77" />


