### PR TITLE
minimal repro for fsdp + tp incorrect permutation

### DIFF
--- a/scripts/checkpoint_conversion/compare_tt_and_tt.py
+++ b/scripts/checkpoint_conversion/compare_tt_and_tt.py
@@ -1,0 +1,132 @@
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+import torch.distributed.checkpoint as dcp
+import torch.nn.functional as F
+from torch.distributed.checkpoint import HuggingFaceStorageReader
+from torchtitan.components.checkpoint import excluded_parameters_for_model_only
+from torchtitan.config import ConfigManager
+from torchtitan.protocols.train_spec import get_train_spec
+from torchtitan.tools.logging import logger
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+device_type = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def loss_fn(logits1, logits2):
+    # Convert logits to probabilities
+    probs1 = F.log_softmax(logits1, dim=-1)
+    probs2 = F.softmax(logits2, dim=-1)
+
+    # Calculate KL Divergence
+    kl_loss = F.kl_div(probs1, probs2, "mean")
+    return kl_loss
+
+
+@torch.no_grad
+def forward_tt(config_path, checkpoint_path, test_set):
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args([f"--job.config_file={config_path}"])
+
+    train_spec = get_train_spec(config.model.name)
+
+    # Tokenizer setup
+    tokenizer = train_spec.build_tokenizer_fn(config)
+
+    model_args = train_spec.model_args[config.model.flavor]
+    model_args.update_from_config(config)
+
+    model = train_spec.model_cls(model_args)
+
+    # materalize model
+    device = torch.device(device_type)
+    model.to_empty(device=device)
+    with torch.no_grad():
+        model.init_weights()
+    model.eval()
+
+    state_dict = model.state_dict()
+    for k in excluded_parameters_for_model_only:
+        state_dict.pop(k, None)
+
+    # Checkpoint Loading
+    logger.info(f"Loading chkpt at: {checkpoint_path}")
+    load_from_hf = False
+    for filename in os.listdir(checkpoint_path):
+        if filename == "model.safetensors.index.json":
+            load_from_hf = True
+    if load_from_hf:
+        sd_adapter = train_spec.state_dict_adapter
+        hf_state_dict = sd_adapter.to_hf(state_dict)
+        dcp.load(hf_state_dict, HuggingFaceStorageReader(path=checkpoint_path))
+        state_dict = sd_adapter.from_hf(hf_state_dict)
+    else:
+        dcp.load(state_dict, checkpoint_id=checkpoint_path)
+
+    output_list = []
+    for prompt in test_set:
+        input_ids = prompt.to(device_type)
+        # ensure batch dimension (T,) --> (B, T)
+        # print(input_ids.shape)
+        if input_ids.ndim == 1:
+            input_ids = input_ids.unsqueeze(0)
+        # print(input_ids.shape)
+
+        # obtains the logits of only the last token in the predictions
+        predictions = model(input_ids)[:, -1, :].unsqueeze(1)
+
+        # print("tt logits")
+        # print(predictions.shape)
+        # print(predictions)
+        output_list.append(predictions)
+
+    del model
+    torch.cuda.empty_cache()
+
+    return output_list
+
+
+if __name__ == "__main__":
+    config_path = "torchtitan/models/llama3/train_configs/llama3_8b.toml"
+
+    # TODO change this to corect path
+    checkpoint_path_baseline = "outputs/checkpoint-test/step-0-fromhf"
+    checkpoint_path_test = "outputs/checkpoint-test/step-1"
+
+    # test params
+    prompt_len = 8
+    test_size = 100
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args([f"--job.config_file={config_path}"])
+    train_spec = get_train_spec(config.model.name)
+    tokenizer = train_spec.build_tokenizer_fn(config)
+
+    test_set = [
+        torch.randint(
+            0,
+            tokenizer.get_vocab_size(),
+            (
+                1,  # batch size
+                prompt_len,
+            ),
+        )
+        for _ in range(test_size)
+    ]
+
+    torch.manual_seed(42)
+    tt_baseline = forward_tt(config_path, checkpoint_path_baseline, test_set)
+    tt_test = forward_tt(config_path, checkpoint_path_test, test_set)
+
+    total_loss = 0
+    for baseline, test in zip(tt_baseline, tt_test):
+        total_loss += loss_fn(baseline, test)
+    avg_loss = total_loss / len(test_set)
+
+    print("Average loss", avg_loss)

--- a/torchtitan/models/llama3/train_configs/llama3_8b_debug.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b_debug.toml
@@ -1,0 +1,65 @@
+# torchtitan Config.toml
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 8B training"
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 1
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "llama3"
+flavor = "8B"
+tokenizer_path = "./assets/tokenizer/Llama-3.1-8B"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 3e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up
+
+[training]
+deterministic = true
+local_batch_size = 1
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 10
+compile = false
+dataset = "c4"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = 2
+tensor_parallel_degree = 2
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable_checkpoint = true
+initial_load_model_only = true
+folder = "checkpoint-test"
+interval = 5
+last_save_model_only = true
+# export_dtype = "bfloat16"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+# exclude_from_loading = ["data_loader", "lr_scheduler"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -503,6 +503,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.checkpointer.load(step=job_config.checkpoint.load_step)
         logger.info(f"Training starts at step {self.step + 1}.")
 
+        self.checkpointer.save(1, last_step=True)
+        return
+
         leaf_folder = (
             ""
             if not self.ft_manager.enabled


### PR DESCRIPTION
This PR minimally reproduces the incorrectness when loading from a checkpoint in hf with tp and fsdp enabled. The train script immediately saves after loading so that we can test the dcp checkpoint for correctness without training.

To reproduce the fsdp+tp incorrectness:
1. Load from hf checkpoint and create dcp checkpoint for testing:
`NGPU=4 CONFIG_FILE=./torchtitan/models/llama3/train_configs/llama3_8b_debug.toml ./run_train.sh`
2. Sanity check using greedy decoding
`python ./scripts/generate/test_generate.py --config "./torchtitan/models/llama3/train_configs/llama3_8b_debug.toml" --checkpoint ./outputs/checkpoint-test/step-1 --top_k 1 --max_new_tokens 200 --prompt "Once upon a time in a land far, far away"`
The correct output should be exactly: <img width="966" height="144" alt="Screenshot 2025-07-29 at 11 14 15 AM" src="https://github.com/user-attachments/assets/f5f0a3f4-ce15-4237-8b10-6a18edb76b05" />
3. Thorough test of entire model weights using KL divergence on logits after forward passes.
`python ./scripts/checkpoint_conversion/compare_tt_and_tt.py`
You will need to create a correct dcp checkpoint to compare to using the `convert_from_hf.py` script which runs on full tensors.
The correct loss should be in a similar order of magnitude as`-1.3229e-13`

### Closed: fixed by https://github.com/pytorch/pytorch/pull/159656