### PR TITLE
feat: Add `experiments/blendcorpus/*`

### DIFF
--- a/torchtitan/experiments/blendcorpus/README.md
+++ b/torchtitan/experiments/blendcorpus/README.md
@@ -1,0 +1,229 @@
+# BlendCorpus Integration with TorchTitan
+
+This document summarizes all code and configuration changes introduced to train on BlendCorpus with TorchTitan, including tokenizer support, dataloader integration, trainer hooks, and configuration schema additions.
+
+⸻
+
+## 1) Tokenizer Support
+
+### 1.1 Added SentencePiece tokenizer adapter
+
+**File**: ``torchtitan/experiments/blendcorpus/dataset/sptoken.py``
+
+**What**: New SPTokenizer wrapper around sentencepiece.SentencePieceProcessor.
+
+**Key features**:
+* Attributes mirroring Titan’s expectations:
+* n_words (alias of SP vocab size), vocab_size
+* bos_id, eos_id, pad_id, unk_id (−1 if absent)
+* API compatible with Titan loaders:
+    ```python
+    ids = tokenizer.encode(text, bos=True, eos=True)
+    text = tokenizer.decode(ids)
+    ```
+
+### 1.2 Added tokenizer router
+
+**File**: ``torchtitan/experiments/blendcorpus/dataset/build_tokenizer.py``
+
+**What changed**:
+* build_tokenizer(job_config) now returns a tokenizer instance, not a function.
+* Accepts common aliases:
+    - SentencePiece: "sptoken"
+    - HuggingFace: "hf"
+
+```python
+from torchtitan.experiments.blendcorpus.dataset.sptoken import build_sentencepiece_tokenizer
+from torchtitan.components.tokenizer import build_hf_tokenizer
+
+def build_tokenizer(job_config):
+    backend = str(getattr(job_config.model, 'tokenizer_backend', '')).strip().lower()
+    if backend in {'', 'sptoken', 'sentencepiece', 'sp', 'spm'}:
+        print('[Tokenizer] Using backend: sptoken (SentencePiece)')
+        return build_sentencepiece_tokenizer(job_config)
+    if backend in {'huggingface', 'hf'}:
+        print('[Tokenizer] Using backend: huggingface (HF AutoTokenizer)')
+        return build_hf_tokenizer(job_config)
+    if backend == 'tiktoken':
+        raise NotImplementedError("tokenizer_backend='tiktoken' is not supported for this training recipe; use 'sptoken'.")
+    raise Exception(f"Unknown tokenizer_backend '{backend}'. Choose 'sptoken' or 'hf'.")
+```
+
+In configuration manager, we extended the following option: 
+```python
+@dataclass
+class Model:
+    tokenizer_backend: str = "sptoken"
+```
+
+## 2) Dataloader Integration for BlendCorpus
+
+### 2.1 New external adapter
+
+**File**: ``torchtitan_ext/datasets/blendcorpus_builder.py`` (new)
+**What**: Bridges BlendCorpus datasets to Titan’s expected batch format.
+
+**Responsibilities**:
+* Build train/valid/test datasets from a file list (one shard path per line) or directory.
+* Collate batches to Titan’s required structure:
+* Return a tuple (input_dict, labels), where
+   - input_dict["input_ids"] is LongTensor [B, L]
+   - (optionally) input_dict["attention_mask"]
+   - labels is LongTensor [B, L]
+* Ensure the training stream is effectively infinite (no StopIteration killing the loop).
+
+Implementation highlights: ``set_consumed_by_global_step(step, global_batch_size)`` to retarget the data stream after checkpoint restore (see §3.2).
+
+## 3) Trainer Wiring
+
+### 3.1 Selecting BlendCorpus as the dataset
+
+**File**: ``torchtitan/experiments/blendcorpus/train.py``
+
+**What**: At dataloader construction time, detect the dataset and route accordingly.
+
+**Example logic**:
+```python
+    train_dl, valid_dl, test_dl = self.train_spec.build_dataloader_fn(self.config, global_batch_size)
+    self.dataloader = train_dl
+    self.eval_dataloader = valid_dl
+    self.test_dataloader = test_dl
+    utils.logger.info("Using BlendCorpus dataloader (torchtitan_ext).")
+else:
+    self.dataloader = self.train_spec.build_dataloader_fn(...)
+```
+### 3.2 Advancing the dataloader after checkpoint restore
+
+**File**: ``torchtitan/experiments/blendcorpus/train.py``
+
+**What**: After ``self.checkpointer.load(...)`` restores self.step, advance BlendCorpus’ dataloader to the correct consumed samples.
+
+**Hook**:
+```python
+self.checkpointer.load(step=job_config.checkpoint.load_step)
+try:
+    ds_name = getattr(getattr(self.job_config, "training", object()), "dataset", "").strip().lower()
+    if ds_name == "blendcorpus" and hasattr(self.dataloader, "set_consumed_by_global_step"):
+        self.dataloader.set_consumed_by_global_step(self.step, self.global_batch_size)
+        logger.info(f"BlendCorpus dataloader advanced to consumed={self.step * self.global_batch_size} samples (step={self.step}).")
+except Exception as e:
+    logger.warning(f"BlendCorpus retarget hook failed: {e}")
+logger.info(f"Training starts at step {self.step + 1}.")
+```
+
+Why: Guarantees data position matches checkpointed progress:
+consumed = step * global_batch_size.
+
+
+## 4) Config Schema (ConfigManager.py)
+
+### 4.1 New [blendcorpus] TOML section and dataclass
+
+**File**: ``torchtitan/experiments/blendcorpus/job_config.py``
+
+**What**: Introduced a new dataclass and a field on JobConfig to expose BlendCorpus-specific knobs directly in the parsed config.
+
+Dataclass added (verbatim):
+
+```python
+
+@dataclass
+class BlendCorpus:
+    """Optional settings specific to the BlendCorpus data loader.
+
+    These map to a TOML section named [blendcorpus]. If present, your
+    adapter can read them from cfg.blendcorpus.*
+    """
+
+    # File list or directory of shards
+    data_file_list: str | None = None
+    """Path to a text file with one shard path per line, or a directory."""
+
+    # Sequence length and batching (can override training.seq_len / local_batch_size)
+    seq_length: int | None = None
+    """Optional override for sequence length. If None, use training.seq_len."""
+
+    micro_batch_size: int | None = None
+    """Optional override for per-rank batch size. If None, use training.local_batch_size."""
+
+    # Loader behavior
+    num_workers: int = 2
+    """Number of DataLoader workers."""
+
+    split: str = "98,1,1"
+    """Train/valid/test split in percentages."""
+
+    dataloader_type: str = "single"
+    """Loader type hint (e.g., 'single', 'repeating')."""
+
+    shuffle_sample_in_corpus: bool = True
+    """Whether to shuffle samples within corpus."""
+
+    blend_sample_in_corpus: bool = True
+    """Whether to shuffle samples within corpus."""
+
+    append_eod: bool = True
+    """Append EOD token at the end of each sample when collating."""
+
+    provide_attention_mask: bool = False
+    """Whether the adapter should compute and return attention masks."""
+
+    eod_token_id: int | None = None
+    """Optional explicit EOD token id; if None the adapter/tokenizer decides."""
+
+    data_cache_path: str = None
+# --- END BlendCorpus dataclass ---
+```
+
+## 5) Configuration Examples
+
+Below is a minimal TOML (SentencePiece + BlendCorpus)
+
+```toml
+[model]
+name = "llama3"
+flavor = "debugmodel"               # or your 1B flavor
+tokenizer_backend = "sptoken"       # aliases: sentencepiece, sp, spm
+tokenizer_path = "/home/USER/blendcorpus/preprocess/tokenizer/tokenizer.model"
+
+[training]
+dataset = "blendcorpus"
+dataset_path = "/home/USER/datasets/blend/file_list.txt"
+seq_len = 8192
+local_batch_size = 1
+# global_batch_size derives from local_batch_size × replicas
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+# eod_token_id = 128001
+
+[parallelism]
+data_parallel_replicate_degree = 4
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 1
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+```
+
+
+## 6) Running
+```bash
+NGPU=1 CONFIG_FILE="./torchtitan/experiments/blendcorpus/train_configs/debug_model.toml" ./torchtitan/experiments/blendcorpus/run_train.sh 
+```
+
+## 7) Experiments Directory
+
+The `torchtitan/experiments/blendcorpus/` folder now contains ready-to-run experiment configurations, logs, and scripts to reproduce BlendCorpus training with TorchTitan.
+
+Typical contents include:
+* Example TOML config files for various scales (debug, 1B scale, etc.)
+* Run scripts adapted for JLSE/Vast paths to facilitate seamless execution
+* Logs and checkpoints for verification and analysis of training runs
+
+Users can start from these provided configs as templates to customize and launch their own BlendCorpus training experiments.

--- a/torchtitan/experiments/blendcorpus/__init__.py
+++ b/torchtitan/experiments/blendcorpus/__init__.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.components.loss import build_cross_entropy_loss
+from torchtitan.components.lr_scheduler import build_lr_schedulers
+from torchtitan.components.optimizer import build_optimizers
+from torchtitan.experiments.blendcorpus.validate import build_blendcorpus_validator
+from torchtitan.experiments.blendcorpus.dataset.blendcorpus_builder import build_blendcorpus_dataloader
+from torchtitan.experiments.blendcorpus.dataset.build_tokenizer import build_tokenizer
+from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+
+from .infra.parallelize import parallelize_llama
+from .infra.pipeline import pipeline_llama
+from .model.args import TransformerModelArgs
+from .model.model import Transformer
+from .model.state_dict_adapter import Llama3StateDictAdapter
+
+__all__ = [
+    "parallelize_llama",
+    "pipeline_llama",
+    "TransformerModelArgs",
+    "Transformer",
+    "llama3_configs",
+]
+
+
+llama3_configs = {
+    "debugmodel": TransformerModelArgs(
+        dim=256, n_layers=6, n_heads=16, vocab_size=32000, rope_theta=500000
+    ),
+    "Llama-2-7b": TransformerModelArgs(
+        dim=4096, n_layers=6, n_heads=32, vocab_size=32000, rope_theta=500000
+    ),
+    "debugmodel_flex_attn": TransformerModelArgs(
+        dim=256,
+        n_layers=6,
+        n_heads=16,
+        vocab_size=2000,
+        rope_theta=500000,
+        use_flex_attn=True,
+        attn_mask_type="block_causal",
+    ),
+    "8B": TransformerModelArgs(
+        dim=4096,
+        n_layers=32,
+        n_heads=32,
+        n_kv_heads=8,
+        ffn_dim_multiplier=1.3,
+        multiple_of=1024,
+        rope_theta=500000,
+    ),
+    "70B": TransformerModelArgs(
+        dim=8192,
+        n_layers=80,
+        n_heads=64,
+        n_kv_heads=8,
+        ffn_dim_multiplier=1.3,
+        multiple_of=4096,
+        rope_theta=500000,
+    ),
+    "405B": TransformerModelArgs(
+        dim=16384,
+        n_layers=126,
+        n_heads=128,
+        n_kv_heads=8,
+        ffn_dim_multiplier=1.2,
+        multiple_of=4096,
+        rope_theta=500000,
+    ),
+}
+
+
+register_train_spec(
+    TrainSpec(
+        name="blendcorpus",
+        model_cls=Transformer,
+        model_args=llama3_configs,
+        parallelize_fn=parallelize_llama,
+        pipelining_fn=pipeline_llama,
+        build_optimizers_fn=build_optimizers,
+        build_lr_schedulers_fn=build_lr_schedulers,
+        build_dataloader_fn=build_blendcorpus_dataloader,
+        build_tokenizer_fn=build_tokenizer,
+        build_loss_fn=build_cross_entropy_loss,
+        build_validator_fn=build_blendcorpus_validator,
+        state_dict_adapter=Llama3StateDictAdapter,
+    )
+)

