### PR TITLE
[rl][ez] Ignoring checkpoint dir from git.

### DIFF
--- a/torchtitan/experiments/rl/.gitignore
+++ b/torchtitan/experiments/rl/.gitignore
@@ -1,0 +1,1 @@
+example_checkpoint/


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2325
* #2324

Summary:

Ignoring example_checkpoint/ dir since it clobbers git status rn.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: