### PR TITLE
Fixing extra averaging performed in validation error

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -261,7 +261,7 @@ class Validator(BaseValidator):
         loss = torch.sum(torch.stack(accumulated_losses))
         loss /= num_steps
         if parallel_dims.dp_cp_enabled:
-            global_avg_loss = dist_utils.dist_mean(
+            global_avg_loss = dist_utils.dist_sum(
                 loss, parallel_dims.get_optional_mesh("loss")
             )
         else:


### PR DESCRIPTION
Summary: The change to averaging over  microbatches to averaging over the global tokens in D91432940, the train loss computation was fixed to account of the change from mean to sum but not the validation loss computation, thus incurring an extra division computation in the validation loss. The operations here has been changed from a mean to a sum.

Differential Revision: D92888963


