### PR TITLE
Fix a none pointer exception in checkpoint.py

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -787,8 +787,9 @@ class CheckpointManager:
             discovered_checkpoints = []
             for filename in os.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
-                path = os.path.join(self.folder, filename)
-                discovered_checkpoints.append((int(match.group(1)), path))
+                if match:
+                    path = os.path.join(self.folder, filename)
+                    discovered_checkpoints.append((int(match.group(1)), path))
 
             discovered_checkpoints.sort()
             to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]


### PR DESCRIPTION
This PR fixes a potential `NoneType` attribute error in the checkpoint purging code. Previously, when the regex did not find a match (i.e., there exists a file of other format), the code would attempt to access `match.group(1)` and raise an none pointer exception:


```
[rank0]: Traceback (most recent call last):
[rank0]:   File "~/.conda/envs/forge/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank0]:     return _run_code(code, main_globals, None,
[rank0]:   File "~/.conda/envs/forge/lib/python3.10/runpy.py", line 86, in _run_code
[rank0]:     exec(code, run_globals)
[rank0]:   File "~/forge/apps/sft/main.py", line 271, in <module>
[rank0]:     sys.exit(recipe_main())
[rank0]:   File "~/forge/forge/config/parse.py", line 174, in wrapper
[rank0]:     sys.exit(recipe_main(conf))
[rank0]:   File "~/forge/apps/sft/main.py", line 266, in recipe_main
[rank0]:     recipe.train()
[rank0]:   File "~/forge/apps/sft/main.py", line 233, in train
[rank0]:     self.checkpointer.save(
[rank0]:   File "~/.conda/envs/forge/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "~/torchtitan/torchtitan/components/checkpoint.py", line 507, in save
[rank0]:     self._purge_stale_checkpoints()
[rank0]:   File "~/torchtitan/torchtitan/components/checkpoint.py", line 795, in _purge_stale_checkpoints
[rank0]:     discovered_checkpoints.append((int(match.group(1)), path))
[rank0]: AttributeError: 'NoneType' object has no attribute 'group'
```