### PR TITLE
Validation loop hangs

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -11,7 +11,7 @@ set -ex
 # e.g.
 # LOG_RANK=0,1 NGPU=4 ./run_train.sh
 NGPU=${NGPU:-"8"}
-export LOG_RANK=${LOG_RANK:-0}
+export LOG_RANK="0,1"
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama3/train_configs/debug_model.toml"}
 
 TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE:-"http://localhost:29510"}

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -147,6 +147,9 @@ class Validator(BaseValidator):
                     else torch.tensor([-1.0], device=device_type)
                 )
             else:
+                logger.info(
+                    f"[Validation Debug]  Rank {torch.distributed.get_rank()} batch {batch_idx} start"
+                )
                 with self.validation_context(optional_context_parallel_ctx):
                     assert len(model_parts) == 1
                     with self.maybe_enable_amp:
@@ -155,7 +158,7 @@ class Validator(BaseValidator):
                         logger.info(
                             f"[Validation Debug]  Rank {torch.distributed.get_rank()} batch {batch_idx} Loss {loss}"
                         )
-                        # print(
+                        # logger.info(
                         #     f"[Validation Debug] Rank {torch.distributed.get_rank()}. Batch {batch_idx}. input_dict['input'].shape",
                         #     str(input_dict["input"].shape),
                         # )
@@ -168,7 +171,7 @@ class Validator(BaseValidator):
             num_steps += 1
 
         logger.info(
-            f"[Validation Debug] Rank {torch.distributed.get_rank()} Validation done. "
+            f"[Validation Debug] Rank {torch.distributed.get_rank()} Validation done at batch {batch_idx}. "
         )
         # Compute average loss
         loss = torch.sum(torch.stack(accumulated_losses))

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -27,9 +27,19 @@ def _load_c4_dataset(dataset_path: str, split: str):
     return load_dataset(dataset_path, name="en", split=split, streaming=True)
 
 
+def _load_alpaca_dataset(dataset_path: str, split: str):
+    """Load Alpaca dataset with default configuration."""
+    return load_dataset(dataset_path, split=split, streaming=False)
+
+
 def _process_c4_text(sample: dict[str, Any]) -> str:
     """Process C4 dataset sample text."""
     return sample["text"]
+
+
+def _process_alpaca_text(sample: dict[str, Any]) -> str:
+    """Process C4 dataset sample text."""
+    return sample["instruction"] + sample["output"]
 
 
 @dataclass
@@ -55,6 +65,11 @@ DATASETS = {
         path="allenai/c4",
         loader=partial(_load_c4_dataset, split="validation"),
         text_processor=_process_c4_text,
+    ),
+    "alpaca_validation": DatasetConfig(
+        path="yahma/alpaca-cleaned",
+        loader=partial(_load_alpaca_dataset, split="train[95%:]"),
+        text_processor=_process_alpaca_text,
     ),
 }
 

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -18,8 +18,8 @@ from torch.distributed.pipelining.schedules import (
     get_schedule_class,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
-    ScheduleDualPipeV,
-    ScheduleZBVZeroBubble,
+    # ScheduleDualPipeV,
+    # ScheduleZBVZeroBubble,
 )
 
 from torchtitan.config import JobConfig
