### PR TITLE
ci: add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,15 @@ repos:
   hooks:
     - id: pydoclint
       args: [--config=pyproject.toml]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+    - id: codespell
+      name: codespell
+      description: Checks for common misspellings in text files.
+      entry: codespell --toml pyproject.toml
+      language: python
+      types: [text]
+      additional_dependencies:
+        - tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
 [tool.setuptools.dynamic]
 version = {file = "assets/version.txt"}
 
+[tool.codespell]
+skip = ["*.json"]
+ignore-words-list = ["assertin", "datas" ,"indx", "inpt", "nd", "socio-economic"]
 
 # ---- Explicit project build information ---- #
 [build-system]


### PR DESCRIPTION
This PR adds a [`codespell`](https://github.com/codespell-project/codespell) pre-commit hook  (see PRs https://github.com/pytorch/torchtitan/pull/1583 / https://github.com/pytorch/torchtitan/pull/1611 / https://github.com/pytorch/torchtitan/pull/1898).

With this PR, if you run `pre-commit run --all-files` on the current state of the repo, you will see:

```
trim trailing whitespace.................................................Passed
check python ast.........................................................Passed
check for merge conflicts................................................Passed
don't commit to branch...................................................Passed
check for added large files..............................................Passed
fix end of files.........................................................Passed
Insert license in comments...............................................Passed
flake8...................................................................Passed
Format files with µfmt...................................................Passed
pydoclint................................................................Passed
codespell................................................................Failed
- hook id: codespell
- exit code: 65

torchtitan/models/utils.py:51: caculate ==> calculate
torchtitan/models/utils.py:71: Calulate ==> Calculate
torchtitan/models/utils.py:71: dimesion ==> dimension
torchtitan/models/utils.py:71: demension ==> dimension
torchtitan/models/utils.py:76: divded ==> divided
torchtitan/experiments/vlm/job_config.py:28: avaliable ==> available
torchtitan/experiments/vlm/README.md:37: patchs ==> patches, paths
torchtitan/experiments/vlm/README.md:40: indicies ==> indices
torchtitan/components/quantization/__init__.py:28: re-usable ==> reusable
torchtitan/models/qwen3/model/state_dict_adapter.py:144: compatibile ==> compatible
torchtitan/models/attention.py:185: argumens ==> arguments
torchtitan/components/metrics.py:322: emtpy ==> empty
docs/torchft.md:60: sychronize ==> synchronize
torchtitan/experiments/simple_fsdp/README.md:56: addtional ==> additional
```
After PR https://github.com/pytorch/torchtitan/pull/1898 is merged, those warnings will disappear.

Configuration for codespell is in `pyproject.toml`:

```
skip = ["*.json"] # <- json files are skipped due to too many false positives
ignore-words-list = ["assertin", "datas" ,"indx", "inpt", "nd", "socio-economic"] # <- words that are ignored because they are used as variables etc.


