### PR TITLE
Add warning to run_tests

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -80,7 +80,7 @@ def run_tests(args, test_list: list[OverrideDefinitions]):
         args.config_path
     ), f"Base config path {args.config_path} does not exist"
 
-    tests_run = 0
+    ran_any_test = False
     for test_flavor in test_list:
         # Filter by test_name if specified
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
@@ -104,9 +104,9 @@ def run_tests(args, test_list: list[OverrideDefinitions]):
             )
         else:
             run_single_test(test_flavor, args.config_path, args.output_dir)
-            tests_run += 1
+            ran_any_test = True
 
-    if tests_run == 0:
+    if not ran_any_test:
         available_tests = [t.test_name for t in test_list if not t.disabled]
         logger.warning(
             f"No tests were run for --test_name '{args.test_name}' in test suite '{args.test_suite}'.\n"


### PR DESCRIPTION
Small addition since right now running a test that doesn't exist just outputs nothing, e.g.

`python -m tests.integration_tests.run_tests ./test-out --test_name does_not_exist`

Now the output is:

`
WARNING:root:No tests were run for --test_name 'does_not_exist' in test suite 'features'.
Available test names in 'features' suite: ['default', '1d_compile', '1d_compile_sac_op', '2d_eager', '2d_compile', 'full_checkpoint', 'model_only_hf_checkpoint', 'last_save_model_only_fp32', 'last_save_model_only_bf16', 'pp_looped_zero_bubble', 'pp_zbv', 'pp_1f1b', 'pp_gpipe', 'pp_dp_1f1b', 'pp_dp_gpipe', 'pp_tp', 'pp_dp_tp', '3d_compile', 'pp_looped_1f1b', 'pp_custom_csv', 'optimizer_foreach', 'ddp', 'hsdp', 'fsdp+flex_attn', 'fsdp+flex_attn+per_op_sac', 'fsdp+varlen_attn+per_op_sac', 'cp_allgather', 'cp_alltoall', 'hsdp+tp', 'fsdp+cp', 'hsdp+cp_without_dp_shard', 'hsdp+cp_with_dp_shard', 'fsdp+tp+cp', 'cpu_offload+opt_in_bwd+TP+DP+CP', 'test_generate', 'fsdp_reshard_always', 'optional_checkpoint', 'float8_emulation', 'gradient_accumulation', 'validation_tp_cp_pp']
`

