### PR TITLE
[minor fix] job config

### DIFF
--- a/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
@@ -126,7 +126,8 @@ def parallelize_llama(
     if job_config.compile.enable and "model" in job_config.compile.components:
         torch._inductor.config.reorder_for_peak_memory = False
         backend = (
-            job_config.compile.model_backend_override or job_config.compile.backend
+            getattr(job_config.compile, "model_backend_override", None)
+            or job_config.compile.backend
         )
         model = torch.compile(
             model,


### PR DESCRIPTION
#1813 added `job_config.compile.model_backend_override` to override configs via `--job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config  --compile.model_backend_override "aot_eager_autobucketing"`.

However, other commands without override would break, since `job_config.compile.model_backend_override` is undefined. This PR fixes the issue.
