### PR TITLE
Add support for loss parallel

### DIFF
--- a/torchtitan/experiments/auto_parallel/parallelize_llama.py
+++ b/torchtitan/experiments/auto_parallel/parallelize_llama.py
@@ -91,7 +91,6 @@ def parallelize_llama(
         # only used if loss parallel is enabled
         possible_output_shardings = {
             # maps relative to mesh dim names used in torchtitan
-            "dp_replicate": Shard(0),
             "dp_shard": Shard(0),
             "tp": Shard(2),
         }


### PR DESCRIPTION
IMO we should just add the loss in the model and let autoparallel parallelize it for us. But for now, let's follow how the other models are implemented