### PR TITLE
fix: ep clipping with no ep grads

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -420,7 +420,11 @@ def _clip_grad_norm_with_ep(
             non_ep_grads.append(p.grad)
     ep_grads_total_norm = torch.nn.utils.get_total_norm(
         ep_grads, norm_type, error_if_nonfinite, foreach
-    ).full_tensor()
+    )
+    # ep_grads may be an empty list, in which case get_total_norm returns tensor(0.), a non-DTensor
+    if isinstance(ep_grads_total_norm, DTensor):
+        ep_grads_total_norm = ep_grads_total_norm.full_tensor()
+
     non_ep_grads_total_norm = torch.nn.utils.get_total_norm(
         non_ep_grads, norm_type, error_if_nonfinite, foreach
     ).full_tensor()

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -422,6 +422,7 @@ def _clip_grad_norm_with_ep(
         ep_grads, norm_type, error_if_nonfinite, foreach
     )
     # ep_grads may be an empty list, in which case get_total_norm returns tensor(0.), a non-DTensor
+    # This can occur in PP + EP setups where certain PP ranks only own non-EP layers, for instance.
     if isinstance(ep_grads_total_norm, DTensor):
         ep_grads_total_norm = ep_grads_total_norm.full_tensor()
 


### PR DESCRIPTION
The current EP grad clipping logic assumes that when using EP all of the norms returned by `torch.nn.utils.get_total_norm` are `DTensor`s. This assumption can be violated and the subsequent `full_tensor` call can correspondingly fail in the edge case where  the [ep_grad list](https://github.com/pytorch/torchtitan/blob/a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41/torchtitan/distributed/utils.py?plain=1#L408) is empty, in which case `get_total_norm` returns `tensor(0.)`, a non-`DTensor`.   

https://github.com/pytorch/torchtitan/blob/a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41/torchtitan/distributed/utils.py?plain=1#L421-L423

```
File "/app/torchtitan/torchtitan/distributed/utils.py", line 423, in _clip_grad_norm_with_ep
    ).full_tensor()
      ^^^^^^^^^^^
AttributeError: 'Tensor' object has no attribute 'full_tensor'
```

This edge case can occur in PP+EP setups when model uses some fully dense and some MoE layers (like DSv3), in which case some pp ranks may not be assigned any MoE layers. 

I suppose it is possible that `non_ep_grads` could also be empty, but I can only imagine this happening in extreme cases, so I did not change the `non_ep_grads` code. 

CC @tianyu-l 