### PR TITLE
Staging SFT training

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -15,6 +15,10 @@ from torchtitan.tools.logging import logger
 
 LossFunction: TypeAlias = Callable[..., torch.Tensor]
 
+IGNORE_INDEX = -100
+# Pytorch's default for F.cross_entropy
+# Used in VLM and SFT training
+
 
 def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
     """Common cross-entropy loss function for Transformer models training."""

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -15,5 +15,6 @@ _supported_experiments = frozenset(
         "autoparallel.llama3",
         "autoparallel.deepseek_v3",
         "autoparallel.local_map_deepseek_v3",
+        "sft.llama3",
     ]
 )

--- a/torchtitan/experiments/sft/auto_tokenizer.py
+++ b/torchtitan/experiments/sft/auto_tokenizer.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.components.tokenizer import BaseTokenizer
+from torchtitan.config import JobConfig
+from torchtitan.tools.logging import logger
+from transformers import AutoTokenizer as HF_AutoTokenizer
+
+
+class HuggingFaceAutoTokenizer(BaseTokenizer):
+    def __init__(
+        self,
+        tokenizer_path: str,
+        eos_token: str,
+        pad_token_id: int,
+        pad_token: str | None = None,
+    ):
+        self.tokenizer = HF_AutoTokenizer.from_pretrained(
+            tokenizer_path, eos_token=eos_token, use_fast=True
+        )
+        self.tokenizer_path = tokenizer_path
+        self.chat_template = self.tokenizer.chat_template
+
+        self.vocab_size = len(self.tokenizer)
+
+        assert (
+            pad_token_id < self.vocab_size
+        ), f"PAD token ID is out of range: {pad_token_id} >= {self.vocab_size}"
+        assert (
+            pad_token_id != self.tokenizer.eos_token_id
+        ), "PAD token ID is the same as EOS token ID, this can cause problems with varlen/flex attention in dynamic packing."
+
+        self.eos_id = self.tokenizer.eos_token_id
+        self.bos_id = self.tokenizer.bos_token_id
+        self.bos_token = self.tokenizer.bos_token
+        self.eos_token = self.tokenizer.eos_token
+
+        self.pad_id = pad_token_id
+
+        self.maybe_original_token_at_pad_id = self.tokenizer._convert_id_to_token(
+            pad_token_id
+        )
+        if pad_token is not None:
+            self.pad_token = pad_token
+        else:
+            self.pad_token = self.maybe_original_token_at_pad_id
+
+        logger.info(
+            f"[SFT AutoTokenizer] Using EOS token: {self.eos_token} - EOS ID: {self.eos_id} "
+            f"[SFT AutoTokenizer] Using PAD token: {self.pad_token} - PAD ID: {self.pad_id}"
+        )
+
+    def apply_chat_template(self, messages: list[dict], **kwargs):
+        return self.tokenizer.apply_chat_template(messages, **kwargs)
+
+    def encode(self, text: str, *args, **kwargs):
+        return self.tokenizer.encode(text, *args, **kwargs)
+
+    def decode(self, tokens: list[int], *args, **kwargs):
+        decoded = self.tokenizer.decode(tokens, *args, **kwargs)
+        # this is an ad-hoc for debugging purpose
+        if self.pad_id in tokens:
+            decoded = decoded.replace(
+                self.maybe_original_token_at_pad_id, self.pad_token
+            )
+        return decoded
+
+    def get_vocab_size(self):
+        return self.tokenizer.vocab_size
+
+    def __call__(self, text: str, *args, **kwargs):
+        return self.tokenizer(text, *args, **kwargs)
+
+
+def build_auto_tokenizer(job_config: JobConfig) -> HuggingFaceAutoTokenizer:
+    eos_token = job_config.sft_config.eos_token
+    pad_token_id = job_config.sft_config.pad_token_id
+    pad_token = job_config.sft_config.pad_token
+    assert (
+        eos_token is not None and pad_token_id is not None
+    ), "EOS and PAD token IDs must be provided"
+    return HuggingFaceAutoTokenizer(
+        job_config.model.hf_assets_path,
+        eos_token=eos_token,
+        pad_token_id=pad_token_id,
+        pad_token=pad_token,
+    )

