### PR TITLE
add titan monarch support 

### DIFF
--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -20,7 +20,7 @@ from torch.distributed.pipelining.schedules import (
     get_schedule_class,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
-    ScheduleDualPipeV,
+    # ScheduleDualPipeV,  # Not available in PyTorch 2.8.0+rocm6.4
     ScheduleZBVZeroBubble,
 )
 
@@ -435,7 +435,7 @@ def pipeline_module_split(
 
     schedule_class = get_schedule_class(pp_schedule)
     style = (
-        "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
+        "v" if schedule_class == ScheduleZBVZeroBubble else "loop"  # Removed ScheduleDualPipeV - not available in PyTorch 2.8.0
     )
 
     def _get_stage_indices() -> tuple[int]:


### PR DESCRIPTION
- Implement lazy compilation pattern for torch.compile in attention.py
- Fix scaled_mm_configs import error by deferring compilation until first use
- Add torch._dynamo.config.disable check to skip compilation when disabled
- Comment out unavailable ScheduleDualPipeV import in pipeline_parallel.py

This fixes the ImportError when using PyTorch 2.8.0+rocm6.4:
  ImportError: cannot import name 'scaled_mm_configs' from
  'torch._inductor.kernel.mm_common'

The lazy compilation pattern checks torch._dynamo.config.disable and uses uncompiled functions when compilation is disabled, maintaining compatibility while preserving compilation capability when available.

Tested on AMD MI325X GPUs with ROCm 6.4.2.

