### PR TITLE
Solving the validation hanging issue

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -18,6 +18,7 @@ from torchtitan.config import JobConfig
 from torchtitan.datasets.hf_datasets import build_hf_validation_dataloader
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.tools import utils
+from torchtitan.tools.logging import logger
 
 
 class BaseValidator:
@@ -67,6 +68,7 @@ class Validator(BaseValidator):
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,
             tokenizer=tokenizer,
+            infinite=self.job_config.validation.steps != -1,
         )
         self.validation_context = validation_context
         self.maybe_enable_amp = maybe_enable_amp
@@ -74,6 +76,11 @@ class Validator(BaseValidator):
         self.pp_schedule = pp_schedule
         self.pp_has_first_stage = pp_has_first_stage
         self.pp_has_last_stage = pp_has_last_stage
+
+        if self.job_config.validation.steps == -1:
+            logger.warning(
+                "Setting validation steps to -1 could cause hangs due to mismatch among ranks."
+            )
 
     @torch.no_grad()
     def validate(

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -729,7 +729,10 @@ class Validation:
     """Frequency of validation"""
 
     steps: int = -1
-    """Number of steps to take in the validation set, -1 means consuming all the data in the validation dataset"""
+    """
+    Number of steps to take in the validation set, -1 means consuming all the data in the validation dataset
+    WARNING: When setting to -1 there could be hangs due to mismatch among ranks
+    """
 
     def __post_init__(self):
         assert (

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -209,6 +209,7 @@ def build_hf_validation_dataloader(
     dp_rank: int,
     tokenizer: BaseTokenizer,
     job_config: JobConfig,
+    infinite: bool = False,
 ) -> ParallelAwareDataloader:
     """Build a validation data loader for HuggingFace datasets."""
     dataset_name = job_config.validation.dataset
@@ -223,7 +224,7 @@ def build_hf_validation_dataloader(
         seq_len=seq_len,
         dp_rank=dp_rank,
         dp_world_size=dp_world_size,
-        infinite=False,
+        infinite=infinite,
     )
 
     return ParallelAwareDataloader(

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -367,6 +367,7 @@ class FluxValidationDataset(FluxDataset):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         generate_timesteps: bool = True,
+        infinite: bool = False,
     ) -> None:
         # Call parent constructor correctly
         super().__init__(
@@ -377,7 +378,7 @@ class FluxValidationDataset(FluxDataset):
             job_config=job_config,
             dp_rank=dp_rank,
             dp_world_size=dp_world_size,
-            infinite=False,
+            infinite=infinite,
         )
 
         # Initialize timestep generation for validation
@@ -406,6 +407,7 @@ def build_flux_validation_dataloader(
     # This parameter is not used, keep it for compatibility
     tokenizer: BaseTokenizer | None,
     generate_timestamps: bool = True,
+    infinite: bool = False,
 ) -> ParallelAwareDataloader:
     """Build a data loader for HuggingFace datasets."""
     dataset_name = job_config.validation.dataset
@@ -423,6 +425,7 @@ def build_flux_validation_dataloader(
         dp_rank=dp_rank,
         dp_world_size=dp_world_size,
         generate_timesteps=generate_timestamps,
+        infinite=infinite,
     )
 
     return ParallelAwareDataloader(

--- a/torchtitan/experiments/flux/train_configs/debug_model.toml
+++ b/torchtitan/experiments/flux/train_configs/debug_model.toml
@@ -69,7 +69,7 @@ enable = false
 dataset = "coco-validation"
 freq = 5
 local_batch_size = 8
-steps = 1
+steps = 48  # Recommended value with the current settings and world_size=8
 # args for sampling images
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0

--- a/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_dev_model.toml
@@ -67,7 +67,7 @@ async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 enable = false
 dataset = "coco-validation"
 local_batch_size = 32
-steps = 1
+steps = 12  # Recommended value with the current settings and world_size=8
 freq = 1000
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0

--- a/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
+++ b/torchtitan/experiments/flux/train_configs/flux_schnell_model.toml
@@ -68,6 +68,7 @@ async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 enable = false
 dataset = "coco-validation"
 local_batch_size=64
+steps = 6   # Recommended value with the current settings and world_size=8
 freq = 1000
 enable_classifier_free_guidance = true
 classifier_free_guidance_scale = 5.0

--- a/torchtitan/experiments/flux/validate.py
+++ b/torchtitan/experiments/flux/validate.py
@@ -32,6 +32,7 @@ from torchtitan.experiments.flux.utils import (
     preprocess_data,
     unpack_latents,
 )
+from torchtitan.tools.logging import logger
 
 
 class FluxValidator(Validator):
@@ -72,11 +73,17 @@ class FluxValidator(Validator):
             dp_rank=dp_rank,
             tokenizer=tokenizer,
             generate_timestamps=not self.all_timesteps,
+            infinite=self.job_config.validation.steps != -1,
         )
         self.validation_context = validation_context
         self.maybe_enable_amp = maybe_enable_amp
         self.metrics_processor = metrics_processor
         self.t5_tokenizer, self.clip_tokenizer = build_flux_tokenizer(self.job_config)
+
+        if self.job_config.validation.steps == -1:
+            logger.warning(
+                "Setting validation steps to -1 could cause hangs due to mismatch among ranks."
+            )
 
     def flux_init(
         self,

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -68,6 +68,4 @@ filter_fqns = ["output"]
 enabled = false
 dataset = "c4_validation"
 freq = 500
-# Set steps to -1 to consume all the data in the dataset
-# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
 steps = 1200  # Recommend value for c4_validation with world-size = 8

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -68,4 +68,4 @@ filter_fqns = ["output"]
 enable = false
 dataset = "c4_validation"
 freq = 500
-steps = 1200  # Recommend value for c4_validation with world-size = 8
+steps = 1200  # Recommend value for c4_validation with world-size=8 and seq_len=8192

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -68,4 +68,6 @@ filter_fqns = ["output"]
 enabled = false
 dataset = "c4_validation"
 freq = 500
-steps = -1
+# Set steps to -1 to consume all the data in the dataset
+# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
+steps = 1200  # Recommend value for c4_validation with world-size = 8

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -67,4 +67,4 @@ filter_fqns = ["output"]
 enable = false
 dataset = "c4_validation"
 freq = 500
-steps = 1200 # Recommend value for c4_validation with world-size = 8
+steps = 1200 # Recommend value for c4_validation with world-size=8 and seq_len=8192

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -67,6 +67,4 @@ filter_fqns = ["output"]
 enabled = false
 dataset = "c4_validation"
 freq = 500
-# Set steps to -1 to consume all the data in the dataset
-# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
 steps = 1200 # Recommend value for c4_validation with world-size = 8

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -67,4 +67,6 @@ filter_fqns = ["output"]
 enabled = false
 dataset = "c4_validation"
 freq = 500
-steps = -1
+# Set steps to -1 to consume all the data in the dataset
+# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
+steps = 1200 # Recommend value for c4_validation with world-size = 8

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -67,7 +67,5 @@ filter_fqns = ["output"]
 [validation]
 enabled = true
 dataset = "c4_validation"
-freq = 1
-# Set steps to -1 to consume all the data in the dataset
-# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
+freq = 500
 steps = 1200 # Recommend value for c4_validation with world-size = 8

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -68,4 +68,4 @@ filter_fqns = ["output"]
 enable = false
 dataset = "c4_validation"
 freq = 500
-steps = 1200 # Recommend value for c4_validation with world-size = 8
+steps = 1200 # Recommend value for c4_validation with world-size=8 and seq_len=8192

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -65,7 +65,9 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
+enabled = true
 dataset = "c4_validation"
-freq = 100
-steps = -1
+freq = 1
+# Set steps to -1 to consume all the data in the dataset
+# WARNING: When setting to -1 there could be hangs due to mismatch among ranks
+steps = 1200 # Recommend value for c4_validation with world-size = 8


### PR DESCRIPTION
As the [discussion](https://github.com/pytorch/torchtitan/issues/1618#issuecomment-3215472411), I added:
- warning message when the validation `steps`=-1 in both comment and logger
- change the default `steps` to reasonable values with the common setup (world size = 8).  
- Add infinite loop support for validator to avoid hang when `steps` is large enough to exhaust the dataset.
- Add the same fix for flux.


## Test
- 8 GPUs with `steps=-1`: hang around step 1270
- 8 GPUs with `steps=1200`: good
- 8 GPUs with `steps=1500`: `infinite` automatically set to true. Exhaust the dataset and re-iterate, but won't hang
- Flux: `steps=-1` doesn't hang
- Flux: `steps=60` doesn't hang; re-loop the dataset.

Full thread: https://github.com/pytorch/torchtitan/issues/1618

cc @ebsmothers @tianyu-l 