### PR TITLE
[rl] GQA attention enablement in torchtitan vllm wrapper

### DIFF
--- a/torchtitan/experiments/rl/unified/models/attention.py
+++ b/torchtitan/experiments/rl/unified/models/attention.py
@@ -61,6 +61,7 @@ class VLLMAttention(torch.nn.Module):
         v: torch.Tensor,
         *,
         scale: float | None = None,
+        enable_gqa: bool = False,
     ) -> torch.Tensor:
         """
         Forward pass using vLLM's Attention layer for inference.
@@ -70,6 +71,7 @@ class VLLMAttention(torch.nn.Module):
             k: Key tensor [batch, num_kv_heads, seq_len, head_dim]
             v: Value tensor [batch, num_kv_heads, seq_len, head_dim]
             scale: Optional attention scale override (unused, vLLM uses internal scale)
+            enable_gqa: Whether GQA is enabled (unused, vLLM handles GQA internally)
 
         Returns:
             output: [batch, num_heads, seq_len, head_dim]

--- a/torchtitan/experiments/rl/unified/models/utils.py
+++ b/torchtitan/experiments/rl/unified/models/utils.py
@@ -54,15 +54,29 @@ def replace_with_vllm_attention(model, tp_degree=1):
         )
 
     model_args = model.model_args
+
+    # Reference: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/qwen3.py#L80
+    # Calculate num_kv_heads based on TP size
+    total_num_kv_heads = model_args.n_kv_heads
+    if total_num_kv_heads >= tp_degree:
+        # Number of KV heads is greater than TP size, so we partition
+        # the KV heads across multiple tensor parallel GPUs.
+        assert total_num_kv_heads % tp_degree == 0
+    else:
+        # Number of KV heads is less than TP size, so we replicate
+        # the KV heads across multiple tensor parallel GPUs.
+        assert tp_degree % total_num_kv_heads == 0
+    num_kv_heads = max(1, total_num_kv_heads // tp_degree)
+
     for layer_name, layer in model.layers.items():
         if not hasattr(layer, "attention"):
             raise ValueError(f"Layer {layer_name} must have .attention attribute")
 
+        # GQA
         vllm_attn = VLLMAttention(
             hidden_size=model_args.dim,
             num_heads=model_args.n_heads // tp_degree,
-            num_kv_heads=model_args.n_heads
-            // tp_degree,  # Use n_heads (already replicated)
+            num_kv_heads=num_kv_heads,
             head_dim=model_args.head_dim,
             layer_name=layer_name,
             scale=model_args.head_dim**-0.5,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2292
* __->__ #2291

Following https://github.com/pytorch/torchtitan/pull/2259

Context: Fix RL attention implementation, add numerics check scripts comparing torchtitan Qwen3 model (with vllm wrapper) and vllm native Qwen3 model

NOTE: I tried enabling CI for this work, but need more efforts install vllm from source code (need to build vllm from scratch). Will enable CI in later PRs