### PR TITLE
Fix data_load_start position

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -361,13 +361,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         data_iterator = iter(data_iterable)
 
         while True:
+            data_load_start = time.perf_counter()
             try:
                 batch = next(data_iterator)
             except StopIteration as ex:
                 # If data runs out during gradient accumulation, that
                 # entire step will not be executed.
                 raise DataloaderStopIteration() from ex
-            data_load_start = time.perf_counter()
             input_dict, labels = batch
             self.metrics_processor.ntokens_since_last_log += labels.numel()
             self.metrics_processor.data_loading_times.append(


### PR DESCRIPTION
# Fix incorrect data loading time measurement

This PR fixes the timing of data_loading_times measurement in batch_generator. Previously, the timer started after calling next(data_iterator), which excluded the actual data fetching time from the measurement.
Now, the timer starts before the next() call to correctly capture the full DataLoader latency.