### PR TITLE
Disable DDP averaging to avoid repeated gradient averaging

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -578,7 +578,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         # Process each microbatch: move to GPU, forward/backward, then free
         accumulated_losses = []
-        for input_dict, labels in microbatches:
+        num_microbatches = len(microbatches)
+
+        # Check if we're using DDP (not FSDP) and need to manage gradient sync
+        # DDP syncs gradients on every backward, so we need to disable sync
+        # for intermediate microbatches to avoid redundant all-reduces
+        using_ddp = (
+            parallel_dims.dp_replicate_enabled and not parallel_dims.fsdp_enabled
+        )
+
+        for microbatch_idx, (input_dict, labels) in enumerate(microbatches):
+            is_last_microbatch = microbatch_idx == num_microbatches - 1
+
+            # For DDP with gradient accumulation: disable gradient sync for
+            # all but the last microbatch to avoid redundant all-reduces
+            if using_ddp and num_microbatches > 1:
+                for model in self.model_parts:
+                    model.set_requires_gradient_sync(is_last_microbatch)
+
             # Move tensors to GPU
             for k, v in input_dict.items():
                 if isinstance(v, torch.Tensor):


### PR DESCRIPTION
Summary:
From the change to averaging over  microbatches to averaging over the global tokens, the averaging for FSDP was disabled in D91432940 but not for DDP. This adds an additional scaling to the gradients diving them twice by the number for DP ranks when using pure DDP. This error does not emerge in change in loss for short runs due to the scale invariance property of the AdamW optimizer but can be seen clearly in the grad norm measuerment and difference in the measurement from FSDP.

To fix this, as DDP does not have a property set_gradient_divide_factor() as FSDP, the solution employed is to put in a comm hook that replaces the default all reduce average operation with an all reduce sum operation

Differential Revision: D92301896


