### PR TITLE
add owners and CI status for experiments

### DIFF
--- a/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
+++ b/.github/workflows/integration_test_8gpu_simple_fsdp.yaml
@@ -1,4 +1,4 @@
-name: SimpleFSDP 8 GPU Integration Test
+name: SimpleFSDP 8 GPU Integration Tests
 
 on:
   push:
@@ -9,8 +9,9 @@ on:
     paths:
       - 'torchtitan/experiments/simple_fsdp/**'
   schedule:
-    # Runs every 6 hours
-    - cron: '0 */6 * * *'
+    # Runs every 12 hours
+    - cron: '0 */12 * * *'
+
 concurrency:
   group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration_test_8gpu_vlm.yaml
+++ b/.github/workflows/integration_test_8gpu_vlm.yaml
@@ -1,4 +1,4 @@
-name: 8 GPU Vision Language Model Tests
+name: VLM 8 GPU Integration Tests
 
 on:
   push:
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - 'torchtitan/experiments/vlm/**'
+  schedule:
+    # Runs every 12 hours
+    - cron: '0 */12 * * *'
 
 concurrency:
   group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/torchtitan/experiments/README.md
+++ b/torchtitan/experiments/README.md
@@ -18,3 +18,12 @@ We provide this `experiments/` folder to host experiments that add significant v
 7. `torchtitan` team reserve the right to remove an experiment. In particular, an experiment should be removed if
     - it has served its purpose (e.g., providing findings, or getting some features upstreamed to `core` or PyTorch, etc.), or
     - it gets stale (e.g. not being maintained).
+
+
+## Current experiments
+
+| Experiment | Test Status | Owners |
+| ----- | ----: | ----: |
+| [simple_fsdp](./simple_fsdp/) | [![SimpleFSDP 8 GPU Integration Tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_simple_fsdp.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_simple_fsdp.yaml?query=branch%3Amain) | [@ruisizhang123](https://github.com/ruisizhang123) [@tianyu-l](https://github.com/tianyu-l) |
+| [vlm](./vlm/) | [![VLM 8 GPU Integration Tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_vlm.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_vlm.yaml?query=branch%3Amain) | [@lkhphuc](https://github.com/lkhphuc) |
+| [forge](./forge/) | TBA | [@allenwang28](https://github.com/allenwang28) [@ebsmothers](https://github.com/ebsmothers) [@joecummings](https://github.com/joecummings) [@pbontrager](https://github.com/pbontrager) |


### PR DESCRIPTION
Next is step is to move `qwen3` and `llama4` to core, and remove outdated experiments.