### PR TITLE
feat(moe): add topk_before_score routing and use_router_bias support

### DIFF
--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -35,13 +35,14 @@ gptoss_configs = {
             num_experts=8,
             num_shared_experts=0,
             score_func="softmax",
-            route_norm=False,
+            route_norm=True,  # Normalize over selected experts (match production configs)
             route_scale=1.0,
             score_before_experts=False,
             top_k=4,
             use_grouped_mm=True,
             load_balance_coeff=1e-3,
         ),
+        use_router_bias=True,  # GPT-OSS models have learned router gate bias
         attn_mask_type="causal",
     ),
     "20b": GptOssModelArgs(
@@ -50,17 +51,15 @@ gptoss_configs = {
             num_experts=32,
             num_shared_experts=0,
             score_func="softmax",
-            route_norm=False,
+            route_norm=True,  # Normalize over selected experts (equivalent to softmax over top-k)
             route_scale=1.0,
             score_before_experts=False,
             top_k=4,
             use_grouped_mm=True,
             load_balance_coeff=None,  # Disabled for fine-tuning - not part of official GPT-OSS model
-            use_router_bias=True,  # GPT-OSS models have learned router bias
-            use_expert_bias=True,  # GPT-OSS models have learned expert biases
-            topk_before_score=True,  # GPT-OSS uses TopK-then-Score routing
         ),
-        attn_mask_type="causal",  # Preserve sample boundaries using EOS token
+        use_router_bias=True,  # GPT-OSS models have learned router gate bias
+        attn_mask_type="causal",
     ),
     "120b": GptOssModelArgs(
         n_layers=36,
@@ -68,17 +67,15 @@ gptoss_configs = {
             num_experts=128,
             num_shared_experts=0,
             score_func="softmax",
-            route_norm=False,
+            route_norm=True,  # Normalize over selected experts (equivalent to softmax over top-k)
             route_scale=1.0,
             score_before_experts=False,
             top_k=8,  # 120B uses top-8 routing (vs top-4 for 20B)
             use_grouped_mm=True,
             load_balance_coeff=None,  # Disabled for fine-tuning - not part of official GPT-OSS model
-            use_router_bias=True,  # GPT-OSS models have learned router bias
-            use_expert_bias=True,  # GPT-OSS models have learned expert biases
-            topk_before_score=True,  # GPT-OSS uses TopK-then-Score routing
         ),
-        attn_mask_type="causal",  # Preserve sample boundaries using EOS token
+        use_router_bias=True,  # GPT-OSS models have learned router gate bias
+        attn_mask_type="causal",
     ),
 }
 

--- a/torchtitan/models/gpt_oss/model/args.py
+++ b/torchtitan/models/gpt_oss/model/args.py
@@ -58,6 +58,7 @@ class GptOssModelArgs(BaseModelArgs):
     # MoE
     moe_args: MoEArgs = field(default_factory=MoEArgs)
     swiglu_limit: float = 7.0
+    use_router_bias: bool = False  # GPT-OSS models have learned router gate bias
     # Multi-Head Latent Attention (MLA)
     head_dim: int = 64
     n_heads: int = 64

--- a/torchtitan/models/gpt_oss/model/moe.py
+++ b/torchtitan/models/gpt_oss/model/moe.py
@@ -5,15 +5,63 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Callable
+from typing import Callable, Literal
 
 import torch
 from torch import nn
 from torch.distributed.tensor import DTensor
-from torchtitan.models.moe.moe import MoE
+from torchtitan.models.moe.moe import MoE, TokenChoiceTopKRouter
 from torchtitan.models.moe.utils import _permute, _unpermute
 
 from .args import GptOssModelArgs
