### PR TITLE
[mxfp8 moe training] add mxfp8 all to all impl

### DIFF
--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -58,5 +58,5 @@ class QuantizationConverter(ModelConverter):
 
 # Import to register quantization modules as ModelConverter
 # (imports down here to avoid circular imports with QuantizationConverter)
-import torchtitan.components.quantization.float8  # noqa: F401
-import torchtitan.components.quantization.mx  # noqa: F401
+import torchtitan.components.quantization.float8.converters  # noqa: F401
+import torchtitan.components.quantization.mx.converters  # noqa: F401

--- a/torchtitan/components/quantization/float8/__init__.py
+++ b/torchtitan/components/quantization/float8/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/components/quantization/float8/converters.py
+++ b/torchtitan/components/quantization/float8/converters.py
@@ -11,6 +11,7 @@ from torchtitan.components.quantization import (
     FP8_GROUP_ALIGNMENT_SIZE,
     QuantizationConverter,
 )
+from torchtitan.components.quantization.utils import module_filter_fn
 
 from torchtitan.config.job_config import Float8Linear, JobConfig
 from torchtitan.distributed import ParallelDims
@@ -18,8 +19,6 @@ from torchtitan.models.moe.utils import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import register_model_converter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
-
-from .utils import module_filter_fn
 
 AUTO_FILTER_SMALL_KN_FLAG = "auto_filter_small_kn"
 

--- a/torchtitan/components/quantization/mx/__init__.py
+++ b/torchtitan/components/quantization/mx/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/components/quantization/mx/converters.py
+++ b/torchtitan/components/quantization/mx/converters.py
@@ -13,6 +13,7 @@ from torchtitan.components.quantization import (
     MXFP8_GROUP_ALIGNMENT_SIZE,
     QuantizationConverter,
 )
+from torchtitan.components.quantization.utils import module_filter_fn
 
 from torchtitan.config.job_config import JobConfig
 from torchtitan.distributed import ParallelDims
@@ -20,8 +21,6 @@ from torchtitan.models.moe.utils import set_token_group_alignment_size_m
 from torchtitan.protocols.model_converter import register_model_converter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
-
-from .utils import module_filter_fn
 
 
 class MXLinearConverter(QuantizationConverter):

--- a/torchtitan/components/quantization/mx/expert_parallel.py
+++ b/torchtitan/components/quantization/mx/expert_parallel.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.distributed.expert_parallel import ExpertParallel
+
+
+class MXExpertParallel(ExpertParallel):
+    def __init__(self) -> None:
+        super().__init__()
+        try:
+            from torchao.prototype.moe_training.kernels.mxfp8.comms import (
+                to_mxfp8_a2a_dequant,
+            )
+        except ImportError as err:
+            raise ImportError(
+                "Please install torchao v0.14+ to use MXExpertParallel"
+            ) from err
+        self._a2a_dispatch_impl = to_mxfp8_a2a_dequant
+        self._a2a_combine_impl = to_mxfp8_a2a_dequant

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -752,6 +752,24 @@ class Quantize:
     grouped_mm: QuantizedGroupedMM = field(default_factory=QuantizedGroupedMM)
     """Quantized training config for grouped GEMMs"""
 
+    expert_parallel_a2a_dispatch_impl: Literal["default", "mxfp8"] = "default"
+    """
+    All-to-all implementation to use for the token dispatch step in expert parallelism.
+    - "default": Directly uses all_to_all_single with inputs/outputs in original precision.
+    - "mxfp8": Reduces network bandwidth utilization by quantizing inputs to MXFP8,
+               using all_to_all_single on the quantized data and scales, then dequantizing
+               the outputs back to original precision.
+    """
+
+    expert_parallel_a2a_combine_impl: Literal["default", "mxfp8"] = "default"
+    """
+    All-to-all implementation to use for the token combine step in expert parallelism.
+    - "default": Directly uses all_to_all_single with inputs/outputs in original precision.
+    - "mxfp8": Reduces network bandwidth utilization by quantizing inputs to MXFP8,
+               using all_to_all_single on the quantized data and scales, then dequantizing
+               the outputs back to original precision.
+    """
+
 
 @dataclass
 class Comm:

--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -71,6 +71,8 @@ class ExpertParallel(ParallelStyle):
         self.output_splits = None
         self.input_shape = None
         self.permuted_indices = None
+        self._a2a_dispatch_impl = all_to_all_single_autograd
+        self._a2a_combine_impl = all_to_all_single_autograd
 
     # performing all-to-all dispatch on the input
     def _token_dispatch(self, mod, inputs, device_mesh):
@@ -107,7 +109,7 @@ class ExpertParallel(ParallelStyle):
             self.output_splits = output_splits.tolist()
 
         # perform all-to-all
