### PR TITLE
[Experimental][rl][vllm compat] Update simple_rl example to work with vLLM nightly

### DIFF
--- a/torchtitan/experiments/rl/vllm_compat/README.md
+++ b/torchtitan/experiments/rl/vllm_compat/README.md
@@ -51,8 +51,12 @@ Note: Currently supports single-device training only.
 ### Prerequisites
 
 ```bash
-# Install vLLM with deterministic support
-pip install vllm
+# Install vLLM with deterministic support (from source)
+git clone https://github.com/vllm-project/vllm.git
+cd vllm
+python use_existing_torch.py
+uv pip install -r requirements/build.txt
+uv pip install --no-build-isolation -e .
 
 # Install TorchTitan (from the repository root)
 pip install -e .
@@ -75,21 +79,17 @@ init_batch_invariance()
 ### Quick Start
 
 ```python
-from vllm.attention.backends.registry import AttentionBackendEnum
-import torch
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+import torch
 from torchtitan.experiments.rl.vllm_compat import (
     enable_batch_invariant_backward_mode,
     Qwen3VLLMCompatModel,
 )
 
 # 1. Enable deterministic mode
-try:
-    init_batch_invariance()
-except TypeError:
-    # Fallback to new version requiring positional arg for attention
-    init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
-
+init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
 enable_batch_invariant_backward_mode()
 
 # 2. Load model
@@ -112,6 +112,7 @@ loss = logits.sum()
 loss.backward()
 
 print("Done running simple model")
+
 ```
 
 ### Full RL Training

--- a/torchtitan/experiments/rl/vllm_compat/batch_invariant_backward.py
+++ b/torchtitan/experiments/rl/vllm_compat/batch_invariant_backward.py
@@ -62,10 +62,14 @@ class SiluAndMulFunction(Function):
         Returns:
             output: silu(gate) * up, shape [..., hidden_dim]
         """
+        from vllm.config import set_current_vllm_config, VllmConfig
         from vllm.model_executor.layers.activation import SiluAndMul as VLLMSiluAndMul
 
         # Use vLLM's implementation for forward
-        vllm_silu_and_mul = VLLMSiluAndMul()
+        # vLLM custom ops require a config context to be set
+        # Since these are parameter free we instantiate default config
+        with set_current_vllm_config(VllmConfig()):
+            vllm_silu_and_mul = VLLMSiluAndMul()
         output = vllm_silu_and_mul(x)
 
         # Save for backward

--- a/torchtitan/experiments/rl/vllm_compat/models/attention.py
+++ b/torchtitan/experiments/rl/vllm_compat/models/attention.py
@@ -8,7 +8,7 @@
 import math
 
 import torch
-from vllm.attention.utils.fa_utils import flash_attn_varlen_func
+from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func
 
 
 class VLLMCompatibleFlashAttention(torch.nn.Module):
@@ -17,8 +17,8 @@ class VLLMCompatibleFlashAttention(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.flash_attn_varlen_func = flash_attn_varlen_func
-        from vllm.attention.utils.fa_utils import get_flash_attn_version
         from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
+        from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 
         self.vllm_is_batch_invariant = vllm_is_batch_invariant
         self.fa_version = get_flash_attn_version()

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -38,14 +38,11 @@ from torchtitan.models.qwen3.model.args import Qwen3ModelArgs
 from transformers import AutoConfig, AutoTokenizer
 
 from vllm import LLM, SamplingParams
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-try:
-    init_batch_invariance()
-except TypeError:
-    # Fallback to new version requiring positional arg for attention
-    init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
+
+init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
 
 
 class VLLMRolloutEngine:

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -38,9 +38,14 @@ from torchtitan.models.qwen3.model.args import Qwen3ModelArgs
 from transformers import AutoConfig, AutoTokenizer
 
 from vllm import LLM, SamplingParams
+from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
 
-init_batch_invariance()
+try:
+    init_batch_invariance()
+except TypeError:
+    # Fallback to new version requiring positional arg for attention
+    init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
 
 
 class VLLMRolloutEngine:
@@ -170,6 +175,7 @@ class VLLMRolloutEngine:
                 gpu_memory_utilization=0.3,  # Reduced from 0.5
                 seed=42,  # Fixed seed for determinism
                 enforce_eager=True,
+                attention_config={"backend": AttentionBackendEnum.FLASH_ATTN},
             )
             print("✓ Created new vLLM engine")
         else:
@@ -340,7 +346,7 @@ def load_model(checkpoint_path: str, model_path: str, use_vllm_compat: bool = Tr
 
     if use_vllm_compat:
         # Create and load model (using vLLM-compat for bitwise determinism)
-        from torchtitan.experiments.deterministic_vllm_rl.vllm_compat.models.qwen3 import (
+        from torchtitan.experiments.rl.vllm_compat.models.qwen3 import (
             Qwen3VLLMCompatModel,
         )
 
@@ -1051,7 +1057,7 @@ def main():
         print("✓ Batch invariance detected - using vLLM-compatible model")
         # Add backward pass support to vLLM's batch_invariant mode
         print("  Adding gradient support to vLLM's batch_invariant mode...")
-        from torchtitan.experiments.deterministic_vllm_rl.vllm_compat.batch_invariant_backward import (
+        from torchtitan.experiments.rl.vllm_compat import (
             enable_batch_invariant_backward_mode,
         )
 


### PR DESCRIPTION
See title; running with the latest version of vLLM nightly ran into a few issues as these APIs have changed and within torch titan some paths have changed

### Test plan
```
VLLM_BATCH_INVARIANT=1 VLLM_FLASH_ATTN_VERSION=3 python -m torchtitan.experiments.rl.vllm_compat.simple_rl
```

### Results
```
  ✓ vLLM-TorchTitan bitwise determinism verified: 100 tokens match exactly

Step   2 | Loss: -0.0033 | Reward: +0.213 | Samples: 160
  Sample:  Natalia sold 48 clips in April. In May, she sold half as many as she sold in Ap...
Converted to 311 vLLM weights
```