### PR TITLE
llama4: Avoid staticmethod nested graph break for MoE compile

### DIFF
--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -30,6 +30,7 @@ class MoEArgs:
     use_grouped_mm: bool = True  # grouped mm or for-loop for the experts computation
     load_balance_coeff: float | None = 1e-3
 
+
 # TODO: keeping this for-loop implementation for comparison
 #       and readability, may remove later
 @expert_parallel


### PR DESCRIPTION
This nested graph break is particularly bad, it is falling back the scaled grouped mm ops to eager

Test plan: `NGPU=2 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" tlp ./run_train.sh --parallelism.data_parallel_shard_degree=2 --parallelism.expert_parallel_d
egree=2 --training.compile`