### PR TITLE
Add local built pytorch path for pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,4 @@ testpaths = ["tests"]
 [tool.pyrefly]
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
 ignore-missing-imports = ["torchao.*", "torchft"]  # optional dependencies
+search-path = ["../pytorch"]  # local built pytorch

--- a/torchtitan/models/moe/moe.py
+++ b/torchtitan/models/moe/moe.py
@@ -245,7 +245,7 @@ class TokenChoiceTopKRouter(nn.Module):
     def _get_node_limited_routing_scores(
         self,
         scores_for_choice: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Select num_limited_groups groups based on group scores,
             and set expert scores in non-selected groups as -inf
 
@@ -259,6 +259,7 @@ class TokenChoiceTopKRouter(nn.Module):
             raise ValueError(
                 "num_limited_groups must be set when num_expert_groups is set"
             )
+        assert self.num_expert_groups is not None
         if self.num_experts % self.num_expert_groups != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by num_expert_groups ({self.num_expert_groups})"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #2156
* __->__ #2155

This assumes that the local built version has the same parent folder as torchtitan.

Also fixes some pyrefly errors for moe.py