### PR TITLE
Update hf_assets_path for llama4

### DIFF
--- a/torchtitan/models/llama4/train_configs/llama4_17bx128e.toml
+++ b/torchtitan/models/llama4/train_configs/llama4_17bx128e.toml
@@ -17,7 +17,7 @@ save_tb_folder = "tb"
 [model]
 name = "llama4"
 flavor = "17bx128e"
-hf_assets_path = "./assets/hf/Llama-4-Scout-17B-128E"
+hf_assets_path = "./assets/hf/Llama-4-Maverick-17B-128E"
 # converters = ["float8"]
 
 [optimizer]


### PR DESCRIPTION
Fix typo in train_config, hf asset should be for maverick, see:

https://huggingface.co/meta-llama/models?search=128e