### PR TITLE
[quantization] Refactor quantization API

### DIFF
--- a/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
+++ b/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
@@ -14,7 +14,10 @@ Each host has
 
 ### Configuration
 
-Runs were invoked with the following, where `NUM_NODES` was `4` and `8`
+Runs were invoked with the following, where `NUM_NODES` was `4` and `8`.
+
+**Warning**: the command here has been updated to use the latest version of torchtitan, which has had API changes since this benchmark was ran.
+To reproduce the results using the original torchtitan commit, change all instances of `quantize.linear.float8` to `float8` in the command below.
 ```
   torchrun \
     --nnodes $NUM_NODES  \
@@ -27,10 +30,10 @@ Runs were invoked with the following, where `NUM_NODES` was `4` and `8`
     --metrics.enable_wandb \
     --training.local_batch_size=2 \
     --training.compile \
-    --model.converters="quantize.linear.fp8" \
-    --quantize.linear.fp8.enable_fsdp_float8_all_gather \
-    --quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp \
-    --quantize.linear.fp8.force_recompute_fp8_weight_in_bwd \
+    --model.converters="quantize.linear.float8" \
+    --quantize.linear.float8.enable_fsdp_float8_all_gather \
+    --quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp \
+    --quantize.linear.float8.force_recompute_fp8_weight_in_bwd \
     --profiling.profile_freq 1000000
     --training.steps 2000
 ```

--- a/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
+++ b/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
@@ -27,10 +27,10 @@ Runs were invoked with the following, where `NUM_NODES` was `4` and `8`
     --metrics.enable_wandb \
     --training.local_batch_size=2 \
     --training.compile \
-    --model.converters="quantize.dense.float8" \
-    --quantize.dense.float8.enable_fsdp_float8_all_gather \
-    --quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp \
-    --quantize.dense.float8.force_recompute_fp8_weight_in_bwd \
+    --model.converters="quantize.linear.fp8" \
+    --quantize.linear.fp8.enable_fsdp_float8_all_gather \
+    --quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp \
+    --quantize.linear.fp8.force_recompute_fp8_weight_in_bwd \
     --profiling.profile_freq 1000000
     --training.steps 2000
 ```

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -11,21 +11,21 @@ USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
 
 For float8 with tensorwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.fp8" --quantize.linear.fp8.enable_fsdp_float8_all_gather --quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp --compile.enable
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.float8" --quantize.linear.float8.enable_fsdp_float8_all_gather --quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp --compile.enable
 ```
-* `--model.converters="quantize.linear.fp8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
-* `--quantize.linear.fp8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
-* `--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
-* `--quantize.linear.fp8.filter_fqns="..."` (optional): a comma separated list of fully qualified names of modules not to convert to float8 training. Example: `--quantize.linear.fp8.filter_fqns="attention.wk,attention.wv"`. You can determine which layers to convert by looking at the microbenchmarks in the [performance section](https://github.com/pytorch/ao/tree/main/torchao/float8#performance) of the torchao documentation for the float8 recipe you're using.
+* `--model.converters="quantize.linear.float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--quantize.linear.float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
+* `--quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
+* `--quantize.linear.float8.filter_fqns="..."` (optional): a comma separated list of fully qualified names of modules not to convert to float8 training. Example: `--quantize.linear.float8.filter_fqns="attention.wk,attention.wv"`. You can determine which layers to convert by looking at the microbenchmarks in the [performance section](https://github.com/pytorch/ao/tree/main/torchao/float8#performance) of the torchao documentation for the float8 recipe you're using.
     * **Auto-filter**: add `"auto_filter_small_kn"` as one of the `filter_fqns` to to enable automatic module filtering, which will automatically not convert linear layers are not large enough to benefit from float8 training, since the GEMM has to be big enough that the speedup from using FP8 tensorcores is greater than the overhead of creating dynamically quantized inputs. The thresholds for conversion are based on microbenchmarks measured on NVIDIA H100 GPUs, where (K,N) represents the linear layer weight shape. For best performance, you should still manually filter out layers that are too small to benefit from float8 training.
 * `--compile.enable` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For float8 with rowwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.fp8" --quantize.linear.fp8.recipe_name rowwise --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.float8" --quantize.linear.float8.recipe_name rowwise --training.compile
 ```
-* `--model.converters="quantize.linear.fp8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
-* `--quantize.linear.fp8.recipe_name="rowwise"`: use the rowwise scaling recipe for higher accuracy compared to tensorwise scaling
+* `--model.converters="quantize.linear.float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--quantize.linear.float8.recipe_name="rowwise"`: use the rowwise scaling recipe for higher accuracy compared to tensorwise scaling
 * `--compile.enable` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For parallelisms, for float8 with tensorwise scaling we support float8 all-gather for FSDP (optional) and for TP (by default for `Float8Linear`). For float8 with rowwise scaling, all distributed communication is done in high precision.

