### PR TITLE
Fix tokenizer error message

### DIFF
--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -161,7 +161,7 @@ class HuggingFaceTokenizer(BaseTokenizer):
             raise FileNotFoundError(
                 f"No supported tokenizer files found in '{tokenizer_path}'. "
                 f"Available files: {available_files}. "
-                "Looking for: tokenizer.json, tokenizer.model, vocab.txt+merges.txt, or vocab.json+merges.txt"
+                "Looking for: tokenizer.json, vocab.txt+merges.txt, or vocab.json+merges.txt"
             )
 
     def _get_token_from_config(self, config: dict[str, Any], key: str) -> Optional[str]:

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -78,7 +78,7 @@ class Model:
     flavor: str = "debugmodel"
     """Which model config to train"""
 
-    tokenizer_path: str = "./torchtitan/datasets/tokenizer/tokenizer.model"
+    tokenizer_path: str = "./tests/assets/tokenizer"
     """Tokenizer path"""
 
     converters: list[str] = field(default_factory=list)


### PR DESCRIPTION
We don't use `tokenizer.model` anymore