### PR TITLE
validation support for pipeline parallelism [WIP]

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -552,6 +552,18 @@ def build_test_list():
             "validation_fsdp_tp_cp",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--validation.enabled",
+                    "--validation.dataset c4_test",
+                    "--parallelism.pipeline_parallel_degree=2",
+                ],
+            ],
+            "Validation test with pp",
+            "validation_pp",
+            ngpu=2,
+        ),
     ]
     return integration_tests_flavors
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -543,26 +543,15 @@ def build_test_list():
                 [
                     "--validation.enabled",
                     "--validation.dataset c4_test",
-                    "--parallelism.data_parallel_replicate_degree=2",
                     "--parallelism.tensor_parallel_degree=2",
                     "--parallelism.context_parallel_degree=2",
-                ],
-            ],
-            "Validation test with fsdp, tp, cp",
-            "validation_fsdp_tp_cp",
-            ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--validation.enabled",
-                    "--validation.dataset c4_test",
                     "--parallelism.pipeline_parallel_degree=2",
+                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
                 ],
             ],
-            "Validation test with pp",
-            "validation_pp",
-            ngpu=2,
+            "Validation test with tp, cp, pp",
+            "validation_tp_cp_pp",
+            ngpu=8,
         ),
     ]
     return integration_tests_flavors

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -9,6 +9,7 @@ from typing import Generator
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule
+from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.loss import LossFunction
 from torchtitan.components.metrics import MetricsProcessor
@@ -54,6 +55,9 @@ class Validator(BaseValidator):
         validation_context: Generator[None, None, None],
         maybe_enable_amp: Generator[None, None, None],
         metrics_processor: MetricsProcessor,
+        pp_schedule: _PipelineSchedule | None = None,
+        pp_has_first_stage: bool | None = None,
+        pp_has_last_stage: bool | None = None,
     ):
         self.job_config = job_config
         self.parallel_dims = parallel_dims
@@ -67,6 +71,9 @@ class Validator(BaseValidator):
         self.validation_context = validation_context
         self.maybe_enable_amp = maybe_enable_amp
         self.metrics_processor = metrics_processor
+        self.pp_schedule = pp_schedule
+        self.pp_has_first_stage = pp_has_first_stage
+        self.pp_has_last_stage = pp_has_last_stage
 
     @torch.no_grad()
     def validate(
@@ -75,7 +82,6 @@ class Validator(BaseValidator):
         step: int,
     ) -> dict[str, float]:
         # Set model to eval mode
-        # TODO: currently does not support pipeline parallelism
         model = model_parts[0]
         model.eval()
 
@@ -110,11 +116,40 @@ class Validator(BaseValidator):
                 else None
             )
 
-            with self.validation_context(optional_context_parallel_ctx):
-                assert len(model_parts) == 1
-                with self.maybe_enable_amp:
-                    predictions = model(inputs)
-                    loss = self.loss_fn(predictions, labels)
+            if parallel_dims.pp_enabled:
+                assert self.pp_schedule is not None
+                assert self.pp_has_first_stage is not None
+                assert self.pp_has_last_stage is not None
+                # Pipeline Parallel forward inside eval() call
+                with self.validation_context(optional_context_parallel_ctx):
+                    targets, losses = (
+                        (labels, []) if self.pp_has_last_stage else (None, None)
+                    )
+                    if self.pp_has_first_stage:
+                        self.pp_schedule.eval(
+                            inputs,
+                            target=targets,
+                            losses=losses,
+                            input_batch=inputs,
+                        )
+                    else:
+                        self.pp_schedule.eval(
+                            target=targets, losses=losses, input_batch=inputs
+                        )
+
+                # accumulate losses across pipeline microbatches
+                # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
+                loss = (
+                    torch.mean(torch.stack(losses)).to(device_type)
+                    if self.pp_has_last_stage
+                    else torch.tensor([-1.0], device=device_type)
+                )
+            else:
+                with self.validation_context(optional_context_parallel_ctx):
+                    assert len(model_parts) == 1
+                    with self.maybe_enable_amp:
+                        predictions = model(inputs)
+                        loss = self.loss_fn(predictions, labels)
 
             accumulated_losses.append(loss.detach())
 
