### PR TITLE
[llama4] combine w1 and w3 for more efficient grouped gemm; store expert weights non-transposed to avoid extra memory layout transformation to col-major

### DIFF
--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -55,11 +55,11 @@ def set_token_group_alignment_size_m(
 class TensorParallel(ParallelStyle):
     def _partition_fn(self, name, module, device_mesh):
         module.register_parameter(
-            "w13", nn.Parameter(distribute_tensor(module.w13, device_mesh, [Shard(2)]))
+            "w13", nn.Parameter(distribute_tensor(module.w13, device_mesh, [Shard(1)]))
         )  # Column-wise sharding
         module.register_parameter(
             "w2",
-            nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(1)])),
+            nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(2)])),
         )  # Row-wise sharding
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
@@ -221,11 +221,11 @@ class ExpertTensorParallel(ExpertParallel):
     def _partition_fn_2d(self, name, mod, ep_tp_mesh):
         mod.register_parameter(
             "w13",
-            nn.Parameter(distribute_tensor(mod.w13, ep_tp_mesh, [Shard(0), Shard(2)])),
+            nn.Parameter(distribute_tensor(mod.w13, ep_tp_mesh, [Shard(0), Shard(1)])),
         )  # Column-wise sharding
         mod.register_parameter(
             "w2",
-            nn.Parameter(distribute_tensor(mod.w2, ep_tp_mesh, [Shard(0), Shard(1)])),
+            nn.Parameter(distribute_tensor(mod.w2, ep_tp_mesh, [Shard(0), Shard(2)])),
         )  # Row-wise sharding
 
     def _token_combine(self, mod, routed_output, device_mesh):

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -55,16 +55,12 @@ def set_token_group_alignment_size_m(
 class TensorParallel(ParallelStyle):
     def _partition_fn(self, name, module, device_mesh):
         module.register_parameter(
-            "w1", nn.Parameter(distribute_tensor(module.w1, device_mesh, [Shard(2)]))
+            "w13", nn.Parameter(distribute_tensor(module.w13, device_mesh, [Shard(2)]))
         )  # Column-wise sharding
         module.register_parameter(
             "w2",
             nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(1)])),
         )  # Row-wise sharding
