### PR TITLE
Add repeated_subgraphs option in AutoParallel example

### DIFF
--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -329,6 +329,7 @@ def parallelize_deepseekv3(
         world_mesh,
         mp_policy=mp_policy,
         compile=job_config.compile,
+        repeated_subgraphs=False,  # switch to True to make it run faster
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 

--- a/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
+++ b/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
@@ -91,6 +91,7 @@ def parallelize_llama(
         world_mesh,
         mp_policy=mp_policy,
         compile=job_config.compile,
+        repeated_subgraphs=True,  # makes it run much faster
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 


### PR DESCRIPTION
Using `repeated_subgraphs` enable AutoParallel to enforce the same solution to repeated regions of the model, making the solver be much faster. For 32 layers, we obtained roughtly 21x speedup compared to without repeated subgraphs.