### PR TITLE
[refactor] dynamically import TrainSpec

### DIFF
--- a/torchtitan/__init__.py
+++ b/torchtitan/__init__.py
@@ -6,8 +6,3 @@
 
 # Import to register quantization modules.
 import torchtitan.components.quantization  # noqa: F401
-
-# Import the built-in models here so that the corresponding register_model_spec()
-# will be called.
-import torchtitan.experiments  # noqa: F401
-import torchtitan.models  # noqa: F401

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -4,7 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torchtitan.experiments.llama4  # noqa: F401
-import torchtitan.experiments.qwen3
-import torchtitan.experiments.simple_fsdp  # noqa: F401
-import torchtitan.experiments.vlm  # noqa: F401
+_supported_experiments = frozenset(["flux", "llama4", "qwen3", "simple_fsdp", "vlm"])

--- a/torchtitan/experiments/flux/__init__.py
+++ b/torchtitan/experiments/flux/__init__.py
@@ -9,7 +9,7 @@
 
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .dataset.flux_dataset import build_flux_dataloader
 from .infra.parallelize import parallelize_flux
@@ -107,8 +107,8 @@ flux_configs = {
 }
 
 
-register_train_spec(
-    TrainSpec(
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
         name="flux",
         model_cls=FluxModel,
         model_args=flux_configs,
@@ -122,4 +122,3 @@ register_train_spec(
         build_validator_fn=build_flux_validator,
         state_dict_adapter=FluxStateDictAdapter,
     )
-)

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -297,8 +297,11 @@ class Trainer(ForgeEngine):
                     break
 
                 # Run validation if validator is available
-                if self.job_config.enable and self.validator.should_validate(self.step):
-                    self.validator.validate(self.model_parts)
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
+                ):
+                    self.validator.validate(self.model_parts, self.step)
 
                 self.checkpointer.save(
                     self.step, last_step=(self.step == job_config.training.steps)

--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -11,7 +11,7 @@ from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.models.moe import MoEArgs
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .infra.parallelize import parallelize_llama
 from .model.args import TransformerModelArgs
@@ -97,8 +97,8 @@ llama4_configs = {
 }
 
 
-register_train_spec(
-    TrainSpec(
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
         name="llama4",
         model_cls=Transformer,
         model_args=llama4_configs,
@@ -111,4 +111,3 @@ register_train_spec(
         build_loss_fn=build_cross_entropy_loss,
         state_dict_adapter=Llama4StateDictAdapter,
     )
-)

--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -10,10 +10,10 @@ pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu
 
 This folder includes an experimental frontend implementation for [SimpleFSDP: Simpler Fully Sharded Data Parallel with torch.compile](https://arxiv.org/abs/2411.00284). SimpleFSDP is a compiler-based Fully Sharded Data Parallel (FSDP) framework, which has a simple implementation for maintenance and composability, allows full computation-communication graph tracing, and brings performance enhancement via compiler backend optimizations.
 
-### Enable SimpleFSDP Training
+### Run SimpleFSDP Training on Llama 3
 
 ```bash
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name llama3_simple_fsdp --compile.enable
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name simple_fsdp --compile.enable
 ```
 
 ### Composability Support

--- a/torchtitan/experiments/simple_fsdp/__init__.py
+++ b/torchtitan/experiments/simple_fsdp/__init__.py
@@ -12,14 +12,15 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.models.llama3 import llama3_configs, pipeline_llama
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .model import SimpleFSDPTransformer
 from .parallelize import parallelize_llama
 
-register_train_spec(
-    TrainSpec(
-        name="llama3_simple_fsdp",
+
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
+        name="simple_fsdp",
         model_cls=SimpleFSDPTransformer,
         model_args=llama3_configs,
         parallelize_fn=parallelize_llama,
@@ -30,4 +31,3 @@ register_train_spec(
         build_tokenizer_fn=build_hf_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
     )
-)

--- a/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
+++ b/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
@@ -21,7 +21,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                 ],
             ],
@@ -31,7 +31,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--activation_checkpoint.mode selective",
                     "--activation_checkpoint.selective_ac_option op",
@@ -43,7 +43,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--activation_checkpoint.mode full",
                 ],
@@ -54,7 +54,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.tensor_parallel_degree 2",
                 ],
