### PR TITLE
[ci] Add DSv3 SimpleFSDP auto_bucketing to h100 ci jobs

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -78,5 +78,24 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "hsdp+cp+compile+float8",
             ngpu=8,
         ),
+        # Experimental, non-blocking: PRs can land if only this test fails
+        OverrideDefinitions(
+            [
+                [
+                    "--job.config_file ./torchtitan/models/deepseek_v3/train_configs/debug_model.toml",
+                    "--model.name simple_fsdp.deepseek_v3",
+                    "--parallelism.tensor_parallel_degree 1",
+                    "--parallelism.expert_parallel_degree 8",
+                    "--job.custom_config_module=torchtitan.experiments.simple_fsdp.job_config",
+                    "--compile.graph_passes auto_bucketing",
+                    "--activation_checkpoint.mode none",
+                    "--compile.backend inductor",
+                    "--compile.enable",
+                ]
+            ],
+            "[Experimental, non-blocking landing if fails] SimpleFSDP DeepSeekV3 auto_bucketing",
+            "simplefsdp_deepseekv3_auto_bucketing",
+            ngpu=8,
+        ),
     ]
     return integration_tests_flavors


### PR DESCRIPTION
Adding DSv3 SimpleFSDP + inductor auto_bucketing passes to H100 CI.

We need H100 to go through grouped_mm path.

Testing:
```
rm -rf /tmp/test_output && python -m tests.integration_tests.run_tests /tmp/test_output --test_suite h100 --test_name simplefsdp_deepseekv3_auto_bucketing --ngpu 8
```

Originally I wanted to add this CI to AutoParallel. But we can not do it as it runs on A100 and goes through non-groupedmm moe part.

