### PR TITLE
fix small typo in type hint

### DIFF
--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -190,7 +190,7 @@ class ParallelDims:
         return mesh
 
     @property
-    def world_mesh(self) -> str:
+    def world_mesh(self) -> DeviceMesh:
         # doing late init so ParallelDims can still be used as a lightweight
         # dataclass without having to initialize the world mesh
         if self._world_mesh is None:


### PR DESCRIPTION
Big fan of torchtitan! Wasnt sure if you guys merged small type hint fixes. No worries if not.

This was just annoying for me in VSCode because I couldnt get it to autocomplete DeviceMesh attributes without the proper type hint