@@ -152,6 +187,9 @@ def build_validator(
     validation_context: Generator[None, None, None],
     maybe_enable_amp: Generator[None, None, None],
     metrics_processor: MetricsProcessor | None = None,
+    pp_schedule: _PipelineSchedule | None = None,
+    pp_has_first_stage: bool | None = None,
+    pp_has_last_stage: bool | None = None,
 ) -> BaseValidator:
     """Build a simple validator focused on correctness."""
     return Validator(
@@ -164,4 +202,7 @@ def build_validator(
         validation_context=validation_context,
         maybe_enable_amp=maybe_enable_amp,
         metrics_processor=metrics_processor,
+        pp_schedule=pp_schedule,
+        pp_has_first_stage=pp_has_first_stage,
+        pp_has_last_stage=pp_has_last_stage,
     )

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -327,9 +327,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         # Build validator if validation is configured
         if job_config.validation.enabled:
             assert self.train_spec.build_validator_fn is not None
-            assert (
-                not parallel_dims.pp_enabled
-            ), "pp is enabled but validation doesn't support pipeline parallelism yet"
 
             self.validator = self.train_spec.build_validator_fn(
                 job_config=job_config,
@@ -341,6 +338,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 validation_context=self.train_context,
                 maybe_enable_amp=self.maybe_enable_amp,
                 metrics_processor=self.metrics_processor,
+                pp_schedule=self.pp_schedule if parallel_dims.pp_enabled else None,
+                pp_has_first_stage=(
+                    self.pp_has_first_stage if parallel_dims.pp_enabled else None
+                ),
+                pp_has_last_stage=(
+                    self.pp_has_last_stage if parallel_dims.pp_enabled else None
+                ),
             )
 
         logger.info(
@@ -430,7 +434,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             with self.train_context(optional_context_parallel_ctx):
                 assert len(model_parts) == 1
                 with self.maybe_enable_amp:
-                    pred = model_parts[0](inputs, self.tokenizer.eos_id)
+                    pred = model_parts[0](inputs, eos_id=self.tokenizer.eos_id)
                     loss = self.loss_fn(pred, labels)
                 # need to free to before bwd to avoid peaking memory
                 del pred

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -328,6 +328,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if job_config.validation.enabled:
             assert self.train_spec.build_validator_fn is not None
 
+            pp_schedule, pp_has_first_stage, pp_has_last_stage = (
+                (
+                    self.pp_schedule,
+                    self.pp_has_first_stage,
+                    self.pp_has_last_stage,
+                )
+                if parallel_dims.pp_enabled
+                else (None, None, None)
+            )
+
             self.validator = self.train_spec.build_validator_fn(
                 job_config=job_config,
                 dp_world_size=dp_degree,
@@ -338,13 +348,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 validation_context=self.train_context,
                 maybe_enable_amp=self.maybe_enable_amp,
                 metrics_processor=self.metrics_processor,
-                pp_schedule=self.pp_schedule if parallel_dims.pp_enabled else None,
-                pp_has_first_stage=(
-                    self.pp_has_first_stage if parallel_dims.pp_enabled else None
-                ),
-                pp_has_last_stage=(
-                    self.pp_has_last_stage if parallel_dims.pp_enabled else None
-                ),
+                pp_schedule=pp_schedule,
+                pp_has_first_stage=pp_has_first_stage,
+                pp_has_last_stage=pp_has_last_stage,
             )
 
         logger.info(


### PR DESCRIPTION
With recent api change to pipeline schedule https://github.com/pytorch/pytorch/pull/157795, we can now schedule forward pass and calculate loss, allowing us to use validation and pp together.

To test correctness we train from a seed checkpoint with training.seed and training.determinism set with varying degrees of parallelism and different pipeline schedules to compare if loss remains the same:

| Parallelism | Loss |
| --- | --- |
| FSDP=2 | <img width="960" height="328" alt="Screenshot 2025-07-29 at 5 12 49 PM" src="https://github.com/user-attachments/assets/3aedc87d-f12c-409c-88da-86b0ac72a1a7" /> |
| FSDP=2, TP=2, PP=2, PP_schedule="1F1B" |  <img width="964" height="334" alt="Screenshot 2025-07-29 at 5 17 18 PM" src="https://github.com/user-attachments/assets/b5f8979b-0f44-48fc-aa4d-38e938c5cf43" />  |
| FSDP=2, PP=4, PP_schedule="1F1B" | <img width="973" height="335" alt="Screenshot 2025-07-29 at 5 15 53 PM" src="https://github.com/user-attachments/assets/29636394-b602-4a21-995d-94769771f599" /> |
| FSDP=2, PP=4, PP_schedule="Interleaved1F1B" |<img width="964" height="329" alt="Screenshot 2025-07-29 at 5 39 39 PM" src="https://github.com/user-attachments/assets/de960111-d0ad-4470-a096-493d7f59461e" /> |
| FSDP=2, PP=4, PP_schedule="GPipe" | <img width="971" height="329" alt="Screenshot 2025-07-29 at 5 49 36 PM" src="https://github.com/user-attachments/assets/2100b2a2-2725-43c8-a937-78fb05962247" />
| FSDP=2, PP=4, PP_schedule="LoopedBFS" | <img width="963" height="330" alt="Screenshot 2025-07-29 at 5 54 55 PM" src="https://github.com/user-attachments/assets/102df0f7-bd4f-47a6-a94a-a1bf488237ce" />
| FSDP=2, PP=4, PP_schedule="InterleavedZeroBubble" | <img width="960" height="343" alt="Screenshot 2025-07-30 at 2 30 53 PM" src="https://github.com/user-attachments/assets/1d2bce1a-0b8c-4d09-85b8-0a0634f68690" />



