### PR TITLE
[deepseek] fix mismatch of model embeddings vs tokenizer size (128815), sync to 671B vocab size, avoids cudaErrorAssert and run termination.

### DIFF
--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -69,7 +69,7 @@ deepseekv3_configs = {
         attn_mask_type="block_causal",
     ),
     "16B": DeepSeekV3ModelArgs(
-        vocab_size=128815,
+        vocab_size=129280,
         dim=2048,
         inter_dim=10944,
         moe_inter_dim=1408,
@@ -88,7 +88,7 @@ deepseekv3_configs = {
         mscale=0.70,
     ),
     "236B": DeepSeekV3ModelArgs(
-        vocab_size=128815,
+        vocab_size=129280,
         dim=5120,
         inter_dim=12288,
         moe_inter_dim=1536,

--- a/torchtitan/models/deepseek_v3/model/args.py
+++ b/torchtitan/models/deepseek_v3/model/args.py
@@ -59,7 +59,7 @@ class DeepSeekV3ModelArgs(BaseModelArgs):
     max_batch_size: int = 8
     max_seq_len: int = 4096 * 4
     dtype: Literal["bf16", "fp8"] = "bf16"
-    vocab_size: int = 128815
+    vocab_size: int = 129280
     dim: int = 2048
     inter_dim: int = 10944
     moe_inter_dim: int = 1408


### PR DESCRIPTION
When trying to run DS v3, 16B, I encounter the following cudaErrorAssert:

~~~
[rank0]:[titan] 2025-07-30 09:13:06,065 - root - INFO - Model deepseek_v3 16B size: 15,706,484,224 total parameters
[rank0]:[titan] 2025-07-30 09:13:06,079 - root - INFO - Applied full activation checkpointing to the model
[rank0]:[titan] 2025-07-30 09:13:06,176 - root - INFO - Applied FSDP to the model
[rank0]:[titan] 2025-07-30 09:13:06,520 - root - INFO - Peak FLOPS used for computing MFU: 2.250e+15
[rank0]:[titan] 2025-07-30 09:13:06,521 - root - INFO - CUDA memory usage for model: 8.80GiB(4.93%)
[rank0]:[titan] 2025-07-30 09:13:06,522 - root - WARNING - Warmup steps (200) exceed total training steps (20). Adjusting warmup steps to 20.
[rank0]:[titan] 2025-07-30 09:13:06,522 - root - WARNING - Warmup (20) + decay (16) steps exceed total training steps (20). Adjusting decay steps to 0.
[rank0]:[titan] 2025-07-30 09:13:06,522 - root - INFO - Mixed precision training is handled by fully_shard
[rank0]:[titan] 2025-07-30 09:13:06,522 - root - INFO - Trainer is initialized with local batch size 8, global batch size 64, gradient accumulation steps 1, sequence length 4096, total steps 20 (warmup 200)
[rank0]:[titan] 2025-07-30 09:13:06,522 - root - INFO - Training starts at step 1
[rank0]:/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [8027,0,0], thread: [64,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
[rank0]:/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [8027,0,0], thread: [65,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
[rank0]:/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [8027,0,0], thread: [66,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
[rank0]:/pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [8027,0,0], thread: [67,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
~~~

This root cause is that the spec'ed model vocab size of 102,400 is less than the tokenizers vocab of 128,000 + 818 added special tokens, or total vocab of 128815 (max token id + 1). 

This PR thus:
updates model config to use the correct vocab_size of > 128815 in both args and init.py.
update: let's move to match 671B vocab size of **129280** for consistency, and this is divisible by 8 which addresses my perf concern below at the same time.


*note - there's a sep discussion to be had about rounding this size to next power of 2 or similar (div by 8) for better perf.  

This let's users run successfully and avoid the crash out from the cudaErrorAssert. 