-        routed_input = all_to_all_single_autograd(
+        routed_input = self._a2a_dispatch_impl(
             routed_input,
             self.output_splits,
             self.input_splits,
@@ -150,7 +152,7 @@ class ExpertParallel(ParallelStyle):
             routed_output, self.input_shape, self.permuted_indices
         )
 
-        routed_output = all_to_all_single_autograd(
+        routed_output = self._a2a_combine_impl(
             routed_output,
             self.input_splits,
             self.output_splits,

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -91,6 +91,7 @@ def parallelize_deepseekv3(
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(
             model,
+            job_config,
             tp_mesh=world_mesh["tp"] if parallel_dims.tp_enabled else None,
             ep_mesh=world_mesh["ep"] if parallel_dims.ep_enabled else None,
             ep_tp_mesh=(

--- a/torchtitan/models/qwen3/infra/parallelize.py
+++ b/torchtitan/models/qwen3/infra/parallelize.py
@@ -95,6 +95,7 @@ def parallelize_qwen3(
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(
             model,
+            job_config,
             tp_mesh=world_mesh["tp"] if parallel_dims.tp_enabled else None,
             ep_mesh=world_mesh["ep"] if parallel_dims.ep_enabled else None,
             ep_tp_mesh=(


### PR DESCRIPTION
## Summary
- Make EP a2a dispatch and a2a combine each be separately configurable to use either `"default"` or `"mxfp8"` impl
- `"mxfp8"` impl uses torchao's new `to_mxfp8_a2a_dequant`, which has the exact same API as functional collective `all_to_all_single_autograd` and is differentiable, so it can be used as a drop-in replacement for the default a2a impl.
- torchao `to_mxfp8_a2a_dequant` works as follows:
    - quantizes the inputs to mxfp8
    - all_to_all_single on e4m3 data
    - all_to_all_single on e8m0 scales
    - dequantize outputs back to original precision

## Performance 
- Single node benchmarks with 4xB200
- Llama4 16e default configs; FSDP=4, EP=4; AC=none; compile=True; seq_len=8192; local_bs=8
- Reduced num layers from 48 -> 2 to avoid OOM in single node setting

- Debug model config:

```python
llama4_configs = {
    "debugmodel": TransformerModelArgs(
        dim=5120,
        n_layers=2,
        n_heads=40,
        n_kv_heads=8,
        ffn_dim_multiplier=1.2,
        multiple_of=2048,
        rope_theta=500000,
        max_seq_len=10485760,
        moe_args=MoEArgs(num_experts=16),
        interleave_moe_layer_step=1,
    ),
```

| Configuration                                                              | Throughput (Median Tokens/s) | Max Memory (GiB) |
|:---------------------------------------------------------------------------|-----------------------------:|-----------------:|
| bf16 baseline                                                              |                      49381.0 |           145.55 |
| MXFP8 for Linears only                                                     |                      52038.0 |           146.62 |
| MXFP8 for Grouped GEMMs only                                               |                      69350.0 |           144.71 |
| MXFP8 for Linears + Grouped GEMMs                                          |                      70747.0 |           145.32 |
| MXFP8 for Linears + Grouped GEMMs + A2A Dispatch                      |                      72602.5 |           145.45 |
| MXFP8 for Linears + Grouped GEMMs + A2A Dispatch + A2A Combine   |                      73152.0 |           146.08 |

## Additional context on design/implementation choices
- Note: both default and mxfp8 impls require the d2h sync to get input_splits/output_splits on the host for the a2a call. 
    - I also explored a no-sync/on-device implementation using Triton + Symmetric memory, and got it working e2e in a torchtitan PoC: https://github.com/pytorch/ao/pull/3088 
    - I found that this design of preallocating over-allocated symmetric memory buffers for exchange of variable token numbers (to avoid syncs required for exact allocation, while risking either crash or token dropping if overflow factor heuristic is wrong), is fundamentally in conflict with the torchtitan MoE design of doing a d2h sync to safely do exact allocation. Extracting out the variable size outputs from the padded buffers causes d2h sync (causing perf to regress below baseline), and we can't avoid this since otherwise downstream ops will break due to shape mismatches - the whole model basically would need to be designed assuming the static padded shapes.
    - Therefore, we choose to integrate this more straight-forward impl that is natively compatible with non-experimental titan MoE design

## Additional background on motivation
- MoE performance [literature](https://arxiv.org/pdf/2502.19811) has shown ~47% average runtime for flagship OSS MoE models (Qwen2, Phi3.5, Mixtra8x7b) is due to exposed MoE comms.
- Torchtitan Llama4 debug model with EP=4, ~30% of MoE training with EP is a2a comms, most of that exposed (see trace screenshot), which directionally corroborates this.
- We can optimize this via (1) quantizing the comms to minimize data sent over NVLink/IB, (2) avoid d2h sync that can occur in implementations which move a2a output splits from device->host to compute exact preallocation necessary for incoming tokens, and (3) finer grained overlapping techniques.


#### 30% of llama4 model profiled runtime is all2all comms
- FSDP=4, EP=4, dim=5120, num_experts=16, seq_len=8192, local_batch_size=8
<img width="1713" height="643" alt="Screenshot 2025-09-29 at 3 08 47 PM" src="https://github.com/user-attachments/assets/9687ec34-ff06-43bd-bb49-0ede06644a61" />

#### 47% avg runtime devoted to MoE comms in profiled OSS models

<img width="334" height="433" alt="Screenshot 2025-09-29 at 3 11 00 PM" src="https://github.com/user-attachments/assets/a329ae15-f6d5-4c49-92b1-c64199195ecc" />

