### PR TITLE
Set proper deepseek-v3 16b parameters

### DIFF
--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml
@@ -35,7 +35,7 @@ decay_type = "cosine"
 min_lr_factor = 0.1
 
 [training]
-local_batch_size = 8
+local_batch_size = 4
 seq_len = 4096
 max_norm = 1.0  # grad norm clipping
 steps = 1000

--- a/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
+++ b/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_671b.toml
@@ -39,7 +39,6 @@ local_batch_size = 4
 seq_len = 4096
 max_norm = 1.0  # grad norm clipping
 steps = 10_000
-compile = false
 dataset = "c4"  # supported datasets: c4_test (2K), c4 (177M)
 
 [parallelism]


### PR DESCRIPTION
As #1789 mentioned, make the 16B default toml config safe for 80GB H100 as well.
<img width="1657" height="770" alt="Screenshot 2025-10-02 at 5 11 32 PM" src="https://github.com/user-attachments/assets/8199cd9b-2354-4029-bd3e-5b58241e6c45" />
