### PR TITLE
[varlen_attn] change is_causal to window_size

### DIFF
--- a/torchtitan/models/attention.py
+++ b/torchtitan/models/attention.py
@@ -84,8 +84,18 @@ class VarlenAttentionWrapper(torch.nn.Module):
             cu_seq_k,
             max_q,
             max_k,
-            is_causal=True,
             scale=scale,
+            # window_size=(left, right) controls the attention window relative to each
+            # query position. 'left' is how many tokens before the query to attend to,
+            # and 'right' is how many tokens after. A value of -1 means unlimited.
+            #
+            # This replaces the is_causal flag:
+            #   - (-1, 0): Causal attention - each token attends to all previous tokens
+            #              and itself, but no future tokens. Equivalent to is_causal=True.
+            #   - (-1, -1): Full bidirectional attention (no masking). Equivalent to
+            #               is_causal=False.
+            #   - (W, 0): Sliding window causal - attend to at most W previous tokens.
+            window_size=(-1, 0),
         )
 
 


### PR DESCRIPTION
`is_causal` flag has been deprecated in `varlen_attn`, use `window_size = [-1, 0]` instead, see [this PR](https://github.com/pytorch/pytorch/pull/172245)

*Test*
<img width="1225" height="496" alt="Screenshot 2026-01-21 at 11 55 59 AM" src="https://github.com/user-attachments/assets/125c56af-76ed-4f6f-a433-da4d9a631dab" />
