### PR TITLE
fix: validation loss accumulation rescaling

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import functools
 from typing import Callable, TypeAlias
 
@@ -30,14 +31,35 @@ def build_cross_entropy_loss(job_config: JobConfig):
     return loss_fn
 
 
+class RescaleAccumulatedLoss:
+    def __init__(self, unwrapped_loss_fn, accumulation_steps):
+        self.unwrapped_loss_fn = unwrapped_loss_fn
+        self.accumulation_steps = accumulation_steps
+        self.skip_rescale = False
+
+        # Copy over attributes from the original function, but don't
+        # copy the dict, which interferes with nested wrapping.
+        functools.update_wrapper(self, unwrapped_loss_fn, updated=tuple())
+
+    def __call__(self, *args, **kwargs):
+        loss = self.unwrapped_loss_fn(*args, **kwargs)
+        if self.skip_rescale:
+            return loss
+        return loss / self.accumulation_steps
+
+    @contextlib.contextmanager
+    def no_rescale(self):
+        """Context manager for disabling rescaling"""
+        previous = self.skip_rescale
+        self.skip_rescale = True
+        try:
+            yield
+        finally:
+            self.skip_rescale = previous
+
+
 def rescale_accumulated_loss(unwrapped_loss_fn, accumulation_steps):
     """Add a mean reduction over `accumulation_steps` to the given
     `unwrapped_loss_fn`.
     """
-
-    @functools.wraps(unwrapped_loss_fn)
-    def accumulated_loss_fn(*args, **kwargs):
-        loss = unwrapped_loss_fn(*args, **kwargs)
-        return loss / accumulation_steps
-
-    return accumulated_loss_fn
+    return RescaleAccumulatedLoss(unwrapped_loss_fn, accumulation_steps)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -607,7 +607,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                     self.job_config.validation.enable
                     and self.validator.should_validate(self.step)
                 ):
-                    self.validator.validate(self.model_parts, self.step)
+                    with self.loss_fn.no_rescale():
+                        self.validator.validate(self.model_parts, self.step)
 
                 # signal the profiler that the next profiling step has started
                 if torch_profiler:


### PR DESCRIPTION
[Problem]
When gradient accumulation is enabled, the validation loss is incorrect. This is a consequence of the loss_fn being shared between train and validation mode. The loss function is wrapped with rescale_accumulated_loss(), which rescales the loss by the number of gradient accumulation steps.

This works for train, as the loss from N accumulation steps is summed at the end of the accumulation, before being logged. In the case of validation, the loop assumes that each step is a normal step, and the reported loss is scaled by 1/N.

There are two separate pathways by which this occurs. In the normal case, the wrapped loss function is used "as-is." In the case of PP, the loss function is not directly used, but is still applied indirectly through the pipeline scheduler.

In both cases, the result is that the reported validation loss is divided by the number of accumulation steps.

[Solution]
The number of gradient accumulation steps is not communicated to the validation-factory, thus it does not have access to this parameter, which is computed in the Trainer's constructor.

One possible solution would be to pass this value, as an argument, to the validator, which could then rescale the loss by this factor, before logging it. This was the suggested solution to the problem.

My solution is a little different. The function
"rescale_accumulated_loss()" now returns a loss function with a "no_rescale()" context manager, which we apply before calling the validator. This transparently disables rescaling while within this context.

This approach avoids the need to communicate this detail to the Validator and avoids having to modify the signature of the Validator factory -- which means modifying quite a few other files.

Note that in the case of PP, we double-wrap the loss function. The context manager only applies to the outer layer, thus has no impact on the PP scaling, which is what we want.

[Testing]
First, run the trainer with both a normal, single GPU, run and a 2-stage pipeline. In both cases, set the number of accumulation steps to be sufficiently hight that the problem is obvious. This covers both pathways to the wrapped loss function.

Repeat the tests with the fix. The magnitude of the validation loss should roughly correlate with the train loss.