### PR TITLE
Fix bug in Qwen3 MOE expert ordering

### DIFF
--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -287,8 +287,8 @@ class MoEStateDictAdapter(StateDictAdapter):
             return None
 
         print("Printing type of experts.keys():")
-        print(type(experts.keys()))
-        sorted_expert_ids = sorted(experts.keys(), key=int)
+        print(type(list(experts.keys())[0]))
+        sorted_expert_ids: list[int] = sorted(experts.keys(), key=int)
         print("Applied sorting fix")
         sorted_experts = [experts[i] for i in sorted_expert_ids]
         # pyrefly: ignore [missing-attribute]


### PR DESCRIPTION
When we sort the `experts.keys()` in order to stack the experts, we are currently sorting them lexicographically as they are strings. We need to pass `key=int` to `sorted()` to sort them as ints.

This causes a bug where the experts are stored in the wrong order when loading the model in TorchTitan.