### PR TITLE
Flux Batched Inference

### DIFF
--- a/torchtitan/experiments/flux/dataset/tokenizer.py
+++ b/torchtitan/experiments/flux/dataset/tokenizer.py
@@ -108,7 +108,7 @@ class FluxTokenizer(BaseTokenizer):
 
     def encode(
         self,
-        s: str,
+        s: str | list[str],
     ) -> torch.Tensor:
         """
         Encode the prompt text into tokens.

--- a/torchtitan/experiments/flux/dataset/tokenizer.py
+++ b/torchtitan/experiments/flux/dataset/tokenizer.py
@@ -45,13 +45,31 @@ class FluxTestTokenizer(BaseTokenizer):
     def get_vocab_size(self) -> int:
         return self.tiktokenizer.vocab_size
 
-    def encode(self, text: str) -> torch.Tensor:
+    def encode(self, text: str | list[str]) -> torch.Tensor:
         """
         Use TikTokenizer to encode the text into tokens, and then pad and chunk the tokens to max_length.
         """
-        tokens = self.tiktokenizer.encode(text, add_bos=True, add_eos=True)
-        tokens = self._pad_and_chunk_tokens(tokens, self._max_length, self.pad_id)
-        return torch.tensor(tokens)
+        if isinstance(text, list):
+            if len(text) == 1:
+                # for single item in list encode and add batch dimension
+                tokens = self.tiktokenizer.encode(text[0], add_bos=True, add_eos=True)
+                tokens = self._pad_and_chunk_tokens(
+                    tokens, self._max_length, self.pad_id
+                )
+                return torch.tensor(tokens).unsqueeze(0)
+            else:
+                all_tokens = []
+                for t in text:
+                    tokens = self.tiktokenizer.encode(t, add_bos=True, add_eos=True)
+                    tokens = self._pad_and_chunk_tokens(
+                        tokens, self._max_length, self.pad_id
+                    )
+                    all_tokens.append(torch.tensor(tokens))
+                return torch.stack(all_tokens)
+        else:
+            tokens = self.tiktokenizer.encode(text, add_bos=True, add_eos=True)
+            tokens = self._pad_and_chunk_tokens(tokens, self._max_length, self.pad_id)
+            return torch.tensor(tokens)
 
     def decode(self, t: List[int]) -> str:
         """

--- a/torchtitan/experiments/flux/inference/infer.py
+++ b/torchtitan/experiments/flux/inference/infer.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import torch
+from torch.distributed.elastic.multiprocessing.errors import record
+
+from torchtitan.config import ConfigManager, JobConfig
+from torchtitan.experiments.flux.dataset.tokenizer import (
+    build_flux_tokenizer,
+    FluxTokenizer,
+)
+from torchtitan.experiments.flux.sampling import generate_image, save_image
+from torchtitan.experiments.flux.train import FluxTrainer
+from torchtitan.tools.logging import init_logger, logger
+
+
+def inference_call(
+    prompts: list[str],
+    trainer: FluxTrainer,
+    t5_tokenizer: FluxTokenizer,
+    clip_tokenizer: FluxTokenizer,
+    bs: int = 1,
+):
+    """
+    Run inference on the Flux model.
+    """
+    results = []
+    with torch.no_grad():
+        for i in range(0, len(prompts), bs):
+            images = generate_image(
+                device=trainer.device,
+                dtype=trainer._dtype,
+                job_config=trainer.job_config,
+                model=trainer.model_parts[0],
+                prompt=prompts[i : i + bs],
+                autoencoder=trainer.autoencoder,
+                t5_tokenizer=t5_tokenizer,
+                clip_tokenizer=clip_tokenizer,
+                t5_encoder=trainer.t5_encoder,
+                clip_encoder=trainer.clip_encoder,
+            )
+            results.append(images.detach())
+    results = torch.cat(results, dim=0)
+    return results
+
+
+@record
+def inference(config: JobConfig):
+    # Reuse trainer to perform forward passes
+    trainer = FluxTrainer(config)
+
+    # Distributed processing setup: Each GPU/process handles a subset of prompts
+    world_size = int(os.environ["WORLD_SIZE"])
+    global_rank = int(os.environ["RANK"])
+    original_prompts = open(config.inference.prompts_path).readlines()
+    total_prompts = len(original_prompts)
+
+    # Distribute prompts across processes using round-robin assignment
+    prompts = original_prompts[global_rank::world_size]
+
+    trainer.checkpointer.load(step=config.checkpoint.load_step)
+    t5_tokenizer, clip_tokenizer = build_flux_tokenizer(config)
+
+    if global_rank == 0:
+        logger.info("Starting inference...")
+
+    if prompts:
+        # Generate images for this process's assigned prompts
+        images = inference_call(
+            prompts,
+            trainer,
+            t5_tokenizer,
+            clip_tokenizer,
+            bs=config.inference.batch_size,
+        )
+
+        if config.inference.save_img_folder:
+            # Create mapping from local indices to global prompt indices
+            global_ids = list(range(global_rank, total_prompts, world_size))
+
+            for i in range(images.shape[0]):
+                # Extract single image while preserving batch dimension [1, C, H, W]
+                img = images[i : i + 1]
+                global_id = global_ids[i]
+
+                save_image(
+                    name=f"image_prompt{global_id}_rank{str(torch.distributed.get_rank())}.png",
+                    output_dir=os.path.join(
+                        config.job.dump_folder,
+                        config.inference.save_img_folder,
+                    ),
+                    x=img,
+                    add_sampling_metadata=True,
+                    prompt=prompts[i],
+                )
+
+    torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    init_logger()
+    config_manager = ConfigManager()
+    config = config_manager.parse_args()
+    inference(config)

