### PR TITLE
[simplefsdp] fix & enable DSV3 manual bucketing

### DIFF
--- a/torchtitan/experiments/simple_fsdp/backend.py
+++ b/torchtitan/experiments/simple_fsdp/backend.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import torch
 import torch._functorch.config as functorch_config
+from functorch.compile import min_cut_rematerialization_partition
 from torchtitan.tools.logging import logger
 
 from .job_config import Compile as CompileConfig
@@ -60,6 +61,7 @@ def get_compile_backend_with_passes(
             backend = aot_autograd_backend(
                 fw_compiler=aot_eager_autobucketing_reordering_pass,
                 bw_compiler=aot_eager_autobucketing_reordering_pass,
+                partition_fn=min_cut_rematerialization_partition,
                 keep_inference_input_mutations=True,
             )
         elif compile_config.backend == "inductor":
@@ -108,6 +110,7 @@ def get_compile_backend_with_passes(
             backend = aot_autograd_backend(
                 fw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
                 bw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
+                partition_fn=min_cut_rematerialization_partition,
                 keep_inference_input_mutations=True,
             )
         elif compile_config.backend == "inductor":

--- a/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
@@ -51,6 +51,8 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
         result = []
         for m in modules:
             if isinstance(m, list):
+                # check if fqn_list is valid. In PP, bucketed module may
+                # not be in the current rank, and fqn_list is None.
                 if fqn_list := convert_modules_to_fqns(m, module_to_fqn_mapping):
                     result.append(fqn_list)
             else:

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -97,8 +97,6 @@ deepseekv3_args = {
         qk_rope_head_dim=64,
         v_head_dim=128,
         mscale=0.70,
-        attn_type="flex",
-        attn_mask_type="block_causal",
     ),
     "236B": DeepSeekV3ModelArgs(
         vocab_size=102400,


### PR DESCRIPTION
Validate DSV3 manual bucketing when EP/TP are enable. Tested on DSV3-16B model. Dependent on Pytorch [PR](https://github.com/pytorch/pytorch/pull/169308)

(Single Node: BS = 1)

| Node | Method | Parallelism | Memory | TPS | Trace|
|------|---------|------------|----------|-----|-------|
|1-Node (8H100) | SimpleFSDP (aot_eager) | FSDP=4 EP=2 | 51.11GiB(53.80%) | 5,136 | [Link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-12-10-19-49-11_rank0_trace.json) |
|1-Node (8H100) | FSDP2-eager | FSDP=4 EP=2 | 59.54GiB(62.68%) | 5,942  | [Link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-11-24-09-41-04_rank0_trace.json) |
|1-Node (8H100) | SimpleFSDP (aot_eager) | FSDP=2 TP=2 EP=2 | 42.21GiB(44.43%) | 2,285  | [Link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-12-10-20-13-39_rank0_trace.json) |
|1-Node (8H100) | FSDP2-eager | FSDP=2 TP=2 EP=2 | 45.41GiB(47.80%) | 2,349 | [Link](https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/ruisizhang123_2025-12-10-20-18-06_rank0_trace.json) |

1. Example Trace

<img width="1260" height="219" alt="Screenshot 2025-12-10 at 7 51 23 PM" src="https://github.com/user-attachments/assets/cf2d3eaf-f1a8-4e23-a60b-d0f29eb554e0" />


