### PR TITLE
Removing call to init_weights in model's __init__

### DIFF
--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -400,7 +400,6 @@ class Transformer(nn.Module, ModelProtocol):
             self.layers[str(layer_id)] = TransformerBlock(layer_id, model_args)
         self.norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
         self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
-        self.init_weights()
 
     def init_weights(
         self,

--- a/torchtitan/experiments/qwen3/model/model.py
+++ b/torchtitan/experiments/qwen3/model/model.py
@@ -378,8 +378,6 @@ class Qwen3Model(nn.Module, ModelProtocol):
 
         self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
 
-        self.init_weights()
-
     def init_weights(
         self,
         buffer_device: torch.device | None = None,

--- a/torchtitan/experiments/simple_fsdp/model.py
+++ b/torchtitan/experiments/simple_fsdp/model.py
@@ -11,7 +11,6 @@ from .simple_fsdp import disable_data_parallel
 class SimpleFSDPTransformer(Transformer):
     def __init__(self, model_args: TransformerModelArgs):
         super().__init__(model_args)
-        self.init_weights()
 
     def init_weights(self, *args, **kwargs):
         with disable_data_parallel():

--- a/torchtitan/models/deepseek_v3/model/model.py
+++ b/torchtitan/models/deepseek_v3/model/model.py
@@ -337,7 +337,6 @@ class DeepSeekV3Model(nn.Module, ModelProtocol):
             bias=False,
         )
         self.model_args = model_args
-        self.init_weights()
 
     def init_weights(self, buffer_device: torch.device | None = None) -> None:
         buffer_device = buffer_device or self.freqs_cis.device

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -344,7 +344,6 @@ class Transformer(nn.Module, ModelProtocol):
             self.layers[str(layer_id)] = TransformerBlock(layer_id, model_args)
         self.norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)
         self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
-        self.init_weights()
 
     def init_weights(
         self,


### PR DESCRIPTION
As discussed [here](https://github.com/pytorch/torchtitan/pull/1615#discussion_r2323062537) and [here](https://github.com/pytorch/torchtitan/pull/1615#discussion_r2342364525), I create this PR to limit the scope of the other PR #1615 .

When subclassing a torchtitan's model for training, the call to `self.init_weights()` inside model `__init__` could have side effect.
Solution is to delete this line because in practice it currently has no effect, we explicitly called `m.init_weights(buffer_device)` in `train.py` already.
Flux model already doesn't do it.
