### PR TITLE
compiler_toolkit: fix args access

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/cudagraph.py
+++ b/torchtitan/experiments/compiler_toolkit/cudagraph.py
@@ -98,7 +98,7 @@ class CUDAGraphWrapper:
 
     def check_static_inputs_address(self) -> None:
         for i in self.static_input_indices:
-            actual = args[i].data_ptr()
+            actual = self.args[i].data_ptr()
             expected = self.input_addresses[i]
             assert expected == actual, (
                 "Expected the same static tensor address but found "


### PR DESCRIPTION
This PR fixes access to args; it's an attribute, not a variable in the scope.
The method itself though would not be used because `should_check_address` seems to be always `False` and there doesn't seem to be a command line argument for it.