### PR TITLE
[mxfp8 training] add new configurable params now exposed by torchao

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -53,12 +53,18 @@ class MXLinearConverter(QuantizationConverter):
 
         # Configure MXFP8
         from torchao.prototype.mx_formats.config import (
+            MXFP8Dim0CastKernelChoice,
             MXFP8Dim1CastKernelChoice,
             MXLinearConfig as TorchAOMXLinearConfig,
         )
 
         mx_job_config = job_config.quantize.linear.mx
         config = TorchAOMXLinearConfig.from_recipe_name(mx_job_config.recipe_name)
+        # pyrefly: ignore [missing-attribute]
+        config.mxfp8_dim0_cast_kernel_choice = MXFP8Dim0CastKernelChoice[
+            mx_job_config.mxfp8_dim0_cast_kernel_choice.upper()
+        ]
+        # pyrefly: ignore [missing-attribute]
         config.mxfp8_dim1_cast_kernel_choice = MXFP8Dim1CastKernelChoice[
             mx_job_config.mxfp8_dim1_cast_kernel_choice.upper()
         ]

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -757,7 +757,17 @@ class Float8GroupedMM:
 
 @dataclass
 class MXLinear:
-    mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "torch"] = "triton"
+    mxfp8_dim0_cast_kernel_choice: Literal["triton", "torch"] = "triton"
+    """
+    Temp work around for inductor performance gap.
+
+    * triton is recommended for best performance for recipe "mxfp8_cublas_rceil" (rceil scale rounding mode)
+    * torch is recommended for best performance for recipe "mxfp8_cublas" (floor scale rounding mode)
+
+    Example: --quantize.linear.mx.mxfp8_dim0_cast_kernel_choice="torch"
+    """
+
+    mxfp8_dim1_cast_kernel_choice: Literal["triton", "cuda", "torch"] = "cuda"
     """
     Temp work around for inductor performance gap.
 

--- a/torchtitan/models/llama4/infra/parallelize.py
+++ b/torchtitan/models/llama4/infra/parallelize.py
@@ -639,10 +639,6 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig, ep_enabled: b
                     # by wrapping each submod's forward instead of their __call__
                     moe = submod
                     for attr_name, submod in moe.named_children():
-                        if attr_name == "experts":
-                            # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
-                            # https://github.com/pytorch/torchtitan/issues/1940
-                            continue
                         setattr(
                             moe,
                             attr_name,


### PR DESCRIPTION
Stacked PRs:
 * #2268
 * __->__#2251
 * #2250
 * #2249


--- --- ---

[mxfp8 training] add new configurable params now exposed by torchao

## Summary

Expose job config param to control mxfp8 dim0 quantization kernel used in torchao.

- dim0 mxfp8 quantization kernel options  
    - `torch`: ~90% memory bandwidth utilization (requires torch.compile for perf)
    - `triton`: ~82% memory bandwidth utilization (does not require torch.compile)

## Tests

(test depends on full PR stack)

```bash
CONFIG_FILE=/home/dev/torchtitan/torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml ./run_train.sh --metrics.log_freq=10 \
--training.steps=1500  \
--parallelism.data_parallel_shard_degree=4 \
--parallelism.expert_parallel_degree=4 \
--parallelism.tensor_parallel_degree=2 \
--parallelism.expert_tensor_parallel_degree=1 \
--training.seq_len=8192 \
--activation_checkpoint.mode=full \
--model.print_after_conversion \
--training.local_batch_size=16 \
--quantize.linear.mx.mxfp8_dim0_cast_kernel_choice="triton" --quantize.linear.mx.mxfp8_dim1_cast_kernel_choice="cuda" \
--quantize.grouped_mm.mx.fqns="experts" --quantize.grouped_mm.mx.recipe_name="mxfp8_wgrad_with_hp" \
--compile.enable --compile.components="model,loss" --debug.moe_force_load_balance \
--model.converters="quantize.grouped_mm.mx"
```