### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ torchtitan/datasets/**/*.model
 
 # hf assets
 assets/hf/*
+assets/tokenizer/*
 torchtitan/experiments/flux/assets/*
 
 # temp files


### PR DESCRIPTION
Added back `assets/tokenizer/*` to `.gitignore` for people still using old `tokenizer_path`