### PR TITLE
Add Transformer-Engine Fused_Adam Optimizer Support

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -314,7 +314,7 @@ def build_optimizers(
 
     if name == 'TE_FusedAdamW':
         try:
-            from transformer_engine.pytorch.optimizers.fused_adam import TE_FusedAdam
+            from transformer_engine.pytorch.optimizers.fused_adam import FusedAdam
         except (ImportError, ModuleNotFoundError) as e:
             raise ImportError(
                 "FusedAdam optimizer could not be imported from transformer_engine. "
@@ -323,7 +323,7 @@ def build_optimizers(
                 "git+https://github.com/NVIDIA/TransformerEngine.git@stable "
                 "or use another optimizer"
             ) from e
-        optimizer_classes["TE_FusedAdamW"] = TE_FusedAdam
+        optimizer_classes["TE_FusedAdamW"] = FusedAdam
         del optimizer_kwargs['fused'], optimizer_kwargs['foreach']
         optimizer_kwargs['exp_avg_dtype'] = torch.bfloat16
         optimizer_kwargs['exp_avg_sq_dtype'] = torch.bfloat16


### PR DESCRIPTION
### Summary
For some models such as DeepSeek-V3, optimizer states (moments) can be stored in lower precision (torch.bfloat16) without loosing training accuracy. Storing optimizer states in lower precisions translates into significant memory saving for large models such as DeepSeek-V3-671B and allows to increase device utilization by increasing Batch-Size. 
This PR adds Transformer-Engine(TE) Fused_Adam optimizer to list of optimizers supported by TorchTitan. This optimizer is a drop-in replacement for torch.optim.AdamW with additional features such as lower precision optimizer states storage support.

### Tests
#### Accuracy
Tested on DeepSeek-V4-671B (EP=64, PP=4, GBS=1024).
<img width="1000" height="600" alt="Code_Generated_Image" src="https://github.com/user-attachments/assets/846e7fff-b4a1-4489-92ba-cc88d50d9026" />

#### Memory
Tested on DeepSeek-V4-671B (EP=64, PP=4, GBS=1024). 
<img width="1200" height="800" alt="Code_Generated_Image (1)" src="https://github.com/user-attachments/assets/d58a3a4e-7e0a-4f07-8116-3a9d0fe44935" />
