### PR TITLE
Add epoch-based training support

### DIFF
--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -41,6 +41,18 @@ class BaseDataLoader(Stateful, ABC):
     def __iter__(self):
         ...
 
+    def reset(self) -> None:
+        """Reset the dataloader state for a new epoch.
+
+        This method is called when epoch-based training transitions to a new epoch.
+        Subclasses should override this if they need to clear any internal state
+        that would prevent re-iteration from the beginning of the dataset.
+
+        The default implementation does nothing, as most dataloaders automatically
+        reset when __iter__ is called again.
+        """
+        pass
+
 
 # pyrefly: ignore [inconsistent-inheritance]
 class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -151,3 +151,13 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         # We don't have to use pickle as DCP will serialize the state_dict. However, we have to
         # keep this for backward compatibility.
         super().load_state_dict(pickle.loads(state_dict[self._rank_id]))
+
+    def reset(self) -> None:
+        """Reset the dataloader state for a new epoch.
+
+        Delegates to the underlying dataset's reset method if available,
+        allowing stateful datasets to clear their internal state and
+        restart iteration from the beginning.
+        """
+        if hasattr(self.dataset, "reset"):
+            self.dataset.reset()

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -257,7 +257,14 @@ class Training:
     """Max norm for gradient clipping"""
 
     steps: int = 10000
