### PR TITLE
[mxfp8 moe training] support wgrad_with_hp recipe

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -132,7 +132,7 @@ class MXGroupedMMConverter(QuantizationConverter):
 
         self.recipe_name = job_config.quantize.grouped_mm.mx.recipe_name
         self.enabled = True
-        logger.info("MXFP8 MoE training enabled")
+        logger.info(f"MXFP8 MoE training enabled with recipe: {self.recipe_name}")
 
     def convert(self, model: nn.Module):
         """
@@ -154,7 +154,7 @@ class MXGroupedMMConverter(QuantizationConverter):
                     return True
             return False
 
-        config = MoETrainingConfig(scaling_type=MoEScalingType.MXFP8)
+        config = MoETrainingConfig(scaling_type=MoEScalingType(self.recipe_name))
         quantize_(model, config=config, filter_fn=moe_module_filter_fn)
         logger.info(
             f"Converted MoE layers matching FQNS {self.moe_fqns} "

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -784,10 +784,15 @@ class MXLinear:
 
 @dataclass
 class MXGroupedMM:
-    recipe_name: Literal["mxfp8"] = "mxfp8"
+    recipe_name: Literal["mxfp8", "mxfp8_wgrad_with_hp"] = "mxfp8"
     """
-    Quantization recipe name for grouped GEMMs. Options: ["mxfp8"]
+    Quantization recipe name for grouped GEMMs. Options: ["mxfp8", "mxfp8_wgrad_with_hp"]
 
+    Recipes:
+        - "mxfp8": Use MXFP8 for all 3 grouped GEMMs in the forward and backward pass (output, dgrad, wgrad).
+        - "mxfp8_wgrad_with_hp": Use MXFP8 for forward output and dgrad, but keep wgrad in high-precision.
+             This can be used to trade-off some performance for improved accuracy. For some smaller expert shapes,
+             it is also better for performance.
     Example: --quantize.grouped_mm.mx.recipe_name="mxfp8"
     """
 


### PR DESCRIPTION
Stacked PRs:
 * #2268
 * #2251
 * #2250
 * __->__#2249


--- --- ---

## Summary

torchao MXFP8 MoE training code now supports a new recipe: `wgrad_with_hp` (described below). This PR update the torchtitan integration to allow users to use. it

  Recipes:
      - "mxfp8": Use MXFP8 for all 3 grouped GEMMs in the forward and backward pass (output, dgrad, wgrad).
      - "mxfp8_wgrad_with_hp": Use MXFP8 for forward output and dgrad, but keep wgrad in high-precision.
           This can be used to trade-off some performance for improved accuracy.

Note: I plan to do some benchmarking to provide more concrete guidance to users on what expert shapes will result in better TPS using wgrad_with_hp

## Tests

mxfp8 recipe:

```
CONFIG_FILE=/home/dev/torchtitan/torchtitan/models/llama4/train_configs/llama4_17bx16e.toml ./run_train.sh --metrics.log_freq=10 \--training.steps=200  \--parallelism.data_parallel_shard_degree=8 \--parallelism.expert_parallel_degree=8 \--parallelism.tensor_parallel_degree=1 \                                                  
--parallelism.expert_tensor_parallel_degree=1 \
--profiling.enable_profiling --profiling.profile_freq=30 \
--training.seq_len=8192 \
--activation_checkpoint.mode=none \
--model.print_after_conversion \
--training.local_batch_size=12 \
--model.converters="quantize.grouped_mm.mx,quantize.linear.mx" \
--quantize.linear.mx.mxfp8_dim1_cast_kernel_choice="cuda" \
--quantize.linear.mx.filter_fqns="output,router.gate,wk,wv" \
--quantize.grouped_mm.mx.fqns="experts" --quantize.grouped_mm.mx.recipe_name="mxfp8_wgrad" \
--compile.enable --debug.moe_force_load_balance
```


mxfp8_wgrad_with_hp recipe:

```
CONFIG_FILE=/home/dev/torchtitan/torchtitan/models/llama4/train_configs/llama4_17bx16e.toml ./run_train.sh --metrics.log_freq=10 \--training.steps=200  \--parallelism.data_parallel_shard_degree=8 \--parallelism.expert_parallel_degree=8 \--parallelism.tensor_parallel_degree=1 \                                                  
--parallelism.expert_tensor_parallel_degree=1 \
--profiling.enable_profiling --profiling.profile_freq=30 \
--training.seq_len=8192 \
--activation_checkpoint.mode=none \
--model.print_after_conversion \
--training.local_batch_size=12 \
--model.converters="quantize.grouped_mm.mx,quantize.linear.mx" \
--quantize.linear.mx.mxfp8_dim1_cast_kernel_choice="cuda" \
--quantize.linear.mx.filter_fqns="output,router.gate,wk,wv" \
--quantize.grouped_mm.mx.fqns="experts" --quantize.grouped_mm.mx.recipe_name="mxfp8_wgrad_with_hp" \
--compile.enable --debug.moe_force_load_balance
```