### PR TITLE
fix: restrict completion logging to rank 0

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -707,8 +707,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         if torch.distributed.get_rank() == 0:
             logger.info("Sleeping 2 seconds for other ranks to complete")
             time.sleep(2)
-
-        logger.info("Training completed")
+            logger.info("Training completed")
 
     def should_continue_training(self) -> bool:
         return self.step < self.job_config.training.steps


### PR DESCRIPTION
## Summary
This PR fixes a logging inconsistency where "Training completed" was printed by all ranks, causing redundant console spam at the end of distributed training runs.

## Changes
- Moved `logger.info("Training completed")` inside the existing `if torch.distributed.get_rank() == 0:` block in `train.py` (Line 711).

## Impact
- Ensures a clean exit message only from the master process, matching the behavior of the preceding "Sleeping..." log.