### PR TITLE
Make SAC save_list configurable

### DIFF
--- a/tests/unit_tests/test_activation_checkpoint.py
+++ b/tests/unit_tests/test_activation_checkpoint.py
@@ -81,7 +81,11 @@ class TestApplyAC(unittest.TestCase):
             early_stop=False,
         )
         apply_ac(
-            model_selective_ac, ac_config_no_force, False, False, save_list=_save_list
+            model_selective_ac,
+            ac_config_no_force,
+            model_compile_enabled=False,
+            use_flex_attn=False,
+            save_list=_save_list,
         )
         flops_selective_ac = get_bw_flops(model_selective_ac)
 
@@ -97,8 +101,8 @@ class TestApplyAC(unittest.TestCase):
         apply_ac(
             model_with_force_first,
             ac_config_with_force_first,
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
         flops_with_force_first = get_bw_flops(model_with_force_first)
@@ -114,8 +118,8 @@ class TestApplyAC(unittest.TestCase):
         apply_ac(
             model_with_force_last,
             ac_config_with_force_last,
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
         flops_with_force_last = get_bw_flops(model_with_force_last)
@@ -127,7 +131,11 @@ class TestApplyAC(unittest.TestCase):
             early_stop=False,
         )
         apply_ac(
-            model_with_full_ac, ac_config_full_ac, False, False, save_list=_save_list
+            model_with_full_ac,
+            ac_config_full_ac,
+            model_compile_enabled=False,
+            use_flex_attn=False,
+            save_list=_save_list,
         )
         flops_full_ac = get_bw_flops(model_with_full_ac)
 
@@ -166,7 +174,11 @@ class TestApplyAC(unittest.TestCase):
             per_op_sac_force_recompute_mm_shapes_by_fqns=[],  # Empty list
         )
         apply_ac(
-            model_selective_ac, ac_config_no_force, False, False, save_list=_save_list
+            model_selective_ac,
+            ac_config_no_force,
+            model_compile_enabled=False,
+            use_flex_attn=False,
+            save_list=_save_list,
         )
         mem_selective_ac = get_act_mem(model_selective_ac)
 
@@ -181,8 +193,8 @@ class TestApplyAC(unittest.TestCase):
         apply_ac(
             model_with_force_first,
             ac_config_with_force_first,
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
         mem_with_force_first = get_act_mem(model_with_force_first)
@@ -197,8 +209,8 @@ class TestApplyAC(unittest.TestCase):
         apply_ac(
             model_with_force_last,
             ac_config_with_force_last,
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
         mem_with_force_last = get_act_mem(model_with_force_last)
@@ -209,7 +221,11 @@ class TestApplyAC(unittest.TestCase):
             mode="full",
         )
         apply_ac(
-            model_with_full_ac, ac_config_full_ac, False, False, save_list=_save_list
+            model_with_full_ac,
+            ac_config_full_ac,
+            model_compile_enabled=False,
+            use_flex_attn=False,
+            save_list=_save_list,
         )
         mem_full_ac = get_act_mem(model_with_full_ac)
 
@@ -234,8 +250,8 @@ class TestApplyAC(unittest.TestCase):
                 selective_ac_option="op",
                 per_op_sac_force_recompute_mm_shapes_by_fqns=[],
             ),
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
         model_force_first = ToyModule()
@@ -247,8 +263,8 @@ class TestApplyAC(unittest.TestCase):
                 selective_ac_option="op",
                 per_op_sac_force_recompute_mm_shapes_by_fqns=["moe.router.gate"],
             ),
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
 
@@ -261,8 +277,8 @@ class TestApplyAC(unittest.TestCase):
                 selective_ac_option="op",
                 per_op_sac_force_recompute_mm_shapes_by_fqns=["output"],
             ),
-            False,
-            False,
+            model_compile_enabled=False,
+            use_flex_attn=False,
             save_list=_save_list,
         )
 

--- a/tests/unit_tests/test_activation_checkpoint.py
+++ b/tests/unit_tests/test_activation_checkpoint.py
@@ -14,6 +14,20 @@ from torchtitan.config.job_config import ActivationCheckpoint as ACConfig
 from torchtitan.distributed.activation_checkpoint import apply_ac
 
 
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
+
+
 class ToyModule(nn.Module):
     def __init__(self):
         super().__init__()
@@ -66,7 +80,9 @@ class TestApplyAC(unittest.TestCase):
             per_op_sac_force_recompute_mm_shapes_by_fqns=[],  # Empty list
             early_stop=False,
         )
-        apply_ac(model_selective_ac, ac_config_no_force, False, False)
+        apply_ac(
+            model_selective_ac, ac_config_no_force, False, False, save_list=_save_list
+        )
         flops_selective_ac = get_bw_flops(model_selective_ac)
 
         # 3. Per-op SAC with force recompute "moe.router.gate"
