### PR TITLE
compiler_toolkit: inputs are not DTensor if TP is not enabled

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/common_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/common_utils.py
@@ -27,7 +27,7 @@ def disable_compile(job_config: JobConfig):
 
 def parallelize_inputs(parallel_dims, args, kwargs):
     def to_dtensor(tensor):
-        if isinstance(tensor, torch.Tensor):
+        if isinstance(tensor, torch.Tensor) and parallel_dims.tp_enabled:
             return DTensor.from_local(
                 tensor, parallel_dims.get_mesh("tp"), [Replicate()]
             )


### PR DESCRIPTION
Run the following command:
```
NGPU=4 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train CONFIG_FILE=./torchtitan/models/llama3/train_configs/debug_model.toml ./run_train.sh --model.name compiler_toolkit.llama3 --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=2 --job.custom_config_module=torchtitan.experiments.compiler_toolkit.job_config --compile.passes transformer_block_bucketing
```

Errors:
```
 traceback : Traceback (most recent call last):
    File "/usr/local/lib/python3.11/dist-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 362, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/train.py", line 669, in train
      self.train_step(data_iterator)
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/train.py", line 568, in train_step
      loss = self.forward_backward_step(input_dict, labels)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/train.py", line 543, in forward_backward_step
      pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py", line 1780, in _wrapped_call_impl
      return self._call_impl(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py", line 1791, in _call_impl
      return forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/experiments/compiler_toolkit/graph_utils.py", line 197, in forward
      dt_args, dt_kwargs = self.parallelize_inputs(self.parallel_dims, args, kwargs)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/experiments/compiler_toolkit/common_utils.py", line 36, in parallelize_inputs
      dt_args = tree_map(to_dtensor, args)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/dist-packages/torch/utils/_pytree.py", line 1539, in tree_map
      return treespec.unflatten(map(func, *flat_args))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/dist-packages/torch/utils/_pytree.py", line 1280, in unflatten
      leaves = list(leaves)
               ^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/experiments/compiler_toolkit/common_utils.py", line 32, in to_dtensor
      tensor, parallel_dims.get_mesh("tp"), [Replicate()]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/mlx_devbox/users/yanbo.liang/playground/torchtitan/torchtitan/distributed/parallel_dims.py", line 272, in get_mesh
      raise ValueError(
  ValueError: Mesh 'tp' is not available. Ensure the corresponding parallelism dimension is enabled (size > 1).
```

Because if TP is not enabled, the input are regular tensors. cc @SherlockNoMad @yiming0416 