### PR TITLE
[Feat] Gradient sync is turned off during gradient accumulation.

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -448,3 +448,25 @@ def _clip_grad_norm_with_ep(
     torch.nn.utils.clip_grads_with_norm_(non_ep_params, max_norm, total_norm, foreach)
 
     return total_norm
+
+
+@contextlib.contextmanager
+def _no_grad_sync(model: torch.nn.Module):
+    model.set_requires_gradient_sync(False)
+    try:
+        yield
+    finally:
+        model.set_requires_gradient_sync(True)
+        
+        
+@contextlib.contextmanager
+def no_grad_sync(models: list[torch.nn.Module], enable: bool = False):
+    if not enable:
+        yield
+        return
+    
+    with contextlib.ExitStack() as stack:
+        for m in models:
+            ctx = _no_grad_sync(m) if hasattr(m, "set_requires_gradient_sync") else contextlib.nullcontext()
+            stack.enter_context(ctx)
+        yield


### PR DESCRIPTION
Gradient sync should be turned off during gradient accumulation.

[FSDPModule.set_requires_gradient_sync](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.FSDPModule.set_requires_gradient_sync)
[DDP.set_requires_gradient_sync](https://github.com/pytorch/pytorch/blob/v2.8.0/torch/distributed/_composable/replicate.py#L163)