### PR TITLE
[ROCm] Support mxfp8 on gfx950.

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -41,7 +41,7 @@ class MXLinearConverter(QuantizationConverter):
         # Can be removed if we enable the emulated versions
         assert has_cuda_capability(10, 0) or has_rocm_capability(
             9, 5
-        ), "MXFP8 is only supported on SM100 or later or ROCm gfx950 or later"
+        ), "MXFP8 is only supported on CUDA SM100 or later, or ROCm gfx950 or later"
 
         # TP not yet supported with torch.compile
         model_compile_enabled = (

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -25,12 +25,9 @@ def has_cuda_capability(major: int, minor: int) -> bool:
     )
 
 
-def is_rocm() -> bool:
-    return torch.cuda.is_available() and torch.version.hip is not None
-
-
 def has_rocm_capability(major: int, minor: int) -> bool:
-    return is_rocm() and torch.cuda.get_device_capability() >= (
+    is_rocm = torch.cuda.is_available() and torch.version.hip is not None
+    return is_rocm and torch.cuda.get_device_capability() >= (
         major,
         minor,
     )


### PR DESCRIPTION
* Support mxfp8 on gfx950.

It depends on TorchAO (https://github.com/pytorch/ao/pull/3620). 