### PR TITLE
[Llama] Add scaled RoPE support for Llama 3 and 4

### DIFF
--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -14,7 +14,7 @@ from torchtitan.models.moe import MoEArgs
 from torchtitan.protocols.train_spec import TrainSpec
 
 from .infra.parallelize import parallelize_llama
-from .model.args import TransformerModelArgs
+from .model.args import RoPEScalingArgs, TransformerModelArgs
 from .model.model import Transformer
 from .model.state_dict_adapter import Llama4StateDictAdapter
 
@@ -32,10 +32,7 @@ llama4_configs = {
         n_heads=16,
         vocab_size=2048,
         rope_theta=500000,
-        rope_scaling_factor=16.0,
-        rope_low_freq_factor=1.0,
-        rope_high_freq_factor=1.0,
-        rope_original_max_position_embeddings=8192,
+        rope_scaling_args=RoPEScalingArgs(),
     ),
     "17bx16e": TransformerModelArgs(
         dim=5120,
@@ -45,10 +42,7 @@ llama4_configs = {
         ffn_dim_multiplier=1.2,
         multiple_of=2048,
         rope_theta=500000,
-        rope_scaling_factor=16.0,
-        rope_low_freq_factor=1.0,
-        rope_high_freq_factor=1.0,
-        rope_original_max_position_embeddings=8192,
+        rope_scaling_args=RoPEScalingArgs(),
         max_seq_len=10485760,
         moe_args=MoEArgs(num_experts=16),
         interleave_moe_layer_step=1,
@@ -69,10 +63,7 @@ llama4_configs = {
         n_heads=16,
         vocab_size=2048,
         rope_theta=500000,
-        rope_scaling_factor=16.0,
-        rope_low_freq_factor=1.0,
-        rope_high_freq_factor=1.0,
-        rope_original_max_position_embeddings=8192,
+        rope_scaling_args=RoPEScalingArgs(),
         every_n_layers_nope=4,
         fixed_attn_block_size=256,
         use_flex_attn=True,
@@ -86,10 +77,7 @@ llama4_configs = {
         ffn_dim_multiplier=1.2,
         multiple_of=2048,
         rope_theta=500000,
-        rope_scaling_factor=16.0,
-        rope_low_freq_factor=1.0,
-        rope_high_freq_factor=1.0,
-        rope_original_max_position_embeddings=8192,
+        rope_scaling_args=RoPEScalingArgs(),
         max_seq_len=10485760,
         moe_args=MoEArgs(num_experts=16),
         interleave_moe_layer_step=1,

--- a/torchtitan/experiments/llama4/model/args.py
+++ b/torchtitan/experiments/llama4/model/args.py
@@ -19,6 +19,14 @@ from torchtitan.tools.utils import has_cuda_capability
 
 
 @dataclass
+class RoPEScalingArgs:
+    scaling_factor: float = 16.0
+    low_freq_factor: float = 1.0
+    high_freq_factor: float = 1.0
+    original_max_position_embeddings: int = 8192
+
+
+@dataclass
 class TransformerModelArgs(BaseModelArgs):
     dim: int = 4096
     n_layers: int = 32
@@ -29,10 +37,7 @@ class TransformerModelArgs(BaseModelArgs):
     ffn_dim_multiplier: float | None = None
     norm_eps: float = 1e-5
     rope_theta: float = 10000
-    rope_scaling_factor: float | None = None
-    rope_low_freq_factor: float | None = None
-    rope_high_freq_factor: float | None = None
-    rope_original_max_position_embeddings: int | None = None
+    rope_scaling_args: RoPEScalingArgs | None = None
 
     max_seq_len: int = 1048576
     # If `True`, then each transformer block init uses its layer ID, and if

--- a/torchtitan/experiments/llama4/model/model.py
+++ b/torchtitan/experiments/llama4/model/model.py
@@ -14,17 +14,14 @@ from torchtitan.models.attention import build_attention
 from torchtitan.models.moe import MoE
 from torchtitan.protocols import ModelProtocol
 
-from .args import TransformerModelArgs
+from .args import RoPEScalingArgs, TransformerModelArgs
 
 
 def precompute_freqs_cis(
     dim: int,
     end: int,
     theta: float = 10000.0,
-    scaling_factor: float | None = None,
-    low_freq_factor: float | None = None,
-    high_freq_factor: float | None = None,
-    original_max_position_embeddings: int | None = None,
+    scaling_args: RoPEScalingArgs | None = None,
 ) -> torch.Tensor:
     """
     Precompute the frequency tensor for complex exponentials (cis) with given dimensions.
@@ -37,29 +34,26 @@ def precompute_freqs_cis(
         dim (int): Dimension of the frequency tensor.
         end (int): End index for precomputing frequencies.
         theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
-        scaling_factor (float | None): RoPE scaling multiplier; larger values
-            stretch positions to support longer contexts. Defaults to 8.0.
-        low_freq_factor (float | None): Extra scaling applied to the low-frequency
-            (long-wavelength) RoPE bands. Defaults to 1.0.
-        high_freq_factor (float | None): Extra scaling applied to the high-frequency
-            (short-wavelength) RoPE bands. Defaults to 4.0.
-        original_max_position_embeddings (int | None): Maximum position embeddings
-            for original model. Defaults to 8192.
+        scaling_args (RoPEScalingArgs | None): RoPE scaling arguments. Defaults to None.
+            scaling_factor (float): RoPE scaling multiplier; larger values
+                stretch positions to support longer contexts. Defaults to 16.0.
+            low_freq_factor (float): Extra scaling applied to the low-frequency
+                (long-wavelength) RoPE bands. Defaults to 1.0.
+            high_freq_factor (float): Extra scaling applied to the high-frequency
+                (short-wavelength) RoPE bands. Defaults to 1.0.
+            original_max_position_embeddings (int): Maximum position embeddings
+                for original model. Defaults to 8192.
     Returns:
         torch.Tensor: Precomputed frequency tensor with complex exponentials.
     """
     freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
 
     # apply rope scaling
-    if all(
-        x is not None
-        for x in (
-            scaling_factor,
-            low_freq_factor,
-            high_freq_factor,
-            original_max_position_embeddings,
-        )
-    ):
+    if scaling_args is not None:
+        scaling_factor = scaling_args.scaling_factor
+        low_freq_factor = scaling_args.low_freq_factor
+        high_freq_factor = scaling_args.high_freq_factor
+        original_max_position_embeddings = scaling_args.original_max_position_embeddings
         wavelen = 2 * math.pi / freqs
         high_freq_wavelen = original_max_position_embeddings / high_freq_factor
         low_freq_wavelen = original_max_position_embeddings / low_freq_factor
@@ -488,10 +482,7 @@ class Transformer(nn.Module, ModelProtocol):
             # relaxing in our CP enablement PR
             self.model_args.max_seq_len,
             self.model_args.rope_theta,
-            self.model_args.rope_scaling_factor,
-            self.model_args.rope_low_freq_factor,
-            self.model_args.rope_high_freq_factor,
-            self.model_args.rope_original_max_position_embeddings,
+            self.model_args.rope_scaling_args,
         )
 
     def forward(

--- a/torchtitan/models/llama3/model/args.py
+++ b/torchtitan/models/llama3/model/args.py
@@ -7,7 +7,7 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from torch import nn
 
@@ -15,6 +15,14 @@ from torchtitan.config import JobConfig
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
 from torchtitan.protocols.model import BaseModelArgs
 from torchtitan.tools.logging import logger
+
+
+@dataclass
+class RoPEScalingArgs:
+    scaling_factor: float = 8.0
+    low_freq_factor: float = 1.0
+    high_freq_factor: float = 4.0
+    original_max_position_embeddings: int = 8192
 
 
 @dataclass
@@ -28,10 +36,7 @@ class TransformerModelArgs(BaseModelArgs):
     ffn_dim_multiplier: float | None = None
     norm_eps: float = 1e-5
     rope_theta: float = 10000
-    rope_scaling_factor: float = 8.0
-    rope_low_freq_factor: float = 1.0
-    rope_high_freq_factor: float = 4.0
-    rope_original_max_position_embeddings: int = 8192
+    rope_scaling_args: RoPEScalingArgs = field(default_factory=RoPEScalingArgs)
 
     max_seq_len: int = 131072
     # If `True`, then each transformer block init uses its layer ID, and if


### PR DESCRIPTION
Llama 3.1 models use scaled RoPE by default, and Llama 4 17B x 16E uses scaled RoPE while 17B x 128E does not. 

1. Verified forward parity between Titan Llama 3.1 8B  and HuggingFace Llama 3.1 8B. The KL divergence of outputs from the same sample inputs is small. 
![llama 3 8b forward parity small](https://github.com/user-attachments/assets/891df89b-006f-4ed0-a68a-36e939d2169b)

    For comparison, before adding scaled RoPE support, the forward parity check on the Llama 3.1 8B model incurred a slightly larger KL divergence on sample inputs.
![llama 3 8b forward parity without scaled rope](https://github.com/user-attachments/assets/9a68357a-34d4-497f-977f-27cc548d8f62)

2. Verified training of Llama 3.1 8B with tensor parallel degree = 4.
![llama 3-1 8b training tp=4](https://github.com/user-attachments/assets/a8b1ab10-0da0-4d02-afbb-a775716beaa3)

3. Verified training of Llama 4 debug model with scaled RoPE.
![llama 4 debug model training](https://github.com/user-attachments/assets/1fbf8939-31a5-475f-987c-d5bcf6d2376b)
