### PR TITLE
add train file specification option to run_start.sh

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -13,6 +13,7 @@ set -ex
 NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
 CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/models/llama3/train_configs/debug_model.toml"}
+TRAIN_FILE=${TRAIN_FILE:-"torchtitan.train"}
 
 TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE:-"http://localhost:29510"}
 
@@ -20,4 +21,4 @@ PYTORCH_ALLOC_CONF="expandable_segments:True" \
 TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
--m torchtitan.train --job.config_file ${CONFIG_FILE} "$@"
+-m ${TRAIN_FILE} --job.config_file ${CONFIG_FILE} "$@"


### PR DESCRIPTION
Summary:
The diff adds the option to specify a different trainer file to run_train.sh in training runs while keeping the default as the previously specifies torchtitan.train when not specified.

OLD command (still works):

'''bash
CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" ./run_train.sh
'''

COMMAND with train file specification:

'''bash
CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" TRAIN_FILE="torchtitan.train" ./run_train.sh
'''

Differential Revision: D81246223


