### PR TITLE
refactor TrainSpec to remove the name field

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -14,7 +14,7 @@ The extension points and protocols mentioned in this note are subject to change.
 The coarse level abstraction tries to hit a balance between flexible component swapping and a straightforward train script ([train.py](../torchtitan/train.py)).
 Note that among all training components, currently [`CheckpointManager`](../torchtitan/components/checkpoint.py) and [`FTManager`](../torchtitan/components/ft.py) are not configurable since we do not expect them to be customized, but we are open to requests.
 
-To register a `TrainSpec`, please follow the example of [Llama 3.1](../torchtitan/models/llama3/__init__.py) to `register_train_spec`. Please make sure the registration code is called before training initialization. In torchtitan, it is performed during  [module import](../torchtitan/__init__.py).
+To register a `TrainSpec`, please use the `register_train_spec` API, and make sure registration happens before `get_train_spec` is called during training initialization. In torchtitan, `get_train_spec` will dynamically look for models in `torchtitan/models` or `torchtitan/experiments`.
 
 
 ### `ModelConverter`

--- a/scripts/estimate/estimation.py
+++ b/scripts/estimate/estimation.py
@@ -95,7 +95,7 @@ def estimate_memory(job_config: JobConfig):
         else contextlib.nullcontext()
     ):
         logger.info(
-            f"Building {train_spec.name} {job_config.model.flavor} with {model_args}"
+            f"Building {job_config.model.name} {job_config.model.flavor} with {model_args}"
         )
         with torch.device("meta"):
             model = train_spec.model_cls(model_args)

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -76,7 +76,6 @@ class TestTrainSpec:
     def test_register_train_spec(self):
         fake_config = {"fake": BaseModelArgs()}
         spec = TrainSpec(
-            name="fake",
             model_cls=FakeModel,
             model_args=fake_config,
             parallelize_fn=parallelize_llama,
@@ -87,7 +86,7 @@ class TestTrainSpec:
             build_tokenizer_fn=build_hf_tokenizer,
             build_loss_fn=build_cross_entropy_loss,
         )
-        register_train_spec(spec)
+        register_train_spec("fake", spec)
         new_spec = get_train_spec("fake")
         assert new_spec == spec
 
@@ -98,7 +97,6 @@ class TestTrainSpec:
         fake_config = {"fake": BaseModelArgs()}
 
         spec = TrainSpec(
-            name="fake2",
             model_cls=FakeModel,
             model_args=fake_config,
             parallelize_fn=parallelize_llama,
@@ -109,7 +107,7 @@ class TestTrainSpec:
             build_tokenizer_fn=build_hf_tokenizer,
             build_loss_fn=build_cross_entropy_loss,
         )
-        register_train_spec(spec)
+        register_train_spec("fake2", spec)
         new_spec = get_train_spec("fake2")
 
         model = new_spec.model_cls(BaseModelArgs())

--- a/torchtitan/experiments/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/deepseek_v3/__init__.py
@@ -40,8 +40,8 @@ deepseek_configs = {
 
 
 register_train_spec(
+    "deepseek3",
     TrainSpec(
-        name="deepseek3",
         model_cls=DeepseekForCausalLM,
         model_args=deepseek_configs,
         parallelize_fn=parallelize_deepseek,
@@ -51,5 +51,5 @@ register_train_spec(
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=get_hf_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
-    )
+    ),
 )

--- a/torchtitan/experiments/flux/__init__.py
+++ b/torchtitan/experiments/flux/__init__.py
@@ -109,7 +109,6 @@ flux_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="flux",
         model_cls=FluxModel,
         model_args=flux_configs,
         parallelize_fn=parallelize_flux,

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -167,7 +167,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful):
         if parallel_dims.pp_enabled:
             if not self.train_spec.pipelining_fn:
                 raise RuntimeError(
-                    f"Pipeline Parallel is enabled but {self.train_spec.name} "
+                    f"Pipeline Parallel is enabled but {job_config.model.name} "
                     f"does not support pipelining"
                 )
 

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -66,7 +66,7 @@ class Trainer(ForgeEngine):
 
         model_args = self.model_args
         logger.info(
-            f"Built {self.train_spec.name} {job_config.model.flavor} with {model_args}"
+            f"Built {job_config.model.name} {job_config.model.flavor} with {model_args}"
         )
 
         # metrics logging
@@ -78,7 +78,7 @@ class Trainer(ForgeEngine):
         self.metrics_processor.num_flops_per_token = self.num_flops_per_token
 
         logger.info(
-            f"{color.blue}Model {self.train_spec.name} {job_config.model.flavor} "
+            f"{color.blue}Model {job_config.model.name} {job_config.model.flavor} "
             f"{color.red}size: {self.model_param_count:,} total parameters{color.reset}"
         )
 

