### PR TITLE
[MoE] DeepEP refactor and fix memory leak during training and inference

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -331,6 +331,7 @@ def _unpermute_tokens(
 @dataclass
 class DispatchState:
     """State from dispatch needed for combine."""
+
     handle_id: torch.Tensor  # CPU tensor used to retrieve cached handle
     permuted_indices: torch.Tensor
     num_recv_tokens: int


### PR DESCRIPTION
1. Simplified the token permutation logic.
2. Updated the handle management so there will be no memory leak during training and inference. Related issue: https://github.com/pytorch/torchtitan/issues/2273

On training on 16b deepseek v3 model, before the fix there was a growing memory usage. 
<img width="479" height="331" alt="image" src="https://github.com/user-attachments/assets/12571963-47a5-4e13-b66a-1b213fc10d66" />
After the fix, the memory usage stabilizes. 
<img width="479" height="328" alt="image" src="https://github.com/user-attachments/assets/9257c7ce-faf6-4330-a295-1ef1150d4ab0" />
