### PR TITLE
Make token group alignment size configurable

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -10,7 +10,9 @@ import torch.nn as nn
 
 from torchtitan.config.job_config import Float8, JobConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.llama4.infra.expert_parallel import set_token_group_alignment_size_m
+from torchtitan.experiments.llama4.infra.expert_parallel import (
+    set_token_group_alignment_size_m,
+)
 from torchtitan.protocols.model_converter import (
     ModelConverter,
     register_model_converter,

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from torchtitan.config.job_config import Float8, JobConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.llama4.infra.expert_parallel import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import (
     ModelConverter,
     register_model_converter,
@@ -65,6 +66,10 @@ class Float8Converter(ModelConverter):
             assert (
                 job_config.parallelism.context_parallel_degree == 1
             ), "Float8 MoE training prototype does not yet support context parallelism"
+
+            # For fp8 grouped GEMM, token group sizes must be multiples of 16
+            # (16 byte alignment / 1 byte per elem = 16 elements)
+            set_token_group_alignment_size_m(16)
 
         if float8_config.recipe_name is not None:
             assert not float8_config.enable_fsdp_float8_all_gather, (

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -59,6 +59,13 @@ class MXConverter(ModelConverter):
             and job_config.parallelism.tensor_parallel_degree > 1
         ), "TP not yet supported with torch.compile for mxfp8"
 
+        # For MoE training with mxfp8, token group sizes must be multiples of 32
+        if job_config.mx.moe_fqns_prototype:
+            from torchtitan.experiments.llama4.infra.expert_parallel import set_token_group_alignment_size
+            mxfp8_block_size = 32
+            set_token_group_alignment_size(mxfp8_block_size)
+            logger.info(f"Setting token group alignment size to {mxfp8_block_size}")
+
         # Configure MXFP8
         from torchao.prototype.mx_formats.config import (
             MXFP8Dim1CastKernelChoice,

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -61,7 +61,10 @@ class MXConverter(ModelConverter):
 
         # For MoE training with mxfp8, token group sizes must be multiples of 32
         if job_config.mx.moe_fqns_prototype:
-            from torchtitan.experiments.llama4.infra.expert_parallel import set_token_group_alignment_size
+            from torchtitan.experiments.llama4.infra.expert_parallel import (
+                set_token_group_alignment_size,
+            )
+
             mxfp8_block_size = 32
             set_token_group_alignment_size(mxfp8_block_size)
             logger.info(f"Setting token group alignment size to {mxfp8_block_size}")

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -567,12 +567,18 @@ class MX:
 
     filter_fqns: list[str] = field(default_factory=lambda: ["output"])
     """
-    Comma-separated list of fully qualified names of modules to skip applying mxfloat8 training to.
+    Comma-separated list of fully qualified names of modules to skip applying mxfp8 training to.
     nn.Linear modules with any dim size not divisible by 16 are also always skipped due to hardware requirements.
     By default we always skip the output layer.
     Example: --mx.filter_fqns "attention.wq,attention.wk,attention.wv,output"
     """
 
+    moe_fqns_prototype: list[str] | str = field(default_factory=list)
+    """
+    Comma-separated list of fully qualified names of MoE modules to apply mxfp8 training to.
+    This is a prototype feature that requires the torchao nightly build.
+    Example: --float8.moe_fqns_prototype="experts"
+    """
 
 @dataclass
 class Comm:

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -580,6 +580,7 @@ class MX:
     Example: --mx.moe_fqns_prototype="experts"
     """
 
+
 @dataclass
 class Comm:
     init_timeout_seconds: int = 300

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -577,7 +577,7 @@ class MX:
     """
     Comma-separated list of fully qualified names of MoE modules to apply mxfp8 training to.
     This is a prototype feature that requires the torchao nightly build.
-    Example: --float8.moe_fqns_prototype="experts"
+    Example: --mx.moe_fqns_prototype="experts"
     """
 
 @dataclass

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -30,16 +30,16 @@ TOKEN_GROUP_ALIGN_SIZE_M = 8
 def set_token_group_alignment_size_m(m: int) -> None:
     """
     Set the token group alignment size for token groups in MoE. This is implemented by
-    padding each token group size to the next multiple of TOKEN_GROUP_ALIGN_SIZE_M. 
+    padding each token group size to the next multiple of TOKEN_GROUP_ALIGN_SIZE_M.
     Different values are needed for different cases:
-    
+
     * For bf16, 8 is enough (16 byte alignment / 2 bytes per elem = 8 elements).
     * For fp8, 16 byte alignment / 1 byte per elem = 16 elements.
-    * For mxfp8, we need 32 (or block_size) because scaling block size is (1 x 32), 
+    * For mxfp8, we need 32 (or block_size) because scaling block size is (1 x 32),
       so when doing per-token-group quantization on each logically distinct subtensor,
-      we need to ensure the contracting dim is divisible by block_size. 
+      we need to ensure the contracting dim is divisible by block_size.
       In the backward pass, grad_weight = (grad_output_t @ input).t() has gemm dims
-      of (N, M) @ (M, K) so M is the contracting dim, and group offsets are along M, 
+      of (N, M) @ (M, K) so M is the contracting dim, and group offsets are along M,
       so we need 32 element alignment.
     """
     global TOKEN_GROUP_ALIGN_SIZE_M

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -24,14 +24,26 @@ from torch.distributed.tensor.parallel import ParallelStyle
 from torch.distributed.tensor.placement_types import Placement
 
 
-TOKEN_GROUP_ALIGN_SIZE_M = 16
+TOKEN_GROUP_ALIGN_SIZE_M = 8
 
 
 def set_token_group_alignment_size_m(m: int) -> None:
-    """Set the alignment size for token groups in MoE."""
+    """
+    Set the token group alignment size for token groups in MoE. This is implemented by
+    padding each token group size to the next multiple of TOKEN_GROUP_ALIGN_SIZE_M. 
+    Different values are needed for different cases:
+    
+    * For bf16, 8 is enough (16 byte alignment / 2 bytes per elem = 8 elements).
+    * For fp8, 16 byte alignment / 1 byte per elem = 16 elements.
+    * For mxfp8, we need 32 (or block_size) because scaling block size is (1 x 32), 
+      so when doing per-token-group quantization on each logically distinct subtensor,
+      we need to ensure the contracting dim is divisible by block_size. 
+      In the backward pass, grad_weight = (grad_output_t @ input).t() has gemm dims
+      of (N, M) @ (M, K) so M is the contracting dim, and group offsets are along M, 
+      so we need 32 element alignment.
+    """
     global TOKEN_GROUP_ALIGN_SIZE_M
     assert m > 0, "Alignment size must be positive"
-    assert m % 16 == 0, "Alignment size must always be a multiple of 16 due to hardware constraints"
     TOKEN_GROUP_ALIGN_SIZE_M = m
 
 

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -6,7 +6,7 @@
 
 
 from functools import partial
-from typing import Callable
+from typing import Callable, Literal
 
 import torch
 import torch.distributed as dist
@@ -25,12 +25,17 @@ from torch.distributed.tensor.placement_types import Placement
 
 
 TOKEN_GROUP_ALIGN_SIZE_M = 8
+ValidTokenGroupAlignmentSize = Literal[8, 16, 32]
 
 
-def set_token_group_alignment_size_m(m: int) -> None:
+def set_token_group_alignment_size_m(
+    alignment_size: ValidTokenGroupAlignmentSize,
+) -> None:
     """
     Set the token group alignment size for token groups in MoE. This is implemented by
     padding each token group size to the next multiple of TOKEN_GROUP_ALIGN_SIZE_M.
+
+    Valid values are: 8, 16, or 32.
     Different values are needed for different cases:
 
     * For bf16, 8 is enough (16 byte alignment / 2 bytes per elem = 8 elements).
@@ -43,8 +48,7 @@ def set_token_group_alignment_size_m(m: int) -> None:
       so we need 32 element alignment.
     """
     global TOKEN_GROUP_ALIGN_SIZE_M
-    assert m > 0, "Alignment size must be positive"
-    TOKEN_GROUP_ALIGN_SIZE_M = m
+    TOKEN_GROUP_ALIGN_SIZE_M = alignment_size
 
 
 # implementation of Tensor Parallel for the GroupedExperts in MoE


### PR DESCRIPTION
## Summary
- For mxfp8, token group sizes must be multiples of "block_size" because in the backward pass for `grad_weight = grad_output_t @ input`, the "M" (token) dimension is the contracting dimension, and each token group is a logically distinct subtensor, so we scale them separately. This means token groups contracting dimension must be divisible by the mxfp8 block_size (default 32). Here is a diagram showing the problem: https://www.internalfb.com/excalidraw/EX521879
- To solve this, this PR makes the token group M aligment configurable.

## Test plan
- Integration test with torchao passes: https://github.com/pytorch/ao/pull/2642
- Did manual test run with llama4 debug model using bf16