### PR TITLE
[rl][poc] Native PyTorch Varlen Attention for inference.

### DIFF
--- a/.github/workflows/integration_test_2gpu_rl_numerics.yaml
+++ b/.github/workflows/integration_test_2gpu_rl_numerics.yaml
@@ -1,0 +1,118 @@
+name: RL Numerics 2 GPU Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - ciflow/8gpu/*
+    paths:
+      - 'torchtitan/experiments/rl/**'
+      - '.github/workflows/integration_test_2gpu_rl_numerics.yaml'
+  pull_request:
+    paths:
+      - 'torchtitan/experiments/rl/**'
+      - '.github/workflows/integration_test_2gpu_rl_numerics.yaml'
+
+concurrency:
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+permissions:
+      id-token: write
+      contents: read
+
+# Steps should be kept in sync with torchtitan/experiments/rl/README.md
+jobs:
+  # Step 1: Dynamically compute the matrix based on conditions
+  set-matrix:
+    uses: ./.github/workflows/set-matrix.yaml
+    with:
+      runner-cuda: linux.aws.h100.8
+
+  # Step 2: Use the dynamic matrix in the build-test job
+  build-test:
+    needs: set-matrix
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    with:
+      runner: ${{ matrix.runner }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      docker-image: ${{ matrix.docker-image }}
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      timeout: 90
+      script: |
+        set -eux
+
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        conda install -y -c conda-forge libstdcxx-ng
+
+        pip install -e .
+
+        # Install CUDA 12.8 toolkit via conda (needed to build vLLM from source)
+        # Temporarily disable -u because conda activation scripts have unbound variables
+        set +u
+        conda install -y -c nvidia cuda-toolkit=12.8
+        set -u
+        # Conda CUDA toolkit puts headers/libs under targets/x86_64-linux/
+        export CUDA_HOME="${CONDA_PREFIX}/targets/x86_64-linux"
+        # Pass as CMake args since CUDA_TOOLKIT_ROOT_DIR is a CMake variable, not an env var
+        export CMAKE_ARGS="-DCUDA_TOOLKIT_ROOT_DIR=${CUDA_HOME} -DCMAKE_CUDA_COMPILER=${CONDA_PREFIX}/bin/nvcc"
+
+        # Log CUDA driver version for debugging.
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
+        echo "CUDA driver version: ${DRIVER_VERSION}"
+
+        pip config --user set global.progress_bar off
+
+        # Install torch nightly first
+        TORCH_SPEC="torch"
+        if [ -n "${{ matrix.torch-version }}" ]; then
+          TORCH_SPEC="torch==${{ matrix.torch-version }}"
+        fi
+        if [ "${{ matrix.gpu-arch-type }}" = "rocm" ]; then
+          python -m pip install --force-reinstall --pre \
+            "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+        else
+          python -m pip install --force-reinstall --pre \
+            torch --index-url ${{ matrix.index-url }}
+        fi
+
+        # Install RL dependencies: xformers, monarch, flash-attn-3
+        pip install xformers --extra-index-url ${{ matrix.index-url }}
+        pip install torchmonarch==0.3.0
+        pip install pygtrie portpicker
+        pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
+        pip install flash-attn-3 --extra-index=https://download.pytorch.org/whl/test/cu128
+
+        # Build and install vLLM from source using existing torch nightly
+        git clone https://github.com/vllm-project/vllm.git /tmp/vllm
+        cd /tmp/vllm
+        python use_existing_torch.py
+        pip install -r requirements/build.txt
+        # Constrain torch to the installed nightly version so pip doesn't try to downgrade it
+        TORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+        echo "Installed torch version: ${TORCH_VERSION}"
+        echo "torch==${TORCH_VERSION}" > /tmp/torch-constraint.txt
+        PIP_CONSTRAINT=/tmp/torch-constraint.txt pip install --no-build-isolation -v -e .
+        cd -
+
+        # Download Qwen3-0.6B checkpoint
+        python scripts/download_hf_assets.py \
+          --repo_id Qwen/Qwen3-0.6B \
+          --local_dir torchtitan/experiments/rl/example_checkpoint \
+          --all
+
+        # Run the attention numerics test (2 GPU, TP=2)
+        torchrun --nproc-per-node=2 \
+          torchtitan/experiments/rl/tests/test_attn_numerics.py

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -25,7 +25,15 @@ uv pip install torchmonarch==0.3.0
 uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
 
 
-2. Install PyTorch nightly for torchtitan, and pre-built vllm wheels (based on PyTorch nightly version).
+2. Install Flash Attention v3 kernels:
+```
+# CUDA 12
+pip install flash-attn-3 --extra-index=https://download.pytorch.org/whl/test/cu128
+# CUDA 13
+pip install flash-attn-3 --extra-index=https://download.pytorch.org/whl/test/cu130
+```
+
+3. Install PyTorch nightly for torchtitan, and pre-built vllm wheels (based on PyTorch nightly version).
 ```bash
 # Install vllm with nightly torch
 uv pip install torch vllm xformers  --pre \
@@ -36,26 +44,26 @@ uv pip install torch vllm xformers  --pre \
 **NOTE:** The pre-built vLLM wheels are only compatible with CUDA 12.8, though they should work with most older CUDA versions. Alternatively, you can install the corresponding vLLM pre-built wheels directly from https://download.pytorch.org/whl/nightly/cu128, for example: `uv pip install vllm-1.0.0.dev20260219+cu130-<suffix>.whl`. Ensure the build version number (e.g., `dev20260219`) matches your PyTorch nightly installation.
 
 
-3. Install TorchTitan in editable mode:
+4. Install TorchTitan in editable mode:
 ```bash
 uv pip install -e .
 ```
 
-4. Download `Qwen/Qwen3-0.6B` (or `Qwen/Qwen3-1.7B`) checkpoint from HuggingFace to `torchtitan/experiments/rl/example_checkpoint` folder.
+5. Download `Qwen/Qwen3-0.6B` (or `Qwen/Qwen3-1.7B`) checkpoint from HuggingFace to `torchtitan/experiments/rl/example_checkpoint` folder.
 ```bash
 python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-0.6B --local_dir torchtitan/experiments/rl/example_checkpoint --all --hf_token=...
 
 python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-1.7B --local_dir torchtitan/experiments/rl/example_checkpoint --all --hf_token=...
 ```
 
-5. Run inference with torchtitan model definition:
+6. Run inference with torchtitan model definition:
 ```bash
 torchrun --nproc_per_node=2 torchtitan/experiments/rl/inference_example.py
 ```
 
 **NOTE:**: Set `--nproc_per_node` to the world size, which should match the `tensor_parallel_degree` in the `VLLMGenerator` config.
 
-6. Run simple GRPO RL loop to learn sum digits task
+7. Run simple GRPO RL loop to learn sum digits task
 ```bash
 python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b
 ```

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -58,7 +58,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
                 top_p=0.95,
                 max_tokens=100,
             ),
-            attention_backend="FLASH_ATTN",
+            attention_backend="CUSTOM",
         ),
     )
 
@@ -97,7 +97,7 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
                 top_p=0.95,
                 max_tokens=100,
             ),
-            attention_backend="FLASH_ATTN",
+            attention_backend="CUSTOM",
         ),
     )
 
@@ -135,6 +135,6 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 top_p=0.95,
                 max_tokens=50,
             ),
-            attention_backend="FLASH_ATTN",
+            attention_backend="CUSTOM",
         ),
     )

--- a/torchtitan/experiments/rl/inference_example.py
+++ b/torchtitan/experiments/rl/inference_example.py
@@ -73,6 +73,7 @@ def generate():
         enforce_eager=gen_config.compile.is_eager,
         # HuggingFace overrides
         hf_overrides={"architectures": [VLLM_MODEL_NAME]},
+        attention_backend=gen_config.attention_backend,
     )
     vllm_compilation_config = gen_config.compile.get_vllm_compilation_config()
     if vllm_compilation_config is not None:

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -8,12 +8,160 @@ import logging
 
 import torch
 from torch.distributed.tensor import DTensor
-from torchtitan.experiments.rl.models.vllm_compat_attention import (
-    VLLMCompatibleFlashAttention,
+from torch.nn.attention import (
+    activate_flash_attention_impl,
+    current_flash_attention_impl,
 )
 from torchtitan.protocols.module import Module
 
 from vllm.model_executor.layers.attention import Attention
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+)
+from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+
+
+@register_backend(AttentionBackendEnum.CUSTOM)
+class PyTorchFlashAttentionBackend(FlashAttentionBackend):
+    """Custom vLLM attention backend using PyTorch's native FlashAttention kernel.
+
+    This class is not directly referenced in user code. It is registered into
+    vLLM's attention backend registry via the ``@register_backend`` decorator
+    and selected at runtime when the vLLM engine is configured to use a CUSTOM
+    attention backend.
+
+    Inheriting from ``FlashAttentionBackend`` is not strictly required for all
+    backends, but it is convenient here to reuse metadata construction logic.
+    """
+
+    @staticmethod
+    def get_name():
+        # vLLM requires any custom attention backend to return "CUSTOM" as its
+        # name so the backend registry can look it up correctly.
+        return "CUSTOM"
+
+    @staticmethod
+    def get_impl_cls():
+        return PyTorchFlashAttentionImpl
+
+
+class PyTorchFlashAttentionImpl(FlashAttentionImpl):
+    """
+    Custom vLLM attention backend impl using PyTorch's native FlashAttention varlen API.
+    Instead of using vLLM's FlashAttention kernel, this implementation takes the kernel
+    dependency from torch directly while supporting the same interface.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Activate PyTorch's FA3 flash attention implementation. This is required for
+        # the varlen attention API to work with paged attention (KV cache in block
+        # layout) because vLLM uses default page size 16 but FA2 only supports
+        # page_size=256. Error out if FA3 is not available in the current environment.
+        if current_flash_attention_impl() != "FA3":
+            activate_flash_attention_impl("FA3")
+
+    # Based on vLLM's FlashAttentionImpl.forward():
+    # https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/flash_attn.py
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward pass with FlashAttention.
+
+        Args:
+            query: shape = [num_tokens, num_heads, head_size]
+            key: shape = [num_tokens, num_kv_heads, head_size]
+            value: shape = [num_tokens, num_kv_heads, head_size]
+            kv_cache: shape =
+                [2, num_blocks, block_size, num_kv_heads, head_size]
+            attn_metadata: Metadata for attention.
+        Returns:
+            shape = [num_tokens, num_heads * head_size]
+        """
+        assert output is not None, "Output tensor must be provided."
+        assert (
+            self.vllm_flash_attn_version is not None
+        ), "FlashAttention version not detected."
+
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported for FlashAttentionImpl"
+            )
+
+        if attn_metadata is None:
+            # Profiling run.
+            return output.fill_(0)
+
+        attn_type = self.attn_type
+
+        # IMPORTANT!
+        # NOTE(woosuk): With piece-wise CUDA graphs, this method is executed in
+        # eager-mode PyTorch. Thus, we need to be careful about any CPU overhead
+        # in this method. For example, `view` and `slice` (or `[:n]`) operations
+        # are surprisingly slow even in the case they do not invoke any GPU ops.
+        # Minimize the PyTorch ops in this method as much as possible.
+        # Whenever making a change in this method, please benchmark the
+        # performance to make sure it does not introduce any overhead.
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+
+        assert attn_type not in (
+            AttentionType.ENCODER_ONLY,
+            AttentionType.ENCODER,
+        ), "Encoder-only attention not supported yet."
+
+        # For decoder and cross-attention, use KV cache as before
+        key_cache, value_cache = kv_cache.unbind(0)
+
+        assert not self.kv_cache_dtype.startswith(
+            "fp8"
+        ), "FP8 KV cache not supported yet."
+
+        assert not attn_metadata.use_cascade, "Cascade not supported yet."
+
+        cu_seqlens_q = attn_metadata.query_start_loc
+        seqused_k = attn_metadata.seq_lens
+        max_seqlen_q = attn_metadata.max_query_len
+        max_seqlen_k = attn_metadata.max_seq_len
+        block_table = attn_metadata.block_table
+
+        assert self.dcp_world_size == 1, "DCP not supported yet."
+
+        if attn_metadata.causal:
+            sliding_window_size = (-1, 0)
+        else:
+            raise RuntimeError("Non-causal attention not supported yet.")
+
+        assert self.alibi_slopes is None, "Alibi slopes not supported yet."
+
+        return torch.nn.attention.varlen.varlen_attn_out(
+            output[:num_actual_tokens],
+            query[:num_actual_tokens],
+            key_cache,
+            value_cache,
+            cu_seqlens_q,
+            None,
+            max_seqlen_q,
+            max_seqlen_k,
+            scale=self.scale,
+            window_size=sliding_window_size,
+            block_table=block_table,
+            seqused_k=seqused_k,
+        )
+
 
 logger = logging.getLogger(__name__)
 

--- a/torchtitan/experiments/rl/tests/__init__.py
+++ b/torchtitan/experiments/rl/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/rl/tests/test_attn_numerics.py
+++ b/torchtitan/experiments/rl/tests/test_attn_numerics.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Test that vLLM engine and TorchTitan Module forward produce bitwise identical
+log-probs for the same prompt + generated token sequence.
+
+Flow:
+  1. Generate tokens from a single prompt via the vLLM engine (greedy decoding).
+  2. Feed [prompt + generated tokens] through a standalone TorchTitan model
+     forward and compute per-token log-probs.
+  3. Compare the two sets of log-probs bitwise.
+
+Run:
+    torchrun --nproc_per_node=2 \
+        torchtitan/experiments/rl/tests/test_attn_numerics.py
+"""
+
+import logging
+import os
+
+# Must set spawn method before any CUDA operations or vLLM imports
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+from torch.distributed.checkpoint.state_dict import (
+    set_model_state_dict,
+    StateDictOptions,
+)
+
+from vllm import EngineArgs, LLMEngine, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode
+from vllm.model_executor.layers.batch_invariant import init_batch_invariance
+from vllm.sampling_params import RequestOutputKind
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+from torchtitan.config import CommConfig, TORCH_DTYPE_MAP
+from torchtitan.config.configs import ParallelismConfig
+from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
+from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
+from torchtitan.experiments.rl.actors.utils import (
+    compute_token_log_probs,
+    verify_logprob_identity,
+)
+from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
+from torchtitan.experiments.rl.plugin import (
+    register_model_to_vllm_model_registry,
+    VLLM_MODEL_NAME,
+)
+from torchtitan.experiments.rl.simple_grpo_sum_digits import RLTrainer
+from torchtitan.models.qwen3 import model_registry
+from torchtitan.tools import utils
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def _log_attention_module(model, label):
+    """Log the inner_attention class name from layer 0 (rank 0 only)."""
+    if dist.get_rank() != 0:
+        return
+    layer_0 = next(iter(model.layers.values()))
+    attn_cls = type(layer_0.attention.inner_attention).__name__
+    logger.info(f"{label} attention module: {attn_cls}")
+
+
+# ---------------------------------------------------------------------------
+# Step 1: vLLM engine generation
+# ---------------------------------------------------------------------------
+
+
+def create_vllm_engine(config):
+    """Create a vLLM LLMEngine from the RL config."""
+    gen_config = config.generator
+    model_path = config.hf_assets_path
+
+    # Enable batch-invariant mode so vLLM uses the deterministic flash-attn path.
+    init_batch_invariance(AttentionBackendEnum[gen_config.attention_backend])
+
+    assert gen_config.attention_backend == "CUSTOM"
+    engine_kwargs = dict(
+        model=model_path,
+        trust_remote_code=True,
+        dtype=gen_config.model_dtype,
+        tensor_parallel_size=gen_config.parallelism.tensor_parallel_degree,
+        distributed_executor_backend="external_launcher",
+        gpu_memory_utilization=gen_config.gpu_memory_limit,
+        hf_overrides={"architectures": [VLLM_MODEL_NAME]},
+        attention_backend=gen_config.attention_backend,
+        compilation_config=CompilationConfig(
+            backend="eager",
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    )
+    if gen_config.seed is not None:
+        engine_kwargs["seed"] = gen_config.seed
+    engine_args = EngineArgs(**engine_kwargs)
+
+    if dist.get_rank() == 0:
+        logger.info("Creating vLLM LLMEngine ...")
+    engine = LLMEngine.from_engine_args(engine_args)
+    if dist.get_rank() == 0:
+        logger.info("vLLM LLMEngine ready.")
+    return engine
+
+
+def generate_with_vllm(engine, prompt, gen_config):
+    """Generate tokens from *prompt*, return IDs + log-probs."""
+    sampling = gen_config.sampling
+    sampling_params = SamplingParams(
+        temperature=sampling.temperature,
+        top_p=sampling.top_p,
+        max_tokens=sampling.max_tokens,
+        logprobs=1,
+        prompt_logprobs=1,
+        output_kind=RequestOutputKind.FINAL_ONLY,
+    )
+
+    engine.add_request("0", prompt, sampling_params)
+
+    outputs = []
+    while engine.has_unfinished_requests():
+        step_outputs = engine.step()
+        outputs.extend(step_outputs)
+
+    assert len(outputs) == 1, f"Expected 1 output, got {len(outputs)}"
+    output = outputs[0]
+
+    prompt_token_ids = list(output.prompt_token_ids)
+    sample = output.outputs[0]
+    generated_token_ids = list(sample.token_ids)
+    vllm_log_probs = [list(lp_dict.values())[0].logprob for lp_dict in sample.logprobs]
+
+    if dist.get_rank() == 0:
+        logger.info(
+            f"vLLM generated {len(generated_token_ids)} tokens "
+            f"(prompt length={len(prompt_token_ids)})"
+        )
+    return prompt_token_ids, generated_token_ids, vllm_log_probs
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Build trainer-side TorchTitan model
+# ---------------------------------------------------------------------------
+
+
+def build_trainer_model(config):
+    """Build, parallelize, and load weights for the trainer model.
+
+    Mirrors PolicyTrainer._build_model() but without the Monarch actor
+    framework.
+
+    TODO(zhxchen17) Switch trainer model to use varlen backend with batch-invariant mode.
+    """
+    model_spec = config.model_spec
+    model_config = model_spec.model
+    hf_assets_path = config.hf_assets_path
+
+    device_module, device_type = utils.device_module, utils.device_type
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    device = torch.device(f"{device_type}:{local_rank}")
+    device_module.set_device(device)
+
+    world_size = dist.get_world_size()
+    parallelism = config.trainer.parallelism
+
+    parallel_dims = ParallelDims(
+        dp_shard=parallelism.data_parallel_shard_degree,
+        dp_replicate=parallelism.data_parallel_replicate_degree,
+        cp=parallelism.context_parallel_degree,
+        tp=parallelism.tensor_parallel_degree,
+        pp=parallelism.pipeline_parallel_degree,
+        ep=parallelism.expert_parallel_degree,
+        etp=parallelism.expert_tensor_parallel_degree,
+        world_size=world_size,
+    )
+
+    # Build model on meta device
+    with torch.device("meta"):
+        with utils.set_default_dtype(TORCH_DTYPE_MAP["bfloat16"]):
+            model = model_config.build()
+
+    # Parallelize (trainer path: has_position_id=False)
+    model = parallelize_qwen3(
+        model,
+        parallel_dims=parallel_dims,
+        parallelism=parallelism,
+    )
+
+    # Materialize on device
+    model.to_empty(device=device_type)
+    with torch.no_grad():
+        model.init_weights(buffer_device=None)
+
+    # Load HF checkpoint (same logic as PolicyTrainer._load_initial_hf_weights)
+    if model_spec.state_dict_adapter is not None:
+        sd_adapter = model_spec.state_dict_adapter(model_config, hf_assets_path)
+        storage_reader = sd_adapter.get_hf_storage_reader(hf_assets_path)
+        hf_state_dict = sd_adapter.to_hf(model.state_dict())
+        dcp.load(hf_state_dict, storage_reader=storage_reader)
+        torchtitan_state_dict = sd_adapter.from_hf(hf_state_dict)
+        set_model_state_dict(
+            model=model,
+            model_state_dict=torchtitan_state_dict,
+            options=StateDictOptions(strict=False),
+        )
+        if dist.get_rank() == 0:
+            logger.info(
+                f"Loaded HF weights from {hf_assets_path} "
+                f"({len(torchtitan_state_dict)} params)"
+            )
+
+    model.eval()
+    return model, device
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _test_config() -> RLTrainer.Config:
+    """Test-specific config: greedy sampling, fewer tokens, single sample."""
+    return RLTrainer.Config(
+        model_spec=model_registry("0.6B"),
+        hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
+        batch_invariant_mode=True,
+        trainer=PolicyTrainer.Config(
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=2,
+                data_parallel_replicate_degree=1,
+            ),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            gpu_memory_limit=0.5,
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=2,
+            ),
+            num_samples_per_prompt=1,
+            sampling=SamplingConfig(
+                temperature=0.0,
+                top_p=1.0,
+                max_tokens=30,
+            ),
+            attention_backend="CUSTOM",
+        ),
+    )
+
+
+def main():
+    # ---- Config setup ----
+    config = _test_config()
+    config.model_spec.parallelize_fn = parallelize_qwen3
+
+    # Register model with vLLM
+    register_model_to_vllm_model_registry(config.model_spec)
+
+    # Initialize distributed (needed for both vLLM and trainer model)
+    dist_utils.init_distributed(CommConfig())
+
+    # ---- Step 1: Generate via vLLM ----
+    prompt = "Hello, my name is"
+
+    engine = create_vllm_engine(config)
+    vllm_model = engine.model_executor.driver_worker.get_model().model
+    _log_attention_module(vllm_model, "vLLM")
+    prompt_token_ids, generated_token_ids, vllm_log_probs = generate_with_vllm(
+        engine, prompt, config.generator
+    )
+
+    if dist.get_rank() == 0:
+        logger.info(f"Prompt token IDs: {prompt_token_ids}")
+        logger.info(
+            f"Generated token IDs ({len(generated_token_ids)}): {generated_token_ids}"
+        )
+
+    # Free vLLM engine GPU memory before building the trainer model
+    del vllm_model, engine
+    torch.cuda.empty_cache()
+
+    # ---- Step 2: Build trainer model and compute log-probs ----
+    trainer_model, device = build_trainer_model(config)
+    _log_attention_module(trainer_model, "Trainer")
+
+    with torch.no_grad():
+        trainer_token_log_probs = compute_token_log_probs(
+            trainer_model, prompt_token_ids, generated_token_ids, device
+        )
+
+    if dist.get_rank() == 0:
+        logger.info(
+            f"Trainer computed {trainer_token_log_probs.shape[0]} token log-probs"
+        )
+        n_preview = min(5, len(vllm_log_probs))
+        logger.info(f"  vLLM   log-probs[:{n_preview}]: {vllm_log_probs[:n_preview]}")
+        logger.info(
+            f"  Trainer log-probs[:{n_preview}]: "
+            f"{trainer_token_log_probs[:n_preview].tolist()}"
+        )
+
+    # ---- Step 3: Compare (rank 0 only) ----
+    if dist.get_rank() == 0:
+        result = verify_logprob_identity(
+            [vllm_log_probs],
+            [trainer_token_log_probs],
+        )
+
+        logger.info("=" * 60)
+        logger.info("LOGPROB COMPARISON RESULTS")
+        logger.info("=" * 60)
+        logger.info(f"  Bitwise identical : {result['logprob_bitwise_identical']}")
+        logger.info(f"  Tokens checked    : {result['total_tokens_checked']}")
+        logger.info(f"  Tokens different  : {result['num_tokens_different']}")
+        logger.info(f"  Max delta         : {result['logprob_max_delta']:.6e}")
+        logger.info(f"  Avg delta         : {result['avg_delta']:.6e}")
+        logger.info(f"  Diff mean         : {result['logprob_diff_mean']:.6e}")
+        logger.info(f"  Diff max          : {result['logprob_diff_max']:.6e}")
+        logger.info("=" * 60)
+
+        assert result["logprob_bitwise_identical"], (
+            f"FAIL: vLLM and trainer log-probs are NOT bitwise identical.\n"
+            f"  max_delta={result['logprob_max_delta']:.6e}, "
+            f"  diff_max={result['logprob_diff_max']:.6e}"
+        )
+        logger.info("PASS: vLLM and trainer log-probs are bitwise identical.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

### what this PR does
This PR adds the option to use PyTorch's native varlen Flash Attention kernel (instead of vllm's custom FA kernel) for vLLM Generator.

### why doing this

Traditionally different training and inference model definitions are used for training and rollout, this causes instability issues. To address this problem, we want to make sure training and inference model definition are matching.
In order to match FA kernel on both sides. There're 3 ways to do this:
1. Use trainer's existing FA kernel on generator side.
2. Use generator's existing FA kernel on trainer side.
3. Have a common dependency and patch it to be used on both sides.

This PR essentially takes a step towards option 3. Since PyTorch is a common dependency to every repo (titan and vllm), and more importantly it recently adds support for pagedd attention, which makes it possible to be used for inference case like vLLM.

### how to enable
When user add `attention_backend='CUSTOM'` to Generator's config, it will automatically switch to PyTorch's native FA kernel for inference.

Test Plan:

```
torchrun --nproc_per_node=2     torchtitan/experiments/rl/unified/validation/test_attn_numerics.py 
```
output result:

```
[2026-03-05 08:57:23] INFO test_attn_numerics.py:118: vLLM LLMEngine ready.
[2026-03-05 08:57:23] INFO test_attn_numerics.py:77: vLLM attention module: VLLMAttention
WARNING 03-05 08:57:23 [input_processor.py:254] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
[2026-03-05 08:57:31] INFO test_attn_numerics.py:150: vLLM generated 30 tokens (prompt length=5)
[2026-03-05 08:57:31] INFO test_attn_numerics.py:291: Prompt token IDs: [9707, 11, 847, 829, 374]
[2026-03-05 08:57:31] INFO test_attn_numerics.py:292: Generated token IDs (30): [444, 2210, 13, 358, 2776, 264, 220, 17, 17, 4666, 6284, 5458, 504, 5616, 13, 358, 2776, 8014, 304, 20956, 304, 279, 2274, 13, 358, 2776, 3330, 369, 264, 2618]
[2026-03-05 08:57:31] INFO attention.py:368: Successfully replaced TorchTitan attention with VLLMCompatibleFlashAttention (28 layers)
[2026-03-05 08:57:31] INFO parallel_dims.py:131: Building device mesh with parallelism: pp=1, dp_replicate=1, dp_shard=1, cp=1, tp=2, ep=1, etp=1
[2026-03-05 08:57:31] INFO attention.py:368: Successfully replaced TorchTitan attention with VLLMCompatibleFlashAttention (28 layers)
[2026-03-05 08:57:31] INFO parallel_dims.py:131: Building device mesh with parallelism: pp=1, dp_replicate=1, dp_shard=1, cp=1, tp=2, ep=1, etp=1
[2026-03-05 08:57:31] INFO parallel_dims.py:184: Successfully created meshes with active dimensions: ['tp', 'efsdp']
[2026-03-05 08:57:31] INFO parallel_dims.py:184: Successfully created meshes with active dimensions: ['tp', 'efsdp']
[2026-03-05 08:57:32] WARNING state_dict_adapter.py:96: model.safetensors.index.json not found at hf_assets_path: torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B/model.safetensors.index.json.                     Defaulting to saving a single safetensors file if checkpoint is saved in HF format
[2026-03-05 08:57:32] WARNING state_dict_adapter.py:96: model.safetensors.index.json not found at hf_assets_path: torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B/model.safetensors.index.json.                     Defaulting to saving a single safetensors file if checkpoint is saved in HF format
[2026-03-05 08:57:32] INFO test_attn_numerics.py:224: Loaded HF weights from torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B (311 params)
[2026-03-05 08:57:32] INFO test_attn_numerics.py:77: Trainer attention module: VLLMCompatibleFlashAttention
[2026-03-05 08:57:32] INFO test_attn_numerics.py:310: Trainer computed 30 token log-probs
[2026-03-05 08:57:32] INFO test_attn_numerics.py:314:   vLLM   log-probs[:5]: [-4.064868450164795, -1.785841941833496, -0.708375871181488, -0.2134280651807785, -0.9917267560958862]
[2026-03-05 08:57:32] INFO test_attn_numerics.py:315:   Trainer log-probs[:5]: [-4.064868450164795, -1.785841941833496, -0.708375871181488, -0.2134280651807785, -0.9917267560958862]
[2026-03-05 08:57:32] INFO test_attn_numerics.py:327: ============================================================
[2026-03-05 08:57:32] INFO test_attn_numerics.py:328: LOGPROB COMPARISON RESULTS
[2026-03-05 08:57:32] INFO test_attn_numerics.py:329: ============================================================
[2026-03-05 08:57:32] INFO test_attn_numerics.py:330:   Bitwise identical : True
[2026-03-05 08:57:32] INFO test_attn_numerics.py:331:   Tokens checked    : 30
[2026-03-05 08:57:32] INFO test_attn_numerics.py:332:   Tokens different  : 0
[2026-03-05 08:57:32] INFO test_attn_numerics.py:333:   Max delta         : 0.000000e+00
[2026-03-05 08:57:32] INFO test_attn_numerics.py:334:   Avg delta         : 0.000000e+00
[2026-03-05 08:57:32] INFO test_attn_numerics.py:335:   Diff mean         : 0.000000e+00
[2026-03-05 08:57:32] INFO test_attn_numerics.py:336:   Diff max          : 0.000000e+00
[2026-03-05 08:57:32] INFO test_attn_numerics.py:337: ============================================================
[2026-03-05 08:57:32] INFO test_attn_numerics.py:344: PASS: vLLM and trainer log-probs are bitwise identical.
```

perf benchmark:
```
torchrun --nproc_per_node=2     torchtitan/experiments/rl/unified/validation/bench_attn_perf.py
```

```
================================================================
  Attention Backend Performance Comparison
  Model: Qwen3-0.6B | TP: 2 | Prompts: 8 | Prompt len: 512
  Decode tokens: 128 | Warmup: 1 | Timed runs: 3
================================================================

Backend        Phase        Tokens     Time (s)      Tok/s
----------------------------------------------------------
FLASH_ATTN     Prefill        4096       0.2325      17615
FLASH_ATTN     Decode         1024      28.6333         36
CUSTOM         Prefill        4096       0.2300      17809
CUSTOM         Decode         1024      29.1132         35

Speedup (CUSTOM / FLASH_ATTN):
  Prefill: 1.01x
  Decode:  0.98x
================================================================
```
Reviewers:

Subscribers:

Tasks:

Tags:
