### PR TITLE
Add CODEOWNERS for experiments/forge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,6 @@
 
 # Exclude the experiments directory by adding a pattern without owners
 /torchtitan/experiments/
+
+# codeowners for experiments/forge
+/torchtitan/experiments/forge/* @ebsmothers @pbontrager @joecummings @tianyu-l @wwwjn


### PR DESCRIPTION
As titled.  Adding folks as code owner for forge folder.

After the change
1. When there's PR to forge folder, code owners users will get auto tagged.
2. At least one of all the Forge code owners need to approve the PR. 

cc @pbontrager @ebsmothers  @joecummings  @tianyu-l 