### PR TITLE
Fixed autoparallel integration tests on ROCm.

### DIFF
--- a/torchtitan/experiments/autoparallel/tests/integration_tests.py
+++ b/torchtitan/experiments/autoparallel/tests/integration_tests.py
@@ -30,7 +30,6 @@ def build_autoparallel_test_list() -> list[OverrideDefinitions]:
             "llama3 AutoParallel FSDP+TP",
             "llama3_autoparallel_fsdp_tp",
             ngpu=4,
-            skip_rocm_test=True,
         ),
         # TODO: Re-enable this once we fix the test
         # deepseek_v3 tests


### PR DESCRIPTION
This PR fixes the autoparallel integration tests on ROCm.

Background:
HIP runtime relies on the file /opt/amdgpu/share/libdrm/amdgpu.ids to look up the product name of AMDGPU. But this file is missing in the CI docker container. Only `/usr/share/libdrm/amdgpu.ids` exists in the docker container and it is out of date - it does not include newer products like MI300. One way to address this is to use `-v /opt/amdgpu:/opt/amdgpu:ro`  when launching the docker container to map the /opt/amdgpu/share/libdrm/amdgpu.ids on the host to the docker container. This, however, requires changes of the workflows files in pytorch/test_infra and pytorch/pytorch. This quick fix works around the issue by updating the amdgpu.ids file within the CI docker container.