### PR TITLE
[VLM] Refactor special tokens by subclassing Tokenizer

### DIFF
--- a/tests/assets/tokenizer/tokenizer.json
+++ b/tests/assets/tokenizer/tokenizer.json
@@ -2029,11 +2029,7 @@
       "land": 1994,
       "?\n": 1995,
       " respect": 1996,
-      "ances": 1997,
-      "<|image|>": 1998,
-      "<|begin_of_image|>": 1999,
-      "<|end_of_image|>": 2000,
-      "<|pad|>": 2001
+      "ances": 1997
     },
     "merges": [
     ]

--- a/tests/assets/tokenizer/tokenizer_config.json
+++ b/tests/assets/tokenizer/tokenizer_config.json
@@ -15,46 +15,11 @@
       "rstrip": false,
       "single_word": false,
       "special": true
-    },
-    "1998": {
-      "content": "<|image|>",
-      "lstrip": false,
-      "normalized": false,
-      "rstrip": false,
-      "single_word": false,
-      "special": true
-    },
-    "1999": {
-      "content": "<|begin_of_image|>",
-      "lstrip": false,
-      "normalized": false,
-      "rstrip": false,
-      "single_word": false,
-      "special": true
-    },
-    "2000": {
-      "content": "<|end_of_image|>",
-      "lstrip": false,
-      "normalized": false,
-      "rstrip": false,
-      "single_word": false,
-      "special": true
-    },
-    "2001": {
-      "content": "<|pad|>",
-      "lstrip": false,
-      "normalized": false,
-      "rstrip": false,
-      "single_word": false,
-      "special": true
     }
   },
   "bos_token": "<|begin_of_text|>",
   "clean_up_tokenization_spaces": true,
   "eos_token": "<|end_of_text|>",
