### PR TITLE
[forge] allow torchforges to set checkpoint base folder

### DIFF
--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import os
 from typing import Generator
 
@@ -22,9 +21,6 @@ from torchtitan.tools import utils
 
 from .job_config import ForgeJobConfig
 from .train_spec import ForgeTrainSpec, get_train_spec
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful):


### PR DESCRIPTION
this PR 
1) allowing Torchforge to decide where to put the checkpoint and wandb, etc, instead of the  "current" folder
~~allowing Torchforge to decide to print / log the configs~~