### PR TITLE
Remove torchao nightly version check in mx component

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import partial
-from importlib.metadata import version
 from importlib.util import find_spec
 from typing import Any, List
 
@@ -107,14 +106,6 @@ class MXGroupedMMConverter(QuantizationConverter):
         if find_spec("torchao") is None:
             raise ImportError(
                 "torchao is not installed. Please install it to use MXFP8 linear layers."
-            )
-        torchao_version = version("torchao")
-
-        # Require latest release or nightly builds for prototype features
-        is_nightly_build = torchao_version.startswith("0.14.0")
-        if not is_nightly_build:
-            raise ImportError(
-                f"torchao version {torchao_version} is too old, please install torchao nightly build and try again"
             )
 
         # Can be removed if we enable the emulated versions


### PR DESCRIPTION
Nightly build is no longer required for MXFP8