@@ -78,7 +94,13 @@ class TestApplyAC(unittest.TestCase):
             per_op_sac_force_recompute_mm_shapes_by_fqns=["moe.router.gate"],
             early_stop=False,
         )
-        apply_ac(model_with_force_first, ac_config_with_force_first, False, False)
+        apply_ac(
+            model_with_force_first,
+            ac_config_with_force_first,
+            False,
+            False,
+            save_list=_save_list,
+        )
         flops_with_force_first = get_bw_flops(model_with_force_first)
 
         # 4. Per-op SAC with force recompute "output"
@@ -89,7 +111,13 @@ class TestApplyAC(unittest.TestCase):
             per_op_sac_force_recompute_mm_shapes_by_fqns=["output"],
             early_stop=False,
         )
-        apply_ac(model_with_force_last, ac_config_with_force_last, False, False)
+        apply_ac(
+            model_with_force_last,
+            ac_config_with_force_last,
+            False,
+            False,
+            save_list=_save_list,
+        )
         flops_with_force_last = get_bw_flops(model_with_force_last)
 
         # 5. Full AC
@@ -98,7 +126,9 @@ class TestApplyAC(unittest.TestCase):
             mode="full",
             early_stop=False,
         )
-        apply_ac(model_with_full_ac, ac_config_full_ac, False, False)
+        apply_ac(
+            model_with_full_ac, ac_config_full_ac, False, False, save_list=_save_list
+        )
         flops_full_ac = get_bw_flops(model_with_full_ac)
 
         self.assertEqual(flops_no_ac, 8.0)
@@ -135,7 +165,9 @@ class TestApplyAC(unittest.TestCase):
             selective_ac_option="op",
             per_op_sac_force_recompute_mm_shapes_by_fqns=[],  # Empty list
         )
-        apply_ac(model_selective_ac, ac_config_no_force, False, False)
+        apply_ac(
+            model_selective_ac, ac_config_no_force, False, False, save_list=_save_list
+        )
         mem_selective_ac = get_act_mem(model_selective_ac)
 
         # 3. Per-op SAC with force recompute "moe.router.gate"
@@ -146,7 +178,13 @@ class TestApplyAC(unittest.TestCase):
             selective_ac_option="op",
             per_op_sac_force_recompute_mm_shapes_by_fqns=["moe.router.gate"],
         )
-        apply_ac(model_with_force_first, ac_config_with_force_first, False, False)
+        apply_ac(
+            model_with_force_first,
+            ac_config_with_force_first,
+            False,
+            False,
+            save_list=_save_list,
+        )
         mem_with_force_first = get_act_mem(model_with_force_first)
 
         # 4. Per-op SAC with force recompute "output"
@@ -156,7 +194,13 @@ class TestApplyAC(unittest.TestCase):
             selective_ac_option="op",
             per_op_sac_force_recompute_mm_shapes_by_fqns=["output"],
         )
-        apply_ac(model_with_force_last, ac_config_with_force_last, False, False)
+        apply_ac(
+            model_with_force_last,
+            ac_config_with_force_last,
+            False,
+            False,
+            save_list=_save_list,
+        )
         mem_with_force_last = get_act_mem(model_with_force_last)
 
         # 5. Full AC
@@ -164,7 +208,9 @@ class TestApplyAC(unittest.TestCase):
         ac_config_full_ac = ACConfig(
             mode="full",
         )
-        apply_ac(model_with_full_ac, ac_config_full_ac, False, False)
+        apply_ac(
+            model_with_full_ac, ac_config_full_ac, False, False, save_list=_save_list
+        )
         mem_full_ac = get_act_mem(model_with_full_ac)
 
         self.assertEqual(mem_no_ac, 2.0)
@@ -190,6 +236,7 @@ class TestApplyAC(unittest.TestCase):
             ),
             False,
             False,
+            save_list=_save_list,
         )
         model_force_first = ToyModule()
         model_force_first.load_state_dict(model_no_ac.state_dict())
@@ -202,6 +249,7 @@ class TestApplyAC(unittest.TestCase):
             ),
             False,
             False,
+            save_list=_save_list,
         )
 
         model_force_last = ToyModule()
@@ -215,6 +263,7 @@ class TestApplyAC(unittest.TestCase):
             ),
             False,
             False,
