### PR TITLE
[checkpoint] let user specify `intial_load_path` and `initial_load_in_hf` when using HF checkpoints

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -68,7 +68,7 @@ NGPU=1 CONFIG=<path_to_model_config> ./run_train.sh --checkpoint.enable_checkpoi
 ### HuggingFace
 `torchtitan` offers two ways to work with Hugging Face models: either by directly saving and loading a Hugging Face checkpoint during training, or by using an example conversion script to directly reformat the model weights on cpu.
 
-1. You can directly save huggingface model weights during training by using the `--checkpoint.last_save_in_safetensors_format` and `--checkpoint.last_save_model_only` options together. To directly load a `torchtitan` training session from a huggingface safetensors file, simply enable `--checkpoint.initial_load_model_only` and set `--checkpoint.initial_load_path` to the directory containing the huggingface checkpoint.
+1. You can directly save huggingface model weights during training by using the `--checkpoint.last_save_in_safetensors_format` and `--checkpoint.last_save_model_only` options together. To directly load a `torchtitan` training session from a huggingface safetensors file, enable `--checkpoint.initial_load_model_only` and `--checkpoint.initial_load_in_hf`, and set `--checkpoint.initial_load_path` to the directory containing the huggingface checkpoint.
 
 2. To directly reformat the weights without the need to run a training loop, run the corresponding conversion script. The naming scheme is `torchtitan`-centric, e.g. convert_from_hf means convert hf->tt.
 
@@ -76,7 +76,7 @@ NGPU=1 CONFIG=<path_to_model_config> ./run_train.sh --checkpoint.enable_checkpoi
 python ./scripts/checkpoint_conversion/convert_from_hf.py <input_dir> <output_dir> --model_name <model_name> --model_flavor <model_flavor>
 python ./scripts/checkpoint_conversion/convert_to_hf.py <input_dir> <output_dir> --model_name <model_name> --model_flavor <model_flavor>
 # e.g.
-python ./scripts/convert_from_hf.py ~/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B/snapshots/8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920/ ./outputs/checkpoint/step-0 --model_name llama3 --model_flavor 8B
+python ./scripts/convert_from_hf.py ~/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B/snapshots/8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920/ ./initial_load_path/ --model_name llama3 --model_flavor 8B
 ```
 
 ### Torch

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -123,12 +123,14 @@ def build_test_list():
                 [
                     "--checkpoint.enable_checkpoint",
                     "--checkpoint.folder hf_checkpoint",
-                    "--checkpoint.last_save_in_hf",
                     "--checkpoint.last_save_model_only",
+                    "--checkpoint.last_save_in_hf",
                 ],
                 [
                     "--checkpoint.enable_checkpoint",
                     "--checkpoint.initial_load_path artifacts-to-be-uploaded/model_only_hf_checkpoint/hf_checkpoint/step-10/",
+                    "--checkpoint.initial_load_model_only",
+                    "--checkpoint.initial_load_in_hf",
                 ],
             ],
             "Checkpoint Integration Test - save load model only checkpoint in HF definition and format",

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -196,12 +196,6 @@ class CheckpointManager:
         ft_manager: FTManager | None = None,
     ) -> None:
         self.enable_checkpoint = checkpoint_config.enable_checkpoint
-        self.last_save_in_hf = checkpoint_config.last_save_in_hf
-        if self.last_save_in_hf:
-            assert (
-                sd_adapter is not None
-            ), "job_config.checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
-        self.sd_adapter = sd_adapter
 
         self.ft_manager = (
             ft_manager.manager if ft_manager and ft_manager.enabled else None
@@ -257,9 +251,16 @@ class CheckpointManager:
         self.folder = os.path.join(base_folder, checkpoint_config.folder)
 
         # Checkpoint policy related fields.
-        self.initial_load_path = checkpoint_config.initial_load_path
         self.initial_load_model_only = checkpoint_config.initial_load_model_only
+        self.initial_load_in_hf = checkpoint_config.initial_load_in_hf
+        self.initial_load_path = checkpoint_config.initial_load_path
         self.last_save_model_only = checkpoint_config.last_save_model_only
+        self.last_save_in_hf = checkpoint_config.last_save_in_hf
+        if self.last_save_in_hf:
+            assert (
+                sd_adapter is not None
+            ), "job_config.checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
+        self.sd_adapter = sd_adapter
         self.export_dtype = TORCH_DTYPE_MAP[checkpoint_config.export_dtype]
         self.exclude_from_loading = checkpoint_config.exclude_from_loading
         self.interval = checkpoint_config.interval
@@ -536,6 +537,7 @@ class CheckpointManager:
             return False
 
         model_only = False
+        from_hf = False
         if not os.path.exists(self.folder):
             if self.initial_load_path:
                 checkpoint_id = self.initial_load_path
@@ -544,13 +546,18 @@ class CheckpointManager:
                         "checkpoint.initial_load_path is specified but the path is not valid."
                     )
                 model_only = self.initial_load_model_only
+                from_hf = self.initial_load_in_hf
+                if from_hf:
+                    assert (
+                        model_only
+                    ), "Only model can be loaded when loading from HF's safetensors checkpoint."
             else:
                 return False
         else:
             if self.initial_load_path:
-                logger.info(
+                logger.warning(
                     "checkpoint.initial_load_path is provided but the checkpoint.folder exists. "
-                    "Checkpointer will use the checkpoints from the checkpoint.folder."
+                    f"Checkpointer will use the checkpoints from the checkpoint.folder {self.folder}."
                 )
             step = self._find_load_step() if step == -1 else step
             if step == -1:
@@ -563,11 +570,6 @@ class CheckpointManager:
                     f"--checkpoint.load_step={step} but checkpoint {checkpoint_id} is not found."
                 )
 
-        from_hf = self._load_checkpoint_in_hf_format(checkpoint_id)
-        if from_hf:
-            assert (
-                model_only
-            ), "Only model can be loaded when loading from HF's safetensors checkpoint."
         logger.info(f"Loading the checkpoint from {checkpoint_id}.")
         begin = time.monotonic()
         states = self._states_to_load(model_only)
@@ -621,21 +623,6 @@ class CheckpointManager:
         if not step_counts:
             return -1
         return max(step_counts)
-
-    def _load_checkpoint_in_hf_format(self, checkpoint_id: str) -> bool:
-        """Find the checkpoint type for the given id.
-
-        Args:
-            checkpoint_id (str): The folder to find the checkpoint type for.
-
-        Returns:
-            CheckpointType: The checkpoint type for the given folder.
-        """
-
-        for filename in os.listdir(checkpoint_id):
-            if filename.endswith(".safetensors"):
-                return True
-        return False
 
     def _ft_folder(self) -> str:
         return os.path.join(self.folder, f"ft-replicat-{self.ft_replica_id}")


### PR DESCRIPTION
This PR
- removes `_load_checkpoint_in_hf_format` and always let user enable `initial_load_in_hf`, which makes it symmetric to `last_save_in_hf` and less ambiguous
- require `intial_load_path` to be used, instead of letting user figure out they can download HF checkpoint to `checkpoint.folder / step-0 / ` which is not intuitive.