### PR TITLE
allow expert_parallel wrapper to handel kwargs

### DIFF
--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -322,6 +322,7 @@ def expert_parallel(func: Callable) -> Callable:
         w3: torch.Tensor,
         x: torch.Tensor,
         num_tokens_per_expert: torch.Tensor,
+        **kwargs,
     ) -> torch.Tensor:
         global TOKEN_GROUP_ALIGN_SIZE_M
         if isinstance(w1, DTensor):
@@ -351,7 +352,7 @@ def expert_parallel(func: Callable) -> Callable:
         input_shape = x.shape
         x = x[permuted_indices, :]
 
-        out = func(w1, w2, w3, x, num_tokens_per_expert)
+        out = func(w1, w2, w3, x, num_tokens_per_expert, **kwargs)
 
         out_unpermuted = out.new_empty(input_shape)
         out_unpermuted[permuted_indices, :] = out


### PR DESCRIPTION
Currently, all MoE models rely on the same forward logic (_run_experts_for_loop or _run_experts_grouped_mm), which is hardcoded to use Swiglu.

This PR allows `expert_parallel` to accept args, allowing users flexibility to define custom expert models. For example, users could specify a different activation function and implement their own forward function, while still reusing the upstream `expert_parallel` logic:

```
@expert_parallel
def cunstom_experts_grouped_mm(
    w1: torch.Tensor,
    w2: torch.Tensor,
    w3: torch.Tensor,
    x: torch.Tensor,
    num_tokens_per_expert: torch.Tensor,
    act_fn: Callable | nn.Module,
) -> torch.Tensor:
    
```
