### PR TITLE
Update CPU unit test to use linux_job_v2

### DIFF
--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-test:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan


### PR DESCRIPTION
Actually unrelated to the [Typing] changes, but recommended by Dev Infra anyways: https://github.com/pytorch/pytorch/issues/123649

cc @atalman 