--- a/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
+++ b/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
@@ -1,0 +1,150 @@
+# torchtitan_ext/datasets/blendcorpus_builder.py
+import math
+from types import SimpleNamespace
+from typing import Tuple, Optional, Dict
+
+import torch
+from torch.utils.data import DataLoader
+
+# BlendCorpus public API (from README)
+# from blendcorpus import (
+#     # get_config as bc_get_config,
+#     # set_config as bc_set_config,
+#     mpu as bc_mpu,
+#     build_gpt_datasets,
+#     build_pretraining_data_loader,
+# )
+#
+from blendcorpus import parallel_state as bc_mpu
+from blendcorpus.data.gpt_dataset import build_gpt_datasets
+from blendcorpus.data.data_samplers import build_pretraining_data_loader
+# from blendcorpus.data.gpt_dataset import build_gpt_datasets, build_pretraining_data_loader
+#
+# from .data.data_samplers import build_pretraining_data_loader
+# from blendcorpus.data.gpt_dataset import build_gpt_datasets
+
+# from blendcorpus import parallel_state as mpu
+# from blendcorpus.data.gpt_dataset import build_gpt_datasets
+# from blendcorpus.data.data_samplers import build_pretraining_data_loader
+# from blendcorpus.data.config import get_config, set_config
+# from blendcorpus.tokenizer import build_tokenizer
+from blendcorpus.data.config import get_config as bc_get_config
+from blendcorpus.data.config import set_config as bc_set_config
+from blendcorpus.utils import get_ltor_masks_and_position_ids as bc_get_masks
+def cyclic_iter(iter):
+    while True:
+        for x in iter:
+            yield x
+
+def _shift_tokens_to_labels(tokens: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    # tokens: [B, T]
+    input_ids = tokens[:, :-1].contiguous()
+    labels    = tokens[:, 1:].contiguous()
+    return input_ids, labels
+
+
+def _maybe_attention_mask(
+    input_ids: torch.Tensor,
+    eod_token_id: Optional[int],
+    reset_pos_ids: bool,
+    reset_attn_mask: bool,
+    eod_mask_loss: bool,
+) -> torch.Tensor:
+    # You can return None if TorchTitan model builds its own causal mask internally.
+    # If you prefer to supply one, BlendCorpus utility builds LTR masks for Megatron-style flows.
+    attn_mask, _, _ = bc_get_masks(
+        input_ids,
+        eod_token_id if eod_token_id is not None else -1,
+        reset_pos_ids,
+        reset_attn_mask,
+        eod_mask_loss,
+    )
+    return attn_mask  # [B, 1, T, T] causal mask
+
+# --- put this at module scope (e.g., above build_blendcorpus_dataloader) ---
+from typing import Optional, Tuple, Dict
+from torch.utils.data import DataLoader
+
+class AdapterDL:
+    """
+    Lightweight wrapper that:
+      - exposes __len__/__iter__ for TorchTitan,
+      - can be re-pointed after restore via set_consumed_by_global_step,
+      - is picklable (top-level class),
+      - can optionally checkpoint only a small state dict.
+    """
+    def __init__(self, dl: DataLoader, *, ds, bc_cfg):
+        self.dl = dl
+        self._ds = ds
+        self._bc_cfg = bc_cfg
+        self._consumed_samples: int = 0  # best-effort, updated when we "retarget"
+        try:
+            self._len = len(dl)  # type: ignore[arg-type]
+        except TypeError:
+            self._len = int(1e12)
+
+    def __len__(self):
+        return self._len
+
+    @staticmethod
+    def _adapt_iter(it):
+        for batch in it:
+            # BC batch: {"dataset_idx": [B], "text": Long[B, T]}
+            tokens = batch["text"].long()
+            input_ids = tokens[:, :-1].contiguous()
+            labels    = tokens[:,  1:].contiguous()
+            # Many TorchTitan paths expect dict-like batches; keep both fields together.
+            yield {"input": input_ids}, labels
+
+    def __iter__(self):
+        return self._adapt_iter(iter(self.dl))
+
+    def set_consumed_by_global_step(self, global_step: int, global_batch_size: int):
+        """Rebuild underlying BC loader to reflect samples already consumed."""
+        consumed = int(global_step) * int(global_batch_size)
+        self._consumed_samples = consumed
+        self.dl = build_pretraining_data_loader(self._ds, consumed, self._bc_cfg)
+
+    # --- Optional: minimal state checkpointing ---
+    def state_dict(self) -> Dict[str, int]:
+        return {"consumed_samples": int(self._consumed_samples)}
+
+    def load_state_dict(self, state: Dict[str, int]) -> None:
+        cs = int(state.get("consumed_samples", 0))
+        if cs != self._consumed_samples:
+            self._consumed_samples = cs
+            self.dl = build_pretraining_data_loader(self._ds, cs, self._bc_cfg)
+# --- end top-level class ---
+def build_blendcorpus_dataloader(cfg, global_batch_size: int) -> Tuple[DataLoader, DataLoader, DataLoader]:
+    # Map TorchTitan config → BlendCorpus config
+    cfg.blendcorpus.seq_length = getattr(cfg.training, "seq_len")
+    cfg.blendcorpus.data_file_list = getattr(cfg.training, "dataset_path")
+    cfg.blendcorpus.train_iters = int(getattr(cfg.training, "steps"))
+    cfg.blendcorpus.micro_batch_size = int(getattr(cfg.training, "local_batch_size"))
+    cfg.blendcorpus.global_batch_size = int(global_batch_size)
+
+    cfg.blendcorpus.tensor_model_parallel_size   = cfg.parallelism.tensor_parallel_degree
+    cfg.blendcorpus.pipeline_model_parallel_size = cfg.parallelism.pipeline_parallel_degree
+    cfg.blendcorpus.sequence_parallel_size       = cfg.parallelism.context_parallel_degree
+
+    bc_mpu.initialize_model_parallel(
+        tensor_model_parallel_size=cfg.blendcorpus.tensor_model_parallel_size,
+        pipeline_model_parallel_size=cfg.blendcorpus.pipeline_model_parallel_size,
+        sequence_parallel_size=cfg.blendcorpus.sequence_parallel_size,
+    )
+
+    bc_set_config(cfg.blendcorpus)
+    bc_cfg = bc_get_config()
+
+    # Build datasets and loaders
+    train_ds, valid_ds, test_ds = build_gpt_datasets(bc_cfg)
+
+    train_loader = build_pretraining_data_loader(train_ds, 0, bc_cfg)
+    valid_loader = build_pretraining_data_loader(valid_ds, 0, bc_cfg) if valid_ds is not None else None
+    test_loader  = build_pretraining_data_loader(test_ds,  0, bc_cfg) if test_ds  is not None else None
+
+    return (
+        AdapterDL(train_loader, ds=train_ds,  bc_cfg=bc_cfg) if train_loader is not None else None,
+        AdapterDL(valid_loader, ds=valid_ds,  bc_cfg=bc_cfg) if valid_loader is not None else None,
+        AdapterDL(test_loader,  ds=test_ds,   bc_cfg=bc_cfg) if test_loader  is not None else None,
+    )

--- a/torchtitan/experiments/blendcorpus/dataset/build_tokenizer.py
+++ b/torchtitan/experiments/blendcorpus/dataset/build_tokenizer.py
@@ -1,0 +1,15 @@
+from torchtitan.experiments.blendcorpus.dataset.sptoken import build_sentencepiece_tokenizer
+from torchtitan.components.tokenizer import build_hf_tokenizer
+
+def build_tokenizer(job_config):
+    backend = str(getattr(job_config.model, 'tokenizer_backend', '')).strip().lower()
+    if backend in {'', 'sptoken', 'sentencepiece', 'sp', 'spm'}:
+        print('[Tokenizer] Using backend: sptoken (SentencePiece)')
+        return build_sentencepiece_tokenizer(job_config)
+    if backend in {'huggingface', 'hf'}:
+        print('[Tokenizer] Using backend: huggingface (HF AutoTokenizer)')
+        return build_hf_tokenizer(job_config)
+    if backend == 'tiktoken':
+        raise NotImplementedError("tokenizer_backend='tiktoken' is not supported for this training recipe; use 'sptoken'.")
+    raise Exception(f"Unknown tokenizer_backend '{backend}'. Choose 'sptoken' or 'hf'.")
+

--- a/torchtitan/experiments/blendcorpus/dataset/sptoken.py
+++ b/torchtitan/experiments/blendcorpus/dataset/sptoken.py
@@ -1,0 +1,54 @@
+# torchtitan/datasets/tokenizer/sptoken.py
+import os
+from typing import List
+import sentencepiece as spm
+
+class SPTokenizer:
+    def __init__(self, model_path: str):
+        assert isinstance(model_path, (str, os.PathLike)) and model_path, f"SP model path must be a non-empty string, got: {model_path!r}"
+        model_path = str(model_path)
+        # Accept a directory containing tokenizer.model or a direct .model file
+        spm_file = model_path if model_path.endswith('.model') else os.path.join(model_path, 'tokenizer.model')
+        assert os.path.exists(spm_file), f"SP model not found: {spm_file}"
+        self.sp = spm.SentencePieceProcessor(model_file=spm_file)
+
+        # Attributes expected by Titan
+        self.vocab_size = self.sp.vocab_size()
+        self.n_words = self.vocab_size
+        print(f"[SPTokenizer] Loaded model: {spm_file}, vocab size: {self.vocab_size}")
+
+        # Common special token ids (use -1 when absent)
+        self.bos_id = self.sp.bos_id() if self.sp.bos_id() != -1 else -1
+        self.eos_id = self.sp.eos_id() if self.sp.eos_id() != -1 else -1
+        self.pad_id = self.sp.pad_id() if self.sp.pad_id() != -1 else -1
+        self.unk_id = self.sp.unk_id() if self.sp.unk_id() != -1 else -1
+
+    def encode(self, text: str, bos: bool = False, eos: bool = False) -> List[int]:
+        """
+        Titan may call encode(..., bos=True, eos=True). Respect those flags.
+        """
+        ids = self.sp.encode(text, out_type=int)
+        if bos and self.bos_id != -1:
+            ids = [self.bos_id] + ids
+        if eos and self.eos_id != -1:
+            ids = ids + [self.eos_id]
+        # Safety: range check
+        if ids:
+            mn, mx = min(ids), max(ids)
+            assert mn >= 0 and mx < self.vocab_size, (
+                f"Token IDs out of range: min={mn}, max={mx}, vocab_size={self.vocab_size}"
+            )
+        return ids
+
+    def decode(self, ids: list[int]) -> str:
+        return self.sp.decode(ids)
+
+def build_sentencepiece_tokenizer(job_config):
+    # Prefer explicit tokenizer_path; fall back to hf_assets_path
+    model_path = getattr(job_config.model, 'tokenizer_path', None) or getattr(job_config.model, 'hf_assets_path', None)
+    assert model_path, (
+        "Neither job_config.model.tokenizer_path nor job_config.model.hf_assets_path is set for SentencePiece tokenizer."
+    )
+    print(f"[SPTokenizer] Using model path: {model_path}")
+    return SPTokenizer(model_path)
+

--- a/torchtitan/experiments/blendcorpus/infra/parallelize.py
+++ b/torchtitan/experiments/blendcorpus/infra/parallelize.py
@@ -1,0 +1,444 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file applies the PT-D parallelisms (except pipeline parallelism) and various
+# training techniques (e.g. activation checkpointing and compile) to the Llama model.
+
+from collections import defaultdict
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch.distributed._composable.replicate import replicate
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    checkpoint_wrapper as ptd_checkpoint_wrapper,
+)
+
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
+from torch.distributed.tensor import Replicate, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    PrepareModuleInput,
+    RowwiseParallel,
+    SequenceParallel,
+)
+
+from torchtitan.config import JobConfig, TORCH_DTYPE_MAP
+from torchtitan.config.job_config import ActivationCheckpoint as ACConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.tools.logging import logger
+
+
+def parallelize_llama(
+    model: nn.Module,
+    parallel_dims: ParallelDims,
+    job_config: JobConfig,
+):
+    """
+    Apply tensor parallelism, activation checkpointing, torch.compile, and data
+    parallelism to the model.
+
+    NOTE: The passed-in model preferably should be on meta device. Otherwise,
+    the model must fit on GPU or CPU memory.
+    """
+    world_mesh = parallel_dims.world_mesh
+    # TODO: TP currently cannot handle uneven seq_len because we set
+    #       `use_local_output=True` to use plain Tensors for legacy reasons.
+    #       Need to revisit this.
+    assert (
+        job_config.training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
+        Sequence length {job_config.training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
+        """
+
+    if (
+        job_config.parallelism.context_parallel_degree > 1
+        and model.model_args.use_flex_attn
+    ):
+        raise NotImplementedError("CP support for FlexAttention is still in progress.")
+
+    model_compile_enabled = (
+        job_config.compile.enable and "model" in job_config.compile.components
+    )
+    if parallel_dims.tp_enabled:
+        if (
+            job_config.parallelism.enable_async_tensor_parallel
+            and not model_compile_enabled
+        ):
+            raise RuntimeError("Async TP requires torch.compile")
+
+        enable_float8_linear = "float8" in job_config.model.converters
+        float8_is_rowwise = job_config.float8.recipe_name in (
+            "rowwise",
+            "rowwise_with_gw_hp",
+        )
+
+        # For now, float8 all-gather with TP is only supported for tensorwise
+        # float8 scaling recipes. For rowwise recipes, we use regular TP and
+        # all-gather happens in high precision.
+        enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
+
+        apply_tp(
+            model,
+            world_mesh["tp"],
+            loss_parallel=not job_config.parallelism.disable_loss_parallel,
+            enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+            enable_async_tp=job_config.parallelism.enable_async_tensor_parallel,
+        )
+
+    if job_config.activation_checkpoint.mode != "none":
+        apply_ac(model, job_config.activation_checkpoint)
+
+    # turn on per-TransformerBlock compile after AC wrapping and before FSDP
+    if model_compile_enabled:
+        apply_compile(model)
+
+    if parallel_dims.fsdp_enabled:
+        # apply FSDP or HSDP, potentially with Context Parallel
+        if parallel_dims.dp_replicate_enabled:
+            dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
+        else:
+            dp_mesh_dim_names = ("dp_shard_cp",)
+
+        apply_fsdp(
+            model,
+            world_mesh[tuple(dp_mesh_dim_names)],
+            param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],
+            reduce_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_reduce],
+            pp_enabled=parallel_dims.pp_enabled,
+            cpu_offload=job_config.training.enable_cpu_offload,
+            reshard_after_forward_policy=job_config.parallelism.fsdp_reshard_after_forward,
+        )
+
+        if parallel_dims.dp_replicate_enabled:
+            logger.info("Applied HSDP to the model")
+        else:
+            logger.info("Applied FSDP to the model")
+
+        if parallel_dims.cp_enabled:
+            logger.info("Applied Context Parallel to the model")
+
+        if job_config.training.enable_cpu_offload:
+            logger.info("Applied CPU Offloading to the model")
+    elif parallel_dims.dp_replicate_enabled:
+        if world_mesh.ndim > 1:
+            raise RuntimeError("DDP has not supported > 1D parallelism")
+        apply_ddp(
+            model,
+            world_mesh,
+            enable_compile=model_compile_enabled,
+            enable_compiled_autograd=job_config.parallelism.enable_compiled_autograd,
+        )
+
+    return model
+
+
+def apply_tp(
+    model: nn.Module,
+    tp_mesh: DeviceMesh,
+    loss_parallel: bool,
+    enable_float8_tensorwise_tp: bool,
+    enable_async_tp: bool,
+):
+    """Apply tensor parallelism."""
+    # 1. Parallelize the embedding and shard its outputs (which are the first
+    # transformer block's inputs)
+    # 2. Parallelize the root norm layer over the sequence dim
+    # 3. Parallelize the final linear output layer
+    parallelize_module(
+        model,
+        tp_mesh,
+        {
+            "tok_embeddings": RowwiseParallel(
+                input_layouts=Replicate(),
+                output_layouts=Shard(1),
+            ),
+            "norm": SequenceParallel(),
+            "output": ColwiseParallel(
+                input_layouts=Shard(1),
+                output_layouts=Shard(-1) if loss_parallel else Replicate(),
+                use_local_output=not loss_parallel,
+            ),
+        },
+    )
+
+    # Parallel styles used for transformer block linear weights and their
+    # inputs may be different for float8 linears with tensorwise scaling.
+    if enable_float8_tensorwise_tp:
+        # TODO(vkuzo): add the items below to __init__.py of torchao.float8 and import from there
+        from torchao.float8.float8_tensor_parallel import (
+            Float8ColwiseParallel,
+            Float8RowwiseParallel,
+            PrepareFloat8ModuleInput,
+        )
+
+        rowwise_parallel, colwise_parallel, prepare_module_input = (
+            Float8RowwiseParallel,
+            Float8ColwiseParallel,
+            PrepareFloat8ModuleInput,
+        )
+    else:
+        rowwise_parallel, colwise_parallel, prepare_module_input = (
+            RowwiseParallel,
+            ColwiseParallel,
+            PrepareModuleInput,
+        )
+
+    # Apply tensor + sequence parallelism to every transformer block
+    # NOTE: At the cost of model code change, we can accelerate Sequence Parallel
+    #       by folding (and unfolding) the batch dimension and the sequence dimension.
+    #       Examples can be found at https://github.com/pytorch/torchtitan/pull/437
+    for transformer_block in model.layers.values():
+        layer_plan = {
+            "attention_norm": SequenceParallel(),
+            "attention": prepare_module_input(
+                input_layouts=(Shard(1), None),
+                desired_input_layouts=(Replicate(), None),
+            ),
+            "attention.wq": colwise_parallel(),
+            "attention.wk": colwise_parallel(),
+            "attention.wv": colwise_parallel(),
+            "attention.wo": rowwise_parallel(output_layouts=Shard(1)),
+            "ffn_norm": SequenceParallel(),
+            "feed_forward": prepare_module_input(
+                input_layouts=(Shard(1),),
+                desired_input_layouts=(Replicate(),),
+            ),
+            "feed_forward.w1": colwise_parallel(),
+            "feed_forward.w2": rowwise_parallel(output_layouts=Shard(1)),
+            "feed_forward.w3": colwise_parallel(),
+        }
+
+        parallelize_module(
+            module=transformer_block,
+            device_mesh=tp_mesh,
+            parallelize_plan=layer_plan,
+        )
+
+    if enable_async_tp:
+        from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+
+        torch._inductor.config._micro_pipeline_tp = True
+        enable_symm_mem_for_group(tp_mesh.get_group().group_name)
+
+    logger.info(
+        f"Applied {'Float8 tensorwise ' if enable_float8_tensorwise_tp else ''}{'Async ' if enable_async_tp else ''}"
+        "Tensor Parallelism to the model"
+    )
+
+
+# for selective op activation checkpointing
+_save_list = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    # for low precision training, it's useful to always save
+    # the result of max, since the absolute maximum is
+    # used to compute the scaling factor for quantization.
+    torch.ops.aten.max.default,
+}
+
+
+def _apply_ac_to_transformer_block(
+    module: nn.Module, ac_config: ACConfig, *, base_fqn: Optional[str] = None
+):
+    valid_ac_modes = ("full", "selective")
+    if ac_config.mode not in valid_ac_modes:
+        raise ValueError(
+            f"Invalid AC mode: {ac_config.mode}. Valid modes: {valid_ac_modes}"
+        )
+
+    if ac_config.mode == "full":
+        return ptd_checkpoint_wrapper(module, preserve_rng_state=False)
+
+    assert ac_config.mode == "selective", f"{ac_config.mode}"
+    use_op_sac = ac_config.selective_ac_option == "op"
+    use_layer_sac = ac_config.selective_ac_option.isdigit()
+    if not use_op_sac and not use_layer_sac:
+        raise ValueError(
+            f"Invalid selective AC option: {ac_config.selective_ac_option}. "
+            f"Valid options: 'op' or a positive int representing layer frequency"
+        )
+    if use_op_sac:
+        from torch.utils.checkpoint import (
+            CheckpointPolicy,
+            create_selective_checkpoint_contexts,
+        )
+
+        mm_recompute_shapes = set()
+        if len(ac_config.per_op_sac_force_recompute_mm_shapes_by_fqns) > 0:
+            for module_fqn, submod in module.named_modules():
+                fqn = module_fqn
+                if base_fqn is not None:
+                    fqn = f"{base_fqn}.{module_fqn}"
+                if not any(
+                    filter_fqn in fqn
+                    for filter_fqn in ac_config.per_op_sac_force_recompute_mm_shapes_by_fqns
+                ):
+                    continue
+                if not isinstance(submod, nn.Linear):
+                    raise ValueError(
+                        "per_op_sac_force_recompute_mm_shapes_by_fqns expected to match "
+                        f"a nn.Linear, but got: {submod}"
+                    )
+                out_f, in_f = submod.weight.shape
+                mm_recompute_shapes.add((in_f, out_f))
+            logger.debug(
+                f"Selective op AC force recomputing mms with rhs shapes {mm_recompute_shapes}"
+            )
+
+        def _get_custom_policy(meta):
+            def _custom_policy(ctx, func, *args, **kwargs):
+                mode = "recompute" if ctx.is_recompute else "forward"
+                mm_count_key = f"{mode}_mm_count"
+                if func == torch.ops.aten.mm.default:
+                    if args[1].shape in mm_recompute_shapes:
+                        return CheckpointPolicy.PREFER_RECOMPUTE
+                    meta[mm_count_key] += 1
+                # Saves output of all compute ops, except every second mm
+                to_save = func in _save_list and not (
+                    func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0
+                )
+                return (
+                    CheckpointPolicy.MUST_SAVE
+                    if to_save
+                    else CheckpointPolicy.PREFER_RECOMPUTE
+                )
+
+            return _custom_policy
+
+        def selective_checkpointing_context_fn():
+            meta = defaultdict(int)
+            return create_selective_checkpoint_contexts(_get_custom_policy(meta))
+
+        return ptd_checkpoint_wrapper(
+            module,
+            context_fn=selective_checkpointing_context_fn,
+            preserve_rng_state=False,
+        )
+    elif use_layer_sac:
+        # Checkpoint every `ac_freq` of the modules passed to this function
+        ac_freq = int(ac_config.selective_ac_option)
+        ptd_checkpoint_wrapper.__dict__.setdefault("_count", 0)
+        ptd_checkpoint_wrapper._count += 1
+        if not ac_freq or ptd_checkpoint_wrapper._count % ac_freq == 0:
+            return ptd_checkpoint_wrapper(module, preserve_rng_state=False)
+        else:
+            return module
+
+
+def apply_ac(model: nn.Module, ac_config: ACConfig):
+    """Apply activation checkpointing to the model."""
+    for layer_id, transformer_block in model.layers.named_children():
+        transformer_block = _apply_ac_to_transformer_block(
+            transformer_block, ac_config, base_fqn=f"layers.{layer_id}"
+        )
+        model.layers.register_module(layer_id, transformer_block)
+
+    logger.info(f"Applied {ac_config.mode} activation checkpointing to the model")
+
+
+def apply_compile(model: nn.Module):
+    """
+    Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
+    repeated structure. Alternatively one can compile the whole model (after applying DP).
+    """
+    for layer_id, transformer_block in model.layers.named_children():
+        transformer_block = torch.compile(transformer_block, fullgraph=True)
+        model.layers.register_module(layer_id, transformer_block)
+
+    logger.info("Compiling each TransformerBlock with torch.compile")
+
+
+def apply_fsdp(
+    model: nn.Module,
+    dp_mesh: DeviceMesh,
+    param_dtype: torch.dtype,
+    reduce_dtype: torch.dtype,
+    pp_enabled: bool,
+    cpu_offload: bool = False,
+    reshard_after_forward_policy: str = "default",
+):
+    """
+    Apply data parallelism (via FSDP2) to the model.
+
+    Args:
+        model (nn.Module): The model to apply data parallelism to.
+        dp_mesh (DeviceMesh): The device mesh to use for data parallelism.
+        param_dtype (torch.dtype): The data type to use for model parameters.
+        reduce_dtype (torch.dtype): The data type to use for reduction operations.
+        pp_enabled (bool): Whether pipeline parallelism is enabled.
+        cpu_offload (bool, optional): Whether to offload model parameters to CPU. Defaults to False.
+        reshard_after_forward_policy (str, optional): The policy to use for resharding after forward pass. Defaults to "default".
+            Other options: "never", "always".
+            - "default" applies default resharding behavior, implementing "smart defaults" for known optimal scenarios.
+            - "always" will enable `reshard_after_forward` for all forward passes.
+            - "never" will disable `reshard_after_forward` for all forward passes.
+
+    """
+    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
+    if cpu_offload:
+        fsdp_config["offload_policy"] = CPUOffloadPolicy()
+
+    match reshard_after_forward_policy:
+        case "always":
+            reshard_after_forward = True
+        case "never":
+            reshard_after_forward = False
+        case "default":
+            # For PP, by default do not reshard after forward to avoid per-microbatch
+            # all-gathers, which can be expensive and non-overlapped
+            reshard_after_forward = not pp_enabled
+        case _:
+            raise ValueError(
+                f"Invalid reshard_after_forward_policy: {reshard_after_forward_policy}."
+            )
+
+    if model.tok_embeddings is not None:
+        fully_shard(
+            model.tok_embeddings,
+            **fsdp_config,
+            reshard_after_forward=reshard_after_forward,
+        )
+    for layer_id, transformer_block in model.layers.items():
+        fully_shard(
+            transformer_block,
+            **fsdp_config,
+            reshard_after_forward=reshard_after_forward,
+        )
+    # As an optimization, do not reshard_after_forward the last layers by default
+    # since FSDP would prefetch them immediately after the forward pass
+    if model.norm is not None and model.output is not None:
+        fully_shard(
+            [model.norm, model.output],
+            **fsdp_config,
+            reshard_after_forward=reshard_after_forward_policy == "always",
+        )
+    fully_shard(model, **fsdp_config)
+
+
+def apply_ddp(
+    model: nn.Module,
+    dp_mesh: DeviceMesh,
+    enable_compile: bool,
+    enable_compiled_autograd: bool,
+):
+    if enable_compile:
+        if enable_compiled_autograd:
+            torch._dynamo.config.optimize_ddp = (
+                "python_reducer_without_compiled_forward"
+            )
+        else:
+            torch._dynamo.config.optimize_ddp = "ddp_optimizer"
+
+    replicate(model, device_mesh=dp_mesh, bucket_cap_mb=100)
+
+    logger.info("Applied DDP to the model")

--- a/torchtitan/experiments/blendcorpus/infra/pipeline.py
+++ b/torchtitan/experiments/blendcorpus/infra/pipeline.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file applies the PT-D pipeline parallelism to the Llama model.
+
+import math
+
+import torch
+import torch.nn as nn
+from torch.distributed.pipelining.schedules import (
+    _PipelineSchedule,
+    get_schedule_class,
+    PipelineScheduleSingle,
+)
+
+from torchtitan.components.loss import LossFunction
+from torchtitan.config import JobConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.pipeline_parallel import (
+    build_pipeline_schedule,
+    generate_llm_fqn_per_model_part,
+    pipeline_module_split,
+)
+
+from torchtitan.protocols.train_spec import BaseModelArgs, ParallelizeFunction
+from torchtitan.tools.logging import logger
+
+
+def pipeline_llama(
+    model: nn.Module,
+    parallel_dims: ParallelDims,
+    job_config: JobConfig,
+    device: torch.device,
+    model_args: BaseModelArgs,
+    parallelize_fn: ParallelizeFunction,
+    loss_fn: LossFunction,
+) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
+    if job_config.parallelism.pipeline_parallel_split_points != []:
+        raise ValueError(
+            "pipeline_parallel_split_points is deprecated. Please use module_fqns_per_model_part instead."
+            "You can generate module_fqns_per_model_part programmatically with generate_llm_fqn_per_model_part"
+        )
+
+    pp_mesh = parallel_dims.world_mesh["pp"]
+
+    # Determine the number of virtual stages based on schedule type
+    schedule_class = get_schedule_class(
+        job_config.parallelism.pipeline_parallel_schedule
+    )
+    is_single_stage_schedule = issubclass(schedule_class, PipelineScheduleSingle)
+    layers_per_stage = job_config.parallelism.pipeline_parallel_layers_per_stage
+    if hasattr(model_args, "n_layers"):
+        num_layers = model_args.n_layers
+    else:
+        raise ValueError("Model does not have n_layers attribute.")
+
+    # You can adjust these weights based on the computational cost of embeddings and output layers
+    # Higher weights mean these modules are treated as "heavier" in the distribution
+    input_weight = job_config.parallelism.pipeline_parallel_first_stage_less_layers
+    output_weight = job_config.parallelism.pipeline_parallel_last_stage_less_layers
+
+    # Calculate number of virtual stages
+    if layers_per_stage is not None:
+
+        # Calculate number of virtual stages needed (using ceiling division)
+        # This allows for unequal distribution where stages can differ by at most 1 layer
+        num_virtual_stages = math.ceil(
+            (num_layers + input_weight + output_weight) / layers_per_stage
+        )
+
+        # Validation: check stages per rank based on schedule type
+        model_config_info = f"Model has {num_layers} layers with pipeline_parallel_layers_per_stage={layers_per_stage}"
+        stage_distribution_info = (
+            f"resulting in {num_virtual_stages=} across {parallel_dims.pp} PP ranks"
+        )
+
+        if num_virtual_stages % parallel_dims.pp != 0:
+            raise ValueError(
+                f"Number of virtual stages ({num_virtual_stages}) must be divisible by "
+                f"pipeline parallel size ({parallel_dims.pp}). "
+                f"{model_config_info}. "
+                f"Please adjust pipeline_parallel_layers_per_stage to a value that results in a number of stages "
+                f"divisible by {parallel_dims.pp}."
+            )
+
+        stages_per_rank = num_virtual_stages // parallel_dims.pp
+
+        if is_single_stage_schedule and stages_per_rank != 1:
+            raise ValueError(
+                f"Single stage schedule requires exactly 1 stage per rank, but got {stages_per_rank} stages per rank. "
+                f"{model_config_info}, {stage_distribution_info}. "
+                f"Please increase pipeline_parallel_layers_per_stage to {num_layers // parallel_dims.pp} or higher "
+                f"to achieve 1 stage per rank."
+            )
+
+        if not is_single_stage_schedule and stages_per_rank < 2:
+            raise ValueError(
+                f"Multi-stage schedule requires at least 2 stages per rank, but got {stages_per_rank} stages per rank. "
+                f"{model_config_info}, {stage_distribution_info}. "
+                f"Please decrease pipeline_parallel_layers_per_stage to achieve at least 2 stages per rank."
+            )
+    else:
+        # Fallback to default behavior when layers_per_stage is not provided
+        # For multi-stage schedules, default is 2 virtual stages per rank
+        # For single-stage schedules, default is 1 virtual stage per rank
+        stages_per_rank = 1 if is_single_stage_schedule else 2
+        num_virtual_stages = parallel_dims.pp * stages_per_rank
+
+    module_names_per_stage = job_config.parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = generate_llm_fqn_per_model_part(
+            num_virtual_stages, num_layers, input_weight, output_weight
+        )
+    for i, stage_ms in enumerate(module_names_per_stage):
+        logger.debug(f"Stage {i}: {stage_ms}")
+
+    stages, model_parts = pipeline_module_split(
+        model,
+        pp_mesh,
+        job_config.parallelism.pipeline_parallel_schedule,
+        device,
+        module_names_per_stage,
+    )
+
+    # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
+    # We need to iterate through model_parts to apply SPMD parallelisms, compilation,
+    # optimizer, and checkpointing
+    for i, m in enumerate(model_parts):
+        # apply SPMD-style PT-D techniques
+        m = parallelize_fn(m, parallel_dims, job_config)
+        model_parts[i] = m
+        # NOTE: this is to update the model in the stage
+        #       in case the model is modified e.g. by torch.compile
+        stages[i].submod = m
+
+    pp_schedule = build_pipeline_schedule(job_config, stages, loss_fn)
+
+    # This is used in the train loop to determine whether to pass in the input_ids and labels
+    has_first_stage = False
+    has_last_stage = False
+    for stage in stages:
+        if stage.is_first:
+            has_first_stage = True
+        if stage.is_last:
+            has_last_stage = True
+
+    return pp_schedule, model_parts, has_first_stage, has_last_stage

--- a/torchtitan/experiments/blendcorpus/job_config.py
+++ b/torchtitan/experiments/blendcorpus/job_config.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+
+@dataclass
+class Model:
+    tokenizer_backend: str = "sptoken"
+
+# --- BEGIN BlendCorpus dataclass ---
+@dataclass
+class BlendCorpus:
+    """Optional settings specific to the BlendCorpus data loader.
+
+    These map to a TOML section named [blendcorpus]. If present, your
+    adapter can read them from cfg.blendcorpus.*
+    """
+
+    # File list or directory of shards
+    data_file_list: str | None = None
+    """Path to a text file with one shard path per line, or a directory."""
+
+    # Sequence length and batching (can override training.seq_len / local_batch_size)
+    seq_length: int | None = None
+    """Optional override for sequence length. If None, use training.seq_len."""
+
+    micro_batch_size: int | None = None
+    """Optional override for per-rank batch size. If None, use training.local_batch_size."""
+
+    # Loader behavior
+    num_workers: int = 2
+    """Number of DataLoader workers."""
+
+    split: str = "98,1,1"
+    """Train/valid/test split in percentages."""
+
+    dataloader_type: str = "single"
+    """Loader type hint (e.g., 'single', 'repeating')."""
+
+    shuffle: bool = True
+    """Whether to shuffle the order of shards."""
+
+    shuffle_sample_in_corpus: bool = True
+    """Whether to shuffle samples within corpus."""
+
+    blend_sample_in_corpus: bool = True
+    """Whether to shuffle samples within corpus."""
+
+    append_eod: bool = True
+    """Append EOD token at the end of each sample when collating."""
+
+    provide_attention_mask: bool = False
+    """Whether the adapter should compute and return attention masks."""
+
+    eod_token_id: int | None = None
+    """Optional explicit EOD token id; if None the adapter/tokenizer decides."""
+
+    data_cache_path: str = None
+# --- END BlendCorpus dataclass ---
+
+
+@dataclass
+class JobConfig:
+    """
+    Extend the tyro parser with custom config classes for Flux model.
+    """
+
+    model: Model = field(default_factory=Model)
+    blendcorpus: BlendCorpus = field(default_factory=BlendCorpus)

--- a/torchtitan/experiments/blendcorpus/model/args.py
+++ b/torchtitan/experiments/blendcorpus/model/args.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+
+from dataclasses import dataclass
+
+from torch import nn
+
+from torchtitan.config import JobConfig
+from torchtitan.protocols.train_spec import BaseModelArgs
+from torchtitan.tools.logging import logger
+
+
+@dataclass
+class TransformerModelArgs(BaseModelArgs):
+    dim: int = 4096
+    n_layers: int = 32
+    n_heads: int = 32
+    n_kv_heads: int | None = None
+    vocab_size: int = 128256
+    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
+    ffn_dim_multiplier: float | None = None
+    norm_eps: float = 1e-5
+    rope_theta: float = 10000
+
+    max_seq_len: int = 131072
+    # If `True`, then each transformer block init uses its layer ID, and if
+    # `False`, each uses the total number of transformer blocks
+    depth_init: bool = True
+
+    use_flex_attn: bool = False
+    attn_mask_type: str = "causal"
+    eos_id: int = 0
+
+    def update_from_config(self, job_config: JobConfig, **kwargs) -> None:
+        seq_len = job_config.training.seq_len
+        if seq_len > self.max_seq_len:
+            logger.warning(
+                f"Sequence length {seq_len} exceeds original maximum {self.max_seq_len}."
+            )
+        self.max_seq_len = seq_len
+
+        if job_config.parallelism.context_parallel_degree > 1 and self.use_flex_attn:
+            raise NotImplementedError(
+                "CP support for FlexAttention is still in progress."
+            )
+
+        if (
+            job_config.parallelism.pipeline_parallel_degree > 1
+            and self.use_flex_attn
+            and self.attn_mask_type == "block_causal"
+        ):
+            raise RuntimeError(
+                "PP + block causal FlexAttention support will be fixed soon."
+            )
+        self.max_seq_len = seq_len
+
+    def get_nparams_and_flops(self, model: nn.Module, seq_len: int) -> tuple[int, int]:
+        nparams = sum(p.numel() for p in model.parameters())
+        nparams_embedding = sum(
+            sum(p.numel() for p in m.parameters())
+            for m in model.children()
+            if isinstance(m, nn.Embedding)
+        )
+
+        l, h, q, t = (
+            self.n_layers,
+            self.n_heads,
+            self.dim // self.n_heads,
+            seq_len,
+        )
+        # Reasoning behind the factor of 12 for the self-attention part of the formula:
+        # 1. each self-attention has 2 matmul in the forward and 4 in the backward (6)
+        # 2. the flash attention does 1 more matmul recomputation in the backward
+        #    but recomputation should not be counted in calculating MFU           (+0)
+        # 3. each matmul performs 1 multiplication and 1 addition                 (*2)
+        # 4. we follow the convention and do not account for sparsity in causal attention
+        num_flops_per_token = 6 * (nparams - nparams_embedding) + 12 * l * h * q * t
+
+        return nparams, num_flops_per_token

--- a/torchtitan/experiments/blendcorpus/model/model.py
+++ b/torchtitan/experiments/blendcorpus/model/model.py
@@ -1,0 +1,431 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from torchtitan.models.attention import build_attention, init_attention_mask
+from torchtitan.protocols.train_spec import ModelProtocol
+
+from .args import TransformerModelArgs
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+    """
+    Precompute the frequency tensor for complex exponentials (cis) with given dimensions.
+
+    This function calculates a frequency tensor with complex exponentials using the given dimension 'dim'
+    and the end index 'end'. The 'theta' parameter scales the frequencies.
+    The returned tensor contains complex values in complex64 data type.
+
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        end (int): End index for precomputing frequencies.
+        theta (float | None): Scaling factor for frequency computation. Defaults to 10000.0.
+
+    Returns:
+        torch.Tensor: Precomputed frequency tensor with complex exponentials.
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)
+    freqs = torch.outer(t, freqs).float()
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+    return freqs_cis
+
+
+def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """
+    Reshape frequency tensor for broadcasting it with another tensor.
+
+    This function reshapes the frequency tensor to have the same shape as the target tensor 'x'
+    for the purpose of broadcasting the frequency tensor during element-wise operations.
+
+    The input freqs_cis tensor is assumed to be of shape (max_seqlen, dim),
+    and the first seqlen elements will be sliced, but dim must match x.
+
+    Args:
+        freqs_cis (torch.Tensor): Frequency tensor to be reshaped.
+        x (torch.Tensor): Target tensor for broadcasting compatibility.
+
+    Returns:
+        torch.Tensor: Reshaped frequency tensor.
+    """
+    ndim = x.ndim
+    assert ndim > 1
+    seqlen = x.shape[1]
+    freqs_cis = freqs_cis[0:seqlen]
+    assert freqs_cis.shape == (seqlen, x.shape[-1])
+    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+    return freqs_cis.view(*shape)
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply rotary embeddings to input tensors using the given frequency tensor.
+
+    This function applies rotary embeddings to the given query 'xq' and key 'xk' tensors using the provided
+    frequency tensor 'freqs_cis'. The input tensors are reshaped as complex numbers, and the frequency tensor
+    is reshaped for broadcasting compatibility. The resulting tensors contain rotary embeddings and are
+    returned as real tensors.
+
+    Args:
+        xq (torch.Tensor): Query tensor to apply rotary embeddings.
+        xk (torch.Tensor): Key tensor to apply rotary embeddings.
+        freqs_cis (torch.Tensor): Precomputed frequency tensor for complex exponentials.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor]: Tuple of modified query tensor and key tensor with rotary embeddings.
+    """
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+    bs, slen, n_kv_heads, head_dim = x.shape
+    if n_rep == 1:
+        return x
+    return (
+        torch.unsqueeze(x, dim=3)
+        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
+        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
+    )
+
+
+class Attention(nn.Module):
+    """
+    Multi-head attention module.
+
+    Args:
+        model_args (TransformerModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_kv_heads (int): Number of key and value heads.
+        n_heads (int): Number of query heads.
+        n_rep (int): Number of repetitions for local heads.
+        head_dim (int): Dimension size of each attention head.
+        wq (Linear): Linear transformation for queries.
+        wk (Linear): Linear transformation for keys.
+        wv (Linear): Linear transformation for values.
+        wo (Linear): Linear transformation for output.
+
+    """
+
+    def __init__(self, model_args: TransformerModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.n_kv_heads = (
+            model_args.n_heads
+            if model_args.n_kv_heads is None
+            else model_args.n_kv_heads
+        )
+        self.n_rep = self.n_heads // self.n_kv_heads
+        self.head_dim = model_args.dim // model_args.n_heads
+
+        self.wq = nn.Linear(
+            model_args.dim, model_args.n_heads * self.head_dim, bias=False
+        )
+        self.wk = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wv = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wo = nn.Linear(
+            model_args.n_heads * self.head_dim, model_args.dim, bias=False
+        )
+        self.sdpa = build_attention(model_args.use_flex_attn, model_args.attn_mask_type)
+
+    def init_weights(self, init_std: float):
+        for linear in (self.wq, self.wk, self.wv):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=0.02)
+        nn.init.trunc_normal_(self.wo.weight, mean=0.0, std=init_std)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+    ):
+        """
+        Forward pass of the attention module.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            freqs_cis (torch.Tensor): Precomputed frequency tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after attention.
+
+        """
+
+        bs, seqlen, _ = x.shape
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+
+        # Use -1 instead of `n_heads` (or `n_kv_heads`) to infer the actual
+        # local heads from sizes of xq, xk, and xv as TP may have sharded them
+        # after the above linear ops.
+        xq = xq.view(bs, seqlen, -1, self.head_dim)
+        xk = xk.view(bs, seqlen, -1, self.head_dim)
+        xv = xv.view(bs, seqlen, -1, self.head_dim)
+
+        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        keys = repeat_kv(xk, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+        values = repeat_kv(xv, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+
+        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xk = keys.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xv = values.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+
+        output = self.sdpa(xq, xk, xv)
+
+        output = output.transpose(
+            1, 2
+        ).contiguous()  # (bs, seqlen, n_local_heads, head_dim)
+        output = output.view(bs, seqlen, -1)
+        return self.wo(output)
+
+
+class FeedForward(nn.Module):
+    """
+    FeedForward module
+
+    Args:
+        dim (int): Input dimension.
+        hidden_dim (int): Hidden dimension of the feedforward layer.
+        multiple_of (int): Value to ensure hidden dimension is a multiple of this value.
+        ffn_dim_multiplier (float | None): Custom multiplier for hidden dimension. Defaults to None.
+
+    Attributes:
+        w1 (Linear): Linear transformation for the first layer.
+        w2 (Linear): Linear transformation for the second layer.
+        w3 (Linear): Linear transformation for the third layer.
+
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        multiple_of: int,
+        ffn_dim_multiplier: float | None,
+    ):
+        super().__init__()
+        hidden_dim = int(2 * hidden_dim / 3)
+        # custom dim factor multiplier
+        if ffn_dim_multiplier is not None:
+            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.w1.weight, mean=0.0, std=0.02)
+        for linear in (self.w2, self.w3):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
+
+
+class TransformerBlock(nn.Module):
+    """
+    TransformerBlock Module
+
+    Args:
+        layer_id (int): Identifier for the layer.
+        model_args (TransformerModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_heads (int): Number of attention heads.
+        dim (int): Dimension size of the model.
+        head_dim (int): Dimension size of each attention head.
+        attention (Attention): Attention module.
+        feed_forward (FeedForward): FeedForward module.
+        layer_id (int): Identifier for the layer.
+        attention_norm (RMSNorm): Layer normalization for attention output.
+        ffn_norm (RMSNorm): Layer normalization for feedforward output.
+
+    """
+
+    def __init__(self, layer_id: int, model_args: TransformerModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.dim = model_args.dim
+        self.attention = Attention(model_args)
+        self.feed_forward = FeedForward(
+            dim=model_args.dim,
+            hidden_dim=4 * model_args.dim,
+            multiple_of=model_args.multiple_of,
+            ffn_dim_multiplier=model_args.ffn_dim_multiplier,
+        )
+        self.attention_norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
+        self.ffn_norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
+
+        if model_args.depth_init:
+            self.weight_init_std = 0.02 / (2 * (layer_id + 1)) ** 0.5
+        else:
+            self.weight_init_std = 0.02 / (2 * model_args.n_layers) ** 0.5
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+    ):
+        """
+        Perform a forward pass through the TransformerBlock.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            freqs_cis (torch.Tensor): Precomputed cosine and sine frequencies.
+
+        Returns:
+            torch.Tensor: Output tensor after applying attention and feedforward layers.
+
+        """
+        h = x + self.attention(self.attention_norm(x), freqs_cis)
+        out = h + self.feed_forward(self.ffn_norm(h))
+        return out
+
+    def init_weights(self):
+        for norm in (self.attention_norm, self.ffn_norm):
+            norm.reset_parameters()
+        self.attention.init_weights(self.weight_init_std)
+        self.feed_forward.init_weights(self.weight_init_std)
+
+
+class Transformer(nn.Module, ModelProtocol):
+    """
+    Transformer Module
+
+    Args:
+        model_args (TransformerModelArgs): Model configuration arguments.
+
+    Attributes:
+        model_args (TransformerModelArgs): Model configuration arguments.
+        vocab_size (int): Vocabulary size.
+        n_layers (int): Number of layers in the model.
+        tok_embeddings (ParallelEmbedding): Token embeddings.
+        layers (torch.nn.ModuleList): List of Transformer blocks.
+        norm (RMSNorm): Layer normalization for the model output.
+        output (Linear): Linear layer for final output.
+        freqs_cis (torch.Tensor): Precomputed cosine and sine frequencies.
+
+    """
+
+    def __init__(self, model_args: TransformerModelArgs):
+        super().__init__()
+        self.model_args = model_args
+        self.vocab_size = model_args.vocab_size
+        self.n_layers = model_args.n_layers
+
+        self.tok_embeddings = nn.Embedding(model_args.vocab_size, model_args.dim)
+
+        self.register_buffer(
+            "freqs_cis", self._precompute_freqs_cis(), persistent=False
+        )
+
+        self.layers = torch.nn.ModuleDict()
+        for layer_id in range(model_args.n_layers):
+            self.layers[str(layer_id)] = TransformerBlock(layer_id, model_args)
+        self.norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
+        self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
+        self.init_weights()
+
+    def init_weights(
+        self,
+        buffer_device: torch.device | None = None,
+    ):
+        """
+        [Note: On ``init_weights`` vs. ``reset_parameters``]
+        Modules may define ``reset_parameters`` to initialize parameter values.
+        ``reset_parameters`` is meant to only initialize directly owned
+        parameters/buffers, not those of their child modules, and it can be
+        used to give the initial values for these tensors.
+        Separately, users may want custom initialization for their modules,
+        different from that in ``reset_parameters``. For this, we define
+        ``init_weights``. We only call it in the constructor of this
+        ``Transformer`` root module to avoid reinitializing tensors.
+        """
+        buffer_device = buffer_device or self.freqs_cis.device
+        with torch.device(buffer_device):
+            self.freqs_cis = self._precompute_freqs_cis()
+        if self.tok_embeddings is not None:
+            nn.init.normal_(self.tok_embeddings.weight)
+        for layer in self.layers.values():
+            if layer is not None:
+                layer.init_weights()
+        if self.norm is not None:
+            self.norm.reset_parameters()
+        final_out_std = self.model_args.dim**-0.5
+        cutoff_factor = 3
+        if self.output is not None:
+            nn.init.trunc_normal_(
+                self.output.weight,
+                mean=0.0,
+                std=final_out_std,
+                a=-cutoff_factor * final_out_std,
+                b=cutoff_factor * final_out_std,
+            )
+
+    def _precompute_freqs_cis(self) -> torch.Tensor:
+        return precompute_freqs_cis(
+            self.model_args.dim // self.model_args.n_heads,
+            # Need to compute until at least the max token limit for generation
+            # TODO: explain in docs/composability.md why we removed the 2x
+            # relaxing in our CP enablement PR
+            self.model_args.max_seq_len,
+            self.model_args.rope_theta,
+        )
+
+    def forward(
+        self,
+        tokens: torch.Tensor,
+        eos_id: int | None = None,
+        input_batch: torch.Tensor | None = None,
+    ):
+        """
+        Perform a forward pass through the Transformer model.
+
+        Args:
+            tokens (torch.Tensor): Input token indices if pipeline parallelism is not enabled.
+                If pipeline parallelism is enabled, this will be the input token indices
+                for the ranks on the first pipeline stage. This will be the activation of the
+                previous pipeline stage if the current rank is not on the first stage.
+            input_batch (torch.Tensor): The input batch read from the dataloader.
+                This will always be the input batch regardless of the pipeline stage.
+                This field is required for non-first PP stages to perform document
+                masking attention (to analyze the boundary of the document).
+
+        Returns:
+            torch.Tensor: Output logits after applying the Transformer model.
+
+        """
+        if self.model_args.use_flex_attn:
+            init_attention_mask(
+                input_batch if input_batch is not None else tokens, eos_id=eos_id
+            )
+
+        # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
+        h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
+
+        for layer in self.layers.values():
+            h = layer(h, self.freqs_cis)
+
+        h = self.norm(h) if self.norm else h
+        output = self.output(h) if self.output else h
+        return output