-    """How many train steps to run"""
+    """How many train steps to run (ignored if epochs > 0)"""
+
+    epochs: int = -1
+    """
+    Number of epochs to train for. If set to a positive value, training will run
+    for the specified number of epochs and the 'steps' setting will be ignored.
+    If set to -1 (default), training will use step-based termination via 'steps'.
+    """
 
     enable_cpu_offload: bool = False
     """

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -165,6 +165,15 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
 
         return _state_dict
 
+    def reset(self) -> None:
+        """Reset dataset state for a new epoch.
+
+        Clears the token buffer and resets the sample index to start
+        iteration from the beginning of the dataset.
+        """
+        self._sample_idx = 0
+        self._token_buffer = []
+
 
 def build_text_dataloader(
     dp_world_size: int,

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -68,6 +68,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
     # additional training states
     step: int
     ntokens_seen: int
+    epoch: int
 
     # Enable debug tracing on failure: https://pytorch.org/docs/stable/elastic/errors.html
     @record
@@ -298,6 +299,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         # These attributes must be initialized before checkpoint loading.
         self.step = 0
         self.ntokens_seen = 0
+        self.epoch = 0
 
         self.checkpointer = CheckpointManager(
             dataloader=self.dataloader,
@@ -357,13 +359,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 pp_has_last_stage=pp_has_last_stage,
             )
 
+        # Determine training termination mode for logging
+        epochs = job_config.training.epochs
+        if epochs > 0:
+            termination_info = f"total epochs {epochs}"
+        else:
+            termination_info = f"total steps {job_config.training.steps}"
+
         logger.info(
             "Trainer is initialized with "
             f"local batch size {job_config.training.local_batch_size}, "
             f"global batch size {global_batch_size}, "
             f"gradient accumulation steps {self.gradient_accumulation_steps}, "
             f"sequence length {job_config.training.seq_len}, "
-            f"total steps {job_config.training.steps} "
+            f"{termination_info} "
             f"(warmup {job_config.lr_scheduler.warmup_steps})"
         )
 
@@ -609,6 +618,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             "n_tokens_seen": global_ntokens_seen,
             "lr": lr,
         }
+        # Add epoch info for epoch-based training
+        if self.job_config.training.epochs > 0:
+            extra_metrics["epoch"] = self.epoch + 1  # 1-indexed for display
         self.metrics_processor.log(
             self.step,
             global_avg_loss,
@@ -622,7 +634,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         job_config = self.job_config
 
         self.checkpointer.load(step=job_config.checkpoint.load_step)
-        logger.info(f"Training starts at step {self.step + 1}")
+        if job_config.training.epochs > 0:
+            logger.info(
+                f"Training starts at step {self.step + 1}, epoch {self.epoch + 1}"
+            )
+        else:
+            logger.info(f"Training starts at step {self.step + 1}")
 
         leaf_folder = (
             ""
@@ -668,12 +685,39 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 try:
                     self.train_step(data_iterator)
                 except DataloaderExhaustedError:
-                    logger.warning("Ran out of data; last step was canceled.")
-                    break
+                    epochs = job_config.training.epochs
+                    if epochs > 0:
+                        # Epoch-based training: advance to next epoch
+                        self.epoch += 1
+                        if self.epoch < epochs:
+                            logger.info(
+                                f"Epoch {self.epoch} completed at step {self.step}. "
+                                f"Starting epoch {self.epoch + 1}/{epochs}."
+                            )
+                            self.dataloader.reset()
+                            data_iterator = self.batch_generator(self.dataloader)
+                            continue
+                        else:
+                            logger.info(
+                                f"All {epochs} epochs completed at step {self.step}."
+                            )
+                            # Save final checkpoint for epoch-based training
+                            self.checkpointer.save(self.step, last_step=True)
+                            break
+                    else:
+                        # Step-based training: data exhausted before reaching target steps
+                        logger.warning("Ran out of data; last step was canceled.")
+                        break
 
-                self.checkpointer.save(
-                    self.step, last_step=(self.step == job_config.training.steps)
-                )
+                # Determine if this is the last step for checkpointing purposes
+                epochs = job_config.training.epochs
+                if epochs > 0:
+                    # For epoch-based training, we don't know the last step upfront
+                    # It will be determined when training completes
+                    is_last_step = False
+                else:
+                    is_last_step = self.step == job_config.training.steps
+                self.checkpointer.save(self.step, last_step=is_last_step)
 
                 # Run validation if validator is available
                 if (
@@ -708,14 +752,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         logger.info("Training completed")
 
     def should_continue_training(self) -> bool:
-        return self.step < self.job_config.training.steps
+        epochs = self.job_config.training.epochs
+        if epochs > 0:
+            # Epoch-based training: continue until we've completed all epochs
+            return self.epoch < epochs
+        else:
+            # Step-based training (default)
+            return self.step < self.job_config.training.steps
 
     def state_dict(self) -> dict[str, Any]:
-        return {"step": self.step, "ntokens_seen": self.ntokens_seen}
+        return {"step": self.step, "ntokens_seen": self.ntokens_seen, "epoch": self.epoch}
 
     def load_state_dict(self, state_dict: dict[str, Any]):
         self.step = state_dict["step"]
         self.ntokens_seen = state_dict["ntokens_seen"]
+        self.epoch = state_dict.get("epoch", 0)  # Backward compatible
 
     def close(self) -> None:
         if hasattr(self, "checkpointer") and self.checkpointer:


### PR DESCRIPTION
## Summary
This PR adds the ability to train models for a specified number of epochs rather than a fixed number of steps, addressing issue #613.

**Key changes:**
- Add `epochs` config option to `Training` dataclass (default `-1` for step-based training)
- Add `epoch` tracking state to `Trainer` class with checkpoint support
- Modify training loop to handle epoch transitions via `DataloaderExhaustedError`
- Add `BaseDataLoader.reset()` method for epoch transitions
- Update logging to show epoch progress when epoch-based training is enabled
- Update checkpointing to properly handle final epoch completion

## Usage
To enable epoch-based training, set `training.epochs` to a positive integer in your config:
```toml
[training]
epochs = 3  # Train for 3 epochs (ignores 'steps' setting)
```

When `epochs` is set to `-1` (default), the existing step-based training behavior is preserved.

## Test plan
- [ ] Verify syntax check passes (done locally)
- [ ] Run existing unit tests
- [ ] Test epoch-based training with a small dataset
- [ ] Verify checkpoint save/load with epoch state
- [ ] Verify backward compatibility with existing step-based configs

Fixes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)