### PR TITLE
[deepseek] update to 16b base tokenizer

### DIFF
--- a/torchtitan/models/deepseek_v3/README.md
+++ b/torchtitan/models/deepseek_v3/README.md
@@ -12,8 +12,8 @@ python scripts/download_tokenizer.py --repo_id deepseek-ai/DeepSeek-V3
 ```
 
 ```bash
-# For 16B model support:
-python scripts/download_tokenizer.py --repo_id deepseek-ai/deepseek-moe-16b-chat
+# DeepSeek 16B tokenizer:
+python scripts/download_tokenizer.py --repo_id deepseek-ai/deepseek-moe-16b-base
 ```
 
 ## Training

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
@@ -22,7 +22,7 @@ enable_wandb = false
 [model]
 name = "deepseek_v3"
 flavor = "16B"
-tokenizer_path = "./assets/tokenizer/deepseek-moe-16b-chat"
+tokenizer_path = "./assets/tokenizer/deepseek-moe-16b-base"
 # converters = ["float8"]
 
 [optimizer]


### PR DESCRIPTION
This PR updates to use base rather than chat (they are the same but name is different) and makes it clear we are not loading the model weights for 16b. 

Testing:
download via script
run 20 iters with 16b_base tokenizer. 