@@ -66,7 +66,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         # OverrideDefinitions(
         #     [
         #         [
-        #             "--model.name llama3_simple_fsdp",
+        #             "--model.name simple_fsdp",
         #             "--compile.enable",
         #             "--parallelism.tensor_parallel_degree 2",
         #             "--parallelism.enable_async_tensor_parallel",
@@ -78,12 +78,12 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                 ],
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                     "--training.steps 20",
@@ -95,7 +95,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -103,7 +103,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                 ],
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--training.steps 20",
                     "--checkpoint.enable",
@@ -119,7 +119,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 1",
                     "--parallelism.data_parallel_replicate_degree 4",
@@ -132,7 +132,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.data_parallel_replicate_degree 2",
@@ -145,7 +145,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.data_parallel_replicate_degree 2",
@@ -159,7 +159,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_replicate_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
@@ -172,7 +172,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.data_parallel_replicate_degree 2",
@@ -186,7 +186,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
@@ -200,7 +200,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                     "--training.steps 10",
@@ -208,7 +208,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
                 # Save at [dp:4] and load at [dp:2, tp:2]. Note that the dataloader should be
                 # excluded during loading to avoid errors caused by mismatched dp_degree.
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                     "--checkpoint.exclude_from_loading lr_scheduler,dataloader,optimizer",
@@ -217,7 +217,7 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
                 ],
                 # load at [tp:4].
                 [
-                    "--model.name llama3_simple_fsdp",
+                    "--model.name simple_fsdp",
                     "--compile.enable",
                     "--checkpoint.enable",
                     "--checkpoint.exclude_from_loading lr_scheduler,dataloader,optimizer",

--- a/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
+++ b/torchtitan/experiments/simple_fsdp/tests/test_numerics.py
@@ -7,7 +7,6 @@ import copy
 
 import torch
 from torch.distributed._composable.fsdp import fully_shard
-
 from torch.testing._internal.common_fsdp import FSDPTest
 
 from torchtitan.components.loss import cross_entropy_loss
@@ -30,7 +29,7 @@ class TestSimpleFSDP(FSDPTest):
             self.dp_mesh_dim_names = ("dp_replicate", "dp_shard_cp")
             data_parallel_replicate_degree = self.world_size // 2
         else:
-            raise ValueError(f"Unsupported mode {mode}")
+            raise ValueError(f"Unsupported mode {self.mode}")
 
         self.parallel_dims = ParallelDims(
             dp_shard=data_parallel_shard_degree,
@@ -39,6 +38,7 @@ class TestSimpleFSDP(FSDPTest):
             tp=1,
             pp=1,
             ep=1,
+            etp=1,
             world_size=self.world_size,
         )
         self.device_mesh = self.parallel_dims.world_mesh

--- a/torchtitan/experiments/vlm/__init__.py
+++ b/torchtitan/experiments/vlm/__init__.py
@@ -12,7 +12,7 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.components.validate import build_validator
 from torchtitan.models.llama3 import llama3_configs
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .datasets.mm_datasets import build_mm_dataloader
 from .infra.parallelize import parallelize_vlm
@@ -40,8 +40,8 @@ llama3_siglip2_configs = {
 }
 
 
-register_train_spec(
-    TrainSpec(
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
         name="llama3-siglip2",
         model_cls=Llama3Siglip2Transformer,
         model_args=llama3_siglip2_configs,
@@ -54,4 +54,3 @@ register_train_spec(
         build_loss_fn=build_cross_entropy_loss,
         build_validator_fn=build_validator,
     )
-)

--- a/torchtitan/experiments/vlm/requirements.txt
+++ b/torchtitan/experiments/vlm/requirements.txt
@@ -1,1 +1,2 @@
 einops
+pillow

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -39,14 +39,16 @@ The folder should be organized as follows
   - Include other util files if necessary.
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: ModelArgs]`.
-  - Call `register_train_spec` to specify a [`TrainSpec`](/torchtitan/protocols/train_spec.py), consisting a tuple of
+  - Define `get_train_spec` to return a [`TrainSpec`](/torchtitan/protocols/train_spec.py), consisting a tuple of
     - model name, model class, model args
+      - Model name should be the same as the folder name, which should be added to `torchtitan/models/__init__.py` or ``torchtitan/experiments/__init__.py``.
     - parallelizing function, pipelining function
     - builder functions for optimizer, lr scheduler, data loader, tokenizer, and loss function
       - More often than not, existing components can be reused.
       - Adding new datasets requires the `torchtitan` team’s review and legal approval.
       - Try to have minimal dependency on external libraries, if any.
     - state dict adapter
+  - If developing outside of torchtitan, one can call `register_train_spec` to register a `TrainSpec` so that `train.py` can be reused.
   - Read [more](/docs/extension.md#trainspec) on `TrainSpec`.
 - `README.md`
   - Include [instructions](/README.md#downloading-a-tokenizer) to download tokenizers / encoders.

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -4,9 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
-# Import the built-in models here so that the corresponding register_model_spec()
-# will be called.
-import torchtitan.models.deepseek_v3  # noqa: F401
-import torchtitan.models.llama3  # noqa: F401
-import torchtitan.models.llama3_ft  # noqa: F401
+_supported_models = frozenset(["llama3", "llama3_ft", "deepseek_v3"])

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -13,8 +13,7 @@ from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.models.llama3.infra.pipeline import pipeline_llama
 from torchtitan.models.moe import MoEArgs
-
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .infra.parallelize import parallelize_deepseekv3
 from .model.args import DeepSeekV3ModelArgs
@@ -160,8 +159,8 @@ deepseekv3_configs = {
 }
 
 
-register_train_spec(
-    TrainSpec(
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
         name="deepseek_v3",
         model_cls=DeepSeekV3Model,
         model_args=deepseekv3_configs,
@@ -174,4 +173,3 @@ register_train_spec(
         build_loss_fn=build_cross_entropy_loss,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
     )
-)

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -10,7 +10,7 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.components.validate import build_validator
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
-from torchtitan.protocols.train_spec import register_train_spec, TrainSpec
+from torchtitan.protocols.train_spec import TrainSpec
 
 from .infra.parallelize import parallelize_llama
 from .infra.pipeline import pipeline_llama
@@ -70,8 +70,8 @@ llama3_configs = {
 }
 
 
-register_train_spec(
-    TrainSpec(
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
         name="llama3",
         model_cls=Transformer,
         model_args=llama3_configs,
@@ -85,4 +85,3 @@ register_train_spec(
         build_validator_fn=build_validator,
         state_dict_adapter=Llama3StateDictAdapter,
     )
-)

--- a/torchtitan/models/llama3_ft/__init__.py
+++ b/torchtitan/models/llama3_ft/__init__.py
@@ -11,7 +11,8 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.components.validate import build_validator
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
-from torchtitan.protocols.train_spec import register_train_spec
+from torchtitan.protocols.train_spec import TrainSpec
+
 from ..llama3 import (
     llama3_configs,
     Llama3StateDictAdapter,
@@ -30,8 +31,8 @@ __all__ = [
 ]
 
 
-register_train_spec(
-    FaultTolerantTrainSpec(
+def get_train_spec() -> TrainSpec:
+    return FaultTolerantTrainSpec(
         name="llama3_ft",
         model_cls=Transformer,
         model_args=llama3_configs,
@@ -46,4 +47,3 @@ register_train_spec(
         build_validator_fn=build_validator,
         state_dict_adapter=Llama3StateDictAdapter,
     )
-)


### PR DESCRIPTION
which handles import more efficiently and avoids accidental failure.

After this PR, each new model or experiment need to define a `get_train_spec` function in their `__init__.py` file.