### PR TITLE
[llama3] Add tied weights support

### DIFF
--- a/torchtitan/models/llama3/infra/pipeline.py
+++ b/torchtitan/models/llama3/infra/pipeline.py
@@ -105,6 +105,7 @@ def pipeline_llama_manual_split(
         stop_layer: str | None,
         is_first: bool = False,
         is_last: bool = False,
+        tied_embeddings: bool = False,
     ) -> tuple[PipelineStage, nn.Module]:
         model = copy.deepcopy(whole_model)
         if not is_first:
@@ -120,9 +121,15 @@ def pipeline_llama_manual_split(
             if drop_layers:
                 del model.layers[name]
 
-        if not is_last:
-            model.norm = None
-            model.output = None
+        if tied_embeddings:
+            if not is_first:
+                # If tied_embeddings is enables, then embeddings and outputs are placed in the first stage.
+                model.norm = None
+                model.output = None
+        else:
+            if not is_last:
+                model.norm = None
+                model.output = None
 
         stage = PipelineStage(
             model,
@@ -151,6 +158,7 @@ def pipeline_llama_manual_split(
             stop_layer,
             is_first=stage_idx == 0,
             is_last=stage_idx == num_stages - 1,
+            tied_embeddings=model_config.tied_embeddings,
         )
         logger.info(
             f"PP rank {pp_rank} is building stage_idx {stage_idx}"

--- a/torchtitan/models/llama3/model/args.py
+++ b/torchtitan/models/llama3/model/args.py
@@ -37,6 +37,10 @@ class TransformerModelArgs(BaseModelArgs):
     attn_mask_type: str = "causal"
     eos_id: int = 0
 
+    # If `True`, then the output layer is tied to the input embedding layer.
+    # This is a common practice in language models to reduce the number of parameters.
+    tied_embeddings: bool = False
+
     def update_from_config(
         self, job_config: JobConfig, tokenizer: BaseTokenizer
     ) -> None:

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -352,6 +352,10 @@ class Transformer(nn.Module, ModelProtocol):
         self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
         self.init_weights()
 
+        if model_args.tied_embeddings:
+            # Tie weights between output and tok_embeddings
+            self.output.weight = self.tok_embeddings.weight
+
     def init_weights(
         self,
         buffer_device: torch.device | None = None,


### PR DESCRIPTION
This PR adds support for LLaMA 3 models with tied weights, building on top of my [previous PR](https://github.com/pytorch/torchtitan/pull/1376) that added LLaMA 1B and 3B support. The main motivation was to enable these models, which require the embedding and output layers to be tied. As I've seen that the repo will be adding [HF model conversion soon](https://github.com/pytorch/torchtitan/pull/1404), it might be useful to have tied weights support for other models as well. I've implemented the necessary changes to support this in the pipeline parallelism path.

A couple of things I’d appreciate feedback on:

**FSDP Compatibility:**  
I added support for pipeline parallelism, but I’m not fully sure if any special handling is required for FSDP when dealing with tied weights. If anyone more familiar with the FSDP path can advise, that’d be great.

**Non-contiguous Stages:**  
Because of the tied weights, the first stage now holds both the first and final layer. This means that stages might not be strictly sequential. In practice, it doesn't seem to have an affect and it is working fine with PP. Still, I want to double-check if I might be overlooking an edge case.

There might be other subtleties I haven’t captured, so I’d really appreciate any guidance or tests I might’ve missed.
