### PR TITLE
Fix bugs in initial_load_in_hf when enable_weight_tying=true in Qwen3

### DIFF
--- a/torchtitan/models/qwen3/model/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/model/state_dict_adapter.py
@@ -124,10 +124,8 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
             self.model_args.enable_weight_tying
             and "lm_head.weight" not in hf_state_dict
         ):
-            if "model.embed_tokens.weight" in hf_state_dict:
-                hf_state_dict["lm_head.weight"] = hf_state_dict[
-                    "model.embed_tokens.weight"
-                ]
+            assert "model.embed_tokens.weight" in hf_state_dict
+            hf_state_dict["lm_head.weight"] = hf_state_dict["model.embed_tokens.weight"]
 
         for key, value in hf_state_dict.items():
             if "mlp.experts" in key:


### PR DESCRIPTION
Rebased on main to merge this pr: https://github.com/pytorch/torchtitan/pull/1964