### PR TITLE
Flux Validation

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -80,7 +80,7 @@ class Validator(BaseValidator):
         self,
         model_parts: list[nn.Module],
         step: int,
-    ) -> dict[str, float]:
+    ) -> None:
         # Set model to eval mode
         model = model_parts[0]
         model.eval()

--- a/torchtitan/experiments/flux/__init__.py
+++ b/torchtitan/experiments/flux/__init__.py
@@ -17,6 +17,7 @@ from .loss import build_mse_loss
 from .model.args import FluxModelArgs
 from .model.autoencoder import AutoEncoderParams
 from .model.model import FluxModel
+from .model.validate import build_flux_validator
 
 __all__ = [
     "FluxModelArgs",
@@ -117,5 +118,6 @@ register_train_spec(
         build_dataloader_fn=build_flux_dataloader,
         build_tokenizer_fn=None,
         build_loss_fn=build_mse_loss,
+        build_validator_fn=build_flux_validator,
     )
 )

--- a/torchtitan/experiments/flux/__init__.py
+++ b/torchtitan/experiments/flux/__init__.py
@@ -17,7 +17,7 @@ from .loss import build_mse_loss
 from .model.args import FluxModelArgs
 from .model.autoencoder import AutoEncoderParams
 from .model.model import FluxModel