@@ -336,9 +336,9 @@ def pipeline_module_split(
     models = []
 
     schedule_class = get_schedule_class(pp_schedule)
-    style = (
-        "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
-    )
+    # style = (
+    #     "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
+    # )
 
     for stage_idx in stage_ids_this_rank(pp_rank, pp_size, num_stages, style=style):
         module_names = module_names_per_stage[stage_idx]

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -42,7 +42,7 @@ llama3_configs = {
     ),
     "8B": TransformerModelArgs(
         dim=4096,
-        n_layers=32,
+        n_layers=2,
         n_heads=32,
         n_kv_heads=8,
         ffn_dim_multiplier=1.3,

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -62,7 +62,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
-dataset = "c4_validation"
-freq = 100
-steps = -1
+enabled = true
+dataset = "alpaca_validation"
+freq = 2
+steps = 5

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -63,6 +63,7 @@ filter_fqns = ["output"]
 
 [validation]
 enabled = true
+local_batch_size=1
 dataset = "alpaca_validation"
 freq = 2
-steps = 5
+steps = -1

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -11,9 +11,9 @@ from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
 import torch
-from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.protocols.train_spec as train_spec_module
+from torch.distributed.elastic.multiprocessing.errors import record
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.dataloader import DataloaderStopIteration
 from torchtitan.components.ft import FTManager, maybe_semi_sync_training
@@ -587,6 +587,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                     self.job_config.validation.enabled
                     and self.validator.should_validate(self.step)
                 ):
+                    logger.info(
+                        f"[Validation Debug] Rank {torch.distributed.get_rank()} Running validation"
+                    )
                     self.validator.validate(self.model_parts, self.step)
 
                 # signal the profiler that the next profiling step has started


### PR DESCRIPTION
Hi folks,

We found an hanging issue in the validation loop that might be related to the dataloder/sharding in FSDP.

Command to reproduce the hang
```
CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" NGPU=2 ./run_train.sh
```

The log: 
```
...
[rank1]:[titan] 2025-08-21 11:19:52,968 - root - INFO - [Validation Debug]  Rank 1 batch 87 Loss 12.241142272949219
[rank1]:[titan] 2025-08-21 11:19:52,972 - root - INFO - [Validation Debug]  Rank 1 batch 88 start
[rank1]:[titan] 2025-08-21 11:19:52,988 - root - INFO - [Validation Debug]  Rank 1 batch 88 Loss 12.209203720092773
[rank1]:[titan] 2025-08-21 11:19:52,993 - root - INFO - [Validation Debug]  Rank 1 batch 89 start
[rank0]:[titan] 2025-08-21 11:19:52,905 - root - INFO - [Validation Debug]  Rank 0 batch 84 Loss 12.281610488891602
[rank0]:[titan] 2025-08-21 11:19:52,910 - root - INFO - [Validation Debug]  Rank 0 batch 85 start
[rank0]:[titan] 2025-08-21 11:19:52,927 - root - INFO - [Validation Debug]  Rank 0 batch 85 Loss 12.214127540588379
[rank0]:[titan] 2025-08-21 11:19:52,931 - root - INFO - [Validation Debug]  Rank 0 batch 86 start
[rank0]:[titan] 2025-08-21 11:19:52,947 - root - INFO - [Validation Debug]  Rank 0 batch 86 Loss 12.226905822753906
[rank0]:[titan] 2025-08-21 11:19:52,951 - root - INFO - [Validation Debug]  Rank 0 batch 87 start
[rank0]:[titan] 2025-08-21 11:19:52,968 - root - INFO - [Validation Debug]  Rank 0 batch 87 Loss 12.206489562988281
[rank0]:[titan] 2025-08-21 11:19:52,972 - root - INFO - [Validation Debug]  Rank 0 batch 88 start
[rank0]:[titan] 2025-08-21 11:19:52,988 - root - INFO - [Validation Debug]  Rank 0 batch 88 Loss 12.239264488220215
[rank0]:[titan] 2025-08-21 11:19:52,992 - root - INFO - [Validation Debug]  Rank 0 batch 89 start
[rank1]:[titan] 2025-08-21 11:19:53,009 - root - INFO - [Validation Debug]  Rank 1 batch 89 Loss 12.284561157226562
[rank1]:[titan] 2025-08-21 11:19:53,013 - root - INFO - [Validation Debug]  Rank 1 batch 90 start
[rank1]:[titan] 2025-08-21 11:19:53,030 - root - INFO - [Validation Debug]  Rank 1 batch 90 Loss 12.25745964050293
[rank1]:[titan] 2025-08-21 11:19:53,034 - root - INFO - [Validation Debug]  Rank 1 batch 91 start
[rank1]:[titan] 2025-08-21 11:19:53,050 - root - INFO - [Validation Debug]  Rank 1 batch 91 Loss 12.285140991210938
[rank1]:[titan] 2025-08-21 11:19:53,054 - root - WARNING - Dataset alpaca_validation has run out of data
[rank1]:[titan] 2025-08-21 11:19:53,054 - root - INFO - [Validation Debug] Rank 1 Validation done at batch 91.
[rank0]:[titan] 2025-08-21 11:19:53,009 - root - INFO - [Validation Debug]  Rank 0 batch 89 Loss 12.28492546081543
[rank0]:[titan] 2025-08-21 11:19:53,014 - root - INFO - [Validation Debug]  Rank 0 batch 90 start
[rank0]:[titan] 2025-08-21 11:19:53,030 - root - INFO - [Validation Debug]  Rank 0 batch 90 Loss 12.212723731994629
[rank0]:[titan] 2025-08-21 11:19:53,034 - root - INFO - [Validation Debug]  Rank 0 batch 91 start
[rank0]:[titan] 2025-08-21 11:19:53,050 - root - INFO - [Validation Debug]  Rank 0 batch 91 Loss 12.228861808776855
[rank0]:[titan] 2025-08-21 11:19:53,055 - root - INFO - [Validation Debug]  Rank 0 batch 92 start
```

Rank 1 finishes validation at batch 91. Rank 0 hangs at batch 92.


If we set the validation step to a fixed number that is smaller than the total steps like this:
```
[validation]
enabled = true
local_batch_size=1
dataset = "alpaca_validation"
freq = 2
steps = 5
```
It doesn't hang. So our guess is that it is because the dataloder yields uneven number of batches in two ranks.

cc @ebsmothers 
