### PR TITLE
minimal repro of error saving pp in hf format

### DIFF
--- a/scripts/checkpoint_conversion/compare_hf_and_hf.py
+++ b/scripts/checkpoint_conversion/compare_hf_and_hf.py
@@ -1,0 +1,109 @@
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+import torch.distributed.checkpoint as dcp
+import torch.nn.functional as F
+from torch.distributed.checkpoint import HuggingFaceStorageReader
+from torchtitan.components.checkpoint import excluded_parameters_for_model_only
+from torchtitan.config import ConfigManager
+from torchtitan.protocols.train_spec import get_train_spec
+from torchtitan.tools.logging import logger
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+device_type = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def loss_fn(logits1, logits2):
+    # Convert logits to probabilities
+    probs1 = F.log_softmax(logits1, dim=-1)
+    probs2 = F.softmax(logits2, dim=-1)
+
+    # Calculate KL Divergence
+    kl_loss = F.kl_div(probs1, probs2, "mean")
+    return kl_loss
+
+
+@torch.no_grad
+def forward_hf(model_name, model_path: Optional[str], input_ids):
+    # Load the tokenizer and model
+    model_path = model_path if model_path else model_name
+    model = AutoModelForCausalLM.from_pretrained(model_path)
+
+    device = torch.device(device_type)
+    model.to(device)
+
+    # List to store outputs
+    outputs_list = []
+
+    for inputs in input_ids:
+        inputs = inputs.to(device)
+        outputs = model.generate(
+            inputs=inputs,
+            max_length=prompt_len + 1,
+            do_sample=False,
+            output_logits=True,
+            return_dict_in_generate=True,
+        )
+
+        print("hf inputs")
+        print(inputs)
+        print("hf outputs")
+        outputs = torch.stack(outputs.logits)
+        print(outputs.shape)
+        print(outputs)
+        outputs_list.append(outputs)
+
+    del model
+    torch.cuda.empty_cache()
+
+    return outputs_list
+
+
+if __name__ == "__main__":
+    # hf params
+    hf_model_name = "meta-llama/Meta-Llama-3-8B"
+    hf_model_path = "outputs/checkpoint/step-0-tohf"
+    hf_model_path_no_perm = "outputs/checkpoint/step-0-tohfnoperm"
+
+    config_path = "torchtitan/models/llama3/train_configs/llama3_8b.toml"
+
+    # test params
+    prompt_len = 8
+    test_size = 100
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args([f"--job.config_file={config_path}"])
+    train_spec = get_train_spec(config.model.name)
+    tokenizer = train_spec.build_tokenizer_fn(config)
+
+    test_set = [
+        torch.randint(
+            0,
+            tokenizer.get_vocab_size(),
+            (
+                1,  # batch size
+                prompt_len,
+            ),
+        )
+        for _ in range(test_size)
+    ]
+
+    # baseline hf generation
+    torch.manual_seed(42)
+    hf_outputs = forward_hf(hf_model_name, None, test_set)
+
+    # testing to hf script by running tt model on hf
+    torch.manual_seed(42)
+    pp_hf_outputs = forward_hf(hf_model_name, hf_model_path, test_set)
+
+    total_loss = 0
+    for hf, pp in zip(hf_outputs, pp_hf_outputs):
+        total_loss += loss_fn(hf, pp)
+    avg_loss = total_loss / len(test_set)
+
+    print("Average loss", avg_loss)

--- a/scripts/test_generate_hf.py
+++ b/scripts/test_generate_hf.py
@@ -1,0 +1,37 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Load the tokenizer and model
+model_name = "meta-llama/Meta-Llama-3-8B"
+model_path = "./outputs/checkpoint-test/step-1"
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+model = AutoModelForCausalLM.from_pretrained(model_path)
+
+device = torch.device("cuda")
+model.to(device)
+
+# Define the input string
+input_text = "Once upon a time in a land far, far away"
+
+# # Tokenize the input
+inputs = tokenizer(input_text, return_tensors="pt").to(device)
+
+# # Generate output
+outputs = model.generate(
+    **inputs,
+    max_length=200,
+    do_sample=False,
+    # return_dict_in_generate=True,
+    output_logits=True,
+    output_scores=True
+)
+# print(outputs.logits)
+
+# # Decode the output
+decoded_output = tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+# # Print the result
+print("Generated text:", decoded_output)
+
+# logits = torch.randn((batch_size, vocab_size)
+# log_probs = torch.nn.functional.log_softmax(logits, dim=-1)

--- a/torchtitan/models/llama3/train_configs/llama3_8b_debug.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b_debug.toml
@@ -1,0 +1,66 @@
+# torchtitan Config.toml
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 8B training"
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 1
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "llama3"
+flavor = "8B"
+tokenizer_path = "./assets/tokenizer/Llama-3.1-8B"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 3e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up
+
+[training]
+deterministic = true
+local_batch_size = 4
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 10
+compile = false
+dataset = "c4"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = 1
+tensor_parallel_degree = 1
+pipeline_parallel_degree = 4
+context_parallel_degree = 1
+
+[checkpoint]
+enable_checkpoint = true
+# initial_load_model_only = true
+folder = "checkpoint-test"
+interval = 5
+last_save_model_only = true
+last_save_in_hf = true
+export_dtype = "bfloat16"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+# exclude_from_loading = ["data_loader", "lr_scheduler"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -434,7 +434,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             with self.train_context(optional_context_parallel_ctx):
                 assert len(model_parts) == 1
                 with self.maybe_enable_amp:
-                    pred = model_parts[0](inputs, self.tokenizer.eos_id)
+                    pred = model_parts[0](inputs, eos_id=self.tokenizer.eos_id)
                     loss = self.loss_fn(pred, labels)
                 # need to free to before bwd to avoid peaking memory
                 del pred
@@ -507,6 +507,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         self.checkpointer.load(step=job_config.checkpoint.load_step)
         logger.info(f"Training starts at step {self.step + 1}")
+
+        self.checkpointer.save(1, last_step=True)
+        return
 
         leaf_folder = (
             ""


### PR DESCRIPTION
This is a minimal repro of saving torchtitan model in hf format during training. Currently the program fails to a Key Error due to missing fqn when saving a Llam3 8B model sharded with pipeline parallelism.

Steps to reproduce:
1. run `NGPU=4 CONFIG_FILE=./torchtitan/models/llama3/train_configs/llama3_8b_debug.toml ./run_train.sh`

To verify correctness after error you can sanity check using greedy decoding.
`python ./scripts/test_generate_hf.py`
To fully verify weights correctness you can compare against actual hf model.
`python ./scripts/checkpoint_conversion/compare_hf_and_hf.py`

### Closed, solved by https://github.com/pytorch/torchtitan/pull/1526