### PR TITLE
Fix integration test gpu_arch_type field

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -89,7 +89,10 @@ def run_tests(args, test_list: list[OverrideDefinitions]):
             continue
 
         # Skip the test for ROCm
-        if args.gpu_arch_type == "rocm" and test_flavor.skip_rocm_test:
+        if (
+            getattr(args, "gpu_arch_type", "cuda") == "rocm"
+            and test_flavor.skip_rocm_test
+        ):
             continue
 
         # Check if we have enough GPUs


### PR DESCRIPTION
All tests in experiments are broken due to the `gpu_arch_type` field added in #2018.