### PR TITLE
Enables parsing of --compile.components through CLI

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -656,9 +656,7 @@ class Compile:
     enable: bool = False
     """Whether to apply torch.compile"""
 
-    components: list[str] = field(
-        default_factory=lambda: ["model", "loss"]
-    )
+    components: list[str] = field(default_factory=lambda: ["model", "loss"])
     """Which components to compile"""
     backend: str = "inductor"
 


### PR DESCRIPTION
Without this PR, I'm not able to pass `--compile.components=model,loss`. Tested using `python -m torchtitan.config.manager --compile.components=model,loss`.