### PR TITLE
[DeepEP] Implement shared_experts overlap with deepep.combine()

### DIFF
--- a/torchtitan/distributed/deepep/__init__.py
+++ b/torchtitan/distributed/deepep/__init__.py
@@ -6,10 +6,11 @@
 
 """DeepEP distributed communication primitives for MoE."""
 
-from .deepep import combine_tokens, dispatch_tokens, DispatchState
+from .deepep import combine_tokens, dispatch_tokens, DispatchState, sync_combine
 
 __all__ = [
     "dispatch_tokens",
     "combine_tokens",
+    "sync_combine",
     "DispatchState",
 ]


### PR DESCRIPTION
### Summary
This PR implements overlap of MOE shared_expert computation with deepep combine communication (during forward pass of training step).  Relates to https://github.com/pytorch/torchtitan/issues/2298 

### Tests
Confirmed expected behavior by taking a profiler trace for reduced DeepSeek-V3-671B model. Also verified loss convergence for 100 training steps.
<img width="1683" height="782" alt="Screenshot 2026-02-02 at 2 50 58 PM" src="https://github.com/user-attachments/assets/878879c6-08f7-4238-8123-b199b8b92dab" />

  