### PR TITLE
[DSV3] Remove keep a copy of GroupedExperts weight, free memory in StateDictAdapter

### DIFF
--- a/torchtitan/models/deepseek_v3/README.md
+++ b/torchtitan/models/deepseek_v3/README.md
@@ -61,6 +61,7 @@ python scripts/checkpoint_conversion/convert_from_hf.py <hf_checkpoints_dir> <dc
 Some limitations:
 1. It can't be used to convert HF checkpoint on the fly using GPU DTensor, because of sharding and quantized blocks may not be aligned well and causing silent numerfical incorrectness.
 2. It can't be used for weight sync to generate a state dict of bf16 because fake quantization to fp8 is applied.
+3. When converting GroupedExperts weights from HF separate expert weights on-the-fly, `torch.split()` will cause huge GPU memory usage. This is because torchtitan GroupedExperts' weight has shape `(num_experts, dim1, dim2)`, and by default shard FSDP on dim-0. When we call `torch.split()` in `to_hf()` function on dim-0, this will incur and all-gather and get replicated expert memory.
 
 ## To be added
 - Parallelism

--- a/torchtitan/models/deepseek_v3/model/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/model/state_dict_adapter.py
@@ -158,6 +158,9 @@ class DeepSeekV3StateDictAdapter(StateDictAdapter):
                     new_key = new_abstract_key.format(layer_num, expert_num)
                     hf_state_dict[new_key] = split_values[expert_num].squeeze()
 
+                # Remove the GroupedExperts' weight from the state_dict to free memory
+                del value
+
             elif "layers" in key:
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
                 layer_num = re.search(r"\d+", key).group(0)


### PR DESCRIPTION
## Context

1. Remove keep a copy of GroupedExperts weight, free memory in StateDictAdapter
2. Add illustration in README about the issue that split() might cause OOM. More details in following figure:
<img width="1153" height="563" alt="Screenshot 2025-08-16 at 3 41 11 PM" src="https://github.com/user-attachments/assets/2c61d57f-47d7-4b59-9712-5a1519427d39" />


## Test


FSDP=8 (FSDP shard dim-0), num_experts = 256
```
[rank0]:In _split_weight function, weights: <class 'torch.distributed.tensor.DTensor'> torch.Size([256, 2048, 7168]) (Shard(dim=0),)
[rank0]:In _split_weight function, split_weight: <class 'torch.distributed.tensor.DTensor'> torch.Size([1, 2048, 7168]) (Replicate(),)
```

FSDP=8 (FSDP shard dim-1), num_experts = 256
```
[rank0]:In _split weights, <class 'torch.distributed.tensor.DTensor'> torch.Size([256, 2048, 7168]) (Shard(dim=1),)
[rank0]:In _split split_weight, <class 'torch.distributed.tensor.DTensor'> torch.Size([1, 2048, 7168]) (Shard(dim=1),)

```