### PR TITLE
[moe][compile] turn on capture_scalar_outputs and assert fullgraph on grouped experts

### DIFF
--- a/torchtitan/models/moe.py
+++ b/torchtitan/models/moe.py
@@ -144,6 +144,13 @@ class GroupedExperts(nn.Module):
         x: torch.Tensor,
         num_tokens_per_expert: torch.Tensor,
     ) -> torch.Tensor:
+        return self._forward(x, num_tokens_per_expert)
+
+    def _forward(
+        self,
+        x: torch.Tensor,
+        num_tokens_per_expert: torch.Tensor,
+    ) -> torch.Tensor:
         if isinstance(self.w1, DTensor):
             # Convert parameters from DTensors to plain Tensors, to work with
             # dynamic-shape inputs in EP which cannot be easily expressed as DTensors.


### PR DESCRIPTION
Stacked PRs:
 * __->__#1861


--- --- ---

1. There's a commitment to turn `capture_scalar_outputs` on by default, and I'm adding sample MoE tests to core. So we can flip this back.
2. using the `compile(disable(compile(_forward, fullgraph=True)), fullgraph=False)` trick, we can ensure the grouped gemm is always captured.

logs: https://gist.github.com/xmfan/4fd7efc7718795d302304dab807fabd6