### PR TITLE
[compiler toolkit] Fix llama3 kwargs

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/README.md
+++ b/torchtitan/experiments/compiler_toolkit/README.md
@@ -26,10 +26,10 @@ NGPU=4 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.tom
 
 **SimpleFSDP + TP**
 ```shell
-NGPU=8 CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" with-proxy ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4
+NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4
 ```
 
 **SimpleFSDP + TP + FlexAttention**
 ```shell
-NGPU=8 CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" with-proxy ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --model.flavor=debugmodel_flex_attn
+NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --model.flavor=debugmodel_flex_attn
 ```

--- a/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
@@ -31,18 +31,17 @@ from torchtitan.experiments.simple_fsdp.llama3.parallelize import (
 from torchtitan.tools.logging import logger
 
 
-def joint_graph_builder(model, *inputs, **kwargs):
+def joint_graph_builder(model, *args, **kwargs):
     assert isinstance(model, SimpleFSDPTransformer)
-    assert isinstance(inputs, tuple)
-    for input in inputs:
-        assert isinstance(input, DTensor)
-    assert not kwargs
+    assert isinstance(args, tuple)
+    for arg in args:
+        assert isinstance(arg, DTensor)
 
     # get joint graph
     (
         joint_with_descriptors,
         tracing_context,
-    ) = export_joint(model, inputs)
+    ) = export_joint(model, args, kwargs)
 
     # verify user annotation show up in the graph
     for node in joint_with_descriptors.graph_module.graph.nodes:


### PR DESCRIPTION
As titled. The current command in readme doesn't work when flex attention is turned on.

```
NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --model.flavor=debugmodel_flex_attn
```