--- a/torchtitan/experiments/sft/job_config.py
+++ b/torchtitan/experiments/sft/job_config.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class SFTConfig:
+    split: str = "train"
+    """Split to use"""
+    dataset_subset: str | None = None
+    """Subset to use"""
+    stream_dataset: bool = True
+    """Whether to stream the dataset"""
+    """
+    At moment we support two types of datasets:
+    # about dataset
+    1. **Multi-turn (`True`):** Loads data from the column specified by `messages_key`.
+        The content must be a list of dictionaries containing 'role' and 'content'.
+        Example:
+        ```
+        [
+            {
+                "role": "user",
+                "content": "Hello, how are you?"
+            },
+            {
+                "role": "assistant",
+                "content": "I am good, thank you!"
+            }
+        ]
+        ```
+    2. **Single-turn (`False`):** Loads data from two separate columns
+        specified by `prompt_key` and `response_key`.
+
+    """
+
+    apply_chat_template: bool = False
+    """
+    If True, we will apply chat template to the messages, otherwise we will use the raw messages.
+    It is important that chat_templated should be properly configured for the tokenizer and
+    it can render the messages for multi-turn mode.
+    """
+    pad_mode: Literal["right_padding", "greedy_packing"] = "greedy_packing"
+    """
+    Padding mode to use.
+    - "right": One batch contains only one unique sequence, the sequence will be padded to the right to reach the max length.
+    - "greedy_packing": One batch contains multiple short sequences and then be padded to the right to reach the max length.
+    """
+    chat_template_kwargs: dict = field(default_factory=dict)
+    """
+    When apply chat template, we will pass these kwargs to the tokenizer.apply_chat_template function.
+    It has to be HF's apply_chat_template kwargs.
+    """
+    ignore_input_ids_mismatch: bool = False
+    """
+    Whether to ignore the input_ids mismatch when apply chat template.
+    """
+
+    eos_token: str | None = None
+    """
+    EOS token to use.
+    """
+    pad_token_id: int | None = None
+    """
+    PAD token ID to use.
+    """
+    pad_token: str | None = None
+    """
+    PAD token to override the tokenizer's pad token.
+    """
+
+
+@dataclass
+class JobConfig:
+    sft_config: SFTConfig = field(default_factory=SFTConfig)

--- a/torchtitan/experiments/sft/llama3/__init__.py
+++ b/torchtitan/experiments/sft/llama3/__init__.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# from torchtitan.components.loss import build_cross_entropy_loss
+from torchtitan.components.lr_scheduler import build_lr_schedulers
+from torchtitan.components.optimizer import build_optimizers
+from torchtitan.distributed.pipeline_parallel import pipeline_llm
+
+from torchtitan.experiments.sft.auto_tokenizer import build_auto_tokenizer
+
+from torchtitan.experiments.sft.sft_text_datasets import (
+    build_sft_text_dataloader,
+    build_sft_validation_dataloader,
+)
+
+from torchtitan.experiments.vlm.infra.loss import build_token_imbalance_ce_loss
+
+from torchtitan.models.llama3 import llama3_args, Transformer
+from torchtitan.models.llama3.infra.parallelize import parallelize_llama
+from torchtitan.models.llama3.model.state_dict_adapter import Llama3StateDictAdapter
+from torchtitan.protocols.train_spec import TrainSpec
+
+
+def get_train_spec() -> TrainSpec:
+    return TrainSpec(
+        model_cls=Transformer,
+        model_args=llama3_args,
+        parallelize_fn=parallelize_llama,
+        pipelining_fn=pipeline_llm,
+        build_optimizers_fn=build_optimizers,
+        build_lr_schedulers_fn=build_lr_schedulers,
+        build_dataloader_fn=build_sft_text_dataloader,
+        build_tokenizer_fn=build_auto_tokenizer,
+        # build_cross_entropy_loss will averaged on pad tokens unexpectedly
+        build_loss_fn=build_token_imbalance_ce_loss,
+        build_validator_fn=build_sft_validation_dataloader,
+        state_dict_adapter=Llama3StateDictAdapter,
+    )

--- a/torchtitan/experiments/sft/requirements
+++ b/torchtitan/experiments/sft/requirements
@@ -1,0 +1,1 @@
+transformers

