### PR TITLE
guard against nvidia-smi command exit code 1

### DIFF
--- a/.github/workflows/integration_test_8gpu.yaml
+++ b/.github/workflows/integration_test_8gpu.yaml
@@ -40,7 +40,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Log CUDA driver version for debugging.
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1)
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
         echo "CUDA driver version: ${DRIVER_VERSION}"
 
         pip config --user set global.progress_bar off

--- a/.github/workflows/integration_test_8gpu_flux.yaml
+++ b/.github/workflows/integration_test_8gpu_flux.yaml
@@ -42,7 +42,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         # Log CUDA driver version for debugging.
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1)
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
         echo "CUDA driver version: ${DRIVER_VERSION}"
 
         python -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -41,7 +41,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Log CUDA driver version for debugging.
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1)
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
         echo "CUDA driver version: ${DRIVER_VERSION}"
 
         pip config --user set global.progress_bar off

--- a/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
+++ b/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
@@ -39,7 +39,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Log CUDA driver version for debugging.
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1)
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
         echo "CUDA driver version: ${DRIVER_VERSION}"
 
         pip config --user set global.progress_bar off

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -39,7 +39,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Log CUDA driver version for debugging.
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1)
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
         echo "CUDA driver version: ${DRIVER_VERSION}"
 
         pip config --user set global.progress_bar off


### PR DESCRIPTION
Somehow, despite the logs showing echo-ing the driver version successfully, it exits with code 1. 

This PR attempts guard against the case where the command writes to stdout successfully but exits with code 1 for some reason.

https://github.com/pytorch/torchtitan/blob/881f0ca465d26ab87ccfc5c89572b8a21c4e9707/.github/workflows/integration_test_8gpu.yaml#L44