### PR TITLE
Wrap sync + a2a in a custom op

### DIFF
--- a/torchtitan/experiments/deepseek_v3/model.py
+++ b/torchtitan/experiments/deepseek_v3/model.py
@@ -559,7 +559,6 @@ class MoE(nn.Module):
     def combine_experts(self, submod_name: str):
         all_weights = []
         for expert in self.experts.values():
-
             lin = expert.get_submodule(submod_name)
             all_weights.append(lin.weight)
             lin.weight = None
@@ -700,10 +699,10 @@ class MoE(nn.Module):
                 output_splits = tokens_per_expert_group.view(self.ep_size, -1).sum(
                     dim=1
                 )
-            gathered_tokens = all_to_all_single_autograd(
+            gathered_tokens, _, _ = all_to_all_single_autograd(
                 sorted_tokens,
-                output_splits.tolist(),
-                input_splits.tolist(),
+                output_splits,
+                input_splits,
                 self.ep_group,
             )
 
@@ -746,10 +745,10 @@ class MoE(nn.Module):
             )
             returned_tokens = token_return_buf[:seqlen_sorted_tokens]
         else:  # "torch_all_to_all"
-            returned_tokens = all_to_all_single_autograd(
+            returned_tokens, _, _ = all_to_all_single_autograd(
                 processed_tokens,
-                input_splits.tolist(),
-                output_splits.tolist(),
+                input_splits,
+                output_splits,
                 self.ep_group,
             )
 

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -236,6 +236,7 @@ _save_list = {
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    torch.ops.titan._sync_and_all_to_all.default,
     # for low precision training, it's useful to always save
     # the result of max, since the absolute maximum is
     # used to compute the scaling factor for quantization.


### PR DESCRIPTION
Today in order to run a2a, the input/output splits must be provided on the host, so we do a D2H sync before the a2a.

The issue is that if eager SAC saves a2a, AC will still recompute the D2H sync to move the input/outputs splits to the host even though it is not needed.

This PR tries to workaround this by wrapping the D2H sync together with the a2a into a single custom op, so that saving this combined op in SAC would prevent both from being recomputed.

```
CONFIG_FILE=./torchtitan/experiments/llama4/train_configs/debug_model.toml ./run_train.sh --parallelism.expert_parallel_degree=4
```

Before PR (selective op AC, a2a not saved)
```
[rank0]:[titan] 2025-08-19 10:28:45,252 - root - INFO - step:  1  loss: 12.0456  grad_norm:  1.8522  memory: 59.45GiB(75.12%)  tps: 320  tflops: 4.81  mfu: 1.54%
[rank0]:[titan] 2025-08-19 10:28:45,253 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-08-19 10:29:30,502 - root - INFO - step: 10  loss: 11.2730  grad_norm:  2.4527  memory: 72.42GiB(91.52%)  tps: 815  tflops: 12.26  mfu: 3.93%
[rank0]:[titan] 2025-08-19 10:30:21,023 - root - INFO - step: 20  loss:  9.4875  grad_norm:  5.8057  memory: 72.42GiB(91.52%)  tps: 811  tflops: 12.20  mfu: 3.91%
[rank0]:[titan] 2025-08-19 10:31:11,977 - root - INFO - step: 30  loss:  8.6525  grad_norm:  2.9780  memory: 72.44GiB(91.53%)  tps: 804  tflops: 12.10  mfu: 3.88%
[rank0]:[titan] 2025-08-19 10:32:02,750 - root - INFO - step: 40  loss:  7.7779  grad_norm:  1.5781  memory: 72.54GiB(91.66%)  tps: 807  tflops: 12.14  mfu: 3.89%
```

After PR (selective op AC, a2a is saved)
```
[rank0]:[titan] 2025-08-19 10:34:06,335 - root - INFO - step:  1  loss: 12.0456  grad_norm:  1.8522  memory: 59.45GiB(75.12%)  tps: 367  tflops: 5.52  mfu: 1.77%
[rank0]:[titan] 2025-08-19 10:34:06,335 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-08-19 10:34:46,180 - root - INFO - step: 10  loss: 11.2730  grad_norm:  2.4523  memory: 77.24GiB(97.60%)  tps: 925  tflops: 13.92  mfu: 4.46%
[rank0]:[titan] 2025-08-19 10:35:31,093 - root - INFO - step: 20  loss:  9.4875  grad_norm:  5.8072  memory: 77.26GiB(97.63%)  tps: 912  tflops: 13.73  mfu: 4.40%
[rank0]:[titan] 2025-08-19 10:36:15,762 - root - INFO - step: 30  loss:  8.6526  grad_norm:  2.9782  memory: 77.28GiB(97.65%)  tps: 917  tflops: 13.80  mfu: 4.42%
[rank0]:[titan] 2025-08-19 10:37:00,228 - root - INFO - step: 40  loss:  7.7778  grad_norm:  1.5777  memory: 77.28GiB(97.66%)  tps: 921  tflops: 13.86  mfu: 4.44%
```

Only cudaStreamSync in the forward

<img width="1149" height="507" alt="image" src="https://github.com/user-attachments/assets/3bf85a4e-1890-42c2-b44f-3555ca4a9ccb" />
