### PR TITLE
[torchtitan] CP + SDPA issue reproduce

### DIFF
--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -8,7 +8,7 @@ description = "Llama 3 8B training"
 [profiling]
 enable_profiling = true
 save_traces_folder = "profile_trace"
-profile_freq = 100
+profile_freq = 20
 
 [metrics]
 log_freq = 10
@@ -33,16 +33,17 @@ warmup_steps = 200  # lr scheduler warm up
 local_batch_size = 1
 seq_len = 8192
 max_norm = 1.0  # grad norm clipping
-steps = 1000
+steps = 20
 compile = false
 dataset = "c4"
+deterministic = true
 
 [parallelism]
 data_parallel_replicate_degree = 1
 data_parallel_shard_degree = -1
 tensor_parallel_degree = 1
 pipeline_parallel_degree = 1
-context_parallel_degree = 1
+context_parallel_degree = 8
 
 [checkpoint]
 enable_checkpoint = false
@@ -53,7 +54,7 @@ export_dtype = "float32"
 async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = "selective"  # ["none", "selective", "full"]
+mode = "none"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
 [float8]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1432

**Summary**
This PR reproduces a type error (`RuntimeError: value cannot be converted to type int64_t without overflow`) found when running CP+SDPA with a specific config

**Command**
`CONFIG_FILE=./torchtitan/models/llama3/train_configs/llama3_8b.toml ./run_train.sh --model.flavor=8B`

