### PR TITLE
[RL] Enable vLLM cudagraphs and compile in expriment/rl for efficiency

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -20,8 +20,10 @@ from torchtitan.distributed import utils as dist_utils
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
 
-from torchtitan.experiments.rl.vllm_compat.simple_rl import (
+from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     build_compilation_config,
+)
+from torchtitan.experiments.rl.vllm_compat.simple_rl import (
     compute_grpo_advantages,
     compute_grpo_advantages_stable,
     math_reward_function,
@@ -215,7 +217,7 @@ class VLLMRolloutEngine:
                 seed=42,  # Fixed seed for determinism
                 enforce_eager=not self.vllm_compile_and_cudagraph,
                 compilation_config=build_compilation_config(
-                    self.vllm_compile_and_cudagraph
+                    self.vllm_compile_and_cudagraph, tp_size=self.tp_size
                 ),
                 tensor_parallel_size=self.tp_size,  # Explicitly single GPU
                 attention_config=AttentionConfig(

--- a/torchtitan/experiments/rl/unified/infer.py
+++ b/torchtitan/experiments/rl/unified/infer.py
@@ -16,7 +16,9 @@ import argparse
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
-from torchtitan.experiments.rl.vllm_compat.simple_rl import build_compilation_config
+from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
+    build_compilation_config,
+)
 from vllm import LLM, SamplingParams
 from vllm.logger import init_logger
 
@@ -87,7 +89,8 @@ def infer():
     logger.info("Creating vLLM LLM engine...")
 
     compilation_config = build_compilation_config(
-        not args.disable_vllm_compile_and_cudagraph
+        not args.disable_vllm_compile_and_cudagraph,
+        tp_size=args.tensor_parallel_size,
     )
 
     llm = LLM(

--- a/torchtitan/experiments/rl/unified/infer.py
+++ b/torchtitan/experiments/rl/unified/infer.py
@@ -16,6 +16,7 @@ import argparse
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
+from torchtitan.experiments.rl.vllm_compat.simple_rl import build_compilation_config
 from vllm import LLM, SamplingParams
 from vllm.logger import init_logger
 
@@ -58,6 +59,12 @@ def parse_args():
         default=1,
         help="Number of GPUs for tensor parallelism (default: 1 for single GPU)",
     )
+    parser.add_argument(
+        "--disable-vllm-compile-and-cudagraph",
+        action="store_true",
+        default=False,
+        help="Enable vLLM compilation with piecewise CUDA graphs and eager backend.",
+    )
     return parser.parse_args()
 
 
@@ -79,6 +86,10 @@ def infer():
     # and will be available in vllm_config in worker processes
     logger.info("Creating vLLM LLM engine...")
 
+    compilation_config = build_compilation_config(
+        not args.disable_vllm_compile_and_cudagraph
+    )
+
     llm = LLM(
         model=args.model_ckpt_path,  # Model checkpoint path
         hf_overrides={
@@ -87,7 +98,8 @@ def infer():
         },
         dtype="bfloat16",
         trust_remote_code=True,
-        enforce_eager=True,  # Use eager mode
+        enforce_eager=args.disable_vllm_compile_and_cudagraph,
+        compilation_config=compilation_config,
         tensor_parallel_size=args.tensor_parallel_size,
         gpu_memory_utilization=0.5,
     )

--- a/torchtitan/experiments/rl/unified/models/utils.py
+++ b/torchtitan/experiments/rl/unified/models/utils.py
@@ -79,6 +79,7 @@ def replace_with_vllm_attention(model, tp_degree=1):
             head_dim=model_args.head_dim,
             layer_name=layer_name,
             scale=model_args.head_dim**-0.5,
+            tp_enabled=(tp_degree > 1),
         )
 
         layer.attention.inner_attention = vllm_attn

