### PR TITLE
[EP] add initial support for NVSHMEM-based all-to-all

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -398,6 +398,13 @@ class Parallelism:
     Note that this is still an experimental feature.
     """
 
+    expert_parallel_a2a_impl: Literal["default", "nvshmem"] = "default"
+    """
+    NVSHMEM-based all-to-all removes the need for device-to-host sync.
+    If building pytorch from source, one needs to `pip install nvshmem` before building.
+    Note that is highly experimental!
+    """
+
 
 @dataclass
 class Checkpoint:

--- a/torchtitan/experiments/kernels/moe/dispatch.py
+++ b/torchtitan/experiments/kernels/moe/dispatch.py
@@ -88,7 +88,9 @@ class AllToAllVDev2d(torch.autograd.Function):
             out_splits_offsets, grad_out_buf, grad_in_buf, grad_in_splits_offsets
         )
         ctx.group_name = group_name
-        return out
+
+        # TODO: why do we need this clone?
+        return out.clone()
 
     @staticmethod
     def backward(  # type: ignore[no-untyped-def]

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -88,6 +88,8 @@ def parallelize_deepseekv3(
                 else None
             ),
             etp_enabled=parallel_dims.etp_enabled,
+            ep_a2a_impl=job_config.parallelism.expert_parallel_a2a_impl,
+            training_config=job_config.training,
         )
 
     if job_config.activation_checkpoint.mode != "none":

--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -10,8 +10,9 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 from torch import nn
+from torch.distributed.tensor import DTensor
 
-from torchtitan.distributed.expert_parallel import expert_parallel
+from torchtitan.distributed.expert_parallel import indices_permutation_wrapper
 
 
 @dataclass
@@ -63,9 +64,8 @@ class FeedForward(nn.Module):
             nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
 
 
-# TODO: keeping this for-loop implementation for comparison
+# NOTE: keeping this for-loop implementation for comparison
 #       and readability, may remove later
-@expert_parallel
 def _run_experts_for_loop(
     w1: torch.Tensor,
     w2: torch.Tensor,
@@ -101,17 +101,15 @@ def _run_experts_for_loop(
     return out
 
 
-@expert_parallel
 def _run_experts_grouped_mm(
     w1: torch.Tensor,
     w2: torch.Tensor,
     w3: torch.Tensor,
     x: torch.Tensor,
-    num_tokens_per_expert: torch.Tensor,
+    _num_tokens_per_expert: torch.Tensor | None,
+    offsets: torch.Tensor,
 ) -> torch.Tensor:
-    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-    # grouped mm between a 2D tensor and a 3D tensor
-    assert x.dim() == 2
+    assert offsets is not None
 
     h = F.silu(
         torch._grouped_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets)
@@ -142,16 +140,37 @@ class GroupedExperts(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        num_tokens_per_expert: torch.Tensor,
+        num_tokens_per_expert: torch.Tensor | None,
+        offsets: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if self.use_grouped_mm:
-            return _run_experts_grouped_mm(
-                self.w1, self.w2, self.w3, x, num_tokens_per_expert
-            )
+        assert num_tokens_per_expert is not None or offsets is not None
+
+        if isinstance(self.w1, DTensor):
+            # Convert parameters from DTensors to plain Tensors, to work with
+            # dynamic-shape inputs in EP which cannot be easily expressed as DTensors.
+            w1 = self.w1.to_local()
+            w2 = self.w2.to_local()
+            w3 = self.w3.to_local()
         else:
-            return _run_experts_for_loop(
-                self.w1, self.w2, self.w3, x, num_tokens_per_expert
-            )
+            w1 = self.w1
+            w2 = self.w2
+            w3 = self.w3
+
+        if self.use_grouped_mm:
+            if (
+                not isinstance(self.w1, DTensor)
+                or "ep" not in self.w1.device_mesh.mesh_dim_names
+            ):
+                # NOTE: If EP is not used, we need to permute the indices
+                #       to prepare for grouped_mm;
+                #       otherwise, EP will handle the permutation.
+                run_experts_fn = indices_permutation_wrapper(_run_experts_grouped_mm)
+            else:
+                assert offsets is not None
+                run_experts_fn = _run_experts_grouped_mm
+            return run_experts_fn(w1, w2, w3, x, num_tokens_per_expert, offsets)
+        else:
+            return _run_experts_for_loop(w1, w2, w3, x, num_tokens_per_expert)
 
     def init_weights(self, init_std: float):
         nn.init.trunc_normal_(self.w1, mean=0.0, std=0.02)


### PR DESCRIPTION
As titled. This PR also does some refactoring around grouped_mm calling, as NVSHMEM-based all-to-all takes `num_tokens_per_expert` and prepares `offsets`.

What works
- when `num_local_experts == 1`

What doesn't work and needs debugging
- when `num_local_experts > 1`

other TODOs
- let multiple MoE layers share the same input / output buffer
- add NVSHMEM-based `ExpertTensorParallel` support (currently only supports ETP=1)