+
+
+class GptOssTokenChoiceTopKRouter(TokenChoiceTopKRouter):
+    """GPT-OSS router that supports learned router gate bias.
+
+    GPT-OSS models use a router with a learned bias term. This class extends
+    the base TokenChoiceTopKRouter to support bias in the gate linear layer.
+
+    Note: Since softmax is a monotonically increasing function, the topk selection
+    is the same whether applied before or after softmax. Therefore, we use the
+    standard Score-then-TopK approach with route_norm=True to normalize over
+    the selected experts (equivalent to softmax over just top-k).
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_experts: int,
+        num_expert_groups: int | None,
+        num_limited_groups: int | None,
+        top_k: int,
+        score_func: Literal["softmax", "sigmoid"],
+        route_norm: bool,
+        route_scale: float,
+        use_router_bias: bool = True,
+        _debug_force_load_balance: bool = False,
+    ):
+        super().__init__(
+            dim=dim,
+            num_experts=num_experts,
+            num_expert_groups=num_expert_groups,
+            num_limited_groups=num_limited_groups,
+            top_k=top_k,
+            score_func=score_func,
+            route_norm=route_norm,
+            route_scale=route_scale,
+            _debug_force_load_balance=_debug_force_load_balance,
+        )
+        # Override the gate with bias support for GPT-OSS.
+        # Note: The parent class creates gate with bias=False, and we recreate it here with bias.
+        # This introduces an implicit ordering dependency - if the parent class changes to do
+        # something with self.gate after creation, this override could cause subtle issues.
+        self.gate = nn.Linear(dim, num_experts, bias=use_router_bias)
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.gate.weight, mean=0.0, std=init_std)
+        if self.gate.bias is not None:
+            nn.init.zeros_(self.gate.bias)
 
 
 class ScaleBiasForward(torch.autograd.Function):
@@ -268,7 +316,13 @@ class GptOssGroupedExperts(nn.Module):
 
 
 class GptOssMoE(MoE):
-    """GptOss MoE implementation that inherits from the base MoE class."""
+    """GptOss MoE implementation that inherits from the base MoE class.
+
+    GPT-OSS MoE supports:
+    - Custom SwiGLU activation with expert biases (mlp1_bias, mlp2_bias)
+    - Optional learned router gate bias (use_router_bias)
+    - route_norm=True for normalizing over selected experts (equivalent to softmax over top-k)
+    """
 
     def __init__(self, model_args: GptOssModelArgs, dim: int, hidden_dim: int):
         # Convert GptOssModelArgs to MoEArgs for base class compatibility
@@ -286,3 +340,19 @@ class GptOssMoE(MoE):
             swiglu_limit=model_args.swiglu_limit,
             use_grouped_mm=moe_args.use_grouped_mm,
         )
+
+        # Override router with GPT-OSS router that supports learned gate bias
+        if model_args.use_router_bias:
+            # pyrefly: ignore [bad-assignment]
+            self.router = GptOssTokenChoiceTopKRouter(
+                dim=dim,
+                num_experts=moe_args.num_experts,
+                num_expert_groups=moe_args.num_expert_groups,
+                num_limited_groups=moe_args.num_limited_groups,
+                top_k=moe_args.top_k,
+                score_func=moe_args.score_func,
+                route_norm=moe_args.route_norm,
+                route_scale=moe_args.route_scale,
+                use_router_bias=True,
+                _debug_force_load_balance=moe_args._debug_force_load_balance,
+            )

--- a/torchtitan/models/moe/moe.py
+++ b/torchtitan/models/moe/moe.py
@@ -26,13 +26,6 @@ class MoEArgs:
     route_norm: bool = False
     route_scale: float = 1.0
     score_before_experts: bool = True
-    use_router_bias: bool = False  # Set to True for GPT-OSS
-    # TopK-then-Score (True) vs Score-then-TopK (False):
-    #   True: Select top-K by raw logits, then apply score_func (GPT-OSS style)
-    #   False: Apply score_func to all experts, then select top-K (DeepSeek-V3 style)
-    # Default is False to preserve backward compatibility with DeepSeek/Llama4 models
-    topk_before_score: bool = False
-    use_expert_bias: bool = False  # Set to True for GPT-OSS (enables mlp1_bias, mlp2_bias in GptOssGroupedExperts)
 
     # token-choice with optional node limited routing
     top_k: int = 1
@@ -220,19 +213,16 @@ class TokenChoiceTopKRouter(nn.Module):
         score_func: Literal["softmax", "sigmoid"],
         route_norm: bool,
         route_scale: float,
-        use_router_bias: bool = False,
-        topk_before_score: bool = False,
         _debug_force_load_balance: bool = False,
     ):
         super().__init__()
-        self.gate = nn.Linear(dim, num_experts, bias=use_router_bias)
+        self.gate = nn.Linear(dim, num_experts, bias=False)
         self.num_experts = num_experts
         self.num_expert_groups = num_expert_groups
         self.num_limited_groups = num_limited_groups
         self.top_k = top_k
         self.score_func = score_func
         self.route_norm = route_norm
-        self.topk_before_score = topk_before_score
         self.route_scale = route_scale
         self._debug_force_load_balance = _debug_force_load_balance
 
@@ -313,91 +303,54 @@ class TokenChoiceTopKRouter(nn.Module):
                 - num_tokens_per_expert (torch.Tensor):
                     Number of tokens assigned to each expert with shape ``(num_experts,)``.
         """
