### PR TITLE
Remove flex+sac restriction

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -347,6 +347,19 @@ def build_test_list():
         OverrideDefinitions(
             [
                 [
+                    "--parallelism.data_parallel_shard_degree=4",
+                    "--activation_checkpoint.mode=selective",
+                    "--activation_checkpoint.selective_ac_option=op",
+                    "--model.flavor=debugmodel_flex_attn",
+                ]
+            ],
+            "FSDP + FLEX + per op SAC",
+            "fsdp+flex_attn+per_op_sac",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--parallelism.context_parallel_degree=4",
                     "--parallelism.context_parallel_rotate_method='allgather'",
                 ]

--- a/torchtitan/experiments/llama4/model/args.py
+++ b/torchtitan/experiments/llama4/model/args.py
@@ -71,12 +71,6 @@ class TransformerModelArgs(BaseModelArgs):
             )
             self.use_grouped_mm = False
 
-        if job_config.activation_checkpoint.mode == "selective" and self.use_flex_attn:
-            raise ValueError(
-                "FlexAttention is not compatible with selective AC yet. "
-                "See https://github.com/pytorch/pytorch/issues/147879"
-            )
-
         if job_config.parallelism.context_parallel_degree > 1 and self.use_flex_attn:
             raise ValueError(
                 "FlexAttention is not compatible with CP yet. "

--- a/torchtitan/models/llama3/model/args.py
+++ b/torchtitan/models/llama3/model/args.py
@@ -44,12 +44,6 @@ class TransformerModelArgs(BaseModelArgs):
         self.max_seq_len = job_config.training.seq_len
         self.eos_id = tokenizer.eos_id
 
-        if job_config.activation_checkpoint.mode == "selective" and self.use_flex_attn:
-            raise ValueError(
-                "FlexAttention is not compatible with selective AC yet. "
-                "See https://github.com/pytorch/pytorch/issues/147879"
-            )
-
         if job_config.parallelism.context_parallel_degree > 1 and self.use_flex_attn:
             raise ValueError(
                 "FlexAttention is not compatible with CP yet. "


### PR DESCRIPTION
Stacked PRs:
 * __->__#1408


--- --- ---

Remove flex+compile restriction

Recently enabled this w/  https://github.com/pytorch/pytorch/pull/150080
Before the change I got:

```Shell

[rank0]:[rank0]:   File "/home/drisspg/meta/torchtitan/torchtitan/models/llama3/model/args.py", line 48, in update_from_config
[rank0]:[rank0]:     raise ValueError(
[rank0]:[rank0]: ValueError: FlexAttention is not compatible with selective AC yet. See https://github.com/pytorch/pytorch/issues/147879
```

I tried running this locally with;
```
 CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" NGPU=1 ./run_train.sh --model.flavor
   debugmodel_flex_attn --training.compile
 ```
 
 Got:
 
<img width="858" height="568" alt="Screenshot 2025-07-16 at 8 25 53 PM" src="https://github.com/user-attachments/assets/f540b01f-62ad-4f81-b5e4-e734e2b09081" />

If there are other more robust testing we can do I am down I am trying to unblock some internal users and ensure I can close this issue: https://github.com/pytorch/pytorch/issues/147879