**Error log**
```
+ NGPU=8
+ export LOG_RANK=0
+ LOG_RANK=0
+ CONFIG_FILE=./torchtitan/models/llama3/train_configs/llama3_8b.toml
+ overrides=
+ '[' 1 -ne 0 ']'
+ overrides=--model.flavor=8B
+ TORCHFT_LIGHTHOUSE=http://localhost:29510
+ PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+ TORCHFT_LIGHTHOUSE=http://localhost:29510
+ torchrun --nproc_per_node=8 --rdzv_backend c10d --rdzv_endpoint=localhost:0 --local-ranks-filter 0 --role rank --tee 3 -m torchtitan.train --job.config_file ./torchtitan/models/llama3/train_configs/llama3_8b.toml --model.flavor=8B
W0721 14:08:07.402000 3165891 torch/distributed/run.py:774] 
W0721 14:08:07.402000 3165891 torch/distributed/run.py:774] *****************************************
W0721 14:08:07.402000 3165891 torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0721 14:08:07.402000 3165891 torch/distributed/run.py:774] *****************************************
[rank0]:[titan] 2025-07-21 14:08:12,906 - root - INFO - Starting job: Llama 3 8B training
[rank0]:[titan] 2025-07-21 14:08:14,126 - root - WARNING - ENV[TORCH_NCCL_ASYNC_ERROR_HANDLING] = 1 will be overridden to 3 based on job config
[rank0]:[titan] 2025-07-21 14:08:14,128 - root - INFO - Building 1-D device mesh with ['cp'], [8]
[rank0]:[titan] 2025-07-21 14:08:14,128 - root - INFO - [GC] Initial GC collection. 0.00 seconds.
[rank0]:[titan] 2025-07-21 14:08:14,128 - root - INFO - Deterministic algorithm enabled (expect perf degradation).
[rank0]:NCCL version 2.27.5+cuda12.6
[rank0]:[titan] 2025-07-21 14:08:18,295 - root - INFO - Loading tokenizer from tokenizer.json
[rank0]:[titan] 2025-07-21 14:08:18,518 - root - INFO - Preparing c4 dataset from allenai/c4
[rank0]:[titan] 2025-07-21 14:08:25,928 - root - INFO - Building llama3 8B with TransformerModelArgs(_enforced='This field is used to enforce all fields have defaults.', dim=4096, n_layers=32, n_heads=32, n_kv_heads=8, vocab_size=128256, multiple_of=1024, ffn_dim_multiplier=1.3, norm_eps=1e-05, rope_theta=500000, max_seq_len=8192, depth_init=True, use_flex_attn=False, attn_mask_type='causal', eos_id=128001)
[rank0]:[titan] 2025-07-21 14:08:26,059 - root - INFO - TensorBoard logging enabled. Logs will be saved at ./outputs/tb/20250721-1408
[rank0]:[titan] 2025-07-21 14:08:26,066 - root - INFO - CUDA capacity: NVIDIA H100 with 95.00GiB memory
[rank0]:[titan] 2025-07-21 14:08:26,104 - root - INFO - Model llama3 8B size: 8,030,261,248 total parameters
[rank0]:[titan] 2025-07-21 14:08:26,166 - root - INFO - Applied FSDP to the model
[rank0]:[titan] 2025-07-21 14:08:26,166 - root - INFO - Applied Context Parallel to the model
[rank0]:[titan] 2025-07-21 14:08:26,734 - root - INFO - Peak FLOPS used for computing MFU: 9.890e+14
[rank0]:[titan] 2025-07-21 14:08:26,734 - root - INFO - CUDA memory usage for model: 3.77GiB(3.97%)
[rank0]:[titan] 2025-07-21 14:08:26,736 - root - WARNING - Warmup steps (200) exceed total training steps (20). Adjusting warmup steps to 20.
[rank0]:[titan] 2025-07-21 14:08:26,736 - root - INFO - Mixed precision training is handled by fully_shard
[rank0]:[titan] 2025-07-21 14:08:26,736 - root - INFO - Trainer is initialized with local batch size 1, global batch size 1, gradient accumulation steps 1, sequence length 8192, total steps 20 (warmup 200).
[rank0]:[titan] 2025-07-21 14:08:26,736 - root - INFO - Training starts at step 1.
[rank0]:[titan] 2025-07-21 14:08:26,736 - root - INFO - Profiling active. Traces will be saved at ./outputs/profile_trace
[rank0]:[titan] 2025-07-21 14:08:44,327 - root - INFO - step:  1  loss: 12.2512  grad_norm:  5.2501  memory: 22.62GiB(23.81%)  tps: 56  tflops: 3.25  mfu: 0.33%
[rank0]:[titan] 2025-07-21 14:08:44,327 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-07-21 14:08:49,908 - root - INFO - step: 10  loss: 10.5732  grad_norm:  7.9686  memory: 29.44GiB(30.99%)  tps: 1,652  tflops: 95.65  mfu: 9.67%
[rank0]:[titan] 2025-07-21 14:08:57,411 - root - INFO - Dumping profiler traces at step 19
[rank0]:[titan] 2025-07-21 14:08:57,422 - root - INFO - Finished dumping profiler traces in 0.01 seconds
[rank0]:[rank0]: Traceback (most recent call last):
[rank0]:[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 583, in <module>
[rank0]:[rank0]:     trainer.train()
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
[rank0]:[rank0]:     return f(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 513, in train
[rank0]:[rank0]:     self.train_step(data_iterator)
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 445, in train_step
[rank0]:[rank0]:     loss = self.forward_backward_step(input_dict, labels)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 423, in forward_backward_step
[rank0]:[rank0]:     pred = model_parts[0](inputs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
[rank0]:[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1879, in _call_impl
[rank0]:[rank0]:     return inner()
[rank0]:[rank0]:            ^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1827, in inner
[rank0]:[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 428, in forward
[rank0]:[rank0]:     h = layer(h, self.freqs_cis)
[rank0]:[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
[rank0]:[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1879, in _call_impl
[rank0]:[rank0]:     return inner()
[rank0]:[rank0]:            ^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1827, in inner
[rank0]:[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 300, in forward
[rank0]:[rank0]:     h = x + self.attention(self.attention_norm(x), freqs_cis)
[rank0]:[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
[rank0]:[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1784, in _call_impl
[rank0]:[rank0]:     return forward_call(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 192, in forward
[rank0]:[rank0]:     output = self.sdpa(xq, xk, xv)
[rank0]:[rank0]:              ^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
[rank0]:[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1784, in _call_impl
[rank0]:[rank0]:     return forward_call(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/attention.py", line 218, in forward
[rank0]:[rank0]:     return F.scaled_dot_product_attention(q, k, v, is_causal=True, scale=scale)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 953, in inner_fn
[rank0]:[rank0]:     output = target_fn(*args, **kwargs)
[rank0]:[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/_compile.py", line 53, in inner
[rank0]:[rank0]:     return disable_fn(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/_dynamo/eval_frame.py", line 1004, in _fn
[rank0]:[rank0]:     return fn(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/_api.py", line 358, in __torch_dispatch__
[rank0]:[rank0]:     return DTensor._op_dispatcher.dispatch(
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/_dispatch.py", line 148, in dispatch
[rank0]:[rank0]:     return self._custom_op_handlers[op_call](op_call, args, kwargs)  # type: ignore[operator]
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 887, in _sdpa_handler
[rank0]:[rank0]:     local_results = call_maps[op_call](
[rank0]:[rank0]:                     ^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 643, in _scaled_dot_product_ring_flash_attention
[rank0]:[rank0]:     return _templated_ring_attention(
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 448, in _templated_ring_attention
[rank0]:[rank0]:     out, logsumexp, *rest = op(
[rank0]:[rank0]:                             ^^^
[rank0]:[rank0]:   File "/data/users/xilunwu/pytorch/torch/_ops.py", line 1254, in __call__
[rank0]:[rank0]:     return self._op(*args, **kwargs)
[rank0]:[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]: RuntimeError: value cannot be converted to type int64_t without overflow
[rank0]:[rank0]:[W721 14:08:58.370694058 ProcessGroup.cpp:364] Warning: At the time of process termination, there are still 1 unwaited collective calls. Please review your program to ensure that:
[rank0]:1. c10d_functional.wait_tensor() is invoked on all tensors returned from c10d_functional collective,
[rank0]:2. c10d_functional.wait_tensor() is invoked on all output tensors of async_op=True torch.distributed collective called under `with allow_inflight_collective_as_graph_input_ctx():`,
[rank0]:before the output tensors of the collective are used. (function ~WorkRegistry)
W0721 14:08:58.799000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166315 closing signal SIGTERM
W0721 14:08:58.799000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166316 closing signal SIGTERM
W0721 14:08:58.800000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166317 closing signal SIGTERM
W0721 14:08:58.800000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166319 closing signal SIGTERM
W0721 14:08:58.800000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166320 closing signal SIGTERM
W0721 14:08:58.801000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166324 closing signal SIGTERM
W0721 14:08:58.801000 3165891 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 3166325 closing signal SIGTERM
E0721 14:09:00.655000 3165891 torch/distributed/elastic/multiprocessing/api.py:874] failed (exitcode: 1) local_rank: 3 (pid: 3166318) of binary: /home/xilunwu/.conda/envs/pytorch-3.12/bin/python
E0721 14:09:00.659000 3165891 torch/distributed/elastic/multiprocessing/errors/error_handler.py:141] no error file defined for parent, to copy child error file (/tmp/torchelastic_qq62_0ay/none_ymn2x22r/attempt_0/3/error.json)
Traceback (most recent call last):
  File "/home/xilunwu/.conda/envs/pytorch-3.12/bin/torchrun", line 33, in <module>
    sys.exit(load_entry_point('torch', 'console_scripts', 'torchrun')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xilunwu/pytorch/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/data/users/xilunwu/pytorch/torch/distributed/run.py", line 901, in main
    run(args)
  File "/data/users/xilunwu/pytorch/torch/distributed/run.py", line 892, in run
    elastic_launch(
  File "/data/users/xilunwu/pytorch/torch/distributed/launcher/api.py", line 143, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/xilunwu/pytorch/torch/distributed/launcher/api.py", line 277, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
torchtitan.train FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2025-07-21_14:08:57
  host      : devgpu263.prn2.facebook.com
  rank      : 3 (local_rank: 3)
  exitcode  : 1 (pid: 3166318)
  error_file: /tmp/torchelastic_qq62_0ay/none_ymn2x22r/attempt_0/3/error.json
  traceback : Traceback (most recent call last):
    File "/data/users/xilunwu/pytorch/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 513, in train
      self.train_step(data_iterator)
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 445, in train_step
      loss = self.forward_backward_step(input_dict, labels)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/train.py", line 423, in forward_backward_step
      pred = model_parts[0](inputs)
             ^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1879, in _call_impl
      return inner()
             ^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1827, in inner
      result = forward_call(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 428, in forward
      h = layer(h, self.freqs_cis)
          ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1879, in _call_impl
      return inner()
             ^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1827, in inner
      result = forward_call(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 300, in forward
      h = x + self.attention(self.attention_norm(x), freqs_cis)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1784, in _call_impl
      return forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/llama3/model/model.py", line 192, in forward
      output = self.sdpa(xq, xk, xv)
               ^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/nn/modules/module.py", line 1784, in _call_impl
      return forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/oss/torchtitan/torchtitan/models/attention.py", line 218, in forward
      return F.scaled_dot_product_attention(q, k, v, is_causal=True, scale=scale)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 953, in inner_fn
      output = target_fn(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/_compile.py", line 53, in inner
      return disable_fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/_dynamo/eval_frame.py", line 1004, in _fn
      return fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/_api.py", line 358, in __torch_dispatch__
      return DTensor._op_dispatcher.dispatch(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/_dispatch.py", line 148, in dispatch
      return self._custom_op_handlers[op_call](op_call, args, kwargs)  # type: ignore[operator]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 887, in _sdpa_handler
      local_results = call_maps[op_call](
                      ^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 643, in _scaled_dot_product_ring_flash_attention
      return _templated_ring_attention(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/data/users/xilunwu/pytorch/torch/distributed/tensor/experimental/_attention.py", line 448, in _templated_ring_attention
      out, logsumexp, *rest = op(
                              ^^^
    File "/data/users/xilunwu/pytorch/torch/_ops.py", line 1254, in __call__
      return self._op(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  RuntimeError: value cannot be converted to type int64_t without overflow
```
