### PR TITLE
Adding small model configurations to torchtitan

### DIFF
--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -40,6 +40,21 @@ llama3_configs = {
         use_flex_attn=True,
         attn_mask_type="block_causal",
     ),
+    "160M": TransformerModelArgs(
+        dim=768,
+        n_layers=18,
+        n_heads=12,
+    ),
+    "300M": TransformerModelArgs(
+        dim=1024,
+        n_layers=20,
+        n_heads=16,
+    ),
+    "660M": TransformerModelArgs(
+        dim=1408,
+        n_layers=24,
+        n_heads=11,
+    ),
     "8B": TransformerModelArgs(
         dim=4096,
         n_layers=32,


### PR DESCRIPTION
Summary: The diff adds some small model configurations to torchtitan, smaller than the currently available 8b models for the llama3 model setup for easy experimentation. The three model sizes added are 160M, 300M and 660M. Would be happy to keep only 160M model size if we are worried about future support. Please let me know if you would also like me to add an example training config for it.

Differential Revision: D82692620