-        # Get raw router logits shape (bs*slen, num_experts)
-        router_logits = self.gate(x)
+        # scores shape (bs*slen, num_experts)
+        scores = self.gate(x)
 
-        if self.topk_before_score:
-            # TopK-then-Score: Select top-K by raw logits, then apply score_func (GPT-OSS style)
-            # This matches HuggingFace GPT-OSS implementation
-            # Note: Node-limited routing is not supported with TopK-then-Score
-            if self.num_expert_groups is not None:
-                raise ValueError(
-                    "topk_before_score=True does not support node-limited routing. "
-                    "Set num_expert_groups=None or use topk_before_score=False."
-                )
-
-            # Handle debug mode for forced load balancing
-            if self._debug_force_load_balance:
-                if self.score_func == "sigmoid":
-                    all_scores = torch.sigmoid(router_logits.to(torch.float32))
-                elif self.score_func == "softmax":
-                    all_scores = F.softmax(router_logits.to(torch.float32), dim=1)
-                else:
-                    raise NotImplementedError(f"Unknown score function {self.score_func}")
-                selected_experts_indices, top_scores = self._debug_force_load_balance_routing(all_scores)
-            else:
-                # Select top-K experts by logits (optionally biased for load balancing)
-                if expert_bias is not None:
-                    _, selected_experts_indices = torch.topk(
-                        router_logits + expert_bias, k=self.top_k, dim=1
-                    )
-                    # Gather UNBIASED logits for score computation (bias only affects routing)
-                    router_top_logits = router_logits.gather(dim=1, index=selected_experts_indices)
-                else:
-                    router_top_logits, selected_experts_indices = torch.topk(
-                        router_logits, k=self.top_k, dim=1
-                    )
-
-                # Apply score function to ONLY the selected top-K expert logits
-                if self.score_func == "sigmoid":
-                    top_scores = torch.sigmoid(router_top_logits.to(torch.float32))
-                elif self.score_func == "softmax":
-                    top_scores = F.softmax(router_top_logits.to(torch.float32), dim=1)
-                else:
-                    raise NotImplementedError(f"Unknown score function {self.score_func}")
+        # By default, sigmoid or softmax is performed in float32 to avoid loss explosion
+        if self.score_func == "sigmoid":
+            scores = torch.sigmoid(scores.to(torch.float32))
+        elif self.score_func == "softmax":
+            scores = F.softmax(scores.to(torch.float32), dim=1)
         else:
-            # Score-then-TopK: Apply score_func to all experts, then select top-K (DeepSeek-V3 style)
-            # This supports node-limited routing
-            if self.score_func == "sigmoid":
-                scores = torch.sigmoid(router_logits.to(torch.float32))
-            elif self.score_func == "softmax":
-                scores = F.softmax(router_logits.to(torch.float32), dim=1)
-            else:
-                raise NotImplementedError(f"Unknown score function {self.score_func}")
+            raise NotImplementedError(f"Unknown score function {self.score_func}")
 
-            # Handle debug mode for forced load balancing
-            if self._debug_force_load_balance:
-                selected_experts_indices, top_scores = self._debug_force_load_balance_routing(scores)
-            else:
-                scores_for_choice = scores if expert_bias is None else scores + expert_bias
+        scores_for_choice = scores if expert_bias is None else scores + expert_bias
+        # Apply node-limited routing if configured
+        if self.num_expert_groups is not None:
+            scores_for_choice = self._get_node_limited_routing_scores(scores_for_choice)
+        _, selected_experts_indices = torch.topk(
+            scores_for_choice, k=self.top_k, dim=-1, sorted=False
+        )
 