+            save_list=_save_list,
         )
 
         def run_fwd_bwd(model, batch):

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -120,8 +120,9 @@ def _apply_ac_to_transformer_block(
 def apply_ac(
     model: nn.Module,
     ac_config: ACConfig,
-    model_compile_enabled: bool,
-    use_flex_attn: bool,
+    *,
+    model_compile_enabled: bool = False,
+    use_flex_attn: bool = False,
     save_list: set[torch._ops.OpOverload] | None = None,
 ) -> None:
     """Apply activation checkpointing to the model.

--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -33,6 +33,20 @@ from torchtitan.models.llama3.infra.parallelize import apply_ddp
 from torchtitan.tools.logging import logger
 
 
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
+
+
 def parallelize_llama(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -104,6 +118,7 @@ def parallelize_llama(
             job_config.activation_checkpoint,
             model_compile_enabled,
             use_flex_attn,
+            save_list=_save_list,
         )
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP

--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -116,8 +116,8 @@ def parallelize_llama(
         apply_ac(
             model,
             job_config.activation_checkpoint,
-            model_compile_enabled,
-            use_flex_attn,
+            model_compile_enabled=model_compile_enabled,
+            use_flex_attn=use_flex_attn,
             save_list=_save_list,
         )
 

--- a/torchtitan/experiments/qwen3/infra/parallelize.py
+++ b/torchtitan/experiments/qwen3/infra/parallelize.py
@@ -32,6 +32,20 @@ from torchtitan.models.llama3.infra.parallelize import (
 from torchtitan.tools.logging import logger
 
 
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
+
+
 def parallelize_qwen3(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -85,6 +99,7 @@ def parallelize_qwen3(
             job_config.activation_checkpoint,
             model_compile_enabled,
             use_flex_attn,
+            save_list=_save_list,
         )
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP

--- a/torchtitan/experiments/qwen3/infra/parallelize.py
+++ b/torchtitan/experiments/qwen3/infra/parallelize.py
@@ -97,8 +97,8 @@ def parallelize_qwen3(
         apply_ac(
             model,
             job_config.activation_checkpoint,
-            model_compile_enabled,
-            use_flex_attn,
+            model_compile_enabled=model_compile_enabled,
+            use_flex_attn=use_flex_attn,
             save_list=_save_list,
         )
 

--- a/torchtitan/experiments/simple_fsdp/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize.py
@@ -17,6 +17,20 @@ from torchtitan.tools.logging import logger
 from .simple_fsdp import data_parallel, MixedPrecisionPolicy
 
 
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
+
+
 def parallelize_llama(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -70,6 +84,7 @@ def parallelize_llama(
             job_config.activation_checkpoint,
             model_compile_enabled,
             use_flex_attn,
+            save_list=_save_list,
         )
 
     # apply data parallel

--- a/torchtitan/experiments/simple_fsdp/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize.py
@@ -82,8 +82,8 @@ def parallelize_llama(
         apply_ac(
             model,
             job_config.activation_checkpoint,
-            model_compile_enabled,
-            use_flex_attn,
+            model_compile_enabled=model_compile_enabled,
+            use_flex_attn=use_flex_attn,
             save_list=_save_list,
         )
 

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -110,8 +110,8 @@ def parallelize_deepseekv3(
         apply_ac(
             model,
             job_config.activation_checkpoint,
-            model_compile_enabled,
-            use_flex_attn,
+            model_compile_enabled=model_compile_enabled,
+            use_flex_attn=use_flex_attn,
             save_list=_save_list,
         )
 

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard
@@ -27,6 +28,20 @@ from torchtitan.experiments.llama4.infra.parallelize import (
 )
 from torchtitan.models.llama3.infra.parallelize import apply_ddp
 from torchtitan.tools.logging import logger
+
+
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
 
 
 # Adapted from llama4/infra/parallelize.py
@@ -97,6 +112,7 @@ def parallelize_deepseekv3(
             job_config.activation_checkpoint,
             model_compile_enabled,
             use_flex_attn,
+            save_list=_save_list,
         )
 
     if model_compile_enabled:

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -98,8 +98,8 @@ def parallelize_llama(
         apply_ac(
             model,
             job_config.activation_checkpoint,
-            model_compile_enabled,
-            use_flex_attn,
+            model_compile_enabled=model_compile_enabled,
+            use_flex_attn=use_flex_attn,
             save_list=_save_list,
         )
 

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -29,6 +29,20 @@ from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.tools.logging import logger
 
 
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+}
+
+
 def parallelize_llama(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -86,6 +100,7 @@ def parallelize_llama(
             job_config.activation_checkpoint,
             model_compile_enabled,
             use_flex_attn,
+            save_list=_save_list,
         )
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP


### PR DESCRIPTION
This PR refactors the `apply_ac` implementation by moving `save_list` out of `activation_checkpoint.py` and making it an argument of `apply_ac()`. This change improves configurability without altering the behavior of any models, as the set of operations saved remains unchanged after this PR.