### PR TITLE
[BE week] Disable CPU wheel builds in nightly CI

### DIFF
--- a/.github/workflows/build_whl_and_publish.yaml
+++ b/.github/workflows/build_whl_and_publish.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - nightly
-      - fix-nightly-cpu  # TODO: Remove after testing
-  pull_request:  # TODO: Remove after testing
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
TorchTitan requires triton which isn't available on CPU-only builds. Since there's no use case for CPU-only torchtitan wheels, disable them rather than adding complexity to support CPU imports.

Testing: All green here: https://github.com/pytorch/torchtitan/actions/runs/21458236045?pr=2289 and on CI