### PR TITLE
Distributed Scion/Muon 

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -21,6 +21,7 @@ from torch.optim import Optimizer
 from torchtitan.components.ft import FTManager, has_torchft
 from torchtitan.config import Optimizer as OptimizerConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.experiments import distributed_scion
 
 __all__ = [
     "OptimizersContainer",
@@ -75,7 +76,12 @@ class OptimizersContainer(Optimizer, Stateful, Generic[T]):
         self.optimizers = []
         self.model_parts = model_parts
         for model in self.model_parts:
-            params = [p for p in model.parameters() if p.requires_grad]
+            if issubclass(optimizer_cls, (distributed_scion.Disco)):
+                params, optimizer_kwargs = distributed_scion.create_disco_param_groups(
+                    model, optimizer_kwargs
+                )
+            else:
+                params = [p for p in model.parameters() if p.requires_grad]
             self.optimizers.append(optimizer_cls(params, **optimizer_kwargs))
             all_params.extend(params)
         self._validate_length(len(self.model_parts))
@@ -302,9 +308,17 @@ def build_optimizers(
         "foreach": foreach,
     }
 
+    if name in ["DistributedScion"]:
+        optimizer_kwargs = (
+            distributed_scion.create_disco_optimizer_kwargs_from_optimizer_config(
+                optimizer_config, parallel_dims
+            )
+        )
+
     optimizer_classes = {
         "Adam": torch.optim.Adam,
         "AdamW": torch.optim.AdamW,
+        "DistributedScion": distributed_scion.Disco,
     }
     if name not in optimizer_classes:
         raise NotImplementedError(f"Optimizer {name} not added.")

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -149,6 +149,27 @@ class Optimizer:
     weight_decay: float = 0.1
     """Weight decay to use"""
 
+    is_light: bool = False
+    """Whether to use Scion's light (memory-saving) version"""
+
+    norm_factor: str = "spectral"
+    """Which norm factor to use"""
+
+    zeropower_backend: str = "newtonschulz5"
+    "Which `zeropower_backend` to use."
+
+    backend_steps: int = 5
+    """Number of steps for the Scion backend"""
+
+    momentum: float = 0.95
+    """Scion momentum to use"""
+
+    nesterov: bool = False
+    """Whether to use Nesterov momentum in Scion"""
+
+    extra_param_group_split_rules: list[dict[str, Any]] | None = None
+    """Extra parameter group splitting rules for Scion optimizers"""
+
     implementation: Literal["for-loop", "foreach", "fused"] = "fused"
     """
     Specify which optimizer implementation to use:

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -414,7 +414,8 @@ def clip_grad_norm_(
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=pp_mesh.get_group())
             total_norm **= 1.0 / norm_type
 
-    torch.nn.utils.clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
+    if max_norm > 0:
+        torch.nn.utils.clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
     return total_norm
 
 
@@ -470,7 +471,10 @@ def _clip_grad_norm_with_ep(
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=pp_mesh.get_group())
             total_norm **= 1.0 / norm_type
 
-    torch.nn.utils.clip_grads_with_norm_(ep_params, max_norm, total_norm, foreach)
-    torch.nn.utils.clip_grads_with_norm_(non_ep_params, max_norm, total_norm, foreach)
+    if max_norm > 0:
+        torch.nn.utils.clip_grads_with_norm_(ep_params, max_norm, total_norm, foreach)
+        torch.nn.utils.clip_grads_with_norm_(
+            non_ep_params, max_norm, total_norm, foreach
+        )
 
     return total_norm

--- a/torchtitan/experiments/distributed_scion/__init__.py
+++ b/torchtitan/experiments/distributed_scion/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .abstract_disco import AbstractDiSCO  # noqa: F401
+from .disco import Disco  # noqa: F401
+from .utils import (  # noqa: F401  # noqa: F401  # noqa: F401
+    create_disco_optimizer_kwargs_from_optimizer_config,
+    create_disco_param_groups,
+    remove_orig_mod_and_weight_for_p_name,
+)

--- a/torchtitan/experiments/distributed_scion/abstract_disco.py
+++ b/torchtitan/experiments/distributed_scion/abstract_disco.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.distributed.tensor import DTensor
+
+from .muon_utils import zeropower_backends
+from .norm_helper import NORM_FUNCTIONS
+
+__all__ = [
+    "AbstractDiSCO",
+]
+
+
+class AbstractDiSCO(torch.optim.Optimizer):
+    """
+    Shared utilities for Spectral Conditioned Optimizer.
+
+    This base class centralizes common functionality not specific to a
+    particular distributed layout, including:
+      - light-mode grad state save/load hooks
+      - zero_grad handling for light mode
+      - gradient normalisation helpers
+      - optional tracking of norms across steps
+    """
+
+    def __init__(self, params, defaults, is_light: bool = False):
+        # Initialize as a torch Optimizer and common state
+        super().__init__(params, defaults)
+        self.is_light: bool = is_light
+
+        # Norm tracking state
+        self.need_to_calculate_norm: bool = False
+        self.norms_to_log: list[str] = list(NORM_FUNCTIONS.keys())
+        self.norms_at_current_step: dict[str, torch.Tensor] = {}
+
+    """
+    def step(self, *args, **kwargs):
+        momentum = update_moment(gradients)
+
+        full_momentum_matrix = maybe_gather_from_shards(momentum)
+
+        update = lmo(full_momentum_matrix)
+
+        shard_update = maybe_scatter_to_shards(update)
+
+        weights -= lr * shard_update
+    """
+
+    # ----- Light mode hooks -----
+    def setup_light_state_hooks(self):
+        if not self.is_light:
+            return
+        # Initialize state immediately to capture existing grads
+        self._store_grads_in_state()
+        # Register hooks so grads persist through state_dict save/load
+        self.register_state_dict_pre_hook(type(self)._store_grads_in_state)
+        self.register_load_state_dict_post_hook(type(self)._load_grads_from_state)
+
+    def __getstate__(self):
+        self._store_grads_in_state()
+        return super().__getstate__()
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._load_grads_from_state()
+
+    def _store_grads_in_state(self, *args, **kwargs):
+        # args/kwargs present to allow hook-style invocation
+        for group in self.param_groups:
+            for param in group["params"]:
+                if isinstance(param, torch.Tensor) and param.grad is not None:
+                    self.state.setdefault(param, {})["grad_state"] = param.grad
+
+    def _load_grads_from_state(self, *args, **kwargs):
+        for param, state in self.state.items():
+            if "grad_state" in state:
+                param.grad = state["grad_state"]
+            elif isinstance(param, torch.Tensor):
+                param.grad = None
+
+    # ----- Step norm tracking -----
+    def calculate_norm_at_next_step(self, norms_to_log: list[str] = None):
+        self.need_to_calculate_norm = True
+        if norms_to_log is not None:
+            self.norms_to_log = norms_to_log
+        self.norms_at_current_step = {}
+
+    def _is_logging_rank(self) -> bool:
+        # Subclasses can override this to restrict logging to rank 0
+        return True
+
+    def get_norms_at_current_step(self):
+        if self._is_logging_rank():
+            return self.norms_at_current_step
+        else:
+            return {}
+
+    def zero_grad(self, *args, **kwargs):
+        # Preserve grads for light mode; otherwise use default behavior
+        if self.is_light:
+            return
+        super().zero_grad(*args, **kwargs)
+
+    @staticmethod
+    @torch.no_grad()
+    def normalise_grad(g: torch.Tensor, norm_factor: str, eps: float):
+        """
+        Normalises a gradient tensor. Handles both 2D [d_out, d_in] and
+        3D [n_experts, d_out, d_in] tensors.
+        """
+        if norm_factor == "spectral":
+            # Use the last two dims so this works for 2-D and batched 3-D
+            g = g * (g.size(-2) / g.size(-1)) ** 0.5
+
+        elif norm_factor == "image_spectral":
+            ratio = (g.size(-2) / g.size(-1)) ** 0.5
+            g = g * (ratio if ratio > 1 else 1)
+
+        elif norm_factor.startswith("embed"):
+            # Handle 2-D and batched 3-D consistently
+            assert g.ndim == 2
+            if g.ndim == 2:
+                rms_values = torch.sqrt(g.pow(2).sum(dim=1, keepdim=True))
+                dim = g.size(1)
+            else:
+                raise ValueError("embed* expects 2-D ")
+            g = g / (rms_values + eps)
+            if norm_factor == "embed_linear":
+                g = g * dim
+            elif norm_factor == "embed_sqrt":
+                g = g * dim**0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        elif norm_factor.startswith("unembed"):
+            assert g.ndim == 2
+            if g.ndim == 2:
+                rms_values = torch.sqrt(g.pow(2).sum(dim=1, keepdim=True))
+                dim = g.size(1)
+            else:
+                raise ValueError("unembed* expects 2-D ")
+            g = g / (rms_values + eps)
+            if norm_factor == "unembed_linear":
+                g = g / dim
+            elif norm_factor == "unembed_sqrt":
+                g = g / dim**0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        elif norm_factor == "sign":
+            g = torch.sign(g)
+
+        elif norm_factor == "bias_rms":
+            rms_value = torch.sqrt(g.pow(2).mean())
+            g = g / (rms_value + eps)
+
+        elif norm_factor == "conv_spectral":
+            # Properly handle Conv2D (4-D) and Conv3D (5-D)
+            if g.ndim == 4:
+                out_ch, in_ch, kh, kw = g.shape
+                spatial = kh * kw
+            elif g.ndim == 5:
+                out_ch, in_ch, kh, kw, kd = g.shape
+                spatial = kh * kw * kd
+            else:
+                raise ValueError("conv_spectral expects 4-D or 5-D conv weights")
+            g *= (out_ch / in_ch) ** 0.5 / spatial
+
+        elif norm_factor == "none":
+            pass
+        else:
+            raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        return g
+
+    @staticmethod
+    @torch.no_grad()
+    def lmo(
+        g,
+        eps,
+        norm_factor,
+        zeropower_backend,
+        backend_steps,
+        transpose_experts=False,
+    ):
+        """Supported Weight Types:
+        - 1-D tensors: Bias vectors (Linear/Convolution layers)
+        - 2-D tensors: Linear layer weights [D_out, D_in]
+        - 3-D tensors: Grouped expert weights [G, D_in, D_out] or [G, D_out, D_in]
+        - 4-D tensors: Conv2D weights [D_out, D_in, KH, KW] (forced to "conv_spectral")
+        - 5-D tensors: Conv3D weights [D_out, D_in, KH, KW, KD] (forced to "conv_spectral")
+
+        Limitations:
+        - Does not support learnable RMS/Layer-norm parameters
+        - Does not support shared experts or Fused GLU in format [D_in, D_out * M], where M > 1
+        - Does not support Conv1D layers Note:
+        - For 3-D expert weights, the layout must be specified during optimizer initialization.
+
+
+        * 0-D (scalar) weights is supported but should not appear in this function call
+        """
+
+        g = g.to_local() if isinstance(g, DTensor) else g
+
+        # NB: make sure this function does not modify the grad inplace
+        #     since it is also called during the log of gradients
+        def _orth_and_norm(x):
+            x = zeropower_backends[zeropower_backend](x, steps=backend_steps, eps=eps)
+            x = AbstractDiSCO.normalise_grad(x, norm_factor=norm_factor, eps=eps)
+            return x
+
+        if g.ndim == 2:
+            return _orth_and_norm(g)
+
+        # 3-D: batched experts [G, D_out, D_in] (or [G, D_in, D_out] if transposed)
+        elif g.ndim == 3:
+            if g.shape[0] > 0:
+                g = g.transpose(1, 2) if transpose_experts else g
+                g = _orth_and_norm(
+                    g
+                )  # backend is batched; normaliser uses last two dims
+                g = g.transpose(1, 2) if transpose_experts else g
+            return g  # empty G==0 falls through unchanged
+
+        # 1-D: bias vector
+        elif g.ndim == 1:
+            if zeropower_backend == "bias_rms" or norm_factor == "bias_rms":
+                # cheap bias path
+                return AbstractDiSCO.normalise_grad(g, norm_factor="bias_rms", eps=eps)
+            # generic: lift to diagonal, apply 2-D logic, project back
+            g_diag = torch.diag_embed(g).contiguous()
+            g_diag = _orth_and_norm(g_diag)
+            return g_diag.diagonal().contiguous()
+
+        # 4-D/5-D: conv weights; flatten spatial dims into 'in' dim
+        elif g.ndim == 4 or g.ndim == 5:
+            shape = g.shape
+            g2d = g.reshape(shape[0], -1)  # [D_out, D_in*prod(K)]
+            g2d = zeropower_backends[zeropower_backend](
+                g2d, steps=backend_steps, eps=eps
+            )
+            # force conv-specific scaling
+            g2d = AbstractDiSCO.normalise_grad(
+                g2d.view(shape), norm_factor="conv_spectral", eps=eps
+            )
+            return g2d.view(shape)
+
+        else:
+            raise ValueError(f"Unknown grad shape: {g.shape}")

--- a/torchtitan/experiments/distributed_scion/clean_distributed_scion.py
+++ b/torchtitan/experiments/distributed_scion/clean_distributed_scion.py
@@ -1,0 +1,875 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from enum import Enum
+from functools import partial
+
+import torch
+import torch.distributed as dist
+import torch.distributed.tensor
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import _StridedShard, Replicate, Shard
+
+from torchtitan.tools.logging import logger
+
+from .muon_utils import zeropower_backends
+from .norm_helper import NORM_FUNCTIONS
+
+__all__ = [
+    "DistributedScion",
+]
+
+
+class ParamType(Enum):
+    DDP = 0
+    FSDP = 1
+    Expert = 2
+    Unknown = 3
+
+
+def get_param_type(p, fsdp_enabled, expert_enabled):
+    """
+    We can aggressively assume that the param is FSDP-Sharded
+    """
+    if p.grad is None:
+        return ParamType.Unknown
+    if not fsdp_enabled and not expert_enabled and isinstance(p, torch.Tensor):
+        return ParamType.DDP
+    if p.ndim == 3:
+        return ParamType.Expert
+    elif fsdp_enabled:
+        return ParamType.FSDP
+    else:
+        return ParamType.Unknown
+
+
+def tp_axis(placements: tuple, tp_enabled: bool = False) -> int | None:
+    """
+    Return the index in `placements` that belongs to *tensor-parallel* (TP).
+
+    Heuristics (PyTorch-TP default layouts):
+      1. Row-parallel weights ⇒ `_StridedShard`  ⟶ that axis is TP.
+      2. Col-parallel weights ⇒ `Shard(dim != 0)` ⟶ that axis is TP
+         (FSDP shards dim-0, so a non-zero dim means TP).
+    """
+    # rule 1 – row-parallel
+    for i, p in enumerate(placements):
+        if isinstance(p, _StridedShard):
+            return i
+
+    # rule 2 – col-parallel
+    for i, p in enumerate(placements):
+        if isinstance(p, Shard) and p.dim != 0:
+            return i
+
+    # this is a special case, We do TP only
+    if tp_enabled and len(placements) == 1:
+        if isinstance(placements[0], Shard):
+            return 0
+    return None  # could not infer
+
+
+def gather_tp_shard(tensor, tp_group, tp_world_size, original_placements):
+    # TP is used, we need to gather the TP-shard params first
+    tp_mesh_dim = tp_axis(original_placements, True)
+    assert tp_mesh_dim is not None, "something wrong here"
+    shard_dim = original_placements[tp_mesh_dim].dim
+
+    output_tensors = [torch.empty_like(tensor) for _ in range(tp_world_size)]
+    dist.all_gather(output_tensors, tensor, group=tp_group)
+    return torch.cat(output_tensors, dim=shard_dim)
+
+
+def calculate_shard_shape(shape, rank, world_size):
+    full = shape[0]
+    splits = torch.arange(full).chunk(world_size)
+    if rank >= len(splits):
+        dim0 = 0
+    else:
+        dim0 = len(splits[rank])
+
+    return (dim0, *shape[1:])
+
+
+class DistributedScion(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        is_light,
+        weight_decay,
+        lr,
+        momentum,
+        nesterov,
+        eps,
+        norm_factor,
+        backend,
+        backend_steps,
+        parallel_dims,
+        communication_dtype=torch.bfloat16,
+        extra_reduce_for_HSDP=False,
+        experts_weights_layout="G-D_out-D_in",
+    ):
+        self.need_to_calculate_norm = False
+        self.norms_to_log: list[str] = list(NORM_FUNCTIONS.keys())
+        self.norms_at_current_step = {}
+        self.extra_reduce_for_HSDP = False
+        self.log_parameters_types = True
+
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            weight_decay=weight_decay,
+            nesterov=nesterov,
+            eps=eps,
+            norm_factor=norm_factor,
+            backend=backend,
+            backend_steps=backend_steps,
+        )
+        self.is_light = is_light
+
+        assert self.is_light is False, " light mode not tested yet"
+
+        is_unconstrained = weight_decay == 0
+
+        self.world_mesh = parallel_dims.world_mesh
+
+        self.fsdp_enabled = parallel_dims.fsdp_enabled
+        self.expert_enabled = parallel_dims.ep_enabled
+        self.dp_replicate_enabled = parallel_dims.dp_replicate_enabled
+        self.tp_enabled = parallel_dims.tp_enabled
+
+        # this is used to ensure only the DP or FSDP rank 0 will have norms
+        self.is_dp_rank_0 = dist.get_rank(self.world_mesh["dp_cp"].get_group()) == 0
+
+        assert experts_weights_layout in [
+            "G-D_in-D_out",
+            "G-D_out-D_in",
+        ], f"Unknown experts weights layout: {experts_weights_layout}"
+        self.experts_need_transpose = experts_weights_layout == "G-D_in-D_out"
+        self.extra_reduce_for_HSDP = extra_reduce_for_HSDP
+
+        logger.info(
+            f"Distributed Scion optimizer "
+            f"(is_light={self.is_light}, is_unconstrained={is_unconstrained}) "
+            f"is enabled with world_mesh={self.world_mesh} | fsdp_enabled={self.fsdp_enabled} | "
+            f"EP={self.expert_enabled} | TP={self.tp_enabled} | DP={self.dp_replicate_enabled}"
+        )
+
+        super().__init__(params, defaults)
+        if self.is_light:
+            # Initialize state
+            self._store_grads_in_state()
+            # Do not pass `self` through syntactic sugar. We need the
+            # argument to not be populated.
+            self.register_state_dict_pre_hook(
+                type(self)._store_grads_in_state,
+            )
+            self.register_load_state_dict_post_hook(
+                type(self)._load_grads_from_state,
+            )
+
+        self.communication_dtype = communication_dtype
+        self.groups_info = {}
+        self.parameters_to_groups = {}
+        for group_idx, group in enumerate(self.param_groups):
+            lr = group["lr"]
+            nesterov = group["nesterov"]
+            momentum = group["momentum"]
+            wd = group["weight_decay"]
+            param_kwargs = {
+                "eps": group["eps"],
+                "norm_factor": group["norm_factor"],
+                "zeropower_backend": group["backend"],
+                "backend_steps": group["backend_steps"],
+            }
+            self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
+            for param in group["params"]:
+                self.parameters_to_groups[id(param)] = group_idx
+
+                # check sanity of MoE, do not allow the Shard(1) for grouped experts
+                if (
+                    param.ndim == 3
+                    and self.expert_enabled
+                    and Shard(1) in param.placements
+                ):
+                    raise NotImplementedError(
+                        "we should now allow the Shard(1) for grouped experts"
+                    )
+
+            if self.is_light and nesterov:
+                raise RuntimeError(
+                    "Nesterov momentum is not supported for Scion's light mode. "
+                    "Please set nesterov=False."
+                )
+
+    def calculate_norm_at_next_step(self, norms_to_log: list[str]):
+        self.need_to_calculate_norm = True
+        self.norms_to_log = norms_to_log
+        self.norms_at_current_step = {}
+
+    def get_norms_at_current_step(self):
+        if self.is_dp_rank_0:
+            return self.norms_at_current_step
+        else:
+            return {}
+
+    def zero_grad(self, *args, **kwargs):
+        if self.is_light:
+            pass
+        else:
+            super().zero_grad(*args, **kwargs)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        scale_params, scale_param_names = [], []
+        embed_params, embed_param_names = [], []
+        ddp_params, ddp_param_names = [], []
+        fsdp_params, fsdp_param_names = [], []
+        expert_params, expert_param_names = [], []
+
+        for group_idx, group in enumerate(self.param_groups):
+            # we should update self.groups_info here incase we have LR and momentum scheduler
+            # We can also optionally do norm_factor and backend scheduler if we want to
+            lr = group["lr"]
+            nesterov = group["nesterov"]
+            momentum = group["momentum"]
+            wd = group["weight_decay"]
+            param_kwargs = {
+                "eps": group["eps"],
+                "norm_factor": group["norm_factor"],
+                "zeropower_backend": group["backend"],
+                "backend_steps": group["backend_steps"],
+            }
+            self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
+
+            for p_name, p in zip(group["param_names"], group["params"]):
+                norm_factor = group["norm_factor"]
+                backend = group["backend"]
+                is_embed_norm = norm_factor.startswith(
+                    "embed"
+                ) or norm_factor.startswith("unembed")
+
+                if p.numel() == 1:
+                    assert (
+                        backend == "identity"
+                    ), "scale params must use identity backend"
+                    assert (
+                        norm_factor == "sign"
+                    ), "scale params must use sign norm factor"
+                    scale_params.append(p)
+                    scale_param_names.append(p_name)
+                    continue
+
+                if backend == "identity" and is_embed_norm:
+                    # for these Row/Col-wise norm, there is no need to gather the gradient
+                    embed_params.append(p)
+                    embed_param_names.append(p_name)
+                    continue
+
+                param_type = get_param_type(p, self.fsdp_enabled, self.expert_enabled)
+                if param_type == ParamType.DDP:
+                    ddp_params.append(p)
+                    ddp_param_names.append(p_name)
+                elif param_type == ParamType.FSDP:
+                    fsdp_params.append(p)
+                    fsdp_param_names.append(p_name)
+                elif param_type == ParamType.Expert:
+                    expert_params.append(p)
+                    expert_param_names.append(p_name)
+                elif param_type == ParamType.Unknown:
+                    logger.warning(
+                        f"Unknown param type: {p_name}, p.shape {p.shape}, grad is None[?] "
+                        f"{p.grad is None}, the optimizer will skip this param"
+                    )
+                    # raise ValueError(f"Unknown param type: {p_name}")
+                    continue
+                else:
+                    raise ValueError("param_type")
+
+        # Sort fsdp_params and their names together
+        fsdp_pairs = list(zip(fsdp_params, fsdp_param_names))
+        fsdp_pairs.sort(key=lambda x: x[0].numel(), reverse=True)
+        fsdp_params, fsdp_param_names = zip(*fsdp_pairs) if fsdp_pairs else ([], [])
+        # Sort expert_params and their names together
+        expert_pairs = list(zip(expert_params, expert_param_names))
+        expert_pairs.sort(key=lambda x: (x[0].numel(), x[0].shape[1]), reverse=True)
+        expert_params, expert_param_names = (
+            zip(*expert_pairs) if expert_pairs else ([], [])
+        )
+        if self.log_parameters_types:
+            # only log once
+            logger.info(
+                f"fsdp_params: {len(fsdp_params)} | expert_params: {len(expert_params)} | "
+                f"ddp_params: {len(ddp_params)} | embed_params: {len(embed_params)} | "
+                f"scale_params: {len(scale_params)}"
+            )
+            self.log_parameters_types = False
+
+        """
+        We could merge `embed_params` and `expert_params` into one list.
+        The diff is, we are sure expert_params have bunch of 2D full-matrixs
+        But we might need to gather the `embed_params` to 2D full-matrixs
+        if we wanna to get the norm of the gradient.
+        """
+        self.step_scalar(scale_params, scale_param_names)
+        self.step_embedding(embed_params, embed_param_names)
+        self.step_experts(expert_params, expert_param_names)
+        self.step_ddp(ddp_params, ddp_param_names)
+        self.step_fsdp(fsdp_params, fsdp_param_names)
+
+        # reset the flag for the next step
+        self.need_to_calculate_norm = False
+        return loss
+
+    @torch.no_grad()
+    def lmo(
+        self,
+        g,
+        eps,
+        norm_factor,
+        zeropower_backend,
+        backend_steps,
+    ):
+        """
+        Supported Weight Types:
+            - 1-D tensors: Bias vectors (Linear/Convolution layers)
+            - 2-D tensors: Linear layer weights [D_out, D_in]
+            - 3-D tensors: Grouped expert weights [G, D_in, D_out] or [G, D_out, D_in]
+            - 4-D tensors: Conv2D weights [D_out, D_in, KH, KW] (forced to "conv_spectral")
+            - 5-D tensors: Conv3D weights [D_out, D_in, KH, KW, KD] (forced to "conv_spectral")
+
+        Limitations:
+            - Does not support learnable RMS/Layer-norm parameters
+            - Does not support shared experts in format [D_in, D_out * n_shared_experts], where n_shared_experts > 1
+            - Does not support Conv1D layers
+
+        Note:
+            - For 3-D expert weights, the layout must be specified during optimizer initialization.
+            - 0-D (scalar) weights is supported but should not appear in this function call
+        """
+        g = g.to_local() if isinstance(g, DTensor) else g
+
+        # NB: make sure this function does not modify the grad inplace
+        #     since it is also called during the log of gradients
+        def _lmo_for_2d_tensor(g, need_transpose=False):
+            g = g if not need_transpose else g.transpose(0, 1)
+            g = zeropower_backends[zeropower_backend](g, steps=backend_steps, eps=eps)
+            g = self.normalise_grad(g, norm_factor=norm_factor, eps=eps)
+            return g if not need_transpose else g.transpose(0, 1)
+
+        if g.ndim == 2:
+            g = _lmo_for_2d_tensor(g, need_transpose=False)
+        elif g.ndim == 3:
+            if g.shape[0] > 0:
+                # When world_size [fsdp x EP] > Total number of experts,
+                # some ranks may have 0 experts that shape will be [0, d-in, d-out]
+                # We should return the original grad here and **do not** do stack
+                g = torch.stack(
+                    [
+                        _lmo_for_2d_tensor(
+                            g[i], need_transpose=self.experts_need_transpose
+                        )
+                        for i in range(g.shape[0])
+                    ],
+                    dim=0,
+                )
+            else:
+                pass
+        elif g.ndim == 1:
+            if zeropower_backend != "bias_rms":
+                g_diag = torch.diag_embed(g).contiguous()
+                result_diag = _lmo_for_2d_tensor(g_diag)
+                g = result_diag.diagonal().contiguous()
+            else:
+                g = self.normalise_grad(g, norm_factor="bias_rms", eps=eps)
+                pass
+
+        elif g.ndim == 4 or g.ndim == 5:
+            g = zeropower_backends[zeropower_backend](
+                g.reshape(len(g), -1), steps=backend_steps, eps=eps
+            ).view(g.shape)
+            g = self.normalise_grad(g, norm_factor="conv_spectral", eps=eps)
+
+        else:
+            raise ValueError(f"Unknown grad shape: {g.shape}")
+
+        return g
+
+    @torch.no_grad()
+    def normalise_grad(self, g, norm_factor, eps):
+        if norm_factor == "spectral":
+            g = g * (g.size(0) / g.size(1)) ** 0.5
+        elif norm_factor == "image_spectral":
+            g = g * max((g.size(0) / g.size(1)) ** 0.5, 1)
+        elif norm_factor.startswith("embed"):
+            # NB: here assume shape [vocab_size, embed_dim]
+            rms_values = torch.sqrt(g.pow(2).sum(axis=1, keepdim=True))
+            g = g / (rms_values + eps)
+            if norm_factor == "embed_linear":
+                g = g * g.size(1)
+            elif norm_factor == "embed_sqrt":
+                g = g * g.size(1) ** 0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+        elif norm_factor.startswith("unembed"):
+            rms_values = torch.sqrt(g.pow(2).sum(axis=1, keepdim=True))
+            g = g / (rms_values + eps)
+            if norm_factor == "unembed_linear":
+                g = g / g.size(1)
+            elif norm_factor == "unembed_sqrt":
+                g = g / g.size(1) ** 0.5
+            else:
+                raise ValueError(f"Unknown norm_factor: {norm_factor}")
+        elif norm_factor == "sign":
+            g = torch.sign(g)
+        elif norm_factor == "bias_rms":
+            rms_value = torch.sqrt(g.pow(2).mean())
+            g = g / (rms_value + eps)
+        elif norm_factor == "conv_spectral":
+            out_channels, in_channels, k, _ = g.shape
+            g *= (out_channels / in_channels) ** 0.5 / (k**2)
+        elif norm_factor == "none":
+            pass
+        else:
+            raise ValueError(f"Unknown norm_factor: {norm_factor}")
+
+        return g
+
+    def __getstate__(self):
+        self._store_grads_in_state()
+        return super().__getstate__()
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._load_grads_from_state()
+
+    def _store_grads_in_state(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                if isinstance(param, torch.Tensor) and param.grad is not None:
+                    self.state.setdefault(param, {})["grad_state"] = param.grad
+
+    def _load_grads_from_state(self):
+        for param, state in self.state.items():
+            if "grad_state" in state:
+                param.grad = state["grad_state"]
+            elif isinstance(param, torch.Tensor):
+                param.grad = None
+
+    def update_bucket_params(self, params, updates, start_idx, end_idx, tp_group=None):
+        # TODO(JSC): we could maybe use tesnor update rather than for-loop here
+        # can be helpful for FSDP and EP params
+        for idx_in_bucket in range(start_idx, end_idx):
+            shift = idx_in_bucket - start_idx
+            p = params[idx_in_bucket]
+            u = updates[shift]
+            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+
+            if wd != 0:
+                # p.data.mul_(1 - wd*lr)
+                p.mul_(1 - wd * lr)
+
+            if isinstance(p, DTensor) and self.tp_enabled:
+                original_placements = p.placements
+                tp_mesh_dim = tp_axis(original_placements, p.shape == u.shape)
+
+            if isinstance(p, DTensor):
+                if tp_group is None or tp_mesh_dim is None:
+                    p.to_local().add_(u, alpha=-lr)
+                else:
+                    tp_rank = tp_group.rank()
+                    tp_sharded_dim = original_placements[tp_mesh_dim].dim
+                    chunk_size = p.to_local().shape[tp_sharded_dim]
+                    start_offset = tp_rank * chunk_size
+
+                    slicer = [slice(None)] * u.dim()
+                    slicer[tp_sharded_dim] = slice(
+                        start_offset, start_offset + chunk_size
+                    )
+                    u_sliced = u[slicer]
+                    p.to_local().add_(u_sliced, alpha=-lr)
+            else:
+                p.add_(u, alpha=-lr)
+
+            if momentum != 1 and self.is_light and p.grad is not None:
+                p.grad.mul_(1 - momentum)
+
+    def step_scalar(
+        self,
+        scalar_params,
+        scalar_param_names,
+        skip_update=False,
+    ):
+        if len(scalar_params) == 0:
+            return {}
+
+        for param_idx in range(len(scalar_params)):
+            p = scalar_params[param_idx]
+            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(
+                p, momentum, nesterov, update_buffer=True, gather_to_local=False
+            )
+            g = g.to_local() if isinstance(g, DTensor) else g
+
+            # the lmo of scalar is just sign
+            u = torch.sign(g)
+
+            if not skip_update:
+                self.update_bucket_params([p], [u], 0, 1)
+
+    def step_embedding(
+        self,
+        embed_params,
+        embed_param_names,
+        skip_update=False,
+    ):
+        if len(embed_params) == 0:
+            return {}
+
+        tp_group = None
+        # if self.dp_replicate_enabled:
+        #     dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
+        # else:
+        #     dp_replicate_group = None
+
+        if self.tp_enabled:
+            tp_group = self.world_mesh["tp"].get_group()
+
+        for param_idx in range(len(embed_params)):
+            p = embed_params[param_idx]
+            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(
+                p, momentum, nesterov, update_buffer=True, gather_to_local=False
+            )
+
+            u = self.lmo(g, **param_kwargs)
+
+            #########################################################
+            # # As of we use norm for Embedding, maybe we should not do Reduce here
+            # if (
+            #     dp_replicate_group is not None
+            #     and self.extra_reduce_for_HSDP
+            #     and self.fsdp_enabled
+            # ):
+            #     dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
+            #     dist.barrier(group=dp_replicate_group)
+            if not skip_update:
+                self.update_bucket_params([p], [u], 0, 1, tp_group=tp_group)
+
+    def step_experts(
+        self,
+        expert_params,
+        expert_param_names,
+        skip_update=False,
+    ):
+        if len(expert_params) == 0:
+            return {}
+
+        device = expert_params[0].device
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+        world_size = dist.get_world_size(fsdp_group)
+        local_rank = dist.get_rank(fsdp_group)
+        ep_per_rank = math.ceil(expert_params[0].shape[0] / world_size)
+
+        # each rank will process `len(expert_params) * ep_per_rank` experts
+        # each expert will have `self.norms_to_log` norms
+        # so each rank will have `len(expert_params) * ep_per_rank * len(self.norms_to_log)`
+        # norms
+        # globally, its [[g0-ep0, g0-ep1, g0-ep2, ...], [g1-ep0, g1-ep1, g1-ep2, ...], ...] on each
+        # rank
+
+        for param_idx in range(len(expert_params)):
+            p = expert_params[param_idx]
+            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(
+                p, momentum, nesterov, update_buffer=True, gather_to_local=False
+            )
+            u = self.lmo(g, **param_kwargs)
+
+            if not skip_update:
+                self.update_bucket_params([p], [u], 0, 1)
+
+    def step_ddp(
+        self,
+        ddp_params,
+        ddp_param_names,
+        skip_update=False,
+    ):
+        # Either we do DDP
+        # or we do TP,  there is no [DDP + TP] case but for safety we add sevel checks
+        # if len(ddp_params) == 0:
+        #     return {}
+
+        tp_group, dp_replicate_group = None, None
+
+        rank = 0
+        bucket_size = world_size = 1
+        total_buckets = len(ddp_params)
+
+        if self.dp_replicate_enabled:
+            dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
+            world_size = dp_replicate_group.size()
+            rank = dp_replicate_group.rank()
+
+            bucket_size = world_size
+            total_buckets = math.ceil(len(ddp_params) / bucket_size)
+
+        if self.tp_enabled:
+            tp_group = self.world_mesh["tp"].get_group()
+            tp_world_size = dist.get_world_size(group=tp_group)
+
+        device = ddp_params[0].device if len(ddp_params) > 0 else torch.device("cuda")
+        cast_dtype = self.communication_dtype
+        zero_tensor = partial(torch.zeros, dtype=cast_dtype, device=device)
+
+        # for DDP, we need to first update the buffer
+        for param_idx in range(len(ddp_params)):
+            p = ddp_params[param_idx]
+            _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(
+                p, momentum, nesterov, update_buffer=True, gather_to_local=False
+            )
+
+        #  then we do scion stuff
+        for bucket_idx in range(total_buckets):
+            start_idx = bucket_idx * bucket_size
+            end_idx = min(start_idx + bucket_size, len(ddp_params))
+            current_rank_idx = start_idx + rank
+            if current_rank_idx < len(ddp_params):
+                p = ddp_params[current_rank_idx]
+                # Step 1: Get the gradient
+                _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                    self.parameters_to_groups[id(p)]
+                ]
+                g = self.get_momentum_or_grad(
+                    p, momentum, nesterov, update_buffer=False, gather_to_local=False
+                )
+                if isinstance(g, DTensor) and self.tp_enabled:
+                    g = gather_tp_shard(
+                        g.to_local(), tp_group, tp_world_size, g.placements
+                    ).to(dtype=cast_dtype)
+
+            else:
+                # To avoid idle stream, we pad the last rank
+                p = ddp_params[end_idx - 1]
+                g = zero_tensor(p.shape)
+                _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                    self.parameters_to_groups[id(p)]
+                ]
+
+            # step 2: lmo
+            u = self.lmo(g, **param_kwargs)
+
+            if not skip_update:
+                # Step 3: FOR DDP, we do all-gather
+                if self.dp_replicate_enabled:
+                    # only gather params when we doing DDP + BUCKET
+                    gather_lists = [None] * world_size
+                    for i in range(world_size):
+                        param_idx = start_idx + i
+                        if i == rank or param_idx >= len(ddp_params):
+                            gather_lists[i] = u.to(dtype=cast_dtype)
+                        elif param_idx < len(ddp_params):
+                            p = ddp_params[start_idx + i]
+                            gather_lists[i] = zero_tensor(p.shape)
+                    dist.all_gather(
+                        gather_lists, u.to(dtype=cast_dtype), group=dp_replicate_group
+                    )
+                    if self.tp_enabled:
+                        # only if DP+TP we need to barrier here other-wise its automatically synced
+                        dist.barrier(group=dp_replicate_group)
+                else:
+                    # other wise (TP only), dp world_size is 1
+                    gather_lists = [u.to(dtype=cast_dtype)]
+
+                # Step 4: Update the parameters
+                self.update_bucket_params(
+                    ddp_params, gather_lists, start_idx, end_idx, tp_group=tp_group
+                )
+
+    def step_fsdp(
+        self,
+        fsdp_params,
+        fsdp_param_names,
+        skip_update=False,
+    ):
+        if len(fsdp_params) == 0:
+            return {}
+        tp_group, dp_replicate_group = None, None
+        """
+        To make FSDP+DP works, we lets step_fsdp work on each dp_replicate separately.
+        Hence, we only care about the world size inside the dp_replicate.
+        """
+
+        # due to the werid implementation of parallel_dims.py (upstream)
+        # here we should use `dp_shard_cp` rather then `dp_shard` as of
+        # CP is also part of the dp_shard
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+
+        if self.dp_replicate_enabled:
+            dp_replicate_group = self.world_mesh["dp_replicate"].get_group()
+
+        if self.tp_enabled:
+            tp_group = self.world_mesh["tp"].get_group()
+            tp_world_size = dist.get_world_size(group=tp_group)
+
+        world_size = dist.get_world_size(fsdp_group)
+        rank = dist.get_rank(fsdp_group)
+
+        # @ THIS IS A HACK
+        bucket_size = world_size
+        total_buckets = math.ceil(len(fsdp_params) / bucket_size)
+
+        device = fsdp_params[0].device
+        cast_dtype = self.communication_dtype
+        zero_tensor = partial(torch.empty, dtype=cast_dtype, device=device)
+
+        # Process each bucket
+        for bucket_idx in range(total_buckets):
+            start_idx = bucket_idx * bucket_size
+            end_idx = min(start_idx + bucket_size, len(fsdp_params))
+
+            # Step 1: Prepare data for first all_to_all
+            grads_send_list, send_shapes = [], []
+            target_shape, param_kwargs = None, None
+
+            for rank_idx in range(world_size):
+                current_rank_idx = start_idx + rank_idx
+
+                if current_rank_idx < len(fsdp_params):
+                    p = fsdp_params[current_rank_idx]
+                    _, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                        self.parameters_to_groups[id(p)]
+                    ]
+
+                    g = self.get_momentum_or_grad(
+                        p,
+                        momentum,
+                        nesterov,
+                        update_buffer=True,
+                        gather_to_local=False,
+                    )
+
+                    original_placements = g.placements
+                    tp_mesh_dim = tp_axis(original_placements)
+                    if tp_group is not None and tp_mesh_dim is not None:
+                        # the reason we need `tp_mesh_dim` is we want a flexible solution
+                        # that Attention go TP and MLP go EP
+                        g = gather_tp_shard(
+                            g.to_local(), tp_group, tp_world_size, original_placements
+                        ).to(dtype=cast_dtype)
+                    else:
+                        g = g.to_local().to(dtype=cast_dtype)
+
+                    # Save the shape info for this parameter
+                    if rank == rank_idx:
+                        target_shape = p.shape
+                else:
+                    # Use a dummy shape for parameters beyond our range
+                    p = fsdp_params[end_idx - 1]
+                    g = zero_tensor(p.to_local().shape)
+
+                grads_send_list.append(g)
+                send_shapes.append(g.shape)
+
+            # Make sure target_shape is initialized
+            # (trigger by the padding of the last ranks)
+            if target_shape is None and end_idx > 0:
+                target_shape = fsdp_params[end_idx - 1].shape
+                param_kwargs = self.groups_info[
+                    self.parameters_to_groups[id(fsdp_params[end_idx - 1])]
+                ][-1]
+
+            recv_shapes = [
+                calculate_shard_shape(target_shape, rank_idx, world_size)
+                for rank_idx in range(world_size)
+            ]
+            recv_list = [zero_tensor(shape) for shape in recv_shapes]
+            # Step 3: First all_to_all - using ASYNC version
+            dist.barrier()
+            dist.all_to_all(recv_list, grads_send_list, group=fsdp_group)
+            # Step 5: Concatenate received gradients along dimension 0 and perform NS5
+            # All tensors in recv_list should have the same dimensions except for dim 0
+
+            full_g = torch.cat(recv_list, dim=0)
+            u = self.lmo(full_g, **param_kwargs)
+            dist.barrier(group=fsdp_group)
+
+            if dp_replicate_group is not None and self.extra_reduce_for_HSDP:
+                dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
+                dist.barrier(group=dp_replicate_group)
+            # in case of FSDP+DP, we can do a All-Reduce here sync the grads
+            if not skip_update:
+                # Step 6: Split the processed tensor back for second all_to_all
+                split_sizes = [shape[0] for shape in recv_shapes]
+
+                grads_send_list = list(torch.split(u, split_sizes, dim=0))
+                recv_list = [zero_tensor(shape) for shape in send_shapes]
+                # Step 8: Second all_to_all - using ASYNC version
+                dist.all_to_all(recv_list, grads_send_list, group=fsdp_group)
+                del grads_send_list
+                # Step 10: Update parameters using the results
+                self.update_bucket_params(
+                    fsdp_params,
+                    recv_list,
+                    start_idx,
+                    end_idx,
+                    tp_group=tp_group,
+                )
+
+    @torch.no_grad()
+    def get_momentum_or_grad(
+        self, p, momentum, nesterov, update_buffer=False, gather_to_local=False
+    ):
+        g = p.grad
+        if g is None or not p.requires_grad:
+            return None
+
+        use_momentum = momentum > 0 and momentum < 1
+
+        if not self.is_light and use_momentum:
+            state = self.state[p]
+            if "momentum_buffer" not in state.keys():
+                if update_buffer:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                else:
+                    """
+                    When you using DDP + Dist-muon,you might trieer an error here.
+                    Because in the optimizer.log you try to log all gradient's norm.
+                    But for DDP + Dist-muon, each rank only has a part of the gradient.
+
+                    --
+                    For debug, you can return None here.
+                    """
+                    raise ValueError(
+                        "Momentum buffer not found in optimizer state. "
+                        "Please check if the optimizer is initialized correctly."
+                    )
+            buf = state["momentum_buffer"]
+            if update_buffer:
+                buf.mul_(1 - momentum).add_(g, alpha=momentum)
+            else:
+                buf = buf.mul(1 - momentum).add(g, alpha=momentum)
+            g = buf if not nesterov else buf.mul(1 - momentum).add(g, alpha=momentum)
+
+        if gather_to_local and isinstance(g, DTensor):
+            g = g.redistribute(placements=[Replicate()] * g.device_mesh.ndim).to_local()
+        return g

--- a/torchtitan/experiments/distributed_scion/disco.py
+++ b/torchtitan/experiments/distributed_scion/disco.py
@@ -1,0 +1,1250 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import math
+import os
+from collections import defaultdict
+from enum import Enum
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import _StridedShard, Replicate, Shard
+from torch.profiler import record_function
+
+from .abstract_disco import AbstractDiSCO
+from .norm_helper import calculate_norm
+from .utils import remove_orig_mod_and_weight_for_p_name
+
+__all__ = [
+    "Disco",
+]
+
+logger = logging.getLogger(__name__)
+
+# these variables are hardcoded for now, taken from torchtitan
+CONST_NAME_OF_EMBEDDING = "tok_embeddings"
+
+# Environment variables and default values
+# DISCO_DEBUG_MODE = "0"
+
+
+class ParamType(Enum):
+    DDP = 0
+    FSDP = 1
+    Expert = 2
+    Unknown = 3
+
+
+def get_param_type(p, fsdp_enabled, expert_enabled):
+    """
+    We can aggressively assume that the param is FSDP-Sharded
+    """
+    # if p.grad is None:
+    #     return ParamType.Unknown
+    if p.numel() == 1:
+        # treat scalars separately in _build_param_lists(); return DDP here by default
+        return ParamType.DDP
+    if p.ndim == 3 and (expert_enabled or fsdp_enabled):
+        # in torchtitan, one EP is enabled, FSDP is automatically enabled
+        # here just for compatibility
+        return ParamType.Expert
+    if fsdp_enabled:
+        return ParamType.FSDP
+    return ParamType.DDP
+
+
+def tp_axis(placements: tuple, tp_enabled: bool = False) -> int | None:
+    """
+    Return the index in `placements` that belongs to *tensor-parallel* (TP).
+
+    Heuristics (PyTorch-TP default layouts):
+      1. Row-parallel weights ⇒ `_StridedShard`  ⟶ that axis is TP.
+      2. Col-parallel weights ⇒ `Shard(dim != 0)` ⟶ that axis is TP
+         (FSDP shards dim-0, so a non-zero dim means TP).
+    """
+    # rule 1 – row-parallel
+    for i, p in enumerate(placements):
+        if isinstance(p, _StridedShard):
+            return i
+
+    # rule 2 – col-parallel
+    for i, p in enumerate(placements):
+        if isinstance(p, Shard) and p.dim != 0:
+            return i
+
+    # this is a special case, We do TP only
+    if tp_enabled and len(placements) == 1:
+        if isinstance(placements[0], Shard):
+            return 0
+    return None  # could not infer
+
+
+def gather_tp_shard(tensor, tp_group, tp_world_size, original_placements):
+    # TP is used, we need to gather the TP-shard params first
+    tp_mesh_dim = tp_axis(original_placements, True)
+    assert tp_mesh_dim is not None, "TP mesh dimension not found"
+    shard_dim = original_placements[tp_mesh_dim].dim
+
+    output_tensors = [torch.empty_like(tensor) for _ in range(tp_world_size)]
+    dist.all_gather(output_tensors, tensor, group=tp_group)
+    return torch.cat(output_tensors, dim=shard_dim)
+
+
+def calculate_shard_shape(shape, rank, world_size):
+    full = shape[0]
+    splits = torch.arange(full).chunk(world_size)
+    if rank >= len(splits):
+        dim0 = 0
+    else:
+        dim0 = len(splits[rank])
+
+    return (dim0, *shape[1:])
+
+
+class Disco(AbstractDiSCO):
+    def __init__(
+        self,
+        params,
+        is_light,
+        weight_decay,
+        lr,
+        momentum,
+        nesterov,
+        eps,
+        norm_factor,
+        backend,
+        backend_steps,
+        parallel_dims,
+        communication_dtype=torch.bfloat16,
+        extra_reduce_for_HSDP=False,
+        experts_weights_layout="G-D_out-D_in",
+        name_of_embedding=CONST_NAME_OF_EMBEDDING,
+    ):
+
+        debug_mode = os.environ.get("DISCO_DEBUG_MODE", "0") == "1"
+
+        # Initialize base optimizer and common state
+        self.extra_reduce_for_HSDP = False
+        self.log_parameters_types = True
+        self.is_light = is_light
+
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            weight_decay=weight_decay,
+            nesterov=nesterov,
+            eps=eps,
+            norm_factor=norm_factor if not debug_mode else "none",
+            backend=backend if not debug_mode else "identity",
+            backend_steps=backend_steps,
+        )
+        assert is_light is False, "is_light must be False, its not supported yet"
+
+        is_unconstrained = weight_decay == 0
+
+        self.world_mesh = parallel_dims.world_mesh
+
+        self.fsdp_enabled = parallel_dims.fsdp_enabled
+        self.expert_enabled = parallel_dims.ep_enabled
+        self.dp_replicate_enabled = parallel_dims.dp_replicate_enabled
+        self.tp_enabled = parallel_dims.tp_enabled
+
+        # this is used to ensure only the DP or FSDP rank 0 will have norms
+        if self.dp_replicate_enabled or self.fsdp_enabled:
+            self.is_dp_rank_0 = dist.get_rank(self.world_mesh["dp_cp"].get_group()) == 0
+        else:
+            # only PP (and/or) TP enabled
+            self.is_dp_rank_0 = dist.get_rank() == 0
+
+        assert experts_weights_layout in [
+            "G-D_in-D_out",
+            "G-D_out-D_in",
+        ], f"Unknown experts weights layout: {experts_weights_layout}"
+        self.experts_need_transpose = experts_weights_layout == "G-D_in-D_out"
+        self.extra_reduce_for_HSDP = extra_reduce_for_HSDP
+
+        self.name_of_embedding = name_of_embedding
+
+        logger.info(
+            f"Distributed Spectral Conditioned Optimizer "
+            f"(is_light={self.is_light}, is_unconstrained={is_unconstrained}) "
+            f"is enabled with world_mesh={self.world_mesh} | fsdp_enabled={self.fsdp_enabled} | "
+            f"EP={self.expert_enabled} | TP={self.tp_enabled} | DP={self.dp_replicate_enabled}"
+        )
+
+        super().__init__(params, defaults, is_light=is_light)
+        # Register light-mode grad state hooks if needed
+        self.setup_light_state_hooks()
+
+        self.communication_dtype = communication_dtype
+        self.groups_info = {}
+        self.parameters_to_groups = {}
+        for group_idx, group in enumerate(self.param_groups):
+            lr = group["lr"]
+            nesterov = group["nesterov"]
+            momentum = group["momentum"]
+            wd = group["weight_decay"]
+            param_kwargs = {
+                "eps": group["eps"],
+                "norm_factor": group["norm_factor"] if not debug_mode else "none",
+                "zeropower_backend": group["backend"] if not debug_mode else "identity",
+                "backend_steps": group["backend_steps"],
+            }
+            self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
+            for param in group["params"]:
+                self.parameters_to_groups[id(param)] = group_idx
+
+                # check sanity of MoE, do not allow the Shard(1) for grouped experts
+                if (
+                    param.ndim == 3
+                    and self.expert_enabled
+                    and Shard(1) in param.placements
+                ):
+                    raise NotImplementedError(
+                        "we should now allow the Shard(1) for grouped experts"
+                    )
+
+            logger.info(
+                f"group_idx: {group_idx} has {len(group['params'])} params ||"
+                f"lr: {lr} || nesterov: {nesterov} || momentum: {momentum} || wd: {wd} ||"
+                f"{param_kwargs}"
+            )
+
+            if self.is_light and nesterov:
+                raise RuntimeError(
+                    "Nesterov momentum is not supported for spectral conditioned optimizer's light mode. "
+                    "Please set nesterov=False."
+                )
+
+        # public caches
+        self.scale_params, self.scale_param_names = [], []
+        self.embed_params, self.embed_param_names = [], []
+        self.ddp_params, self.ddp_param_names = [], []
+        self.fsdp_params, self.fsdp_param_names = [], []
+        self.expert_params, self.expert_param_names = [], []
+        # build once now
+        self._build_param_lists()
+
+    def _build_param_lists(self):
+        # clear
+        self.scale_params.clear()
+        self.scale_param_names.clear()
+        self.embed_params.clear()
+        self.embed_param_names.clear()
+        self.ddp_params.clear()
+        self.ddp_param_names.clear()
+        self.fsdp_params.clear()
+        self.fsdp_param_names.clear()
+        self.expert_params.clear()
+        self.expert_param_names.clear()
+
+        # decide embedding per-group exactly like in step()
+        # (backend == "identity" and norm_factor startswith embed/unembed)
+        def _is_embed_group(g):
+            nf, be = g["norm_factor"], g["backend"]
+            return (be == "identity") and (
+                nf.startswith("embed") or nf.startswith("unembed")
+            )
+
+        for group in self.param_groups:
+            route_to_embed = _is_embed_group(group)
+            for p_name, p in zip(group["param_names"], group["params"]):
+                if not p.requires_grad:
+                    # ignore the non-trainable parameters
+                    continue
+
+                # 1) scalar branch identical to step()
+                if p.numel() == 1:
+                    assert (
+                        group["backend"] == "identity"
+                    ), "scale params must use identity backend"
+                    assert (
+                        group["norm_factor"] == "sign"
+                    ), "scale params must use sign norm factor"
+                    self.scale_params.append(p)
+                    self.scale_param_names.append(p_name)
+                    continue
+                # 2) embedding fast path identical to step() predicate
+                if route_to_embed:
+                    self.embed_params.append(p)
+                    self.embed_param_names.append(p_name)
+                    continue
+                # 3) structural type without reading p.grad (init-time)
+                ptype = get_param_type(p, self.fsdp_enabled, self.expert_enabled)
+                if ptype == ParamType.DDP:
+                    self.ddp_params.append(p)
+                    self.ddp_param_names.append(p_name)
+                elif ptype == ParamType.FSDP:
+                    self.fsdp_params.append(p)
+                    self.fsdp_param_names.append(p_name)
+                elif ptype == ParamType.Expert:
+                    self.expert_params.append(p)
+                    self.expert_param_names.append(p_name)
+                else:
+                    # static classifier should not return Unknown
+                    pass
+        if self.ddp_params:
+            pairs = list(zip(self.ddp_params, self.ddp_param_names))
+            # sort big → small to reduce padding and make buckets well-conditioned
+            pairs.sort(key=lambda x: x[0].numel(), reverse=True)
+
+            # snake interleave across buckets to balance per-rank Phase-A compute
+            dp_group = (
+                self.world_mesh["dp_replicate"].get_group()
+                if self.dp_replicate_enabled
+                else None
+            )
+            w = dp_group.size() if dp_group is not None else 1
+            if w > 1:
+                blocks = [pairs[i : i + w] for i in range(0, len(pairs), w)]
+                for b, blk in enumerate(blocks):
+                    if b % 2 == 1:
+                        blk.reverse()
+                pairs = [p for blk in blocks for p in blk]
+
+            self.ddp_params, self.ddp_param_names = (
+                (list(t) if pairs else [] for t in zip(*pairs)) if pairs else ([], [])
+            )
+
+        if self.fsdp_params:
+            pairs = list(zip(self.fsdp_params, self.fsdp_param_names))
+            pairs.sort(key=lambda x: x[0].numel(), reverse=True)
+            self.fsdp_params, self.fsdp_param_names = list(zip(*pairs))
+            self.fsdp_params, self.fsdp_param_names = list(self.fsdp_params), list(
+                self.fsdp_param_names
+            )
+
+        if self.expert_params:
+            pairs = list(zip(self.expert_params, self.expert_param_names))
+            pairs.sort(key=lambda x: (x[0].numel(), x[0].shape[1]), reverse=True)
+            self.expert_params, self.expert_param_names = list(zip(*pairs))
+            self.expert_params, self.expert_param_names = list(
+                self.expert_params
+            ), list(self.expert_param_names)
+
+        if self.log_parameters_types:
+            logger.info(
+                f"fsdp_params: {len(self.fsdp_params)} | expert_params: {len(self.expert_params)} | "
+                f"ddp_params: {len(self.ddp_params)} | embed_params: {len(self.embed_params)} | "
+                f"scale_params: {len(self.scale_params)}"
+            )
+            self.log_parameters_types = False
+
+    @record_function("disco.step")
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        # only refresh schedulables each step (unchanged behaviour)
+        for group_idx, group in enumerate(self.param_groups):
+            lr = group["lr"]
+            nesterov = group["nesterov"]
+            momentum = group["momentum"]
+            wd = group["weight_decay"]
+            param_kwargs = {
+                "eps": group["eps"],
+                "norm_factor": group["norm_factor"],
+                "zeropower_backend": group["backend"],
+                "backend_steps": group["backend_steps"],
+            }
+            self.groups_info[group_idx] = [lr, nesterov, momentum, wd, param_kwargs]
+
+        self.prepare_gradients_and_momentum()
+
+        # If you ever flip routing (backend/norm_factor) and want new buckets, call self._build_param_lists() explicitly.
+        # Otherwise, just dispatch with the cached lists
+
+        self.step_scalar(self.scale_params, self.scale_param_names)
+        self.step_embedding(self.embed_params, self.embed_param_names)
+        self.step_experts(self.expert_params, self.expert_param_names)
+        self.step_ddp(self.ddp_params, self.ddp_param_names)
+
+        self.step_fsdp(self.fsdp_params, self.fsdp_param_names)
+
+        self.need_to_calculate_norm = False
+        return loss
+
+    @record_function("disco.step_scalar")
+    @torch.compile()
+    def step_scalar(
+        self,
+        scalar_params,
+        scalar_param_names,
+        skip_update=False,
+        apply_on_weight=True,
+    ):
+        """
+        We hardcode the update for scalar parameters to be the `sign` of the gradient.
+        """
+        if not scalar_params:
+            return
+
+        updates = []
+        for p in scalar_params:
+            _, nesterov, momentum, _, _ = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(p, momentum, nesterov)
+
+            if g is None:
+                updates.append(None)
+                continue
+
+            g_local = g.to_local() if isinstance(g, DTensor) else g
+            u = torch.sign(g_local)
+            updates.append(u)
+
+        if not skip_update:
+            # Scalar parameters are not TP-sharded, so tp_group is None.
+            self.update_bucket_params(
+                scalar_params, updates, 0, len(scalar_params), tp_group=None
+            )
+
+        if not self.need_to_calculate_norm:
+            return
+
+        final_norms = {}
+        if apply_on_weight and self.need_to_calculate_norm:
+            for i, p in enumerate(scalar_params):
+                p_local = p.to_local() if isinstance(p, DTensor) else p
+                cleaned_p_name = remove_orig_mod_and_weight_for_p_name(
+                    scalar_param_names[i]
+                )
+                # The original code only logs the parameter's absolute value, as the
+                # update norm is constant (learning_rate * 1.0).
+                final_norms[f"scalar_param_supremum/{cleaned_p_name}"] = p_local.abs()
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_embedding")
+    def step_embedding(
+        self, embed_params, embed_param_names, skip_update=False, apply_on_weight=True
+    ):
+        if len(embed_params) == 0:
+            return
+
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+
+        # --- Phase 1: Parameter Update (Efficient, on shards) ---
+        # This part of your refactor is efficient and correct for the update.
+        # It computes updates on shards and applies them locally.
+        effective_grads = []
+        for p in embed_params:
+            _, nesterov, momentum, _, _ = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            # Get gradient without gathering for efficiency
+            g = self.get_momentum_or_grad(p, momentum, nesterov, gather_to_local=False)
+
+            if not self.fsdp_enabled and self.tp_enabled:
+                # here is an edge case where [e.g. GPUS=TP, or GPUS=PP x TP]
+                # model weight is sharded, but gradient is Replicate
+                original_placements = p.placements
+                tp_mesh_dim = tp_axis(original_placements, True)
+                tp_sharded_dim = original_placements[tp_mesh_dim].dim
+                chunk_size = p.to_local().shape[tp_sharded_dim]
+                start_offset = tp_group.rank() * chunk_size
+                slicer = [slice(None)] * g.dim()
+                slicer[tp_sharded_dim] = slice(start_offset, start_offset + chunk_size)
+                g = g[tuple(slicer)]
+
+            effective_grads.append(g)
+
+        # LMO bucketed by param_kwargs
+        lmo_buckets = defaultdict(lambda: {"grads": [], "indices": []})
+        for i, g in enumerate(effective_grads):
+            if g is not None:
+                p = embed_params[i]
+                *_, param_kwargs = self.groups_info[self.parameters_to_groups[id(p)]]
+                kwargs_key = tuple(sorted(param_kwargs.items()))
+                lmo_buckets[kwargs_key]["grads"].append(g)
+                lmo_buckets[kwargs_key]["indices"].append(i)
+
+        updates = [None] * len(embed_params)
+        for kwargs_key, data in lmo_buckets.items():
+            param_kwargs = dict(kwargs_key)
+            for j, g in enumerate(data["grads"]):
+                updates[data["indices"][j]] = self.lmo(g, **param_kwargs)
+
+        if not skip_update:
+            self.update_bucket_params(
+                embed_params, updates, 0, len(embed_params), tp_group=None
+            )
+
+        # --- Phase 2: Norm Calculation (On Full Tensors for Correctness) ---
+        if not self.need_to_calculate_norm:
+            return
+        final_norms = {}
+        apply_on_weight = apply_on_weight and self.need_to_calculate_norm
+
+        for i, (p, p_name) in enumerate(zip(embed_params, embed_param_names)):
+            lr, nesterov, momentum, _, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+
+            # Gathering Gradient to a full tensor for norm calculation
+            g = self.get_momentum_or_grad(p, momentum, nesterov, gather_to_local=True)
+            u = self.lmo(g, **param_kwargs)
+
+            # Calculate norms on the full tensors
+            need_T = self.name_of_embedding in p_name
+            upd_norms = calculate_norm(-lr * u, self.norms_to_log, transpose=need_T)
+
+            # Gather the parameter itself to a full tensor if needed
+            if apply_on_weight and isinstance(p, DTensor):
+                p = p.full_tensor()
+
+            if apply_on_weight:
+                wnorm = calculate_norm(p, self.norms_to_log, transpose=need_T)
+
+            cleaned_p_name = remove_orig_mod_and_weight_for_p_name(p_name)
+            for norm_name in self.norms_to_log:
+                final_norms[f"track_update_{norm_name}/{cleaned_p_name}"] = upd_norms[
+                    norm_name
+                ]
+                if apply_on_weight:
+                    final_norms[f"track_param_{norm_name}/{cleaned_p_name}"] = wnorm[
+                        norm_name
+                    ]
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_experts")
+    def step_experts(
+        self,
+        expert_params,
+        expert_param_names,
+        skip_update=False,
+        apply_on_weight=True,
+    ):
+        if len(expert_params) == 0:
+            return
+
+        need_to_calculate_norm = self.need_to_calculate_norm
+
+        norms_of_update, norms_of_weight, final_norms = [], [], {}
+        apply_on_weight = apply_on_weight and need_to_calculate_norm
+
+        device = expert_params[0].device
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+        world_size = dist.get_world_size(fsdp_group)
+        local_rank = dist.get_rank(fsdp_group)
+        ep_per_rank = math.ceil(expert_params[0].shape[0] / world_size)
+
+        kinds_of_norms = len(self.norms_to_log)
+
+        padding_norms = torch.tensor(0.0, device=device)
+        # each rank will process `len(expert_params) * ep_per_rank` experts
+        # each expert will have `self.norms_to_log` norms
+        # so each rank will have `len(expert_params) * ep_per_rank * len(self.norms_to_log)`
+        # norms
+        # globally, its [[g0-ep0, g0-ep1, g0-ep2, ...], [g1-ep0, g1-ep1, g1-ep2, ...], ...] on each
+        # rank
+
+        transpose = self.experts_need_transpose
+        for param_idx in range(len(expert_params)):
+            p = expert_params[param_idx]
+            lr, nesterov, momentum, wd, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(p, momentum, nesterov)
+            u = self.lmo(g, **param_kwargs, transpose_experts=transpose)
+
+            if not skip_update:
+                self.update_bucket_params([p], [u], 0, 1)
+
+            if need_to_calculate_norm:
+                # cleaned_p_name = remove_orig_mod_and_weight_for_p_name(
+                #     expert_param_names[param_idx]
+                # )
+                assert u.ndim == 3
+                for ep_idx in range(u.shape[0]):
+                    update_norms = calculate_norm(
+                        u[ep_idx], self.norms_to_log, transpose=transpose
+                    )
+                    # Template for MoE norm keys
+                    norms_of_update.extend(update_norms.values())
+                    if apply_on_weight:
+                        weight_norms = calculate_norm(
+                            p.to_local()[ep_idx], self.norms_to_log, transpose=transpose
+                        )
+                        norms_of_weight.extend(weight_norms.values())
+
+        if need_to_calculate_norm:
+            expected_total = len(expert_params) * ep_per_rank * kinds_of_norms
+            pad_needed = expected_total - len(norms_of_update)
+            if pad_needed > 0:
+                norms_of_update.extend([padding_norms] * pad_needed)
+                if apply_on_weight:  # keep weight-norms aligned
+                    norms_of_weight.extend([padding_norms] * pad_needed)
+
+            norms_tensor = torch.stack(norms_of_update).float().to(device)
+            gathered_update_norms = torch.empty(
+                world_size * norms_tensor.shape[0],
+                dtype=norms_tensor.dtype,
+                device=norms_tensor.device,
+            )
+            dist.all_gather_into_tensor(
+                gathered_update_norms, norms_tensor, group=fsdp_group
+            )
+
+            if apply_on_weight:
+                norms_tensor = torch.stack(norms_of_weight).float().to(device)
+                gathered_weight_norms = torch.empty(
+                    world_size * norms_tensor.shape[0],
+                    dtype=norms_tensor.dtype,
+                    device=norms_tensor.device,
+                )
+                dist.barrier()
+                dist.all_gather_into_tensor(
+                    gathered_weight_norms, norms_tensor, group=fsdp_group
+                )
+
+            if local_rank == 0:
+                norm_names = list(self.norms_to_log)
+
+                P = len(expert_params)  # parameters per rank
+                E = ep_per_rank  # experts per rank
+                K = kinds_of_norms  # norms per expert
+                block = P * E * K  # values contributed by each rank
+
+                for idx in range(world_size * block):
+                    r, rem = divmod(idx, block)  # producing rank
+                    p, rem = divmod(rem, E * K)  # parameter index
+                    e, k = divmod(rem, K)  # expert, norm indices
+
+                    actual_ep_idx = e + r * E
+                    if actual_ep_idx >= expert_params[0].shape[0]:
+                        continue  # skip pure padding slots
+
+                    cleaned_name = remove_orig_mod_and_weight_for_p_name(
+                        expert_param_names[p]
+                    )
+                    norm_name = norm_names[k]
+
+                    key_update = (
+                        f"track_update_{norm_name}/ep_{actual_ep_idx}/{cleaned_name}"
+                    )
+                    final_norms[key_update] = gathered_update_norms[idx]
+
+                    if apply_on_weight:
+                        key_param = (
+                            f"track_param_{norm_name}/ep_{actual_ep_idx}/{cleaned_name}"
+                        )
+                        final_norms[key_param] = gathered_weight_norms[idx]
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_ddp")
+    def step_ddp(
+        self,
+        ddp_params,
+        ddp_param_names,
+        skip_update: bool = False,
+        apply_on_weight: bool = True,
+    ):
+        if len(ddp_params) == 0:
+            return
+
+        need_to_calculate_norm = self.need_to_calculate_norm
+        apply_on_weight = apply_on_weight and need_to_calculate_norm
+
+        # --- distributed groups ---
+        dp_group = (
+            self.world_mesh["dp_replicate"].get_group()
+            if self.dp_replicate_enabled
+            else None
+        )  # DDP group accessor
+        world_size = dp_group.size() if dp_group is not None else 1
+        rank = dp_group.rank() if dp_group is not None else 0
+
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+        tp_world_size = (
+            dist.get_world_size(group=tp_group) if tp_group is not None else 1
+        )
+
+        device = ddp_params[0].device
+        cast_dtype = self.communication_dtype  # comm/exchange dtype
+
+        # one DDP bucket spans `world_size` params
+        bucket_size = world_size
+        total_buckets = (
+            math.ceil(len(ddp_params) / bucket_size)
+            if world_size > 1
+            else len(ddp_params)
+        )
+
+        # --- Initializations for norm calculation ---
+        norms_of_update, norms_of_weight, final_norms = [], [], {}
+
+        # -------- Phase A: precompute local LMO updates (no comm) --------
+        local_updates: dict[int, torch.Tensor] = {}
+        local_indices = range(rank, len(ddp_params), world_size)
+        for i in local_indices:
+            p = ddp_params[i]
+            _, nesterov, momentum, _, param_kwargs = self.groups_info[
+                self.parameters_to_groups[id(p)]
+            ]
+            g = self.get_momentum_or_grad(p, momentum, nesterov)  # relies on pre-pass
+            if isinstance(g, DTensor) and tp_group is not None:
+                g = gather_tp_shard(
+                    g.to_local(), tp_group, tp_world_size, g.placements
+                )  # TP tolerant
+            else:
+                g = g.to_local() if isinstance(g, DTensor) else g
+            u = self.lmo(g.to(dtype=cast_dtype), **param_kwargs)
+            local_updates[i] = u
+
+        # -------- Phase B: DDP communication (per bucket) and build a global update cache --------
+        global_updates: list[torch.Tensor | None] = [None] * len(ddp_params)
+
+        for bucket_idx in range(total_buckets):
+            start_idx = bucket_idx * bucket_size
+            end_idx = min(start_idx + bucket_size, len(ddp_params))
+            my_idx = start_idx + rank
+
+            if my_idx < end_idx:
+                send_u = local_updates[my_idx]
+            else:
+                ref = ddp_params[end_idx - 1]
+                send_u = torch.zeros(ref.shape, dtype=cast_dtype, device=device)
+
+            if dp_group is not None and world_size > 1 and not skip_update:
+                gathered = []
+                pad_buffer = None
+                for i in range(world_size):
+                    param_idx = start_idx + i
+                    if param_idx < len(ddp_params):
+                        ref = ddp_params[param_idx]
+                        if global_updates[param_idx] is None:
+                            global_updates[param_idx] = torch.empty(
+                                ref.shape, dtype=cast_dtype, device=device
+                            )
+                        recv = global_updates[param_idx]
+                    else:
+                        ref = ddp_params[end_idx - 1]
+                        if pad_buffer is None or pad_buffer.shape != ref.shape:
+                            pad_buffer = torch.empty(
+                                ref.shape, dtype=cast_dtype, device=device
+                            )
+                        recv = pad_buffer
+                    gathered.append(recv)
+                dist.all_gather(gathered, send_u, group=dp_group)
+            else:
+                gathered = [send_u] if not skip_update else []
+            if not skip_update:
+                for i in range(end_idx - start_idx):
+                    global_updates[start_idx + i] = gathered[i]
+
+            # ---- local norms (on our owned slot only) ----
+            if need_to_calculate_norm:
+                if my_idx < end_idx:
+                    p = ddp_params[my_idx]
+                    lr, *_ = self.groups_info[self.parameters_to_groups[id(p)]]
+                    upd_norms = calculate_norm(
+                        -lr * local_updates[my_idx], self.norms_to_log
+                    )
+                else:
+                    upd_norms = {
+                        k: torch.tensor(0.0, device=device) for k in self.norms_to_log
+                    }
+                for v in upd_norms.values():
+                    norms_of_update.append(v)
+
+        # -------- Phase C: apply once (vectorised foreach inside update_bucket_params) --------
+        if not skip_update:
+            self.update_bucket_params(
+                ddp_params, global_updates, 0, len(ddp_params), tp_group=tp_group
+            )
+
+        # -------- Phase C.5: Calculate Weight Norms (POST-UPDATE) --------
+        if apply_on_weight:
+            for bucket_idx in range(total_buckets):
+                my_idx = bucket_idx * world_size + rank
+                if my_idx < len(ddp_params):
+                    w = ddp_params[my_idx]
+                    if isinstance(w, DTensor) and tp_group is not None:
+                        w = gather_tp_shard(
+                            w.to_local(), tp_group, tp_world_size, w.placements
+                        )
+                    w_norms = calculate_norm(w, self.norms_to_log)
+                else:
+                    w_norms = {
+                        k: torch.tensor(0.0, device=device) for k in self.norms_to_log
+                    }
+                for v in w_norms.values():
+                    norms_of_weight.append(v)
+
+        # -------- Phase D: final norm gather/log --------
+        if not need_to_calculate_norm:
+            return
+
+        upd = torch.stack(norms_of_update).float().to(device)
+        if dp_group is not None and world_size > 1:
+            gathered_upd = torch.empty(
+                world_size * upd.shape[0], dtype=upd.dtype, device=device
+            )
+            dist.all_gather_into_tensor(gathered_upd, upd, group=dp_group)
+        else:
+            gathered_upd = upd
+
+        if apply_on_weight:
+            w = torch.stack(norms_of_weight).float().to(device)
+            if dp_group is not None and world_size > 1:
+                gathered_w = torch.empty(
+                    world_size * w.shape[0], dtype=w.dtype, device=device
+                )
+                dist.all_gather_into_tensor(gathered_w, w, group=dp_group)
+            else:
+                gathered_w = w
+        else:
+            gathered_w = None
+
+        if self.is_dp_rank_0:
+            num_norm_types = len(self.norms_to_log)
+            for param_idx, p_name in enumerate(ddp_param_names):
+                cleaned = remove_orig_mod_and_weight_for_p_name(p_name)
+                owner_rank = param_idx % world_size
+                owner_bucket = param_idx // world_size
+                base = (owner_rank * total_buckets + owner_bucket) * num_norm_types
+                for k, norm_name in enumerate(self.norms_to_log):
+                    idx = base + k
+                    final_norms[f"track_update_{norm_name}/{cleaned}"] = gathered_upd[
+                        idx
+                    ]
+                    if apply_on_weight:
+                        final_norms[f"track_param_{norm_name}/{cleaned}"] = gathered_w[
+                            idx
+                        ]
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    def _gather_and_log_fsdp_norms(
+        self,
+        norms_of_update,
+        norms_of_weight,
+        fsdp_group,
+        rank,
+        device,
+        fsdp_param_names,
+        world_size,
+        total_buckets,
+        apply_on_weight,
+    ):
+        """
+        Gathers FSDP norm tensors from all ranks and logs them on rank 0.
+        This is a collective operation followed by a rank-0 logging step.
+        """
+        # --- 1. Collective Communication: All ranks must participate ---
+        upd = torch.stack(norms_of_update).float().to(device)
+        gathered_update_norms = torch.empty(
+            world_size * upd.numel(), dtype=upd.dtype, device=device
+        )
+        dist.all_gather_into_tensor(gathered_update_norms, upd, group=fsdp_group)
+
+        gathered_weight_norms = None
+        if apply_on_weight and norms_of_weight:
+            w = torch.stack(norms_of_weight).float().to(device)
+            gathered_weight_norms = torch.empty(
+                world_size * w.numel(), dtype=w.dtype, device=device
+            )
+            dist.all_gather_into_tensor(gathered_weight_norms, w, group=fsdp_group)
+
+        # --- 2. Local Processing: Only rank 0 processes and logs the results ---
+        final_norms = {}
+        if self.is_dp_rank_0:
+            num_norm_types = len(self.norms_to_log)
+            entries_per_rank = total_buckets * num_norm_types
+            cleaned_names = [
+                remove_orig_mod_and_weight_for_p_name(pn) for pn in fsdp_param_names
+            ]
+
+            for param_idx, cleaned_p_name in enumerate(cleaned_names):
+                owner_rank = param_idx % world_size
+                bucket_idx_on_owner = param_idx // world_size
+                base = (
+                    owner_rank * entries_per_rank + bucket_idx_on_owner * num_norm_types
+                )
+
+                for norm_idx, norm_name in enumerate(self.norms_to_log):
+                    idx = base + norm_idx
+                    final_norms[
+                        f"track_update_{norm_name}/{cleaned_p_name}"
+                    ] = gathered_update_norms[idx]
+                    if apply_on_weight and gathered_weight_norms is not None:
+                        final_norms[
+                            f"track_param_{norm_name}/{cleaned_p_name}"
+                        ] = gathered_weight_norms[idx]
+
+        if self.is_dp_rank_0:
+            self.norms_at_current_step.update(final_norms)
+
+    @record_function("disco.step_fsdp")
+    def step_fsdp(
+        self, fsdp_params, fsdp_param_names, skip_update=False, apply_on_weight=True
+    ):
+        if not fsdp_params:
+            return
+
+        # ---- Setup (as in your code) ----
+        need_to_calculate_norm = self.need_to_calculate_norm
+        apply_on_weight = apply_on_weight and need_to_calculate_norm
+
+        fsdp_group = self.world_mesh["dp_shard_cp"].get_group()
+        world_size = dist.get_world_size(fsdp_group)
+        rank = dist.get_rank(fsdp_group)
+        device = fsdp_params[0].device
+        cast_dtype = self.communication_dtype
+
+        tp_group = self.world_mesh["tp"].get_group() if self.tp_enabled else None
+        tp_world_size = dist.get_world_size(group=tp_group) if tp_group else 1
+        dp_replicate_group = (
+            self.world_mesh["dp_replicate"].get_group()
+            if self.dp_replicate_enabled
+            else None
+        )
+
+        global_updates = [None] * len(fsdp_params)
+        norms_of_update, norms_of_weight = [], []
+        padding_norms = {k: torch.tensor(0.0, device=device) for k in self.norms_to_log}
+
+        # ---- Owner-per-bucket scheme (bucket size = world_size) ----
+        total_buckets = math.ceil(len(fsdp_params) / world_size)
+
+        for bucket_idx in range(total_buckets):
+            start_idx = bucket_idx * world_size
+            end_idx = min(start_idx + world_size, len(fsdp_params))
+
+            grads_send_list, send_shapes = [], []
+            target_shape, param_kwargs_me = None, None
+
+            # Build per-destination payloads:
+            for i in range(world_size):
+                p_idx = start_idx + i
+                if p_idx < end_idx:
+                    p = fsdp_params[p_idx]
+                    _, nesterov, momentum, _, param_kwargs = self.groups_info[
+                        self.parameters_to_groups[id(p)]
+                    ]
+                    g = self.get_momentum_or_grad(
+                        p, momentum, nesterov
+                    )  # may be DTensor
+
+                    if isinstance(g, DTensor):
+                        original_placements = g.placements
+                        tp_mesh_dim = tp_axis(original_placements)
+                        if tp_group and tp_mesh_dim is not None:
+                            g_local = gather_tp_shard(
+                                g.to_local(),
+                                tp_group,
+                                tp_world_size,
+                                original_placements,
+                            )
+                        else:
+                            g_local = g.to_local()
+                    else:
+                        g_local = g
+
+                    grads_send_list.append(g_local.to(dtype=cast_dtype))
+                    send_shapes.append(g_local.shape)
+
+                    if i == rank:
+                        target_shape = p.shape
+                        param_kwargs_me = param_kwargs
+                else:
+                    # pad so that list length == world_size
+                    ref_p = fsdp_params[end_idx - 1]
+                    dummy = torch.zeros(
+                        ref_p.to_local().shape, dtype=cast_dtype, device=device
+                    )
+                    grads_send_list.append(dummy)
+                    send_shapes.append(dummy.shape)
+
+            # Pick a reference target if this rank owns none in this bucket
+            if target_shape is None:
+                ref_idx = end_idx - 1
+                target_shape = fsdp_params[ref_idx].shape
+                param_kwargs_me = self.groups_info[
+                    self.parameters_to_groups[id(fsdp_params[ref_idx])]
+                ][-1]
+
+            # Receive slices (one from each source) that together make the full grad for the owned param
+            recv_shapes = [
+                calculate_shard_shape(target_shape, r, world_size)
+                for r in range(world_size)
+            ]
+            recv_list_grads = [
+                torch.empty(s, dtype=cast_dtype, device=device) for s in recv_shapes
+            ]
+
+            # A2A: shards -> owners
+            dist.all_to_all(
+                recv_list_grads, grads_send_list, group=fsdp_group
+            )  # list API
+
+            full_g = torch.cat(recv_list_grads, dim=0)
+            u = self.lmo(full_g, **param_kwargs_me)
+
+            if dp_replicate_group and self.extra_reduce_for_HSDP:
+                dist.all_reduce(u, group=dp_replicate_group, op=dist.ReduceOp.AVG)
+
+            if not skip_update:
+                # Split owner’s update by destination rows and scatter back
+                split_rows = [s[0] for s in recv_shapes]
+                updates_send_list = list(torch.split(u, split_rows, dim=0))
+                recv_list_updates = [
+                    torch.empty(s, dtype=cast_dtype, device=device) for s in send_shapes
+                ]
+
+                # A2A: owners -> shards
+                dist.all_to_all(recv_list_updates, updates_send_list, group=fsdp_group)
+
+                # Materialise bucket’s updates into global list
+                for i in range(end_idx - start_idx):
+                    global_updates[start_idx + i] = recv_list_updates[i]
+
+            # optional logging of update norms
+            if need_to_calculate_norm:
+                my_param_in_bucket = (start_idx + rank) < end_idx
+                if my_param_in_bucket:
+                    p = fsdp_params[start_idx + rank]
+                    lr, *_ = self.groups_info[self.parameters_to_groups[id(p)]]
+                    upd_norms = calculate_norm(-lr * u, self.norms_to_log)
+                else:
+                    upd_norms = padding_norms
+                norms_of_update.extend(upd_norms.values())
+
+        # Single vectorised apply (as in your file)
+        if not skip_update:
+            self.update_bucket_params(
+                fsdp_params,
+                global_updates,
+                0,
+                len(fsdp_params),
+                tp_group=self.world_mesh["tp"].get_group() if self.tp_enabled else None,
+            )
+
+        # --- Calculate Weight Norms (POST-UPDATE) ---
+        if apply_on_weight:
+            for bucket_idx in range(total_buckets):
+                start_idx = bucket_idx * world_size
+                end_idx = min(start_idx + world_size, len(fsdp_params))
+                my_param_in_bucket = (start_idx + rank) < end_idx
+
+                # Determine target shape for reconstruction, even if this rank is padding
+                ref_p_idx = start_idx + rank if my_param_in_bucket else end_idx - 1
+                target_shape = fsdp_params[ref_p_idx].shape
+
+                params_send_list = []
+                for i in range(world_size):
+                    param_idx = start_idx + i
+                    p = fsdp_params[param_idx if param_idx < end_idx else end_idx - 1]
+
+                    original_placements = p.placements
+                    tp_mesh_dim = tp_axis(original_placements)
+                    if tp_group and tp_mesh_dim is not None:
+                        p_local = gather_tp_shard(
+                            p.to_local(), tp_group, tp_world_size, original_placements
+                        )
+                    else:
+                        p_local = p.to_local()
+                    params_send_list.append(p_local.to(dtype=cast_dtype))
+
+                recv_shapes = [
+                    calculate_shard_shape(target_shape, r, world_size)
+                    for r in range(world_size)
+                ]
+                recv_list_params = [
+                    torch.empty(s, dtype=cast_dtype, device=device) for s in recv_shapes
+                ]
+                dist.all_to_all(recv_list_params, params_send_list, group=fsdp_group)
+
+                full_weight = torch.cat(recv_list_params, dim=0)
+
+                w_norms = (
+                    calculate_norm(full_weight, self.norms_to_log)
+                    if my_param_in_bucket
+                    else padding_norms
+                )
+                norms_of_weight.extend(w_norms.values())
+
+        # --- Phase D: gather and log norms once ---
+
+        if need_to_calculate_norm and norms_of_update:
+            self._gather_and_log_fsdp_norms(
+                norms_of_update,
+                norms_of_weight,
+                fsdp_group,
+                rank,
+                device,
+                fsdp_param_names,
+                world_size,
+                total_buckets,
+                apply_on_weight,
+            )
+
+    @record_function("disco._prepare_gradients_and_momentum")
+    def prepare_gradients_and_momentum(self) -> None:
+        """
+        Fused pre-pass that updates momentum buffers for *all* parameters
+        with available grads:
+            buf <- (1 - m) * buf + m * g
+        It performs foreach-kernel updates per (device, dtype, momentum),
+        """
+        buckets = defaultdict(lambda: {"bufs": [], "grads": [], "m": 0.0})
+
+        for group in self.param_groups:
+            m = float(group["momentum"])
+            use_momentum = (not self.is_light) and (0.0 < m < 1.0)
+
+            if not use_momentum:
+                continue
+
+            for p in group["params"]:
+                g = getattr(p, "grad", None)
+                if g is None or not p.requires_grad:
+                    continue
+
+                # Initialize the momentum buffer if it's the first time.
+                state = self.state.setdefault(p, {})
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+
+                # Add the buffer and gradient to the appropriate bucket.
+                key = (g.dtype, m)
+                bucket = buckets[key]
+                bucket["bufs"].append(buf)
+                bucket["grads"].append(g)
+                bucket["m"] = m
+
+        # Launch the fused kernels for each bucket.
+        for (_, m), bucket_data in buckets.items():
+            if not bucket_data["bufs"]:
+                continue
+            # Perform the momentum update: buf = buf * (1 - m) + g * m
+            torch._foreach_mul_(bucket_data["bufs"], 1.0 - m)
+            torch._foreach_add_(bucket_data["bufs"], bucket_data["grads"], alpha=m)
+
+    @record_function("disco.get_momentum_or_grad")
+    def get_momentum_or_grad(self, p, momentum, nesterov, gather_to_local=False):
+        """
+        Retrieves the effective gradient for a parameter.
+        Assumes the momentum buffer has already been updated in a pre-pass.
+        """
+        g = p.grad
+        if g is None or not p.requires_grad:
+            return None
+
+        use_momentum = momentum > 0 and momentum < 1
+
+        if not self.is_light and use_momentum:
+            state = self.state.get(p, None)
+            if state is None or "momentum_buffer" not in state:
+                raise ValueError(
+                    "Momentum buffer missing; ensure pre-pass ran before calling get_momentum_or_grad."
+                )
+            # The buffer is already updated, so we just retrieve it.
+            buf = state["momentum_buffer"]
+            g = buf if not nesterov else buf.mul(1 - momentum).add(g, alpha=momentum)
+
+        if gather_to_local and isinstance(g, DTensor):
+            g = g.redistribute(placements=[Replicate()] * g.device_mesh.ndim).to_local()
+
+        return g
+
+    @record_function("disco.update_bucket_params")
+    def update_bucket_params(self, params, updates, start_idx, end_idx, tp_group=None):
+        slice_params = params[start_idx:end_idx]
+        slice_updates = updates[: (end_idx - start_idx)]
+        # already prepare a bucket of same length
+
+        prepared = []
+        if tp_group is not None:
+            tp_rank = tp_group.rank()
+            for p, u in zip(slice_params, slice_updates):
+                if u is None:
+                    prepared.append((p, None))
+                    continue
+                if isinstance(p, DTensor):
+                    p_local = p.to_local()
+                    placements = p.placements
+                    tp_mesh_dim = tp_axis(placements, tp_enabled=(u.shape == p.shape))
+                    if tp_mesh_dim is not None:
+                        shard_dim = placements[tp_mesh_dim].dim
+                        # Skip TP slicing if the update already matches the local shard.
+                        if u.shape != p_local.shape:
+                            chunk_size = p_local.shape[shard_dim]
+                            start = tp_rank * chunk_size
+                            slicer = [slice(None)] * u.dim()
+                            slicer[shard_dim] = slice(start, start + chunk_size)
+                            u = u[tuple(slicer)]
+                prepared.append((p, u))
+        else:
+            prepared = list(zip(slice_params, slice_updates))
+
+        # ------------- Phase 2: foreach buckets -------------
+        buckets = defaultdict(
+            lambda: {
+                "orig": [],
+                "locals": [],
+                "updates": [],
+                "lr": None,
+                "wd": None,
+                "m": None,
+            }
+        )
+
+        for p, u in prepared:
+            if u is None:
+                continue
+            lr, _, momentum, wd, _ = self.groups_info[self.parameters_to_groups[id(p)]]
+            p_local = p.to_local() if isinstance(p, DTensor) else p
+
+            # robust shape check after TP slicing; if it still fails, it’s a caller misalignment
+            if p_local.shape != u.shape:
+                raise ValueError(
+                    f"Shape mismatch between parameter shard {p_local.shape} and update slice {u.shape}. "
+                    f"Ensure you pass the same DDP/FSDP window and slice TP updates. "
+                )
+
+            # dtype/device consistency for foreach
+            if u.dtype is not p_local.dtype:
+                u = u.to(p_local.dtype)
+
+            key = (p_local.device, p_local.dtype, float(lr), float(wd), float(momentum))
+            b = buckets[key]
+            b["orig"].append(p)
+            b["locals"].append(p_local)
+            b["updates"].append(u)
+            b["lr"], b["wd"], b["m"] = lr, wd, momentum
+
+        for (_, _, lr, wd, m), data in buckets.items():
+            if not data["locals"]:
+                continue
+            if wd != 0.0:
+                torch._foreach_mul_(data["locals"], 1.0 - wd * lr)
+            torch._foreach_add_(data["locals"], data["updates"], alpha=-lr)
+
+            # light-mode grad decay retained for parity (won’t run; is_light is False in this optimizer)
+            if self.is_light and m != 1.0:
+                # group grads by device/dtype for foreach
+                gmap = defaultdict(list)
+                for p in data["orig"]:
+                    if p.grad is not None:
+                        g = p.grad.to_local() if isinstance(p.grad, DTensor) else p.grad
+                        gmap[(g.device, g.dtype)].append(g)
+                for _, gs in gmap.items():
+                    torch._foreach_mul_(gs, 1.0 - m)

--- a/torchtitan/experiments/distributed_scion/muon_utils.py
+++ b/torchtitan/experiments/distributed_scion/muon_utils.py
@@ -1,0 +1,300 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from itertools import repeat
+from typing import cast, List, Tuple
+
+import torch
+from torch import Tensor
+from torch.optim.optimizer import _device_dtype_check_for_fused, _get_scalar_dtype
+
+
+# def zeropower_via_svd(G, **kwargs):
+#     U, S, V = G.svd()
+#     X = U @ V.T
+#     return X
+
+
+def zeropower_via_svd(G, **kwargs):
+    original_dtype = G.dtype
+    is_2d = G.dim() == 2
+    if is_2d:
+        G = G.unsqueeze(0)  # batch of 1
+
+    assert G.dim() == 3, f"Expected 2D or 3D tensor, got {G.shape}"
+
+    G32 = G.to(torch.float32)  # SVD does not support bfloat16 reliably
+    rows, cols = G32.shape[-2], G32.shape[-1]
+    transposed = rows > cols
+    if transposed:
+        G32 = G32.transpose(-2, -1)
+
+    X_list = []
+    for b in range(G32.shape[0]):
+        U, S, V = G32[b].svd()  # per-matrix SVD (matches your API choice)
+        Xb = U @ V.t()  # orthogonal factor
+        X_list.append(Xb)
+
+    X = torch.stack(X_list, dim=0)
+
+    if transposed:
+        X = X.transpose(-2, -1)
+    if is_2d:
+        X = X.squeeze(0)
+
+    return X.to(original_dtype).contiguous()
+
+
+# Polar Express
+@torch.compile
+def zeropower_via_polar_express(G, steps=5, eps=1e-7):
+    # https://arxiv.org/abs/2505.16932
+    # Support 2D (unsqueezed to batch=1) and 3D inputs.
+    is_2d = G.dim() == 2
+    if is_2d:
+        G = G.unsqueeze(0)
+    assert (
+        G.dim() == 3
+    ), f"Please make sure gradients are 2D or 3D tensors, got shape: {G.shape}"
+
+    coeffs_base = [
+        (8.28721201814563, -23.595886519098837, 17.300387312530933),
+        (4.107059111542203, -2.9478499167379106, 0.5448431082926601),
+        (3.948690853482295, -2.908902115962949, 0.5518191394370137),
+        (3.318419657370602, -2.488488024314874, 0.51004894012372),
+        (2.300652019954817, -1.668903984574749, 0.4188073119525673),
+        (1.891301407787398, -1.267995827194587, 0.3768040894852483),
+        (1.875001480853448, -1.250001645399949, 0.3750001645474248),
+        (1.875000000000000, -1.250000000000000, 0.375000000000000),  # limit
+    ]
+
+    # apply the 1/1.01 stabiliser only to the first seven triples
+    coeffs_base = [
+        (a / 1.01, b / (1.01**3), c / (1.01**5)) for (a, b, c) in coeffs_base[:-1]
+    ] + [coeffs_base[-1]]
+    coeffs = coeffs_base + list(
+        repeat(coeffs_base[-1], max(0, steps - len(coeffs_base)))
+    )
+
+    original_dtype = G.dtype
+    X = G.bfloat16()
+
+    # Transpose whole batch if rows > cols (same rule as your 2D version).
+    rows, cols = X.shape[-2], X.shape[-1]
+    transposed = False
+    if rows > cols:
+        X = X.transpose(1, 2)
+        transposed = True
+
+    # Per-matrix normalisation; matches your scalar normalisation when batch=1.
+    norm = torch.linalg.norm(X, dim=(-2, -1), keepdim=True)
+    X = X / (norm * 1.01 + eps)  # ensure top singular value <= 1
+
+    # Main loop (batched matmuls).
+    for k in range(steps):
+        a, b, c = coeffs[k]
+        A = torch.bmm(X, X.transpose(1, 2))
+        B = b * A + c * torch.bmm(A, A)
+        X = a * X + torch.bmm(B, X)
+
+    if transposed:
+        X = X.transpose(1, 2)
+    if is_2d:
+        X = X.squeeze(0)
+
+    return X.to(original_dtype)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-7):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' \\sim Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+
+    assert (
+        len(G.shape) == 2 or len(G.shape) == 3
+    ), f"Please make sure gradients are 2D tensors to use NS, got shape: {G.shape}"
+
+    is_2d = len(G.shape) == 2
+    if is_2d:
+        G = G.unsqueeze(0)
+
+    assert (
+        len(G.shape) == 3
+    ), f"Please make sure gradients are 2D or 3D tensors, got shape: {G.shape}"
+
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    original_dtype = G.dtype
+    X = G.bfloat16()
+
+    # Determine if we need to transpose the matrices based on their dimensions
+    rows, cols = X.shape[-2], X.shape[-1]
+    transposed = False
+    if rows > cols:
+        transposed = True
+        X = X.transpose(1, 2)
+
+    # Normalize each matrix in the batch individually
+    norm = torch.linalg.norm(X, dim=(-2, -1), keepdim=True)
+    X = X / (norm + eps)  # ensure top singular value <= 1 for each matrix
+
+    # Perform the iteration using batched matrix multiplication (torch.bmm)
+    for _ in range(steps):
+        # A = X @ X.T for a batch
+        A = torch.bmm(X, X.transpose(1, 2))
+        # B = b*A + c*A@A for a batch
+        B = b * A + c * torch.bmm(A, A)
+        # X = a*X + B@X for a batch
+        X = a * X + torch.bmm(B, X)
+
+    # Transpose back if we did it at the beginning
+    if transposed:
+        X = X.transpose(1, 2)
+
+    # If the original input was a 2D tensor, squeeze the batch dimension out
+    if is_2d:
+        X = X.squeeze(0)
+
+    return X.to(original_dtype)
+
+
+zeropower_backends = dict(
+    svd=zeropower_via_svd,
+    newtonschulz5=zeropower_via_newtonschulz5,
+    polar_express=zeropower_via_polar_express,
+    identity=lambda x, **kwargs: x,
+)
+
+
+def _init_adamw_group(
+    self,
+    group,
+    params_with_grad,
+    grads,
+    amsgrad,
+    exp_avgs,
+    exp_avg_sqs,
+    max_exp_avg_sqs,
+    state_steps,
+):
+    has_complex = False
+    for p in group["params"]:
+        if p.grad is None and not self.state[p]["use_muon"]:
+            continue
+        has_complex |= torch.is_complex(p)
+        params_with_grad.append(p)
+        if p.grad.is_sparse:
+            raise RuntimeError("AdamW does not support sparse gradients")
+        grads.append(p.grad)
+
+        state = self.state[p]
+
+        # State initialization
+        if "exp_avg" not in state:
+            if group["adamw_fused"]:
+                _device_dtype_check_for_fused(p)
+            # note(crcrpar): Deliberately host `step` on CPU if both capturable and fused are off.
+            # This is because kernel launches are costly on CUDA and XLA.
+            state["step"] = (
+                torch.zeros(
+                    (),
+                    dtype=_get_scalar_dtype(is_fused=group["adamw_fused"]),
+                    device=p.device,
+                )
+                if group["adamw_capturable"] or group["adamw_fused"]
+                else torch.tensor(0.0, dtype=_get_scalar_dtype())
+            )
+            # Exponential moving average of gradient values
+            state["exp_avg"] = torch.zeros_like(p, memory_format=torch.preserve_format)
+            # Exponential moving average of squared gradient values
+            state["exp_avg_sq"] = torch.zeros_like(
+                p, memory_format=torch.preserve_format
+            )
+            if amsgrad:
+                # Maintains max of all exp. moving avg. of sq. grad. values
+                state["max_exp_avg_sq"] = torch.zeros_like(
+                    p, memory_format=torch.preserve_format
+                )
+
+        exp_avgs.append(state["exp_avg"])
+        exp_avg_sqs.append(state["exp_avg_sq"])
+
+        if group["adamw_amsgrad"]:
+            max_exp_avg_sqs.append(state["max_exp_avg_sq"])
+        if group["adamw_differentiable"] and state["step"].requires_grad:
+            raise RuntimeError(
+                "`requires_grad` is not supported for `step` in differentiable mode"
+            )
+
+        # Foreach without capturable does not support a tensor lr
+        if (
+            group["adamw_foreach"]
+            and isinstance(group["adamw_lr"], Tensor)
+            and not group["adamw_capturable"]
+        ):
+            raise RuntimeError(
+                "lr as a Tensor is not supported for capturable=False and foreach=True"
+            )
+
+        state_steps.append(state["step"])
+    return has_complex
+
+
+@torch.no_grad()
+def update_adamw(self):
+    """
+    Optimized AdamW implementation using PyTorch's _functional.adamw or foreach operations.
+    """
+    for group in self.param_groups:
+        params_with_grad: List[Tensor] = []
+        grads: List[Tensor] = []
+        exp_avgs: List[Tensor] = []
+        exp_avg_sqs: List[Tensor] = []
+        max_exp_avg_sqs: List[Tensor] = []
+        state_steps: List[Tensor] = []
+        amsgrad: bool = group["adamw_amsgrad"]
+        beta1, beta2 = cast(Tuple[float, float], group["adamw_betas"])
+
+        has_complex = _init_adamw_group(
+            self,
+            group,
+            params_with_grad,
+            grads,
+            amsgrad,
+            exp_avgs,
+            exp_avg_sqs,
+            max_exp_avg_sqs,
+            state_steps,
+        )
+
+        torch.optim._functional.adamw(
+            params_with_grad,
+            grads,
+            exp_avgs,
+            exp_avg_sqs,
+            max_exp_avg_sqs,
+            state_steps,
+            amsgrad=amsgrad,
+            beta1=beta1,
+            beta2=beta2,
+            lr=group["adamw_lr"],
+            weight_decay=group["adamw_weight_decay"],
+            eps=group["adamw_eps"],
+            maximize=group["adamw_maximize"],
+            foreach=group["adamw_foreach"],
+            capturable=group["adamw_capturable"],
+            differentiable=group["adamw_differentiable"],
+            fused=group["adamw_fused"],
+            grad_scale=getattr(self, "grad_scale", None),
+            found_inf=getattr(self, "found_inf", None),
+            has_complex=has_complex,
+        )

--- a/torchtitan/experiments/distributed_scion/norm_helper.py
+++ b/torchtitan/experiments/distributed_scion/norm_helper.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from torch.distributed.tensor import DTensor
+
+
+@torch.no_grad()
+def rms_to_rms_norm(W):
+    """
+    Note:
+        Be aware that ``fan_in`` and ``fan_out`` are calculated assuming
+        that the weight matrix is used in a transposed manner,
+        (i.e., ``x @ w.T`` in ``Linear`` layers, where ``w.shape = [fan_out, fan_in]``).
+        This is important for correct initialization.
+        If you plan to use ``x @ w``, where ``w.shape = [fan_in, fan_out]``,
+        pass in a transposed weight matrix, i.e. ``nn.init.xavier_uniform_(w.T, ...)``.
+    """
+    assert W.ndim == 2, "operator norm can only be applied to matrices"
+    norm = torch.linalg.norm(W.to(torch.float32), ord=2, dtype=torch.float32)
+    fan_out, fan_in = W.shape
+    scale = math.sqrt(fan_in / fan_out)
+    norm *= scale
+    return norm
+
+
+@torch.no_grad()
+def l1_to_rms_norm(W):
+    assert W.ndim == 2, "operator norm can only be applied to matrices"
+    norm = torch.max(
+        torch.linalg.norm(W.to(torch.float32), ord=2, dim=0, dtype=torch.float32)
+    )
+    scale = torch.sqrt(torch.tensor(W.shape[0], dtype=W.dtype, device=W.device))
+    norm /= scale
+    return norm
+
+
+@torch.no_grad()
+def rms_to_inf_norm(W):
+    assert W.ndim == 2, "operator norm can only be applied to matrices"
+    norm = torch.max(
+        torch.linalg.norm(W.to(torch.float32), ord=2, dim=1, dtype=torch.float32)
+    )
+    scale = torch.sqrt(torch.tensor(W.shape[1], dtype=W.dtype, device=W.device))
+    norm *= scale
+    return norm
+
+
+@torch.no_grad()
+def supremum_norm(x):
+    return x.abs().max()
+
+
+@torch.no_grad()
+def condition_number(W):
+    assert W.ndim == 2, "condition number calculation can only be applied to matrices"
+    S = _safe_svdvals(W.to(torch.float32))
+    return S[0] / S[-1]
+
+
+NORM_FUNCTIONS = {
+    "rms_to_rms": rms_to_rms_norm,
+    "l1_to_rms": l1_to_rms_norm,
+    "rms_to_inf": rms_to_inf_norm,
+    "supremum": supremum_norm,
+    "condition_number": condition_number,
+}
+
+
+@torch.no_grad()
+@torch.compile(dynamic=True)
+def fused_metrics(W, eps=1e-20):
+    if W.ndim < 2:
+        # Operator norms require a matrix.
+        return {"supremum": W.abs().max()}
+
+    Wf = W.float()
+    Wf_square = Wf * Wf
+    fan_out, fan_in = Wf.shape
+
+    sup = Wf.abs().amax()
+    rowsqsum = Wf_square.sum(1)
+    colsqsum = Wf_square.sum(0)
+
+    row_l2 = rowsqsum.sqrt()
+    col_l2 = colsqsum.sqrt()
+
+    l1_to_rms = col_l2.max() / math.sqrt(fan_out)
+    rms_to_inf = row_l2.max() * math.sqrt(fan_in)
+
+    S = torch.linalg.svdvals(Wf, driver="gesvd")
+
+    spec = S[0] * math.sqrt(fan_in / fan_out)
+
+    cond = S[0] / (S[-1] + eps)
+    cond = cond.clamp_min(eps)
+
+    return {
+        "rms_to_rms": spec,
+        "l1_to_rms": l1_to_rms,
+        "rms_to_inf": rms_to_inf,
+        "supremum": sup,
+        "condition_number": cond,
+    }
+
+
+def calculate_norm(
+    W: torch.Tensor,
+    norms_to_log: list[str] | None = None,
+    transpose: bool = False,
+    use_fused_metrics: bool = True,
+) -> dict[str, torch.Tensor]:
+    """
+    It is important to note that the order of the norms is the same
+    as the order of `norms_to_log`.
+
+    we expect the weights to be [D_out, D_in], otherwise, we need to set `transpose` to True
+    """
+    if norms_to_log is None:
+        norms_to_log = list(NORM_FUNCTIONS.keys())
+
+    W = W.to_local() if isinstance(W, DTensor) else W
+
+    if W.ndim == 1 and W.numel() > 1:
+        # we will expand the 1D tensor to a diagonal matrix
+        original_shape = W.shape
+        W = torch.diag_embed(W)
+
+    if transpose:
+        W = W.transpose(0, 1)
+    if use_fused_metrics:
+        norms = fused_metrics(W)
+        norms = {norm_name: norms[norm_name] for norm_name in norms_to_log}
+    else:
+        norms = {norm_name: NORM_FUNCTIONS[norm_name](W) for norm_name in norms_to_log}
+
+    return norms

--- a/torchtitan/experiments/distributed_scion/train_configs/debug_model.toml
+++ b/torchtitan/experiments/distributed_scion/train_configs/debug_model.toml
@@ -1,0 +1,107 @@
+[job]
+dump_folder = "./outputs"
+description = "DeepSeek-V3 debug training"
+print_config = false
+
+[profiling]
+enable_profiling = false
+save_traces_folder = "profile_trace"
+profile_freq = 10
+enable_memory_snapshot = false
+save_memory_snapshot_folder = "memory_snapshot"
+
+[metrics]
+log_freq = 1
+disable_color_printing = false
+enable_tensorboard = false
+save_tb_folder = "tb"
+enable_wandb = false
+
+[model]
+name = "deepseek_v3"
+flavor = "debugmodel"
+# test tokenizer, for debug purpose only
+hf_assets_path = "./tests/assets/tokenizer"
+# converters = ["float8"]
+
+[optimizer]
+name = "DistributedScion"
+beta1 = 0.0
+beta2 = 0.0
+implementation = "fused"
+early_step_in_backward = false
+lr = 0.1
+eps = 1e-20
+weight_decay = 0.0
+is_light = false
+norm_factor = "spectral"
+zeropower_backend = "newtonschulz5"
+backend_steps = 5
+momentum = 0.1
+nesterov = false
+
+[[optimizer.extra_param_group_split_rules]]
+lr = 0.1
+str_match = "tok_embeddings.weight"
+norm_factor = "embed_sqrt"
+backend = "identity"
+
+[[optimizer.extra_param_group_split_rules]]
+lr = 0.1
+str_match = "output.weight"
+norm_factor = "unembed_sqrt"
+backend = "identity"
+
+[[optimizer.extra_param_group_split_rules]]
+str_match = "\\.router.gate.weight"
+norm_factor = "spectral"
+
+
+[lr_scheduler]
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
+decay_type = "linear"
+min_lr_factor = 0.0
+
+[training]
+local_batch_size = 8
+seq_len = 2048
+max_norm = 0.0  # grad norm clipping
+steps = 10
+dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+fsdp_reshard_after_forward = "default" # default / never / always
+tensor_parallel_degree = 1
+enable_async_tensor_parallel = false
+pipeline_parallel_degree = 1
+pipeline_parallel_schedule = "1F1B"
+context_parallel_degree = 1
+expert_parallel_degree = 1
+expert_tensor_parallel_degree = 1
+
+[checkpoint]
+enable = false
+folder = "checkpoint"
+interval = 10
+last_save_model_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[quantize.linear.float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output", "router.gate"]
+
+[quantize.grouped_mm.float8]
+fqns = ["experts"]

--- a/torchtitan/experiments/distributed_scion/utils.py
+++ b/torchtitan/experiments/distributed_scion/utils.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from torchtitan.tools.logging import logger
+
+
+def remove_orig_mod_and_weight_for_p_name(name: str) -> str:
+    """
+    Remove "._orig_mod", ".weight", and "._checkpoint_wrapped_module" to
+    get the clean layer name.
+    """
+    name = re.sub(r"\._orig_mod", "", name)  # comes from compiled model
+    name = re.sub(r"\.weight", "", name)  # param.weight
+    name = re.sub(
+        r"\._checkpoint_wrapped_module", "", name
+    )  # comes from activation checkpointing
+    return name
+
+
+def create_disco_optimizer_kwargs_from_optimizer_config(
+    optimizer_config,
+    parallel_dims,
+) -> dict[str, Any]:
+    backend_steps = optimizer_config.backend_steps
+    zeropower_backend_algorithm = optimizer_config.zeropower_backend
+    momentum = optimizer_config.momentum
+    nesterov = optimizer_config.nesterov
+    is_light = optimizer_config.is_light
+    weight_decay = optimizer_config.weight_decay
+    lr = optimizer_config.lr
+    eps = optimizer_config.eps
+    norm_factor = optimizer_config.norm_factor
+
+    optimizer_kwargs = {
+        "parallel_dims": parallel_dims,
+        "is_light": is_light,
+        "weight_decay": weight_decay,
+        "lr": lr,
+        "momentum": momentum,
+        "nesterov": nesterov,
+        "eps": eps,
+        "norm_factor": norm_factor,
+        "backend": zeropower_backend_algorithm,
+        "backend_steps": backend_steps,
+    }
+
+    # Add extra_param_group_split_rules if present
+    if (
+        hasattr(optimizer_config, "extra_param_group_split_rules")
+        and optimizer_config.extra_param_group_split_rules
+    ):
+        optimizer_kwargs[
+            "extra_param_group_split_rules"
+        ] = optimizer_config.extra_param_group_split_rules
+
+    return optimizer_kwargs
+
+
+def create_disco_param_groups(
+    model: torch.nn.Module,
+    optimizer_kwargs: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """
+    Create and extract parameter groups for DiSCO optimizer.
+
+    This function combines parameter group configuration creation and parameter extraction:
+    1. Creates parameter group configurations from optimizer_kwargs
+    2. Extracts actual parameters from the model based on the configurations
+    3. Returns clean kwargs for the optimizer (without extra_param_group_split_rules)
+
+    This function supports a new parameter group configuration system where:
+    - Default values are taken from the top-level optimizer_kwargs
+    - Special parameter groups are defined in the 'extra_param_group_split_rules' list
+    - Each entry in extra_param_group_split_rules can override any default value
+
+    Example configuration:
+    ```python
+    optimizer_kwargs = {
+        "lr": 1e-3,
+        "weight_decay": 0.1,
+        "momentum": 0.9,
+        "norm_factor": "spectral",
+        "backend": "newtonschulz5",
+        "backend_steps": 5,
+        "extra_param_group_split_rules": [
+            {
+                "str_match": "embedding",
+                "lr": 1e-4,  # Override default lr
+                "norm_factor": "embed_sqrt"  # Override default norm_factor
+            },
+            {
+                "str_match": "router",
+                "lr": 5e-4,
+                "backend": "identity"  # Override default backend
+            }
+        ]
+    }
+    ```
+    Args:
+        model: The model to extract parameters from
+        optimizer_kwargs: Dictionary containing optimizer configuration
+
+    Returns:
+        Tuple of (parameter_groups, clean_kwargs) where:
+        - parameter_groups: List of parameter groups with actual parameters
+        - clean_kwargs: Clean kwargs for the optimizer (without extra_param_group_split_rules)
+    """
+    import functools
+    import re
+    from collections import OrderedDict
+
+    # Step 1: Create parameter group configurations
+    param_groups_config = []
+
+    # Get default configuration
+    default_config = {
+        "lr": optimizer_kwargs.get("lr"),
+        "weight_decay": optimizer_kwargs.get("weight_decay"),
+        "momentum": optimizer_kwargs.get("momentum"),
+        "nesterov": optimizer_kwargs.get("nesterov"),
+        "eps": optimizer_kwargs.get("eps"),
+        "norm_factor": optimizer_kwargs.get("norm_factor"),
+        "backend": optimizer_kwargs.get("backend"),
+        "backend_steps": optimizer_kwargs.get("backend_steps"),
+    }
+
+    # Process extra_param_group_split_rules if provided
+    extra_param_group_split_rules = optimizer_kwargs.get(
+        "extra_param_group_split_rules", []
+    )
+    for param_group in extra_param_group_split_rules:
+        # Start with default config and override with param_group specific values
+        group_config = default_config.copy()
+        group_config.update(param_group)
+
+        # Ensure str_match is present
+        if "str_match" not in group_config:
+            logger.warning(
+                "extra_param_group_split_rules entry missing 'str_match', skipping"
+            )
+            continue
+
+        # Rename str_match to param_str_match for compatibility
+        group_config["param_str_match"] = group_config.pop("str_match")
+
+        param_groups_config.append(group_config)
+
+    # Detect RMSNorm parameters and set requires_grad=False
+    for name, module in model.named_modules():
+        # Check if the module is an RMSNorm layer
+        if hasattr(module, "__class__") and (
+            "RMSNorm" in module.__class__.__name__
+            or "LayerNorm" in module.__class__.__name__
+        ):
+            for param_name, param in module.named_parameters():
+                param.requires_grad = False
+                logger.info(
+                    f"Setting requires_grad=False for LayerNorm/RMSNorm parameter: {name}.{param_name}"
+                )
+
+    # Step 2: Extract actual parameters from the model
+    param_dict = OrderedDict(
+        (n, p) for n, p in model.named_parameters() if p.requires_grad
+    )
+    params = []
+
+    for param_group_config in param_groups_config:
+        # Make a copy to avoid modifying the original
+        group_config = param_group_config.copy()
+        str_match = group_config.pop("param_str_match")
+        filter_fn = functools.partial(re.search, str_match)
+        param_names = [n for n in param_dict.keys() if filter_fn(n)]
+
+        group_params = {
+            "params": [param_dict.pop(n) for n in param_names],
+            "param_names": param_names,
+        }
+        assert len(group_params["params"]) == len(group_params["param_names"])
+
+        if len(param_names) == 0:
+            try:
+                rank = dist.get_rank() if dist.is_initialized() else 0
+            except Exception:
+                rank = 0
+            logger.warning(
+                f'Notice: No parameters found for `str_match` "{str_match}" on '
+                f"global rank {rank}"
+            )
+            continue
+        group_params.update(group_config)
+        params.append(group_params)
+
+    # Add remaining parameters as the default group
+    param_names = list(param_dict.keys())
+    if param_names:
+        default_group = {
+            "params": [param_dict.pop(n) for n in param_names],
+            "param_names": param_names,
+        }
+        # Add default configuration to the default group
+        default_group.update(default_config)
+        params.insert(0, default_group)
+
+    # Create clean kwargs for the optimizer (remove extra_param_group_split_rules)
+    clean_kwargs = optimizer_kwargs.copy()
+    clean_kwargs.pop("extra_param_group_split_rules", None)
+
+    return params, clean_kwargs


### PR DESCRIPTION
This is a distributed version of [Scion](https://arxiv.org/abs/2502.07529) or [Modular Norm](https://arxiv.org/abs/2405.14813), muon is considered to be a variant of this by using explicit AdamW for LLM's embedding/output.

Works:
- Embedding/head
- FSDP/DP/TP/EP/CP/PP parameters
- Bias 
- weight decay
- Conv 
- Automatically disable RMSNORM's grad
- raise error for EP with [shard(1)] 


Maybe need to check ETP? And it's not working for multiple shared_experts.


CC @janEbert @ofivite