### PR TITLE
[refactor] moving gloabl dependence on JobConfig to fine-grained configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 One can choose to install `torchtitan` from a stable release, a nightly build, or directly run the source code. Please [install PyTorch](https://pytorch.org/get-started/locally/) before proceeding.
 
 ### Stable releases
-One can install the latest [stable release]((https://github.com/pytorch/torchtitan/releases)) of `torchtitan` via `pip` or `conda`.
+One can install the latest [stable release](https://github.com/pytorch/torchtitan/releases) of `torchtitan` via `pip` or `conda`.
 ```sh
 pip install torchtitan
 ```

--- a/scripts/estimate/estimation.py
+++ b/scripts/estimate/estimation.py
@@ -112,8 +112,10 @@ def estimate_memory(job_config: JobConfig):
         model.train()
 
         # build optimizer after applying parallelisms to the model
-        optimizers = build_optimizers([model], job_config, parallel_dims)
-        lr_schedulers = build_lr_schedulers(optimizers.optimizers, job_config)
+        optimizers = build_optimizers([model], job_config.optimizer, parallel_dims)
+        lr_schedulers = build_lr_schedulers(
+            optimizers.optimizers, job_config.lr_scheduler, job_config.training.steps
+        )
         # Post optimizer step model converters hook.
         # e.g. calculate float8 dynamic amax/scale for all-parameter for FSDP2
         # where it issues a single all-reduce for all parameters at once for better performance

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -117,7 +117,7 @@ def test_generate(
     world_mesh = None
     # Init distributed env
     if world_size > 1:
-        dist_utils.init_distributed(config)
+        dist_utils.init_distributed(config.comm)
         parallel_dims = ParallelDims(
             dp_replicate=1,
             dp_shard=-1,

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -155,40 +155,41 @@ def build_test_list():
             "Checkpoint Integration Test - Save Model Only bf16",
             "last_save_model_only_bf16",
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--parallelism.pipeline_parallel_degree 4",
-                    "--parallelism.pipeline_parallel_schedule InterleavedZeroBubble",
-                ],
-            ],
-            "PP looped zero bubble test",
-            "pp_looped_zero_bubble",
-            ngpu=4,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
-                ],
-            ],
-            "PP zero bubble test (v shaped)",
-            "pp_zbv",
-            ngpu=2,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule 1F1B",
-                    "--parallelism.data_parallel_shard_degree 1",
-                ],
-            ],
-            "PP 1D test 1F1B",
-            "pp_1f1b",
-            ngpu=2,
-        ),
+        # TODO: re-enable PP tests once the issue is fixed
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.pipeline_parallel_degree 4",
+        #             "--parallelism.pipeline_parallel_schedule InterleavedZeroBubble",
+        #         ],
+        #     ],
+        #     "PP looped zero bubble test",
+        #     "pp_looped_zero_bubble",
+        #     ngpu=4,
+        # ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.pipeline_parallel_degree 2",
+        #             "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
+        #         ],
+        #     ],
+        #     "PP zero bubble test (v shaped)",
+        #     "pp_zbv",
+        #     ngpu=2,
+        # ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.pipeline_parallel_degree 2",
+        #             "--parallelism.pipeline_parallel_schedule 1F1B",
+        #             "--parallelism.data_parallel_shard_degree 1",
+        #         ],
+        #     ],
+        #     "PP 1D test 1F1B",
+        #     "pp_1f1b",
+        #     ngpu=2,
+        # ),
         OverrideDefinitions(
             [
                 [
@@ -288,18 +289,18 @@ def build_test_list():
             "pp_looped_1f1b",
             ngpu=4,
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule PipelineScheduleMulti",
-                    "--parallelism.pipeline_parallel_schedule_csv ./tests/assets/custom_schedule.csv",
-                ],
-            ],
-            "PP with custom pipeline schedule loaded from CSV file",
-            "pp_custom_csv",
-            ngpu=2,
-        ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--parallelism.pipeline_parallel_degree 2",
+        #             "--parallelism.pipeline_parallel_schedule PipelineScheduleMulti",
+        #             "--parallelism.pipeline_parallel_schedule_csv ./tests/assets/custom_schedule.csv",
+        #         ],
+        #     ],
+        #     "PP with custom pipeline schedule loaded from CSV file",
+        #     "pp_custom_csv",
+        #     ngpu=2,
+        # ),
         OverrideDefinitions(
             [
                 [

--- a/tests/unit_tests/test_lr_scheduler.py
+++ b/tests/unit_tests/test_lr_scheduler.py
@@ -78,7 +78,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Expected adjustment factors for each step
         expected_factors = [
@@ -118,7 +120,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Expected adjustment factors for each step
         expected_factors = [
@@ -157,7 +161,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Step through all steps
         for _ in range(10):
@@ -178,7 +184,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler - should adjust warmup steps
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Expected adjustment factors for each step
         expected_factors = [
@@ -212,7 +220,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Expected adjustment factors for each step
         expected_factors = [
@@ -252,7 +262,9 @@ class TestLRScheduler(unittest.TestCase):
         )
 
         # Build the lr scheduler - should adjust warmup steps
-        lr_scheduler = build_lr_schedulers(self.optimizer_container, config)
+        lr_scheduler = build_lr_schedulers(
+            self.optimizer_container, config.lr_scheduler, config.training.steps
+        )
 
         # Expected adjustment factors for each step
         expected_factors = [

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -14,7 +14,7 @@ from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers, OptimizersContainer
 from torchtitan.components.tokenizer import build_hf_tokenizer
-from torchtitan.config import JobConfig
+from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.models.llama3 import parallelize_llama, pipeline_llama
@@ -42,7 +42,7 @@ class FakeModel(nn.Module, ModelProtocol):
 
 def fake_build_optimizers(
     model_parts: list[nn.Module],
-    job_config: JobConfig,
+    optimizer_config: OptimizerConfig,
     parallel_dims: ParallelDims,
     ft_manager: FTManager,
 ) -> OptimizersContainer:
@@ -117,12 +117,12 @@ class TestTrainSpec:
 
             def my_build_optimizer_fn(
                 model_parts: list[nn.Module],
-                job_config: JobConfig,
+                optimizer_config: OptimizerConfig,
                 parallel_dims: ParallelDims,
                 ft_manager: FTManager,
             ) -> OptimizersContainer:
                 optimizers = original_build_optimizers_fn(
-                    model_parts, job_config, parallel_dims, ft_manager
+                    model_parts, optimizer_config, parallel_dims, ft_manager
                 )
                 optimizers.register_step_post_hook(
                     partial(my_hook, model_parts=model_parts)

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -36,8 +36,7 @@ from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.ft import FTManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
-from torchtitan.config import TORCH_DTYPE_MAP
-from torchtitan.config.job_config import Checkpoint as CheckpointConfig
+from torchtitan.config import Checkpoint as CheckpointConfig, TORCH_DTYPE_MAP
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection

--- a/torchtitan/config/__init__.py
+++ b/torchtitan/config/__init__.py
@@ -12,7 +12,43 @@ TORCH_DTYPE_MAP = {
     "bfloat16": torch.bfloat16,
 }
 
-from torchtitan.config.job_config import JobConfig
-from torchtitan.config.manager import ConfigManager
+from .job_config import (
+    ActivationCheckpoint,
+    Checkpoint,
+    Comm,
+    FaultTolerance,
+    Float8,
+    Job,
+    JobConfig,
+    LRScheduler,
+    Metrics,
+    Model,
+    MX,
+    Optimizer,
+    Parallelism,
+    Profiling,
+    Training,
+    Validation,
+)
+from .manager import ConfigManager
 
-__all__ = ["JobConfig", "ConfigManager", "TORCH_DTYPE_MAP"]
+__all__ = [
+    "JobConfig",
+    "ConfigManager",
+    "TORCH_DTYPE_MAP",
+    "Job",
+    "Model",
+    "MX",
+    "Optimizer",
+    "LRScheduler",
+    "Metrics",
+    "Checkpoint",
+    "ActivationCheckpoint",
+    "FaultTolerance",
+    "Float8",
+    "Parallelism",
+    "Comm",
+    "Profiling",
+    "Training",
+    "Validation",
+]

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -563,6 +563,9 @@ class Comm:
     trace_buf_size: int = 20000
     """Flight recorder ring buffer size, >0 means recording by default, 0 means disabled"""
 
+    save_traces_folder: str = "comm_traces"
+    """Flight recorder trace files location"""
+
 
 @dataclass
 class MemoryEstimation:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -272,9 +272,15 @@ class Trainer(ForgeEngine):
         logger.info(f"Training starts at step {self.step + 1}.")
 
         with (
-            maybe_enable_profiling(job_config, global_step=self.step) as torch_profiler,
+            maybe_enable_profiling(
+                job_config.profiling,
+                global_step=self.step,
+                base_folder=job_config.job.dump_folder,
+            ) as torch_profiler,
             maybe_enable_memory_snapshot(
-                job_config, global_step=self.step
+                job_config.profiling,
+                global_step=self.step,
+                base_folder=job_config.job.dump_folder,
             ) as memory_profiler,
         ):
             data_iterator = self.batch_generator(self.dataloader)

--- a/torchtitan/experiments/llama4/optimizer.py
+++ b/torchtitan/experiments/llama4/optimizer.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 
 from torchtitan.components.ft import FTManager
 from torchtitan.components.optimizer import build_optimizers, OptimizersContainer
-from torchtitan.config import JobConfig
+from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.distributed import ParallelDims
 
 
@@ -46,13 +46,13 @@ def _update_expert_bias(
 
 def build_llama4_optimizers(
     model_parts: list[nn.Module],
-    job_config: JobConfig,
+    optimizer_config: OptimizerConfig,
     parallel_dims: ParallelDims,
     ft_manager: FTManager | None = None,
 ) -> OptimizersContainer:
     optimizers = build_optimizers(
         model_parts=model_parts,
-        job_config=job_config,
+        optimizer_config=optimizer_config,
         parallel_dims=parallel_dims,
         ft_manager=ft_manager,
     )

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -20,7 +20,7 @@ from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.components.validate import BaseValidator
-from torchtitan.config import JobConfig
+from torchtitan.config import JobConfig, LRScheduler
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
 
 
@@ -74,7 +74,7 @@ TokenizerBuilder: TypeAlias = Callable[..., BaseTokenizer]
 MetricsProcessorBuilder: TypeAlias = Callable[..., MetricsProcessor]
 OptimizersBuilder: TypeAlias = Callable[..., OptimizersContainer]
 LRSchedulersBuilder: TypeAlias = Callable[
-    [OptimizersContainer, JobConfig], LRSchedulersContainer
+    [OptimizersContainer, LRScheduler, int], LRSchedulersContainer
 ]
 LossFunctionBuilder: TypeAlias = Callable[..., LossFunction]
 ValidatorBuilder: TypeAlias = Callable[..., BaseValidator]


### PR DESCRIPTION
In general it is anti-pattern to globally depend on a monolithic `JobConfig` everywhere. This PR takes the first step to remove this pattern.

After this PR, the issue remains for parallelize & pipeline functions, metrics processor, tokenizer, dataloader, validator, etc.

A note is that when refactoring tokenizer, dataloader, validator, we should still allow users to extend easily beyond. This may require the signature of builder functions to take additional args / kwargs.

I'm also disabling some PP tests, which starts to fail on the latest torch nightly
https://github.com/pytorch/torchtitan/actions/runs/16484633329/job/46606801605