### PR TITLE
bug fix: don't swallow OutOfMemoryError when enable_memory_snapshot=True

### DIFF
--- a/torchtitan/tools/profiling.py
+++ b/torchtitan/tools/profiling.py
@@ -143,5 +143,6 @@ def maybe_enable_memory_snapshot(
             yield profiler
         except torch.OutOfMemoryError as e:
             profiler.step(exit_ctx=True)
+            raise
     else:
         yield None


### PR DESCRIPTION
fix https://github.com/pytorch/torchtitan/issues/2362

claude ran a OOM job to verified 3 things. super safe!

1. Exit code 1 (not 0) — the process failed as expected:
  exitcode  : 1 (pid: 2663521)

  2. The OOM traceback was surfaced instead of being swallowed:
  torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 14.00 GiB. GPU 0 has a total capacity of 94.99 GiB of which 9.30 GiB is free.

  3. The memory snapshot was still saved before the error propagated:
  outputs/memory_snapshot/iteration_0_exit/rank0_memory_snapshot.pickle