### PR TITLE
fix: moe load balancing pp edge cases

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -11,9 +11,9 @@ import torch
 import torch.nn as nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl
 from torch.distributed.checkpoint.state_dict import (
-    StateDictOptions,
     get_optimizer_state_dict,
     set_optimizer_state_dict,
+    StateDictOptions,
 )
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.optim import Optimizer


### PR DESCRIPTION
The current moe load balancing logic can fail in the edge case where the model has a mix of `MoE` and `FeedForward`, pipeline parallelism is being used, and some PP ranks only own `FeedForward` layers.  In that case, `tokens_per_expert_list` is an empty list and the following call fails

https://github.com/pytorch/torchtitan/blob/99c0cb28f615d99290273afa1da01fd72f01f1a5/torchtitan/components/optimizer.py?plain=1#L372

Deepseek v3 style models with `n_dense_layers > 0` can hit this type of issue, for instance.

This PR handles this edge case by skipping the load balancing logic when `tokens_per_expert_list` is empty.  Tested locally for a two-layer model with one `MoE` and one `FeedForward` instance and `pp_degree==2`.  

Relates to #1593. CC @rakkit @tianyu-l 