### PR TITLE
separate outputs for ft replicas

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -261,6 +261,12 @@ def _build_metric_logger(
         dump_dir, metrics_config.save_tb_folder, datetime.now().strftime("%Y%m%d-%H%M")
     )
 
+    if job_config.fault_tolerance.enable:
+        base_log_dir = os.path.join(
+            base_log_dir,
+            f"replica_{job_config.fault_tolerance.replica_id}",
+        )
+
     if metrics_config.save_for_all_ranks:
         base_log_dir = os.path.join(
             base_log_dir, f"rank_{torch.distributed.get_rank()}"


### PR DESCRIPTION

Summary:
- log the tensorboard for ft replicas to a separate folder
- log profiles for ft replicas to a separate folder

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/1410).
* #1411
* __->__ #1410