### PR TITLE
[do not land] trying invoke_subgraph on torchtitan

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/graph_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/graph_utils.py
@@ -56,6 +56,9 @@ def export_joint(
                 print_output=False, include_stride=True, include_device=True
             )
         )
+        # TODO: get item node on invoke_subgraph not properly DCE'd need to fix this properly
+        gm.graph.eliminate_dead_code()
+        gm.recompile()
         _dump_gm(dump_folder, gm, "dynamo_gm")
 
         tracing_context = gm.meta["tracing_context"]

--- a/torchtitan/experiments/compiler_toolkit/passes.py
+++ b/torchtitan/experiments/compiler_toolkit/passes.py
@@ -17,6 +17,7 @@ import torch
 from torch._inductor.fx_passes.overlap_manual_scheduling import manual_overlap_bucketing
 from torch._inductor.fx_passes.overlap_scheduling import schedule_overlap_bucketing
 from torch.fx.passes.regional_inductor import regional_inductor
+from torch.fx.passes.regional_inductor_invoke_subgraph import regional_inductor_invoke_subgraph
 from torchtitan.experiments.compiler_toolkit.cudagraph import (
     CUDAGraphWrapper,
     get_static_input_indices,
@@ -61,6 +62,13 @@ def regional_inductor_pass(
     """
     return regional_inductor(gm, example_inputs)
 
+def regional_inductor_invoke_subgraph_pass(
+    gm, example_inputs
+) -> torch.fx.GraphModule:
+    """
+    Apply regional inductor compilation based on invoke_subgraph configs
+    """
+    return regional_inductor_invoke_subgraph(gm, example_inputs)
 
 def cudagraph_pass(
     gm: torch.fx.GraphModule, example_inputs: Sequence[Any], is_forward: bool
@@ -112,4 +120,6 @@ AVAILABLE_COMPILER_PASSES = {
     "transformer_block_bucketing": transformer_block_bucketing_reordering_pass,
     "regional_inductor": regional_inductor_pass,
     "cudagraph": cudagraph_pass,
+    "regional_inductor_invoke_subgraph": regional_inductor_invoke_subgraph,
+
 }


### PR DESCRIPTION
```
 NCCL_GRAPH_REGISTER=0  NGPU=4 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 \
--parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 \
--model.flavor=debugmodel_flex_attn \
--job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config \
--compile.passes autobucketing_reordering,regional_inductor_invoke_subgraph,cudagraph
 
 [rank0]:[titan] 2025-12-19 16:23:29,336 - root - INFO - step:  1  loss:  8.1054  grad_norm:  1.3749  memory:  0.79GiB(0.83%)  tps: 319  tflops: 0.02  mfu: 0.00%
[rank0]:[titan] 2025-12-19 16:23:29,336 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:/data/users/shangdiy/torchtitan/torchtitan/distributed/utils.py:396: UserWarning: Set timeout is now only supported for either nccl or gloo.
[rank0]:  torch.distributed.distributed_c10d._set_pg_timeout(timeout, group)
[rank0]:[titan] 2025-12-19 16:23:29,841 - root - INFO - step:  2  loss:  7.8149  grad_norm:  1.4469  memory:  0.79GiB(0.83%)  tps: 16,246  tflops: 1.16  mfu: 0.12%
[rank0]:[titan] 2025-12-19 16:23:29,898 - root - INFO - step:  3  loss:  7.0895  grad_norm:  1.8651  memory:  0.87GiB(0.91%)  tps: 144,565  tflops: 10.35  mfu: 1.05%
[rank0]:[titan] 2025-12-19 16:23:29,959 - root - INFO - step:  4  loss:  6.2660  grad_norm:  2.2963  memory:  0.87GiB(0.91%)  tps: 135,517  tflops: 9.70  mfu: 0.98%
[rank0]:[titan] 2025-12-19 16:23:30,022 - root - INFO - step:  5  loss:  5.3179  grad_norm:  2.4595  memory:  0.87GiB(0.91%)  tps: 129,957  tflops: 9.30  mfu: 0.94%
[rank0]:[titan] 2025-12-19 16:23:30,088 - root - INFO - step:  6  loss:  4.7919  grad_norm:  2.1717  memory:  0.87GiB(0.91%)  tps: 125,330  tflops: 8.97  mfu: 0.91%
[rank0]:[titan] 2025-12-19 16:23:30,150 - root - INFO - step:  7  loss:  4.5015  grad_norm:  2.0600  memory:  0.87GiB(0.91%)  tps: 132,604  tflops: 9.49  mfu: 0.96%
[rank0]:[titan] 2025-12-19 16:23:30,211 - root - INFO - step:  8  loss:  4.3082  grad_norm:  1.9720  memory:  0.87GiB(0.91%)  tps: 133,375  tflops: 9.55  mfu: 0.97%
[rank0]:[titan] 2025-12-19 16:23:30,272 - root - INFO - step:  9  loss:  4.4945  grad_norm:  1.7208  memory:  0.87GiB(0.91%)  tps: 134,776  tflops: 9.65  mfu: 0.98%
[rank0]:[titan] 2025-12-19 16:23:30,335 - root - INFO - step: 10  loss:  4.1239  grad_norm:  1.7451  memory:  0.87GiB(0.91%)  tps: 131,096  tflops: 9.38  mfu: 0.95%
[rank0]:[titan] 2025-12-19 16:23:30,335 - root - INFO - Sleeping 2 seconds for other ranks to complete
[rank0]:[titan] 2025-12-19 16:23:32,336 - root - INFO - Training completed
[rank0]:[titan] 2025-12-19 16:23:34,573 - root - INFO - Process group destroyed
 ```