### PR TITLE
 Fake balanced routing in MoE

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -239,6 +239,9 @@ class Training:
     deterministic: bool = False
     """Use deterministic algorithms wherever possible, may be slower"""
 
+    debug_moe_force_load_balance: bool = False
+    """If True, we force each experts to get the same amount of tokens via round-robin. This option is for debugging usage only."""
+
 
 @dataclass
 class Parallelism:

--- a/torchtitan/experiments/llama4/model/args.py
+++ b/torchtitan/experiments/llama4/model/args.py
@@ -72,6 +72,10 @@ class TransformerModelArgs(BaseModelArgs):
                 "CP support for FlexAttention is still in progress."
             )
 
+        self.moe_args._debug_force_load_balance = (
+            job_config.training.debug_moe_force_load_balance
+        )
+
     def get_nparams_and_flops(
         self, model: nn.Module, seq_len: int
     ) -> tuple[int, float]:

--- a/torchtitan/experiments/qwen3/model/args.py
+++ b/torchtitan/experiments/qwen3/model/args.py
@@ -55,6 +55,10 @@ class Qwen3ModelArgs(BaseModelArgs):
             )
         self.max_seq_len = seq_len
 
+        self.moe_args._debug_force_load_balance = (
+            job_config.training.debug_moe_force_load_balance
+        )
+
     def get_nparams_and_flops(
         self, model: nn.Module, seq_len: int
     ) -> tuple[int, float]:

--- a/torchtitan/models/deepseek_v3/model/args.py
+++ b/torchtitan/models/deepseek_v3/model/args.py
@@ -106,6 +106,10 @@ class DeepSeekV3ModelArgs(BaseModelArgs):
                 "CP support for FlexAttention is still in progress."
             )
 
+        self.moe_args._debug_force_load_balance = (
+            job_config.training.debug_moe_force_load_balance
+        )
+
     def get_nparams_and_flops(
         self, model: nn.Module, seq_len: int
     ) -> tuple[int, float]:


### PR DESCRIPTION
we can set `DEBUG_FORCE_LOAD_BALANCED=1` to force each experts get same amount of tokens. 

reprodue: `DEBUG_FORCE_LOAD_BALANCED=1 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/debug_model.toml" NGPU=4 ./run_train.sh --compile.enable`

here is test on 8layers, 8 activate and 64 total experts.  Green one is vanilla one and purple one is with force load balance
<img width="2672" height="1222" alt="image" src="https://github.com/user-attachments/assets/fa2cdec5-d266-4949-86ef-e86afeaac2c1" />

<img width="2712" height="1324" alt="image" src="https://github.com/user-attachments/assets/f013098f-7538-4870-b2f4-7ac0e93a9706" />

