### PR TITLE
[Typing] Fix some pyrefly ignores in optimizer.py

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -351,9 +351,9 @@ def build_optimizers_with_moe_load_balancing(
 
     def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
         for model_part in model_parts:
-            # pyrefly: ignore [not-callable]
-            for transformer_block in model_part.layers.values():
-                # pyrefly: ignore [missing-attribute]
+            layers = model_part.get_submodule("layers")
+            assert isinstance(layers, nn.ModuleDict)
+            for transformer_block in layers.values():
                 if transformer_block.moe_enabled:
                     # Assumption: load_balance_coeff is set universally on all moe blocks.
                     # pyrefly: ignore [missing-attribute]
@@ -373,9 +373,9 @@ def build_optimizers_with_moe_load_balancing(
         # default compute stream. Need to assess if this is OK performance-wise.
         tokens_per_expert_list = []
         for model_part in model_parts:
-            # pyrefly: ignore [not-callable]
-            for transformer_block in model_part.layers.values():
-                # pyrefly: ignore [missing-attribute]
+            layers = model_part.get_submodule("layers")
+            assert isinstance(layers, nn.ModuleDict)
+            for transformer_block in layers.values():
                 if not transformer_block.moe_enabled:
                     continue
                 # pyrefly: ignore [missing-attribute]
@@ -411,12 +411,11 @@ def build_optimizers_with_moe_load_balancing(
         moe_layer_idx = 0
         with torch.no_grad():
             for model_part in model_parts:
-                # pyrefly: ignore [not-callable]
-                for transformer_block in model_part.layers.values():
-                    # pyrefly: ignore [missing-attribute]
+                layers = model_part.get_submodule("layers")
+                assert isinstance(layers, nn.ModuleDict)
+                for transformer_block in layers.values():
                     if not transformer_block.moe_enabled:
                         continue
-                    # pyrefly: ignore [missing-attribute]
                     moe = transformer_block.moe
 
                     tokens_per_expert = tokens_per_expert_by_layer[
@@ -426,11 +425,14 @@ def build_optimizers_with_moe_load_balancing(
 
                     # update the expert bias
                     # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
+                    # pyrefly: ignore [missing-attribute]
                     expert_bias_delta = moe.load_balance_coeff * torch.sign(
                         tokens_per_expert.mean() - tokens_per_expert
                     )
                     expert_bias_delta = expert_bias_delta - expert_bias_delta.mean()
+                    # pyrefly: ignore [missing-attribute]
                     moe.expert_bias.add_(expert_bias_delta)
+                    # pyrefly: ignore [missing-attribute]
                     moe.tokens_per_expert.zero_()
 
     if _should_register_moe_balancing_hook(model_parts):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2295
* __->__ #2294

This PR fixes some ignores but not all. The MoE part will be fixed later with other MoE related components.