--- a/docs/float8.md
+++ b/docs/float8.md
@@ -11,21 +11,21 @@ USE_CPP=0 python -m pip install git+https://github.com/pytorch/ao.git
 
 For float8 with tensorwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.dense.float8" --quantize.dense.float8.enable_fsdp_float8_all_gather --quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp --compile.enable
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.fp8" --quantize.linear.fp8.enable_fsdp_float8_all_gather --quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp --compile.enable
 ```
-* `--model.converters="quantize.dense.float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
-* `--quantize.dense.float8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
-* `--quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
-* `--quantize.dense.float8.filter_fqns="..."` (optional): a comma separated list of fully qualified names of modules not to convert to float8 training. Example: `--quantize.dense.float8.filter_fqns="attention.wk,attention.wv"`. You can determine which layers to convert by looking at the microbenchmarks in the [performance section](https://github.com/pytorch/ao/tree/main/torchao/float8#performance) of the torchao documentation for the float8 recipe you're using.
+* `--model.converters="quantize.linear.fp8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--quantize.linear.fp8.enable_fsdp_float8_all_gather`: cast `Float8Linear.weight` from high precision to float8 before FSDP all-gather so we can communicate in float8 to save bandwidth.
+* `--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp` (optional): communicate AMAX/scales efficiently in a single all-reduce for all parameters instead of doing many small all-reduce for each parameter.
+* `--quantize.linear.fp8.filter_fqns="..."` (optional): a comma separated list of fully qualified names of modules not to convert to float8 training. Example: `--quantize.linear.fp8.filter_fqns="attention.wk,attention.wv"`. You can determine which layers to convert by looking at the microbenchmarks in the [performance section](https://github.com/pytorch/ao/tree/main/torchao/float8#performance) of the torchao documentation for the float8 recipe you're using.
     * **Auto-filter**: add `"auto_filter_small_kn"` as one of the `filter_fqns` to to enable automatic module filtering, which will automatically not convert linear layers are not large enough to benefit from float8 training, since the GEMM has to be big enough that the speedup from using FP8 tensorcores is greater than the overhead of creating dynamically quantized inputs. The thresholds for conversion are based on microbenchmarks measured on NVIDIA H100 GPUs, where (K,N) represents the linear layer weight shape. For best performance, you should still manually filter out layers that are too small to benefit from float8 training.
 * `--compile.enable` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For float8 with rowwise scaling, launch training job with the following command (or alternatively set configs in toml files)
 ```
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.dense.float8" --quantize.dense.float8.recipe_name rowwise --training.compile
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.converters="quantize.linear.fp8" --quantize.linear.fp8.recipe_name rowwise --training.compile
 ```
-* `--model.converters="quantize.dense.float8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
-* `--quantize.dense.float8.recipe_name="rowwise"`: use the rowwise scaling recipe for higher accuracy compared to tensorwise scaling
+* `--model.converters="quantize.linear.fp8"`: swap `nn.Linear` with `Float8Linear` to perform float8 matmul.
+* `--quantize.linear.fp8.recipe_name="rowwise"`: use the rowwise scaling recipe for higher accuracy compared to tensorwise scaling
 * `--compile.enable` (required for competitive performance): use `torch.compile` to fuse the float8 scaling/casting kernels
 
 For parallelisms, for float8 with tensorwise scaling we support float8 all-gather for FSDP (optional) and for TP (by default for `Float8Linear`). For float8 with rowwise scaling, all distributed communication is done in high precision.

--- a/tests/integration_tests/base_config.toml
+++ b/tests/integration_tests/base_config.toml
@@ -69,7 +69,7 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/tests/integration_tests/base_config.toml
+++ b/tests/integration_tests/base_config.toml
@@ -69,7 +69,7 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -488,10 +488,10 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.converters quantize.linear.fp8",
-                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
-                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--quantize.linear.fp8.emulate",
+                    "--model.converters quantize.linear.float8",
+                    "--quantize.linear.float8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--quantize.linear.float8.emulate",
                 ],
             ],
             "Float8 emulation test",

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -488,10 +488,10 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.converters quantize.dense.float8",
-                    "--quantize.dense.float8.enable_fsdp_float8_all_gather",
-                    "--quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp",
-                    "--quantize.dense.float8.emulate",
+                    "--model.converters quantize.linear.fp8",
+                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--quantize.linear.fp8.emulate",
                 ],
             ],
             "Float8 emulation test",

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -35,9 +35,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.converters quantize.linear.fp8",
-                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
-                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.float8",
+                    "--quantize.linear.float8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp",
                 ],
             ],
             "Float8 test",
@@ -52,9 +52,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.enable_async_tensor_parallel",
-                    "--model.converters quantize.linear.fp8",
-                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
-                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.float8",
+                    "--quantize.linear.float8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp",
                 ],
             ],
             "FSDP+async TP+PP+torch.compile+Float8",
@@ -69,9 +69,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.data_parallel_replicate_degree 2",
                     "--parallelism.context_parallel_degree 2",
-                    "--model.converters quantize.linear.fp8",
-                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
-                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.float8",
+                    "--quantize.linear.float8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp",
                 ]
             ],
             "HSDP+CP+torch.compile+Float8",

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -35,9 +35,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--model.converters quantize.dense.float8",
-                    "--quantize.dense.float8.enable_fsdp_float8_all_gather",
-                    "--quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.fp8",
+                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
                 ],
             ],
             "Float8 test",
@@ -52,9 +52,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.enable_async_tensor_parallel",
-                    "--model.converters quantize.dense.float8",
-                    "--quantize.dense.float8.enable_fsdp_float8_all_gather",
-                    "--quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.fp8",
+                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
                 ],
             ],
             "FSDP+async TP+PP+torch.compile+Float8",
@@ -69,9 +69,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.data_parallel_replicate_degree 2",
                     "--parallelism.context_parallel_degree 2",
-                    "--model.converters quantize.dense.float8",
-                    "--quantize.dense.float8.enable_fsdp_float8_all_gather",
-                    "--quantize.dense.float8.precompute_float8_dynamic_scale_for_fsdp",
+                    "--model.converters quantize.linear.fp8",
+                    "--quantize.linear.fp8.enable_fsdp_float8_all_gather",
+                    "--quantize.linear.fp8.precompute_float8_dynamic_scale_for_fsdp",
                 ]
             ],
             "HSDP+CP+torch.compile+Float8",

--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.quantization.float8 import Float8DenseConverter
+from torchtitan.components.quantization.float8 import FP8LinearConverter
 from torchtitan.config import ConfigManager
 from torchtitan.distributed import ParallelDims
 from torchtitan.protocols.model_converter import (
@@ -43,8 +43,8 @@ def test_build_model_converters_float8_converter():
     config = config_manager.parse_args(
         [
             "--model.converters",
-            "quantize.dense.float8",
-            "--quantize.dense.float8.emulate",
+            "quantize.linear.fp8",
+            "--quantize.linear.fp8.emulate",
         ]
     )
     parallel_dims = build_parallel_dims(config, 1)
@@ -52,4 +52,4 @@ def test_build_model_converters_float8_converter():
     model_converters = build_model_converters(config, parallel_dims)
     assert isinstance(model_converters, ModelConvertersContainer)
     assert len(model_converters.converters) == 1
-    assert isinstance(model_converters.converters[0], Float8DenseConverter)
+    assert isinstance(model_converters.converters[0], FP8LinearConverter)

--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.quantization.float8 import FP8LinearConverter
+from torchtitan.components.quantization.float8 import Float8LinearConverter
 from torchtitan.config import ConfigManager
 from torchtitan.distributed import ParallelDims
 from torchtitan.protocols.model_converter import (
@@ -43,8 +43,8 @@ def test_build_model_converters_float8_converter():
     config = config_manager.parse_args(
         [
             "--model.converters",
-            "quantize.linear.fp8",
-            "--quantize.linear.fp8.emulate",
+            "quantize.linear.float8",
+            "--quantize.linear.float8.emulate",
         ]
     )
     parallel_dims = build_parallel_dims(config, 1)
@@ -52,4 +52,4 @@ def test_build_model_converters_float8_converter():
     model_converters = build_model_converters(config, parallel_dims)
     assert isinstance(model_converters, ModelConvertersContainer)
     assert len(model_converters.converters) == 1
-    assert isinstance(model_converters.converters[0], FP8LinearConverter)
+    assert isinstance(model_converters.converters[0], Float8LinearConverter)

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -17,12 +17,6 @@
 FP8_GROUP_ALIGNMENT_SIZE = 16
 MXFP8_GROUP_ALIGNMENT_SIZE = 32
 
-# Quantization converter names
-FP8_DENSE_CONVERTER_NAME = "quantize.dense.float8"
-MXFP8_DENSE_CONVERTER_NAME = "quantize.dense.mx"
-FP8_MOE_CONVERTER_NAME = "quantize.moe.float8"
-MXFP8_MOE_CONVERTER_NAME = "quantize.moe.mx"
-
 # Import to register quantization modules as ModelConverter
 import torchtitan.components.quantization.float8  # noqa: F401
 import torchtitan.components.quantization.mx  # noqa: F401

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -17,10 +17,7 @@
 FP8_GROUP_ALIGNMENT_SIZE = 16
 MXFP8_GROUP_ALIGNMENT_SIZE = 32
 
-# Import to register quantization modules as ModelConverter
-import torchtitan.components.quantization.float8  # noqa: F401
-import torchtitan.components.quantization.mx  # noqa: F401
-from torchtitan.config.job import JobConfig
+from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
 
 from torchtitan.protocols.model_converter import ModelConverter
@@ -57,3 +54,9 @@ class QuantizationConverter(ModelConverter):
                         "Cannot combine model converters with different quantization types: "
                         f"'{quantization_type(converter)}' and '{quantization_type(existing_quantization_converter)}'"
                     )
+
+
+# Import to register quantization modules as ModelConverter
+# (imports down here to avoid circular imports with QuantizationConverter)
+import torchtitan.components.quantization.float8  # noqa: F401
+import torchtitan.components.quantization.mx  # noqa: F401

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -40,7 +40,7 @@ class QuantizationConverter(ModelConverter):
         """
         # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
         # quantization converter format:
-        # `quantize.[linear | grouped_mm].[fp8 | mx]`
+        # `quantize.[linear | grouped_mm].[float8 | mx]`
         quantization_type = lambda converter: converter.split(".")[-1]
         existing_quantization_converter = None
         for converter in job_config.model.converters:

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -40,7 +40,7 @@ class QuantizationConverter(ModelConverter):
         """
         # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
         # quantization converter format:
-        # `quantize.[dense|moe].[mx|float8]`
+        # `quantize.[linear | grouped_mm].[fp8 | mx]`
         quantization_type = lambda converter: converter.split(".")[-1]
         existing_quantization_converter = None
         for converter in job_config.model.converters:

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -20,3 +20,40 @@ MXFP8_GROUP_ALIGNMENT_SIZE = 32
 # Import to register quantization modules as ModelConverter
 import torchtitan.components.quantization.float8  # noqa: F401
 import torchtitan.components.quantization.mx  # noqa: F401
+from torchtitan.config.job import JobConfig
+from torchtitan.distributed import ParallelDims
+
+from torchtitan.protocols.model_converter import ModelConverter
+
+
+class QuantizationConverter(ModelConverter):
+    """
+    Base class for quantization converters, which implements generic validation re-usable across all quantization converters.
+    """
+
+    enabled: bool = False
+
+    def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
+        self._validate(job_config)
+
+    @staticmethod
+    def _validate(job_config: JobConfig):
+        """
+        Validates that the job config uses the same quantization type for dense and MoE layers.
+        """
+        # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
+        # quantization converter format:
+        # `quantize.[dense|moe].[mx|float8]`
+        quantization_type = lambda converter: converter.split(".")[-1]
+        existing_quantization_converter = None
+        for converter in job_config.model.converters:
+            if "quantize" in converter:
+                if existing_quantization_converter is None:
+                    existing_quantization_converter = converter
+                else:
+                    assert quantization_type(converter) == quantization_type(
+                        existing_quantization_converter
+                    ), (
+                        "Cannot combine model converters with different quantization types: "
+                        f"'{quantization_type(converter)}' and '{quantization_type(existing_quantization_converter)}'"
+                    )

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -17,6 +17,12 @@
 FP8_GROUP_ALIGNMENT_SIZE = 16
 MXFP8_GROUP_ALIGNMENT_SIZE = 32
 
+# Quantization converter names
+FP8_DENSE_CONVERTER_NAME = "quantize.dense.float8"
+MXFP8_DENSE_CONVERTER_NAME = "quantize.dense.mx"
+FP8_MOE_CONVERTER_NAME = "quantize.moe.float8"
+MXFP8_MOE_CONVERTER_NAME = "quantize.moe.mx"
+
 # Import to register quantization modules as ModelConverter
 import torchtitan.components.quantization.float8  # noqa: F401
 import torchtitan.components.quantization.mx  # noqa: F401

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -43,14 +43,14 @@ class FP8LinearConverter(QuantizationConverter):
                 "To enable testing on older hardware, set `float8.emulate` to True in eager mode.",
             )
         try:
-            from torchao.float8 import Float8LinearConfig
+            from torchao.float8 import Float8LinearConfig as TorchAOFloat8LinearConfig
         except ImportError as e:
             raise ImportError(
                 "torchao is not installed. Please install it to use float8 linear layers."
             ) from e
 
         if float8_config.recipe_name is not None and not hasattr(
-            Float8LinearConfig, "from_recipe_name"
+            TorchAOFloat8LinearConfig, "from_recipe_name"
         ):
             logger.warning(
                 "Failed to swap to Float8Linear with recipe lookup because the torchao version "
@@ -67,7 +67,9 @@ class FP8LinearConverter(QuantizationConverter):
                 "with `float8_config.recipe_name` is not supported"
             )
 
-            self.config = Float8LinearConfig.from_recipe_name(float8_config.recipe_name)
+            self.config = TorchAOFloat8LinearConfig.from_recipe_name(
+                float8_config.recipe_name
+            )
             self.precompute_scale = False
             logger.info(
                 f"Float8 training active with recipe {float8_config.recipe_name}"
@@ -85,7 +87,7 @@ class FP8LinearConverter(QuantizationConverter):
                 parallel_dims.dp_shard_enabled
                 and float8_config.enable_fsdp_float8_all_gather
             )
-            self.config = Float8LinearConfig(
+            self.config = TorchAOFloat8LinearConfig(
                 enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
                 emulate=float8_config.emulate,
             )

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -12,7 +12,7 @@ from torchtitan.components.quantization import (
     QuantizationConverter,
 )
 
-from torchtitan.config.job_config import FP8LinearConfig, JobConfig
+from torchtitan.config.job_config import Float8Linear, JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import register_model_converter
@@ -24,10 +24,10 @@ from .utils import module_filter_fn
 AUTO_FILTER_SMALL_KN_FLAG = "auto_filter_small_kn"
 
 
-class FP8LinearConverter(QuantizationConverter):
+class Float8LinearConverter(QuantizationConverter):
     def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
         super().__init__(job_config, parallel_dims)
-        float8_config: FP8LinearConfig = job_config.quantize.linear.fp8
+        float8_config: Float8Linear = job_config.quantize.linear.float8
         compile_config = job_config.compile
         model_compile_enabled = (
             compile_config.enable and "model" in compile_config.components
@@ -100,7 +100,7 @@ class FP8LinearConverter(QuantizationConverter):
 
         self.enabled = True
 
-    def _init_filter_fn(self, float8_config: FP8LinearConfig):
+    def _init_filter_fn(self, float8_config: Float8Linear):
         # use auto_filter if filter_fqns "auto_filter_small_kn" is one of the given fqns.
         use_auto_filter = AUTO_FILTER_SMALL_KN_FLAG in float8_config.filter_fqns
         if use_auto_filter:
@@ -172,10 +172,10 @@ class FP8LinearConverter(QuantizationConverter):
             precompute_float8_dynamic_scale_for_fsdp(m)
 
 
-class FP8GroupedMMConverter(QuantizationConverter):
+class Float8GroupedMMConverter(QuantizationConverter):
     def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
         super().__init__(job_config, parallel_dims)
-        self.fqns = job_config.quantize.grouped_mm.fp8.fqns
+        self.fqns = job_config.quantize.grouped_mm.float8.fqns
         compile_config = job_config.compile
         model_compile_enabled = (
             compile_config.enable and "model" in compile_config.components
@@ -234,5 +234,5 @@ class FP8GroupedMMConverter(QuantizationConverter):
         pass
 
 
-register_model_converter(FP8LinearConverter, "quantize.linear.fp8")
-register_model_converter(FP8GroupedMMConverter, "quantize.grouped_mm.fp8")
+register_model_converter(Float8LinearConverter, "quantize.linear.float8")
+register_model_converter(Float8GroupedMMConverter, "quantize.grouped_mm.float8")

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -12,7 +12,7 @@ from torchtitan.components.quantization import (
     QuantizationConverter,
 )
 
-from torchtitan.config.job_config import Float8Dense, JobConfig
+from torchtitan.config.job_config import FP8LinearConfig, JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import register_model_converter
@@ -27,7 +27,7 @@ AUTO_FILTER_SMALL_KN_FLAG = "auto_filter_small_kn"
 class FP8LinearConverter(QuantizationConverter):
     def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
         super().__init__(job_config, parallel_dims)
-        float8_config: Float8Dense = job_config.quantize.dense.float8
+        float8_config: FP8LinearConfig = job_config.quantize.linear.fp8
         compile_config = job_config.compile
         model_compile_enabled = (
             compile_config.enable and "model" in compile_config.components
@@ -98,7 +98,7 @@ class FP8LinearConverter(QuantizationConverter):
 
         self.enabled = True
 
-    def _init_filter_fn(self, float8_config: Float8Dense):
+    def _init_filter_fn(self, float8_config: FP8LinearConfig):
         # use auto_filter if filter_fqns "auto_filter_small_kn" is one of the given fqns.
         use_auto_filter = AUTO_FILTER_SMALL_KN_FLAG in float8_config.filter_fqns
         if use_auto_filter:
@@ -173,7 +173,7 @@ class FP8LinearConverter(QuantizationConverter):
 class FP8GroupedMMConverter(QuantizationConverter):
     def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
         super().__init__(job_config, parallel_dims)
-        self.fqns = job_config.quantize.moe.float8.fqns
+        self.fqns = job_config.quantize.grouped_mm.fp8.fqns
         compile_config = job_config.compile
         model_compile_enabled = (
             compile_config.enable and "model" in compile_config.components

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -7,9 +7,15 @@ from functools import partial
 
 import torch
 import torch.nn as nn
-from torchtitan.components.quantization import FP8_GROUP_ALIGNMENT_SIZE
+from torchtitan.components.quantization import (
+    FP8_DENSE_CONVERTER_NAME,
+    FP8_GROUP_ALIGNMENT_SIZE,
+    FP8_MOE_CONVERTER_NAME,
+    MXFP8_DENSE_CONVERTER_NAME,
+    MXFP8_MOE_CONVERTER_NAME,
+)
 
-from torchtitan.config.job_config import Float8Dense, Job, JobConfig
+from torchtitan.config.job_config import Float8Dense, JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import (
@@ -243,11 +249,11 @@ def validate_only_float8_converters(job_config: JobConfig):
     Validates that the job config only specifies one quantization method for dense and MoE layers.
     """
     for converter in job_config.model.converters:
-        if converter == "quantize.dense.mx" or converter == "quantize.moe.mx":
+        if converter in (MXFP8_DENSE_CONVERTER_NAME, MXFP8_MOE_CONVERTER_NAME):
             raise ValueError(
                 f"Cannot combine float8 MoE training with {converter} quantization"
             )
 
 
-register_model_converter(Float8DenseConverter, "quantize.dense.float8")
-register_model_converter(Float8MoEConverter, "quantize.moe.float8")
+register_model_converter(Float8DenseConverter, FP8_DENSE_CONVERTER_NAME)
+register_model_converter(Float8MoEConverter, FP8_MOE_CONVERTER_NAME)

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -7,11 +7,7 @@ from functools import partial
 
 import torch
 import torch.nn as nn
-from torchtitan.components.quantization import (
-    FP8_DENSE_CONVERTER_NAME,
-    FP8_GROUP_ALIGNMENT_SIZE,
-    FP8_MOE_CONVERTER_NAME,
-)
+from torchtitan.components.quantization import FP8_GROUP_ALIGNMENT_SIZE
 
 from torchtitan.config.job_config import Float8Dense, JobConfig
 from torchtitan.distributed import ParallelDims
@@ -236,5 +232,5 @@ class Float8MoEConverter(QuantizationConverter):
         pass
 
 
-register_model_converter(Float8DenseConverter, FP8_DENSE_CONVERTER_NAME)
-register_model_converter(Float8MoEConverter, FP8_MOE_CONVERTER_NAME)
+register_model_converter(Float8DenseConverter, "quantize.float8.dense")
+register_model_converter(Float8MoEConverter, "quantize.float8.moe")

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -243,7 +243,7 @@ def validate_only_float8_converters(job_config: JobConfig):
     Validates that the job config only specifies one quantization method for dense and MoE layers.
     """
     for converter in job_config.model.converters:
-        if converter != "quantize.dense.mx" and converter != "quantize.moe.mx":
+        if converter == "quantize.dense.mx" or converter == "quantize.moe.mx":
             raise ValueError(
                 f"Cannot combine float8 MoE training with {converter} quantization"
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -183,7 +183,7 @@ def validate_only_mx_converters(job_config: JobConfig):
     Validates that the job config only specifies one quantization method for dense and MoE layers.
     """
     for converter in job_config.model.converters:
-        if converter != "quantize.dense.float8" and converter != "quantize.moe.float8":
+        if converter == "quantize.dense.float8" or converter == "quantize.moe.float8":
             raise ValueError(
                 f"Cannot combine mxfp8 MoE training with {converter} quantization"
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -10,7 +10,13 @@ from importlib.util import find_spec
 from typing import Any, List
 
 import torch.nn as nn
-from torchtitan.components.quantization import MXFP8_GROUP_ALIGNMENT_SIZE
+from torchtitan.components.quantization import (
+    FP8_DENSE_CONVERTER_NAME,
+    FP8_MOE_CONVERTER_NAME,
+    MXFP8_DENSE_CONVERTER_NAME,
+    MXFP8_GROUP_ALIGNMENT_SIZE,
+    MXFP8_MOE_CONVERTER_NAME,
+)
 
 from torchtitan.config.job_config import JobConfig, MXDense
 from torchtitan.distributed import ParallelDims
@@ -183,11 +189,11 @@ def validate_only_mx_converters(job_config: JobConfig):
     Validates that the job config only specifies one quantization method for dense and MoE layers.
     """
     for converter in job_config.model.converters:
-        if converter == "quantize.dense.float8" or converter == "quantize.moe.float8":
+        if converter in (FP8_DENSE_CONVERTER_NAME, FP8_MOE_CONVERTER_NAME):
             raise ValueError(
                 f"Cannot combine mxfp8 MoE training with {converter} quantization"
             )
 
 
-register_model_converter(MXLinearConverter, "quantize.dense.mx")
-register_model_converter(MXGroupedGemmConverter, "quantize.moe.mx")
+register_model_converter(MXLinearConverter, MXFP8_DENSE_CONVERTER_NAME)
+register_model_converter(MXGroupedGemmConverter, MXFP8_MOE_CONVERTER_NAME)

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -15,7 +15,7 @@ from torchtitan.components.quantization import (
     QuantizationConverter,
 )
 
-from torchtitan.config.job_config import JobConfig, MXDense
+from torchtitan.config.job_config import JobConfig, MXFP8LinearConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import register_model_converter
@@ -58,7 +58,7 @@ class MXFP8LinearConverter(QuantizationConverter):
             MXLinearConfig,
         )
 
-        mx_job_config: MXDense = job_config.quantize.dense.mx
+        mx_job_config: MXFP8LinearConfig = job_config.quantize.linear.mxfp8
         config = MXLinearConfig.from_recipe_name(mx_job_config.recipe_name)
         config.mxfp8_dim1_cast_kernel_choice = MXFP8Dim1CastKernelChoice[
             mx_job_config.mxfp8_dim1_cast_kernel_choice.upper()
@@ -130,7 +130,7 @@ class MXFP8GroupedMMConverter(QuantizationConverter):
             )
 
         # For MoE training with mxfp8, token group sizes must be multiples of 32
-        self.moe_fqns = job_config.quantize.moe.mx.fqns
+        self.moe_fqns = job_config.quantize.grouped_mm.mxfp8.fqns
         if self.moe_fqns:
             logger.info(
                 f"Setting token group alignment size to {MXFP8_GROUP_ALIGNMENT_SIZE}"

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -10,22 +10,22 @@ from importlib.util import find_spec
 from typing import Any, List
 
 import torch.nn as nn
-from torchtitan.components.quantization import MXFP8_GROUP_ALIGNMENT_SIZE
+from torchtitan.components.quantization import (
+    MXFP8_GROUP_ALIGNMENT_SIZE,
+    QuantizationConverter,
+)
 
 from torchtitan.config.job_config import JobConfig, MXDense
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.expert_parallel import set_token_group_alignment_size_m
-from torchtitan.protocols.model_converter import (
-    QuantizationConverter,
-    register_model_converter,
-)
+from torchtitan.protocols.model_converter import register_model_converter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
 
 from .utils import module_filter_fn
 
 
-class MXLinearConverter(QuantizationConverter):
+class MXFP8LinearConverter(QuantizationConverter):
     """Converts the linear layers of `model` to `MXLinear`."""
 
     filter_fqns: List[str]
@@ -95,7 +95,7 @@ class MXLinearConverter(QuantizationConverter):
         return
 
 
-class MXGroupedGemmConverter(QuantizationConverter):
+class MXFP8GroupedMMConverter(QuantizationConverter):
     """Converts target 3D nn.Parameters of a model, representing 'experts',
     to use MXFP8 scaled grouped GEMMs instead of a high precision grouped GEMMs."""
 
@@ -173,5 +173,5 @@ class MXGroupedGemmConverter(QuantizationConverter):
         return
 
 
-register_model_converter(MXLinearConverter, "quantize.dense.mx")
-register_model_converter(MXGroupedGemmConverter, "quantize.moe.mx")
+register_model_converter(MXFP8LinearConverter, "quantize.linear.mxfp8")
+register_model_converter(MXFP8GroupedMMConverter, "quantize.grouped_mm.mxfp8")

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -10,11 +10,7 @@ from importlib.util import find_spec
 from typing import Any, List
 
 import torch.nn as nn
-from torchtitan.components.quantization import (
-    MXFP8_DENSE_CONVERTER_NAME,
-    MXFP8_GROUP_ALIGNMENT_SIZE,
-    MXFP8_MOE_CONVERTER_NAME,
-)
+from torchtitan.components.quantization import MXFP8_GROUP_ALIGNMENT_SIZE
 
 from torchtitan.config.job_config import JobConfig, MXDense
 from torchtitan.distributed import ParallelDims
@@ -177,5 +173,5 @@ class MXGroupedGemmConverter(QuantizationConverter):
         return
 
 
-register_model_converter(MXLinearConverter, MXFP8_DENSE_CONVERTER_NAME)
-register_model_converter(MXGroupedGemmConverter, MXFP8_MOE_CONVERTER_NAME)
+register_model_converter(MXLinearConverter, "quantize.dense.mx")
+register_model_converter(MXGroupedGemmConverter, "quantize.moe.mx")

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -33,9 +33,12 @@ def validate_quantization_converters(job_config: JobConfig):
     Validates that the job config uses the same quantization type for dense and MoE layers.
     """
     # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
+    # quantization converter format:
+    # `quantize.[dense|moe].[mx|float8]`
+    quantization_type = lambda converter: converter.split(".")[-1]
     existing_quantization_converter = None
     for converter in job_config.model.converters:
-        if is_quantization_converter(converter):
+        if "quantize" in converter:
             if existing_quantization_converter is None:
                 existing_quantization_converter = converter
             else:
@@ -45,13 +48,3 @@ def validate_quantization_converters(job_config: JobConfig):
                     "Cannot combine model converters with different quantization types: "
                     f"'{quantization_type(converter)}' and '{quantization_type(existing_quantization_converter)}'"
                 )
-
-
-def is_quantization_converter(converter: str):
-    return "quantize" in converter
-
-
-def quantization_type(converter: str):
-    # quantization converter format:
-    # `quantize.[dense|moe].[mx|float8]`
-    return converter.split(".")[-1]

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch.nn as nn
-from torchtitan.config import JobConfig
 
 
 def module_filter_fn(mod: nn.Module, fqn: str, filter_fqns: list[str]) -> bool:
@@ -26,25 +25,3 @@ def module_filter_fn(mod: nn.Module, fqn: str, filter_fqns: list[str]) -> bool:
     is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
 
     return dims_multiples_of_16 and not is_filtered_fqn
-
-
-def validate_quantization_converters(job_config: JobConfig):
-    """
-    Validates that the job config uses the same quantization type for dense and MoE layers.
-    """
-    # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
-    # quantization converter format:
-    # `quantize.[dense|moe].[mx|float8]`
-    quantization_type = lambda converter: converter.split(".")[-1]
-    existing_quantization_converter = None
-    for converter in job_config.model.converters:
-        if "quantize" in converter:
-            if existing_quantization_converter is None:
-                existing_quantization_converter = converter
-            else:
-                assert quantization_type(converter) == quantization_type(
-                    existing_quantization_converter
-                ), (
-                    "Cannot combine model converters with different quantization types: "
-                    f"'{quantization_type(converter)}' and '{quantization_type(existing_quantization_converter)}'"
-                )

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch.nn as nn
+from torchtitan.config import JobConfig
 
 
 def module_filter_fn(mod: nn.Module, fqn: str, filter_fqns: list[str]) -> bool:
@@ -25,3 +26,32 @@ def module_filter_fn(mod: nn.Module, fqn: str, filter_fqns: list[str]) -> bool:
     is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
 
     return dims_multiples_of_16 and not is_filtered_fqn
+
+
+def validate_quantization_converters(job_config: JobConfig):
+    """
+    Validates that the job config uses the same quantization type for dense and MoE layers.
+    """
+    # TODO: Explore supporting applying different quantization methods to dense and MoE layers.
+    existing_quantization_converter = None
+    for converter in job_config.model.converters:
+        if is_quantization_converter(converter):
+            if existing_quantization_converter is None:
+                existing_quantization_converter = converter
+            else:
+                assert quantization_type(converter) == quantization_type(
+                    existing_quantization_converter
+                ), (
+                    "Cannot combine model converters with different quantization types: "
+                    f"'{quantization_type(converter)}' and '{quantization_type(existing_quantization_converter)}'"
+                )
+
+
+def is_quantization_converter(converter: str):
+    return "quantize" in converter
+
+
+def quantization_type(converter: str):
+    # quantization converter format:
+    # `quantize.[dense|moe].[mx|float8]`
+    return converter.split(".")[-1]

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -569,7 +569,7 @@ class Compile:
 
 
 @dataclass
-class FP8LinearConfig:
+class Float8Linear:
     enable_fsdp_float8_all_gather: bool = False
     """Whether enable float8 all-gather in FSDP, recommended for tensorwise scaling"""
 
@@ -583,7 +583,7 @@ class FP8LinearConfig:
     """
     Comma-separated list of fully qualified names of modules to skip applying float8 training to.
     nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
-    Example: --quantize.linear.fp8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
+    Example: --quantize.linear.float8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
     """
     emulate: bool = False
     """
@@ -594,18 +594,18 @@ class FP8LinearConfig:
 
 
 @dataclass
-class FP8GroupedMMConfig:
+class Float8GroupedMM:
     fqns: list[str] | str = field(default_factory=list)
     """
     *Prototype feature, performance optimization still in progress*
     Comma-separated list of fully qualified names of MoE Layers to apply FP8 dynamic quantization on grouped GEMM operations.
     This is a prototype feature that requires the torchao nightly build.
-    Example: --quantize.grouped_mm.fp8.fqns="experts"
+    Example: --quantize.grouped_mm.float8.fqns="experts"
     """
 
 
 @dataclass
-class MXLinearConfig:
+class MXLinear:
     mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "torch"] = "triton"
     """
     Temp work around for inductor performance gap.
@@ -632,7 +632,7 @@ class MXLinearConfig:
 
 
 @dataclass
-class MXGroupedMMConfig:
+class MXGroupedMM:
     recipe_name: Literal["mxfp8"] = "mxfp8"
     """
     Quantization recipe name for grouped GEMMs. Options: ["mxfp8"]
@@ -650,29 +650,29 @@ class MXGroupedMMConfig:
 
 
 @dataclass
-class LinearConfig:
-    fp8: FP8LinearConfig = field(default_factory=FP8LinearConfig)
+class QuantizedLinear:
+    float8: Float8Linear = field(default_factory=Float8Linear)
     """FP8 training config for nn.Linear layers"""
 
-    mx: MXLinearConfig = field(default_factory=MXLinearConfig)
+    mx: MXLinear = field(default_factory=MXLinear)
     """MX training config for nn.Linear layers"""
 
 
 @dataclass
-class GroupedMMConfig:
-    fp8: FP8GroupedMMConfig = field(default_factory=FP8GroupedMMConfig)
+class QuantizedGroupedMM:
+    float8: Float8GroupedMM = field(default_factory=Float8GroupedMM)
     """FP8 training config for grouped GEMMs"""
 
-    mx: MXGroupedMMConfig = field(default_factory=MXGroupedMMConfig)
+    mx: MXGroupedMM = field(default_factory=MXGroupedMM)
     """MX training config for grouped GEMMs"""
 
 
 @dataclass
 class Quantize:
-    linear: LinearConfig = field(default_factory=LinearConfig)
+    linear: QuantizedLinear = field(default_factory=QuantizedLinear)
     """Quantized training config for nn.Linear layers"""
 
-    grouped_mm: GroupedMMConfig = field(default_factory=GroupedMMConfig)
+    grouped_mm: QuantizedGroupedMM = field(default_factory=QuantizedGroupedMM)
     """Quantized training config for grouped GEMMs"""
 
 

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -375,7 +375,7 @@ class Parallelism:
 
     expert_parallel_degree: int = 1
     """
-    Expert parallelism degree. 1 means disabled. No effect for non-GroupedMMConfig models.
+    Expert parallelism degree. 1 means disabled. No effect for non-MoE models.
     Currently, it is supported with the following constraints:
     - when etp = tp:
       - cp <= ep <= dp_shard * cp
@@ -391,7 +391,7 @@ class Parallelism:
 
     expert_tensor_parallel_degree: int = 1
     """
-    Expert tensor parallelism degree. 1 means disabled. No effect for non-GroupedMMConfig models, or when ep = 1.
+    Expert tensor parallelism degree. 1 means disabled. No effect for non-MoE models, or when ep = 1.
     With this option, the tensor parallel degree on routed experts can be different from that on other params.
     Currently, we only support either
     - [partial dp -> ep] etp = tp

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -600,26 +600,26 @@ class FP8GroupedMMConfig:
     *Prototype feature, performance optimization still in progress*
     Comma-separated list of fully qualified names of MoE Layers to apply FP8 dynamic quantization on grouped GEMM operations.
     This is a prototype feature that requires the torchao nightly build.
-    Example: --quantize.linear.fp8.fqns="experts"
+    Example: --quantize.grouped_mm.fp8.fqns="experts"
     """
 
 
 @dataclass
-class MXFP8LinearConfig:
+class MXLinearConfig:
     mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "torch"] = "triton"
     """
     Temp work around for inductor performance gap.
 
     CUDA is recommended for best performance.
 
-    Example: --mx.dense.mxfp8_dim1_cast_kernel_choice="cuda"
+    Example: --quantize.linear.mx.mxfp8_dim1_cast_kernel_choice="cuda"
     """
 
     recipe_name: str = "mxfp8_cublas"
     """
     If specified, creates MX config from recipe name. See
     https://github.com/pytorch/ao/tree/main/torchao/prototype/mx_formats for more information.
-    Example: --mx.dense.recipe_name="mxfp8_cublas"
+    Example: --quantize.linear.mx.recipe_name="mxfp8_cublas"
     """
 
     filter_fqns: list[str] = field(default_factory=lambda: ["output"])
@@ -627,18 +627,25 @@ class MXFP8LinearConfig:
     Comma-separated list of fully qualified names of modules to skip applying mxfp8 training to.
     nn.Linear modules with any dim size not divisible by 16 are also always skipped due to hardware requirements.
     By default we always skip the output layer.
-    Example: --mx.dense.filter_fqns "attention.wq,attention.wk,attention.wv,output"
+    Example: --quantize.linear.mx.filter_fqns="attention.wq,attention.wk,attention.wv,output"
     """
 
 
 @dataclass
-class MXFP8GroupedMMConfig:
+class MXGroupedMMConfig:
+    recipe_name: Literal["mxfp8"] = "mxfp8"
+    """
+    Quantization recipe name for grouped GEMMs. Options: ["mxfp8"]
+
+    Example: --quantize.grouped_mm.mx.recipe_name="mxfp8"
+    """
+
     fqns: list[str] | str = field(default_factory=list)
     """
     *Prototype feature, performance optimization still in progress*
     Comma-separated list of fully qualified names of MoE modules to apply MXFP8 dynamic quantization on grouped GEMM operations.
     This is a prototype feature that requires the torchao nightly build.
-    Example: --mx.moe.fqns="experts"
+    Example: --quantize.grouped_mm.mx.fqns="experts"
     """
 
 
@@ -647,8 +654,8 @@ class LinearConfig:
     fp8: FP8LinearConfig = field(default_factory=FP8LinearConfig)
     """FP8 training config for nn.Linear layers"""
 
-    mxfp8: MXFP8LinearConfig = field(default_factory=MXFP8LinearConfig)
-    """MXFP8 training config for nn.Linear layers"""
+    mx: MXLinearConfig = field(default_factory=MXLinearConfig)
+    """MX training config for nn.Linear layers"""
 
 
 @dataclass
@@ -656,8 +663,8 @@ class GroupedMMConfig:
     fp8: FP8GroupedMMConfig = field(default_factory=FP8GroupedMMConfig)
     """FP8 training config for grouped GEMMs"""
 
-    mxfp8: MXFP8GroupedMMConfig = field(default_factory=MXFP8GroupedMMConfig)
-    """MXFP8 training config for grouped GEMMs"""
+    mx: MXGroupedMMConfig = field(default_factory=MXGroupedMMConfig)
+    """MX training config for grouped GEMMs"""
 
 
 @dataclass

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -375,7 +375,7 @@ class Parallelism:
 
     expert_parallel_degree: int = 1
     """
-    Expert parallelism degree. 1 means disabled. No effect for non-MoE models.
+    Expert parallelism degree. 1 means disabled. No effect for non-GroupedMMConfig models.
     Currently, it is supported with the following constraints:
     - when etp = tp:
       - cp <= ep <= dp_shard * cp
@@ -391,7 +391,7 @@ class Parallelism:
 
     expert_tensor_parallel_degree: int = 1
     """
-    Expert tensor parallelism degree. 1 means disabled. No effect for non-MoE models, or when ep = 1.
+    Expert tensor parallelism degree. 1 means disabled. No effect for non-GroupedMMConfig models, or when ep = 1.
     With this option, the tensor parallel degree on routed experts can be different from that on other params.
     Currently, we only support either
     - [partial dp -> ep] etp = tp
@@ -569,7 +569,7 @@ class Compile:
 
 
 @dataclass
-class Float8Dense:
+class FP8LinearConfig:
     enable_fsdp_float8_all_gather: bool = False
     """Whether enable float8 all-gather in FSDP, recommended for tensorwise scaling"""
 
@@ -583,7 +583,7 @@ class Float8Dense:
     """
     Comma-separated list of fully qualified names of modules to skip applying float8 training to.
     nn.Linear modules with any dim size not divisible by 16 are always skipped due to hardware requirements.
-    Example: --quantize.dense.float8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
+    Example: --quantize.linear.fp8.filter_fqns "attention.wq,attention.wk,attention.wv,output"
     """
     emulate: bool = False
     """
@@ -594,18 +594,18 @@ class Float8Dense:
 
 
 @dataclass
-class Float8MoE:
+class FP8GroupedMMConfig:
     fqns: list[str] | str = field(default_factory=list)
     """
     *Prototype feature, performance optimization still in progress*
-    Comma-separated list of fully qualified names of MoE modules to apply float8 rowwise training to.
+    Comma-separated list of fully qualified names of MoE Layers to apply FP8 dynamic quantization on grouped GEMM operations.
     This is a prototype feature that requires the torchao nightly build.
-    Example: --quantize.dense.float8.fqns="experts"
+    Example: --quantize.linear.fp8.fqns="experts"
     """
 
 
 @dataclass
-class MXDense:
+class MXFP8LinearConfig:
     mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "torch"] = "triton"
     """
     Temp work around for inductor performance gap.
@@ -632,41 +632,41 @@ class MXDense:
 
 
 @dataclass
-class MXMoE:
+class MXFP8GroupedMMConfig:
     fqns: list[str] | str = field(default_factory=list)
     """
     *Prototype feature, performance optimization still in progress*
-    Comma-separated list of fully qualified names of MoE modules to apply the given
+    Comma-separated list of fully qualified names of MoE modules to apply MXFP8 dynamic quantization on grouped GEMM operations.
     This is a prototype feature that requires the torchao nightly build.
     Example: --mx.moe.fqns="experts"
     """
 
 
 @dataclass
-class Dense:
-    float8: Float8Dense = field(default_factory=Float8Dense)
-    """Float8 training config for dense layers"""
+class LinearConfig:
+    fp8: FP8LinearConfig = field(default_factory=FP8LinearConfig)
+    """FP8 training config for nn.Linear layers"""
 
-    mx: MXDense = field(default_factory=MXDense)
-    """MX training config for dense layers"""
+    mxfp8: MXFP8LinearConfig = field(default_factory=MXFP8LinearConfig)
+    """MXFP8 training config for nn.Linear layers"""
 
 
 @dataclass
-class MoE:
-    float8: Float8MoE = field(default_factory=Float8MoE)
-    """Float8 training config for MoE layers"""
+class GroupedMMConfig:
+    fp8: FP8GroupedMMConfig = field(default_factory=FP8GroupedMMConfig)
+    """FP8 training config for grouped GEMMs"""
 
-    mx: MXMoE = field(default_factory=MXMoE)
-    """MX training config for MoE layers"""
+    mxfp8: MXFP8GroupedMMConfig = field(default_factory=MXFP8GroupedMMConfig)
+    """MXFP8 training config for grouped GEMMs"""
 
 
 @dataclass
 class Quantize:
-    dense: Dense = field(default_factory=Dense)
-    """Quantized training config for dense layers."""
+    linear: LinearConfig = field(default_factory=LinearConfig)
+    """Quantized training config for nn.Linear layers"""
 
-    moe: MoE = field(default_factory=MoE)
-    """Quantized training config for MoE layers."""
+    grouped_mm: GroupedMMConfig = field(default_factory=GroupedMMConfig)
+    """Quantized training config for grouped GEMMs"""
 
 
 @dataclass

--- a/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
+++ b/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
@@ -66,7 +66,7 @@ async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 mode = "none"  # ["none", "selective", "full"]
 selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
+++ b/torchtitan/experiments/deepseek_v3/train_configs/deepseek_v2.toml
@@ -66,7 +66,7 @@ async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 mode = "none"  # ["none", "selective", "full"]
 selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/forge/job_config.py
+++ b/torchtitan/experiments/forge/job_config.py
@@ -12,7 +12,7 @@ from torchtitan.config.job_config import (
     Checkpoint,
     Comm,
     Compile,
-    Float8Dense,
+    FP8LinearConfig,
     LRScheduler,
     Model,
     Optimizer,
@@ -33,7 +33,7 @@ class ForgeJobConfig:
         default_factory=ActivationCheckpoint
     )
     compile: Compile = field(default_factory=Compile)
-    float8: Float8Dense = field(default_factory=Float8Dense)
+    float8: FP8LinearConfig = field(default_factory=FP8LinearConfig)
     comm: Comm = field(default_factory=Comm)
 
     def to_dict(self) -> dict[str, Any]:

--- a/torchtitan/experiments/forge/job_config.py
+++ b/torchtitan/experiments/forge/job_config.py
@@ -12,7 +12,7 @@ from torchtitan.config.job_config import (
     Checkpoint,
     Comm,
     Compile,
-    FP8LinearConfig,
+    Float8Linear,
     LRScheduler,
     Model,
     Optimizer,
@@ -33,7 +33,7 @@ class ForgeJobConfig:
         default_factory=ActivationCheckpoint
     )
     compile: Compile = field(default_factory=Compile)
-    float8: FP8LinearConfig = field(default_factory=FP8LinearConfig)
+    float8: Float8Linear = field(default_factory=Float8Linear)
     comm: Comm = field(default_factory=Comm)
 
     def to_dict(self) -> dict[str, Any]:

--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -76,7 +76,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.float8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/experiments/llama4/infra/parallelize.py
+++ b/torchtitan/experiments/llama4/infra/parallelize.py
@@ -76,7 +76,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.dense.float8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -70,12 +70,12 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.grouped_mm.fp8]
+[quantize.grouped_mm.float8]
 fqns = ["experts"]
 
 [quantize.linear.mx]

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -70,16 +70,16 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.moe.float8]
+[quantize.grouped_mm.fp8]
 fqns = ["experts"]
 
-[quantize.dense.mx]
+[quantize.linear.mxfp8]
 filter_fqns = ["output", "router.gate"]
 
-[quantize.moe.mx]
+[quantize.grouped_mm.mxfp8]
 fqns = ["experts"]

--- a/torchtitan/experiments/llama4/train_configs/debug_model.toml
+++ b/torchtitan/experiments/llama4/train_configs/debug_model.toml
@@ -78,8 +78,8 @@ filter_fqns = ["output", "router.gate"]
 [quantize.grouped_mm.fp8]
 fqns = ["experts"]
 
-[quantize.linear.mxfp8]
+[quantize.linear.mx]
 filter_fqns = ["output", "router.gate"]
 
-[quantize.grouped_mm.mxfp8]
+[quantize.grouped_mm.mx]
 fqns = ["experts"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
@@ -63,10 +63,10 @@ mode = "full" # ["none", "selective", "full"]
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.dense.mx]
+[quantize.linear.mxfp8]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
@@ -68,5 +68,5 @@ enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[mx]
+[quantize.dense.mx]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
@@ -63,7 +63,7 @@ mode = "full" # ["none", "selective", "full"]
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx128e.toml
@@ -68,5 +68,5 @@ enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.linear.mxfp8]
+[quantize.linear.mx]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
@@ -61,7 +61,7 @@ mode = "full" # ["none", "selective", "full"]
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
@@ -66,5 +66,5 @@ enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[mx]
+[quantize.dense.mx]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
@@ -66,5 +66,5 @@ enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.linear.mxfp8]
+[quantize.linear.mx]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
+++ b/torchtitan/experiments/llama4/train_configs/llama4_17bx16e.toml
@@ -61,10 +61,10 @@ mode = "full" # ["none", "selective", "full"]
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.dense.mx]
+[quantize.linear.mxfp8]
 filter_fqns = ["output", "router.gate"]

--- a/torchtitan/experiments/qwen3/infra/parallelize.py
+++ b/torchtitan/experiments/qwen3/infra/parallelize.py
@@ -74,7 +74,7 @@ def parallelize_qwen3(
             raise RuntimeError("Async TP requires torch.compile")
 
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.dense.float8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/experiments/qwen3/infra/parallelize.py
+++ b/torchtitan/experiments/qwen3/infra/parallelize.py
@@ -74,7 +74,7 @@ def parallelize_qwen3(
             raise RuntimeError("Async TP requires torch.compile")
 
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.float8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_0.6b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_0.6b.toml
@@ -56,7 +56,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_0.6b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_0.6b.toml
@@ -56,7 +56,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_1.7b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_1.7b.toml
@@ -56,7 +56,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_1.7b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_1.7b.toml
@@ -56,7 +56,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_32b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_32b.toml
@@ -58,7 +58,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_32b.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_32b.toml
@@ -58,7 +58,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_moe_debug.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_moe_debug.toml
@@ -58,7 +58,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/qwen3/train_configs/qwen3_moe_debug.toml
+++ b/torchtitan/experiments/qwen3/train_configs/qwen3_moe_debug.toml
@@ -58,7 +58,7 @@ selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/experiments/simple_fsdp/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize.py
@@ -55,7 +55,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.float8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/experiments/simple_fsdp/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/parallelize.py
@@ -55,7 +55,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.dense.float8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -67,7 +67,7 @@ def parallelize_deepseekv3(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.dense.float8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -67,7 +67,7 @@ def parallelize_deepseekv3(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.float8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/models/deepseek_v3/train_configs/debug_model.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/debug_model.toml
@@ -70,10 +70,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.grouped_mm.fp8]
+[quantize.grouped_mm.float8]
 fqns = ["experts"]

--- a/torchtitan/models/deepseek_v3/train_configs/debug_model.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/debug_model.toml
@@ -70,10 +70,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.moe.float8]
+[quantize.grouped_mm.fp8]
 fqns = ["experts"]

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
@@ -68,10 +68,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=true
 components = ["loss"] # ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.grouped_mm.fp8]
+[quantize.grouped_mm.float8]
 fqns = ["experts"]

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
@@ -68,10 +68,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=true
 components = ["loss"] # ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.moe.float8]
+[quantize.grouped_mm.fp8]
 fqns = ["experts"]

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
@@ -69,10 +69,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=true
 components = ["loss"] # ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.moe.float8]
+[quantize.grouped_mm.fp8]
 fqns = ["experts"]

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
@@ -69,10 +69,10 @@ selective_ac_option = 'op'  # 'int' = ac every positive int layer or 'op', ac ba
 enable=true
 components = ["loss"] # ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output", "router.gate"]
 
-[quantize.grouped_mm.fp8]
+[quantize.grouped_mm.float8]
 fqns = ["experts"]

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -72,7 +72,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.dense.float8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/models/llama3/infra/parallelize.py
+++ b/torchtitan/models/llama3/infra/parallelize.py
@@ -72,7 +72,7 @@ def parallelize_llama(
 
     if parallel_dims.tp_enabled:
         enable_float8_linear = "float8" in job_config.model.converters
-        float8_is_rowwise = job_config.quantize.linear.fp8.recipe_name in (
+        float8_is_rowwise = job_config.quantize.linear.float8.recipe_name in (
             "rowwise",
             "rowwise_with_gw_hp",
         )

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -67,7 +67,7 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -67,7 +67,7 @@ selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac bas
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -58,7 +58,7 @@ mode = "full" # ["none", "selective", "full"]
 enable=true
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = true
 precompute_float8_dynamic_scale_for_fsdp = true
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_405b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_405b.toml
@@ -58,7 +58,7 @@ mode = "full" # ["none", "selective", "full"]
 enable=true
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = true
 precompute_float8_dynamic_scale_for_fsdp = true
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -57,7 +57,7 @@ mode = "full"
 enable=false
 components = ["model", "loss"]
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_70b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_70b.toml
@@ -57,7 +57,7 @@ mode = "full"
 enable=false
 components = ["model", "loss"]
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -58,7 +58,7 @@ components = ["model", "loss"]
 mode = "selective"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
-[quantize.linear.fp8]
+[quantize.linear.float8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/models/llama3/train_configs/llama3_8b.toml
+++ b/torchtitan/models/llama3/train_configs/llama3_8b.toml
@@ -58,7 +58,7 @@ components = ["model", "loss"]
 mode = "selective"  # ["none", "selective", "full"]
 selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
 
-[quantize.dense.float8]
+[quantize.linear.fp8]
 enable_fsdp_float8_all_gather = false
 precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -7,8 +7,6 @@ from typing import Dict, List, Protocol, Union
 
 import torch.nn as nn
 
-from torchtitan.components.quantization.utils import validate_quantization_converters
-
 from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
@@ -84,14 +82,3 @@ def build_model_converters(
 ) -> ModelConvertersContainer:
     """Build the collection of model converters to apply to the model."""
     return ModelConvertersContainer(job_config, parallel_dims)
-
-
-class QuantizationConverter(ModelConverter):
-    """
-    Base class for quantization converters, which implements generic validation re-usable across all quantization converters.
-    """
-
-    enabled: bool = False
-
-    def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
-        validate_quantization_converters(job_config)

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Protocol, Union
 
 import torch.nn as nn
 
+from torchtitan.components.quantization.utils import validate_quantization_converters
+
 from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
@@ -82,3 +84,14 @@ def build_model_converters(
 ) -> ModelConvertersContainer:
     """Build the collection of model converters to apply to the model."""
     return ModelConvertersContainer(job_config, parallel_dims)
+
+
+class QuantizationConverter(ModelConverter):
+    """
+    Base class for quantization converters, which implements generic validation re-usable across all quantization converters.
+    """
+
+    enabled: bool = False
+
+    def __init__(self, job_config: JobConfig, parallel_dims: ParallelDims):
+        validate_quantization_converters(job_config)


### PR DESCRIPTION
## Summary
- Float8 training and mx training cannot be combined. Add validation to ensure either one or the other is used.
- Fix tomls which still use old config naming (addresses #1764)
- Refactor quantization config naming so (1) job_config class names are consistent with converter names, and (2) naming is more explicit and aligned with semantics of what conversions actually happen
   - Old: 
       - Converter classes: 
           - `Float8Converter`
           - `Float8MoEConverter` 
          - `MXConverter`
           - `MXMoEConverter`
       - User-facing args: 
            - `quantize.dense.float8`
            - `quantize.moe.float8`
            - `quantize.dense.mx`
            - `quantize.moe.mx`
   - New:
       - Converter classes: 
           - `Float8LinearConverter`
           - `Float8GroupedGEMMConverter`
           - `MXLinearConverter`
           - `MXGroupedGEMMConverter`
       - User-facing args: 
            - `quantize.linear.float8`
            - `quantize.grouped_mm.float8`
            - `quantize.linear.mx`
            - `quantize.grouped_mm.mx`

## Tests: mx on B200
- Test new config/args with valid job:
     - `NGPU=4 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml"  ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=1 --parallelism.tensor_parallel_degree=1  --model.print-after-conversion --metrics.log_freq=10 --training.steps=30 --model.converters="quantize.linear.mx,quantize.grouped_mm.mx" --quantize.linear.mx.recipe_name="mxfp8_cublas"  --quantize.groupe
d_mm.mx.fqns="experts" --compile.enable`
    - Result: training as expected 
- Test mixing converters for different quantization methods, validate error:
    - `NGPU=4 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml"  ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=1 --parallelism.tensor_parallel_degree=1  --model.print-after-conversion --metrics.log_freq=10 --training.steps=30 --model.converters="quantize.linear.fp8,quantize.grouped_mm.mx" --quantize.linear.mx.recipe_name="mxfp8_cublas"  --quantize.grouped_mm.mx.fqns="experts" --compile.enable`
        - Result `AssertionError: Cannot combine model converters with different quantization types: 'mx' and 'fp8'`

## Tests: FP8 rowwise on H100
- Test new config/args with valid job: 
    - `NGPU=4 CONFIG_FILE="./torchtitan/experiments/llama4/train_configs/debug_model.toml"  ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=1 --parallelism.tensor_parallel_degree=1  --model.print-after-conversion --metrics.log_freq=10 --training.steps=30 --model.converters="quantize.linear.float8,quantize.grouped_mm.float8" --quantize.linear.float8.recipe_name="rowwise"  --quantize.grouped_mm.float8.fqns="experts" --compile.enable`
    - Result: training as expected
   