--- a/torchtitan/experiments/forge/train_spec.py
+++ b/torchtitan/experiments/forge/train_spec.py
@@ -21,7 +21,6 @@ from torchtitan.protocols.train_spec import (
 
 @dataclass
 class ForgeTrainSpec:
-    name: str
     model_cls: type[ModelProtocol]
     model_args: Mapping[str, BaseModelArgs]
     parallelize_fn: ParallelizeFunction
@@ -39,7 +38,6 @@ def _transform_train_spec(original_spec: TrainSpec):
     """Transform the original train spec to ForgeTrainSpec format."""
     # Create a new TrainSpec with only the fields we need in forge
     return ForgeTrainSpec(
-        name=original_spec.name,
         model_cls=original_spec.model_cls,
         model_args=original_spec.model_args,
         parallelize_fn=original_spec.parallelize_fn,
@@ -51,13 +49,13 @@ def _transform_train_spec(original_spec: TrainSpec):
     )
 
 
-def register_train_spec(train_spec: ForgeTrainSpec) -> None:
+def register_train_spec(name: str, train_spec: ForgeTrainSpec) -> None:
     global _extra_train_specs
-    if train_spec.name in _extra_train_specs:
-        raise ValueError(f"ForgeTrainSpec {train_spec.name} is already registered.")
+    if name in _extra_train_specs:
+        raise ValueError(f"ForgeTrainSpec {name} is already registered.")
 
     # user can define a ForgeTrainSpec from outside of torchtitan
-    _extra_train_specs[train_spec.name] = train_spec
+    _extra_train_specs[name] = train_spec
 
 
 def get_train_spec(name: str) -> ForgeTrainSpec:

--- a/torchtitan/experiments/llama4/__init__.py
+++ b/torchtitan/experiments/llama4/__init__.py
@@ -8,6 +8,7 @@ from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers_with_moe_load_balancing
 from torchtitan.components.tokenizer import build_hf_tokenizer
+from torchtitan.components.validate import build_validator
 from torchtitan.datasets.hf_datasets import build_hf_dataloader
 from torchtitan.models.llama3 import pipeline_llama
 from torchtitan.models.moe import MoEArgs
@@ -103,7 +104,6 @@ llama4_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="llama4",
         model_cls=Transformer,
         model_args=llama4_configs,
         parallelize_fn=parallelize_llama,
@@ -113,5 +113,6 @@ def get_train_spec() -> TrainSpec:
         build_dataloader_fn=build_hf_dataloader,
         build_tokenizer_fn=build_hf_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
+        build_validator_fn=build_validator,
         state_dict_adapter=Llama4StateDictAdapter,
     )

--- a/torchtitan/experiments/multimodal/__init__.py
+++ b/torchtitan/experiments/multimodal/__init__.py
@@ -22,8 +22,8 @@ llama4_mm_configs = {
 }
 
 register_train_spec(
+    "llama4_multimodal",
     TrainSpec(
-        name="llama4_multimodal",
         model_cls=MultimodalDecoder,
         model_args=llama4_mm_configs,
         parallelize_fn=parallelize_llama,
@@ -33,5 +33,5 @@ register_train_spec(
         build_dataloader_fn=build_mm_dataloader,
         build_tokenizer_fn=build_hf_tokenizer,
         build_loss_fn=build_cross_entropy_loss,
-    )
+    ),
 )

--- a/torchtitan/experiments/qwen3/__init__.py
+++ b/torchtitan/experiments/qwen3/__init__.py
@@ -180,7 +180,6 @@ qwen3_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="qwen3",
         model_cls=Qwen3Model,
         model_args=qwen3_configs,  # Change from dict to Mapping
         parallelize_fn=parallelize_qwen3,

--- a/torchtitan/experiments/vlm/__init__.py
+++ b/torchtitan/experiments/vlm/__init__.py
@@ -6,6 +6,7 @@
 
 from dataclasses import asdict, replace
 
+from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.lr_scheduler import build_lr_schedulers
 from torchtitan.components.optimizer import build_optimizers
 from torchtitan.components.tokenizer import build_hf_tokenizer
@@ -41,7 +42,6 @@ llama3_siglip2_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="llama3-siglip2",
         model_cls=Llama3Siglip2Transformer,
         model_args=llama3_siglip2_configs,
         parallelize_fn=parallelize_vlm,

--- a/torchtitan/experiments/vlm/train_configs/debug_model.toml
+++ b/torchtitan/experiments/vlm/train_configs/debug_model.toml
@@ -23,7 +23,7 @@ save_tb_folder = "tb"
 enable_wandb = false
 
 [model]
