### PR TITLE
refactor: use a common DatasetConfig class

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -48,7 +48,7 @@ DATASETS = {
     "wikipedia": DatasetConfig(
         path="wikipedia",  # default HuggingFace dataset path
         loader=load_wikipedia_dataset,
-        text_processor=process_wikipedia_text,
+        sample_processor=process_wikipedia_text,
     ),
 }
 ```
@@ -66,7 +66,7 @@ That's it! Your custom dataset is now ready to use with `torchtitan`.
 - The DatasetConfig contains all necessary components for a dataset:
   - `path`: The default path to the dataset (can be overridden during training)
   - `loader`: Function to load the dataset
-  - `text_processor`: Function to process individual samples
+  - `sample_processor`: Function to process individual samples
 - The loader function should return a HuggingFace dataset object
 - The processor function should return a string that combines the relevant fields from your dataset
 - Use `streaming=True` for large datasets to manage memory efficiently

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -10,7 +10,8 @@ import torch
 from datasets import load_dataset
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
 from torchtitan.config import ConfigManager
-from torchtitan.datasets.hf_datasets import build_hf_dataloader, DatasetConfig, DATASETS
+from torchtitan.datasets import DatasetConfig
+from torchtitan.datasets.hf_datasets import build_hf_dataloader, DATASETS
 
 
 class TestDatasetCheckpointing(unittest.TestCase):
@@ -20,7 +21,7 @@ class TestDatasetCheckpointing(unittest.TestCase):
             loader=lambda path: load_dataset(path, split="train").to_iterable_dataset(
                 num_shards=4
             ),
-            text_processor=lambda sample: sample["text"],
+            sample_processor=lambda sample: sample["text"],
         )
 
     def tearDown(self):

--- a/torchtitan/datasets/__init__.py
+++ b/torchtitan/datasets/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+__all__ = ["DatasetConfig"]
+
+
+@dataclass
+class DatasetConfig:
+    path: str
+    loader: Callable
+    sample_processor: Callable

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
-
 from functools import partial
 from typing import Any, Callable
 
@@ -19,6 +17,7 @@ from torch.utils.data import IterableDataset
 from torchtitan.components.dataloader import ParallelAwareDataloader
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.config import JobConfig
+from torchtitan.datasets import DatasetConfig
 from torchtitan.tools.logging import logger
 
 
@@ -32,29 +31,22 @@ def _process_c4_text(sample: dict[str, Any]) -> str:
     return sample["text"]
 
 
-@dataclass
-class DatasetConfig:
-    path: str
-    loader: Callable
-    text_processor: Callable
-
-
-# Add your dataset here here - more information at docs/datasets.md
+# Add your dataset here - more information at docs/datasets.md
 DATASETS = {
     "c4": DatasetConfig(
         path="allenai/c4",
         loader=partial(_load_c4_dataset, split="train"),
-        text_processor=_process_c4_text,
+        sample_processor=_process_c4_text,
     ),
     "c4_test": DatasetConfig(
         path="tests/assets/c4_test",
         loader=lambda path: load_dataset(path, split="train"),
-        text_processor=_process_c4_text,
+        sample_processor=_process_c4_text,
     ),
     "c4_validation": DatasetConfig(
         path="allenai/c4",
         loader=partial(_load_c4_dataset, split="validation"),
-        text_processor=_process_c4_text,
+        sample_processor=_process_c4_text,
     ),
 }
 
@@ -72,7 +64,7 @@ def _validate_dataset(
     config = DATASETS[dataset_name]
     path = dataset_path or config.path
     logger.info(f"Preparing {dataset_name} dataset from {path}")
-    return path, config.loader, config.text_processor
+    return path, config.loader, config.sample_processor
 
 
 class HuggingFaceDataset(IterableDataset, Stateful):

--- a/torchtitan/experiments/flux/dataset/flux_dataset.py
+++ b/torchtitan/experiments/flux/dataset/flux_dataset.py
@@ -6,7 +6,6 @@
 
 import itertools
 import math
-from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 import numpy as np
@@ -23,6 +22,7 @@ from torchtitan.components.dataloader import ParallelAwareDataloader
 
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.config import JobConfig
+from torchtitan.datasets import DatasetConfig
 from torchtitan.experiments.flux.dataset.tokenizer import (
     build_flux_tokenizer,
     FluxTokenizer,
@@ -139,30 +139,23 @@ def _coco_data_processor(
     }
 
 
-@dataclass
-class TextToImageDatasetConfig:
-    path: str
-    loader: Callable
-    data_processor: Callable
-
-
 DATASETS = {
-    "cc12m-wds": TextToImageDatasetConfig(
+    "cc12m-wds": DatasetConfig(
         path="pixparse/cc12m-wds",
         loader=lambda path: load_dataset(path, split="train", streaming=True),
-        data_processor=_cc12m_wds_data_processor,
+        sample_processor=_cc12m_wds_data_processor,
     ),
-    "cc12m-test": TextToImageDatasetConfig(
+    "cc12m-test": DatasetConfig(
         path="torchtitan/experiments/flux/tests/assets/cc12m_test",
         loader=lambda path: load_dataset(
             path, split="train", data_files={"train": "*.tar"}, streaming=True
         ),
-        data_processor=_cc12m_wds_data_processor,
+        sample_processor=_cc12m_wds_data_processor,
     ),
-    "coco-validation": TextToImageDatasetConfig(
+    "coco-validation": DatasetConfig(
         path="howard-hou/COCO-Text",
         loader=lambda path: load_dataset(path, split="validation", streaming=True),
-        data_processor=_coco_data_processor,
+        sample_processor=_coco_data_processor,
     ),
 }
 
@@ -180,7 +173,7 @@ def _validate_dataset(
     config = DATASETS[dataset_name]
     path = dataset_path or config.path
     logger.info(f"Preparing {dataset_name} dataset from {path}")
-    return path, config.loader, config.data_processor
+    return path, config.loader, config.sample_processor
 
 
 class FluxDataset(IterableDataset, Stateful):

--- a/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
+++ b/torchtitan/experiments/flux/tests/unit_tests/test_flux_dataloader.py
@@ -11,22 +11,22 @@ import torch
 from datasets import load_dataset
 
 from torchtitan.config import ConfigManager
+from torchtitan.datasets import DatasetConfig
 from torchtitan.experiments.flux.dataset.flux_dataset import (
     _cc12m_wds_data_processor,
     build_flux_dataloader,
     DATASETS,
-    TextToImageDatasetConfig,
 )
 
 
 class TestFluxDataLoader(unittest.TestCase):
     def setUp(self):
-        DATASETS["cc12m-test-iterable"] = TextToImageDatasetConfig(
+        DATASETS["cc12m-test-iterable"] = DatasetConfig(
             path="torchtitan/experiments/flux/tests/assets/cc12m_test",
             loader=lambda path: load_dataset(
                 path, split="train", data_files={"train": "*tar"}
             ).to_iterable_dataset(num_shards=4),
-            data_processor=_cc12m_wds_data_processor,
+            sample_processor=_cc12m_wds_data_processor,
         )
 
     def tearDown(self):

--- a/torchtitan/experiments/multimodal/mm_dataset.py
+++ b/torchtitan/experiments/multimodal/mm_dataset.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
@@ -21,6 +20,7 @@ from utils import load_image
 
 from torchtitan.components.dataloader import ParallelAwareDataloader
 from torchtitan.config import JobConfig
+from torchtitan.datasets import DatasetConfig
 from torchtitan.tools.logging import logger
 
 
@@ -51,13 +51,6 @@ def _process_obelics_sample(
         "images": [load_image(image) for image in sample_images],
         "text": "".join(map(str, sample_text)),
     }
-
-
-@dataclass
-class DatasetConfig:
-    path: str
-    loader: Callable
-    sample_processor: Callable
 
 
 # Add your dataset here here - more information at docs/datasets.md


### PR DESCRIPTION
As suggested in the comment [here](https://github.com/pytorch/torchtitan/pull/1615#discussion_r2342453286) for PR #1615 , I refactored all the dataset config instance to a common one in `torchtitan/datasets/__init__.py`, with a common name `sample_processor`.
Doing it here to make it easier to review and limit scope of the other PR. 