--- a/torchtitan/experiments/blendcorpus/model/state_dict_adapter.py
+++ b/torchtitan/experiments/blendcorpus/model/state_dict_adapter.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger()
+
+from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+
+from .args import TransformerModelArgs
+
+
+class Llama3StateDictAdapter(StateDictAdapter):
+    def __init__(self, model_args: TransformerModelArgs, hf_assets_path: str | None):
+        super().__init__(model_args, hf_assets_path)
+
+        self.model_args = model_args
+        self.hf_assets_path = hf_assets_path
+        self.from_hf_map = {
+            "model.embed_tokens.weight": "tok_embeddings.weight",
+            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
+            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
+            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
+            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
+            "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
+            "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
+            "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
+            "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
+            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
+            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
+            "model.norm.weight": "norm.weight",
+            "lm_head.weight": "output.weight",
+        }
+
+    # HuggingFace permutation function (exact copy from their conversion script)
+    def _permute(self, w, n_heads_arg, dim1=None, dim2=None):
+        if dim1 is None:
+            dim1 = w.shape[0]
+        if dim2 is None:
+            dim2 = w.shape[1]
+        return (
+            w.view(n_heads_arg, dim1 // n_heads_arg // 2, 2, dim2)
+            .transpose(1, 2)
+            .reshape(dim1, dim2)
+            .clone()
+        )
+
+    def _reverse_permute(self, w, n_heads_arg, dim1=None, dim2=None):
+        if dim1 is None:
+            dim1 = w.shape[0]
+        if dim2 is None:
+            dim2 = w.shape[1]
+        return (
+            w.view(n_heads_arg, 2, dim1 // n_heads_arg // 2, dim2)
+            .transpose(1, 2)
+            .reshape(dim1, dim2)
+        )
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+
+        n_heads = self.model_args.n_heads
+        n_kv_heads = (
+            self.model_args.n_kv_heads
+            if self.model_args.n_kv_heads is not None
+            else n_heads
+        )
+        dim = self.model_args.dim
+        head_dim = dim // n_heads
+        hf_state_dict = {}
+
+        for key, value in state_dict.items():
+            if "layers" in key:
+                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
+                layer_num = re.search(r"\d+", key).group(0)
+                new_key = to_hf_map[abstract_key]
+                # We need to permute the weights in wq and wk layer in order to account for the difference between
+                # the native Llama and huggingface RoPE implementation.
+                if abstract_key == "layers.{}.attention.wq.weight":
+                    value = self._permute(value, n_heads)
+                if abstract_key == "layers.{}.attention.wk.weight":
+                    key_value_dim = head_dim * n_kv_heads
+                    value = self._permute(value, n_kv_heads, key_value_dim, dim)
+
+                if new_key is None:
+                    continue
+                new_key = new_key.format(layer_num)
+            else:
+                new_key = to_hf_map[key]
+
+            hf_state_dict[new_key] = value
+
+        return hf_state_dict
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        n_heads = self.model_args.n_heads
+        n_kv_heads = (
+            self.model_args.n_kv_heads
+            if self.model_args.n_kv_heads is not None
+            else n_heads
+        )
+        dim = self.model_args.dim
+        head_dim = dim // n_heads
+        state_dict = {}
+
+        for key, value in hf_state_dict.items():
+            if "layers" in key:
+                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
+                layer_num = re.search(r"\d+", key).group(0)
+                new_key = self.from_hf_map[abstract_key]
+
+                # We need to permute the weights in wq and wk layer in order to account for the difference between
+                # the native Llama and huggingface RoPE implementation.
+                if abstract_key == "model.layers.{}.self_attn.q_proj.weight":
+                    value = self._reverse_permute(value, n_heads)
+                if abstract_key == "model.layers.{}.self_attn.k_proj.weight":
+                    key_value_dim = head_dim * n_kv_heads
+                    value = self._reverse_permute(value, n_kv_heads, key_value_dim, dim)
+
+                if new_key is None:
+                    continue
+                new_key = new_key.format(layer_num)
+            else:
+                new_key = self.from_hf_map[key]
+
+            state_dict[new_key] = value
+        return state_dict

--- a/torchtitan/experiments/blendcorpus/run_train.sh
+++ b/torchtitan/experiments/blendcorpus/run_train.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+set -ex
+
+# use envs as local overwrites for convenience
+# e.g.
+# LOG_RANK=0,1 NGPU=4 ./run_train.sh
+NGPU=${NGPU:-"8"}
+export LOG_RANK=${LOG_RANK:-0}
+CONFIG_FILE=${CONFIG_FILE:-"./torchtitan/experiments/blendcorpus/train_configs/llama2_7b.toml"}
+
+TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE:-"http://localhost:29510"}
+
+PYTORCH_ALLOC_CONF="expandable_segments:True" \
+TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
+torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
+--local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
+-m torchtitan.experiments.blendcorpus.train --job.config_file ${CONFIG_FILE} "$@"

--- a/torchtitan/experiments/blendcorpus/train.py
+++ b/torchtitan/experiments/blendcorpus/train.py
@@ -1,0 +1,687 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+import os
+import time
+from datetime import timedelta
+from typing import Any, Generator, Iterable, Optional
+
+import ezpz
+import torch
+from torch.distributed.elastic.multiprocessing.errors import record
+
+import torchtitan.protocols.train_spec as train_spec_module
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.dataloader import DataloaderStopIteration
+from torchtitan.components.ft import FTManager, maybe_semi_sync_training
+from torchtitan.components.loss import rescale_accumulated_loss
+from torchtitan.components.metrics import (
+    build_metrics_processor,
+    ensure_pp_loss_visible,
+)
+from torchtitan.config import ConfigManager, JobConfig
+from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.protocols.model_converter import build_model_converters
+from torchtitan.tools import utils
+# from torchtitan.tools.logging import init_logger, logger
+from torchtitan.tools.profiling import (
+    maybe_enable_memory_snapshot,
+    maybe_enable_profiling,
+)
+
+
+logger = ezpz.get_logger(__name__)
+
+
+
+class Trainer(torch.distributed.checkpoint.stateful.Stateful):
+    # core configs
+    job_config: JobConfig
+    parallel_dims: ParallelDims
+    train_spec: train_spec_module.TrainSpec
+
+    # swappable training components in TrainSpec
+    tokenizer: train_spec_module.BaseTokenizer | None
+    dataloader: train_spec_module.BaseDataLoader
+    model_parts: list[torch.nn.Module]
+    loss_fn: train_spec_module.LossFunction
+    optimizers: train_spec_module.OptimizersContainer
+    lr_schedulers: train_spec_module.LRSchedulersContainer
+    validator: train_spec_module.BaseValidator
+    metrics_processor: train_spec_module.MetricsProcessor
+    model_args: train_spec_module.BaseModelArgs
+
+    # non-swappable training components
+    checkpointer: CheckpointManager
+    ft_manager: FTManager
+
+    # runtime utilities
+    device: torch.device
+    gc_handler: utils.GarbageCollection
+    train_context: Generator[None, None, None]
+    gradient_accumulation_steps: int
+    pp_has_first_stage: bool
+    pp_has_last_stage: bool
+
+    # additional training states
+    step: int
+    ntokens_seen: int
+
+    # Enable debug tracing on failure: https://pytorch.org/docs/stable/elastic/errors.html
+    @record
+    def __init__(self, job_config: JobConfig):
+        torch._C._log_api_usage_once("torchtitan.train")
+
+        self.job_config = job_config
+
+        logger.info(f"Starting job: {job_config.job.description}")
+
+        if job_config.experimental.custom_import:
+            importlib.import_module(job_config.experimental.custom_import)
+
+        if job_config.job.print_args:
+            logger.info(f"Running with args: {job_config.to_dict()}")
+
+        device_module, device_type = utils.device_module, utils.device_type
+        from blendcorpus.dist_setup import init_distributed, get_device, get_device_type                
+        self.device = get_device()
+        #self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+        # Device has to be set before creating TorchFT manager.
+        device_module.set_device(self.device)
+        dist, rank, world_size = init_distributed()
+        # init distributed and build meshes
+        dist_utils.init_distributed(
+            job_config.comm,
+            enable_cpu_backend=job_config.training.enable_cpu_offload,
+            base_folder=job_config.job.dump_folder,
+        )
+        #world_size = int(os.environ["WORLD_SIZE"])
+        parallelism_config = job_config.parallelism
+        self.parallel_dims = parallel_dims = ParallelDims(
+            dp_shard=parallelism_config.data_parallel_shard_degree,
+            dp_replicate=parallelism_config.data_parallel_replicate_degree,
+            cp=parallelism_config.context_parallel_degree,
+            tp=parallelism_config.tensor_parallel_degree,
+            pp=parallelism_config.pipeline_parallel_degree,
+            ep=parallelism_config.expert_parallel_degree,
+            etp=parallelism_config.expert_tensor_parallel_degree,
+            world_size=world_size,
+        )
+
+        world_mesh = parallel_dims.world_mesh
+        if parallel_dims.dp_enabled:
+            dp_mesh = world_mesh["dp"]
+            dp_degree, dp_rank = dp_mesh.size(), dp_mesh.get_local_rank()
+        else:
+            dp_degree, dp_rank = 1, 0
+
+        self.ft_manager = FTManager(job_config.fault_tolerance)
+        dp_degree, dp_rank = self.ft_manager.get_dp_info(dp_degree, dp_rank)
+
+        # take control of garbage collection to avoid stragglers
+        self.gc_handler = utils.GarbageCollection(
+            gc_freq=job_config.training.gc_freq, debug=job_config.training.gc_debug
+        )
+
+        # Set random seed, and maybe enable deterministic mode
+        # (mainly for debugging, expect perf loss).
+        dist_utils.set_determinism(
+            world_mesh,
+            self.device,
+            job_config.training.seed,
+            job_config.training.deterministic,
+        )
+        self.train_spec = train_spec_module.get_train_spec(job_config.model.name)
+
+        # build tokenizer and dataloader
+        self.tokenizer = (
+            self.train_spec.build_tokenizer_fn(job_config)
+            if self.train_spec.build_tokenizer_fn is not None
+            else None
+        )
+        # verify batch sizes
+        global_batch_size = job_config.training.global_batch_size
+        if global_batch_size < 0:
+            # This global batch size results in 1 gradient accumulation
+            # step.
+            global_batch_size = job_config.training.local_batch_size * dp_degree
+        assert global_batch_size > 0
+        assert (
+            global_batch_size % (job_config.training.local_batch_size * dp_degree) == 0
+        ), (
+            f"global batch size must be multiple of local batch size times "
+            f"data-parallel degree ({global_batch_size} "
+            f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
+        )
+        # --- BlendCorpus integration ---
+        train_dl, valid_dl, test_dl = self.train_spec.build_dataloader_fn(job_config, global_batch_size)  # returns (train, valid, test)
+        self.dataloader = train_dl
+        # If your Trainer uses eval/test loaders, surface them too:
+        self.eval_dataloader = valid_dl if valid_dl is not None else None
+        self.test_dataloader = test_dl if test_dl is not None else None
+        utils.logger.info("Using BlendCorpus dataloader.")
+
+        # build model (using meta init)
+        model_args = self.train_spec.model_args[job_config.model.flavor]
+        # set the model args from training job configs
+        model_args.update_from_config(job_config)
+        self.model_args = model_args
+
+        logger.info(
+            f"Building {self.train_spec.name} {job_config.model.flavor} with {model_args}"
+        )
+        with torch.device("meta"):
+            model = self.train_spec.model_cls(model_args)
+
+        # Build the collection of model converters. No-op if `model.converters` empty
+        model_converters = build_model_converters(job_config, parallel_dims)
+        model_converters.convert(model)
+
+        # metrics logging
+        build_metrics_processor_fn = (
+            build_metrics_processor
+            if self.train_spec.build_metrics_processor_fn is None
+            else self.train_spec.build_metrics_processor_fn
+        )
+        self.metrics_processor = build_metrics_processor_fn(
+            job_config, parallel_dims, model_args
+        )
+        color = self.metrics_processor.color
+
+        # calculate model size and flops per token
+        (
+            model_param_count,
+            self.metrics_processor.num_flops_per_token,
+        ) = model_args.get_nparams_and_flops(model, job_config.training.seq_len)
+
+        logger.info(
+            f"{color.blue}Model {self.train_spec.name} {job_config.model.flavor} "
+            f"{color.red}size: {model_param_count:,} total parameters{color.reset}"
+        )
+
+        # move sharded model to CPU/GPU and initialize weights via DTensor
+        if job_config.checkpoint.create_seed_checkpoint:
+            init_device = "cpu"
+            buffer_device = None
+        elif job_config.training.enable_cpu_offload:
+            init_device = "cpu"
+            buffer_device = device_type
+        else:
+            init_device = device_type
+            buffer_device = None
+
+        self.loss_fn = self.train_spec.build_loss_fn(job_config)
+
+
+
+        # calculate gradient accumulation steps
+        self.gradient_accumulation_steps = global_batch_size // (
+            job_config.training.local_batch_size * dp_degree
+        )
+        assert self.gradient_accumulation_steps > 0
+        self.loss_fn = rescale_accumulated_loss(
+            self.loss_fn, self.gradient_accumulation_steps
+        )
+
+        # apply parallelisms and initialization
+        if parallel_dims.pp_enabled:
+            if not self.train_spec.pipelining_fn:
+                raise RuntimeError(
+                    f"Pipeline Parallel is enabled but {self.train_spec.name} "
+                    f"does not support pipelining"
+                )
+
+            # apply both PT-D Pipeline Parallel and SPMD-style PT-D techniques
+            (
+                self.pp_schedule,
+                self.model_parts,
+                self.pp_has_first_stage,
+                self.pp_has_last_stage,
+            ) = self.train_spec.pipelining_fn(
+                model,
+                parallel_dims,
+                job_config,
+                self.device,
+                model_args,
+                self.train_spec.parallelize_fn,
+                self.loss_fn,
+            )
+            # when PP is enabled, `model` obj is no longer used after this point,
+            # model_parts is used instead
+            del model
+
+            for m in self.model_parts:
+                m.to_empty(device=init_device)
+                with torch.no_grad():
+                    m.init_weights(buffer_device=buffer_device)
+                m.train()
+
+            # confirm that user will be able to view loss metrics on the console
+            ensure_pp_loss_visible(parallel_dims, job_config, color)
+        else:
+            # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel
+            model = self.train_spec.parallelize_fn(model, parallel_dims, job_config)
+
+            model.to_empty(device=init_device)
+            with torch.no_grad():
+                model.init_weights(buffer_device=buffer_device)
+            model.train()
+
+            self.model_parts = [model]
+
+        self.ft_manager.maybe_set_all_reduce_hook(self.model_parts)
+
+        # initialize device memory monitor and get peak flops for MFU calculation
+        device_memory_monitor = self.metrics_processor.device_memory_monitor
+        gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
+        logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
+        device_mem_stats = device_memory_monitor.get_peak_stats()
+        logger.info(
+            f"{device_type.upper()} memory usage for model: "
+            f"{device_mem_stats.max_reserved_gib:.2f}GiB"
+            f"({device_mem_stats.max_reserved_pct:.2f}%)"
+        )
+
+        # build optimizer after applying parallelisms to the model
+        self.optimizers = self.train_spec.build_optimizers_fn(
+            self.model_parts, job_config.optimizer, parallel_dims, self.ft_manager
+        )
+        self.lr_schedulers = self.train_spec.build_lr_schedulers_fn(
+            self.optimizers, job_config.lr_scheduler, job_config.training.steps
+        )
+        # Post optimizer step model converters hook.
+        # e.g. calculate float8 dynamic amax/scale for all-parameter for FSDP2
+        # where it issues a single all-reduce for all parameters at once for better performance
+        self.optimizers.register_step_post_hook(
+            lambda *args, **kwargs: model_converters.post_optimizer_hook(
+                self.model_parts
+            )
+        )
+        self.metrics_processor.optimizers = self.optimizers
+
+        # Initialize trainer states that will be saved in checkpoint.
+        # These attributes must be initialized before checkpoint loading.
+        self.step = 0
+        self.ntokens_seen = 0
+
+        self.checkpointer = CheckpointManager(
+            dataloader=self.dataloader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states={"train_state": self},
+            checkpoint_config=job_config.checkpoint,
+            sd_adapter=(
+                self.train_spec.state_dict_adapter(
+                    model_args, job_config.model.hf_assets_path
+                )
+                if self.train_spec.state_dict_adapter
+                else None
+            ),
+            base_folder=job_config.job.dump_folder,
+            ft_manager=self.ft_manager,
+        )
+
+        loss_parallel_enabled = (
+            parallel_dims.tp_enabled and not parallelism_config.disable_loss_parallel
+        )
+        self.train_context = dist_utils.get_train_context(
+            loss_parallel_enabled,
+            parallelism_config.enable_compiled_autograd,
+        )
+        self.maybe_enable_amp = dist_utils.maybe_enable_amp(
+            parallel_dims,
+            job_config.training.mixed_precision_param,
+            device_type,
+        )
+
+        # Build validator if validation is configured
+        if job_config.validation.enable:
+            assert self.train_spec.build_validator_fn is not None
+
+            pp_schedule, pp_has_first_stage, pp_has_last_stage = (
+                (
+                    self.pp_schedule,
+                    self.pp_has_first_stage,
+                    self.pp_has_last_stage,
+                )
+                if parallel_dims.pp_enabled
+                else (None, None, None)
+            )
+
+            self.validator = self.train_spec.build_validator_fn(
+                job_config=job_config,
+                dp_world_size=dp_degree,
+                dp_rank=dp_rank,
+                tokenizer=self.tokenizer,
+                parallel_dims=parallel_dims,
+                loss_fn=self.train_spec.build_loss_fn(job_config),
+                validation_context=self.train_context,
+                maybe_enable_amp=self.maybe_enable_amp,
+                metrics_processor=self.metrics_processor,
+                pp_schedule=pp_schedule,
+                pp_has_first_stage=pp_has_first_stage,
+                pp_has_last_stage=pp_has_last_stage,
+            )
+            self.validator.blendcorpus_init(validation_dataloader=self.eval_dataloader)
+
+        logger.info(
+            "Trainer is initialized with "
+            f"local batch size {job_config.training.local_batch_size}, "
+            f"global batch size {global_batch_size}, "
+            f"gradient accumulation steps {self.gradient_accumulation_steps}, "
+            f"sequence length {job_config.training.seq_len}, "
+            f"total steps {job_config.training.steps} "
+            f"(warmup {job_config.lr_scheduler.warmup_steps})"
+        )
+
+    def batch_generator(
+        self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
+    ) -> Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]:
+        """Returns an iterator that processes batches from the data iterator."""
+        device_type = utils.device_type
+        data_iterator = iter(data_iterable)
+
+        while True:
+            data_load_start = time.perf_counter()
+            try:
+                batch = next(data_iterator)
+            except StopIteration as ex:
+                # If data runs out during gradient accumulation, that
+                # entire step will not be executed.
+                raise DataloaderStopIteration() from ex
+            input_dict, labels = batch
+            ntokens_batch = labels.numel()
+            self.ntokens_seen += ntokens_batch
+            self.metrics_processor.ntokens_since_last_log += ntokens_batch
+            self.metrics_processor.data_loading_times.append(
+                time.perf_counter() - data_load_start
+            )
+
+            # Move tensors to the appropriate device
+            for k, v in input_dict.items():
+                if isinstance(v, torch.Tensor):
+                    input_dict[k] = v.to(device_type)
+            labels = labels.to(device_type)
+
+            yield input_dict, labels
+
+    def forward_backward_step(
+        self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
+    ) -> torch.Tensor:
+        model_parts = self.model_parts
+        parallel_dims = self.parallel_dims
+
+        # apply context parallelism if cp is enabled
+        # ensure CP handles the separate freqs_cis buffer for each pp stage
+        inputs = input_dict["input"]
+        optional_context_parallel_ctx = (
+            dist_utils.create_context_parallel_ctx(
+                cp_mesh=parallel_dims.world_mesh["cp"],
+                cp_buffers=[inputs, labels] + [m.freqs_cis for m in model_parts],
+                cp_seq_dims=[1, 1] + [0 for _ in model_parts],
+                cp_no_restore_buffers={inputs, labels},
+                cp_rotate_method=self.job_config.parallelism.context_parallel_rotate_method,
+            )
+            if parallel_dims.cp_enabled
+            else None
+        )
+
+        if parallel_dims.pp_enabled:
+            # Pipeline Parallel forward / backward inside step() call
+            with self.train_context(optional_context_parallel_ctx):
+                targets, losses = (
+                    (labels, []) if self.pp_has_last_stage else (None, None)
+                )
+                if self.pp_has_first_stage:
+                    self.pp_schedule.step(
+                        inputs, target=targets, losses=losses, input_batch=inputs
+                    )
+                else:
+                    self.pp_schedule.step(
+                        target=targets, losses=losses, input_batch=inputs
+                    )
+
+            # accumulate losses across pipeline microbatches
+            # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
+            loss = (
+                torch.mean(torch.stack(losses)).to(self.device)
+                if self.pp_has_last_stage
+                else torch.tensor([-1.0], device=self.device)
+            )
+        else:
+            # Non-PP forward / backward
+            with self.train_context(optional_context_parallel_ctx):
+                assert len(model_parts) == 1
+                with self.maybe_enable_amp:
+                    pred = model_parts[0](inputs, eos_id=self.tokenizer.eos_id)
+                    loss = self.loss_fn(pred, labels)
+                # need to free to before bwd to avoid peaking memory
+                del pred
+                loss.backward()
+
+        return loss
+
+    def train_step(
+        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
+    ):
+        self.optimizers.zero_grad()
+        # Save the current step learning rate for logging
+        lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
+
+        # Keep these variables local to shorten the code as these are
+        # the major variables that are used in the training loop.
+        parallel_dims = self.parallel_dims
+
+        accumulated_losses = []
+        # If data runs out during gradient accumulation, that
+        # entire step will not be executed.
+        for microbatch in range(self.gradient_accumulation_steps):
+            input_dict, labels = next(data_iterator)
+            loss = self.forward_backward_step(input_dict, labels)
+            accumulated_losses.append(loss.detach())
+
+        grad_norm = dist_utils.clip_grad_norm_(
+            [p for m in self.model_parts for p in m.parameters()],
+            self.job_config.training.max_norm,
+            foreach=True,
+            pp_mesh=(
+                parallel_dims.world_mesh["pp"] if parallel_dims.pp_enabled else None
+            ),
+            ep_enabled=parallel_dims.ep_enabled,
+        )
+        self.checkpointer.maybe_wait_for_staging()
+        self.optimizers.step()
+        self.lr_schedulers.step()
+
+        # Reduce the data collected over gradient accumulation steps.
+        loss = torch.sum(torch.stack(accumulated_losses))
+
+        # log metrics
+        if not self.metrics_processor.should_log(self.step):
+            return
+
+        if parallel_dims.dp_cp_enabled:
+            loss = loss.detach()
+            ft_pg = self.ft_manager.loss_sync_pg
+            global_avg_loss, global_max_loss, global_ntokens_seen = (
+                dist_utils.dist_mean(loss, parallel_dims.world_mesh["dp_cp"], ft_pg),
+                dist_utils.dist_max(loss, parallel_dims.world_mesh["dp_cp"], ft_pg),
+                dist_utils.dist_sum(
+                    torch.tensor(
+                        self.ntokens_seen, dtype=torch.int64, device=self.device
+                    ),
+                    parallel_dims.world_mesh["dp_cp"],
+                    ft_pg,
+                ),
+            )
+        else:
+            global_avg_loss = global_max_loss = loss.detach().item()
+            global_ntokens_seen = self.ntokens_seen
+
+        extra_metrics = {
+            "n_tokens_seen": global_ntokens_seen,
+            "lr": lr,
+        }
+        self.metrics_processor.log(
+            self.step,
+            global_avg_loss,
+            global_max_loss,
+            grad_norm.item(),
+            extra_metrics=extra_metrics,
+        )
+
+    @record
+    def train(self):
+        job_config = self.job_config
+
+        self.checkpointer.load(step=job_config.checkpoint.load_step)
+        # If using BlendCorpus, retarget the dataloader to the restored step.
+        try:
+            ds_name = getattr(getattr(self.job_config, "training", object()), "dataset", "").strip().lower()
+            if ds_name == "blendcorpus" and hasattr(self.dataloader, "set_consumed_by_global_step"):
+                self.dataloader.set_consumed_by_global_step(self.step, job_config.blendcorpus.global_batch_size)
+                if self.eval_dataloader is not None:
+                    self.eval_dataloader.set_consumed_by_global_step(
+                        self.step, job_config.blendcorpus.global_batch_size
+                    )
+                logger.info(f"BlendCorpus dataloader advanced to consumed={self.step * job_config.blendcorpus.global_batch_size} samples (step={self.step}).")
+        except Exception as _e:
+            logger.warning(f"BlendCorpus retarget hook failed: {_e}")
+
+        logger.info(f"Training starts at step {self.step + 1}.")
+
+        leaf_folder = (
+            ""
+            if not self.ft_manager.enabled
+            else f"replica_{self.ft_manager.replica_id}"
+        )
+        with (
+            maybe_enable_profiling(
+                job_config.profiling,
+                global_step=self.step,
+                base_folder=job_config.job.dump_folder,
+                leaf_folder=leaf_folder,
+            ) as torch_profiler,
+            maybe_enable_memory_snapshot(
+                job_config.profiling,
+                global_step=self.step,
+                base_folder=job_config.job.dump_folder,
+                leaf_folder=leaf_folder,
+            ) as memory_profiler,
+            maybe_semi_sync_training(
+                job_config.fault_tolerance,
+                ft_manager=self.ft_manager,
+                model=self.model_parts[0],
+                n_layers=(
+                    self.model_args.n_layers
+                    if hasattr(self.model_args, "n_layers")
+                    else 0
+                ),
+                optimizer=self.optimizers,
+                fragment_fn=(
+                    self.train_spec.fragment_fn
+                    if hasattr(self.train_spec, "fragment_fn")
+                    else None
+                ),
+            ),
+        ):
+            data_iterator = self.batch_generator(self.dataloader)
+            while self.step < job_config.training.steps:
+                self.step += 1
+                self.gc_handler.run(self.step)
+                try:
+                    self.train_step(data_iterator)
+                except DataloaderStopIteration:
+                    logger.warning("Ran out of data; last step was canceled.")
+                    break
+
+                self.checkpointer.save(
+                    self.step, last_step=(self.step == job_config.training.steps)
+                )
+
+                # Run validation if validator is available
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
+                ):
+                    self.validator.validate(self.model_parts, self.step)
+
+                # signal the profiler that the next profiling step has started
+                if torch_profiler:
+                    torch_profiler.step()
+                if memory_profiler:
+                    memory_profiler.step()
+
+                # reduce timeout after first train step for faster signal
+                # (assuming lazy init and compilation are finished)
+                if self.step == 1:
+                    dist_utils.set_pg_timeouts(
+                        timeout=timedelta(
+                            seconds=job_config.comm.train_timeout_seconds
+                        ),
+                        world_mesh=self.parallel_dims.world_mesh,
+                    )
+
+        if torch.distributed.get_rank() == 0:
+            logger.info("Sleeping 2 seconds for other ranks to complete")
+            time.sleep(2)
+
+        logger.info("Training completed")
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"step": self.step, "ntokens_seen": self.ntokens_seen}
+
+    def load_state_dict(self, state_dict: dict[str, Any]):
+        self.step = state_dict["step"]
+        self.ntokens_seen = state_dict["ntokens_seen"]
+
+    def close(self) -> None:
+        if self.checkpointer:
+            self.checkpointer.close()
+        if self.metrics_processor:
+            self.metrics_processor.close()
+
+
+if __name__ == "__main__":
+    _ = ezpz.setup_torch()
+    # init_logger()
+    config_manager = ConfigManager()
+    config = config_manager.parse_args()
+    trainer: Optional[Trainer] = None
+
+    try:
+        trainer = Trainer(config)
+
+        if config.checkpoint.create_seed_checkpoint:
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable
+            ), "Must enable checkpointing when creating a seed checkpoint."
+            trainer.checkpointer.save(curr_step=0, last_step=True)
+            logger.info("Created seed checkpoint")
+        else:
+            try:
+                logger.info(f"Using SDPBackend.FLASH_ATTENTION backend for SDPA")
+                from torch.nn.functional import scaled_dot_product_attention
+                from torch.nn.attention import SDPBackend, sdpa_kernel
+                with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    trainer.train()
+            except Exception:
+                # Fallback to default attention implementation
+                logger.warning("Falling back to default attention implementation")
+                trainer.train()
+    except Exception:
+        if trainer:
+            trainer.close()
+        raise
+    else:
+        trainer.close()
+        torch.distributed.destroy_process_group()
+        logger.info("Process group destroyed")

