### PR TITLE
Fix HF -> Torchtitan Expert Conversion Sorting Bug

### DIFF
--- a/torchtitan/models/deepseek_v3/model/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/model/state_dict_adapter.py
@@ -171,7 +171,7 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
                 if titan_abstract_key not in expert_weights_by_layer[layer_num]:
                     expert_weights_by_layer[layer_num][titan_abstract_key] = {}
                 expert_weights_by_layer[layer_num][titan_abstract_key][
-                    expert_num
+                    int(expert_num)
                 ] = value
 
                 if isinstance(value, DTensor):

--- a/torchtitan/models/qwen3/model/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/model/state_dict_adapter.py
@@ -131,7 +131,7 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 if titan_abstract_key not in expert_weights_by_layer[layer_num]:
                     expert_weights_by_layer[layer_num][titan_abstract_key] = {}
                 expert_weights_by_layer[layer_num][titan_abstract_key][
-                    expert_num
+                    int(expert_num)
                 ] = value
 
                 if isinstance(value, DTensor):


### PR DESCRIPTION
The expert_num is a string, which causes `sorted_expert_ids = sorted(experts.keys())` to not sort correctly for Deepseek and Qwen3 (sorts lexicographically).
This means, that converting from huggingface currently results in wrongly ordered experts. Roundtripping a state dict with more than 10 experts catches this bug.
Fix: Cast to int, as the type signature was intended.