-  "img_token": "<|image|>",
-  "boi_token": "<|begin_of_image|>",
-  "eoi_token": "<|end_of_image|>",
   "pad_token": "<|pad|>",
   "model_input_names": [
     "input_ids",

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -190,7 +190,10 @@ class HuggingFaceTokenizer(BaseTokenizer):
         return token
 
     def _process_special_token(
-        self, token_str: str, token_config: dict, token_id: Optional[int] = None
+        self,
+        token_str: str,
+        token_config: dict | None = None,
+        token_id: int | None = None,
     ) -> AddedToken:
         """
         Process a special token and update BOS/EOS attributes if applicable.

--- a/torchtitan/experiments/vlm/__init__.py
+++ b/torchtitan/experiments/vlm/__init__.py
@@ -4,13 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import asdict, replace
+from dataclasses import asdict
 
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
-from torchtitan.components.tokenizer import build_hf_tokenizer
 from torchtitan.components.validate import build_validator
+from torchtitan.experiments.vlm.tokenizer import build_vlm_tokenizer
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.protocols.train_spec import TrainSpec
 
@@ -29,7 +29,7 @@ __all__ = [
 
 llama3_siglip2_configs = {
     "debugmodel": Llama3Siglip2ModelArgs(
-        **asdict(replace(llama3_configs["debugmodel"], vocab_size=2048)),
+        **asdict(llama3_configs["debugmodel"]),
         encoder=Siglip2ModelArgs(
             dim=128,
             ffn_dim=256,
@@ -50,7 +50,7 @@ def get_train_spec() -> TrainSpec:
         build_optimizers_fn=build_optimizers,
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_mm_dataloader,
-        build_tokenizer_fn=build_hf_tokenizer,
+        build_tokenizer_fn=build_vlm_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
         build_validator_fn=build_validator,
     )

--- a/torchtitan/experiments/vlm/datasets/utils/text.py
+++ b/torchtitan/experiments/vlm/datasets/utils/text.py
@@ -6,6 +6,8 @@
 
 import torch
 
+from ...tokenizer import VLMTokenizer
+
 
 def pad_text_batch(
     input_ids: torch.Tensor,
@@ -97,8 +99,7 @@ def pad_input_ids_and_labels_to_target_batch_size(
 def process_text_with_images(
     text: list[str],
     image_tokens: list[tuple[int, int, int]],  # [(total, width, height), ...]
-    tokenizer,
-    special_tokens,
+    tokenizer: VLMTokenizer,
     add_eos: bool = True,
 ) -> str:
     """Process text by interleaving image tokens efficiently.
@@ -122,14 +123,14 @@ def process_text_with_images(
     image_idx = 0
 
     for part in text:
-        if part == special_tokens.img_token and image_idx < len(image_tokens):
+        if part == tokenizer.img_token and image_idx < len(image_tokens):
             num_image_tokens, _, _ = image_tokens[image_idx]
 
             parts.extend(
                 [
-                    special_tokens.boi_token,
-                    *([special_tokens.img_token] * num_image_tokens),
-                    special_tokens.eoi_token,
+                    tokenizer.boi_token,
+                    *([tokenizer.img_token] * num_image_tokens),
+                    tokenizer.eoi_token,
                 ]
             )
             image_idx += 1

--- a/torchtitan/experiments/vlm/model/args.py
+++ b/torchtitan/experiments/vlm/model/args.py
@@ -6,38 +6,7 @@
 
 from dataclasses import dataclass, field
 
-from torchtitan.components.tokenizer import HuggingFaceTokenizer
-
 from torchtitan.models.llama3 import TransformerModelArgs as Llama3Args
-
-
-@dataclass
-class SpecialTokens:
-    img_token: str
-    img_id: int
-    boi_token: str
-    boi_id: int
-    eoi_token: str
-    eoi_id: int
-    pad_token: str
-    pad_id: int
-    ignore_id: int = -100  # Pytorch F.cross_entropy default
-
-    @classmethod
-    def from_tokenizer(cls, tokenizer: HuggingFaceTokenizer):
-        SPECIAL_TOKENS_MAP = {
-            "img": "<|image|>",
-            "boi": "<|begin_of_image|>",
-            "eoi": "<|end_of_image|>",
-            "pad": "<|pad|>",
-        }
-        added_tokens = tokenizer.tokenizer.get_added_tokens_decoder()
-        token_to_id = {tok.content: tok_id for tok_id, tok in added_tokens.items()}
-        special_tokens_dict = {}
-        for prefix, tok in SPECIAL_TOKENS_MAP.items():
-            special_tokens_dict[f"{prefix}_token"] = tok
-            special_tokens_dict[f"{prefix}_id"] = token_to_id[tok]
-        return cls(**special_tokens_dict)
 
 
 @dataclass

--- a/torchtitan/experiments/vlm/tokenizer.py
+++ b/torchtitan/experiments/vlm/tokenizer.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from tokenizers import AddedToken
+
+from torchtitan.components.tokenizer import HuggingFaceTokenizer
+from torchtitan.config.job_config import JobConfig
+from torchtitan.tools.logging import logger
+
+
+class VLMTokenizer(HuggingFaceTokenizer):
+    def __init__(self, tokenizer_path: str):
+        super().__init__(tokenizer_path)
+        self.pad_token = "<|pad|>"
+        self.img_token = "<|image|>"
+        self.boi_token = "<|begin_of_image|>"
+        self.eoi_token = "<|end_of_image|>"
+        _special_tokens = [
+            AddedToken(token_str, special=True)
+            for token_str in [
+                self.pad_token,
+                self.img_token,
+                self.boi_token,
+                self.eoi_token,
+            ]
+        ]
+        num_new_tokens = self.tokenizer.add_special_tokens(_special_tokens)
+        logger.info(f"{num_new_tokens} new tokens were added to the tokenizer.")
+
+        self.pad_id = self.tokenizer.token_to_id(self.pad_token)
+        self.img_id = self.tokenizer.token_to_id(self.img_token)
+        self.boi_id = self.tokenizer.token_to_id(self.boi_token)
+        self.eoi_id = self.tokenizer.token_to_id(self.eoi_token)
+
+
+def build_vlm_tokenizer(job_config: JobConfig) -> VLMTokenizer:
+    tokenizer = VLMTokenizer(job_config.model.hf_assets_path)
+    return tokenizer

--- a/torchtitan/experiments/vlm/train_configs/debug_model.toml
+++ b/torchtitan/experiments/vlm/train_configs/debug_model.toml
@@ -23,7 +23,7 @@ save_tb_folder = "tb"
 enable_wandb = false
 
 [model]
-name = "llama3-siglip2"
+name = "vlm"
 flavor = "debugmodel"
 # test folder with tokenizer.json, for debug purpose only
 hf_assets_path = "tests/assets/tokenizer"


### PR DESCRIPTION
Follow up on the previous comment https://github.com/pytorch/torchtitan/pull/1615#discussion_r2369059607, in this PR I refactor the bit about special tokens by subclassing the tokenizer and add the special tokens as class attribute there.

Also, we are adding the special tokens dynamically to the tokenizer, and the tokenizer will create new tokens if they are not already exists in the tokenizer's vocab.

This make it cleaner later when we provide the script to load pretrained LLM, so that we don't have to instruct users to separately download and modify the tokenizer's config manually. 