--- a/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
@@ -11,8 +11,6 @@ This module provides TorchTitanVLLMModel: Core model class that adapts
 TorchTitan models for vLLM.
 """
 
-from functools import partial
-
 import torch
 import torch.nn as nn
 from torch.distributed._tensor import DTensor, Replicate
@@ -20,25 +18,45 @@ from torch.distributed.checkpoint.state_dict import (
     set_model_state_dict,
     StateDictOptions,
 )
-
 from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_job_config_from_vllm_config,
     create_parallel_dims_from_vllm_config,
 )
-
 from torchtitan.experiments.rl.unified.models.utils import replace_with_vllm_attention
 from torchtitan.models.qwen3.model.model import precompute_rope_cache
 from torchtitan.protocols.model import BaseModelArgs, ModelProtocol
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.protocols.train_spec import ParallelizeFunction
-
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
 
 logger = init_logger(__name__)
 
+from torch.distributed.tensor._ops._pointwise_ops import pointwise_strategy
 
+# Register DTensor sharding strategy for vLLM's _C.weak_ref_tensor custom op.
+# This op is called by vLLM's CUDAGraphWrapper on piecewise subgraph outputs
+# (via weak_ref_tensors()). Without a registered strategy, DTensor dispatch
+# raises RuntimeError when intermediate hidden states are DTensors (e.g. with
+# SequenceParallel / Shard(1) placements under TP).
+# weak_ref_tensor is semantically identity (same data pointer), so pointwise
+# strategy (propagate input placement to output) is correct.
+# We also need a Meta/FakeTensor impl since DTensor's sharding propagation
+# calls the op on FakeTensors to determine output tensor metadata.
+from torch.distributed.tensor._ops.utils import register_op_strategy
+
+torch.library.register_fake(
+    "_C::weak_ref_tensor",
+    lambda tensor: torch.empty_like(tensor),
+)
+register_op_strategy(torch.ops._C.weak_ref_tensor.default)(pointwise_strategy)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={"input_ids": 0, "positions": 0, "inputs_embeds": 0}
+)
 class TorchTitanVLLMModelWrapper(nn.Module):
     """
     Generic vLLM-compatible model wrapper for TorchTitan models. Implemented
@@ -82,13 +100,6 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         logger.info(f"Creating {self.model_cls.__name__} with config: {model_args}")
         self.model = self.model_cls(model_args)
 
-        # Setup RoPE cache extension function if provided
-        self.rope_cache_extension_fn = partial(
-            precompute_rope_cache,
-            dim=self.config.head_dim,
-            base=self.config.rope_theta,
-        )
-
         # Create ParallelDims and JobConfig from vLLM config at runtime
         # vLLM config contains the tensor_parallel_size from command-line args
         # and this will be consistent across all worker processes
@@ -114,67 +125,24 @@ class TorchTitanVLLMModelWrapper(nn.Module):
             job_config=self.parallel_config,
         )
 