-name = "llama3-siglip2"
+name = "vlm"
 flavor = "debugmodel"
 # test folder with tokenizer.json, for debug purpose only
 hf_assets_path = "tests/assets/tokenizer"

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -40,7 +40,7 @@ The folder should be organized as follows
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: ModelArgs]`.
   - Define `get_train_spec` to return a [`TrainSpec`](/torchtitan/protocols/train_spec.py), consisting a tuple of
-    - model name, model class, model args
+    - model class, model args
       - Model name should be the same as the folder name, which should be added to `torchtitan/models/__init__.py` or ``torchtitan/experiments/__init__.py``.
     - parallelizing function, pipelining function
     - builder functions for optimizer, lr scheduler, data loader, tokenizer, and loss function

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -161,7 +161,6 @@ deepseekv3_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="deepseek_v3",
         model_cls=DeepSeekV3Model,
         model_args=deepseekv3_configs,
         parallelize_fn=parallelize_deepseekv3,

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -72,7 +72,6 @@ llama3_configs = {
 
 def get_train_spec() -> TrainSpec:
     return TrainSpec(
-        name="llama3",
         model_cls=Transformer,
         model_args=llama3_configs,
         parallelize_fn=parallelize_llama,

--- a/torchtitan/models/llama3_ft/__init__.py
+++ b/torchtitan/models/llama3_ft/__init__.py
@@ -33,12 +33,10 @@ __all__ = [
 
 def get_train_spec() -> TrainSpec:
     return FaultTolerantTrainSpec(
-        name="llama3_ft",
         model_cls=Transformer,
         model_args=llama3_configs,
         parallelize_fn=parallelize_llama,
         pipelining_fn=pipeline_llama,
-        fragment_fn=fragment_llm,
         build_optimizers_fn=build_optimizers,
         build_lr_schedulers_fn=build_lr_schedulers,
         build_dataloader_fn=build_hf_dataloader,
@@ -46,4 +44,5 @@ def get_train_spec() -> TrainSpec:
         build_loss_fn=build_cross_entropy_loss,
         build_validator_fn=build_validator,
         state_dict_adapter=Llama3StateDictAdapter,
+        fragment_fn=fragment_llm,
     )

--- a/torchtitan/protocols/train_spec.py
+++ b/torchtitan/protocols/train_spec.py
@@ -42,7 +42,6 @@ ValidatorBuilder: TypeAlias = Callable[..., BaseValidator]
 
 @dataclass
 class TrainSpec:
-    name: str
     model_cls: type[ModelProtocol]
     model_args: Mapping[str, BaseModelArgs]
     parallelize_fn: ParallelizeFunction
@@ -60,13 +59,13 @@ class TrainSpec:
 _extra_train_specs: dict[str, TrainSpec] = {}
 
 
-def register_train_spec(train_spec: TrainSpec) -> None:
+def register_train_spec(name: str, train_spec: TrainSpec) -> None:
     global _extra_train_specs
-    if train_spec.name in _extra_train_specs:
-        raise ValueError(f"TrainSpec {train_spec.name} is already registered.")
+    if name in _extra_train_specs:
+        raise ValueError(f"TrainSpec {name} is already registered.")
 
     # user can define a TrainSpec from outside of torchtitan
-    _extra_train_specs[train_spec.name] = train_spec
+    _extra_train_specs[name] = train_spec
 
 
 def get_train_spec(name: str) -> TrainSpec:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -152,7 +152,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.model_args = model_args
 
         logger.info(
-            f"Building {self.train_spec.name} {job_config.model.flavor} with {model_args}"
+            f"Building {job_config.model.name} {job_config.model.flavor} with {model_args}"
         )
         with (
             torch.device("meta"),
@@ -182,7 +182,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         ) = model_args.get_nparams_and_flops(model, job_config.training.seq_len)
 
         logger.info(
-            f"{color.blue}Model {self.train_spec.name} {job_config.model.flavor} "
+            f"{color.blue}Model {job_config.model.name} {job_config.model.flavor} "
             f"{color.red}size: {model_param_count:,} total parameters{color.reset}"
         )
 
@@ -229,7 +229,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if parallel_dims.pp_enabled:
             if not self.train_spec.pipelining_fn:
                 raise RuntimeError(
-                    f"Pipeline Parallel is enabled but {self.train_spec.name} "
+                    f"Pipeline Parallel is enabled but {job_config.model.name} "
                     f"does not support pipelining"
                 )
 


### PR DESCRIPTION
Previously we have redundant field `job_config.model.name` and `train_spec.name` and we used to implicitly require them to be the same.

This ambiguity was exaggerated in https://github.com/pytorch/torchtitan/pull/1740, after which we can tolerate the two fields to be different, without good reasons.

This PR removes `train_spec.name`.

For models inside torchtitan:
- we rely on folder path as the implicit source of truth for "registering" models.
- `job_config.model.name` will be used to search for models in the `torchtitan/models` folder and `torchtitan/experiments` folder

For models outside torchtitan:
- users can still register `TrainSpec`, but with names explicitly specified so that `job_config.model.name` could be used to fetch the `TrainSpec`