-from .model.validate import build_flux_validator
+from .validate import build_flux_validator
 
 __all__ = [
     "FluxModelArgs",

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -127,7 +127,7 @@ def _coco_data_processor(
     img = _process_cc12m_image(sample["image"], output_size=output_size)
     prompt = sample["caption"]
     if isinstance(prompt, list):
-        prompt = " ".join(prompt)
+        prompt = prompt[0]
     t5_tokens = t5_tokenizer.encode(prompt)
     clip_tokens = clip_tokenizer.encode(prompt)
 
@@ -280,7 +280,6 @@ class FluxDataset(IterableDataset, Stateful):
 
             # skip low quality image or image with color channel = 1
             if sample_dict["image"] is None:
-                # sample_id = sample.get('sample_id')
                 sample = sample.get("__key__", "unknown")
                 logger.warning(
                     f"Low quality image {sample} is skipped in Flux Dataloader."

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -6,8 +6,6 @@
 
 from dataclasses import dataclass, field
 
-from torchtitan.config import Validation
-
 
 @dataclass
 class Training:
@@ -38,7 +36,7 @@ class Encoder:
 
 
 @dataclass
-class Validation(Validation):
+class Validation:
     enable_classifier_free_guidance: bool = False
     """Whether to use classifier-free guidance during sampling"""
     classifier_free_guidance_scale: float = 5.0
@@ -47,10 +45,13 @@ class Validation(Validation):
     """How many denoising steps to sample when generating an image"""
     eval_freq: int = 100
     """Frequency of evaluation/sampling during training"""
-    save_imgs: int = 1
-    """ How many images to generate and save in validation, -1 means same number as steps"""
+    save_img_count: int = 1
+    """ How many images to generate and save during validation, starting from
+    the beginning of validation set, -1 means generate on all samples"""
     save_img_folder: str = "img"
     """Directory to save image generated/sampled from the model"""
+    all_timesteps: bool = False
+    """Whether to generate all stratified timesteps per sample or use round robin"""
 
 
 @dataclass

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -6,6 +6,8 @@
 
 from dataclasses import dataclass, field
 
+from torchtitan.config import Validation
+
 
 @dataclass
 class Training:
@@ -36,7 +38,7 @@ class Encoder:
 
 
 @dataclass
-class Eval:
+class Validation(Validation):
     enable_classifier_free_guidance: bool = False
     """Whether to use classifier-free guidance during sampling"""
     classifier_free_guidance_scale: float = 5.0
@@ -45,6 +47,8 @@ class Eval:
     """How many denoising steps to sample when generating an image"""
     eval_freq: int = 100
     """Frequency of evaluation/sampling during training"""
+    save_imgs: int = 1
+    """ How many images to generate and save in validation, -1 means same number as steps"""
     save_img_folder: str = "img"
     """Directory to save image generated/sampled from the model"""
 
@@ -57,4 +61,4 @@ class JobConfig:
 
     training: Training = field(default_factory=Training)
     encoder: Encoder = field(default_factory=Encoder)
-    eval: Eval = field(default_factory=Eval)
+    validation: Validation = field(default_factory=Validation)

--- a/torchtitan/experiments/flux/model/validate.py
+++ b/torchtitan/experiments/flux/model/validate.py
@@ -10,6 +10,7 @@ from typing import Generator
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule
+from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.loss import LossFunction
 from torchtitan.components.metrics import MetricsProcessor
@@ -57,6 +58,9 @@ class FluxValidator(Validator):
         validation_context: Generator[None, None, None],
         maybe_enable_amp: Generator[None, None, None],
         metrics_processor: MetricsProcessor | None = None,
+        pp_schedule: _PipelineSchedule | None = None,
+        pp_has_first_stage: bool | None = None,
+        pp_has_last_stage: bool | None = None,
     ):
         self.job_config = job_config
         self.parallel_dims = parallel_dims
@@ -250,6 +254,9 @@ def build_flux_validator(
     validation_context: Generator[None, None, None],
     maybe_enable_amp: Generator[None, None, None],
     metrics_processor: MetricsProcessor | None = None,
+    pp_schedule: _PipelineSchedule | None = None,
+    pp_has_first_stage: bool | None = None,
+    pp_has_last_stage: bool | None = None,
 ) -> FluxValidator:
     """Build a simple validator focused on correctness."""
     return FluxValidator(
@@ -262,4 +269,7 @@ def build_flux_validator(
         validation_context=validation_context,
         maybe_enable_amp=maybe_enable_amp,
         metrics_processor=metrics_processor,
+        pp_schedule=pp_schedule,
+        pp_has_first_stage=pp_has_first_stage,
+        pp_has_last_stage=pp_has_last_stage,
     )

--- a/torchtitan/experiments/flux/model/validate.py
+++ b/torchtitan/experiments/flux/model/validate.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import time
+from typing import Generator
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import FSDPModule
+from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.loss import LossFunction
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.tokenizer import BaseTokenizer
+from torchtitan.components.validate import Validator
+from torchtitan.config import JobConfig
+from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.experiments.flux.dataset.flux_dataset import (
+    build_flux_validation_dataloader,
+)
+
+from torchtitan.experiments.flux.dataset.tokenizer import build_flux_tokenizer
+from torchtitan.experiments.flux.model.autoencoder import AutoEncoder
+from torchtitan.experiments.flux.model.hf_embedder import FluxEmbedder
+from torchtitan.experiments.flux.sampling import generate_image, save_image
+from torchtitan.experiments.flux.utils import (
+    create_position_encoding_for_latents,
+    pack_latents,
+    preprocess_data,
+    unpack_latents,
+)
+
+
+class FluxValidator(Validator):
+    """
+    Simple validator focused on correctness and integration.
+
+    Args:
+        job_config: Job configuration
+        validation_dataloader: The validation dataloader
+        loss_fn: Loss function to use for validation
+        model: The model to validate (single model, no parallelism)
+    """
+
+    validation_dataloader: BaseDataLoader
+
+    def __init__(
+        self,
+        job_config: JobConfig,
+        dp_world_size: int,
+        dp_rank: int,
+        tokenizer: BaseTokenizer,
+        parallel_dims: ParallelDims,
+        loss_fn: LossFunction,
+        validation_context: Generator[None, None, None],
+        maybe_enable_amp: Generator[None, None, None],
+        metrics_processor: MetricsProcessor | None = None,
+    ):
+        self.job_config = job_config
+        self.parallel_dims = parallel_dims
+        self.loss_fn = loss_fn
+        self.validation_dataloader = build_flux_validation_dataloader(
+            job_config=job_config,
+            dp_world_size=dp_world_size,
+            dp_rank=dp_rank,
+            tokenizer=tokenizer,
+        )
+        self.validation_context = validation_context
+        self.maybe_enable_amp = maybe_enable_amp
+        self.metrics_processor = metrics_processor
+        self.t5_tokenizer, self.clip_tokenizer = build_flux_tokenizer(self.job_config)
+
+    def flux_init(
+        self,
+        device: torch.device,
+        _dtype: torch.dtype,
+        autoencoder: AutoEncoder,
+        t5_encoder: FluxEmbedder,
+        clip_encoder: FluxEmbedder,
+        all_timesteps: bool = False,
+    ):
+        self.device = device
+        self._dtype = _dtype
+        self.autoencoder = autoencoder
+        self.t5_encoder = t5_encoder
+        self.clip_encoder = clip_encoder
+        self.all_timesteps = all_timesteps
+
+    @torch.no_grad()
+    def validate(
+        self,
+        model_parts: list[nn.Module],
+        step: int,
+    ) -> None:
+        # Start timing validation
+        validation_start_time = time.time()
+
+        # # Set model to eval mode
+        # # TODO: currently does not support pipeline parallelism
+        model = model_parts[0]
+        model.eval()
+
+        parallel_dims = self.parallel_dims
+
+        accumulated_losses = []
+        device_type = dist_utils.device_type
+        num_steps = 0
+
+        for input_dict, labels in self.validation_dataloader:
+            if (
+                self.job_config.validation.steps != -1
+                and num_steps >= self.job_config.validation.steps
+            ):
+                break
+
+            prompt = input_dict.pop("prompt")
+
+            save_imgs = self.job_config.validation.save_imgs
+            if save_imgs == -1 or num_steps < save_imgs:
+                t5_tokenizer, clip_tokenizer = build_flux_tokenizer(self.job_config)
+                # take only the first sample if prompt is a batch
+                if isinstance(prompt, list):
+                    prompt = prompt[0]
+
+                image = generate_image(
+                    device=self.device,
+                    dtype=self._dtype,
+                    job_config=self.job_config,
+                    model=model,
+                    prompt=prompt,
+                    autoencoder=self.autoencoder,
+                    t5_tokenizer=t5_tokenizer,
+                    clip_tokenizer=clip_tokenizer,
+                    t5_encoder=self.t5_encoder,
+                    clip_encoder=self.clip_encoder,
+                )
+
+                save_image(
+                    name=f"image_rank{str(torch.distributed.get_rank())}_{step}.png",
+                    output_dir=os.path.join(
+                        self.job_config.job.dump_folder,
+                        self.job_config.validation.save_img_folder,
+                    ),
+                    x=image,
+                    add_sampling_metadata=True,
+                    prompt=prompt,
+                )
+
+            # generate t5 and clip embeddings
+            input_dict["image"] = labels
+            input_dict = preprocess_data(
+                device=self.device,
+                dtype=self._dtype,
+                autoencoder=self.autoencoder,
+                clip_encoder=self.clip_encoder,
+                t5_encoder=self.t5_encoder,
+                batch=input_dict,
+            )
+            labels = input_dict["img_encodings"].to(device_type)
+            clip_encodings = input_dict["clip_encodings"]
+            t5_encodings = input_dict["t5_encodings"]
+
+            bsz = labels.shape[0]
+
+            # To evaluate all 8 timesteps per sample do
+            if self.all_timesteps:
+                stratified_timesteps = torch.tensor(
+                    [1 / 8 * (i + 0.5) for i in range(8)],
+                    dtype=torch.float32,
+                    device=self.device,
+                ).repeat(bsz)
+                clip_encodings = clip_encodings.repeat_interleave(8, dim=0)
+                t5_encodings = t5_encodings.repeat_interleave(8, dim=0)
+                labels = labels.repeat_interleave(8, dim=0)
+                input_dict.pop("timestep")
+            else:
+                stratified_timesteps = input_dict.pop("timestep")
+
+            # Note the tps may be inaccurate due to the generating image step not being counted
+            self.metrics_processor.ntokens_since_last_log += labels.numel()
+
+            # increase the batch size and input sizes to complete all batches in a single forward pass for efficiency
+            with torch.no_grad(), torch.device(self.device):
+                noise = torch.randn_like(labels)
+                timesteps = stratified_timesteps.to(labels)
+                sigmas = timesteps.view(-1, 1, 1, 1)
+                latents = (1 - sigmas) * labels + sigmas * noise
+
+            bsz, _, latent_height, latent_width = latents.shape
+
+            POSITION_DIM = 3  # constant for Flux flow model
+            with torch.no_grad(), torch.device(self.device):
+                # Create positional encodings
+                latent_pos_enc = create_position_encoding_for_latents(
+                    bsz, latent_height, latent_width, POSITION_DIM
+                )
+                text_pos_enc = torch.zeros(bsz, t5_encodings.shape[1], POSITION_DIM)
+
+                # Patchify: Convert latent into a sequence of patches
+                latents = pack_latents(latents)
+
+                latent_noise_pred = model(
+                    img=latents,
+                    img_ids=latent_pos_enc,
+                    txt=t5_encodings,
+                    txt_ids=text_pos_enc,
+                    y=clip_encodings,
+                    timesteps=timesteps,
+                )
+
+            # Convert sequence of patches to latent shape
+            pred = unpack_latents(latent_noise_pred, latent_height, latent_width)
+            target = noise - labels
+            loss = self.loss_fn(pred, target)
+
+            del pred, noise, target, latent_noise_pred, latents
+
+            accumulated_losses.append(loss.detach())
+
+            num_steps += 1
+
+        # Compute average loss
+        loss = torch.sum(torch.stack(accumulated_losses))
+        loss /= num_steps
+        if parallel_dims.dp_cp_enabled:
+            global_avg_loss = dist_utils.dist_mean(
+                loss, parallel_dims.world_mesh["dp_cp"]
+            )
+        else:
+            global_avg_loss = loss.item()
+
+        self.metrics_processor.log_validation(loss=global_avg_loss, step=step)
+
+        # Calculate and log validation timing
+        validation_end_time = time.time()
+        validation_duration = validation_end_time - validation_start_time
+
+        # Log timing information
+        from torchtitan.tools.logging import logger
+
+        logger.info(f"Validation step {step} completed in {validation_duration:.3f}s ")
+
+        # Reshard after run forward pass
+        # This is to ensure the model weights are sharded the same way for checkpoint saving.
+        for module in model.modules():
+            if isinstance(module, FSDPModule):
+                module.reshard()
+
+        # Set model back to train mode
+        model.train()
+
+
+def build_flux_validator(
+    job_config: JobConfig,
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: BaseTokenizer,
+    parallel_dims: ParallelDims,
+    loss_fn: LossFunction,
+    validation_context: Generator[None, None, None],
+    maybe_enable_amp: Generator[None, None, None],
+    metrics_processor: MetricsProcessor | None = None,
+) -> FluxValidator:
+    """Build a simple validator focused on correctness."""
+    return FluxValidator(
+        job_config=job_config,
+        dp_world_size=dp_world_size,
+        dp_rank=dp_rank,
+        tokenizer=tokenizer,
+        parallel_dims=parallel_dims,
+        loss_fn=loss_fn,
+        validation_context=validation_context,
+        maybe_enable_amp=maybe_enable_amp,
+        metrics_processor=metrics_processor,
+    )

--- a/torchtitan/experiments/flux/model/validate.py
+++ b/torchtitan/experiments/flux/model/validate.py
@@ -74,8 +74,6 @@ class FluxValidator(Validator):
         self.metrics_processor = metrics_processor
         self.t5_tokenizer, self.clip_tokenizer = build_flux_tokenizer(self.job_config)
 
-        self.save_img_count = self.job_config.validation.save_img_count
-
     def flux_init(
         self,
         device: torch.device,
@@ -101,6 +99,8 @@ class FluxValidator(Validator):
         model = model_parts[0]
         model.eval()
 
+        save_img_count = self.job_config.validation.save_img_count
+
         parallel_dims = self.parallel_dims
 
         accumulated_losses = []
@@ -118,7 +118,7 @@ class FluxValidator(Validator):
             if not isinstance(prompt, list):
                 prompt = [prompt]
             for p in prompt:
-                if self.save_img_count != -1 and self.save_img_count <= 0:
+                if save_img_count != -1 and save_img_count <= 0:
                     break
                 image = generate_image(
                     device=self.device,
@@ -143,7 +143,7 @@ class FluxValidator(Validator):
                     add_sampling_metadata=True,
                     prompt=p,
                 )
-                self.save_img_count -= 1
+                save_img_count -= 1
 
             # generate t5 and clip embeddings
             input_dict["image"] = labels

--- a/torchtitan/experiments/flux/sampling.py
+++ b/torchtitan/experiments/flux/sampling.py
@@ -93,7 +93,9 @@ def generate_image(
     img_height = 16 * (job_config.training.img_size // 16)
     img_width = 16 * (job_config.training.img_size // 16)
 
-    enable_classifier_free_guidance = job_config.eval.enable_classifier_free_guidance
+    enable_classifier_free_guidance = (
+        job_config.validation.enable_classifier_free_guidance
+    )
 
     # Tokenize the prompt. Unsqueeze to add a batch dimension.
     clip_tokens = clip_tokenizer.encode(prompt).unsqueeze(0)
@@ -132,7 +134,7 @@ def generate_image(
         model=model,
         img_width=img_width,
         img_height=img_height,
-        denoising_steps=job_config.eval.denoising_steps,
+        denoising_steps=job_config.validation.denoising_steps,
         clip_encodings=batch["clip_encodings"],
         t5_encodings=batch["t5_encodings"],
         enable_classifier_free_guidance=enable_classifier_free_guidance,
@@ -142,7 +144,7 @@ def generate_image(
         empty_clip_encodings=(
             empty_batch["clip_encodings"] if enable_classifier_free_guidance else None
         ),
-        classifier_free_guidance_scale=job_config.eval.classifier_free_guidance_scale,
+        classifier_free_guidance_scale=job_config.validation.classifier_free_guidance_scale,
     )
 
     img = autoencoder.decode(img)

--- a/torchtitan/experiments/flux/tests/integration_tests.py
+++ b/torchtitan/experiments/flux/tests/integration_tests.py
@@ -64,6 +64,9 @@ def build_test_list():
             "Checkpoint Integration Test - Save Model Only fp32",
             "last_save_model_only_fp32",
         ),
+        OverrideDefinitions(
+            [["--validation.enabled"]], "Flux Validation Test", "validation"
+        ),
         # Parallelism tests.
         OverrideDefinitions(
             [

--- a/torchtitan/experiments/flux/tests/test_generate_image.py
+++ b/torchtitan/experiments/flux/tests/test_generate_image.py
@@ -57,12 +57,12 @@ class TestGenerateImage:
                 "--training.img_size",
                 str(img_width),
                 # eval params
-                "--eval.denoising_steps",
+                "--validation.denoising_steps",
                 str(num_steps),
-                "--eval.enable_classifier_free_guidance",
-                "--eval.classifier_free_guidance_scale",
+                "--validation.enable_classifier_free_guidance",
+                "--validation.classifier_free_guidance_scale",
                 str(classifier_free_guidance_scale),
-                "--eval.save_img_folder",
+                "--validation.save_img_folder",
                 "img",
             ]
         )
@@ -120,7 +120,7 @@ class TestGenerateImage:
         save_image(
             name=f"img_unit_test_{config.training.seed}.jpg",
             output_dir=os.path.join(
-                config.job.dump_folder, config.eval.save_img_folder
+                config.job.dump_folder, config.validation.save_img_folder
             ),
             x=image,
             add_sampling_metadata=True,

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -79,7 +79,9 @@ class TestFluxDataLoader(unittest.TestCase):
                 for i in range(0, num_steps):
                     input_data, labels = next(it)
 
-                    assert len(input_data) == 2  # (clip_encodings, t5_encodings)
+                    assert (
+                        len(input_data) == 3
+                    )  # (clip_encodings, t5_encodings, prompt)
                     assert labels.shape == (batch_size, 3, 256, 256)
                     assert input_data["clip_tokens"].shape == (
                         batch_size,

--- a/torchtitan/experiments/flux/train.py
+++ b/torchtitan/experiments/flux/train.py
@@ -5,21 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Iterable, Optional
+from typing import Optional
 
 import torch
-from torch.distributed.fsdp import FSDPModule
 
 from torchtitan.config import ConfigManager, JobConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.tools.logging import init_logger, logger
 from torchtitan.train import Trainer
 
-from .dataset.tokenizer import build_flux_tokenizer
 from .infra.parallelize import parallelize_encoders
 from .model.autoencoder import load_ae
 from .model.hf_embedder import FluxEmbedder
-from .sampling import generate_image, save_image
 from .utils import (
     create_position_encoding_for_latents,
     pack_latents,
@@ -80,6 +77,15 @@ class FluxTrainer(Trainer):
             parallel_dims=self.parallel_dims,
             job_config=job_config,
         )
+
+        if job_config.validation.enabled:
+            self.validator.flux_init(
+                device=self.device,
+                _dtype=self._dtype,
+                autoencoder=self.autoencoder,
+                t5_encoder=self.t5_encoder,
+                clip_encoder=self.clip_encoder,
+            )
 
     def forward_backward_step(
         self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
@@ -146,64 +152,6 @@ class FluxTrainer(Trainer):
         loss.backward()
 
         return loss
-
-    def eval_step(self, prompt: str = "A photo of a cat"):
-        """
-        Evaluate the Flux model.
-        1) generate and save images every few steps. Currently, we run the eval and on the same
-        prompts across all DP ranks. We will change this behavior to run on validation set prompts.
-        Due to random noise generation, results could be different across DP ranks cause we assign
-        different random seeds to each DP rank.
-        2) [TODO] Calculate loss with fixed t value on validation set.
-        """
-
-        t5_tokenizer, clip_tokenizer = build_flux_tokenizer(self.job_config)
-
-        image = generate_image(
-            device=self.device,
-            dtype=self._dtype,
-            job_config=self.job_config,
-            model=self.model_parts[0],
-            prompt=prompt,  # TODO(jianiw): change this to a prompt from validation set
-            autoencoder=self.autoencoder,
-            t5_tokenizer=t5_tokenizer,
-            clip_tokenizer=clip_tokenizer,
-            t5_encoder=self.t5_encoder,
-            clip_encoder=self.clip_encoder,
-        )
-
-        save_image(
-            name=f"image_rank{str(torch.distributed.get_rank())}_{self.step}.png",
-            output_dir=os.path.join(
-                self.job_config.job.dump_folder, self.job_config.eval.save_img_folder
-            ),
-            x=image,
-            add_sampling_metadata=True,
-            prompt=prompt,
-        )
-
-        # Reshard after run forward pass in eval_step.
-        # This is to ensure the model weights are sharded the same way for checkpoint saving.
-        for module in self.model_parts[0].modules():
-            if isinstance(module, FSDPModule):
-                module.reshard()
-
-    def train_step(
-        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
-        super().train_step(data_iterator)
-
-        # Evaluate the model during training
-        if (
-            self.step % self.job_config.eval.eval_freq == 0
-            or self.step == self.job_config.training.steps
-        ):
-            model = self.model_parts[0]
-            model.eval()
-            # We need to set reshard_after_forward before last forward pass.
-            # So the model wieghts are sharded the same way for checkpoint saving.
-            self.eval_step()
-            model.train()
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -47,13 +47,6 @@ clip_encoder = "openai/clip-vit-large-patch14"
 max_t5_encoding_len = 256
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
-[eval]
-enable_classifier_free_guidance = true
-classifier_free_guidance_scale = 5.0
-denoising_steps = 4
-save_img_folder = "img"
-eval_freq = 5
-
 [parallelism]
 data_parallel_replicate_degree = 1
 data_parallel_shard_degree = -1
@@ -71,3 +64,15 @@ interval = 10
 last_save_model_only = false
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[validation]
+enabled = false
+dataset = "coco-validation"
+freq = 5
+local_batch_size = 8
+steps = 1
+enable_classifier_free_guidance = true
+classifier_free_guidance_scale = 5.0
+denoising_steps = 4
+save_imgs = 0
+save_img_folder = "img"

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -74,5 +74,6 @@ steps = 1
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0
 denoising_steps = 4
-save_imgs = 0
+save_img_count = 1
 save_img_folder = "img"
+all_timesteps = false

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -46,13 +46,6 @@ clip_encoder = "openai/clip-vit-large-patch14"
 max_t5_encoding_len = 512
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
-[eval]
-enable_classifier_free_guidance = true
-classifier_free_guidance_scale = 5.0
-denoising_steps = 50
-save_img_folder = "img"
-eval_freq = 1000
-
 [parallelism]
 data_parallel_replicate_degree = 1
 data_parallel_shard_degree = -1
@@ -70,3 +63,15 @@ interval = 1_000
 last_save_model_only = true
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[validation]
+enabled = false
+dataset = "coco-validation"
+local_batch_size = 32
+steps = 1
+freq = 1000
+enable_classifier_free_guidance = true
+classifier_free_guidance_scale = 5.0
+denoising_steps = 50
+save_imgs = 1
+save_img_folder = "img"

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -73,5 +73,6 @@ freq = 1000
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0
 denoising_steps = 50
-save_imgs = 1
+save_img_count = 50
 save_img_folder = "img"
+all_timesteps = false

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -73,5 +73,6 @@ freq = 1000
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0
 denoising_steps = 50
-save_imgs = 1
+save_img_count = 50
 save_img_folder = "img"
+all_timesteps = false

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -46,12 +46,6 @@ clip_encoder = "openai/clip-vit-large-patch14"
 max_t5_encoding_len = 256
 autoencoder_path = "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"  # Autoencoder to use for image
 
-[eval]
-enable_classifier_free_guidance = true
-classifier_free_guidance_scale = 5.0
-denoising_steps = 50
-save_img_folder = "img"
-eval_freq = 1000
 
 [parallelism]
 data_parallel_replicate_degree = 1
@@ -70,3 +64,14 @@ interval = 1_000
 last_save_model_only = true
 export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[validation]
+enabled = false
+dataset = "coco-validation"
+local_batch_size=64
+freq = 1000
+enable_classifier_free_guidance = true
+classifier_free_guidance_scale = 5.0
+denoising_steps = 50
+save_imgs = 1
+save_img_folder = "img"

--- a/torchtitan/experiments/flux/validate.py
+++ b/torchtitan/experiments/flux/validate.py
@@ -11,6 +11,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.fsdp import FSDPModule
 from torch.distributed.pipelining.schedules import _PipelineSchedule
+
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.loss import LossFunction
 from torchtitan.components.metrics import MetricsProcessor

--- a/torchtitan/experiments/multimodal/tokenizer/tiktoken.py
+++ b/torchtitan/experiments/multimodal/tokenizer/tiktoken.py
@@ -32,7 +32,7 @@ import torch
 from tiktoken.load import load_tiktoken_bpe
 
 from torchtitan.components.tokenizer import BaseTokenizer
-from torchtitan.config_manager import JobConfig
+from torchtitan.config import JobConfig
 from torchtitan.tools.logging import logger
 
 IMAGE_TOKEN_ID = 128256


### PR DESCRIPTION
# This pr implements the validator class for flux following the method discussed in Stable Diffusion 3 paper.

The paper shows that creating 8 equidistant timesteps and calculating the average loss on them will result in a highly correlated loss to external validation methods such as CLIP or FID score.

This pr's implementation rather than creating 8 stratified timesteps per sample, only applies one of these equidistant timesteps to each sample in a round-robin fashion. Aggregated over many samples in a validation set, this should give a similar validation score as the full timestep method, but will process more validation samples quickly.

### Implementations
- Integrates the image generation evaluation in the validation step, users can 
- Refactors and combines eval job_config with validation
    - Adds an `all_timesteps` option to the job_config to choose whether to use round robin timesteps or full timesteps per sample
- Creates validator class and validation dataloader for flux, validator dataloader handles generating timesteps for round-robin method of validation

### Enabling all timesteps
Developers can enable the full timestamp method of validation by setting `all_timesteps = True` in the flux validation job config. Enabling all_timesteps may require tweaking some hyperparams `validation.local_batch_size, validation.steps` to prevent spiking memory and optimizing throughput. By using a ratio of around 1/4 for `validation.local_batch_size` to `training.local_batch_size` will not spike the memory higher than training when `fsdp = 8`.

Below we can see the difference between round robin and all timesteps. In the comparison the total number of validation samples processed is the same, but in `all_timesteps=True` configuration we have to lower the batch size to prevent memory spiking. All timesteps also achieves a higher throughput (tps) but still processes total samples of validation set more slowly.

| Round Robin (batch_size=32, steps=1, fsdp=8) | All Timesteps (batch_size=8, steps=4, fsdp=8) |
| ---- | --- |
| <img width="682" height="303" alt="Screenshot 2025-08-01 at 3 46 42 PM" src="https://github.com/user-attachments/assets/30328bfe-4c3c-4912-a329-2b94c834b67b" /> | <img width="719" height="308" alt="Screenshot 2025-08-01 at 3 30 10 PM" src="https://github.com/user-attachments/assets/c7325d21-8a7b-41d9-a0d2-74052e425083" /> |