-    def _extend_rope_cache_if_needed(
-        self, rope_cache: torch.Tensor, max_position: int
-    ) -> torch.Tensor:
-        """
-        Extend RoPE cache if needed during vLLM profiling stage.
+        # Store compile-friendly TP flag (bool attribute — no graph break)
+        self._tp_enabled = self.parallel_dims.tp > 1
 
-        Args:
-            rope_cache: Current RoPE cache tensor
-            max_position: Maximum position index needed
-
-        Returns:
-            Extended RoPE cache if needed, otherwise original cache
-        """
-        required_len = max_position + 1
-
-        # No extension needed
-        if required_len <= rope_cache.shape[0]:
-            return rope_cache
-
-        # If no extension function provided, return original cache
-        if self.rope_cache_extension_fn is None:
-            logger.warning(
-                f"RoPE cache extension needed (required_len={required_len}, "
-                f"current_len={rope_cache.shape[0]}) but no rope_cache_extension_fn provided. "
-                "Returning original cache."
+        # Pre-extend RoPE cache to vLLM's max model length for compile-friendly forward
+        max_model_len = vllm_config.model_config.max_model_len
+        if (
+            hasattr(self.model, "rope_cache")
+            and self.model.rope_cache.shape[0] < max_model_len
+        ):
+            extended_cache = precompute_rope_cache(
+                dim=self.config.head_dim,
+                max_seq_len=max_model_len,
+                base=self.config.rope_theta,
             )
-            return rope_cache
-
-        # Handle DTensor case
-        is_dtensor = isinstance(rope_cache, DTensor)
-        if is_dtensor:
-            device_mesh = rope_cache.device_mesh
-            local_rope_cache = rope_cache.to_local()
-            device = local_rope_cache.device
-            dtype = local_rope_cache.dtype
-        else:
-            device = rope_cache.device
-            dtype = rope_cache.dtype
-
-        # Use provided extension function
-        try:
-            extended_cache = self.rope_cache_extension_fn(self.config, required_len)
-            extended_cache = extended_cache.to(device=device, dtype=dtype)
-        except Exception as e:
-            logger.warning(
-                f"Failed to extend RoPE cache using rope_cache_extension_fn: {e}. "
-                "Returning original cache."
+            self.model.rope_cache = extended_cache.to(
+                device=self.model.rope_cache.device,
+                dtype=self.model.rope_cache.dtype,
             )
-            return rope_cache
-
-        # Convert back to DTensor if needed
-        if is_dtensor:
-            rope_cache = DTensor.from_local(
-                extended_cache,
-                device_mesh=device_mesh,
-                placements=[Replicate()],
-            )
-        else:
-            rope_cache = extended_cache
-
-        return rope_cache
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         """Convert input token IDs to embeddings."""
@@ -203,52 +171,28 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         Returns:
             hidden_states: Final hidden states [total_tokens, hidden_size]
         """
-        if inputs_embeds is not None:
-            raise NotImplementedError("inputs_embeds not yet supported")
-
-        if input_ids is None:
-            raise ValueError("Either input_ids or inputs_embeds must be provided")
-
-        # Convert vLLM interface to TorchTitan interface
-        # vLLM: [total_tokens] → TorchTitan: [batch_size, seq_len]
+        # Convert vLLM 1D format to TorchTitan 2D format
         tokens_2d = input_ids.unsqueeze(0)
+        positions_2d = positions.unsqueeze(0)
 
         # Get embeddings
         h = self.model.tok_embeddings(tokens_2d)
 
-        # Get RoPE cache (handle model-specific attribute names)
-        # Use hasattr to avoid ambiguous boolean value error with tensors
-        if hasattr(self.model, "rope_cache"):
-            rope_attr = self.model.rope_cache
-        elif hasattr(self.model, "freqs_cis"):
-            rope_attr = self.model.freqs_cis
-        else:
-            rope_attr = None
-
-        # Extend RoPE cache if needed (vLLM profiling may use 2x max_seq_len)
-        if positions is not None:
-            max_position = positions.max().item()
-        else:
-            max_position = 0
-
-        rope_cache = self._extend_rope_cache_if_needed(rope_attr, max_position)
-        positions = positions.unsqueeze(0)
+        # RoPE cache: always self.model.rope_cache, pre-extended in __init__
+        rope_cache = self.model.rope_cache
 
         # Pass through transformer layers
         for layer in self.model.layers.values():
-            h = layer(h, rope_cache, attention_masks=None, positions=positions)
+            h = layer(h, rope_cache, attention_masks=None, positions=positions_2d)
 
         h = self.model.norm(h)
-        # When parallelism is applied, get full tensor before return to vLLM Engine
-        # The original placement is Shard(1) (shard on sequence dimension, as it will prepare for sequence parallel in `self.norm`).
-        # vLLM's engine expects plain, non-distributed tensors to slice the last token for each request.
-        if isinstance(h, DTensor):
+
+        # When TP enabled, norm output is DTensor Shard(1); gather for vLLM engine
+        if self._tp_enabled:
             h = h.full_tensor()
 
-        # Convert to vLLM format: [total_tokens, hidden_size]
-        if h.dim() == 3:
-            batch_size, seq_len, hidden_size = h.shape
-            h = h.view(batch_size * seq_len, hidden_size)
+        # Flatten to vLLM format: [total_tokens, hidden_size]
+        h = h.view(-1, h.shape[-1])
 
         return h
 

--- a/torchtitan/experiments/rl/unified/simple_rl_multiprocess.py
+++ b/torchtitan/experiments/rl/unified/simple_rl_multiprocess.py
@@ -64,6 +64,9 @@ async def main():
     trainer_tp_size = 1
     generator_tp_size = 1
 
+    # vLLM compilation config
+    vllm_compile_and_cudagraph = True
+
     init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
     batch_invariant = vllm_is_batch_invariant()
     mode = ModelMode.UNIFIED
@@ -151,6 +154,7 @@ async def main():
         grpo_beta,
         use_stable_grpo,
         generator_tp_size,
+        vllm_compile_and_cudagraph,
     )
 
     # Initialize generator with trainer weights

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -38,11 +38,28 @@ from torchtitan.models.qwen3.model.args import Qwen3ModelArgs
 from transformers import AutoConfig, AutoTokenizer
 
 from vllm import LLM, SamplingParams
+from vllm.config import CompilationConfig
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
+
+
+def build_compilation_config(
+    vllm_compile_and_cudagraph: bool,
+) -> CompilationConfig | None:
+    """Build a CompilationConfig when vllm_compile_and_cudagraph is enabled."""
+    if not vllm_compile_and_cudagraph:
+        return None
+    # NOTE: these options optimize speed while retaining numerics, but
+    # greatly increase memory usage
+    # see https://docs.vllm.ai/en/stable/design/cuda_graphs/#cudagraphmodes
+    return CompilationConfig(
+        cudagraph_mode="full_and_piecewise",
+        # Prefer eager over inductor for the sake of numerics
+        backend="eager",
+    )
 
 
 class VLLMRolloutEngine:
@@ -58,8 +75,14 @@ class VLLMRolloutEngine:
         temp_checkpoint_dir: Directory to save temporary weight checkpoints
     """
 
-    def __init__(self, model_path: str, temp_checkpoint_dir: str = "./converted"):
+    def __init__(
+        self,
+        model_path: str,
+        temp_checkpoint_dir: str = "./converted",
+        vllm_compile_and_cudagraph: bool = False,
+    ):
         self.base_model_path = model_path
+        self.vllm_compile_and_cudagraph = vllm_compile_and_cudagraph
         self.temp_model_dir = os.path.abspath(
             os.path.join(temp_checkpoint_dir, "vllm_temp_model")
         )
@@ -171,7 +194,10 @@ class VLLMRolloutEngine:
                 dtype="bfloat16",
                 gpu_memory_utilization=0.3,  # Reduced from 0.5
                 seed=42,  # Fixed seed for determinism
-                enforce_eager=True,
+                enforce_eager=not self.vllm_compile_and_cudagraph,
+                compilation_config=build_compilation_config(
+                    self.vllm_compile_and_cudagraph
+                ),
                 attention_config={"backend": AttentionBackendEnum.FLASH_ATTN},
             )
             print("✓ Created new vLLM engine")
@@ -1045,6 +1071,9 @@ def main():
     )
     num_dataset_samples = 10  # Number of prompts from dataset
 
