### PR TITLE
[autoparallel] Update local_map_deepseek_v3 device mesh usage

### DIFF
--- a/torchtitan/experiments/autoparallel/README.md
+++ b/torchtitan/experiments/autoparallel/README.md
@@ -16,7 +16,7 @@ Requires installing [git@github.com:meta-pytorch/autoparallel.git](https://githu
 
 **DeepSeekv3**
 
-`CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.toml ./run_train.sh --model.name autoparallel.deepseek_v3 --job.custom_config_module=torchtitan.experiments.autoparallel.job_config`
+`NGPU=2 CONFIG_FILE=./torchtitan/models/deepseek_v3/train_configs/debug_model.toml ./run_train.sh --model.name autoparallel.deepseek_v3 --job.custom_config_module=torchtitan.experiments.autoparallel.job_config`
 
 **DeepSeekv3 local_map**
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#2231


--- --- ---

Follow the new device mesh convention from https://github.com/pytorch/torchtitan/pull/1660/ for the local_map_deepseek_v3 config (wasn't covered by CI)

This lets the configs get further, but it still errors