### PR TITLE
[compiler toolkit] compiler toolkit without TP

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/README.md
+++ b/torchtitan/experiments/compiler_toolkit/README.md
@@ -12,6 +12,11 @@ Joint Graph based Training Prototype:
 
 ## DeepSeek v3
 
+**SimpleFSDP + EP**
+```shell
+NGPU=4 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.deepseek_v3 --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=2 --activation_checkpoint.mode none
+```
+
 **SimpleFSDP + TP + EP**
 ```shell
 NGPU=4 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.deepseek_v3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2 --activation_checkpoint.mode none
@@ -23,6 +28,11 @@ NGPU=4 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.tom
 ```
 
 ## llama3
+
+**SimpleFSDP**
+```shell
+NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=8
+```
 
 **SimpleFSDP + TP**
 ```shell

--- a/torchtitan/experiments/compiler_toolkit/graph_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/graph_utils.py
@@ -15,7 +15,6 @@ from torch._functorch.aot_autograd import (
     JointWithDescriptors,
 )
 from torch._guards import tracing, TracingContext
-from torch.distributed.tensor import DTensor
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
@@ -93,8 +92,10 @@ def joint_graph_builder(
         joint_custom_pass: Optional custom pass to run on the joint graph
     """
     assert isinstance(model_args, tuple)
-    for arg in model_args:
-        assert isinstance(arg, DTensor)
+
+    # TODO: Enable this when we have full-DTensorize inputs support of SimpleFSDP
+    # for arg in model_args:
+    #     assert isinstance(arg, DTensor)
 
     # get joint graph
     (


### PR DESCRIPTION
Currently we hardcode "tp" dimension when parallelizing inputs (converting from plain tensor to DTensor). This won't work when there is no TP is our parallelisms (e.g., SimpleFSDP only or SimpleFSDP + EP)

The fundamental reason is that currently SimpleFSDP only accepts plain tensor inputs. Making it accept DTensor inputs would require eager rewrite of SimpleFSDP's frontend. 

So as a workaround, we only DTensorize the inputs when there is a "tp" dimension in the world_mesh.

SimpleFSDP Only on llama3 
```
NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=8
```

SimpleFSDP + EP on dsv3
```
NGPU=4 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.deepseek_v3 --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=2 --activation_checkpoint.mode none
```

