### PR TITLE
[TorchComms] Support N-D parallelism device mesh setup

### DIFF
--- a/torchtitan/experiments/torchcomms/parallel_dims.py
+++ b/torchtitan/experiments/torchcomms/parallel_dims.py
@@ -26,12 +26,12 @@ def _calculate_ranks_per_dimension(
     dim_sizes: List[int],
     cur_rank: int,
 ) -> Dict[str, List[int]]:
-    """Calculate global ranks mapping for each mesh dimension.
+    """Util function to calculate global ranks mapping for each mesh dimension.
 
     Args:
         meshes: List of mesh tensors to calculate ranks from
         dim_names: List of dimension names corresponding to each mesh
-        dim_sizes: List of dimension sizes for reshaping
+        dim_sizes: List of dimension sizes corresponding to each mesh
         cur_rank: The current rank to find in the global ranks
 
     Returns:
@@ -99,7 +99,7 @@ class TorchCommsParallelDims(ParallelDims):
                     comm_per_dim["cp"],
                     comm_per_dim["tp"],
                 ),
-                mesh_dim_names=("pp", "dp_replicate", "dp_shard", "cp", "tp"),
+                mesh_dim_names=tuple(mesh_dim_names),
                 _global_comm=comm,
             )
         except TypeError as e:


### PR DESCRIPTION
Support ND device mesh among [pp, dp, cp, tp]
Used comm.split() to split the sub device mesh at each parallelism
Flatten the mesh to dp, dp_shard_cp, dp_cp, which will be access in titan training


`TEST_BACKEND=nccl TRAIN_FILE=torchtitan.experiments.torchcomms.train CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" ./run_train.sh --parallelism.context_parallel_degree 2 --parallelism.tensor_parallel_degree 2`


[rank0]:[titan] 2025-10-14 14:56:30,464 - root - INFO - step:  1  loss:  8.1440  grad_norm:  1.3609  memory:  0.78GiB(0.82%)  tps: 775  tflops: 0.06  mfu: 0.01%
[rank0]:[titan] 2025-10-14 14:56:30,465 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2025-10-14 14:56:30,615 - root - INFO - step:  2  loss:  7.8313  grad_norm:  1.4321  memory:  0.85GiB(0.89%)  tps: 27,316  tflops: 1.96  mfu: 0.20%
[rank0]:[titan] 2025-10-14 14:56:30,736 - root - INFO - step:  3  loss:  7.1126  grad_norm:  1.8422  memory:  0.85GiB(0.89%)  tps: 33,869  tflops: 2.42  mfu: 0.25%
[rank0]:[titan] 2025-10-14 14:56:30,849 - root - INFO - step:  4  loss:  6.2534  grad_norm:  2.2657  memory:  0.85GiB(0.89%)  tps: 36,315  tflops: 2.60  mfu: 0.26%
[rank0]:[titan] 2025-10-14 14:56:30,960 - root - INFO - step:  5  loss:  5.3031  grad_norm:  2.3692  memory:  0.85GiB(0.89%)  tps: 37,302  tflops: 2.67  mfu: 0.27%
[rank0]:[titan] 2025-10-14 14:56:31,078 - root - INFO - step:  6  loss:  4.8114  grad_norm:  2.2013  memory:  0.85GiB(0.89%)  tps: 34,679  tflops: 2.48  mfu: 0.25%
[rank0]:[titan] 2025-10-14 14:56:31,188 - root - INFO - step:  7  loss:  4.5279  grad_norm:  2.2304  memory:  0.85GiB(0.89%)  tps: 37,238  tflops: 2.67  mfu: 0.27%
[rank0]:[titan] 2025-10-14 14:56:31,302 - root - INFO - step:  8  loss:  4.3251  grad_norm:  2.1220  memory:  0.85GiB(0.89%)  tps: 36,187  tflops: 2.59  mfu: 0.26%
[rank0]:[titan] 2025-10-14 14:56:31,413 - root - INFO - step:  9  loss:  4.5047  grad_norm:  1.7700  memory:  0.85GiB(0.89%)  tps: 37,154  tflops: 2.66  mfu: 0.27%
[rank0]:[titan] 2025-10-14 14:56:31,528 - root - INFO - step: 10  loss:  4.1099  grad_norm:  1.7139  memory:  0.85GiB(0.89%)  tps: 35,564  tflops: 2.55  mfu: 0.26%
[rank0]:[titan] 2025-10-14 14:56:31,528 - root - INFO - Sleeping 2 seconds for other ranks to complete