--- a/torchtitan/experiments/flux/inference/prompts.txt
+++ b/torchtitan/experiments/flux/inference/prompts.txt
@@ -1,0 +1,28 @@
+A serene mountain landscape at sunset with a crystal clear lake reflecting the golden sky
+A futuristic cityscape with flying cars and neon lights illuminating the night sky
+A cozy cafe interior with steam rising from coffee cups and warm lighting
+A magical forest with glowing mushrooms and fireflies dancing between ancient trees
+A peaceful beach scene with turquoise waves and palm trees swaying in the breeze
+A steampunk-inspired mechanical dragon soaring through clouds
+A mystical library with floating books and magical artifacts
+A Japanese garden in spring with cherry blossoms falling gently
+A space station orbiting a colorful nebula
+A medieval castle on a hilltop during a dramatic thunderstorm
+A underwater scene with bioluminescent creatures and coral reefs
+A desert oasis with a majestic palace and palm trees
+A cyberpunk street market with holographic signs and diverse crowds
+A cozy winter cabin surrounded by snow-covered pine trees
+A fantasy tavern filled with unique characters and magical atmosphere
+A tropical rainforest with exotic birds and waterfalls
+A steampunk airship navigating through storm clouds
+A peaceful zen garden with a traditional Japanese tea house
+A magical potion shop with bubbling cauldrons and mysterious ingredients
+A futuristic space colony on Mars with domed habitats
+A mystical temple hidden in the clouds
+A vintage train station with steam locomotives and period architecture
+A magical bakery with floating pastries and enchanted ingredients
+A peaceful countryside scene with rolling hills and a rustic farmhouse
+A underwater city with advanced technology and marine life
+A fantasy marketplace with magical creatures and exotic goods
+A peaceful meditation garden with lotus flowers and koi ponds
+A steampunk laboratory with intricate machinery and glowing elements

