### PR TITLE
[AC] Set preserve_rng_state=True as default for activation checkpointing

### DIFF
--- a/torchtitan/config/job_config.py
+++ b/torchtitan/config/job_config.py
@@ -696,7 +696,7 @@ class ActivationCheckpoint:
     https://github.com/pytorch/pytorch/pull/126320#discussion_r1625104015
     """
 
-    preserve_rng_state: bool = False
+    preserve_rng_state: bool = True
     """
     If deterministic output compared to non-checkpointed passes is required, set
     to true. Results in stashing and restoring the RNG state during each checkpoint,

--- a/torchtitan/models/flux/infra/parallelize.py
+++ b/torchtitan/models/flux/infra/parallelize.py
@@ -119,13 +119,13 @@ def apply_ac(model: nn.Module, ac_config):
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, block in model.double_blocks.named_children():
-        block = ptd_checkpoint_wrapper(block, preserve_rng_state=False)
+        block = ptd_checkpoint_wrapper(block, preserve_rng_state=True)
         # pyrefly: ignore [missing-attribute]
         model.double_blocks.register_module(layer_id, block)
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, block in model.single_blocks.named_children():
-        block = ptd_checkpoint_wrapper(block, preserve_rng_state=False)
+        block = ptd_checkpoint_wrapper(block, preserve_rng_state=True)
         # pyrefly: ignore [missing-attribute]
         model.single_blocks.register_module(layer_id, block)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchtitan/issues/1323

Set preserve_rng_state to True for all checkpoint_wrapper calls to ensure deterministic output compared to non-checkpointed passes. This changes the default in the ActivationCheckpoint config and updates the hardcoded values in the Flux model's activation checkpointing.

Measured overhead is 30-50us on 8gpu node. For comparison, AC already has a 350us constant overhead. Overhead scales linearly when inputs are on more distinct devices, but that is rare . This shouldn't matter anyway because AC regions are fairly large (transformer blocks). It is possible the constant overhead will matter more when only several ops are being AC'd.

```python
  """Measure the overhead of preserve_rng_state in torch.utils.checkpoint."""

  import torch
  import torch.nn as nn
  import torch.utils.checkpoint as checkpoint
  import time


  class Block(nn.Module):
      def __init__(self, dim=1024):
          super().__init__()
          self.linear1 = nn.Linear(dim, dim)
          self.linear2 = nn.Linear(dim, dim)

      def forward(self, x):
          return self.linear2(torch.relu(self.linear1(x)))


  def bench(block, x, preserve_rng_state, warmup=10, iters=100):
      for _ in range(warmup):
          out = checkpoint.checkpoint(block, x, preserve_rng_state=preserve_rng_state, use_reentrant=False)
          out.sum().backward()
          torch.cuda.synchronize()

      torch.cuda.synchronize()
      t0 = time.perf_counter()
      for _ in range(iters):
          out = checkpoint.checkpoint(block, x, preserve_rng_state=preserve_rng_state, use_reentrant=False)
          out.sum().backward()
          torch.cuda.synchronize()

      return (time.perf_counter() - t0) / iters * 1000  # ms per iter


  block = Block(dim=1024).cuda()
  x = torch.randn(64, 128, 1024, device="cuda", requires_grad=True)

  ms_false = bench(block, x, preserve_rng_state=False)
  ms_true = bench(block, x, preserve_rng_state=True)

  print(f"preserve_rng_state=False: {ms_false:.3f} ms/iter")
  print(f"preserve_rng_state=True:  {ms_true:.3f} ms/iter")
  print(f"Overhead: {ms_true - ms_false:.3f} ms ({(ms_true / ms_false - 1) * 100:.2f}%)")
```