### PR TITLE
Run Torchtitan ROCm workflow on cron schedule & push to Main branch only

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   build-test:
+    if: |
+      matrix.gpu-arch-type == 'cuda' ||
+      (matrix.gpu-arch-type == 'rocm' &&
+       (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule'))
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
       fail-fast: false

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -111,7 +111,7 @@ def main():
         "--gpu_arch_type",
         default="cuda",
         choices=["cuda", "rocm"],
-        help="GPU architecture type. Must be specified as either 'cuda' or 'rocm'."
+        help="GPU architecture type. Must be specified as either 'cuda' or 'rocm'.",
     )
     parser.add_argument(
         "--test_suite",


### PR DESCRIPTION
Addressing following issues in this PR-

- Running Torchtitan ROCm workflow on cron schedule & only when push to Main branch. CUDA workflow will run as is.
- Refactor Torchtitan test run to address older PR comment https://github.com/pytorch/torchtitan/pull/1786#discussion_r2476279289
