### PR TITLE
[DONT LAND] Implement PrefetchedDataloader for overlapped data loading

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -423,8 +423,14 @@ class MetricsProcessor:
         tflops = self.num_flops_per_token * tps / 1e12
 
         time_end_to_end = time_delta / self.job_config.metrics.log_freq
-        time_data_loading = sum(self.data_loading_times) / len(self.data_loading_times)
-        time_data_loading_pct = 100 * sum(self.data_loading_times) / time_delta
+        if self.data_loading_times:
+            time_data_loading = sum(self.data_loading_times) / len(
+                self.data_loading_times
+            )
+            time_data_loading_pct = 100 * sum(self.data_loading_times) / time_delta
+        else:
+            time_data_loading = 0.0
+            time_data_loading_pct = 0.0
 
         device_mem_stats = self.device_memory_monitor.get_peak_stats()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #2232

This is a demonstration of how we can overlap to(device) and post dataloading processing with forward/backward/optimizer.  

IGNORE the flux change.

Right now this PR assumes post dataloading processing uses GPU, which will still use another stream other than main stream to compute. While this can make the dataloading processing and forward/backward/optimizer computation run concurrently, the overlapping may slow down the main computation. This can be avoid by move the post dataloading processing to CPU.

This PR is Mostly written by Claude and only serves as a demonstration.