### PR TITLE
Fix FLUX attention by exposing is_causal in SDPA

### DIFF
--- a/torchtitan/models/attention.py
+++ b/torchtitan/models/attention.py
@@ -185,10 +185,11 @@ class ScaledDotProductAttentionWrapper(torch.nn.Module):
         *,
         scale: float | None = None,
         enable_gqa: bool = False,
+        is_casual: bool = True,
     ) -> torch.Tensor:
         with sdpa_kernel(self.sdpa_backends, set_priority=True):
             return F.scaled_dot_product_attention(
-                q, k, v, scale=scale, is_causal=True, enable_gqa=enable_gqa
+                q, k, v, scale=scale, is_causal=is_casual, enable_gqa=enable_gqa
             )
 
 

--- a/torchtitan/models/flux/model/layers.py
+++ b/torchtitan/models/flux/model/layers.py
@@ -139,7 +139,7 @@ class SelfAttention(nn.Module):
         q, k, v = rearrange(qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
         q, k = self.norm(q, k, v)
         q, k = apply_rope(q, k, pe)
-        x = self.inner_attention(q, k, v)
+        x = self.inner_attention(q, k, v, is_causal=False)
         x = rearrange(x, "B H L D -> B L (H D)")
         x = self.proj(x)
         return x


### PR DESCRIPTION
fix #2297 

the official implementation from black-forest-lab (https://github.com/black-forest-labs/flux/blob/main/src/flux/math.py#L6) they are using `torch.nn.functional.scaled_dot_product_attention` with default is_casual = False