### PR TITLE
logging: clear root handlers to prevent duplicate logs and use stdout for StreamHandler

### DIFF
--- a/torchtitan/tools/logging.py
+++ b/torchtitan/tools/logging.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import sys
 
 
 logger = logging.getLogger()
@@ -14,7 +15,7 @@ logger = logging.getLogger()
 def init_logger():
     logger.setLevel(logging.INFO)
     logger.handlers.clear()
-    ch = logging.StreamHandler()
+    ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
     formatter = logging.Formatter(
         "[titan] %(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/torchtitan/tools/logging.py
+++ b/torchtitan/tools/logging.py
@@ -13,6 +13,7 @@ logger = logging.getLogger()
 
 def init_logger():
     logger.setLevel(logging.INFO)
+    logger.handlers.clear()
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
     formatter = logging.Formatter(


### PR DESCRIPTION
When init_logger() runs after another component has already configured logging (e.g., torchrun/torchelastic or a library calling basicConfig), the root logger may already have handlers. Adding our StreamHandler on top causes duplicate log lines.

The changes:
- Clears existing handlers on the root logger before adding ours
- Sends logs to stdout (default StreamHandler is stderr)