### PR TITLE
[autoparallel] Add experimental configs for inductor aten overlap/bucketing, autoparallel_asynctp

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -739,6 +739,11 @@ class Experimental:
 
     enable_simplefsdp_passes: bool = False
 
+    enable_inductor_aten_fx_overlap_scheduler: bool = False
+    enable_inductor_aten_fx_overlap_scheduler_bucketing: bool = False
+    enable_autoparallel_asynctp: bool = False
+
+
 @dataclass
 class Validation:
     enable: bool = False


### PR DESCRIPTION
stack-info: PR: https://github.com/pytorch/torchtitan/pull/1772, branch: IvanKobzarev/stack/2