### PR TITLE
Fixing global_max_loss computation

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -409,7 +409,7 @@ class MetricsProcessor:
             global_avg_loss: Global average loss across all valid tokens on all ranks
                 Defined as global_loss_sum / global_valid_tokens
             global_max_loss: Maximum local loss across all ranks
-                Defined as max(local_loss_sum / global_valid_tokens)
+                Defined as max(local_loss_sum / local_valid_tokens)
             grad_norm: Gradient norm after clipping
             extra_metrics: Optional additional metrics to log
 


### PR DESCRIPTION
Summary:
As per the fix to handle token imbalance D91432940 , the global_max_loss computed is below the global_avg_loss as shown in the test plan. This is because of the pre division of the loss to the global tokens. While the avg loss computation is correct, the global max loss in this case becomes the max of the loss contribution of each rank, no the max of the local loss of each rank.

One fix is to recale the local loss to the average loss for each rank to get the local average loss and then perform the max operation. The result can be seen in the test plan.

Differential Revision: D92079302


