### PR TITLE
[draft] Activation offloading

### DIFF
--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -260,6 +260,14 @@ class ActivationCheckpointConfig:
     mode: Literal["selective", "full", "memory_budget", "none"] = "selective"
     """Type of activation checkpointing to use"""
 
+    cpu_offload: bool = False
+    """
+    When enabled, activations saved for backward are offloaded to CPU memory
+    during forward and copied back to GPU during backward. This can be combined
+    with any AC mode to further reduce GPU memory usage at the cost of additional
+    CPU-GPU transfer overhead.
+    """
+
     selective_ac_option: str = "2"
     """
     Selective activation checkpointing options ['int', 'op'].

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -13,7 +13,9 @@ from collections import defaultdict
 import torch
 import torch._functorch.config
 import torch.nn as nn
+from torch.autograd.graph import save_on_cpu
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    ActivationWrapper,
     checkpoint_wrapper as ptd_checkpoint_wrapper,
 )
 
@@ -167,6 +169,26 @@ def _apply_full_ac(module: nn.Module, ac_config: ACConfig) -> nn.Module:
     )
 
 
+class CPUOffloadWrapper(ActivationWrapper):
+    """Wrapper that offloads activations saved for backward to CPU memory.
+
+    Args:
+        mod (nn.Module): The module to wrap.
+        pin_memory (bool): If True, use pinned (page-locked) CPU memory for
+            faster async GPU transfers. If False, use regular pageable memory
+            which avoids pinned memory exhaustion at the cost of synchronous
+            transfers. Defaults to True.
+    """
+
+    def __init__(self, mod: nn.Module, pin_memory: bool = True) -> None:
+        super().__init__(mod)
+        self.pin_memory = pin_memory
+
+    def forward(self, *args, **kwargs):
+        with save_on_cpu(pin_memory=self.pin_memory):
+            return self._checkpoint_wrapped_module(*args, **kwargs)
+
+
 def _apply_ac_to_transformer_block(
     module: nn.Module,
     ac_config: ACConfig,
@@ -248,13 +270,19 @@ def apply_ac(
     else:
         layers = model.get_submodule("layers")
         for layer_id, transformer_block in layers.named_children():
-            transformer_block = _apply_ac_to_transformer_block(
-                transformer_block,
-                ac_config,
-                base_fqn=f"layers.{layer_id}",
-                model_compile_enabled=model_compile_enabled,
-                op_sac_save_list=op_sac_save_list,
-            )
+            if ac_config.mode != "none":
+                transformer_block = _apply_ac_to_transformer_block(
+                    transformer_block,
+                    ac_config,
+                    base_fqn=f"layers.{layer_id}",
+                    model_compile_enabled=model_compile_enabled,
+                    op_sac_save_list=op_sac_save_list,
+                )
+            if ac_config.cpu_offload:
+                transformer_block = CPUOffloadWrapper(transformer_block)
             layers.register_module(layer_id, transformer_block)
 
-    logger.info(f"Applied {ac_config.mode} activation checkpointing to the model")
+    ac_label = ac_config.mode
+    if ac_config.cpu_offload:
+        ac_label += " + cpu_offload"
+    logger.info(f"Applied {ac_label} activation checkpointing to the model")

--- a/torchtitan/distributed/dual_pipe_v.py
+++ b/torchtitan/distributed/dual_pipe_v.py
@@ -51,7 +51,9 @@ def get_dual_pipe_v_flag(
     if dual_pipe_v and ac_config.mode != "none":
         raise NotImplementedError(
             "Expert Parallel with DualPipeV and Activation Checkpointing "
-            "cannot be used together. Please disable one of them."
+            "cannot be used together. Please set mode='none'. "
+            "You can use cpu_offload=true with mode='none' to reduce "
+            "GPU memory usage without recomputation."
         )
 
     return dual_pipe_v

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -123,7 +123,7 @@ def parallelize_llama(
         compile_config.enable and "model" in compile_config.components
     )
 
-    if ac_config.mode != "none":
+    if ac_config.mode != "none" or ac_config.cpu_offload:
         apply_ac(
             model,
             ac_config,


### PR DESCRIPTION
Currently in draft mode. This implements a naive, less-performant form of activation offloading. A more performant version with stream is here: https://github.com/pytorch/pytorch/pull/174436

## Changes

AC is applied first (inner), then CPUOffloadWrapper wraps around it (outer):

```python
  CPUOffloadWrapper.forward()
    with save_on_cpu():          ← intercepts tensor saves
      CheckpointWrapper.forward()  ← decides what to save vs recompute
        actual_module.forward()
```
This means AC still controls recomputation. save_on_cpu only intercepts whatever tensors
the checkpoint wrapper decides to save.

What this means:
- full AC + offload: All intermediates are offloaded to CPU
- selective AC + offload:  Saved ops (not recomputed) are offloaded to CPU
- no AC + offload: All intermediates offloaded to CPU (maybe should not allow full AC + offload?)

## Metrics
For llama3-8b, memory (in GB):
<img width="1432" height="733" alt="image" src="https://github.com/user-attachments/assets/f96700ea-44d1-41ef-82cb-e09b15f42f82" />

throughput:
<img width="1438" height="750" alt="image" src="https://github.com/user-attachments/assets/71052dfc-6511-48fb-b296-ee6859089d37" />

Full graphs here: https://meta.wandb.io/howardhuang_meta/torchtitan-ac-benchmark/reports/Untitled-Report--VmlldzoxNzUxNA

Run commands:

`CONFIG_FILE="./torchtitan/models/llama3/train_configs/llama3_8b.toml" ./run_train.sh`

`NGPU=4 CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/debug_model.toml" ./run_train.sh`

`TORCH_NCCL_TRACE_BUFFER_SIZE=2000 TORCH_NCCL_DUMP_ON_TIMEOUT=true TORCH_FR_DUMP_TEMP_FILE=./nccl_trace_rank_ NGPU=8  CONFIG_FILE="./torchtitan/models/deepseek_v3/train_configs/deepseek_v3_16b.toml" ./run_train.sh`