### PR TITLE
fix: remove redundant legacy usage of mp in checkpoint

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -292,7 +292,6 @@ class CheckpointManager:
         else:
             self.purge_thread = None
 
-        self.mp = None
         self.staging_future = None
         self.save_future = None
         if async_mode == AsyncMode.DISABLED:
@@ -315,9 +314,6 @@ class CheckpointManager:
 
     def close(self):
         if hasattr(self, "enable_checkpoint") and self.enable_checkpoint:
-            if hasattr(self, "mp") and self.mp and self.mp.is_alive():
-                self.mp_queue_send.put(Terminate())
-                self.mp.join()
             if (
                 hasattr(self, "purge_thread")
                 and self.purge_thread


### PR DESCRIPTION
https://github.com/pytorch/torchtitan/pull/1287 removes the usage of mp for checkpointing. 
This is a follow-up cleanup.