### PR TITLE
[do not land] Example augmenting GPU profiler trace with model stack traces 

### DIFF
--- a/torchtitan/models/llama3/train_configs/debug_model.toml
+++ b/torchtitan/models/llama3/train_configs/debug_model.toml
@@ -4,7 +4,7 @@ description = "Llama 3 debug training"
 print_config = false
 
 [profiling]
-enable_profiling = false
+enable_profiling = true
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = false


### PR DESCRIPTION
```
TORCH_ENRICH_RPOFILER_STACK_TRACE=1  NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --model.flavor=debugmodel_flex_attn 
```

Requires https://github.com/pytorch/pytorch/pull/167171 and https://github.com/pytorch/pytorch/pull/167114

<img width="1241" height="644" alt="Screenshot 2025-11-04 at 10 17 03 AM" src="https://github.com/user-attachments/assets/c3b137b2-2426-47d8-b5c2-57a80d251cd1" />

You can check the augmented trace in manifold/explorer/pytorch/tree/shangdiy/rank0_trace_augmented.json

cc @SherlockNoMad 