### PR TITLE
Improve logging by formatting the dict as JSON.

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -961,7 +961,9 @@ class JobConfig:
 
     def maybe_log(self) -> None:
         if self.job.print_config:
-            logger.info(f"Running with configs: {self.to_dict()}")
+            logger.info(
+                f"Running with configs: {json.dumps(self.to_dict(), indent=2, ensure_ascii=False)}"
+            )
 
         if self.job.save_config_file is not None:
             config_file = os.path.join(self.job.dump_folder, self.job.save_config_file)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import importlib
+import json
 import os
 import time
 from datetime import timedelta
@@ -135,7 +137,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         self.model_args = model_args
 
         logger.info(
-            f"Building {job_config.model.name} {job_config.model.flavor} with {model_args}"
+            f"Building {job_config.model.name} {job_config.model.flavor}"
+            f"with {json.dumps(dataclasses.asdict(model_args), indent=2, ensure_ascii=False)}"
         )
         with (
             torch.device("meta"),


### PR DESCRIPTION
We use Slurm to run jobs, and i just noticed that job configs and model args were being logged on a single line by default, which makes the logs hard to read.

This PR improves readability by formatting these dictionaries with `json.dumps` before logging, so the configs are formatted nicely and easier for humans to read.

before:
<img width="2594" height="640" alt="image" src="https://github.com/user-attachments/assets/c3c07b09-d12c-484d-aa90-a626cd25c6d2" />

after:
<img width="2252" height="1032" alt="image" src="https://github.com/user-attachments/assets/4cbde979-c34c-4fc5-aa55-f280f39cf9ef" />
