### PR TITLE
skip varlen integration test on rocm

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -357,6 +357,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "FSDP+VARLEN_ATTN",
             "fsdp+varlen_attn",
             ngpu=4,
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
as title since varlen attention is not supported on rocm 