--- a/torchtitan/experiments/blendcorpus/train_configs/debug_model.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/debug_model.toml
@@ -1,0 +1,104 @@
+# torchtitan Config.toml
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 debug training"
+print_args = false
+use_for_integration_test = true
+
+[profiling]
+enable_profiling = false
+save_traces_folder = "profile_trace"
+profile_freq = 10
+enable_memory_snapshot = false
+save_memory_snapshot_folder = "memory_snapshot"
+
+[metrics]
+log_freq = 1
+disable_color_printing = false
+enable_tensorboard = false
+save_tb_folder = "tb"
+enable_wandb = false
+
+[model]
+# choose which preset to start from
+name   = "blendcorpus"
+flavor = "debugmodel"         # this picks the preset your log shows
+
+# tokenizer wiring (your local SPM)
+tokenizer_backend = "sptoken"
+hf_assets_path    = "./assets/hf/Llama-2-7b"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 8e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
+decay_type = "linear"
+min_lr_factor = 0.0
+
+[training]
+local_batch_size = 1
+seq_len = 2048
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+dataset_path = "/home/hzheng/AuroraGPT/datasets/dolma/file_list.txt"
+# "/flare/Aurora_deployment/AuroraGPT/datasets/dolma/dolma_v1_7_file_list_v2.txt"
+
+[experimental]
+custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+fsdp_reshard_after_forward = "default" # default / never / always
+tensor_parallel_degree = 1
+enable_async_tensor_parallel = false
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable = false
+folder = "checkpoint"
+interval = 10
+last_save_model_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enabled = false
+dataset = "c4_validation"
+freq = 5
+steps = 10
+
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+shuffle_sample_in_corpus = true
+blend_sample_in_corpus=false
+eod_token_id = 2
+#data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama2_7b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama2_7b.toml
@@ -1,0 +1,104 @@
+# torchtitan Config.toml
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 debug training"
+print_args = false
+use_for_integration_test = true
+
+[profiling]
+enable_profiling = false
+save_traces_folder = "profile_trace"
+profile_freq = 10
+enable_memory_snapshot = false
+save_memory_snapshot_folder = "memory_snapshot"
+
+[metrics]
+log_freq = 1
+disable_color_printing = false
+enable_tensorboard = false
+save_tb_folder = "tb"
+enable_wandb = false
+
+[model]
+# choose which preset to start from
+name   = "blendcorpus"
+flavor = "Llama-2-7b"         # this picks the preset your log shows
+
+# tokenizer wiring (your local SPM)
+tokenizer_backend = "sptoken"
+hf_assets_path    = "./assets/hf/Llama-2-7b"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 8e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
+decay_type = "linear"
+min_lr_factor = 0.0
+
+[training]
+local_batch_size = 1
+seq_len = 4096
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+#dataset_path = "/home/hzheng/AuroraGPT/datasets/dolma/file_list.txt" 
+dataset_path = "/flare/Aurora_deployment/AuroraGPT/datasets/dolma/dolma_v1_7_file_list_mini.txt"
+
+[experimental]
+custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+fsdp_reshard_after_forward = "default" # default / never / always
+tensor_parallel_degree = 1
+enable_async_tensor_parallel = false
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+# enable = false
+folder = "checkpoint"
+interval = 10
+last_save_model_only = false
+export_dtype = "float32"
+async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enable = false
+dataset = "c4_validation"
+freq = 5
+steps = 10
+
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+shuffle_sample_in_corpus = true
+blend_sample_in_corpus=false
+eod_token_id = 2
+#data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_405b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_405b.toml
@@ -1,0 +1,88 @@
+# torchtitan Config.toml
+# NOTE: this toml config is a preset for 128 H100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 405B training"
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 10
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "llama3"
+flavor = "405B"
+hf_assets_path = "./assets/hf/Llama-3.1-405B"
+converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 8e-5
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 600  # lr scheduler warm up, normally 20% of the train steps
+
+[training]
+local_batch_size = 2
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 3000
+dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+dataset_path = "/home/huihuo.zheng/vast/AuroraGPT/datasets/data_list.txt"
+
+[experimental]
+custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 8  # 8-way TP
+enable_async_tensor_parallel = true
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable_checkpoint = false
+folder = "checkpoint"
+interval = 500
+last_save_model_only = true
+export_dtype = "float32"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = "full" # ["none", "selective", "full"]
+
+[compile]
+enable=true
+components = ["model", "loss"]
+
+[float8]
+enable_fsdp_float8_all_gather = true
+precompute_float8_dynamic_scale_for_fsdp = true
+filter_fqns = ["output"]
+
+[validation]
+enabled = false
+dataset = "c4_validation"
+freq = 500
+steps = -1
+
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+shuffle_sample_in_corpus = true
+eod_token_id = 2
+data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_70b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_70b.toml
@@ -1,0 +1,87 @@
+# torchtitan Config.toml
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 70B training"
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 10
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "llama3"
+flavor = "70B"
+hf_assets_path = "./assets/hf/Llama-3.1-70B"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 1.5e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up, normally 20% of the train steps
+
+[training]
+local_batch_size = 8
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+dataset_path = "/home/huihuo.zheng/vast/AuroraGPT/datasets/data_list.txt"
+
+[experimental]
+custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 8  # 8-way TP
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable_checkpoint = false
+folder = "checkpoint"
+interval = 500
+last_save_model_only = true
+export_dtype = "float32"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = "full"
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enabled = false
+dataset = "c4_validation"
+freq = 500
+steps = -1
+
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+shuffle_sample_in_corpus = true
+eod_token_id = 2
+data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_8b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_8b.toml
@@ -1,0 +1,89 @@
+# torchtitan Config.toml
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 8B training"
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 10
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "blendcorpus"
+flavor = "8B"
+tokenizer_backend = "hf"
+hf_assets_path = "./assets/hf/Llama-3.1-8B"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 3e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up
+
+[training]
+local_batch_size = 1
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+dataset_path = "/flare/Aurora_deployment/AuroraGPT/datasets/dolma/dolma_v1_7_file_list_mini.txt"
+
+[experimental]
+custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 1
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable_checkpoint = false
+folder = "checkpoint"
+interval = 500
+last_save_model_only = true
+export_dtype = "float32"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+[float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enabled = false
+dataset = "c4_validation"
+freq = 100
+steps = -1
+
+
+[blendcorpus]
+# Optional overrides / extras
+num_workers = 2
+split = "98,1,1"
+dataloader_type = "single"
+shuffle = true
+append_eod = true
+provide_attention_mask = false
+shuffle_sample_in_corpus = true
+eod_token_id = 2
+#data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/validate.py
+++ b/torchtitan/experiments/blendcorpus/validate.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import Generator
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import FSDPModule
+from torch.distributed.pipelining.schedules import _PipelineSchedule
+
+from torchtitan.components.dataloader import BaseDataLoader
+from torchtitan.components.loss import LossFunction
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.tokenizer import BaseTokenizer
+from torchtitan.components.validate import Validator
+from torchtitan.config import JobConfig
+from torchtitan.distributed import ParallelDims, utils as dist_utils
+
+class BlendCorpusValidator(Validator):
+    """
+    Simple validator focused on correctness and integration.
+
+    Args:
+        job_config: Job configuration
+        validation_dataloader: The validation dataloader
+        loss_fn: Loss function to use for validation
+        model: The model to validate (single model, no parallelism)
+    """
+
+    validation_dataloader: BaseDataLoader
+    def blendcorpus_init(
+        self,
+        validation_dataloader: BaseDataLoader,
+    ):
+        self.validation_dataloader = validation_dataloader
+
+def build_blendcorpus_validator(
+    job_config: JobConfig,
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: BaseTokenizer,
+    parallel_dims: ParallelDims,
+    loss_fn: LossFunction,
+    validation_context: Generator[None, None, None],
+    maybe_enable_amp: Generator[None, None, None],
+    metrics_processor: MetricsProcessor | None = None,
+    pp_schedule: _PipelineSchedule | None = None,
+    pp_has_first_stage: bool | None = None,
+    pp_has_last_stage: bool | None = None,
+) -> BlendCorpusValidator:
+    """Build a simple validator focused on correctness."""
+    return BlendCorpusValidator(
+        job_config=job_config,
+        dp_world_size=dp_world_size,
+        dp_rank=dp_rank,
+        tokenizer=tokenizer,
+        parallel_dims=parallel_dims,
+        loss_fn=loss_fn,
+        validation_context=validation_context,
+        maybe_enable_amp=maybe_enable_amp,
+        metrics_processor=metrics_processor,
+        pp_schedule=pp_schedule,
+        pp_has_first_stage=pp_has_first_stage,
+        pp_has_last_stage=pp_has_last_stage,
+    )


### PR DESCRIPTION
## Copilot Summary

This pull request introduces comprehensive support for training on BlendCorpus within the TorchTitan framework. The changes add a new tokenizer adapter for SentencePiece, integrate BlendCorpus dataloader logic, update configuration schemas, and wire up the necessary training hooks. These improvements allow for seamless selection, configuration, and checkpointing of BlendCorpus experiments using TorchTitan.

**BlendCorpus integration and dataloader support:**

* Added `AdapterDL` wrapper and `build_blendcorpus_dataloader` to bridge BlendCorpus datasets to Titan’s batch format, including checkpoint-aware data stream retargeting and batch collation logic. (`torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py`)
* Registered the BlendCorpus training spec, connecting model, optimizer, dataloader, tokenizer, loss, and validator components for end-to-end experiment wiring. (`torchtitan/experiments/blendcorpus/__init__.py`)

**Tokenizer support and routing:**

* Added a new `SPTokenizer` class wrapping SentencePiece, with Titan-compatible attributes and encode/decode API, plus a builder function. (`torchtitan/experiments/blendcorpus/dataset/sptoken.py`)
* Implemented a tokenizer router to select between SentencePiece and HuggingFace tokenizers based on config, with clear error handling for unsupported backends. (`torchtitan/experiments/blendcorpus/dataset/build_tokenizer.py`)

**Configuration and documentation:**

* Documented all integration steps, configuration schema additions, dataloader logic, trainer hooks, and provided example TOML configs for BlendCorpus experiments. (`torchtitan/experiments/blendcorpus/README.md`)