### PR TITLE
Add FP16 mixed precision training support with GradScaler

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -570,6 +570,63 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "dataloader_kwargs",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.mixed_precision_param=float16",
+                ],
+            ],
+            "FP16 mixed precision with FSDP and GradScaler",
+            "fsdp_fp16",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.mixed_precision_param=float16",
+                    "--checkpoint.enable",
+                ],
+                [
+                    "--training.mixed_precision_param=float16",
+                    "--checkpoint.enable",
+                    "--training.steps 20",
+                ],
+            ],
+            "FP16 checkpoint save and resume with GradScaler state",
+            "fp16_checkpoint",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.mixed_precision_param=float16",
+                    "--compile.enable",
+                ],
+            ],
+            "FP16 mixed precision with torch.compile",
+            "fp16_compile",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.mixed_precision_param=float16",
+                    "--activation_checkpoint.mode selective",
+                    "--activation_checkpoint.selective_ac_option op",
+                ],
+            ],
+            "FP16 mixed precision with selective activation checkpointing",
+            "fp16_sac",
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--training.mixed_precision_param=float16",
+                    "--compile.enable",
+                    "--activation_checkpoint.mode selective",
+                    "--activation_checkpoint.selective_ac_option op",
+                ],
+            ],
+            "FP16 mixed precision with torch.compile and selective AC",
+            "fp16_compile_sac",
+        ),
     ]
 
     return integration_tests_flavors

--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -272,14 +272,14 @@ class Training:
     Whether to apply CPU offloading of parameters, gradients, and optimizer states in FSDP
     """
 
-    dtype: Literal["bfloat16", "float32"] = "float32"
+    dtype: Literal["bfloat16", "float16", "float32"] = "float32"
     """
     torch dtype for training. In contrast to mixed precision training, setting training_dtype=bfloat16 will
     put all parameters, gradients, and optimizer states in bfloat16, without an extra copy of fp32 weights.
     In the case of full bf16 training, RoPE calculations and logits will still be in fp32.
     """
 
-    mixed_precision_param: Literal["bfloat16", "float32"] = "bfloat16"
+    mixed_precision_param: Literal["bfloat16", "float16", "float32"] = "bfloat16"
     """
     torch dtype to use for parameters when applying mixed precision via fully_shard or torch.autocast.
     This feature takes effect via fully_shard when data_parallel_shard_degree > 1 or


### PR DESCRIPTION
FP16 has higher mantissa precision (10 bits vs BF16's 7 bits) which reduces rounding errors during RL fine-tuning, but requires loss scaling to prevent gradient underflow due to its limited exponent range (5 bits).

This commit integrates torch.amp.GradScaler into the training loop when FP16 is configured via training.dtype or training.mixed_precision_param, with proper support for FSDP, Pipeline Parallel, gradient clipping, checkpointing, and FluxTrainer. The implementation of composing `grad scalar` with `grad clipping` follows the example in https://github.com/pytorch/pytorch/blob/8f5c518dd325a7779d194c8961f670befb28f5d9/docs/source/notes/amp_examples.rst#gradient-clipping.


Resolves #2356

Authorized by Claude