### PR TITLE
remove float8 force_recompute_fp8_weight_in_bwd flag

### DIFF
--- a/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
+++ b/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
@@ -30,7 +30,6 @@ Runs were invoked with the following, where `NUM_NODES` was `4` and `8`
     --model.converters="float8" \
     --float8.enable_fsdp_float8_all_gather \
     --float8.precompute_float8_dynamic_scale_for_fsdp \
-    --float8.force_recompute_fp8_weight_in_bwd \
     --profiling.profile_freq 1000000
     --training.steps 2000
 ```

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -11,12 +11,11 @@ USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
 
 For float8 with tensorwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --float8.force_recompute_fp8_weight_in_bwd --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="float8" --float8.enable_fsdp_float8_all_gather --float8.precompute_float8_dynamic_scale_for_fsdp --training.compile
 ```
 * `--model.converters="float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
 * `--float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
 * `--float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
-* `--float8.force_recompute_fp8_weight_in_bwd` (optional): force recomputation of fp8 weights during backward pass, preventing unsharded fp8 weights from being saved for backward.
 * `--float8.filter_fqns="..."` (optional): a comma separated list of fully qualified names of modules not to convert to float8 training. Example: `--float8.filter_fqns="attention.wk,attention.wv"`. You can determine which layers to convert by looking at the microbenchmarks in the [performance section](https://github.com/pytorch/ao/tree/main/torchao/float8#performance) of the torchao documentation for the float8 recipe you're using.
     * **Auto-filter**: add `"auto_filter_small_kn"` as one of the `--float8.filter_fqns=...` to to enable automatic module filtering, which will automatically not convert linear layers are not large enough to benefit from float8 training, since the GEMM has to be big enough that the speedup from using FP8 tensorcores is greater than the overhead of creating dynamically quantized inputs. The thresholds for conversion are based on microbenchmarks measured on NVIDIA H100 GPUs, where (K,N) represents the linear layer weight shape. For best performance, you should still manually filter out layers that are too small to benefit from float8 training.
 * `--training.compile` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -517,7 +517,6 @@ def build_test_list():
                     "--model.converters float8",
                     "--float8.enable_fsdp_float8_all_gather",
                     "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
                     "--float8.emulate",
                 ],
             ],

--- a/tests/integration_tests_h100.py
+++ b/tests/integration_tests_h100.py
@@ -46,7 +46,6 @@ def build_test_list():
                     "--model.converters float8",
                     "--float8.enable_fsdp_float8_all_gather",
                     "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
                 ],
             ],
             "Float8 test",
@@ -63,7 +62,6 @@ def build_test_list():
                     "--model.converters float8",
                     "--float8.enable_fsdp_float8_all_gather",
                     "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
                 ]
             ],
             "FSDP+async TP+PP+torch.compile+Float8",
@@ -80,7 +78,6 @@ def build_test_list():
                     "--model.converters float8",
                     "--float8.enable_fsdp_float8_all_gather",
                     "--float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--float8.force_recompute_fp8_weight_in_bwd",
                 ]
             ],
             "HSDP+CP+torch.compile+Float8",

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -72,11 +72,6 @@ class Float8Converter(ModelConverter):
                 "with `float8_config.recipe_name` is not supported"
             )
 
-            assert not float8_config.force_recompute_fp8_weight_in_bwd, (
-                "using `float8_config.force_recompute_fp8_weight_in_bwd` together "
-                "with `float8_config.recipe_name` is not supported"
-            )
-
             self.config = Float8LinearConfig.from_recipe_name(float8_config.recipe_name)
             self.precompute_scale = False
             logger.info(
@@ -97,7 +92,6 @@ class Float8Converter(ModelConverter):
             )
             self.config = Float8LinearConfig(
                 enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
-                force_recompute_fp8_weight_in_bwd=float8_config.force_recompute_fp8_weight_in_bwd,
                 emulate=float8_config.emulate,
             )
             # for precompute_float8_dynamic_scale_for_fsdp

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -499,14 +499,6 @@ class Float8:
     precompute_float8_dynamic_scale_for_fsdp: bool = False
     """Whether precompute float8 scales dynamically for FSDP, recommended for tensorwise scaling"""
 
-    force_recompute_fp8_weight_in_bwd: bool = False
-    """
-    Whether to force the recomputation of FP8 weights during backward pass.
-    When using FSDP with tensorwise scaling, it is recommended to enable
-    `force_recompute_fp8_weight_in_bwd` to prevent saving unsharded FP8 weights
-    for backward computation.
-    """
-
     recipe_name: Literal["tensorwise", "rowwise", "rowwise_with_gw_hp"] | None = None
     """If specified, creates float8 config from recipe name"""
 


### PR DESCRIPTION
Summary:

This flag has been deprecated in
https://github.com/pytorch/ao/pull/2356,
deleting it from torchtitan to prepare for future deletion from torchao.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags: