### PR TITLE
[Float8] Fix intermediate Float8 checkpoint loading

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -35,6 +35,14 @@ from torchtitan.config_manager import JobConfig, TORCH_DTYPE_MAP
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
+try:
+    # allow unpicking of WeightWithDynamicFloat8CastTensor, which are saved
+    # when doing FP8 training
+    from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
+    torch.serialization.add_safe_globals([WeightWithDynamicFloat8CastTensor])
+except:
+    pass
+
 
 MODEL = "model"
 OPTIMIZER = "optimizer"


### PR DESCRIPTION
Loading intermediate checkpoints that are training with Float8 will error right now because the `torchao`'s Tensor type is not in the safe-to-unpickle list by default.

When loading a checkpoint to resume training from, you'll get an error like this

```
[rank72]: Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
[rank72]: Traceback (most recent call last): (RANK 121)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/utils.py", line 276, in all_gather
[rank72]:     result = map_fun()
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/logger.py", line 87, in wrapper
[rank72]:     result = func(*args, **kwargs)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/state_dict_loader.py", line 240, in read_data
[rank72]:     all_reads = storage_reader.read_data(final_local_plan, planner)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/filesystem.py", line 862, in read_data
[rank72]:     torch.load(
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/serialization.py", line 1529, in load
[rank72]:     raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
[rank72]: _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint[0m. 
[rank72]: 	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
[rank72]: 	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
[rank72]: 	WeightsUnpickler error: Unsupported global: GLOBAL torchao.float8.fsdp_utils.WeightWithDynamicFloat8CastTensor was not an allowed global by default. Please use `torch.serialization.add_safe_globals([torchao.float8.fsdp_utils.WeightWithDynamicFloat8CastTensor])` or the `torch.serialization.safe_globals([torchao.float8.fsdp_utils.WeightWithDynamicFloat8CastTensor])` context manager to allowlist this global if you trust this class/function.
[rank72]: Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
[rank72]: Traceback (most recent call last): (RANK 122)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/utils.py", line 276, in all_gather
[rank72]:     result = map_fun()
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/logger.py", line 87, in wrapper
[rank72]:     result = func(*args, **kwargs)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/state_dict_loader.py", line 240, in read_data
[rank72]:     all_reads = storage_reader.read_data(final_local_plan, planner)
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/distributed/checkpoint/filesystem.py", line 862, in read_data
[rank72]:     torch.load(
[rank72]:   File "/home/emozilla/torchtitan/.venv/lib/python3.10/site-packages/torch/serialization.py", line 1529, in load
[rank72]:     raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
[rank72]: _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint[0m. 
[rank72]: 	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if ls.WeightWithDynamicFloat8CastTensor])` or the `torch.serialization.safe_globals([torchao.float8.fsdp_utils.WeightWithDynamicFloat8CastTensor])` context manager to allowlist this global if you trust this class/function.
```

This adds PR adds `WeightWithDynamicFloat8CastTensor` to the allowed unpicklable-types, gated behind a slient-fail try/except for when `torchao` is not available

