### PR TITLE
fix set_determinism on single gpu

### DIFF
--- a/tests/unit_tests/test_set_determinism.py
+++ b/tests/unit_tests/test_set_determinism.py
@@ -208,6 +208,27 @@ class TestSetDeterminismWithFakeMesh(unittest.TestCase):
             f"Expected {mesh_sizes[0] * mesh_sizes[1]} unique seeds for (dp_shard, dp_replicate) combinations",
         )
 
+    @patch("torch.distributed.distributed_c10d.get_world_size")
+    @patch("torch.distributed.distributed_c10d.get_rank")
+    def test_set_determinism_single_gpu(self, mock_get_rank, mock_get_world_size):
+        """Test set_determinism for single GPU (empty mesh)"""
+        mock_get_world_size.return_value = 1
+        mock_get_rank.return_value = 0
+
+        base_seed = 42
+
+        fake_mesh = MagicMock()
+        fake_mesh.mesh_dim_names = None
+        fake_mesh.get_coordinate.return_value = None
+
+        debug_config = DebugConfig(seed=base_seed, deterministic=False)
+        set_determinism(
+            world_mesh=fake_mesh,
+            device=self.device,
+            debug_config=debug_config,
+            distinct_seed_mesh_dims=["pp"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -145,7 +145,9 @@ def set_determinism(
     # and choose a unique seed for each rank on the PP mesh.
     # We support multiple distinct dimensions by adding each distinct dimension's local rank to the seed.
     distinct_dims_in_mesh = [
-        dim for dim in distinct_seed_mesh_dims if dim in world_mesh.mesh_dim_names
+        dim
+        for dim in distinct_seed_mesh_dims
+        if world_mesh.mesh_dim_names and dim in world_mesh.mesh_dim_names
     ]
 
     if c10d.get_world_size() > 1 and distinct_dims_in_mesh:


### PR DESCRIPTION
**Summary**

Currently, running `CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" NGPU=1 CUDA_VISIBLE_DEVICES=0 ./run_train.sh` returns 

```
 dim for dim in distinct_seed_mesh_dims if dim in world_mesh.mesh_dim_names
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: argument of type 'NoneType' is not iterable
```

This PR fixes the case for a single GPU or when world_mesh.mesh_dim_names is None 

**Testing**

Added unit test to `tests/unit_tests/test_set_determinism.py`