### PR TITLE
minor refactor over EP

### DIFF
--- a/torchtitan/experiments/kernels/moe/dispatch.py
+++ b/torchtitan/experiments/kernels/moe/dispatch.py
@@ -88,7 +88,6 @@ class AllToAllVDev2d(torch.autograd.Function):
             out_splits_offsets, grad_out_buf, grad_in_buf, grad_in_splits_offsets
         )
         ctx.group_name = group_name
-        return out
 
     @staticmethod
     def backward(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
This PR:

- let `ExpertParallel` handles indices permute / unpermute when EP is used
- move `to_local` to model code to be more explicit
- rename the `expert_parallel` wrapper which does permute / unpermute to `indices_permutation_wrapper` to be more accurate