--- a/torchtitan/experiments/flux/inference/run_infer.sh
+++ b/torchtitan/experiments/flux/inference/run_infer.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+# use envs as local overrides for convenience
+# e.g.
+# LOG_RANK=0,1 NGPU=4 ./torchtitan/experiments/flux/run_train.sh
+NGPU=${NGPU:-"8"}
+export LOG_RANK=${LOG_RANK:-0}
+CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/experiments/flux/train_configs/debug_model.toml"}
+
+overrides=""
+if [ $# -ne 0 ]; then
+    overrides="$*"
+fi
+
+
+PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
+torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
+--local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
+-m torchtitan.experiments.flux.inference.infer --job.config_file ${CONFIG_FILE} \
+--checkpoint.enable_checkpoint \
+--checkpoint.exclude_from_loading=lr_scheduler,dataloader,optimizer $overrides

--- a/torchtitan/experiments/flux/inference/run_infer.sh
+++ b/torchtitan/experiments/flux/inference/run_infer.sh
@@ -14,15 +14,9 @@ NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/experiments/flux/train_configs/debug_model.toml"}
 
-overrides=""
-if [ $# -ne 0 ]; then
-    overrides="$*"
-fi
-
-
 PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
 -m torchtitan.experiments.flux.inference.infer --job.config_file ${CONFIG_FILE} \
 --checkpoint.enable_checkpoint \
---checkpoint.exclude_from_loading=lr_scheduler,dataloader,optimizer $overrides
+--checkpoint.exclude_from_loading=lr_scheduler,dataloader,optimizer "$@"

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -55,6 +55,20 @@ class Validation:
 
 
 @dataclass
+class Inference:
+    """Inference configuration"""
+
+    save_img_folder: str = "inference_results"
+    """Path to save the inference results"""
+    prompts_path: str = "./torchtitan/experiments/flux/inference/prompts.txt"
+    """Path to file with newline separated prompts to generate images for"""
+    batch_size: int = 16
+    """Batch size for inference"""
+    img_size: int = 256
+    """Image size for inference"""
+
+
+@dataclass
 class JobConfig:
     """
     Extend the tyro parser with custom config classe for Flux model.
@@ -63,3 +77,4 @@ class JobConfig:
     training: Training = field(default_factory=Training)
     encoder: Encoder = field(default_factory=Encoder)
     validation: Validation = field(default_factory=Validation)
+    inference: Inference = field(default_factory=Inference)

--- a/torchtitan/experiments/flux/job_config.py
+++ b/torchtitan/experiments/flux/job_config.py
@@ -62,7 +62,7 @@ class Inference:
     """Path to save the inference results"""
     prompts_path: str = "./torchtitan/experiments/flux/inference/prompts.txt"
     """Path to file with newline separated prompts to generate images for"""
-    batch_size: int = 16
+    local_batch_size: int = 2
     """Batch size for inference"""
     img_size: int = 256
     """Image size for inference"""

--- a/torchtitan/experiments/flux/run_train.sh
+++ b/torchtitan/experiments/flux/run_train.sh
@@ -14,13 +14,7 @@ NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/experiments/flux/train_configs/debug_model.toml"}
 
-overrides=""
-if [ $# -ne 0 ]; then
-    overrides="$*"
-fi
-
-
 PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
--m torchtitan.experiments.flux.train --job.config_file ${CONFIG_FILE} $overrides
+-m torchtitan.experiments.flux.train --job.config_file ${CONFIG_FILE} "$@"

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -82,4 +82,4 @@ all_timesteps = false
 [inference]
 save_img_folder = "inference_results"
 prompts_path = "./torchtitan/experiments/flux/inference/prompts.txt"
-batch_size = 8
+local_batch_size = 2

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -71,9 +71,15 @@ dataset = "coco-validation"
 freq = 5
 local_batch_size = 8
 steps = 1
+# args for sampling images
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0
 denoising_steps = 4
 save_img_count = 1
 save_img_folder = "img"
 all_timesteps = false
+
+[inference]
+save_img_folder = "inference_results"
+prompts_path = "./torchtitan/experiments/flux/inference/prompts.txt"
+batch_size = 8


### PR DESCRIPTION
This PR reuses the trainer's parallelization to perform batched inference on Flux. It follows up from and addresses comments on @CarlosGomes98 https://github.com/pytorch/torchtitan/pull/1227. This irons out some optimizations for better code clarity.

In this implementation saves images locally from each rank but maintains the global information such as prompt and idx of each image.  It also removes unnecessary padding and handles prompt sets that are not divisible by the batch size.