### PR TITLE
[CI] Disable Async TP CI

### DIFF
--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -22,6 +22,7 @@ class OverrideDefinitions:
     test_descr: str = "default"
     test_name: str = "default"
     ngpu: int = 4
+    disabled: bool = False
 
     def __repr__(self):
         return self.test_descr

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -29,6 +29,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             ],
             "2D async TP compile",
             "2d_asynctp_compile",
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -57,6 +58,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "FSDP+async TP+PP+torch.compile+Float8",
             "fsdp+tp+cp+compile+float8",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -84,6 +84,9 @@ def run_tests(args, test_list: list[OverrideDefinitions]):
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
             continue
 
+        if test_flavor.disabled:
+            continue
+
         # Check if we have enough GPUs
         if args.ngpu < test_flavor.ngpu:
             logger.info(


### PR DESCRIPTION
Async TP related CI started to fail since Sep 22 2025. However even if we roll back the nightly PyTorch to 0919, the tests still failed.
```
python -m pip install --force-reinstall torch==2.10.0.dev20250917+cu126 --index-url https://download.pytorch.org/whl/nightly/cu126
```

This is not an async TP issue but symmetric memory. This simple line can cause issues on the CI machine/docker.

```
symm_mem = get_symm_mem_workspace(torch.distributed.group.WORLD.group_name, min_size=1024*1024*64)
```