### PR TITLE
Disable dynamo LRU cache when AC is enabled 

### DIFF
--- a/torchtitan/models/llama4/infra/parallelize.py
+++ b/torchtitan/models/llama4/infra/parallelize.py
@@ -592,9 +592,6 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig, ep_enabled: b
     # NOTE: This flag is needed for torch.compile to avoid graph breaking on dynamic shapes in token-choice MoE
     # but it is experimental.
     torch._dynamo.config.capture_scalar_outputs = True
-    # Workaround for https://github.com/pytorch/pytorch/issues/166926
-    # pyrefly: ignore [missing-attribute]
-    torch._C._dynamo.eval_frame._set_lru_cache(False)
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
         if transformer_block.moe_enabled:


### PR DESCRIPTION
Previously this config is flipped whenever compile is enabled. This PR updates it so that the config is flipped whenever AC is applied, so that the only flex compiled case is also covered. 

Code comment:
```
# Disable dynamo LRU cache to workaround an interaction between SAC, PP, and Flex:
#
# When forward runs with a second PP microbatch, it triggers recompilation with dynamic
# shapes enabled. Now there are two valid compiled graphs. By default, dynamo selects
# the latest one (the dynamic shapes version), so the runtime wrapper expects an extra
# symint output. When SAC caches the inductor HOP output from the static graph for
# batch_idx=0, it would miss that symint and cause an assertion failure. The workaround
# here is to disable the LRU cache, and select graphs in insertion order instead.
#
# Also see: https://github.com/pytorch/pytorch/issues/166926
```