### PR TITLE
[deepseek] integrate 16B tokenizer to match 16B official model

### DIFF
--- a/torchtitan/models/deepseek_v3/README.md
+++ b/torchtitan/models/deepseek_v3/README.md
@@ -7,8 +7,13 @@ DeepSeek-V3 is a Mixture-of-Experts (MoE) transformer model with Multi-head Late
 ### Download Tokenizer
 
 ```bash
-# DeepSeek tokenizer (automatically downloads tokenizer.json and tokenizer_config.json)
+# DeepSeek 671B tokenizer (automatically downloads tokenizer.json and tokenizer_config.json)
 python scripts/download_tokenizer.py --repo_id deepseek-ai/DeepSeek-V3
+```
+
+```bash
+# For 16B model support:
+python scripts/download_tokenizer.py --repo_id deepseek-ai/deepseek-moe-16b-chat
 ```
 
 ## Training

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
@@ -22,7 +22,7 @@ enable_wandb = false
 [model]
 name = "deepseek_v3"
 flavor = "16B"
-tokenizer_path = "./assets/tokenizer/DeepSeek-V3"
+tokenizer_path = "./assets/tokenizer/deepseek-moe-16b-chat"
 # converters = ["float8"]
 
 [optimizer]


### PR DESCRIPTION
Based on the discussion in this PR (https://github.com/pytorch/torchtitan/pull/1495), the conclusion was to ensure that 16B uses the proper tokenizer to avoid the cudaAssertError in the current config which comes from mismatch between embeddings and tokenizer vocab.

Thus, this PR;
1 - adds additional line to the readme for enabling users to pull the 16B-chat tokenizer, 
2- updates the 16_toml config to point to the 16B tokenizer under /assets/tokenizer/deepseek-moe-16b-chat

With that, the vocab size of 102400 already in the toml now works flawlessly. 


**Testing:**
run download tokenizer 
run 20 iters with 16B without issue.

<img width="1255" height="201" alt="Screenshot 2025-07-30 at 12 46 38 PM" src="https://github.com/user-attachments/assets/e33556bf-51c6-4fa0-ab71-d1b02ef74d99" />
