### PR TITLE
port true bf16 training into forge experiment

### DIFF
--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -13,6 +13,8 @@ from torch.distributed.elastic.multiprocessing.errors import record
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import rescale_accumulated_loss
+from torchtitan.config import TORCH_DTYPE_MAP
+
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.protocols import BaseModelArgs
 from torchtitan.tools import utils
@@ -114,7 +116,10 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful):
         # set the model args from training job configs
         model_args.update_from_config(job_config)
 
-        with torch.device("meta"):
+        with (
+            torch.device("meta"),
+            utils.set_default_dtype(TORCH_DTYPE_MAP[job_config.training.dtype]),
+        ):
             model = self.train_spec.model_cls(model_args)
 
         # calculate model size and flops per token


### PR DESCRIPTION
Unfortunately I went out on leave after opening #1646 so never actually finished it out to enable bf16 training in the forge experiment, which is what we ultimately wanted (thanks to @joecummings and @tianyu-l for pushing it through). 

I also see there was some discussion on the original PR which I belatedly responded to. If there are still concerns there let me know. Otherwise if we are not gonna revert that PR we should at least that one so that forge can reap the benefits as intended.