### PR TITLE
Compute validation metrics at first step

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -28,7 +28,7 @@ class BaseValidator:
         raise NotImplementedError("validate method not implemented")
 
     def should_validate(self, step: int) -> bool:
-        return step % self.job_config.validation.freq == 0
+        return step == 1 or step % self.job_config.validation.freq == 0
 
 
 class Validator(BaseValidator):


### PR DESCRIPTION
Currently, the first time validation metrics are computed is when `step == job_config.validation.freq`. I think it is preferable to always compute them for the first step as well.