### PR TITLE
[simplefsdp] add reshard after forward option

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -15,13 +15,13 @@ This folder includes an experimental frontend implementation for [SimpleFSDP: Si
 #### Training Llama3 models
 
 ```bash
-CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name simple_fsdp.llama3 --compile.enable
+CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh --model.name simple_fsdp.llama3 --compile.enable --job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config
 ```
 
 #### Training DeepSeek_v3 models
 
 ```bash
-CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/debug_model.toml" ./run_train.sh --model.name simple_fsdp.deepseek_v3 --compile.enable
+CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/debug_model.toml" ./run_train.sh --model.name simple_fsdp.deepseek_v3 --compile.enable --activation_checkpoint.mode "none" --job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config
 ```
 
 ### Composability Support
@@ -56,7 +56,7 @@ SimpleFSDP relies on compiler backend to perform optimizations (i.e., bucketing 
 users can specify the pass (e.g., "aot_eager_autobucketing") via additional configs:
 
 ```bash
---job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config  --compile.model_backend_override "aot_eager_autobucketing"
+--compile.model_backend_override "aot_eager_autobucketing"
 ```
 
 ### Citation


### PR DESCRIPTION
As titled, this pr adds zero2-style FSDP sharding option to SimpleFSDP. It can be enabled with `--parallelism.simple_fsdp_reshard_after_forward "never"` config. 

As seen, with `--job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config --parallelism.simple_fsdp_reshard_after_forward "always"`, there is AG in bwd for re-gather parameters (Trace [link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-29-20-02-34_rank0_trace.json))

<img width="1289" height="234" alt="Screenshot 2025-10-29 at 8 03 05 PM" src="https://github.com/user-attachments/assets/a6e5b736-9d1f-44a2-aa35-af7b315fd24a" />


with `--parallelism.simple_fsdp_reshard_after_forward "never"`, there is no AG in bwd (Trace [link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-10-29-20-04-49_rank0_trace.json))

<img width="870" height="215" alt="Screenshot 2025-10-29 at 8 05 07 PM" src="https://github.com/user-attachments/assets/022f1a02-fe45-45d6-ba04-6bcaf2e9d64f" />

