### PR TITLE
add safety checks for varlen 

### DIFF
--- a/torchtitan/models/deepseek_v3/model/model.py
+++ b/torchtitan/models/deepseek_v3/model/model.py
@@ -237,9 +237,13 @@ class Attention(nn.Module):
         match self.attn_type:
             case "flex":
                 self.inner_attention = FlexAttentionWrapper()
-            case _:
+            case "sdpa":
                 # pyrefly: ignore [bad-assignment]
                 self.inner_attention = ScaledDotProductAttentionWrapper()
+            case "varlen":
+                raise ValueError("Varlen attention is not supported with Deepseek V3.")
+            case _:
+                raise ValueError(f"Unknown attention type: {self.attn_type}")
 
     def forward(
         self,

--- a/torchtitan/models/llama3/model/model.py
+++ b/torchtitan/models/llama3/model/model.py
@@ -225,9 +225,11 @@ class Attention(nn.Module):
             case "varlen":
                 # pyrefly: ignore [bad-assignment]
                 self.inner_attention = VarlenAttentionWrapper()
-            case _:
+            case "sdpa":
                 # pyrefly: ignore [bad-assignment]
                 self.inner_attention = ScaledDotProductAttentionWrapper()
+            case _:
+                raise ValueError(f"Unknown attention type: {self.attn_type}")
 
     def init_weights(self, init_std: float):
         for linear in (self.wq, self.wk, self.wv):

--- a/torchtitan/models/llama4/model/model.py
+++ b/torchtitan/models/llama4/model/model.py
@@ -230,9 +230,13 @@ class Attention(nn.Module):
         match self.attn_type:
             case "flex":
                 self.inner_attention = FlexAttentionWrapper()
-            case _:
+            case "sdpa":
                 # pyrefly: ignore [bad-assignment]
                 self.inner_attention = ScaledDotProductAttentionWrapper()
+            case "varlen":
+                raise ValueError("Varlen attention is not supported with Llama 4.")
+            case _:
+                raise ValueError(f"Unknown attention type: {self.attn_type}")
 
     def init_weights(self, init_std: float):
         for linear in (self.wq, self.wk, self.wv):


### PR DESCRIPTION
since varlen attn is not supported for deepseek v3 and llama4, we should raise an error if someone attempts to use it