### PR TITLE
Add einops to requirements.txt

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -8,3 +8,4 @@ fsspec
 tyro
 tokenizers >= 0.15.0
 safetensors
+einops


### PR DESCRIPTION
This is required by the new VLM code:

```
[rank0]:Traceback (most recent call last):
[rank0]:  File "/home/ezyang/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 187, in _run_module_as_main
[rank0]:    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
[rank0]:  File "/home/ezyang/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/runpy.py", line 110, in _get_module_details
[rank0]:    __import__(pkg_name)
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/__init__.py", line 12, in <module>
[rank0]:    import torchtitan.experiments  # noqa: F401
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/experiments/__init__.py", line 10, in <module>
[rank0]:    import torchtitan.experiments.vlm  # noqa: F401
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/experiments/vlm/__init__.py", line 17, in <module>
[rank0]:    from .datasets.mm_datasets import build_mm_dataloader
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/experiments/vlm/datasets/mm_datasets.py", line 29, in <module>
[rank0]:    from .mm_collator_nld import MultiModalCollatorNLD
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/experiments/vlm/datasets/mm_collator_nld.py", line 17, in <module>
[rank0]:    from .utils.image import (
[rank0]:  File "/data/users/ezyang/b/torchtitan/torchtitan/experiments/vlm/datasets/utils/image.py", line 12, in <module>
[rank0]:    import einops as E
[rank0]:ModuleNotFoundError: No module named 'einops'
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>