### PR TITLE
Add DualPipeV

### DIFF
--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -18,6 +18,7 @@ from torch.distributed.pipelining.schedules import (
     get_schedule_class,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
+    ScheduleDualPipeV,
     ScheduleZBVZeroBubble,
 )
 
@@ -335,7 +336,9 @@ def pipeline_module_split(
     models = []
 
     schedule_class = get_schedule_class(pp_schedule)
-    style = "v" if schedule_class == ScheduleZBVZeroBubble else "loop"
+    style = (
+        "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
+    )
 
     for stage_idx in stage_ids_this_rank(pp_rank, pp_size, num_stages, style=style):
         module_names = module_names_per_stage[stage_idx]


### PR DESCRIPTION
DualPipeV was added to pt-core (https://github.com/pytorch/pytorch/pull/159591) so just adding code to support it in titan

To use, in .toml file set:
```
pipeline_parallel_schedule = "DualPipeV"
```

Ideally we don't have this if-statement check, so as a future BE task I can look into removing it