### PR TITLE
Add logging for learning rates in MetricsProcessor

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -399,11 +399,6 @@ class MetricsProcessor:
             "memory/num_ooms": device_mem_stats.num_ooms,
         }
 
-        if self.lr_schedulers:
-            # Log the learning rate from the first scheduler
-            # Note: This logs the LR for step i+1 when logging is done at the end of step i
-            metrics.update({"lr": self.lr_schedulers.schedulers[0].get_last_lr()[0]})
-
         if extra_metrics:
             metrics.update(extra_metrics)
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -291,7 +291,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             )
         )
         self.metrics_processor.optimizers = self.optimizers
-        self.metrics_processor.lr_schedulers = self.lr_schedulers
 
         # Initialize trainer states that will be saved in checkpoint.
         # These attributes must be initialized before checkpoint loading.
@@ -447,6 +446,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
         self.optimizers.zero_grad()
+        # Save the current step learning rate for logging
+        lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
@@ -494,12 +495,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         else:
             global_avg_loss = global_max_loss = loss.detach().item()
 
+        extra_metrics = {
+            "n_tokens_seen": self.ntokens_seen,
+            "lr": lr,
+        }
         self.metrics_processor.log(
             self.step,
             global_avg_loss,
             global_max_loss,
             grad_norm.item(),
-            extra_metrics={"ntokens_seen": self.ntokens_seen},
+            extra_metrics=extra_metrics,
         )
 
     @record


### PR DESCRIPTION
This PR adds learning rate logging. There was a previous attempt to implement this in an [earlier PR](https://github.com/pytorch/torchtitan/pull/937), but that one was ultimately **closed**. This version ensures that LR logging works properly, I verified it using the WSD scheduler that was recently added in [another PR](https://github.com/pytorch/torchtitan/pull/938).
<img width="1842" height="730" alt="image" src="https://github.com/user-attachments/assets/8f23674a-d689-4cc2-9d9b-30bff4e63f3b" />

One design consideration here is that torchtitan supports multiple optimizers and learning rate schedules, each potentially having its own LR. However, in practice, I believe that 99.9999% of use cases will use a single LR. 

Given that, the logging works as follows:
- If there is only one learning rate, it gets logged directly under the main charts as `lr`.
- If there are multiple learning rates, they are logged under a separate section, each with its corresponding label.

Alternatively, we could have ignored the multi-LR case and always logged a single LR, but I prefer this approach since it handles both scenarios robustly with minimal extra code.

Happy to adjust if others have a strong preference for simplicity over robustness.
