### PR TITLE
[demo][fsdp2][ep] explicit prefetching to overlap all-gather with cuda sync

### DIFF
--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -385,10 +385,7 @@ def apply_fsdp(
         if next_transformer_block is not None:
             if transformer_block.moe_enabled and ep_degree > 1:
                 transformer_block.moe.experts.set_modules_to_forward_prefetch([next_transformer_block])
-                try:
-                    transformer_block.set_modules_to_forward_prefetch([next_transformer_block.moe.experts])
-                except:
-                    torch.distributed.breakpoint()
+                transformer_block.set_modules_to_forward_prefetch([next_transformer_block.moe.experts])
         else:
             # for non-ep code path
             if transformer_block.moe_enabled and ep_degree > 1:

--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -297,7 +297,9 @@ class TransformerBlock(nn.Module):
 
         # use MoE layer for every interleave_moe_layer_step FFN layers
         moe_args = model_args.moe_args
-        self.moe_enabled = (layer_id + 1) % model_args.interleave_moe_layer_step == 0
+        # self.moe_enabled = (layer_id + 1) % model_args.interleave_moe_layer_step == 0
+        # for debugging purpose. easy to showcase how to do explicit prefetching
+        self.moe_enabled = True
         if self.moe_enabled:
             dim = model_args.dim
             hidden_dim = 4 * model_args.dim

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -5,9 +5,9 @@ print_args = false
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = false
+enable_profiling = true
 save_traces_folder = "profile_trace"
-profile_freq = 10
+profile_freq = 5
 enable_memory_snapshot = false
 save_memory_snapshot_folder = "memory_snapshot"
 
@@ -37,7 +37,7 @@ decay_type = "linear"
 min_lr_factor = 0.1
 
 [training]
-local_batch_size = 8
+local_batch_size = 512
 seq_len = 2048
 max_norm = 1.0  # grad norm clipping
 steps = 10


### PR DESCRIPTION
EP triggers cuda sync. enable explicit prefetch in fsdp2 so we can overlap all-gather with cuda sync. in other words, cuda sync should not block all-gather for next layer


```
NGPU=4 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml" ./run_train.sh --parallelism.expert_parallel_degree 2
```

<img width="1119" height="564" alt="Screenshot 2025-08-15 at 15 11 02" src="https://github.com/user-attachments/assets/4d93be18-9f24-497a-8e05-b3d8fa33d8bc" />