+    # vLLM compilation
+    vllm_compile_and_cudagraph = True
+
     # Check if batch invariance is enabled
     from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
 
@@ -1091,7 +1120,9 @@ def main():
 
     # Initialize persistent vLLM engine for rollouts
     print("\nInitializing vLLM engine for rollouts...")
-    vllm_engine = VLLMRolloutEngine(model_path)
+    vllm_engine = VLLMRolloutEngine(
+        model_path, vllm_compile_and_cudagraph=vllm_compile_and_cudagraph
+    )
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)


### PR DESCRIPTION
## Summary

We utilize vLLM's compile and cudagraph integration in order to greatly speedup iteration time.

To do so, we use a compilation config with `full_and_piecewise` cudagraphs, and `eager` compilation (of note, `full_and_piecewise` is the most efficient for speed, but comes with extra memory overhead; `eager` is needed for compilation, and `inductor` impacts numerics so can't be used here)

Running vLLM inference for generating 20 tokens ~100 times, we see the following average difference:
```bash
SUMMARY
============================================================

  Eager mode:    199.104 ms ± 4.669 ms
  Compiled mode: 51.841 ms ± 1.415 ms
  Speedup:       3.84x

  ✓ Generated tokens are identical
  ✓ Logprobs are nearly identical (max diff: 0.00e+00)
```

Similarly, in our testplan, we see ~4x speedup in iteration speed and tok/s with no impact on numerics

## Test plan

```bash
VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 torchtitan/experiments/rl/unified/simple_rl_multiprocess.py
```

### Result (main)
```bash
✓ Created new vLLM engine
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 2411.35it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████| 80/80 [00:03<00:00, 24.69it/s, est. speed input: 1609.70 toks/s, output: 2468.86 toks/s]
  ✓ vLLM-TorchTitan bitwise determinism verified: 100 tokens match exactly
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 3464.36it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████| 80/80 [00:02<00:00, 27.21it/s, est. speed input: 1774.20 toks/s, output: 2721.16 toks/s]
  ✓ vLLM-TorchTitan bitwise determinism verified: 100 tokens match exactly

Step   0 | Loss: -0.0036 | Reward: +0.075 | Samples: 160
  Sample:  48 + 24 = 72.
Let me check the reasoning.
Okay, so Natalia sold clips to 48 of ...
Converted to 311 vLLM weights
```
### Result (these changes)
<TODO: Fill in>
```bash
```