### PR TITLE
temporarily removed cudnn attention backend

### DIFF
--- a/torchtitan/models/attention.py
+++ b/torchtitan/models/attention.py
@@ -20,8 +20,6 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 
-from torchtitan.tools.utils import has_cuda_capability
-
 # FlexAttention mask type. For each mask type, we initialize it at most once per
 # batch. To record what it is initialized, FLEX_ATTN_MASK_T is used as the key to
 # track the initialized mask.
@@ -203,14 +201,11 @@ class ScaledDotProductAttention(torch.nn.Module):
         if cls.backends:
             return
 
-        # Add CuDNN on B200 w/ highest priority
         cls.backends = [
             SDPBackend.FLASH_ATTENTION,
             SDPBackend.EFFICIENT_ATTENTION,
             SDPBackend.MATH,
         ]
-        if has_cuda_capability(10, 0):
-            cls.backends.insert(0, SDPBackend.CUDNN_ATTENTION)
 
     def forward(
         self,


### PR DESCRIPTION
We should remove this until long term fix for https://github.com/pytorch/torchtitan/issues/1713 is landed. I believe @eqy is working on a fix. I tried using pytorch built from source with latest changes just now, but the issue persists, so for now we can remove cudnn attention backend and add back later.