### PR TITLE
Remove deprecated enable_symm_mem_for_group

### DIFF
--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -22,9 +22,6 @@ def maybe_enable_async_tp(job_config: JobConfig, tp_mesh: DeviceMesh):
             "Async TP requires 'model' in --compile.components and --compile.enable"
         )
 
-    from torch.distributed._symmetric_memory import enable_symm_mem_for_group
-
     torch._inductor.config._micro_pipeline_tp = True
-    enable_symm_mem_for_group(tp_mesh.get_group().group_name)
 
     logger.info("Async TP is enabled")

--- a/torchtitan/models/gpt_oss/infra/parallelize.py
+++ b/torchtitan/models/gpt_oss/infra/parallelize.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+import torch._inductor.config
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 
@@ -248,11 +249,7 @@ def apply_non_moe_tp(
         )
 
     if enable_async_tp:
-        from torch.distributed._symmetric_memory import enable_symm_mem_for_group
-
-        # pyrefly: ignore [implicit-import]
         torch._inductor.config._micro_pipeline_tp = True
-        enable_symm_mem_for_group(tp_mesh.get_group().group_name)
 
     logger.info(
         f"Applied {'Float8 tensorwise ' if enable_float8_tensorwise_tp else ''}{'Async ' if enable_async_tp else ''}"

--- a/torchtitan/models/qwen3/infra/parallelize.py
+++ b/torchtitan/models/qwen3/infra/parallelize.py
@@ -279,10 +279,7 @@ def apply_non_moe_tp(
         )
 
     if enable_async_tp:
-        from torch.distributed._symmetric_memory import enable_symm_mem_for_group
-
         torch._inductor.config._micro_pipeline_tp = True
-        enable_symm_mem_for_group(tp_mesh.get_group().group_name)
 
     logger.info(
         f"Applied {'Float8 tensorwise ' if enable_float8_tensorwise_tp else ''}{'Async ' if enable_async_tp else ''}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2246
* #2245
* __->__ #2256

This API is not needed any more. pyrefly will give us a warning.