### PR TITLE
validate attn_type fix

### DIFF
--- a/torchtitan/models/llama4/model/model.py
+++ b/torchtitan/models/llama4/model/model.py
@@ -577,9 +577,7 @@ class Transformer(ModelProtocol):
             case "sdpa":
                 raise TypeError("SDPA attention does not require attention masks")
             case _:
-                raise ValueError(
-                    f"Unknown attention type: {self.model_args.attn_type}"
-                )
+                raise ValueError(f"Unknown attention type: {self.model_args.attn_type}")
 
     def forward(
         self,


### PR DESCRIPTION

The `post_dataloading_process` function does not verify the model's attention type, whereas the trainer’s `post_dataloading_process` does.

Validating a model with `sdpa` triggers the following assertion error:

```python
File "/leonardo_scratch/fast/iGen_train/fbertolo/torchtitan/torchtitan/models/llama4/model/model.py", line 285, in forward
    assert attention_masks is None and self.attn_type == "sdpa"
AssertionError
```

The issue is resolved by adding a check for the attention type before generating the attention mask.