-        module.register_parameter(
-            "w3",
-            nn.Parameter(distribute_tensor(module.w3, device_mesh, [Shard(2)])),
-        )  # Column-wise sharding
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         return distribute_module(
@@ -224,17 +220,13 @@ class ExpertTensorParallel(ExpertParallel):
 
     def _partition_fn_2d(self, name, mod, ep_tp_mesh):
         mod.register_parameter(
-            "w1",
-            nn.Parameter(distribute_tensor(mod.w1, ep_tp_mesh, [Shard(0), Shard(2)])),
+            "w13",
+            nn.Parameter(distribute_tensor(mod.w13, ep_tp_mesh, [Shard(0), Shard(2)])),
         )  # Column-wise sharding
         mod.register_parameter(
             "w2",
             nn.Parameter(distribute_tensor(mod.w2, ep_tp_mesh, [Shard(0), Shard(1)])),
         )  # Row-wise sharding
-        mod.register_parameter(
-            "w3",
-            nn.Parameter(distribute_tensor(mod.w3, ep_tp_mesh, [Shard(0), Shard(2)])),
-        )  # Column-wise sharding
 
     def _token_combine(self, mod, routed_output, device_mesh):
         # token combine happens on the EP mesh, whereas device_mesh is [ep, tp] mesh

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -272,24 +272,22 @@ def expert_parallel(func: Callable) -> Callable:
     """
 
     def wrapper(
-        w1: torch.Tensor,
+        w13: torch.Tensor,
         w2: torch.Tensor,
-        w3: torch.Tensor,
         x: torch.Tensor,
         num_tokens_per_expert: torch.Tensor | None = None,
     ) -> torch.Tensor:
         global TOKEN_GROUP_ALIGN_SIZE_M
-        if isinstance(w1, DTensor):
-            w1 = w1.to_local()
+        if isinstance(w13, DTensor):
+            w13 = w13.to_local()
             w2 = w2.to_local()
-            w3 = w3.to_local()
 
         if num_tokens_per_expert is not None:
             from torchtitan.experiments.kernels.moe.indices import (
                 generate_permute_indices,
             )
 
-            experts_per_ep_rank = w1.shape[0]
+            experts_per_ep_rank = w13.shape[0]
             num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
 
             with torch.no_grad():
@@ -309,7 +307,7 @@ def expert_parallel(func: Callable) -> Callable:
             input_shape = x.shape
             x = x[permuted_indices, :]
 
-        out = func(w1, w2, w3, x, num_tokens_per_expert)
+        out = func(w13, w2, x, num_tokens_per_expert)
 
         if num_tokens_per_expert is not None:
             out_unpermuted = out.new_empty(input_shape)

--- a/torchtitan/experiments/llama4/infra/expert_parallel.py
+++ b/torchtitan/experiments/llama4/infra/expert_parallel.py
@@ -54,13 +54,16 @@ def set_token_group_alignment_size_m(
 # implementation of Tensor Parallel for the GroupedExperts in MoE
 class TensorParallel(ParallelStyle):
     def _partition_fn(self, name, module, device_mesh):
+        # w13 shape = (num_experts, hidden_dim, dim)
         module.register_parameter(
             "w13", nn.Parameter(distribute_tensor(module.w13, device_mesh, [Shard(1)]))
-        )  # Column-wise sharding
+        )
+
+        # w2 shape = (num_experts, dim, hidden_dim)
         module.register_parameter(
             "w2",
             nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(2)])),
-        )  # Row-wise sharding
+        )
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         return distribute_module(
@@ -219,14 +222,17 @@ class ExpertTensorParallel(ExpertParallel):
         return super()._token_dispatch(mod, inputs, self.ep_mesh)
 
     def _partition_fn_2d(self, name, mod, ep_tp_mesh):
+        # w13 shape = (num_experts, hidden_dim, dim)
         mod.register_parameter(
             "w13",
             nn.Parameter(distribute_tensor(mod.w13, ep_tp_mesh, [Shard(0), Shard(1)])),
-        )  # Column-wise sharding
+        )
+
+        # w2 shape = (num_experts, dim, hidden_dim)
         mod.register_parameter(
             "w2",
             nn.Parameter(distribute_tensor(mod.w2, ep_tp_mesh, [Shard(0), Shard(2)])),
-        )  # Row-wise sharding
+        )
 
     def _token_combine(self, mod, routed_output, device_mesh):
         # token combine happens on the EP mesh, whereas device_mesh is [ep, tp] mesh

--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -25,7 +25,7 @@ class GroupedExperts(nn.Module):
         self.num_experts = num_experts
         # Combine w1 and w3 into a single tensor to perform so we can combine
         # `x @ w1` and `x @ w3` into a single grouped mm.
-        self.w13 = nn.Parameter(torch.empty(num_experts, hidden_dim, dim * 2))
+        self.w13 = nn.Parameter(torch.empty(num_experts, hidden_dim * 2, dim))
         self.w2 = nn.Parameter(torch.empty(num_experts, dim, hidden_dim))
         self.use_grouped_mm = use_grouped_mm
 
@@ -55,6 +55,7 @@ class GroupedExperts(nn.Module):
             # fall back to regular bmm between 3D tensors
             assert x.dim() == 3
 
+        # Perform `x @ w1` and `x @ w3` in a single grouped mm.
         x1, x3 = torch._grouped_mm(x, w13.transpose(-2, -1), offs=offsets).chunk(
             2, dim=-1
         )

--- a/torchtitan/experiments/llama4/model/moe.py
+++ b/torchtitan/experiments/llama4/model/moe.py
@@ -250,8 +250,9 @@ class MoE(nn.Module):
 
         # shared expert
         if self.shared_expert is not None:
-            out = self.shared_expert(x.reshape(1, bs * slen, dim))
-            out = out.reshape(bs * slen, dim)
+            out = self.shared_expert(x.reshape(1, bs * slen, dim)).reshape(
+                bs * slen, dim
+            )
         else:
             out = torch.zeros_like(x.reshape(bs * slen, dim))
 


### PR DESCRIPTION
## Summary of changes
1. Rather than store experts weights pre-transposed (E, in_dim, out_dim), we should store the expert weights non-transposed (E, out_dim, in_dim) then transpose before grouped gemm for (1) compatible dims for gemm, and (2) column-major memory layout required for right operand in grouped gemm. This will eliminate the need for us to do this [inefficient memory layout transformation before every GEMM in fp8](https://github.com/pytorch/ao/blob/6e941c87c4d9fb9a74e6f979dd522605c696ca42/torchao/prototype/moe_training/scaled_grouped_mm.py#L96). 
3. Combine 2 grouped gemms into 1 bigger one for higher device utilization and minimizing number of kernel dispatches.
4. I also removed the fallback looped-matmuls approach in this PR, since it is incompatible with a combined `w13` tensor. 

Instead of:
```python
# x shape = (M, in_features)
# w1 shape = (E, in_features, out_features), row major format
# w3 shape = (E, in_features, out_features), row major format
# w2 shape = (E, out_features, in_features), row major format
x1 = torch._grouped_mm(x, self.w1, offs=offsets)
x3 = torch._grouped_mm(x, self.w3, offs=offsets)
y = F.silu(x1) * x3
out =  torch._grouped_mm(y, self.w2, offs=offsets)
```

We can do:
```python
# x shape = (M, in_features)
# w13 shape = (E, out_features * 2, in_features), row major format
# w2 shape = (E, in_features, out_features), row major format
x1, x3 = torch._grouped_mm(x, self.w13.transpose(-2, -1), offs=offsets).chunk(2, dim=-1)
y = F.silu(x1) * x3
out =  torch._grouped_mm(y, self.w2.transpose(-2, -1), offs=offsets)
```


## Test plan
- FSDP only: `NGPU=8 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --training.steps=50`
- FSDP+TP: `NGPU=8 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --training.steps=50 --parallelism.tensor_parallel_degree=2`
- FSDP+EP+TP: `NGPU=8 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --training.steps=50 --parallelism.tensor_parallel_degree=2  --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=4`