### PR TITLE
[compiler toolkit] Code deduplication between llama3 and deepseek_v3

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/common_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/common_utils.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 import torch
 from torch.distributed.tensor import DTensor, Replicate
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import register_pytree_node, tree_map
 
 from torchtitan.config import JobConfig
 
@@ -40,3 +40,16 @@ def parallelize_inputs(world_mesh, args, kwargs):
     dt_kwargs = kwargs
 
     return dt_args, dt_kwargs
+
+
+def register_blockmask_pytree_node():
+    from torch.nn.attention.flex_attention import BlockMask
+
+    if BlockMask not in torch.utils._pytree.SUPPORTED_NODES:
+        register_pytree_node(
+            BlockMask,
+            BlockMask._flatten,
+            BlockMask._unflatten,
+            flatten_with_keys_fn=BlockMask._flatten_with_keys,
+            serialized_type_name="torch.nn.attention.flex_attention.BlockMask",
+        )

--- a/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
@@ -5,79 +5,46 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import functools
+
 import torch
-import torch.nn as nn
-
-from torch._functorch.aot_autograd import aot_compile_joint_with_descriptors
-from torch._guards import tracing
-
-from torch.distributed.tensor import DTensor
 
 from torch.fx.traceback import annotate_fn
 from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.expert_parallel import ExpertParallel
 from torchtitan.experiments.compiler_toolkit.common_utils import (
     disable_compile,
     parallelize_inputs,
+    register_blockmask_pytree_node,
 )
 
 from torchtitan.experiments.compiler_toolkit.graph_utils import (
     CompiledModule,
-    export_joint,
+    joint_graph_builder,
 )
 
 from torchtitan.experiments.simple_fsdp.deepseek_v3.parallelize import (
     parallelize_deepseekv3 as simple_fsdp_parallelize_deepseekv3,
 )
-from torchtitan.models.moe.moe import MoE
 from torchtitan.tools.logging import logger
 
 
-def joint_graph_builder(model, *args, **kwargs):
-    assert isinstance(args, tuple)
-    for arg in args:
-        assert isinstance(arg, DTensor)
-
-    # get joint graph
-    (
-        joint_with_descriptors,
-        tracing_context,
-    ) = export_joint(model, args, kwargs)
-
-    def fw_compiler(gm: torch.fx.GraphModule, example_inputs):
-        logger.info("fwd_gm:")
-        logger.info(gm.print_readable(print_output=False))
-
-        # logger.info("fwd_gm after compiler:")
-        # logger.info(gm.print_readable(print_output=False))
-        return gm
-
-    def bw_compiler(gm: torch.fx.GraphModule, example_inputs):
-        logger.info("bwd_gm:")
-        logger.info(gm.print_readable(print_output=False))
-
-        # logger.info("bwd_gm after compiler:")
-        # logger.info(gm.print_readable(print_output=False))
-        return gm
-
-    with tracing(tracing_context):
-        fn = aot_compile_joint_with_descriptors(
-            joint_with_descriptors, fw_compiler=fw_compiler, bw_compiler=bw_compiler
-        )
-
-    def wrapper_fn(args, kwargs):
-        inputs = [
-            *model.parameters(),
-            *model.buffers(),
-            *args,
-        ]
-        return fn(*inputs, **kwargs)
-
-    return wrapper_fn
+def fw_compiler(gm: torch.fx.GraphModule, example_inputs) -> torch.fx.GraphModule:
+    logger.info("fwd_gm:")
+    logger.info(gm.print_readable(print_output=False))
+    return gm
 
 
-def annotate_model() -> None:
+def bw_compiler(gm: torch.fx.GraphModule, example_inputs) -> torch.fx.GraphModule:
+    logger.info("bwd_gm:")
+    logger.info(gm.print_readable(print_output=False))
+    return gm
+
+
+def annotate_deepseekv3() -> None:
+    from torchtitan.distributed.expert_parallel import ExpertParallel
+    from torchtitan.models.moe.moe import MoE
+
     # annotate the MoE with dispatch, compute and combine
     ExpertParallel._token_dispatch = annotate_fn({"EP": "dispatch"})(
         ExpertParallel._token_dispatch
@@ -89,21 +56,31 @@ def annotate_model() -> None:
 
 
 def parallelize_deepseekv3(
-    model: nn.Module,
+    model: torch.nn.Module,
     parallel_dims: ParallelDims,
     job_config: JobConfig,
 ) -> CompiledModule:
 
-    annotate_model()
+    annotate_deepseekv3()
+
+    if job_config.model.flavor.endswith("flex_attn"):
+        register_blockmask_pytree_node()
 
     # Disable torch.compile over the model in the compiler toolkit style workflow
     with disable_compile(job_config):
         model = simple_fsdp_parallelize_deepseekv3(model, parallel_dims, job_config)
 
+    deepseekv3_joint_graph_builder = functools.partial(
+        joint_graph_builder,
+        fw_compiler=fw_compiler,
+        bw_compiler=bw_compiler,
+        joint_custom_pass=None,
+    )
+
     # TODO: CompiledModule should take sample input as well, so that we can
     # compile ahead of time.
     model = CompiledModule(
-        model, parallel_dims, joint_graph_builder, parallelize_inputs
+        model, parallel_dims, deepseekv3_joint_graph_builder, parallelize_inputs
     )
 
     return model


### PR DESCRIPTION
- Moved `joint_graph_builder` to `graph_utils.py` so that it can be shared between llama3 and deepseek_v3
- Rename annotate functions to be model specific.
- Added some type annotations