### PR TITLE
Update vocab_size for debugmodel_moe of qwen3 moe

### DIFF
--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -120,7 +120,7 @@ qwen3_configs = {
     ),
     # Qwen3-MoE models
     "debugmodel_moe": Qwen3ModelArgs(
-        vocab_size=2048,
+        vocab_size=151936,
         max_seq_len=4096,
         head_dim=128,
         dim=256,


### PR DESCRIPTION
Setting vocab_size to 2048 without updating the tokenizer accordingly will cause a CUDA illegal memory access error. Maybe it's better to keep the model's vocab_size consistent with other model sizes.