### PR TITLE
[SimpleFSDP] add manual bucketing pass

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -52,14 +52,16 @@ SimpleFSDP relies on compiler backend to perform optimizations (i.e., bucketing 
 1. no optimization: default torch.compile backends (e.g., "inductor", "aot_eager", "eager")
 
 2. auto optimization: perform auto-bucketing & reordering without user inputs. **Note: it is not guaranteed that users will get the most optimized training performance**
-    - "aot_eager_autobucketing": perform autobucketing at aten fx-level, and perform code execution with aot_eager backend.
+    - "auto_bucketing": perform autobucketing at aten fx-level, and perform code execution with aot_eager backend. (We also support `inductor` backend).
+      ```bash
+      --compile.backend "aot_eager" --compile.graph_passes "auto_bucketing"
+      ```
 
-
-users can specify the pass (e.g., "aot_eager_autobucketing") via additional configs:
-
-```bash
---compile.model_backend_override "aot_eager_autobucketing"
-```
+3. manual optimization: perform manual bucketing & reordering with user FQN inputs.
+    - "transformer_block_bucketing": perform bucketing by transformer blocks at aten fx-level, and perform code execution with aot_eager backend. (We also support `inductor` backend).
+      ```bash
+      --compile.backend "aot_eager" --compile.graph_passes "transformer_block_bucketing"
+      ```
 
 ### Citation
 

--- a/torchtitan/experiments/simple_fsdp/backend.py
+++ b/torchtitan/experiments/simple_fsdp/backend.py
@@ -8,49 +8,132 @@ from typing import Any
 
 import torch
 import torch._functorch.config as functorch_config
+from torchtitan.tools.logging import logger
+
+from .job_config import Compile as CompileConfig
 
 from .reshard_after_forward import annotate_fsdp_all_gather
 
 
-def get_compile_backend(
-    backend_name: str, fsdp_reshard_after_forward: bool
+def get_compile_backend_with_passes(
+    compile_config: CompileConfig,
+    fsdp_reshard_after_forward: bool,
+    fsdp_manual_buckets: list[list[str] | str] | None,
 ) -> callable:
-    # return the compile backends used in SimpleFSDP training
-    # Step1: check if backend_name is inside available torch.compile backends
-    # Step2: check if the backend_name has been registered as a customized backend
-    available_torch_backend = torch._dynamo.list_backends(exclude_tags=())
+    """
+    Apply compile backend and additional graph passes.
+    Args:
+        compile_config: compile configs to apply torch.compile.
+        fsdp_reshard_after_forward: whether to enable reshard_after_forward in SimpleFSDP,
+            which is implemented via a customized AC graph pass.
+        fsdp_manual_buckets: used in transformer_block_bucketing to define which modules should be bucketed.
+    Returns:
+        compile backend with applied graph passes.
+    """
+    backend = torch._dynamo.lookup_backend(compile_config.backend)
 
-    if backend_name in available_torch_backend:
-        backend = torch._dynamo.lookup_backend(backend_name)
-    elif backend_name == "aot_eager_autobucketing":
-        # Perform auto optimization in aten fx-level and execute code in aot_eager backend
+    # Apply bucketing and overlapping pass on fwd and bwd graph separately
+    if compile_config.graph_passes == "auto_bucketing":
+        # Perform auto optimization in aten fx-level and execute code in aot_eager/inductor backend
         # The autobucketing logic is here: https://github.com/pytorch/pytorch/pull/163960
-        from torch._dynamo.backends.common import aot_autograd as aot_autograd_backend
-
         from torch._inductor.config import aten_distributed_optimizations as dist_opts
         from torch._inductor.fx_passes.overlap_scheduling import (
             schedule_overlap_bucketing,
         )
 
         dist_opts.collective_bucketing = True
-        dist_opts.insert_overlap_deps = False
         torch._inductor.config.allow_buffer_reuse = False
 
-        def aten_autobucketing_reordering_pass(
-            gm: torch.fx.GraphModule, example_inputs: Any
-        ) -> torch.fx.GraphModule:
-            schedule_overlap_bucketing(gm)
-            gm.recompile()
-            return gm
+        if compile_config.backend == "aot_eager":
+            from torch._dynamo.backends.common import (
+                aot_autograd as aot_autograd_backend,
+            )
 
-        backend = aot_autograd_backend(
-            fw_compiler=aten_autobucketing_reordering_pass,
-            bw_compiler=aten_autobucketing_reordering_pass,
-            keep_inference_input_mutations=True,
+            def aot_eager_autobucketing_reordering_pass(
+                gm: torch.fx.GraphModule, example_inputs: Any
+            ) -> torch.fx.GraphModule:
+                schedule_overlap_bucketing(gm)
+                gm.recompile()
+                return gm
+
+            dist_opts.insert_overlap_deps = False
+            backend = aot_autograd_backend(
+                fw_compiler=aot_eager_autobucketing_reordering_pass,
+                bw_compiler=aot_eager_autobucketing_reordering_pass,
+                keep_inference_input_mutations=True,
+            )
+        elif compile_config.backend == "inductor":
+
+            def inductor_autobucketing_reordering_pass(
+                gm: torch.fx.Graph,
+            ) -> torch.fx.GraphModule:
+                return schedule_overlap_bucketing(gm.owning_module)
+
+            dist_opts.insert_overlap_deps = True
+            torch._inductor.config.reorder_for_peak_memory = False
+            torch._inductor.config.reorder_for_compute_comm_overlap = False
+            torch._inductor.config.post_grad_custom_post_pass = (
+                inductor_autobucketing_reordering_pass
+            )
+        else:
+            raise ValueError(
+                f"Unsupported backend {compile_config.backend} for auto_bucketing pass"
+            )
+        logger.info("Auto bucketing pass is applied")
+
+    elif compile_config.graph_passes == "transformer_block_bucketing":
+        # Perform manual optimization in aten fx-level and execute code in aot_eager/inductor backend
+        # The manualbucketing logic is here: https://github.com/pytorch/pytorch/pull/165487
+        from functools import partial
+
+        from torch._dynamo.backends.common import aot_autograd as aot_autograd_backend
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            manual_overlap_bucketing,
         )
-    else:
-        raise AssertionError(f"Unsupported customized backend: {backend_name}")
 
+        torch._inductor.config.allow_buffer_reuse = False
+        manual_overlap_bucketing = partial(
+            manual_overlap_bucketing,
+            module_bucket_plans=fsdp_manual_buckets,
+        )
+
+        if compile_config.backend == "aot_eager":
+
+            def aot_eager_transformer_block_bucketing_reordering_pass(
+                gm: torch.fx.GraphModule, example_inputs: Any
+            ) -> torch.fx.GraphModule:
+                manual_overlap_bucketing(gm, insert_overlap_deps=False)
+                return gm
+
+            backend = aot_autograd_backend(
+                fw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
+                bw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
+                keep_inference_input_mutations=True,
+            )
+        elif compile_config.backend == "inductor":
+
+            def inductor_transformer_block_bucketing_reordering_pass(
+                gm: torch.fx.Graph,
+            ) -> torch.fx.GraphModule:
+                return manual_overlap_bucketing(
+                    gm.owning_module, insert_overlap_deps=True
+                )
+
+            torch._inductor.config.reorder_for_peak_memory = False
+            torch._inductor.config.reorder_for_compute_comm_overlap = False
+            torch._inductor.config.post_grad_custom_post_pass = (
+                inductor_transformer_block_bucketing_reordering_pass
+            )
+        else:
+            raise ValueError(
+                f"Unsupported backend {compile_config.backend} for transformer_block_bucketing pass"
+            )
+        logger.info("Transformer block bucketing pass is applied")
+
+    else:
+        logger.info("No bucketing or overlapping pass is applied")
+
+    # Apply activation checkpointing on joint graph before partitioner
     def joint_ac_pass(
         gm: torch.fx.GraphModule, example_inputs: Any
     ) -> torch.fx.GraphModule:

--- a/torchtitan/experiments/simple_fsdp/job_config.py
+++ b/torchtitan/experiments/simple_fsdp/job_config.py
@@ -5,12 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass
 class Compile:
-    model_backend_override: str | None = None
-    """Override backend to compile in simplefsdp. Additional backend includes aot_eager_autobucketing"""
+    graph_passes: Literal["auto_bucketing", "transformer_block_bucketing"] | None = None
+    """
+    Bucketing and overlapping passes in simplefsdp. Additional passes include:
+        auto_bucketing, transformer_block_bucketing
+    """
 
 
 @dataclass

--- a/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
+++ b/torchtitan/experiments/simple_fsdp/tests/integration_tests.py
@@ -35,11 +35,25 @@ def build_simple_fsdp_test_list() -> list[OverrideDefinitions]:
                     "--model.name simple_fsdp.llama3",
                     "--compile.enable",
                     "--job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config",
-                    "--compile.model_backend_override aot_eager_autobucketing",
+                    "--compile.backend aot_eager",
+                    "--compile.graph_passes auto_bucketing",
                 ],
             ],
