### PR TITLE
allow specifying ft pg

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -261,6 +261,12 @@ def _build_metric_logger(
         dump_dir, metrics_config.save_tb_folder, datetime.now().strftime("%Y%m%d-%H%M")
     )
 
+    if job_config.fault_tolerance.enable:
+        base_log_dir = os.path.join(
+            base_log_dir,
+            f"replica_{job_config.fault_tolerance.replica_id}",
+        )
+
     if metrics_config.save_for_all_ranks:
         base_log_dir = os.path.join(
             base_log_dir, f"rank_{torch.distributed.get_rank()}"

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -606,6 +606,17 @@ class FaultTolerance:
     Note that this is still an experimental feature.
     """
 
+    process_group: str = "gloo"
+    """
+    The process group to use for fault tolerance. Currently, only "gloo" and "nccl" are supported.
+    """
+
+    process_group_timeout_ms: int = 10000
+    """
+    The process group will abort if operations don't succeed within this duration.
+    Note: This currently only works with gloo process group.
+    """
+
     replica_id: int = 0
     """The TorchFT replica ID of this run."""
 


### PR DESCRIPTION

Summary:
- allow using gloo process group
- add a parameter to the ft config
- only nccl and gloo will be supported for now

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/1411).
* __->__ #1411
* #1410