### PR TITLE
Run DSv3 on 1D AP w/ local_map

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -309,7 +309,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # confirm that user will be able to view loss metrics on the console
             ensure_pp_loss_visible(parallel_dims, job_config, color)
         else:
-            # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel
+            # apply Autoparallel
             model = self.train_spec.parallelize_fn(model, parallel_dims, job_config)
 
             model.to_empty(device=init_device)


### PR DESCRIPTION
Make 1D AP work on DSv3.

requires stack on https://github.com/pytorch/pytorch/pull/162702 and AP main

doesn't yet contain all the fixes to local_map, but putting up the PR since the current branch doesn't run, and this at least runs (just inefficient because of EP's inputs/outputs being force replicated).

1D AP logs: https://gist.github.com/xmfan/51402bd27716303b76e6ebd022f92036
non-AP still runs: https://gist.github.com/xmfan/82c8e988fba26fe5322fdc9be74c9c64