-                # Apply node-limited routing if configured
-                if self.num_expert_groups is not None:
-                    scores_for_choice = self._get_node_limited_routing_scores(scores_for_choice)
+        # top scores shape (bs*slen, top_k)
+        # NOTE: The expert_bias is only used for routing. The gating value
+        #       top_scores is still derived from the original scores.
+        top_scores = scores.gather(dim=1, index=selected_experts_indices)
 
-                _, selected_experts_indices = torch.topk(
-                    scores_for_choice, k=self.top_k, dim=-1, sorted=False
-                )
-                # Gather scores from original (non-biased) distribution
-                top_scores = scores.gather(dim=1, index=selected_experts_indices)
+        # debug override: balanced round-robin routing
+        if self._debug_force_load_balance:
+            (
+                selected_experts_indices,
+                top_scores,
+            ) = self._debug_force_load_balance_routing(scores)
 
         if self.route_norm:
             denominator = top_scores.sum(dim=-1, keepdim=True) + 1e-20
             top_scores = top_scores / denominator
         top_scores = top_scores * self.route_scale
 
-        # Count tokens per expert using bincount (more reliable than histc for integer indices)
-        num_tokens_per_expert = torch.bincount(
+        # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
+        num_tokens_per_expert = torch.histc(
             selected_experts_indices.view(-1),
-            minlength=self.num_experts,
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
         )
 
         return top_scores, selected_experts_indices, num_tokens_per_expert
 
     def init_weights(self, init_std: float):
         nn.init.trunc_normal_(self.gate.weight, mean=0.0, std=init_std)
-        if self.gate.bias is not None:
-            nn.init.zeros_(self.gate.bias)
 
 
 # NOTE: the reason we make this a stateless module is to support
@@ -437,10 +390,12 @@ class TokenReorderer(nn.Module):
                 - token_indices_experts_sorted: Token indices reordered to match expert ordering
                 - num_tokens_per_expert: Number of tokens assigned to each expert
         """
-        # Count tokens per expert using bincount (more reliable than histc for integer indices)
-        num_tokens_per_expert = torch.bincount(
+        # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
+        num_tokens_per_expert = torch.histc(
             selected_experts_indices.view(-1),
-            minlength=self.num_experts,
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
         )
 
         # Reorder the token indices to match the order of the experts
@@ -478,8 +433,6 @@ class MoE(nn.Module):
             score_func=moe_args.score_func,
             route_norm=moe_args.route_norm,
             route_scale=moe_args.route_scale,
-            use_router_bias=moe_args.use_router_bias,
-            topk_before_score=moe_args.topk_before_score,
             _debug_force_load_balance=moe_args._debug_force_load_balance,
         )
         self.reorderer = TokenReorderer(num_experts=num_experts, top_k=moe_args.top_k)


### PR DESCRIPTION
Add support for GPT-OSS style MoE routing with TopK-then-Score strategy.

Changes to MoEArgs:
- Add topk_before_score: bool = False (preserve backward compat)
- Add use_router_bias: bool = False (for GPT-OSS learned router bias)
- Add use_expert_bias: bool = False (for GPT-OSS expert biases)

Changes to TokenChoiceTopKRouter:
- Support both routing strategies:
  - TopK-then-Score (GPT-OSS): topk on raw logits, then score_func
  - Score-then-TopK (DeepSeek-V3): score_func to all, then topk
- Add validation: node-limited routing not supported with topk_before_score
- Fix expert_bias handling: gather unbiased logits for score computation
- Add _debug_force_load_balance support for TopK-then-Score path
- Add explicit bias initialization in init_weights
- Change histc to bincount for token counting (more reliable)

GPT-OSS config updates:
- 20B/120B: Add topk_before_score=True, use_router_bias=True, use_expert_bias=True
- 120B: Fix top_k from 4 to 8 (correct value for 120B model)
- Add GptOssStateDictAdapter to __all__