### PR TITLE
[compiler toolkit] Add graph based SAC

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/common_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/common_utils.py
@@ -103,3 +103,22 @@ def create_extra_fsdp_pg(parallel_dims: ParallelDims) -> None:
 def get_extra_fsdp_pg_name(original_pg_name: str) -> str | None:
     """Look up the extra PG name for a given original FSDP PG name."""
     return _EXTRA_FSDP_PG_REGISTRY.get(original_pg_name)
+
+
+def maybe_disable_eager_ac(
+    compile_config: CompileConfig,
+    ac_config: "ActivationCheckpointConfig",
+) -> None:
+    """Disable eager AC when apply_sac graph pass is enabled.
+
+    When apply_sac is used as a joint graph pass, eager activation checkpointing
+    must be disabled to avoid double-checkpointing. This must be called before
+    the model parallelization step that applies eager AC.
+    """
+    joint_pass_names = getattr(compile_config, "joint_passes", [])
+    if "apply_sac" in joint_pass_names:
+        if ac_config.mode != "none":
+            logger.info(
+                "apply_sac graph pass is enabled, overriding eager AC mode to none"
+            )
+            ac_config.mode = "none"

--- a/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/deepseek_v3/parallelize.py
@@ -17,6 +17,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.compiler_toolkit.common_utils import (
     disable_compile,
+    maybe_disable_eager_ac,
     parallelize_inputs,
     register_blockmask_pytree_node,
 )
@@ -79,6 +80,8 @@ def parallelize_deepseekv3(
     annotate_deepseekv3()
 
     register_blockmask_pytree_node()
+
+    maybe_disable_eager_ac(compile_config, ac_config)
 
     # Disable torch.compile over the model in the compiler toolkit style workflow
     with disable_compile(compile_config):

--- a/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
+++ b/torchtitan/experiments/compiler_toolkit/llama3/parallelize.py
@@ -17,6 +17,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.compiler_toolkit.common_utils import (
     disable_compile,
+    maybe_disable_eager_ac,
     parallelize_inputs,
     register_blockmask_pytree_node,
 )
@@ -68,6 +69,8 @@ def parallelize_llama(
     annotate_llama()
 
     register_blockmask_pytree_node()
+
+    maybe_disable_eager_ac(compile_config, ac_config)
 
     # Disable torch.compile over the model in the compiler toolkit style workflow
     with disable_compile(compile_config):


### PR DESCRIPTION
Add graph-based SAC as a joint graph pass in alternative to eager-mode AC. Previously eager AC and fullmodel trace don't compose in DSv3 (See https://github.com/pytorch/torchtitan/issues/1935). With graph based AC, it's no longer an issue.

Set `--compile.joint_passes apply_sac` to turn it on

Llama3-8B (TP=2, FSDP=2)
no-AC: memory: 67.19GiB(37.67%)  tps: 9,569  tflops: 554.17  mfu: 24.63%
eager SAC: memory: 45.88GiB(25.73%)  tps: 8,627  tflops: 499.62  mfu: 22.21%
graph SAC: memory: 44.20GiB(24.78%)  tps: 8,007  tflops: 463.74  mfu: 20.61%

DeepSeek-v3 Debug model(TP=2, FSDP=2, EP=2)
no-AC: memory: memory: 12.26GiB(6.88%)  tps: 59,927  tflops: 32.54  mfu: 1.45%
eager SAC: doesn't work (due to AC HOP mutation issue https://github.com/pytorch/torchtitan/issues/1935)
graph SAC:  memory: 11.01GiB(6.17%)  tps: 53,939  tflops: 29.29  mfu: 1.30%
