### PR TITLE
auto-chunk unembed & loss

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -26,7 +26,11 @@ def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
 def build_cross_entropy_loss(job_config: JobConfig, **kwargs):
     del kwargs  # delete any unused arguments
     loss_fn = cross_entropy_loss
-    if job_config.compile.enable and "loss" in job_config.compile.components:
+    if (
+        job_config.compile.enable
+        and "loss" in job_config.compile.components
+        and "unembed_and_loss" not in job_config.compile.components
+    ):
         logger.info("Compiling the loss function with torch.compile")
         loss_fn = torch.compile(loss_fn, backend=job_config.compile.backend)
     return loss_fn

--- a/torchtitan/models/qwen3/model/model.py
+++ b/torchtitan/models/qwen3/model/model.py
@@ -560,6 +560,7 @@ class Qwen3Model(nn.Module, ModelProtocol):
         tokens: torch.Tensor,
         attention_masks: AttentionMasksType | None = None,
         positions: torch.Tensor | None = None,
+        unembed: bool = True,
     ):
         """
         Perform a forward pass through the Transformer model.
@@ -586,5 +587,5 @@ class Qwen3Model(nn.Module, ModelProtocol):
         # pyrefly: ignore [not-callable]
         h = self.norm(h) if self.norm else h
         # pyrefly: ignore [not-callable]
-        output = self.output(h) if self.output else h
+        output = self.output(h) if self.output and unembed else h
         return output


### PR DESCRIPTION
Add the ability to compile the loss together with the unembed linear layer. The benefit is that we would be able to chunk the logits (which is usually quite large due to large vocab size) by the compiler and reduce peak memory usage.

Here are testing results on qwen3 1.7B. With batch-size=16, the baseline uses 115.85GiB peak memory and gets 54_450 tps. 
By applying the autochunker, we uses 84.15GiB peak memory with 54_244 tps. This is ***37.7%*** peak memory saving trading with ***0.38%*** perf loss. For larger model, the percentage of saving can be smaller since memory usage per layer and activations/optimizer state becomes larger. But saving peak memory usage by auto-chunking is still very nice if perf trade off is very small.

Command for baseline: ```NGPU=1 CONFIG_FILE=torchtitan/models/qwen3/train_configs/qwen3_1.7b.toml ./run_train.sh --compile.enable --training.local_batch_size=16 ```
Command enabling autochunking: ```NGPU=1 CONFIG_FILE=torchtitan/models/qwen3/train_configs/qwen3_1.7b.toml ./run_train.sh --compile.enable --training.local_batch_size=16 --compile.components=model,unembed_and_loss ```


To enable a model for auto-chunking, one tiny change is needed. The forward method need to have an 'unembed' boolean arguments. If it's false, the forward method should not do the unembed linear compuation so we can do that together with the loss compulation

cc @jansel , @eellison , @v0i0 