### PR TITLE
Fix dry run mode

### DIFF
--- a/scripts/dry_run.py
+++ b/scripts/dry_run.py
@@ -151,6 +151,9 @@ class DryRunTrainer(Trainer):
         logger.info("Configuration is ready for training execution.")
         logger.info("=" * 80)
 
+    def train(self):
+        return
+
 
 if __name__ == "__main__":
     main(DryRunTrainer)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -735,7 +735,8 @@ def main(trainer_class: type[Trainer]) -> None:
         raise
     else:
         trainer.close()
-        torch.distributed.destroy_process_group()
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
         logger.info("Process group destroyed")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #2025
* #2024
* __->__ #2023
* #2022

Dry run mode works but it doesn't exit gracefully for all cases. This PR fixes it

```
DRY_RUN=1 CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" ./run_train.sh   --training.steps=10 --activation_checkpoint.mode="none"
--debug.deterministic --debug.seed=42
```