### PR TITLE
Fix semi-sync training with 1GPU per FT replica

### DIFF
--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -105,6 +105,13 @@ class ParallelDims:
                 names.append(name)
 
         logger.info(f"Building {len(dims)}-D device mesh with {names}, {dims}")
+
+        # Handle the case where all parallelism dimensions are 1
+        # We still need to create a mesh with named dimensions for submesh access
+        if not dims:
+            dims = [1]
+            names = ["world"]
+
         mesh = init_device_mesh(device_type, dims, mesh_dim_names=names)
 
         # Create all the submesh here to ensure all required process groups are
@@ -137,6 +144,11 @@ class ParallelDims:
         if self.etp == 1 and self.tp_enabled:
             ep_mesh_dim_names.append("tp")
 
+        # Ensure dp_cp submesh exists even when all parallelism dimensions are 1
+        # This is required for fault tolerance functionality
+        if not dp_cp_mesh_dim_names and "world" in names:
+            dp_cp_mesh_dim_names = ["world"]
+
         mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
         mesh[tuple(dp_shard_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_shard_cp")
         mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
@@ -156,6 +168,13 @@ class ParallelDims:
                 names.append(name)
 
         logger.info(f"Building {len(dims)}-D device mesh with {names}, {dims}")
+
+        # Handle the case where all parallelism dimensions are 1
+        # We still need to create a mesh with named dimensions for submesh access
+        if not dims:
+            dims = [1]
+            names = ["world"]
+
         mesh = init_device_mesh(device_type, dims, mesh_dim_names=names)
 
         # Create all the submesh here to ensure all required process groups are
@@ -177,6 +196,12 @@ class ParallelDims:
         if self.cp_enabled:
             dp_shard_cp_mesh_dim_names.append("cp")
             dp_cp_mesh_dim_names.append("cp")
+
+        # Ensure dp_cp submesh exists even when all parallelism dimensions are 1
+        # This is required for fault tolerance functionality
+        if not dp_cp_mesh_dim_names and "world" in names:
+            dp_cp_mesh_dim_names = ["world"]
+
 
         if dp_mesh_dim_names != []:
             mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")


### PR DESCRIPTION
When using semi-sync training with a single GPU per replica, no mesh is created in ParallelDims, causing an error when all-reducing the loss.

The slicing error occurs on this line: https://github.com/pytorch/torchtitan/blob/cf30b2902718790cbe91900414c3201b6d7680b0/torchtitan/train.py#L502

This PR prevents this from happening by creating a default mesh when no parallelism is used.