### PR TITLE
[rl][ez] Fix import errors. (#2324)

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 import torch
 from monarch.actor import Actor, endpoint
 from torchtitan.experiments.rl.unified.actors.generator import TrajectoryData
-from torchtitan.experiments.rl.unified.models.parallelism_utils import (
+from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_trainer_parallel_dims,
 )
 from torchtitan.experiments.rl.unified.models.utils import load_model, ModelMode

--- a/torchtitan/experiments/rl/unified/models/attention.py
+++ b/torchtitan/experiments/rl/unified/models/attention.py
@@ -5,7 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from vllm.attention.layer import Attention
+
+try:
+    from vllm.attention.layer import Attention
+except ModuleNotFoundError:
+    from vllm.model_executor.layers.attention import Attention
 
 
 class VLLMAttention(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2325
* __->__ #2324

Summary:

I'm seeing some import errors while rebasing on the latest vllm and torchtitan. Fixing these.

Test Plan:
python torchtitan/experiments/rl/unified/infer.py

Reviewers:

Subscribers:

Tasks:

Tags: