### PR TITLE
[Compiler Toolkit] Add option for full inductor.

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/README.md
+++ b/torchtitan/experiments/compiler_toolkit/README.md
@@ -61,3 +61,9 @@ NGPU=8 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train CONFIG_FILE=./to
 ```shell
 NCCL_GRAPH_REGISTER=0 NGPU=8 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config --compile.passes transformer_block_bucketing,regional_inductor,cudagraph
 ```
+
+**SimpleFSDP + TP + Full Inductor compilation**
+
+```shell
+NGPU=8 CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train ./run_train.sh --model.name $MODEL_NAME compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=4 --job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config --compile.joint_passes inductor_decomposition --compile.passes full_inductor_compilation
+```

--- a/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
@@ -82,7 +82,7 @@ def parallelize_deepseekv3(
     # Get compiler passes from config
     compiler_passes = get_compiler_passes_from_config(model, job_config)
 
-    # Create compilers with specified passes (defaults to no passes)
+    # Create compilers with specified passes
     fw_compiler, bw_compiler = make_compiler_with_passes(
         compiler_passes, dump_folder=job_config.job.dump_folder
     )
@@ -94,6 +94,7 @@ def parallelize_deepseekv3(
         bw_compiler=bw_compiler,
         joint_custom_passes=joint_custom_passes,
         dump_folder=job_config.job.dump_folder,
+        job_config=job_config,
     )
 
     # TODO: CompiledModule should take sample input as well, so that we can

--- a/torchtitan/experiments/compiler_toolkit/job_config.py
+++ b/torchtitan/experiments/compiler_toolkit/job_config.py
@@ -10,11 +10,22 @@ from dataclasses import dataclass, field
 @dataclass
 class Compile:
     """
-    List of compiler pass names to apply in the compiler toolkit workflow.
-    By default, no passes are applied.
-    Example: --compile.passes autobucketing_reordering,regional_inductor
+    Compiler configuration for the compiler toolkit workflow.
+
+    - joint_passes: List of joint graph pass names to apply on the joint forward-backward
+      graph before partitioning.
+
+      Example: --compile.joint_passes inductor_decomposition
+
+    - passes: List of compiler pass names to apply to the partitioned forward/backward graphs.
+
+      Example: --compile.passes full_inductor_compilation
+
+      Note: If "full_inductor_compilation" is specified, "inductor_decomposition" must
+      be included in joint_passes.
     """
 
+    joint_passes: list[str] = field(default_factory=list)
     passes: list[str] = field(default_factory=list)
 
 

--- a/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
@@ -69,7 +69,7 @@ def parallelize_llama(
     # Get compiler passes from config
     compiler_passes = get_compiler_passes_from_config(model, job_config)
 
-    # Create compilers with specified passes (defaults to no passes)
+    # Create compilers with specified passes
     fw_compiler, bw_compiler = make_compiler_with_passes(
         compiler_passes, dump_folder=job_config.job.dump_folder
     )
@@ -81,6 +81,7 @@ def parallelize_llama(
         bw_compiler=bw_compiler,
         joint_custom_passes=joint_custom_passes,
         dump_folder=job_config.job.dump_folder,
+        job_config=job_config,
     )
 
     # TODO: CompiledModule should take sample input as well, so that we can

--- a/torchtitan/experiments/compiler_toolkit/tests/integration_tests.py
+++ b/torchtitan/experiments/compiler_toolkit/tests/integration_tests.py
@@ -122,7 +122,21 @@ def build_compiler_toolkit_test_list() -> list[OverrideDefinitions]:
                     "--model.name compiler_toolkit.llama3",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
-                    "--model.flavor debugmodel_flex_attn",
+                    "--job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config",
+                    "--compile.joint_passes inductor_decomposition",
+                    "--compile.passes full_inductor_compilation",
+                ],
+            ],
+            "llama3 full_inductor_compilation",
+            "llama3_full_inductor_compilation",
+            ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--model.name compiler_toolkit.llama3",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
                     "--job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config",
                     "--compile.passes transformer_block_bucketing,regional_inductor",
                 ],


### PR DESCRIPTION
Being able to compile fw/bw graphs using compile_fx_inner could help with establishing perf rooflines.

Full inductor compilation is achieved using `compile_fx_inner`, however, it requires the graph to have been decomposed using Inductor's default decomposition table. We apply this decomposition as a pass on the joint graph. We need to be careful to suitably unwrap the primals/tangents before running this decomposition. 

Manual testing:
NGPU=4 \
CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml \
TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train \
./run_train.sh \
--model.name $MODEL_NAME \
--parallelism.data_parallel_shard_degree=2 \
--parallelism.tensor_parallel_degree=2 \
--job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config \
--compile.joint_passes inductor_decomposition \
--compile.passes full_inductor_compilation

<!-- ps-id: 5d590700-6d1f-44fe-8f70-4d2ea39106f4 -->