### PR TITLE
Apply #1895 only when really necessary

### DIFF
--- a/torchtitan/models/deepseek_v3/infra/parallelize.py
+++ b/torchtitan/models/deepseek_v3/infra/parallelize.py
@@ -156,7 +156,12 @@ def parallelize_deepseekv3(
         )
 
     if model_compile_enabled:
-        apply_compile(model, job_config.compile, parallel_dims.ep_enabled)
+        apply_compile(
+            model,
+            job_config.compile,
+            parallel_dims.ep_enabled,
+            parallel_dims.fsdp_enabled,
+        )
 
     dp_mesh: DeviceMesh | None = None
     if parallel_dims.fsdp_enabled or parallel_dims.ep_enabled:

--- a/torchtitan/models/qwen3/infra/parallelize.py
+++ b/torchtitan/models/qwen3/infra/parallelize.py
@@ -137,7 +137,12 @@ def parallelize_qwen3(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile(model, job_config.compile, parallel_dims.ep_enabled)
+        apply_compile(
+            model,
+            job_config.compile,
+            parallel_dims.ep_enabled,
+            parallel_dims.fsdp_enabled,
+        )
 
     if parallel_dims.fsdp_enabled:
         # apply FSDP or HSDP, potentially with Context Parallel


### PR DESCRIPTION
We observed a significant performance regression for MoE models using pure FSDP, with MFU dropping from [24.5%](https://gist.github.com/ericschreiber/4c260ff1d40954cc979fbb35fc3c3b2a) to [16.3%](https://gist.github.com/ericschreiber/5e5ddd0f3fa6bd4aacff596abd16f1fc) when running [Qwen3 30A3B](https://gist.github.com/ericschreiber/2d5e795c60b07bd759c2a8e98b946e18) on 2×8 B200s. This regression was traced back to commit 2a7a148, associated with issue #1895. 

While 2a7a148 correctly fixes Dynamo graph breaks for combined EP + FSDP setups, the change is unnecessary for pure FSDP configurations and introduces avoidable overhead in that case.

This pull request refactors and extends the `apply_compile` logic used for MoE model parallelization (DeepSeekV3, Llama4, Qwen3) to better distinguish between EP/FSDP combinations. The fix from #1895 is now applied only when it is actually required. We verified that the experiments from #1895 continue to work as expected.

Because FSDP is applied after `apply_compile`, we introduce an additional `fsdp_enabled` flag, which results in corresponding updates to files that inherit from this logic.

Finally, as was the case prior to commit 2a7a148, enabling SAC with Qwen3 30A3B triggers the warning:
```
Detected that context_fn is passed to torch.utils.checkpoint under torch.compile.
Please make sure the checkpointed region does not contain in-place ops (e.g. torch.relu_).
```

This appears to be related to how SAC augments `context_fn`. For Qwen3, we verified that this warning can be safely ignored. Still, we would appreciate reviewer input on how this warning should be handled going forward.