--- a/torchtitan/experiments/sft/sft_text_datasets.py
+++ b/torchtitan/experiments/sft/sft_text_datasets.py
@@ -1,0 +1,622 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# code are heavily borrowed from
+# [1] https://github.com/volcengine/verl/blob/main/verl/utils/dataset/multiturn_sft_dataset.py
+# [2] https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/datasets/sft_dataset.py#L35
+# [3] https://github.com/volcengine/verl/blob/main/verl/utils/dataset/sft_dataset.py#L33
+from dataclasses import field
+from functools import partial
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn.functional as F
+
+from datasets import Dataset, load_dataset
+from datasets.distributed import split_dataset_by_node
+from torch.distributed.checkpoint.stateful import Stateful
+from torch.utils.data import IterableDataset
+
+from torchtitan.components.dataloader import ParallelAwareDataloader
+
+from torchtitan.components.loss import IGNORE_INDEX
+from torchtitan.components.tokenizer import BaseTokenizer
+from torchtitan.config.job_config import JobConfig
+from torchtitan.experiments.sft.job_config import SFTConfig
+from torchtitan.tools.logging import logger
+
+
+def _build_multi_turn_messages_from_row_dict(
+    row_dict: dict,
+    messages_key: str = "messages",
+    tools_key: str = "tools",
+    thinking_key: str = "thinking",
+):
+    """Build multi-turn messages from row dictionary."""
+    # return the message, tools, and enable_thinking
+    message = row_dict[messages_key]
+    tools = row_dict.get(tools_key, None)
+    enable_thinking = row_dict.get(thinking_key, None)
+    if isinstance(enable_thinking, str):
+        enable_thinking = enable_thinking == "on"
+    return message, tools, enable_thinking
+
+
+def _build_prompt_response_messages_from_row_dict(
+    row_dict: dict,
+    prompt_key: str = "prompt",
+    response_key: str = "response",
+):
+    """Build one turn messages from row dictionary."""
+    # return the message, tools, and enable_thinking
+    message = [
+        {"role": "user", "content": row_dict[prompt_key]},
+        {"role": "assistant", "content": row_dict[response_key]},
+    ]
+    return message, None, None
+
+
+DATASET_MESSAGE_BUILDERS = {
+    "multi_turn": _build_multi_turn_messages_from_row_dict,
+    "prompt_response": _build_prompt_response_messages_from_row_dict,
+    "question_answer": partial(
+        _build_prompt_response_messages_from_row_dict,
+        prompt_key="question",
+        response_key="answer",
+    ),
+}
+
+
+"""
+From DataFrame rows to a "sequence"
+
+1) [Get row data]
+   Iterate over the DataFrame to obtain a per-row dictionary (row_dict).
+
+2) [Build messages]
+   Given row_dict, call `_build_messages` to convert the original data into `messages`.
+
+   Here, `messages` is a list of dicts with at least the keys "role" and "content", e.g.
+   [
+       {"role": "user", "content": "Hello, how are you?"},
+       {"role": "assistant", "content": "I am good, thank you!"}
+   ]
+
+   We currently support two ways to parse the original data into `messages`:
+
+   2.1) [QA mode]
+        If this is NOT multi-turn mode, we build messages by explicitly assigning "user"
+        and "assistant" roles, reading from `prompt_key` and `response_key`:
+        [
+            {"role": "user", "content": row_dict[prompt_key]},
+            {"role": "assistant", "content": row_dict[response_key]},
+        ]
+
+   2.2) [Multi-turn mode]
+        If this IS multi-turn mode (even if there is only one turn), we read the full
+        message list from the column `messages_key`. The expected input format is:
+        {
+            messages_key: [
+                {"role": "user", "content": "Hello, how are you?"},
+                {"role": "assistant", "content": "I am good, thank you!"},
+                {"role": "user", "content": "What is your name?"},
+            ]
+        }
+
+   2.3) [Not landed yet]
+        If your data format is completely different, you can implement your own
+        `_build_messages` function. It must return a `messages` list in the same format.
+
+3) [Convert messages to tokens]
+   After we have `messages`, we tokenize them by calling `_process_one_row`.
+
+   3.1) If there is only ONE message, we tokenize it via `_process_single_message`:
+        - Either tokenize the message["content"] directly, OR
+        - Apply the tokenizer's chat template (requires the chat template to be configured).
+
+   3.2) If there are MULTIPLE messages, we call `_process_single_message` for each message.
+        There is one special case:
+        When `apply_chat_template=True`, each call to `_process_single_message` may add a
+        [system prompt]. That can produce:
+        [System] [User] [System] [Assistant] [System] [User] [System] [Assistant] ...
+        which is not what we want for a single conversation. Therefore, we include special
+        handling to remove the unexpected [system prompt] and [generation prompt] added
+        from the second message onward.
+"""
+
+"""
+From one or more "sequences" to a "batch"
+
+We offer two modes to handle padding and truncation when forming a batch.
+Padding is needed because sequences may have different lengths, and PyTorch
+cannot stack variable-length sequences into a single tensor directly.
+
+Example:
+    batch = [
+        sequence_1,
+        sequence_2,
+        sequence_3,
+    ]
+
+### Right padding
+The simplest approach is to right-pad each sequence to a target length using
+a special `<pad_token>`. The batch then looks like:
+    batch = [
+        [sequence_1 + several <pad_token>],
+        [sequence_2 + several <pad_token>],
+        [sequence_3 + several <pad_token>],
+    ]
+
+After right padding, all sequences have the same length. We set the
+`attention_mask` for `<pad_token>` positions to 0 so that attention
+implementations such as `varlen_attn` or `flex_attn` can ignore them.
+
+### Greedy packing
+Alternatively, we can use greedy packing to reduce padding waste by packing
+multiple sequences into a single fixed-length row:
+    batch = [
+        [sequence_1, sequence_2, sequence_3],
+        [sequence_4, sequence_5, <pad_token>],
+    ]
+    **We need strictly compact padding without no gap between sequences.**
+
+We still right-pad each packed row to the target length with `<pad_token>`.
+To prevent cross-document attention, we must also infer (or track) the
+boundaries between sequences within each packed row.
+"""
+
+
+def extract_system_prompt_and_generation(tokenizer):
+    """Derive system and generation prompt token chunks from the tokenizer's chat template."""
+    token1 = tokenizer.apply_chat_template(
+        [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True
+    )
+    token2 = tokenizer.apply_chat_template(
+        [{"role": "user", "content": ""}] * 2,
+        add_generation_prompt=False,
+        tokenize=True,
+    )
+    # get system prompt tokens
+    system_prompt = token1[: -(len(token2) - len(token1))]
+    # get generate prompt tokens
+    token3 = tokenizer.apply_chat_template(
+        [{"role": "user", "content": ""}], add_generation_prompt=True, tokenize=True
+    )
+    generate_prompt = token3[len(token1) :]
+
+    return system_prompt, generate_prompt
+
+
+class SFTDataset(IterableDataset, Stateful):
+    """
+    Iterable dataset that tokenizes a conversational stream for SFT training.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        tokenizer: BaseTokenizer,
+        message_builder: Callable,
+        seq_len: int = 2048,
+        dp_rank: int = 0,
+        dp_world_size: int = 1,
+        infinite: bool = False,
+        sft_config: SFTConfig = field(default_factory=SFTConfig()),
+    ) -> None:
+        super().__init__()
+        self.tokenizer = tokenizer
+        self._data = split_dataset_by_node(dataset, dp_rank, dp_world_size)
+        self.message_builder = message_builder
+        self.infinite = infinite
+
+        self.sft_config = sft_config
+
+        self.pad_mode = sft_config.pad_mode
+        self.ignore_input_ids_mismatch = sft_config.ignore_input_ids_mismatch
+
+        self.max_length = seq_len
+        self.apply_chat_template_kwargs = sft_config.chat_template_kwargs
+
+        self.apply_chat_template = sft_config.apply_chat_template
+        if self.apply_chat_template:
+            assert self.tokenizer.chat_template is not None, (
+                f"Chat template is not set for the tokenizer {self.tokenizer.tokenizer_path}, "
+                f"please set it in the tokenizer config file"
+            )
+            (
+                self.system_prompt,
+                self.generation_prompt,
+            ) = extract_system_prompt_and_generation(self.tokenizer)
+        else:
+            self.system_prompt = torch.tensor([], dtype=torch.long)
+            self.generation_prompt = torch.tensor([], dtype=torch.long)
+
+        logger.info(
+            f"[sft_text_datasets.py] Infer system_prompt: {self.tokenizer.decode(self.system_prompt)}"
+        )
+        logger.info(
+            f"[sft_text_datasets.py] Infer generation_prompt: {self.tokenizer.decode(self.generation_prompt)}"
+        )
+
+        self.pad_id = self.tokenizer.pad_id
+        self.pad_token = self.tokenizer.pad_token
+        self.eos_id = self.tokenizer.eos_id
+
+        self.buffer_max_length = self.max_length
+        # Stateful variables
+        self._sample_idx = 0
+        self._buffer = self._reset_buffer()
+
+    def _reset_buffer(self):
+        """Reset the greedy packing buffer to empty tensors."""
+        return {
+            "input_ids": [],
+            "position_ids": [],
+            "labels": [],
+            "segment_lens": [],
+            "current_len": 0,
+        }
+
+    def _get_data_iter(self):
+        """Return an iterator over the local partition, resuming for map-style datasets."""
+        # For map-style datasets, resume by skipping to the correct index
+        # For iterable-style datasets, the underlying iterator already points to the correct index
+        if isinstance(self._data, Dataset):
+            if self._sample_idx == len(self._data):
+                return iter([])
+            else:
+                return iter(self._data.skip(self._sample_idx))
+
+        return iter(self._data)
+
+    def load_state_dict(self, state_dict):
+        self._buffer = state_dict["buffer"]
+
+        if isinstance(self._data, Dataset):
+            self._sample_idx = state_dict["sample_idx"]
+        else:
+            assert "dataset" in state_dict
+            self._data.load_state_dict(state_dict["dataset"])
+
+    def state_dict(self):
+        _state_dict = {"buffer": self._buffer}
+
+        if isinstance(self._data, Dataset):
+            _state_dict["sample_idx"] = self._sample_idx
+        else:
+            # Save the iterable dataset's state to later efficiently resume from it
+            # https://huggingface.co/docs/datasets/v3.5.0/en/stream#save-a-dataset-checkpoint-and-resume-iteration
+            _state_dict["dataset"] = self._data.state_dict()
+
+        return _state_dict
+
+    def _process_single_message(
+        self,
+        index: int,
+        message: dict[str, Any],
+        tools: Optional[list[dict[str, Any]]] = None,
+        enable_thinking: Optional[bool] = None,
+    ) -> tuple[list[int], list[int], list[int]]:
+        """Tokenize one conversation turn while applying template overrides."""
+        apply_chat_template_kwargs = {**self.apply_chat_template_kwargs}
+        if enable_thinking is not None:
+            apply_chat_template_kwargs["enable_thinking"] = enable_thinking
+        if self.apply_chat_template:
+            inputs = self.tokenizer.apply_chat_template(
+                [message],
+                tools=tools,
+                add_generation_prompt=False,
+                tokenize=True,
+                return_dict=True,
+                return_attention_mask=False,
+                return_tensors="pt",
+                **apply_chat_template_kwargs,
+            )
+            inputs = dict(inputs)
+            input_ids = inputs.pop("input_ids")[0]
+        else:
+            content = message["content"]
+            if isinstance(content, list):
+                content = "".join(
+                    [item["text"] for item in content if item["type"] == "text"]
+                )
+            enc = self.tokenizer(
+                content,
+                add_special_tokens=False,
+                return_tensors="pt",
+                return_attention_mask=False,
+            )
+            input_ids = enc["input_ids"][0]
+
+            if message["role"] == "assistant":
+                input_ids = torch.cat([input_ids, input_ids.new_tensor([self.eos_id])])
+
+        # remove system prompt if exists
+        if index != 0 and message["role"] != "system":
+            input_ids = input_ids[len(self.system_prompt) :]
+
+        if message["role"] == "assistant":
+            loss_mask = torch.ones_like(input_ids)
+            # mask out generation prompt if assistant message
+            loss_mask[: len(self.generation_prompt)] = 0
+        else:
+            loss_mask = torch.zeros_like(input_ids)
+
+        return input_ids, loss_mask
+
+    def sanity_check(
+        self,
+        input_ids: torch.Tensor,
+        messages: list[dict],
+        tools: list[dict],
+        enable_thinking: bool,
+    ):
+        """Ensure concatenated per-turn templates match a single-shot template invocation."""
+        if not self.apply_chat_template:
+            return
+        apply_chat_template_kwargs = {**self.apply_chat_template_kwargs}
+        if enable_thinking is not None:
+            apply_chat_template_kwargs["enable_thinking"] = enable_thinking
+        inputs = self.tokenizer.apply_chat_template(
+            messages,
+            tools=tools,
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            **apply_chat_template_kwargs,
+        )
+
+        error_message = (
+            "MultiTurnSFTDataset apply_chat_template to each turn separately and concat `input_ids` "
+            "as a whole sequence, which may not equal to apply_chat_template to whole messages at once.\n"
+            "For example, Qwen Thinking series models add <think></think> tags to last turn, please check "
+            "your tokenizer chat template settings.\n"
+            "Set `ignore_input_ids_mismatch=True` to ignore input_ids mismatch and use the concatenated "
+            "input_ids as the final input_ids. "
+        )
+
+        if not torch.equal(input_ids, inputs["input_ids"].squeeze(0)):
+            if self.ignore_input_ids_mismatch:
+                logger.warning_once(error_message)
+            else:
+                raise AssertionError(error_message)
+
+    def _process_one_row(self, row_dict: dict):
+        """Convert a dataset row into model-ready tensors with causal labels."""
+        messages, tools, enable_thinking = self.message_builder(row_dict)
+
+        # tokenize each message
+        input_ids, loss_mask = [], []
+        for i, message in enumerate(messages):
+            _input_ids, _loss_mask = self._process_single_message(
+                index=i,
+                message=message,
+                tools=tools if i == 0 else None,
+                enable_thinking=enable_thinking,
+            )
+            input_ids.append(_input_ids)
+            loss_mask.append(_loss_mask)
+
+        input_ids = torch.cat(input_ids, dim=0)
+        loss_mask = torch.cat(loss_mask, dim=0)
+
+        self.sanity_check(input_ids, messages, tools, enable_thinking)
+
+        # when chat template is applied, append the EOS token to the input_ids and loss_mask
+        if self.apply_chat_template:
+            input_ids = torch.cat(
+                [input_ids, input_ids.new_tensor([self.eos_id])], dim=0
+            )
+            loss_mask = torch.cat([loss_mask, loss_mask.new_tensor([0])], dim=0)
+
+        position_ids = torch.arange(input_ids.shape[0], dtype=torch.long)  # (seq_len,)
+
+        # comment out these two lines to log the actual text for debugging purpose
+        # actaul_text = self.tokenizer.decode(input_ids, skip_special_tokens=False)
+        # logger.info(f"actual_text: {actaul_text} ||-> last mask : {loss_mask[-3:]}")
+
+        # handle padding
+        sequence_length = input_ids.shape[0]
+        target_length = self.max_length + 1
+
+        # Calculate valid length (unpadded) of the sequence for the model
+        # Note: We slice input_ids[:-1] later, so the valid length for training is len - 1
+        # If truncated, it is target_length - 1
+        if self.pad_mode == "right_padding":
+            if sequence_length < target_length:
+                # Pad sequences
+                pad_token_id = self.pad_id
+                padded_input_ids = torch.full(
+                    (target_length - sequence_length,),
+                    pad_token_id,
+                    dtype=input_ids.dtype,
+                )
+                padded_loss_mask = torch.zeros(
+                    (target_length - sequence_length,), dtype=loss_mask.dtype
+                )
+
+                input_ids = torch.cat((input_ids, padded_input_ids))
+                loss_mask = torch.cat((loss_mask, padded_loss_mask))
+                position_ids = F.pad(
+                    position_ids, (0, target_length - sequence_length), value=0
+                )
+            elif sequence_length > target_length:
+                # "right_trunc":
+                input_ids = input_ids[:target_length]
+                loss_mask = loss_mask[:target_length]
+                position_ids = position_ids[:target_length]
+
+        elif self.pad_mode == "greedy_packing":
+            # notice the actual packing logic happens in the `_yield_buffer` function.
+            # truncate if longer than max_length (respect truncation setting)
+            if len(input_ids) > target_length:
+                input_ids = input_ids[:target_length]
+                loss_mask = loss_mask[:target_length]
+                position_ids = position_ids[:target_length]
+            # In GREEDY_PACKING mode, keep a real attention mask (all ones).
+            # Collate will pad it later in `collate_sft_batch`.
+        else:
+            raise ValueError(f"Unknown pad mode {self.pad_mode}")
+
+        labels = input_ids[1:].clone()
+        labels[loss_mask[1:] == 0] = IGNORE_INDEX
+        input_ids = input_ids[:-1]
+        position_ids = position_ids[:-1]
+
+        return input_ids, labels, position_ids
+
+    def _greedy_pack_buffer(self):
+        if not self._buffer["input_ids"]:
+            return None
+
+        # Concatenate buffer
+        input_ids = torch.cat(self._buffer["input_ids"], dim=0)
+        labels = torch.cat(self._buffer["labels"], dim=0)
+        positions = torch.cat(self._buffer["position_ids"], dim=0)
+
+        L = int(input_ids.numel())
+        T = int(self.buffer_max_length)
+        if L < T:
+            pad_len = T - L
+            input_ids = F.pad(input_ids, (0, pad_len), value=self.pad_id)
+            positions = F.pad(positions, (0, pad_len), value=0)
+            labels = F.pad(labels, (0, pad_len), value=IGNORE_INDEX)
+
+        return {
+            "input": input_ids,
+            "positions": positions,
+        }, labels
+
+    def __iter__(self):
+        while True:
+            for sample in self._get_data_iter():
+                input_ids, labels, positions = self._process_one_row(sample)
+                new_len = input_ids.shape[0]
+
+                if self.pad_mode == "right_padding":
+                    # Yield consistent dict structure immediately
+                    return_dict = {
+                        "input": input_ids,
+                        "positions": positions,
+                    }
+                    yield return_dict, labels
+                    self._sample_idx += 1
+                    continue
+
+                if self._buffer["current_len"] + new_len > self.buffer_max_length:
+                    if self._buffer["current_len"] > 0:
+                        yield self._greedy_pack_buffer()
+
+                    self._buffer = self._reset_buffer()
+                    self._buffer["input_ids"].append(input_ids)
+                    self._buffer["position_ids"].append(positions)
+                    self._buffer["labels"].append(labels)
+                    self._buffer["current_len"] = new_len
+                else:
+                    self._buffer["input_ids"].append(input_ids)
+                    self._buffer["position_ids"].append(positions)
+                    self._buffer["labels"].append(labels)
+                    self._buffer["current_len"] += new_len
+                self._sample_idx += 1
+
+            if not self.infinite:
+                logger.warning("Dataset has run out of data")
+                break
+            else:
+                # Reset offset for the next iteration
+                self._sample_idx = 0
+                logger.warning("Dataset is being re-looped")
+                # Ensures re-looping a dataset loaded from a checkpoint works correctly
+                if not isinstance(self._data, Dataset):
+                    if hasattr(self._data, "set_epoch") and hasattr(
+                        self._data, "epoch"
+                    ):
+                        self._data.set_epoch(self._data.epoch + 1)
+
+
+def build_sft_text_dataloader(
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: BaseTokenizer,
+    job_config: JobConfig,
+    infinite: bool = True,
+) -> ParallelAwareDataloader:
+    """Build a data loader for HuggingFace datasets."""
+    dataset_name = job_config.training.dataset
+    dataset_path = job_config.training.dataset_path
+    batch_size = job_config.training.local_batch_size
+    seq_len = job_config.training.seq_len
+
+    sft_config = job_config.sft_config
+    # TODO: Improving the dataset loading, its easy to fix
+    dataset = load_dataset(
+        dataset_path,
+        sft_config.dataset_subset,
+        split=sft_config.split,
+        streaming=sft_config.stream_dataset,
+    )
+
+    message_builder = DATASET_MESSAGE_BUILDERS[dataset_name]
+    hf_ds = SFTDataset(
+        dataset=dataset,
+        message_builder=message_builder,
+        tokenizer=tokenizer,
+        seq_len=seq_len,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        infinite=infinite,
+        sft_config=sft_config,
+    )
+
+    return ParallelAwareDataloader(
+        dataset=hf_ds,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        batch_size=batch_size,
+    )
+
+
+def build_sft_validation_dataloader(
+    dp_world_size: int,
+    dp_rank: int,
+    tokenizer: BaseTokenizer,
+    job_config: JobConfig,
+    infinite: bool = False,
+) -> ParallelAwareDataloader:
+    """Build a validation data loader for HuggingFace datasets."""
+    dataset_name = job_config.validation.dataset
+    dataset_path = job_config.validation.dataset_path
+    batch_size = job_config.validation.local_batch_size
+    seq_len = job_config.validation.seq_len
+
+    sft_config = job_config.sft_config
+    # TODO: Improving the dataset loading, its easy to fix
+    dataset = load_dataset(
+        dataset_path,
+        sft_config.dataset_subset,
+        split=sft_config.split,
+        streaming=sft_config.stream_dataset,
+    )
+
+    message_builder = DATASET_MESSAGE_BUILDERS[dataset_name]
+    hf_ds = SFTDataset(
+        dataset=dataset,
+        message_builder=message_builder,
+        tokenizer=tokenizer,
+        seq_len=seq_len,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        infinite=infinite,
+        sft_config=sft_config,
+    )
+
+    return ParallelAwareDataloader(
+        dataset=hf_ds,
+        dp_rank=dp_rank,
+        dp_world_size=dp_world_size,
+        batch_size=batch_size,
+    )

--- a/torchtitan/experiments/sft/train_configs/llama3_8b_gsm8k.toml
+++ b/torchtitan/experiments/sft/train_configs/llama3_8b_gsm8k.toml
@@ -1,0 +1,81 @@
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 8B training"
+custom_config_module = "torchtitan.experiments.sft.job_config" # [for sft]
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 10
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "sft.llama3" # [for sft]
+flavor = "8B_flex" # [for sft]
+hf_assets_path = "./assets/hf/Meta-Llama-3.1-8B-Instruct"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 3e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up
+
+[training]
+local_batch_size = 1
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "question_answer" # [for sft]
+dataset_path = "openai/gsm8k" # [for sft]
+
+
+[sft_config]
+eos_token = "<|end_of_text|>"
+pad_token = "<|i_am_pad|>"
+pad_token_id = 128014
+apply_chat_template = false
+dataset_subset = "main"
+stream_dataset = true
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 1
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable = false
+folder = "checkpoint"
+interval = 500
+last_save_model_only = true
+export_dtype = "float32"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+[quantize.linear.float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enable = false
+dataset = "c4_validation"
+freq = 500
+steps = 1200 # Recommend value for c4_validation with world-size=8 and seq_len=8192

--- a/torchtitan/experiments/sft/train_configs/llama3_8b_multiturn.toml
+++ b/torchtitan/experiments/sft/train_configs/llama3_8b_multiturn.toml
@@ -1,0 +1,79 @@
+# NOTE: this toml config is a preset for 64 A100 GPUs.
+
+[job]
+dump_folder = "./outputs"
+description = "Llama 3 8B training"
+custom_config_module = "torchtitan.experiments.sft.job_config" # [for sft]
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 100
+
+[metrics]
+log_freq = 10
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "sft.llama3" # [for sft]
+flavor = "8B_flex" # [for sft]
+hf_assets_path = "./assets/hf/Meta-Llama-3.1-8B-Instruct"
+# converters = ["float8"]
+
+[optimizer]
+name = "AdamW"
+lr = 3e-4
+eps = 1e-8
+
+[lr_scheduler]
+warmup_steps = 200  # lr scheduler warm up
+
+[training]
+local_batch_size = 1
+seq_len = 8192
+max_norm = 1.0  # grad norm clipping
+steps = 1000
+dataset = "multi_turn" # [for sft]
+dataset_path = "allenai/Dolci-Think-SFT-7B" # [for sft]
+# dataset_path = "nvidia/Puzzle-KD-Nemotron-Post-Training-Dataset-v2" # [for sft]
+
+[sft_config]
+eos_token = "<|end_of_text|>"
+pad_token = "<|i_am_pad|>"
+pad_token_id = 128014
+apply_chat_template = true
+
+[parallelism]
+data_parallel_replicate_degree = 1
+data_parallel_shard_degree = -1
+tensor_parallel_degree = 1
+pipeline_parallel_degree = 1
+context_parallel_degree = 1
+
+[checkpoint]
+enable = false
+folder = "checkpoint"
+interval = 500
+last_save_model_only = true
+export_dtype = "float32"
+async_mode = "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+[compile]
+enable=false
+components = ["model", "loss"]
+
+[activation_checkpoint]
+mode = "selective"  # ["none", "selective", "full"]
+selective_ac_option = "op"  # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+[quantize.linear.float8]
+enable_fsdp_float8_all_gather = false
+precompute_float8_dynamic_scale_for_fsdp = false
+filter_fqns = ["output"]
+
+[validation]
+enable = false
+dataset = "c4_validation"
+freq = 500
+steps = 1200 # Recommend value for c4_validation with world-size=8 and seq_len=8192

--- a/torchtitan/experiments/vlm/infra/loss.py
+++ b/torchtitan/experiments/vlm/infra/loss.py
@@ -13,12 +13,10 @@ from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
 from torchtitan.components.ft.manager import FTManager
+from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config.job_config import JobConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.tools.logging import logger
-
-
-IGNORE_INDEX = -100  # Pytorch's default for F.cross_entropy
 
 
 # WARNING: currently this does not take into account gradient accumulation

--- a/torchtitan/experiments/vlm/model/siglip2.py
+++ b/torchtitan/experiments/vlm/model/siglip2.py
@@ -213,7 +213,6 @@ class VisionTransformer(nn.Module):
         tokenizer: BaseTokenizer,
         extra_inputs: dict[str, torch.Tensor] | None = None,
     ) -> AttentionMasksType:
-
         # TODO: this is duplicated in the main model forward.
         # TODO: is this really required? Can we call this `get_attention_masks`
         # inside the main model forward? At that time PP should already split the

--- a/torchtitan/models/deepseek_v3/model/model.py
+++ b/torchtitan/models/deepseek_v3/model/model.py
@@ -345,7 +345,6 @@ class TransformerBlock(nn.Module):
     """
 
     def __init__(self, layer_id: int, model_args: DeepSeekV3ModelArgs):
-
         super().__init__()
         self.attention = Attention(model_args)
         self.attention_norm = nn.RMSNorm(model_args.dim, eps=model_args.norm_eps)

--- a/torchtitan/models/gpt_oss/model/model.py
+++ b/torchtitan/models/gpt_oss/model/model.py
@@ -216,7 +216,6 @@ class TransformerBlock(nn.Module):
     """
 
     def __init__(self, layer_id: int, model_args: GptOssModelArgs):
-
         super().__init__()
         self.use_sliding_attention = layer_id % 2 == 0
         self.attention = Attention(model_args)
@@ -334,7 +333,6 @@ class GptOssModel(nn.Module, ModelProtocol):
         tokenizer: BaseTokenizer,
         extra_inputs: dict[str, torch.Tensor] | None = None,
     ) -> AttentionMasksType:
-
         basic_mask_mods = []
         sliding_window_mask_mods = [
             get_sliding_window_mask_mod(self.model_args.sliding_window_size)


### PR DESCRIPTION
### TL;DR
Adds SFT training to Torchtitan plus a small `greedy_packing` addition. 

## **Most of code borrowed from  [Verl](https://github.com/volcengine/verl/blob/main/verl/utils/dataset/multiturn_sft_dataset.py) and [OpenRLHF](https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/datasets/sft_dataset.py#L35)**

### Changes
- Added SFT dataset config to job config
- Updated attention + modifying `get_attention_masks` to support SFT masks (only landed on Llama3 now)
- Temporarily use `HFTokenizer`,  need to fix this later
- Added SFT dataset/dataloader that returns `input_ids`, `labels` (user tokens masked), `attention_masks`, `position_ids`

###  TODO
- Need to verify PP / CP
- Val dataset not working yet (may depend on https://github.com/pytorch/torchtitan/pull/2142)

### Run
```bash
CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" NGPU=4 ./run_train.sh \
  --training.running_sft_training \
  --model.flavor=debugmodel_varlen_attn \
  --training.dataset_path=openai/gsm8k \
  --sft_data_config.dataset_subset=main
  ```
  
<img width="2382" height="322" alt="image" src="https://github.com/user-attachments/assets/a2e94c12-4358-48eb-a11e-14161f9f52c2" />


## more test
```
CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" NGPU=4 ./run_train.sh \
 --training.running_sft_training \ --model.flavor=8B_varlen \ --training.dataset_path=openai/gsm8k \
 --sft_data_config.dataset_subset=main \
 --model.hf_assets_path="$Home/Meta-Llama-3.1-8B-Instruct/" \
 --training.local_batch_size=8 \ --activation_checkpoint.mode=full \
 --training.seq_len=2048 \ --training.steps=100 \
 --lr_scheduler.warmup_steps=10 \  --debug.seed 10 \
 --sft_data_config.pad_mode=right_padding \
 --metrics.enable_wandb \
 ```
 (`torch                    2.10.0.dev20251124+cu129` and i am using cudnn attention )
<img width="2470" height="782" alt="image" src="https://github.com/user-attachments/assets/aae96d77-8c68-4fd1-a6af-9da5461046bb" />

<img width="5056" height="2656" alt="W B Chart 12_12_2025, 8_32_32 PM" src="https://github.com/user-attachments/assets/587688d0-1bce-43d7-a65c-e011935746f2" />

compile does not work for no-padding because the seq-len for each training step keeps changing. We could pad the buffer to `seqlen` when turning on `greedy_packing`. (its `packing_on++`) to make compile happy. 

<img width="2478" height="812" alt="image" src="https://github.com/user-attachments/assets/8bd1b716-3270-47a4-bb8c-fa196ed91bd1" />

