### PR TITLE
[NOT for land] cleaner workaround for moe + compile + ac graph break issue

### DIFF
--- a/torchtitan/models/llama4/infra/parallelize.py
+++ b/torchtitan/models/llama4/infra/parallelize.py
@@ -514,16 +514,7 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
     for layer_id, transformer_block in model.layers.named_children():
         # TODO: remove when torch.compile supports fullgraph=True for MoE
         if transformer_block.moe_enabled:
-            transformer_block.moe.experts = torch.compile(
-                transformer_block.moe.experts,
-                backend=compile_config.backend,
-                fullgraph=True,
-            )
-            transformer_block.moe.shared_experts = torch.compile(
-                transformer_block.moe.shared_experts,
-                backend=compile_config.backend,
-                fullgraph=True,
-            )
+            continue
         else:
             transformer_block = torch.compile(
                 transformer_block,


### PR DESCRIPTION
Compile dense layers, run MoE layer in eager.


## Commands

mxfp8 grouped mm:

```
LOG_RANK=4 NGPU=8 CONFIG_FILE="/home/${USER}/torchtitan/torchtitan/models/llama4/train_configs/llama4_17bx16e.toml" ./run_train.sh \
--metrics.log_freq=10 --training.steps=1000  \
--parallelism.data_parallel_shard_degree=4 \
--parallelism.expert_parallel_degree=4 \
--parallelism.tensor_parallel_degree=1 \
--parallelism.expert_tensor_parallel_degree=1 \
--training.seq_len=8192 \
--training.local_batch_size=12 \
--model.print_after_conversion \
--activation_checkpoint.mode="full" \
--parallelism.pipeline_parallel_degree 2 \
--parallelism.pipeline_parallel_schedule "Interleaved1F1B" \
--parallelism.pipeline_parallel_layers_per_stage 1 \
--model.converters="quantize.grouped_mm.mx,quantize.linear.mx" \
--quantize.grouped_mm.mx.fqns="experts" \
--quantize.linear.mx.filter_fqns="output,moe,wk,wv" \
--compile.enable
```


bf16 baseline:

```
LOG_RANK=4 NGPU=8 CONFIG_FILE="/home/${USER}/torchtitan/torchtitan/models/llama4/train_configs/llama4_17bx16e.toml" ./run_train.sh \
--metrics.log_freq=10 --training.steps=1000  \
--parallelism.data_parallel_shard_degree=4 \
--parallelism.expert_parallel_degree=4 \
--parallelism.tensor_parallel_degree=1 \
--parallelism.expert_tensor_parallel_degree=1 \
--training.seq_len=8192 \
--training.local_batch_size=12 \
--model.print_after_conversion \
--activation_checkpoint.mode="full" \
--parallelism.pipeline_parallel_degree 2 \
--parallelism.pipeline_parallel_schedule "Interleaved1F1B" \
--parallelism.pipeline_parallel_layers_per_stage 1 \
--compile.enable
```
