### PR TITLE
fix: pp grad accumulation is broken

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -147,7 +147,10 @@ class Validator(BaseValidator):
                 # accumulate losses across pipeline microbatches
                 # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
                 loss = (
-                    torch.mean(torch.stack(losses)).to(device_type)
+                    # using sum instead of mean because we already rescale the
+                    # loss_fn down by a factor of n_microbatches in
+                    # torchtitan/distributed/pipeline_parallel.py
+                    torch.sum(torch.stack(losses)).to(device_type)
                     if self.pp_has_last_stage
                     else torch.tensor([-1.0], device=device_type)
                 )

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -83,6 +83,7 @@ def build_pipeline_schedule(
         stages if looped_schedule else stages[0],
         n_microbatches=n_microbatches,
         loss_fn=loss_fn,
+        scale_grads=False,
     )
     logger.info(
         f"Using pipeline schedule {job_config.parallelism.pipeline_parallel_schedule} "

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -22,6 +22,7 @@ from torch.distributed.pipelining.schedules import (
     ScheduleZBVZeroBubble,
 )
 
+from torchtitan.components.loss import rescale_accumulated_loss
 from torchtitan.config import JobConfig
 from torchtitan.tools.logging import logger
 
@@ -82,7 +83,7 @@ def build_pipeline_schedule(
     schedule = schedule_class(
         stages if looped_schedule else stages[0],
         n_microbatches=n_microbatches,
-        loss_fn=loss_fn,
+        loss_fn=rescale_accumulated_loss(loss_fn, n_microbatches),
         scale_grads=False,
     )
     logger.info(

--- a/torchtitan/experiments/deepseek_v3/train_ds_dev.py
+++ b/torchtitan/experiments/deepseek_v3/train_ds_dev.py
@@ -126,7 +126,10 @@ def run_full_model(
                 y = pp_schedule.step(x)
             elif pp_rank == pp_size - 1:
                 y = pp_schedule.step(target=label, losses=losses)
-                loss = torch.mean(torch.stack(losses))
+                # using sum instead of mean because we already rescale the
+                # loss_fn down by a factor of n_microbatches in
+                # torchtitan/distributed/pipeline_parallel.py
+                loss = torch.sum(torch.stack(losses))
             else:
                 pp_schedule.step()
         else:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -197,7 +197,10 @@ class Trainer(ForgeEngine):
             # accumulate losses across pipeline microbatches
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
             loss = (
-                torch.mean(torch.stack(losses)).to(self.device)
+                # using sum instead of mean because we already rescale the
+                # loss_fn down by a factor of n_microbatches in
+                # torchtitan/distributed/pipeline_parallel.py
+                torch.sum(torch.stack(losses)).to(self.device)
                 if self.pp_has_last_stage
                 else torch.tensor([-1.0], device=self.device)
             )

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -62,7 +62,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     gradient_accumulation_steps: int
     pp_has_first_stage: bool
     pp_has_last_stage: bool
-    pp_n_microbatches: int
 
     # additional training states
     step: int
@@ -215,21 +214,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
         )
 
-        if parallel_dims.pp_enabled:
-            # When using pp, loss needs to be scaled by the number of microbatches
-            microbatch_size = job_config.parallelism.pipeline_parallel_microbatch_size
-            batch_size = job_config.training.local_batch_size
-            self.pp_n_microbatches = batch_size // microbatch_size
-        else:
-            self.pp_n_microbatches = 1
-
         # calculate gradient accumulation steps
         self.gradient_accumulation_steps = global_batch_size // (
             job_config.training.local_batch_size * dp_degree
         )
         assert self.gradient_accumulation_steps > 0
         self.loss_fn = rescale_accumulated_loss(
-            self.loss_fn, self.gradient_accumulation_steps * self.pp_n_microbatches
+            self.loss_fn, self.gradient_accumulation_steps
         )
 
         # apply parallelisms and initialization
@@ -461,9 +452,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # accumulate losses across pipeline microbatches
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
             loss = (
-                torch.mean(torch.stack(losses))
-                .multiply(self.pp_n_microbatches)
-                .to(self.device)
+                torch.sum(torch.stack(losses)).to(self.device)
                 if self.pp_has_last_stage
                 else torch.tensor([-1.0], device=self.device)
             )

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -452,6 +452,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # accumulate losses across pipeline microbatches
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
             loss = (
+                # using sum instead of mean because we already rescale the
+                # loss_fn down by a factor of n_microbatches in
+                # torchtitan/distributed/pipeline_parallel.py
                 torch.sum(torch.stack(losses)).to(self.device)
                 if self.pp_has_last_stage
                 else torch.tensor([-1.0], device=self.device)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -461,7 +461,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             # accumulate losses across pipeline microbatches
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
             loss = (
-                torch.mean(torch.stack(losses)).multiply(self.pp_n_microbatches).to(self.device)
+                torch.mean(torch.stack(losses))
+                .multiply(self.pp_n_microbatches)
+                .to(self.device)
                 if self.pp_has_last_stage
                 else torch.tensor([-1.0], device=self.device)
             )


### PR DESCRIPTION
[problem]
Using gradient accumulation is incompatible with PipleineSchedule(..., scale_grads=True) option, which defaults to True.

When this option is set, at each step, all gradients are scaled by the micro-batch size. This works fine for a single gradient accumulation step, but when using multiple steps, this will rescale the total gradient by this factor, not just at the end of gradient accumulation.

The result is that the accumulated gradient is an exponential moving average, rather than a sum. Overall, the resulting gradients are much smaller than they should be and using gradient accumulation with PP is not equivalent to using it without PP -- the loss curves diverge substantially, as well as the gradient-norms are way off.

A secondary consequence of is that at every step, it divides the gradients by n_microbatches, which is computationally expensive when applied to a large model.

[solution]
Set "scale_grads=False" when creating the scheduler instance.

Compute "n_microbatches" in the constructor and apply this factor, along with gradient_accumulation_steps, to the scale factor in "rescale_accumulated_loss()". This will cause the loss to be scaled, rather than the gradients, at each step by the correct factor.

A secondary benifit of this approach is that it avoids having to modify all of the gradients. It's much cheaper, computationally than modifying all of the gradients -- and it's correct, which it is not, without the change.

A side effect of the previous change is that the loss values returned by the pipeline have been scaled by this factor, which makes them too small by a factor of n_microbatches. We can correct this by rescaling the returned loss by the same factor.

[testing]
Witout these changes, a baseline run, with 10 gradient accumulation steps, on a single GPU is compared against a run (without the changes) to a 2 GPU pipeline, using 1F1B. The effective batch size is 320 in both cases, with all other variables controlled. The result is a substantial divergence between the loss curves and gradient-norm of the two runs.

With this change applied, the results are nearly identical, ignoring minor differences from non-determinism.

[references]
scale_grads option: https://github.com/pytorch/pytorch/blob/281bb56cc50073159c8418c5c99c7459c914c4db/torch/distributed/pipelining/schedules.py#L286

scale_grads implementation: https://github.com/pytorch/pytorch/blob/281bb56cc50073159c8418c5c99c7459c914c4db/torch/distributed/pipelining/stage.py#L567

Test code for reproduction of the issue and the testing the fix:
https://github.com/jdinalt/forgather/tree/main/examples/torchtitan/test_parallelisms