### PR TITLE
Add run-to-run determinism testing to H100 CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -91,14 +91,14 @@ jobs:
           exit 1
         fi
 
-        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --export-result="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs/result.txt" --steps=100
+        python -m scripts.loss_compare . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --export-result="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs/result.txt" --steps=100
 
          echo "Checking FSDP8 the first tep loss is the same as FSDP2HSDP4"
-        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --test-options="${test_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --assert-equal --steps=1
+        python -m scripts.loss_compare . . --baseline-options="${baseline_options}" --test-options="${test_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --assert-equal --steps=1
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
          echo "Checking FSDP8 loss from a new run v.s. FSDP8 loss from text file parity"
-        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --import-result="${LOSS_FILE}" --assert-equal --steps=100
+        python -m scripts.loss_compare . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --import-result="${LOSS_FILE}" --assert-equal --steps=100
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
         python -m tests.integration_tests.run_tests --gpu_arch_type ${{ matrix.gpu-arch-type }} --test_suite features $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -71,5 +71,5 @@ jobs:
         sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
 
         # Enable CPP stacktraces for debugging symmetric memory initialization errors.
-        TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --test_suite h100 $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
+        TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --test_suite h100 --gpu_arch_type ${{ matrix.gpu-arch-type }} $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Commit messages
+
+Don't commit unless the user explicitly asks you to.
+
+When writing a commit message, don't make a bullet list of the individual
+changes. Instead, if the PR is large, explain the order to review changes
+(e.g., the logical progression), or if it's short just omit the bullet list
+entirely.
+
+Disclose that the PR was authored with Claude.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -24,6 +24,7 @@ class OverrideDefinitions:
     ngpu: int = 4
     disabled: bool = False
     skip_rocm_test: bool = False
+    determinism_test: bool = False  # Run twice and verify losses are identical
 
     def __repr__(self):
         return self.test_descr

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -42,6 +42,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             ],
             "Float8 test",
             "float8",
+            determinism_test=True,
         ),
         # TODO: re-enable this test once the async TP issue is fixed
         OverrideDefinitions(
@@ -77,6 +78,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "HSDP+CP+torch.compile+Float8",
             "hsdp+cp+compile+float8",
             ngpu=8,
+            determinism_test=True,
         ),
     ]
     return integration_tests_flavors

--- a/torchtitan/tools/loss_utils.py
+++ b/torchtitan/tools/loss_utils.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Shared utilities for loss extraction and comparison.
+
+This module provides common functionality used by both:
+- scripts/loss_compare.py (CLI tool for comparing losses across commits)
+- tests/integration_tests/run_tests.py (integration test runner)
+"""
+
+import re
+
+
+def extract_losses_from_log(log_file: str) -> dict[int, float]:
+    """Extract step and loss pairs from a training log file.
+
+    Parses log lines matching the pattern: "step: N loss: X.XXXX"
+    Handles ANSI escape codes that may be present in colored terminal output.
+
+    Args:
+        log_file: Path to the training log file
+
+    Returns:
+        Dictionary mapping step numbers to loss values
+    """
+    losses = {}
+    step_loss_pattern = re.compile(r"step:\s*(\d+)\s*loss:\s*(\d+\.\d+)")
+    ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
+
+    with open(log_file, "r") as f:
+        for line in f:
+            # Strip ANSI codes before matching
+            clean_line = ansi_escape.sub("", line)
+            match = step_loss_pattern.search(clean_line)
+            if match:
+                step, loss = match.groups()
+                losses[int(step)] = float(loss)
+
+    return losses
+
+
+def compare_losses(
+    losses1: dict[int, float],
+    losses2: dict[int, float],
+    name1: str = "run1",
+    name2: str = "run2",
+) -> tuple[bool, str]:
+    """Compare two loss dictionaries for equality.
+
+    Args:
+        losses1: First loss dictionary (step -> loss)
+        losses2: Second loss dictionary (step -> loss)
+        name1: Name for first run (for error messages)
+        name2: Name for second run (for error messages)
+
+    Returns:
+        Tuple of (success: bool, message: str)
+        - success is True if all losses match exactly
+        - message contains details about the comparison or mismatch
+    """
+    if not losses1:
+        return False, f"No losses found in {name1}"
+
+    if not losses2:
+        return False, f"No losses found in {name2}"
+
+    steps1 = set(losses1.keys())
+    steps2 = set(losses2.keys())
+
+    if steps1 != steps2:
+        return False, (
+            f"Steps mismatch: {name1} has {len(steps1)} steps, "
+            f"{name2} has {len(steps2)} steps"
+        )
+
+    mismatches = []
+    for step in sorted(steps1):
+        loss1 = losses1[step]
+        loss2 = losses2[step]
+        if loss1 != loss2:
+            mismatches.append(f"  step {step}: {name1}={loss1}, {name2}={loss2}")
+
+    if mismatches:
+        return False, "Loss mismatches:\n" + "\n".join(mismatches)
+
+    return True, f"All {len(steps1)} steps have identical losses"


### PR DESCRIPTION
Add run-to-run determinism testing to H100 CI

This adds automatic run-to-run determinism verification for H100 integration tests. Tests marked with `determinism_test=True` will run twice with identical configuration and deterministic flags, then compare losses to ensure they match exactly.

The core loss extraction logic is factored into `torchtitan/tools/loss_utils.py` and shared between the integration test runner and the existing `loss_compare.py` script. The scripts directory is now a package to enable clean imports via `python -m scripts.loss_compare`.

The Float8 and HSDP+CP+compile+Float8 tests in the H100 suite are enabled for determinism testing (CUDA only).

Co-authored-by: Claude <noreply@anthropic.com>