### PR TITLE
Add config to AC to toggle early-stop and revert A2A autograd.Function workaround

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -546,6 +546,12 @@ class ActivationCheckpoint:
     ANY mm with shape matching (*, in) x (in, out) will be force recomputed.
     """
 
+    early_stop: bool = False
+    """
+    Whether to stop recomputing early when all activations have already been
+    rematerialized.
+    """
+
 
 @dataclass
 class Compile:

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -42,7 +42,9 @@ def _apply_ac_to_transformer_block(
         )
 
     if ac_config.mode == "full":
-        return ptd_checkpoint_wrapper(module, preserve_rng_state=False)
+        return ptd_checkpoint_wrapper(
+            module, preserve_rng_state=False, early_stop=ac_config.early_stop
+        )
 
     assert ac_config.mode == "selective", f"{ac_config.mode}"
     use_op_sac = ac_config.selective_ac_option == "op"
@@ -108,6 +110,7 @@ def _apply_ac_to_transformer_block(
             module,
             context_fn=selective_checkpointing_context_fn,
             preserve_rng_state=False,
+            early_stop=ac_config.early_stop,
         )
     elif use_layer_sac:
         # Checkpoint every `ac_freq` of the modules passed to this function
@@ -115,7 +118,9 @@ def _apply_ac_to_transformer_block(
         ptd_checkpoint_wrapper.__dict__.setdefault("_count", 0)
         ptd_checkpoint_wrapper._count += 1
         if not ac_freq or ptd_checkpoint_wrapper._count % ac_freq == 0:
-            return ptd_checkpoint_wrapper(module, preserve_rng_state=False)
+            return ptd_checkpoint_wrapper(
+                module, preserve_rng_state=False, early_stop=ac_config.early_stop
+            )
         else:
             return module
 


### PR DESCRIPTION
Depends on https://github.com/pytorch/pytorch/pull/160781

This PR:
- Add config to AC to toggle early-stop with a default of False
- Reverts A2A autograd.Function workaround


More context in https://github.com/pytorch/torchtitan/issues/1467#issuecomment-3181235004

Leak reproable from @tianyu-l 's comment:
```
CONFIG_FILE=./torchtitan/experiments/llama4/train_configs/debug_model.toml ./run_train.sh --parallelism.expert_parallel_degree=2 --activation_checkpoint.mode=full
```

Without early-stop=False:
```
[rank0]:[titan] 2025-08-18 06:07:18,537 - root - INFO - step:  1  loss:  8.0588  grad_norm:  1.4694  memory:  0.82GiB(1.03%)  tps: 4,900  tflops: 0.37  mfu: 0.12%
[rank0]:[titan] 2025-08-18 06:07:18,538 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-08-18 06:07:18,718 - root - INFO - step:  2  loss:  6.6677  grad_norm:  2.1904  memory:  1.35GiB(1.71%)  tps: 91,012  tflops: 6.83  mfu: 2.19%
[rank0]:[titan] 2025-08-18 06:07:18,910 - root - INFO - step:  3  loss:  4.3877  grad_norm:  2.3935  memory:  1.73GiB(2.19%)  tps: 85,603  tflops: 6.43  mfu: 2.06%
[rank0]:[titan] 2025-08-18 06:07:19,076 - root - INFO - step:  4  loss:  4.1728  grad_norm:  3.0683  memory:  2.25GiB(2.84%)  tps: 98,808  tflops: 7.42  mfu: 2.38%
[rank0]:[titan] 2025-08-18 06:07:19,247 - root - INFO - step:  5  loss:  3.5788  grad_norm:  3.1740  memory:  2.64GiB(3.34%)  tps: 96,348  tflops: 7.23  mfu: 2.32%
[rank0]:[titan] 2025-08-18 06:07:19,419 - root - INFO - step:  6  loss:  3.2758  grad_norm:  1.7157  memory:  3.04GiB(3.84%)  tps: 95,197  tflops: 7.15  mfu: 2.29%
[rank0]:[titan] 2025-08-18 06:07:19,581 - root - INFO - step:  7  loss:  3.1672  grad_norm:  1.7939  memory:  3.46GiB(4.37%)  tps: 101,865  tflops: 7.65  mfu: 2.45%
[rank0]:[titan] 2025-08-18 06:07:19,768 - root - INFO - step:  8  loss:  3.0511  grad_norm:  1.2923  memory:  3.88GiB(4.90%)  tps: 87,393  tflops: 6.56  mfu: 2.10%
[rank0]:[titan] 2025-08-18 06:07:19,933 - root - INFO - step:  9  loss:  3.1330  grad_norm:  0.7737  memory:  4.41GiB(5.58%)  tps: 99,667  tflops: 7.48  mfu: 2.40%
[rank0]:[titan] 2025-08-18 06:07:20,126 - root - INFO - step: 10  loss:  2.9731  grad_norm:  0.5428  memory:  4.87GiB(6.15%)  tps: 85,447  tflops: 6.42  mfu: 2.06%
```

With early-stop=False:
```
[rank0]:[titan] 2025-08-18 06:09:32,465 - root - INFO - step:  1  loss:  8.0588  grad_norm:  1.4694  memory:  0.61GiB(0.77%)  tps: 4,709  tflops: 0.35  mfu: 0.11%
[rank0]:[titan] 2025-08-18 06:09:32,465 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-08-18 06:09:32,643 - root - INFO - step:  2  loss:  6.6677  grad_norm:  2.1904  memory:  0.70GiB(0.89%)  tps: 92,171  tflops: 6.92  mfu: 2.22%
[rank0]:[titan] 2025-08-18 06:09:32,799 - root - INFO - step:  3  loss:  4.3877  grad_norm:  2.3935  memory:  0.70GiB(0.89%)  tps: 105,162  tflops: 7.90  mfu: 2.53%
[rank0]:[titan] 2025-08-18 06:09:32,960 - root - INFO - step:  4  loss:  4.1729  grad_norm:  3.0684  memory:  0.70GiB(0.89%)  tps: 102,732  tflops: 7.71  mfu: 2.47%
[rank0]:[titan] 2025-08-18 06:09:33,117 - root - INFO - step:  5  loss:  3.5789  grad_norm:  3.1744  memory:  0.70GiB(0.89%)  tps: 104,545  tflops: 7.85  mfu: 2.52%
[rank0]:[titan] 2025-08-18 06:09:33,284 - root - INFO - step:  6  loss:  3.2758  grad_norm:  1.7160  memory:  0.70GiB(0.89%)  tps: 98,415  tflops: 7.39  mfu: 2.37%
[rank0]:[titan] 2025-08-18 06:09:33,437 - root - INFO - step:  7  loss:  3.1672  grad_norm:  1.7937  memory:  0.70GiB(0.89%)  tps: 107,744  tflops: 8.09  mfu: 2.59%
[rank0]:[titan] 2025-08-18 06:09:33,594 - root - INFO - step:  8  loss:  3.0512  grad_norm:  1.2927  memory:  0.70GiB(0.89%)  tps: 104,634  tflops: 7.86  mfu: 2.52%
[rank0]:[titan] 2025-08-18 06:09:33,754 - root - INFO - step:  9  loss:  3.1330  grad_norm:  0.7741  memory:  0.70GiB(0.89%)  tps: 102,704  tflops: 7.71  mfu: 2.47%
[rank0]:[titan] 2025-08-18 06:09:33,926 - root - INFO - step: 10  loss:  2.9730  grad_norm:  0.5423  memory:  0.70GiB(0.89%)  tps: 96,116  tflops: 7.22  mfu: 2.31%
```

Another workaround as suggested by @xmfan is to have a SAC policy to save the A2A. This PR intends to address the full AC case. 

