### PR TITLE
[mxfp8 moe training] mxfp8 all to all

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -57,7 +57,7 @@ class MXLinearConverter(QuantizationConverter):
             MXLinearConfig as TorchAOMXLinearConfig,
         )
 
-        mx_job_config: TorchAOMXLinearConfig = job_config.quantize.linear.mx
+        mx_job_config = job_config.quantize.linear.mx
         config = TorchAOMXLinearConfig.from_recipe_name(mx_job_config.recipe_name)
         config.mxfp8_dim1_cast_kernel_choice = MXFP8Dim1CastKernelChoice[
             mx_job_config.mxfp8_dim1_cast_kernel_choice.upper()

--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -120,6 +120,10 @@ def parallelize_deepseekv3(
     else:
         use_deepep = False
 
+    use_mxfp8_a2a = (
+        "quantize.grouped_mm.mx" in job_config.model.converters
+        and job_config.quantize.grouped_mm.mx.recipe_name == "mxfp8_wgrad_with_hp"
+    )
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         dual_pipe_v = get_dual_pipe_v_flag(job_config, parallel_dims)
 
@@ -131,6 +135,7 @@ def parallelize_deepseekv3(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             dual_pipe_v=dual_pipe_v,
             use_deepep=use_deepep,
+            use_mxfp8_a2a=use_mxfp8_a2a,
         )
 
     if parallel_dims.cp_enabled:

--- a/torchtitan/models/qwen3/infra/parallelize.py
+++ b/torchtitan/models/qwen3/infra/parallelize.py
@@ -108,6 +108,10 @@ def parallelize_qwen3(
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         dual_pipe_v = get_dual_pipe_v_flag(job_config, parallel_dims)
 
+        use_mxfp8_a2a = (
+            "quantize.grouped_mm.mx" in job_config.model.converters
+            and job_config.quantize.grouped_mm.mx.recipe_name == "mxfp8_wgrad_with_hp"
+        )
         apply_moe_ep_tp(
             model,
             tp_mesh=parallel_dims.get_optional_mesh("tp"),
@@ -115,6 +119,7 @@ def parallelize_qwen3(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             dual_pipe_v=dual_pipe_v,
+            use_mxfp8_a2a=use_mxfp8_a2a,
         )
 
     if parallel_dims.cp_enabled:


### PR DESCRIPTION
Stacked PRs:
 * #2268
 * #2251
 * __->__#2250
 * #2249


--- --- ---

[mxfp8 moe training] mxfp8 all to all

## High level design

- The goal is to reduce all-to-all communication volume in expert parallelism, to achieve a speedup.
- Key idea: instead of waiting until directly before the grouped GEMM to quantize the inputs, we quantize a couple steps earlier, before the all2all, and stay in MXFP8 through the token shuffle, so the MXFP8 grouped GEMM receives pre-quantized input activations.
 
<img width="995" height="673" alt="Screenshot 2026-02-04 at 11 00 34 AM" src="https://github.com/user-attachments/assets/b0792b40-891e-4c15-a027-4c1230ae175e" />

Forward flow:
                1. a2a dispatch forward: high-precision input, MXFP8 output
                2. permute forward: MXFP8 input, MXFP8 output
                3. MXFP8 grouped GEMM: MXFP8 input, high-precision output
                4. unpermute forward: high-precision input and output
                5. a2a combine forward: high-precision input and output

Backward flow:
                1. a2a combine backward: high-precision input, MXFP8 output
                2. unpermute backward: MXFP8 input, MXFP8 output
                3. MXFP8 grouped GEMM: MXFP8 input, high-precision output
                4. permute backward: high-precision input and output
                5. a2a dispatch backward: high-precision input and output

## Benchmarks
- +10% TPS on single node 8xB200 training with EP over NVLink domain
- +24% TPS on multi-node B200 cluster with IB inter-node networking (more bandwidth constrained -> bigger speedup)

## Limitations
- Not compatible with DeepEP
    - Recipe `"mxfp8"` IS compatible with DeepEP, but `"mxfp8_wgrad_with_hp"` (which uses MXFP8 all2all, is not)

## Testing
 
(test depends on the full PR stack)

```bash
CONFIG_FILE=/home/dev/torchtitan/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml ./run_train.sh --metrics.log_freq=10 \
--training.steps=1500  \
--parallelism.data_parallel_shard_degree=4 \
--parallelism.expert_parallel_degree=4 \
--parallelism.tensor_parallel_degree=2 \
--parallelism.expert_tensor_parallel_degree=1 \
--training.seq_len=8192 \
--activation_checkpoint.mode=full \
--model.print_after_conversion \
--training.local_batch_size=16 \
--quantize.linear.mx.mxfp8_dim0_cast_kernel_choice="triton" --quantize.linear.mx.mxfp8_dim1_cast_kernel_choice="cuda" \
--quantize.grouped_mm.mx.fqns="experts" --quantize.grouped_mm.mx.recipe_name="mxfp8_wgrad_with_hp" \
--compile.enable --compile.components="model,loss" --debug.moe_force_load_balance \
--model.converters="quantize.grouped_mm.mx"
```