### PR TITLE
Annotate EP with dispatch/compute/combine

### DIFF
--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -73,6 +73,7 @@ class ExpertParallel(ParallelStyle):
         self.permuted_indices = None
 
     # performing all-to-all dispatch on the input
+    @torch.fx.traceback.annotate_fn({"EP": "dispatch"})
     def _token_dispatch(self, mod, inputs, device_mesh):
         # annotate module input placements/sharding with input_layouts
         routed_input, num_tokens_per_expert = inputs
@@ -145,6 +146,7 @@ class ExpertParallel(ParallelStyle):
             mod.register_parameter(name, dist_param)
 
     # performing all-to-all combine on the output
+    @torch.fx.traceback.annotate_fn({"EP": "combine"})
     def _token_combine(self, mod, routed_output, device_mesh):
         routed_output = _unpermute(
             routed_output, self.input_shape, self.permuted_indices

--- a/torchtitan/models/moe/moe.py
+++ b/torchtitan/models/moe/moe.py
@@ -139,6 +139,7 @@ class GroupedExperts(nn.Module):
         self.w3 = nn.Parameter(torch.empty(num_experts, hidden_dim, dim))
         self.use_grouped_mm = use_grouped_mm
 
+    @torch.fx.traceback.annotate_fn({"EP": "compute"})
     def forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1905


Sample output: P1996227609


```
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:484 in all_to_all_single, code: tensor = torch.ops._c10d_functional.all_to_all_single(  # type: ignore[attr-defined]
[rank0]:        all_to_all_single: "i64[8]" = torch.ops._c10d_functional.all_to_all_single.default(histc_1, [4, 4], [4, 4], '11')
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:135 in wait_tensor, code: return torch.ops._c10d_functional.wait_tensor(tensor)  # type: ignore[attr-defined]
[rank0]:        wait_tensor_27: "i64[8]" = torch.ops._c10d_functional.wait_tensor.default(all_to_all_single);  all_to_all_single = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:93 in _token_dispatch, code: num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
[rank0]:        wait_tensor_28: "i64[8]" = torch.ops._c10d_functional.wait_tensor.default(wait_tensor_27);  wait_tensor_27 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:97 in _token_dispatch, code: num_tokens_per_expert.view(ep_degree, -1)
[rank0]:        view_136: "i64[2, 4]" = torch.ops.aten.view.default(histc_1, [2, -1]);  histc_1 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:98 in _token_dispatch, code: .sum(dim=1)
[rank0]:        sum_1: "i64[2]" = torch.ops.aten.sum.dim_IntList(view_136, [1]);  view_136 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:99 in _token_dispatch, code: .to(torch.device("cpu"), non_blocking=True)
[rank0]:        _to_copy_28: "i64[2]" = torch.ops.aten._to_copy.default(sum_1, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'), non_blocking = True);  sum_1 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:103 in _token_dispatch, code: num_tokens_per_expert_group.view(ep_degree, -1)
[rank0]:        view_137: "i64[2, 4]" = torch.ops.aten.view.default(wait_tensor_28, [2, -1])
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:104 in _token_dispatch, code: .sum(dim=1)
[rank0]:        sum_2: "i64[2]" = torch.ops.aten.sum.dim_IntList(view_137, [1])
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:105 in _token_dispatch, code: .to(torch.device("cpu"), non_blocking=False)
[rank0]:        _to_copy_29: "i64[2]" = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'));  sum_2 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:107 in _token_dispatch, code: self.input_splits = input_splits.tolist()
[rank0]:        select: "i64[]" = torch.ops.aten.select.int(_to_copy_28, 0, 0)
[rank0]:        _local_scalar_dense: "Sym(u0)" = torch.ops.aten._local_scalar_dense.default(select);  select = None
[rank0]:        
[rank0]:        # File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:107 in _token_dispatch, code: self.input_splits = input_splits.tolist()
[rank0]:        ge_1: "Sym(u0 >= 0)" = _local_scalar_dense >= 0
[rank0]:        _assert_scalar = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u0 >= 0 on node 'ge'");  ge_1 = _assert_scalar = None
[rank0]:        le: "Sym(u0 <= 24576)" = _local_scalar_dense <= 24576
[rank0]:        _assert_scalar_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u0 <= 24576 on node 'le'");  le = _assert_scalar_1 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:107 in _token_dispatch, code: self.input_splits = input_splits.tolist()
[rank0]:        select_1: "i64[]" = torch.ops.aten.select.int(_to_copy_28, 0, 1);  _to_copy_28 = None
[rank0]:        _local_scalar_dense_1: "Sym(u1)" = torch.ops.aten._local_scalar_dense.default(select_1);  select_1 = None
[rank0]:        
[rank0]:        # File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:107 in _token_dispatch, code: self.input_splits = input_splits.tolist()
[rank0]:        ge_2: "Sym(u1 >= 0)" = _local_scalar_dense_1 >= 0
[rank0]:        _assert_scalar_2 = torch.ops.aten._assert_scalar.default(ge_2, "Runtime assertion failed for expression u1 >= 0 on node 'ge_1'");  ge_2 = _assert_scalar_2 = None
[rank0]:        le_1: "Sym(u1 <= 24576)" = _local_scalar_dense_1 <= 24576
[rank0]:        _assert_scalar_3 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u1 <= 24576 on node 'le_1'");  le_1 = _assert_scalar_3 = None
[rank0]:        
[rank0]:        # No stacktrace found for following nodes
[rank0]:        add_6: "Sym(u0 + u1)" = _local_scalar_dense + _local_scalar_dense_1
[rank0]:        eq: "Sym(Eq(u0 + u1, 24576))" = add_6 == 24576;  add_6 = None
[rank0]:        _assert_scalar_4 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u0 + u1, 24576) on node 'eq'");  eq = _assert_scalar_4 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:108 in _token_dispatch, code: self.output_splits = output_splits.tolist()
[rank0]:        select_2: "i64[]" = torch.ops.aten.select.int(_to_copy_29, 0, 0)
[rank0]:        _local_scalar_dense_2: "Sym(u2)" = torch.ops.aten._local_scalar_dense.default(select_2);  select_2 = None
[rank0]:        
[rank0]:        # File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:108 in _token_dispatch, code: self.output_splits = output_splits.tolist()
[rank0]:        ge_3: "Sym(u2 >= 0)" = _local_scalar_dense_2 >= 0
[rank0]:        _assert_scalar_5 = torch.ops.aten._assert_scalar.default(ge_3, "Runtime assertion failed for expression u2 >= 0 on node 'ge_2'");  ge_3 = _assert_scalar_5 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:108 in _token_dispatch, code: self.output_splits = output_splits.tolist()
[rank0]:        select_3: "i64[]" = torch.ops.aten.select.int(_to_copy_29, 0, 1);  _to_copy_29 = None
[rank0]:        _local_scalar_dense_3: "Sym(u3)" = torch.ops.aten._local_scalar_dense.default(select_3);  select_3 = None
[rank0]:        
[rank0]:        # File: /data/users/bahuang/torchtitan/torchtitan/distributed/expert_parallel.py:108 in _token_dispatch, code: self.output_splits = output_splits.tolist()
[rank0]:        ge_4: "Sym(u3 >= 0)" = _local_scalar_dense_3 >= 0
[rank0]:        _assert_scalar_6 = torch.ops.aten._assert_scalar.default(ge_4, "Runtime assertion failed for expression u3 >= 0 on node 'ge_3'");  ge_4 = _assert_scalar_6 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:521 in all_to_all_single_autograd, code: tensor = torch.ops._c10d_functional_autograd.all_to_all_single(  # type: ignore[attr-defined]
[rank0]:        all_to_all_single_1: "bf16[u2 + u3, 256]" = torch.ops._c10d_functional.all_to_all_single.default(gather_1, [_local_scalar_dense_2, _local_scalar_dense_3], [_local_scalar_dense, _local_scalar_dense_1], '11');  gather_1 = None
[rank0]:        sym_size_int: "Sym(u2 + u3)" = torch.ops.aten.sym_size.int(all_to_all_single_1, 0)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:527 in all_to_all_single_autograd, code: return _FromTorchTensor.apply(tensor)
[rank0]:        wait_tensor_29: "bf16[u2 + u3, 256]" = torch.ops._c10d_functional.wait_tensor.default(all_to_all_single_1);  all_to_all_single_1 = None
[rank0]:        
[rank0]:        # File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:44 in _permute, code: x_padded_per_expert = x.shape[0] + num_local_experts * TOKEN_GROUP_ALIGN_SIZE_M
[rank0]:        add_13: "Sym(u2 + u3)" = _local_scalar_dense_2 + _local_scalar_dense_3
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:44 in _permute, code: x_padded_per_expert = x.shape[0] + num_local_experts * TOKEN_GROUP_ALIGN_SIZE_M
[rank0]:        add_14: "Sym(u2 + u3 + 32)" = add_13 + 32;  add_13 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/tools/utils.py:209 in _round_up, code: x_ceil_div_y = (x + y - 1) // y
[rank0]:        add_15: "Sym(u2 + u3 + 40)" = add_14 + 8;  add_14 = None
[rank0]:        sub_3: "Sym(u2 + u3 + 39)" = add_15 - 1;  add_15 = None
[rank0]:        floordiv: "Sym(((u2 + u3 + 39)//8))" = sub_3 // 8;  sub_3 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/tools/utils.py:210 in _round_up, code: return x_ceil_div_y * y
[rank0]:        mul_10: "Sym(8*(((u2 + u3 + 39)//8)))" = floordiv * 8;  floordiv = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:174 in generate_permute_indices, code: torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
[rank0]:        cumsum: "i64[8]" = torch.ops.aten.cumsum.default(wait_tensor_28, 0)
[rank0]:        sub_4: "i64[8]" = torch.ops.aten.sub.Tensor(cumsum, wait_tensor_28);  cumsum = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:178 in generate_permute_indices, code: total_tokens_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
[rank0]:        sum_3: "i64[4]" = torch.ops.aten.sum.dim_IntList(view_137, [0]);  view_137 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:181 in generate_permute_indices, code: total_tokens_per_expert = torch.clamp_min(total_tokens_per_expert, alignment)
[rank0]:        clamp_min: "i64[4]" = torch.ops.aten.clamp_min.default(sum_3, 8);  sum_3 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:184 in generate_permute_indices, code: m_sizes = ((total_tokens_per_expert + alignment - 1) // alignment * alignment).to(
[rank0]:        add_16: "i64[4]" = torch.ops.aten.add.Tensor(clamp_min, 8);  clamp_min = None
[rank0]:        sub_5: "i64[4]" = torch.ops.aten.sub.Tensor(add_16, 1);  add_16 = None
[rank0]:        floor_divide_1: "i64[4]" = torch.ops.aten.floor_divide.default(sub_5, 8);  sub_5 = None
[rank0]:        mul_11: "i64[4]" = torch.ops.aten.mul.Tensor(floor_divide_1, 8);  floor_divide_1 = None
[rank0]:        _to_copy_30: "i32[4]" = torch.ops.aten._to_copy.default(mul_11, dtype = torch.int32);  mul_11 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:190 in generate_permute_indices, code: m_offsets = torch.cumsum(m_sizes, 0)
[rank0]:        cumsum_1: "i64[4]" = torch.ops.aten.cumsum.default(_to_copy_30, 0)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:191 in generate_permute_indices, code: write_offsets = m_offsets - m_sizes
[rank0]:        sub_6: "i64[4]" = torch.ops.aten.sub.Tensor(cumsum_1, _to_copy_30);  cumsum_1 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:80 in fill_indices_wrapper, code: permuted_indices = torch.full(
[rank0]:        full: "i32[8*(((u2 + u3 + 39)//8))]" = torch.ops.aten.full.default([mul_10], -1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False);  mul_10 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/kernels.py:90 in fill_indices_wrapper, code: _fill_indices_kernel[grid](
[rank0]:        triton_kernel_wrapper_functional_proxy = torch.ops.higher_order.triton_kernel_wrapper_functional(kernel_idx = 0, constant_args_idx = 0, grid = [(4, 1, 1)], tma_descriptor_metadata = {}, kwargs = {'tokens_per_expert_group_ptr': wait_tensor_28, 'start_index_values_ptr': sub_4, 'write_offsets_ptr': sub_6, 'output_ptr': full}, tensors_to_clone = ['output_ptr']);  wait_tensor_28 = sub_4 = sub_6 = full = None
[rank0]:        getitem_60: "i32[8*(((u2 + u3 + 39)//8))]" = triton_kernel_wrapper_functional_proxy['output_ptr'];  triton_kernel_wrapper_functional_proxy = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:55 in _permute, code: x = torch.vstack((x, x.new_zeros((x.shape[-1]))))
[rank0]:        new_zeros: "bf16[256]" = torch.ops.aten.new_zeros.default(wait_tensor_29, [256], pin_memory = False)
[rank0]:        unsqueeze_2: "bf16[1, 256]" = torch.ops.aten.unsqueeze.default(new_zeros, 0);  new_zeros = None
[rank0]:        cat_12: "bf16[u2 + u3 + 1, 256]" = torch.ops.aten.cat.default([wait_tensor_29, unsqueeze_2]);  wait_tensor_29 = unsqueeze_2 = None
[rank0]:        sym_size_int_1: "Sym(u2 + u3 + 1)" = torch.ops.aten.sym_size.int(cat_12, 0)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'dispatch'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:57 in _permute, code: x = x[permuted_indices, :]
[rank0]:        index_1: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten.index.Tensor(cat_12, [getitem_60]);  cat_12 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:257 in replicate_compute, code: sharded_local_tensor = x.to_local()
[rank0]:        view_139: "f32[2, 256, 256]" = torch.ops.aten.view.default(primals_19, [2, 256, 256])
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:258 in replicate_compute, code: sharded_dtensor = DTensor.from_local(
[rank0]:        view_140: "f32[2, 256, 256]" = torch.ops.aten.view.default(view_139, [2, 256, 256]);  view_139 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:264 in replicate_compute, code: replicated_dtensor = sharded_dtensor.redistribute(
[rank0]:        _to_copy_32: "bf16[2, 256, 256]" = torch.ops.aten._to_copy.default(view_140, dtype = torch.bfloat16);  view_140 = None
[rank0]:        all_gather_into_tensor_23: "bf16[4, 256, 256]" = torch.ops._c10d_functional.all_gather_into_tensor.default(_to_copy_32, 2, '1');  _to_copy_32 = None
[rank0]:        wait_tensor_30: "bf16[4, 256, 256]" = torch.ops._c10d_functional.wait_tensor.default(all_gather_into_tensor_23);  all_gather_into_tensor_23 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:272 in replicate_compute, code: replicated_local_tensor = replicated_dtensor.to_local(
[rank0]:        view_145: "bf16[4, 256, 256]" = torch.ops.aten.view.default(wait_tensor_30, [4, 256, 256]);  wait_tensor_30 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:282 in replicate_compute, code: output = DTensor.from_local(
[rank0]:        view_146: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_145, [4, 256, 256]);  view_145 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:151 in forward, code: w1 = self.w1.to_local()
[rank0]:        view_147: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_146, [4, 256, 256]);  view_146 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:257 in replicate_compute, code: sharded_local_tensor = x.to_local()
[rank0]:        view_148: "f32[2, 256, 256]" = torch.ops.aten.view.default(primals_20, [2, 256, 256])
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:258 in replicate_compute, code: sharded_dtensor = DTensor.from_local(
[rank0]:        view_149: "f32[2, 256, 256]" = torch.ops.aten.view.default(view_148, [2, 256, 256]);  view_148 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:264 in replicate_compute, code: replicated_dtensor = sharded_dtensor.redistribute(
[rank0]:        _to_copy_34: "bf16[2, 256, 256]" = torch.ops.aten._to_copy.default(view_149, dtype = torch.bfloat16);  view_149 = None
[rank0]:        all_gather_into_tensor_25: "bf16[4, 256, 256]" = torch.ops._c10d_functional.all_gather_into_tensor.default(_to_copy_34, 2, '1');  _to_copy_34 = None
[rank0]:        wait_tensor_32: "bf16[4, 256, 256]" = torch.ops._c10d_functional.wait_tensor.default(all_gather_into_tensor_25);  all_gather_into_tensor_25 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:272 in replicate_compute, code: replicated_local_tensor = replicated_dtensor.to_local(
[rank0]:        view_150: "bf16[4, 256, 256]" = torch.ops.aten.view.default(wait_tensor_32, [4, 256, 256]);  wait_tensor_32 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:282 in replicate_compute, code: output = DTensor.from_local(
[rank0]:        view_151: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_150, [4, 256, 256]);  view_150 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:152 in forward, code: w2 = self.w2.to_local()
[rank0]:        view_152: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_151, [4, 256, 256]);  view_151 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:257 in replicate_compute, code: sharded_local_tensor = x.to_local()
[rank0]:        view_153: "f32[2, 256, 256]" = torch.ops.aten.view.default(primals_21, [2, 256, 256])
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:258 in replicate_compute, code: sharded_dtensor = DTensor.from_local(
[rank0]:        view_154: "f32[2, 256, 256]" = torch.ops.aten.view.default(view_153, [2, 256, 256]);  view_153 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:264 in replicate_compute, code: replicated_dtensor = sharded_dtensor.redistribute(
[rank0]:        _to_copy_35: "bf16[2, 256, 256]" = torch.ops.aten._to_copy.default(view_154, dtype = torch.bfloat16);  view_154 = None
[rank0]:        all_gather_into_tensor_26: "bf16[4, 256, 256]" = torch.ops._c10d_functional.all_gather_into_tensor.default(_to_copy_35, 2, '1');  _to_copy_35 = None
[rank0]:        wait_tensor_33: "bf16[4, 256, 256]" = torch.ops._c10d_functional.wait_tensor.default(all_gather_into_tensor_26);  all_gather_into_tensor_26 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:272 in replicate_compute, code: replicated_local_tensor = replicated_dtensor.to_local(
[rank0]:        view_155: "bf16[4, 256, 256]" = torch.ops.aten.view.default(wait_tensor_33, [4, 256, 256]);  wait_tensor_33 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/experiments/simple_fsdp/simple_fsdp.py:282 in replicate_compute, code: output = DTensor.from_local(
[rank0]:        view_156: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_155, [4, 256, 256]);  view_155 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:153 in forward, code: w3 = self.w3.to_local()
[rank0]:        view_157: "bf16[4, 256, 256]" = torch.ops.aten.view.default(view_156, [4, 256, 256]);  view_156 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:114 in _run_experts_grouped_mm, code: offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
[rank0]:        cumsum_2: "i32[4]" = torch.ops.aten.cumsum.default(_to_copy_30, 0, dtype = torch.int32);  _to_copy_30 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:117 in _run_experts_grouped_mm, code: torch._grouped_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets)
[rank0]:        transpose_8: "bf16[4, 256, 256]" = torch.ops.aten.transpose.int(view_147, -2, -1);  view_147 = None
[rank0]:        _grouped_mm: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten._grouped_mm.default(index_1, transpose_8, cumsum_2)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:116 in _run_experts_grouped_mm, code: h = F.silu(
[rank0]:        silu_1: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten.silu.default(_grouped_mm)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:120 in _run_experts_grouped_mm, code: x.bfloat16(), w3.bfloat16().transpose(-2, -1), offs=offsets
[rank0]:        transpose_9: "bf16[4, 256, 256]" = torch.ops.aten.transpose.int(view_157, -2, -1);  view_157 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:119 in _run_experts_grouped_mm, code: h = h * torch._grouped_mm(
[rank0]:        _grouped_mm_1: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten._grouped_mm.default(index_1, transpose_9, cumsum_2)
[rank0]:        mul_23: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten.mul.Tensor(silu_1, _grouped_mm_1);  silu_1 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'compute'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/moe.py:122 in _run_experts_grouped_mm, code: out = torch._grouped_mm(h, w2.bfloat16().transpose(-2, -1), offs=offsets).type_as(x)
[rank0]:        transpose_10: "bf16[4, 256, 256]" = torch.ops.aten.transpose.int(view_152, -2, -1);  view_152 = None
[rank0]:        _grouped_mm_2: "bf16[8*(((u2 + u3 + 39)//8)), 256]" = torch.ops.aten._grouped_mm.default(mul_23, transpose_10, cumsum_2)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'combine'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:63 in _unpermute, code: out_unpermuted = out.new_empty(input_shape)
[rank0]:        new_empty: "bf16[u2 + u3 + 1, 256]" = torch.ops.aten.new_empty.default(_grouped_mm_2, [sym_size_int_1, 256], pin_memory = False)
[rank0]:        
[rank0]:        # Annotation: {'EP': 'combine'} File: /data/users/bahuang/torchtitan/torchtitan/models/moe/utils.py:64 in _unpermute, code: out_unpermuted[permuted_indices, :] = out
[rank0]:        index_put_2: "bf16[u2 + u3 + 1, 256]" = torch.ops.aten.index_put.default(new_empty, [getitem_60], _grouped_mm_2);  new_empty = _grouped_mm_2 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'combine'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:521 in all_to_all_single_autograd, code: tensor = torch.ops._c10d_functional_autograd.all_to_all_single(  # type: ignore[attr-defined]
[rank0]:        slice_4: "bf16[u2 + u3, 256]" = torch.ops.aten.slice.Tensor(index_put_2, 0, 0, -1);  index_put_2 = None
[rank0]:        all_to_all_single_2: "bf16[u0 + u1, 256]" = torch.ops._c10d_functional.all_to_all_single.default(slice_4, [_local_scalar_dense, _local_scalar_dense_1], [_local_scalar_dense_2, _local_scalar_dense_3], '11');  slice_4 = None
[rank0]:        
[rank0]:        # Annotation: {'EP': 'combine'} File: /data/users/bahuang/pytorch/torch/distributed/_functional_collectives.py:527 in all_to_all_single_autograd, code: return _FromTorchTensor.apply(tensor)
[rank0]:        wait_tensor_36: "bf16[u0 + u1, 256]" = torch.ops._c10d_functional.wait_tensor.default(all_to_all_single_2);  all_to_all_single_2 = None
```

