### PR TITLE
Adding prefetching of first shards to train script when fsdp enabled

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -506,7 +506,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         for _microbatch in range(self.gradient_accumulation_steps):
             if self.parallel_dims.fsdp_enabled:
                 # NOTE: prefetches the model
-                self.model_parts[0].unshard()
+                self.model_parts[0].unshard(async_op=True)
             input_dict, labels = next(data_iterator)
             loss = self.forward_backward_step(input_dict, labels)
             accumulated_losses.append(loss.detach())


### PR DESCRIPTION
If model is sharded calling `.unshard()` will prefetch the first shard. I placed this before the data loader & other preprocessing so it should overlap.

Sources:
- https://docs.pytorch.org/docs/main/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.FSDPModule.unshard

- https://docs.pytorch.org/tutorials/intermediate/FSDP_tutorial.html#forward-backward-with-prefetching 
>Issuing 1st all-gather earlier: Implicit prefetching happens at the time of calling model(x). The 1st all-gather gets exposed. We can call [model.unshard()](https://docs.pytorch.org/docs/main/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.FSDPModule.unshard) explicitly earlier to issue 1st all-gather earlier