### PR TITLE
Update PP to release memory earlier

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -460,12 +460,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                         **extra_kwargs,
                         target=targets,
                         losses=losses,
+                        return_outputs=False,
                     )
                 else:
                     self.pp_schedule.step(
                         **extra_kwargs,
                         target=targets,
                         losses=losses,
+                        return_outputs=False,
                     )
 
             # accumulate losses across pipeline microbatches


### PR DESCRIPTION
Uses the API added in https://github.com/pytorch/pytorch/pull/165822, since we do not return any output from PP step(). This allows us to release the memory earlier,