### PR TITLE
Log total number of tokens seen

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -312,6 +312,7 @@ class MetricsProcessor:
     color: utils.NoColor | utils.Color
 
     gpu_peak_flops: int
+    ntokens_seen: int
     ntokens_since_last_log: int
     data_loading_times: list[float]
     time_last_log: float
@@ -340,6 +341,7 @@ class MetricsProcessor:
         self.gpu_peak_flops = utils.get_peak_flops(
             self.device_memory_monitor.device_name
         )
+        self.ntokens_seen = 0
         self.ntokens_since_last_log = 0
         self.data_loading_times = []
         self.time_last_log = time.perf_counter()
@@ -365,6 +367,9 @@ class MetricsProcessor:
 
         time_delta = time.perf_counter() - self.time_last_log
 
+        # update the total number of tokens seen
+        self.ntokens_seen += self.ntokens_since_last_log
+
         # tokens per second per device, abbreviated as tps
         tps = self.ntokens_since_last_log / (
             time_delta * self.parallel_dims.non_data_parallel_size
@@ -385,6 +390,7 @@ class MetricsProcessor:
             "loss_metrics/global_avg_loss": global_avg_loss,
             "loss_metrics/global_max_loss": global_max_loss,
             "grad_norm": grad_norm,
+            "ntokens_seen": self.ntokens_seen,
             "throughput(tps)": tps,
             "tflops": tflops,
             "mfu(%)": mfu,


### PR DESCRIPTION
I added logging of the total number of tokens that have been used for training up to the current `log` call. This is useful for plotting metrics like the loss against the number of tokens instead of steps.

Since `metrics_processor` is part of the `Trainer`'s state, this change should be compatible with checkpointing and resuming the count of `ntokens_seen`.