### PR TITLE
Fix flux image_generation_test.  Change input dim to match encoder

### DIFF
--- a/torchtitan/experiments/flux/tests/test_generate_image.py
+++ b/torchtitan/experiments/flux/tests/test_generate_image.py
@@ -98,7 +98,7 @@ class TestGenerateImage:
         t1 = time.perf_counter()
 
         model = self._get_test_model(
-            context_in_dim=4096, device=torch_device, dtype=torch.bfloat16
+            context_in_dim=768, device=torch_device, dtype=torch.bfloat16
         )
         model.eval()
 


### PR DESCRIPTION
Quick fix to address issue a failing test for `experiments/flux` that I encountered and opened and described in #1725.

Fix is to match `context_in_dim` to the corresponding text embedding size of the encoder model `t5-v1_1-base`.