-            "1D+aot_eager_autobucketing",
-            "1d_aot_eager_autobucketing",
+            "1D+autobucketing",
+            "1d_autobucketing",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--model.name simple_fsdp.llama3",
+                    "--compile.enable",
+                    "--job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config",
+                    "--compile.backend aot_eager",
+                    "--compile.graph_passes transformer_block_bucketing",
+                ],
+            ],
+            "1D+transformer_block_bucketing",
+            "1d_transformer_block_bucketing",
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
This PR adds support for aten-level manual bucketing in SimpleFSDP+`aot_eager` backend. Dependent on PyTorch [PR](https://github.com/pytorch/pytorch/pull/165487)

TODO List:
- [ ]  We should have better way of handling region info other than a list of str FQNs in current `manual_bucketed_modules`.  It would be very easy to miss some of model modules. (cc. @xmfan @SherlockNoMad )
- [ ] Currently, the reordering happens under the hood and overlap with last/next compute. We should allow users to specify which module they want to reorder. 
- [x] Loss difference on multi-node training
- [x] DSV3 manual bucketing

I'll address the TODO items in follow up PRs. Let's start with this simple FSDP+TP+llama3 PR.

1. Performance (FSDP2 under eager mode, SimpleFSDP uses `aot_eager` backend)

**Llama 3-8B**

*  Performance (All Batch_size = 1). (The slower TPS on Single Node is sort of as expected, since FSDP2 handles copy-in/out in two different streams, whereas SimpleFSDP handles copy-in/out in the same stream)

|Node| Method | Parallelism | Memory | TPS | Trace|
|---------|---------|-----------|----------|------|------|
|1-Node (8H100)|SimpleFSDP | FSDP=8| 40.96GiB(43.12%) | 7,227| [LINK](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-16-10-48-48_rank0_trace.json)|
|1-Node (8H100)|FSDP2-eager| FSDP=8| 47.82GiB(50.35%) | 7,380 | [LINK](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-16-10-54-14_rank0_trace.json)|
|8-Node (64H100)|SimpleFSDP| FSDP=64  | 29.37GiB | 4,984| |
|8-Node (64H100)|FSDP2| FSDP=64 | 31.41GiB  |5,097 | |
|1-Node (8H100)|SimpleFSDP| FSDP=4 TP=2 | 28.28GiB(29.77%) | 5,881 | [LINK](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-26-18-00-18_rank0_trace.json) |
|1-Node (8H100)|FSDP2| FSDP=4 TP=2 | 35.33GiB(37.20%) | 5,898 | [LINK](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-26-15-35-47_rank0_trace.json) |
|8-Node (64H100)|SimpleFSDP| FSDP=8 TP=8  |   |||
|8-Node (64H100)|FSDP2| FSDP=8 TP=8 |   |||

Example SimpleFSDP 1D overlapping trace:

<img width="1127" height="127" alt="Screenshot 2025-10-16 at 10 49 55 AM" src="https://github.com/user-attachments/assets/2d9e3ff8-8e9b-40a7-a666-3c0a0975186e" />

Example SimpleFSDP 2D overlapping trace:
<img width="1162" height="166" alt="Screenshot 2025-10-26 at 6 00 51 PM" src="https://github.com/user-attachments/assets/bc5cc031-5b6c-4e4d-a9da-70c43114f49a" />


- Bitwise Loss:

FSDP-only:
<img width="1266" height="837" alt="Screenshot 2025-10-17 at 10 41 56 AM" src="https://github.com/user-attachments/assets/30f83d95-1eca-4f10-9e7e-47c45278cd8d" />

FSDP+TP:
<img width="1259" height="808" alt="Screenshot 2025-10-26 at 9 03 58 PM" src="https://github.com/user-attachments/assets/b75b452b-adb9-4078-9412-ee9e584ffe15" />