### PR TITLE
[NOT4REVIEW] Make RL model compilable: ops rewrite + per-sample backward

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -7,7 +7,6 @@
 import os
 import time
 from collections import namedtuple
-from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, TYPE_CHECKING
 
@@ -94,37 +93,6 @@ class DeviceMemoryMonitor:
 
     def reset_peak_stats(self):
         device_module.reset_peak_memory_stats()
-
-
-@contextmanager
-def gpu_timer(sync: bool = True, enabled: bool = True):
-    """Context manager that optionally synchronizes the device and measures wall-clock time.
-
-    Yields a dict; on exit it is populated with an ``elapsed_s`` key.
-
-    Args:
-        sync: If True, synchronizes the device before and after timing.
-        enabled: If False, skips all timing/sync overhead and yields an empty dict.
-
-    Usage::
-
-        with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as t:
-            do_work()
-        print(t.get("elapsed_s", 0.0))
-    """
-    result: dict[str, float] = {}
-    if not enabled:
-        yield result
-        return
-    if sync:
-        device_module.synchronize()
-    t0 = time.perf_counter()
-    try:
-        yield result
-    finally:
-        if sync:
-            device_module.synchronize()
-        result["elapsed_s"] = time.perf_counter() - t0
 
 
 def build_device_memory_monitor():

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -7,6 +7,7 @@
 import os
 import time
 from collections import namedtuple
+from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, TYPE_CHECKING
 
@@ -93,6 +94,37 @@ class DeviceMemoryMonitor:
 
     def reset_peak_stats(self):
         device_module.reset_peak_memory_stats()
+
+
+@contextmanager
+def gpu_timer(sync: bool = True, enabled: bool = True):
+    """Context manager that optionally synchronizes the device and measures wall-clock time.
+
+    Yields a dict; on exit it is populated with an ``elapsed_s`` key.
+
+    Args:
+        sync: If True, synchronizes the device before and after timing.
+        enabled: If False, skips all timing/sync overhead and yields an empty dict.
+
+    Usage::
+
+        with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as t:
+            do_work()
+        print(t.get("elapsed_s", 0.0))
+    """
+    result: dict[str, float] = {}
+    if not enabled:
+        yield result
+        return
+    if sync:
+        device_module.synchronize()
+    t0 = time.perf_counter()
+    try:
+        yield result
+    finally:
+        if sync:
+            device_module.synchronize()
+        result["elapsed_s"] = time.perf_counter() - t0
 
 
 def build_device_memory_monitor():

--- a/torchtitan/experiments/rl/metrics.py
+++ b/torchtitan/experiments/rl/metrics.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Shared metrics utilities for RL training loops.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CumulativeMetrics:
+    """Accumulator for timing and memory metrics across training steps."""
+
+    rollout_s: float = 0.0
+    train_s: float = 0.0
+    optimizer_s: float = 0.0
+    weight_sync_s: float = 0.0
+    total_s: float = 0.0
+    peak_rollout_gib: float = 0.0
+    peak_train_gib: float = 0.0
+    peak_optimizer_gib: float = 0.0
+    peak_weight_sync_gib: float = 0.0
+    completed_steps: int = 0
+
+
+@dataclass(frozen=True)
+class PhaseMetrics:
+    """Metrics for a single phase of a RL step."""
+
+    name: str
+    time_s: float
+    peak_mem_gib: float = 0.0
+    peak_mem_pct: float = 0.0
+    note: str | None = None
+
+
+def update_cumulative_metrics(
+    cumulative: CumulativeMetrics,
+    rollout_time_s: float,
+    train_time_s: float,
+    optimizer_time_s: float,
+    weight_sync_time_s: float,
+    total_time_s: float,
+    rollout_peak_gib: float = 0.0,
+    train_peak_gib: float = 0.0,
+    optimizer_peak_gib: float = 0.0,
+    weight_sync_peak_gib: float = 0.0,
+) -> None:
+    """Update cumulative metrics with data from a single RL step.
+
+    Args:
+        cumulative: The CumulativeMetrics instance to update.
+        rollout_time_s: Time spent in rollout phase (seconds).
+        train_time_s: Time spent in training phase (seconds).
+        optimizer_time_s: Time spent in optimizer step (seconds).
+        weight_sync_time_s: Time spent syncing weights (seconds).
+        total_time_s: Total step time (seconds).
+        rollout_peak_gib: Peak memory during rollout phase (GiB).
+        train_peak_gib: Peak memory during train phase (GiB).
+        optimizer_peak_gib: Peak memory during optimizer step (GiB).
+        weight_sync_peak_gib: Peak memory during weight sync phase (GiB).
+    """
+    cumulative.rollout_s += rollout_time_s
+    cumulative.train_s += train_time_s
+    cumulative.optimizer_s += optimizer_time_s
+    cumulative.weight_sync_s += weight_sync_time_s
+    cumulative.total_s += total_time_s
+    cumulative.completed_steps += 1
+    cumulative.peak_rollout_gib = max(cumulative.peak_rollout_gib, rollout_peak_gib)
+    cumulative.peak_train_gib = max(cumulative.peak_train_gib, train_peak_gib)
+    cumulative.peak_optimizer_gib = max(
+        cumulative.peak_optimizer_gib, optimizer_peak_gib
+    )
+    cumulative.peak_weight_sync_gib = max(
+        cumulative.peak_weight_sync_gib, weight_sync_peak_gib
+    )
+
+
+def print_step_metrics(
+    phases: list[PhaseMetrics],
+    total_time_s: float,
+    include_mem_pct: bool = False,
+) -> None:
+    """Print per-phase timing and memory breakdown for a training step.
+
+    Args:
+        phases: List of PhaseMetrics for each phase in the step.
+        total_time_s: Total time for the step (seconds).
+        include_mem_pct: If True, include memory percentage in output.
+    """
+    print(f"  {'Phase':<16s} {'Time':>8s}  {'Peak Mem':>10s}")
+    print(f"  {'-' * 38}")
+
+    for phase in phases:
+        line = f"  {phase.name + ':':<16s} {phase.time_s:>7.2f}s"
+        if phase.peak_mem_gib > 0:
+            line += f",  {phase.peak_mem_gib:>5.2f} GiB"
+            if include_mem_pct and phase.peak_mem_pct > 0:
+                line += f"  ({phase.peak_mem_pct:.1f}%)"
+            if phase.note:
+                line += f"  {phase.note}"
+        elif phase.note:
+            line += f"  {phase.note}"
+        print(line)
+
+    print(f"  {'total:':<16s} {total_time_s:>7.2f}s")
+
+
+def print_training_summary(
+    cumulative: CumulativeMetrics,
+    only_print_memory_if_nonzero: bool = False,
+) -> None:
+    """Print a formatted training summary.
+
+    Args:
+        cumulative: The CumulativeMetrics instance containing accumulated data.
+        only_print_memory_if_nonzero: If True, only print memory stats when > 0.
+            If False, always print memory stats.
+    """
+    if cumulative.completed_steps == 0:
+        return
+
+    print("\n" + "=" * 80)
+    print(f"Training Summary ({cumulative.completed_steps} steps):")
+    print(f"  {'Total wall-clock:':<28s} {cumulative.total_s:>9.2f}s")
+
+    for label, val in [
+        ("Cumul. rollout:", cumulative.rollout_s),
+        ("Cumul. train:", cumulative.train_s),
+        ("Cumul. optimizer:", cumulative.optimizer_s),
+        ("Cumul. weight_sync:", cumulative.weight_sync_s),
+    ]:
+        pct = 100 * val / cumulative.total_s
+        print(f"  {label:<28s} {val:>9.2f}s  ({pct:>5.1f}%)")
+
+    should_print_rollout_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_rollout_gib > 0
+    )
+    should_print_train_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_train_gib > 0
+    )
+    should_print_optimizer_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_optimizer_gib > 0
+    )
+    should_print_weight_sync_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_weight_sync_gib > 0
+    )
+
+    if should_print_rollout_mem:
+        print(
+            f"  {'Peak mem (rollout):':<28s} "
+            f"{cumulative.peak_rollout_gib:>8.2f} GiB"
+        )
+    if should_print_train_mem:
+        print(f"  {'Peak mem (train):':<28s} " f"{cumulative.peak_train_gib:>8.2f} GiB")
+    if should_print_optimizer_mem:
+        print(
+            f"  {'Peak mem (optimizer):':<28s} "
+            f"{cumulative.peak_optimizer_gib:>8.2f} GiB"
+        )
+    if should_print_weight_sync_mem:
+        print(
+            f"  {'Peak mem (weight_sync):':<28s} "
+            f"{cumulative.peak_weight_sync_gib:>8.2f} GiB"
+        )
+
+    print("=" * 80)

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -13,12 +13,13 @@ from typing import List
 import torch
 from monarch.actor import Actor, endpoint
 from safetensors.torch import save_file
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
 from torchtitan.config.job_config import Comm
 from torchtitan.distributed import utils as dist_utils
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
+from torchtitan.experiments.rl.metrics import gpu_timer
 from torchtitan.experiments.rl.vllm_compat.simple_rl import (
     compute_grpo_advantages,
     compute_grpo_advantages_stable,

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -7,19 +7,18 @@
 import asyncio
 import logging
 import os
-
 from dataclasses import dataclass
 from typing import List
 
 import torch
 from monarch.actor import Actor, endpoint
 from safetensors.torch import save_file
+from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
 from torchtitan.config.job_config import Comm
 from torchtitan.distributed import utils as dist_utils
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
-
 from torchtitan.experiments.rl.vllm_compat.simple_rl import (
     compute_grpo_advantages,
     compute_grpo_advantages_stable,
@@ -47,6 +46,10 @@ class TrajectoryData:
         prompt_token_ids: List of prompt token ID lists
         rewards: Computed rewards for each completion
         advantages: Computed advantages for each completion
+        gen_time_s: Generation wall-clock time in seconds
+        gen_peak_active_gib: Peak active GPU memory during generation (GiB)
+        gen_peak_active_pct: Peak active GPU memory as percentage of capacity
+        gen_peak_reserved_gib: Peak reserved GPU memory during generation (GiB)
     """
 
     policy_version: int
@@ -56,6 +59,10 @@ class TrajectoryData:
     prompt_token_ids: List[List[int]]
     rewards: torch.Tensor
     advantages: torch.Tensor
+    gen_time_s: float = 0.0
+    gen_peak_active_gib: float = 0.0
+    gen_peak_active_pct: float = 0.0
+    gen_peak_reserved_gib: float = 0.0
 
 
 class VLLMRolloutEngine:
@@ -348,6 +355,8 @@ class Generator(Actor):
         grpo_beta: float = 0.1,
         use_stable_grpo: bool = False,
         tp_size: int = 1,
+        cuda_sync_for_metrics: bool = True,
+        enable_profiling: bool = True,
     ):
         self.model_path = model_path
         self.prompt_texts = prompt_texts
@@ -359,6 +368,8 @@ class Generator(Actor):
         self.grpo_beta = grpo_beta
         self.use_stable_grpo = use_stable_grpo
         self.tp_size = tp_size
+        self.cuda_sync_for_metrics = cuda_sync_for_metrics
+        self.enable_profiling = enable_profiling
 
         # Initialize distributed environment for SPMD generator
         world_size = dist_utils.init_distributed(
@@ -366,6 +377,9 @@ class Generator(Actor):
         )
         # Initialize vLLM engine
         self.vllm_engine = VLLMRolloutEngine(model_path, tp_size=self.tp_size)
+
+        if enable_profiling:
+            self.device_memory_monitor = DeviceMemoryMonitor()
 
         # State machine
         self.state = GeneratorState.READY_TO_UPDATE
@@ -391,42 +405,60 @@ class Generator(Actor):
                 lambda: self.state == GeneratorState.READY_TO_GENERATE
             )
 
-            # Generate samples using vLLM
-            (
-                completions,
-                vllm_log_probs,
-                vllm_token_ids,
-                vllm_token_log_probs,
-                prompt_token_ids,
-            ) = self.vllm_engine.generate(
-                self.prompt_texts,
-                self.max_new_tokens,
-                self.temperature,
-                n_samples_per_prompt=self.group_size,
-            )
+            if self.enable_profiling:
+                self.device_memory_monitor.reset_peak_stats()
 
-            # Compute rewards
-            rewards = self.reward_fn(
-                completions, self.expected_answers, self.group_size
-            )
-
-            # Normalize rewards
-            reward_mean = rewards.mean()
-            reward_std = rewards.std()
-            if reward_std > 1e-8:
-                rewards_normalized = (rewards - reward_mean) / reward_std
-            else:
-                rewards_normalized = rewards - reward_mean
-
-            # Compute advantages using GRPO
-            if self.use_stable_grpo:
-                advantages = compute_grpo_advantages_stable(
-                    rewards_normalized, self.group_size
+            with gpu_timer(
+                sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+            ) as gen_t:
+                # Generate samples using vLLM
+                (
+                    completions,
+                    vllm_log_probs,
+                    vllm_token_ids,
+                    vllm_token_log_probs,
+                    prompt_token_ids,
+                ) = self.vllm_engine.generate(
+                    self.prompt_texts,
+                    self.max_new_tokens,
+                    self.temperature,
+                    n_samples_per_prompt=self.group_size,
                 )
-            else:
-                advantages = compute_grpo_advantages(
-                    rewards_normalized, self.group_size, beta=self.grpo_beta
+
+                # Compute rewards
+                rewards = self.reward_fn(
+                    completions, self.expected_answers, self.group_size
                 )
+
+                # Normalize rewards
+                reward_mean = rewards.mean()
+                reward_std = rewards.std()
+                if reward_std > 1e-8:
+                    rewards_normalized = (rewards - reward_mean) / reward_std
+                else:
+                    rewards_normalized = rewards - reward_mean
+
+                # Compute advantages using GRPO
+                if self.use_stable_grpo:
+                    advantages = compute_grpo_advantages_stable(
+                        rewards_normalized, self.group_size
+                    )
+                else:
+                    advantages = compute_grpo_advantages(
+                        rewards_normalized, self.group_size, beta=self.grpo_beta
+                    )
+
+            if self.enable_profiling:
+                mem_stats = self.device_memory_monitor.get_peak_stats()
+                gen_time_s = gen_t.get("elapsed_s", 0.0)
+                gen_peak_active_gib = mem_stats.max_active_gib
+                gen_peak_active_pct = mem_stats.max_active_pct
+                gen_peak_reserved_gib = mem_stats.max_reserved_gib
+            else:
+                gen_time_s = 0.0
+                gen_peak_active_gib = 0.0
+                gen_peak_active_pct = 0.0
+                gen_peak_reserved_gib = 0.0
 
             # Create trajectory data
             trajectory = TrajectoryData(
@@ -437,6 +469,10 @@ class Generator(Actor):
                 prompt_token_ids=prompt_token_ids,
                 rewards=rewards,
                 advantages=advantages,
+                gen_time_s=gen_time_s,
+                gen_peak_active_gib=gen_peak_active_gib,
+                gen_peak_active_pct=gen_peak_active_pct,
+                gen_peak_reserved_gib=gen_peak_reserved_gib,
             )
 
             # Signal ready for update

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -10,7 +10,8 @@ from typing import Any, Optional
 
 import torch
 from monarch.actor import Actor, endpoint
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
+from torchtitan.experiments.rl.metrics import gpu_timer
 from torchtitan.experiments.rl.unified.actors.generator import TrajectoryData
 from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_trainer_parallel_dims,

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 from monarch.actor import Actor, endpoint
+from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
 from torchtitan.experiments.rl.unified.actors.generator import TrajectoryData
 from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_trainer_parallel_dims,
@@ -37,6 +38,7 @@ class Trainer(Actor):
         learning_rate: Learning rate for optimizer
         model_mode: Indicates which model to use. Train inferece unified model, batch invariant Torchtitan model,
             or plain Torchtitan model
+        enable_profiling: If True, track timing and memory metrics
     """
 
     def __init__(
@@ -47,11 +49,18 @@ class Trainer(Actor):
         model_mode: str = ModelMode.VLLM_COMPAT,
         ddp_size: int = 1,
         tp_size: int = 1,
+        cuda_sync_for_metrics: bool = True,
+        enable_profiling: bool = True,
     ):
         # Explicitly set cuda device for each trainer, otherwise different processes will use the same CUDA device
         local_rank = int(os.environ["LOCAL_RANK"])
         device = torch.device(f"cuda:{local_rank}")
         torch.cuda.set_device(local_rank)
+
+        self.cuda_sync_for_metrics = cuda_sync_for_metrics
+        self.enable_profiling = enable_profiling
+        if enable_profiling:
+            self.device_memory_monitor = DeviceMemoryMonitor(f"cuda:{local_rank}")
 
         self.model = load_model(
             titan_checkpoint_path, model_path, model_mode=model_mode
@@ -101,21 +110,41 @@ class Trainer(Actor):
         logger.info(
             f"{os.getpid()=} Trainer starts to train {self.policy_version} on traj:"
         )
-        # Compute loss
-        loss, loss_metrics = compute_policy_gradient_loss_vllm(
-            self.model,
-            trajectory.vllm_token_ids,
-            trajectory.vllm_token_log_probs,
-            trajectory.prompt_token_ids,
-            trajectory.advantages,
-            kl_coef=0.1,
-        )
 
-        # Update weights
-        self.optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
-        self.optimizer.step()
+        if self.enable_profiling:
+            self.device_memory_monitor.reset_peak_stats()
+        with gpu_timer(
+            sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+        ) as train_t:
+            # Compute loss
+            loss, loss_metrics = compute_policy_gradient_loss_vllm(
+                self.model,
+                trajectory.vllm_token_ids,
+                trajectory.vllm_token_log_probs,
+                trajectory.prompt_token_ids,
+                trajectory.advantages,
+                kl_coef=0.1,
+            )
+
+            # Backward pass
+            self.optimizer.zero_grad()
+            loss.backward()
+
+        if self.enable_profiling:
+            train_time_s = train_t["elapsed_s"]
+            train_mem = self.device_memory_monitor.get_peak_stats()
+            self.device_memory_monitor.reset_peak_stats()
+
+        with gpu_timer(
+            sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+        ) as opt_t:
+            # Gradient clipping + optimizer step
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+            self.optimizer.step()
+
+        if self.enable_profiling:
+            optimizer_time_s = opt_t["elapsed_s"]
+            optimizer_mem = self.device_memory_monitor.get_peak_stats()
 
         self.policy_version += 1
 
@@ -132,5 +161,18 @@ class Trainer(Actor):
             "policy_version": self.policy_version,
             **loss_metrics,
         }
+        if self.enable_profiling:
+            metrics.update(
+                {
+                    "train_time_s": train_time_s,
+                    "train_peak_active_gib": train_mem.max_active_gib,
+                    "train_peak_active_pct": train_mem.max_active_pct,
+                    "train_peak_reserved_gib": train_mem.max_reserved_gib,
+                    "optimizer_time_s": optimizer_time_s,
+                    "optimizer_peak_active_gib": optimizer_mem.max_active_gib,
+                    "optimizer_peak_active_pct": optimizer_mem.max_active_pct,
+                    "optimizer_peak_reserved_gib": optimizer_mem.max_reserved_gib,
+                }
+            )
         logger.info(f"{os.getpid()=} Trainer finish step {self.policy_version}")
         return metrics

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -127,7 +127,7 @@ class Trainer(Actor):
                 kl_coef=0.1,
             )
 
-            # Backward pass
+            # Update weights
             self.optimizer.zero_grad()
             loss.backward()
 

--- a/torchtitan/experiments/rl/vllm_compat/batch_invariant_backward.py
+++ b/torchtitan/experiments/rl/vllm_compat/batch_invariant_backward.py
@@ -7,225 +7,161 @@
 """
 Batch-invariant operations with backward pass support.
 
-This module adds gradient support to vLLM's deterministic batch_invariant mode
-by registering backward operations that also use vLLM's deterministic kernels.
-
-Key architecture:
-- Forward: Uses vLLM's batch_invariant Triton kernels (deterministic)
-- Backward: Also uses vLLM's batch_invariant kernels (deterministic)
+Adds gradient support to vLLM's deterministic batch_invariant mode by:
+- Registering aten::matmul_backward and aten::linear_backward dispatch overrides
+  that use vLLM's deterministic matmul kernels
+- Providing custom ops (torch.library.custom_op) for rms_norm and silu_and_mul
+  that are opaque to Dynamo/AOT autograd with proper backward implementations
 
 This achieves bitwise-deterministic RL training where both rollouts (forward)
 and training (forward + backward) produce identical results.
-
-Usage:
-    from vllm.model_executor.layers.batch_invariant import init_batch_invariance
-    from batch_invariant_backward import enable_batch_invariant_backward_mode
-
-    # Initialize vLLM's deterministic mode first
-    init_batch_invariance(AttentionBackendEnum.FLASH_ATTN)
-
-    # Then enable gradient support
-    enable_batch_invariant_backward_mode()
-
-    # Now all operations are deterministic AND support gradients
-    model = MyModel()
-    output = model(input)  # deterministic forward
-    loss = compute_loss(output)
-    loss.backward()  # gradients work with deterministic backward!
 """
 
 import torch
-from torch.autograd import Function
+import torch.library
 
 
 # ============================================================================
-# Custom autograd Functions for vLLM operations
+# Custom ops via torch.library.custom_op
+#
+# These are opaque to both Dynamo and AOT autograd, so the compiled graph
+# preserves them as single nodes that call vLLM kernels at runtime.
 # ============================================================================
 
 
-class SiluAndMulFunction(Function):
-    """
-    Autograd function for vLLM's SiluAndMul activation.
+_cached_silu_and_mul = None
 
-    Forward: splits input into [gate, up], returns silu(gate) * up
-    where silu(x) = x * sigmoid(x)
-    """
-
-    @staticmethod
-    def forward(ctx, x):
-        """
-        Forward pass using vLLM's SiluAndMul.
-
-        Args:
-            x: Input tensor [..., hidden_dim * 2] where first half is gate, second half is up
-
-        Returns:
-            output: silu(gate) * up, shape [..., hidden_dim]
-        """
+# Avoid reinstantiating SiluAndMul each time it's called
+def _get_silu_and_mul():
+    global _cached_silu_and_mul
+    if _cached_silu_and_mul is None:
         from vllm.config import set_current_vllm_config, VllmConfig
         from vllm.model_executor.layers.activation import SiluAndMul as VLLMSiluAndMul
 
-        # Use vLLM's implementation for forward
-        # vLLM custom ops require a config context to be set
-        # Since these are parameter free we instantiate default config
         with set_current_vllm_config(VllmConfig()):
-            # compile_native=False to avoid compiling the inner details of
-            # the CustomOp for now - NOTE: if we enable compile in vLLM in
-            # the future, we need to compile this op as well.
-            # see vllm-project/vllm#32806  for more details
-            vllm_silu_and_mul = VLLMSiluAndMul(compile_native=False)
-
-        output = vllm_silu_and_mul(x)
-
-        # Save for backward
-        ctx.save_for_backward(x)
-
-        return output
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        """
-        Backward pass for SiluAndMul.
-
-        Let gate = x[:d], up = x[d:] where d = hidden_dim
-        Forward: out = silu(gate) * up = (gate * sigmoid(gate)) * up
-
-        Gradients:
-        - grad_gate = grad_out * up * d_silu(gate)
-        - grad_up = grad_out * silu(gate)
-
-        where d_silu(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
-        """
-        (x,) = ctx.saved_tensors
-
-        # Split input into gate and up
-        d = x.shape[-1] // 2
-        gate = x[..., :d]
-        up = x[..., d:]
-
-        # Compute sigmoid and silu for backward
-        sigmoid_gate = torch.sigmoid(gate)
-        silu_gate = gate * sigmoid_gate
-
-        # Gradient of silu: d_silu(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
-        d_silu_gate = sigmoid_gate * (1 + gate * (1 - sigmoid_gate))
-
-        # Compute gradients
-        grad_gate = grad_output * up * d_silu_gate
-        grad_up = grad_output * silu_gate
-
-        # Concatenate gradients
-        grad_x = torch.cat([grad_gate, grad_up], dim=-1)
-
-        return grad_x
+            _cached_silu_and_mul = VLLMSiluAndMul(compile_native=False)
+    return _cached_silu_and_mul
 
 
-class RMSNormFunction(Function):
+@torch.library.custom_op("vllm_compat::silu_and_mul", mutates_args=())
+def silu_and_mul_op(x: torch.Tensor) -> torch.Tensor:
+    """SiluAndMul activation using vLLM's implementation.
+
+    Splits input into [gate, up], returns silu(gate) * up.
     """
-    Autograd function for RMS normalization using vLLM's Triton kernel in forward
-    and batch-invariant operations in backward.
-    """
+    return _get_silu_and_mul()(x)
 
-    @staticmethod
-    def forward(ctx, input, weight, eps):
-        """
-        Forward pass using vLLM's rms_norm Triton kernel.
 
-        Args:
-            input: Input tensor [*, hidden_size]
-            weight: Weight tensor [hidden_size]
-            eps: Epsilon for numerical stability
+@silu_and_mul_op.register_fake
+def silu_and_mul_fake(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    return x[..., :d].contiguous()
 
-        Returns:
-            output: Normalized and scaled tensor [*, hidden_size]
-        """
-        from vllm.model_executor.layers.batch_invariant import rms_norm as vllm_rms_norm
 
-        # Use vLLM's Triton kernel for forward (deterministic)
-        output = vllm_rms_norm(input, weight, eps)
+def _silu_and_mul_setup_context(ctx, inputs, output):
+    (x,) = inputs
+    ctx.save_for_backward(x)
 
-        # Save for backward
-        ctx.save_for_backward(input, weight)
-        ctx.eps = eps
 
-        return output
+def _silu_and_mul_backward(ctx, grad_output):
+    (x,) = ctx.saved_tensors
+    d = x.shape[-1] // 2
+    gate = x[..., :d]
+    up = x[..., d:]
 
-    @staticmethod
-    def backward(ctx, grad_output):
-        """
-        Backward pass using batch-invariant PyTorch operations.
+    sigmoid_gate = torch.sigmoid(gate)
+    silu_gate = gate * sigmoid_gate
+    d_silu_gate = sigmoid_gate * (1 + gate * (1 - sigmoid_gate))
 
-        Returns:
-            (grad_input, grad_weight, None)
-        """
-        input, weight = ctx.saved_tensors
-        eps = ctx.eps
+    grad_gate = grad_output * up * d_silu_gate
+    grad_up = grad_output * silu_gate
+    grad_x = torch.cat([grad_gate, grad_up], dim=-1)
+    return (grad_x,)
 
-        # Compute forward pass values needed for backward
-        # variance = mean(x^2) along last dim
-        variance = (input * input).mean(dim=-1, keepdim=True)
-        rms = torch.sqrt(variance + eps)
-        x_norm = input / rms
 
-        # Gradient w.r.t. weight
-        # grad_weight = sum(grad_output * x_norm) over all dims except last
-        grad_weight = (grad_output * x_norm).sum(dim=tuple(range(grad_output.ndim - 1)))
+torch.library.register_autograd(
+    "vllm_compat::silu_and_mul",
+    _silu_and_mul_backward,
+    setup_context=_silu_and_mul_setup_context,
+)
 
-        # Gradient w.r.t. input
-        # grad_x_norm = grad_output * weight
-        grad_x_norm = grad_output * weight
 
-        # grad_x = (grad_x_norm - mean(grad_x_norm * x_norm) * x_norm) / rms
-        mean_term = (grad_x_norm * x_norm).mean(dim=-1, keepdim=True)
-        grad_input = (grad_x_norm - mean_term * x_norm) / rms
+@torch.library.custom_op("vllm_compat::rms_norm", mutates_args=())
+def rms_norm_op(input: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """RMS normalization using vLLM's Triton kernel."""
+    from vllm.model_executor.layers.batch_invariant import rms_norm as vllm_rms_norm
 
-        return grad_input, grad_weight, None
+    return vllm_rms_norm(input, weight, eps)
+
+
+@rms_norm_op.register_fake
+def rms_norm_fake(
+    input: torch.Tensor, weight: torch.Tensor, eps: float
+) -> torch.Tensor:
+    return torch.empty_like(input)
+
+
+def _rms_norm_setup_context(ctx, inputs, output):
+    input, weight, eps = inputs
+    ctx.save_for_backward(input, weight)
+    ctx.eps = eps
+
+
+def _rms_norm_backward(ctx, grad_output):
+    input, weight = ctx.saved_tensors
+    eps = ctx.eps
+
+    # Recompute forward values for backward
+    # Use sum/count instead of mean to avoid vLLM's mean_batch_invariant
+    # which converts to float32.
+    squared = input * input
+    variance = squared.sum(dim=-1, keepdim=True) / input.shape[-1]
+    rms = torch.sqrt(variance + eps)
+    x_norm = input / rms
+
+    # grad_weight = sum(grad_output * x_norm) over all dims except last
+    grad_weight = (grad_output * x_norm).sum(dim=tuple(range(grad_output.ndim - 1)))
+
+    # grad_input
+    grad_x_norm = grad_output * weight
+    product = grad_x_norm * x_norm
+    mean_term = product.sum(dim=-1, keepdim=True) / input.shape[-1]
+    grad_input = (grad_x_norm - mean_term * x_norm) / rms
+
+    return grad_input, grad_weight, None
+
+
+torch.library.register_autograd(
+    "vllm_compat::rms_norm",
+    _rms_norm_backward,
+    setup_context=_rms_norm_setup_context,
+)
 
 
 # ============================================================================
-# Backward operation implementations for autograd
+# Backward operation implementations for aten matmul/linear dispatch overrides
 # ============================================================================
 
 
 def matmul_backward_impl(grad_output, self, other, output_mask):
     """
     Backward pass for matmul: y = matmul(a, b)
-    Returns: (grad_a, grad_b)
-
-    Args:
-        grad_output: Gradient from downstream
-        self: First input tensor (a)
-        other: Second input tensor (b)
-        output_mask: List of bools indicating which gradients to compute [self, other]
 
     grad_a = grad_output @ b.T
     grad_b = a.T @ grad_output
 
-    Uses torch.matmul which is overridden by vLLM's batch_invariant mode!
+    Uses torch.matmul which is overridden by vLLM's batch_invariant mode.
     """
     grad_self = grad_other = None
 
-    # output_mask is a list [compute_grad_self, compute_grad_other]
     compute_grad_self = output_mask[0] if len(output_mask) > 0 else True
     compute_grad_other = output_mask[1] if len(output_mask) > 1 else True
 
     if compute_grad_self:
-        # grad_self = grad_output @ other.T
-        if other.ndim == 2:
-            grad_self = torch.matmul(grad_output, other.t())
-        elif other.ndim == 3:
-            grad_self = torch.matmul(grad_output, other.transpose(-2, -1))
-        else:
-            grad_self = torch.matmul(grad_output, other.transpose(-2, -1))
+        grad_self = torch.matmul(grad_output, other.transpose(-2, -1))
 
     if compute_grad_other:
-        # grad_other = self.T @ grad_output
-        if self.ndim == 2:
-            grad_other = torch.matmul(self.t(), grad_output)
-        elif self.ndim == 3:
-            grad_other = torch.matmul(self.transpose(-2, -1), grad_output)
-        else:
-            grad_other = torch.matmul(self.transpose(-2, -1), grad_output)
+        grad_other = torch.matmul(self.transpose(-2, -1), grad_output)
 
     return grad_self, grad_other
 
@@ -233,49 +169,26 @@ def matmul_backward_impl(grad_output, self, other, output_mask):
 def linear_backward_impl(grad_output, input, weight, output_mask):
     """
     Backward pass for linear: y = input @ weight.T + bias
-    Returns: (grad_input, grad_weight, grad_bias)
 
-    Args:
-        grad_output: Gradient from downstream (actually the saved input!)
-        input: Input tensor (actually grad_output!)
-        weight: Weight tensor
-        output_mask: List of bools indicating which gradients to compute [input, weight, bias]
-
-    PyTorch passes args in weird order: (saved_input, grad_output, weight, output_mask)
-    So we swap the first two args in our implementation.
+    PyTorch passes args in swapped order: (saved_input, grad_output, weight, output_mask)
+    so we swap the first two args.
     """
-    # Swap: PyTorch passes (saved_input, grad_output, ...) but we want (grad_output, input, ...)
     input, grad_output = grad_output, input
 
     grad_input = grad_weight = grad_bias = None
 
-    # output_mask is a list [compute_grad_input, compute_grad_weight, compute_grad_bias]
     compute_grad_input = output_mask[0] if len(output_mask) > 0 else True
     compute_grad_weight = output_mask[1] if len(output_mask) > 1 else True
     compute_grad_bias = output_mask[2] if len(output_mask) > 2 else True
 
     if compute_grad_input:
-        # grad_input = grad_output @ weight
         grad_input = torch.matmul(grad_output, weight)
 
     if compute_grad_weight:
-        # PyTorch linear: y = x @ W.T + b where W is [out, in]
-        # Backward: grad_W = grad_y.T @ x
-        # grad_output: (batch, out), input: (batch, in)
-        # grad_output.T @ input: (out, batch) @ (batch, in) = (out, in) ✓
-
-        # Handle multi-dimensional inputs
-        if input.ndim == 3:
-            # Reshape for matmul: (batch, seq, in) -> (batch*seq, in)
-            input_2d = input.reshape(-1, input.shape[-1])
-            grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
-            # grad_output_2d: (batch*seq, out), input_2d: (batch*seq, in)
-            # grad_output_2d.T @ input_2d: (out, batch*seq) @ (batch*seq, in) = (out, in) ✓
-            grad_weight = torch.matmul(grad_output_2d.transpose(0, 1), input_2d)
-        else:
-            # input: (batch, in), grad_output: (batch, out)
-            # grad_output.T @ input: (out, batch) @ (batch, in) = (out, in) ✓
-            grad_weight = torch.matmul(grad_output.transpose(0, 1), input)
+        # Flatten to 2D for multi-dimensional inputs
+        input_2d = input.reshape(-1, input.shape[-1])
+        grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        grad_weight = torch.matmul(grad_output_2d.transpose(0, 1), input_2d)
 
     if compute_grad_bias:
         # grad_bias = sum(grad_output) along all dims except last
@@ -293,12 +206,7 @@ _batch_invariant_backward_lib = None
 
 
 def enable_batch_invariant_backward_mode():
-    """Enable batch invariant backward mode to support gradients.
-
-    This function adds backward pass support to vLLM's existing batch_invariant
-    implementations by registering the backward operations. vLLM handles all the
-    forward passes, we just add gradient support.
-    """
+    """Register backward pass support for vLLM's batch_invariant dispatch overrides."""
     global _batch_invariant_backward_mode, _batch_invariant_backward_lib
 
     if _batch_invariant_backward_mode:
@@ -354,34 +262,10 @@ def is_batch_invariant_backward_mode_enabled():
 def rms_norm_with_gradients(
     input: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6
 ) -> torch.Tensor:
-    """
-    RMS normalization with gradient support.
-
-    Uses vLLM's Triton kernel for forward pass (deterministic) and
-    batch-invariant PyTorch operations for backward pass.
-
-    Args:
-        input: Input tensor [*, hidden_size]
-        weight: Weight tensor [hidden_size]
-        eps: Epsilon for numerical stability
-
-    Returns:
-        output: Normalized and scaled tensor [*, hidden_size]
-    """
-    return RMSNormFunction.apply(input, weight, eps)
+    """RMS normalization with gradient support."""
+    return torch.ops.vllm_compat.rms_norm(input, weight, eps)
 
 
 def silu_and_mul_with_gradients(x: torch.Tensor) -> torch.Tensor:
-    """
-    SiluAndMul activation with gradient support.
-
-    Uses vLLM's implementation for forward pass (deterministic) and
-    implements proper backward pass for training.
-
-    Args:
-        x: Input tensor [..., hidden_dim * 2] where first half is gate, second half is up
-
-    Returns:
-        output: silu(gate) * up, shape [..., hidden_dim]
-    """
-    return SiluAndMulFunction.apply(x)
+    """SiluAndMul activation with gradient support."""
+    return torch.ops.vllm_compat.silu_and_mul(x)

--- a/torchtitan/experiments/rl/vllm_compat/models/attention.py
+++ b/torchtitan/experiments/rl/vllm_compat/models/attention.py
@@ -6,10 +6,166 @@
 
 
 import math
-from collections.abc import Callable
 
 import torch
 from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func
+
+
+# ============================================================================
+# Flash attention custom op via torch.library.custom_op
+#
+# Opaque to both Dynamo and AOT autograd, so the compiled graph preserves
+# it as a single node that calls vLLM's flash attention at runtime.
+# ============================================================================
+
+
+@torch.library.custom_op("vllm_compat::flash_attn", mutates_args=())
+def flash_attn_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_len: int,
+    scale: float,
+    num_splits: int,
+) -> torch.Tensor:
+    """Flash attention varlen using vLLM's implementation."""
+    from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
+
+    total_tokens = q.shape[0]
+    num_heads = q.shape[1]
+    head_dim = q.shape[2]
+
+    out = torch.empty(
+        (total_tokens, num_heads, head_dim), dtype=q.dtype, device=q.device
+    )
+
+    output = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=seq_len,
+        max_seqlen_k=seq_len,
+        softmax_scale=scale,
+        causal=True,
+        num_splits=num_splits,
+        fa_version=get_flash_attn_version(),
+        out=out,
+    )
+    return output
+
+
+@flash_attn_op.register_fake
+def flash_attn_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_len: int,
+    scale: float,
+    num_splits: int,
+) -> torch.Tensor:
+    total_tokens = q.shape[0]
+    num_heads = q.shape[1]
+    head_dim = q.shape[2]
+    return torch.empty(
+        (total_tokens, num_heads, head_dim), dtype=q.dtype, device=q.device
+    )
+
+
+def _flash_attn_setup_context(ctx, inputs, output):
+    q, k, v, cu_seqlens, seq_len, scale, num_splits = inputs
+    ctx.save_for_backward(q, k, v)
+    ctx.scale = scale
+    ctx.seq_len = seq_len
+
+
+def _flash_attn_backward(ctx, grad_output):
+    q, k, v = ctx.saved_tensors
+    scale = ctx.scale
+    seq_len = ctx.seq_len
+
+    total_tokens = q.shape[0]
+    num_heads = q.shape[1]
+    num_kv_heads = k.shape[1]
+    head_dim = q.shape[2]
+    batch_size = total_tokens // seq_len
+
+    q_batch = q.reshape(batch_size, seq_len, num_heads, head_dim)
+    k_batch = k.reshape(batch_size, seq_len, num_kv_heads, head_dim)
+    v_batch = v.reshape(batch_size, seq_len, num_kv_heads, head_dim)
+    grad_out_batch = grad_output.reshape(batch_size, seq_len, num_heads, head_dim)
+
+    # Transpose to (batch, num_heads, seq_len, head_dim)
+    q_t = q_batch.transpose(1, 2)
+    k_t = k_batch.transpose(1, 2)
+    v_t = v_batch.transpose(1, 2)
+    grad_out_t = grad_out_batch.transpose(1, 2)
+
+    # For GQA, expand K/V to match Q's num_heads
+    if num_kv_heads < num_heads:
+        n_rep = num_heads // num_kv_heads
+        k_t = k_t.repeat_interleave(n_rep, dim=1)
+        v_t = v_t.repeat_interleave(n_rep, dim=1)
+
+    # Compute attention scores: QK^T * scale
+    scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale
+
+    # Apply causal mask
+    causal_mask = torch.triu(
+        torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool),
+        diagonal=1,
+    )
+    scores = scores.masked_fill(causal_mask, float("-inf"))
+
+    # Softmax
+    attn_weights = torch.nn.functional.softmax(scores, dim=-1)
+
+    # grad_v = attn_weights^T @ grad_out
+    grad_v_t = torch.matmul(attn_weights.transpose(-2, -1), grad_out_t)
+
+    # grad_attn_weights = grad_out @ v^T
+    grad_attn_weights = torch.matmul(grad_out_t, v_t.transpose(-2, -1))
+
+    # Backward through softmax
+    sum_term = (grad_attn_weights * attn_weights).sum(dim=-1, keepdim=True)
+    grad_scores = attn_weights * (grad_attn_weights - sum_term)
+    grad_scores = grad_scores.masked_fill(causal_mask, 0.0)
+    grad_scores = grad_scores * scale
+
+    # grad_q = grad_scores @ K
+    grad_q_t = torch.matmul(grad_scores, k_t)
+
+    # grad_k = grad_scores^T @ Q
+    grad_k_t = torch.matmul(grad_scores.transpose(-2, -1), q_t)
+
+    # Transpose back and reshape to varlen format
+    grad_q = grad_q_t.transpose(1, 2).reshape(total_tokens, num_heads, head_dim)
+
+    # For GQA, reduce grad_k and grad_v back to num_kv_heads
+    if num_kv_heads < num_heads:
+        n_rep = num_heads // num_kv_heads
+        grad_k_t = grad_k_t.reshape(
+            batch_size, num_kv_heads, n_rep, seq_len, head_dim
+        ).sum(dim=2)
+        grad_v_t = grad_v_t.reshape(
+            batch_size, num_kv_heads, n_rep, seq_len, head_dim
+        ).sum(dim=2)
+
+    grad_k = grad_k_t.transpose(1, 2).reshape(total_tokens, num_kv_heads, head_dim)
+    grad_v = grad_v_t.transpose(1, 2).reshape(total_tokens, num_kv_heads, head_dim)
+
+    # Return gradients for all inputs (None for non-differentiable ones)
+    return grad_q, grad_k, grad_v, None, None, None, None
+
+
+torch.library.register_autograd(
+    "vllm_compat::flash_attn",
+    _flash_attn_backward,
+    setup_context=_flash_attn_setup_context,
+)
 
 
 class VLLMCompatibleFlashAttention(torch.nn.Module):
@@ -17,12 +173,9 @@ class VLLMCompatibleFlashAttention(torch.nn.Module):
 
     def __init__(self) -> None:
         super().__init__()
-        self.flash_attn_varlen_func = flash_attn_varlen_func
         from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
-        from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 
-        self.vllm_is_batch_invariant = vllm_is_batch_invariant
-        self.fa_version = get_flash_attn_version()
+        self._num_splits = 1 if vllm_is_batch_invariant() else 0
 
     def forward(
         self,
@@ -31,12 +184,8 @@ class VLLMCompatibleFlashAttention(torch.nn.Module):
         v: torch.Tensor,
         *,
         scale: float | None = None,
-        enable_gqa: bool = False,
+        enable_gqa: bool = False,  # unused; GQA handled automatically in backward
     ) -> torch.Tensor:
-        # Flash Attention varlen expects: (batch, seqlen, nheads, headdim)
-        # The input from TorchTitan is always (batch, num_heads, seq_len, head_dim)
-        # We need to transpose to (batch, seq_len, num_heads, head_dim)
-
         # Input is (batch, num_heads, seq_len, head_dim) - need to transpose
         q = q.transpose(1, 2)  # -> (batch, seq_len, num_heads, head_dim)
         k = k.transpose(1, 2)
@@ -47,204 +196,30 @@ class VLLMCompatibleFlashAttention(torch.nn.Module):
         num_kv_heads = k.shape[2]
 
         # Convert to varlen format: flatten batch and sequence dimensions
-        # (batch, seqlen, nheads, headdim) -> (total_tokens, nheads, headdim)
         q_varlen = q.reshape(-1, num_heads, head_dim)
         k_varlen = k.reshape(-1, num_kv_heads, head_dim)
         v_varlen = v.reshape(-1, num_kv_heads, head_dim)
 
         # Create cumulative sequence lengths
-        # cu_seqlens: [0, seq_len, 2*seq_len, ..., batch_size*seq_len]
         cu_seqlens = torch.arange(
             0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device=q.device
         )
 
-        # Scaling factor applied prior to softmax. If none, the default value is set to :math:`\frac{1}{\sqrt{E}}`.
         if scale is None:
             scale = 1.0 / math.sqrt(q.size(-1))
 
-        # Pre-allocate output tensor with correct shape (num_heads from Q, not K/V)
-        # This ensures flash attention writes to a tensor with the correct GQA output shape
-        total_tokens = batch_size * seq_len
-        out_varlen = torch.empty(
-            (total_tokens, num_heads, head_dim), dtype=q.dtype, device=q.device
-        )
-
-        # Wrap Flash Attention with manual backward pass
-        class FlashAttnWithBackward(torch.autograd.Function):
-            @staticmethod
-            def forward(
-                ctx: torch.autograd.function.FunctionCtx,
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                out: torch.Tensor,
-                cu_seqlens: torch.Tensor,
-                seq_len: int,
-                scale: float,
-                num_splits: int,
-                flash_fn: Callable[..., torch.Tensor],
-                fa_version: int,
-            ) -> torch.Tensor:
-                # Call flash attention for forward (fast)
-                output = flash_fn(
-                    q,
-                    k,
-                    v,
-                    cu_seqlens_q=cu_seqlens,
-                    cu_seqlens_k=cu_seqlens,
-                    max_seqlen_q=seq_len,
-                    max_seqlen_k=seq_len,
-                    softmax_scale=scale,
-                    causal=True,
-                    num_splits=num_splits,
-                    fa_version=fa_version,
-                    out=out,
-                )
-                # Save for backward
-                ctx.save_for_backward(q, k, v, output)
-                ctx.scale = scale
-                ctx.seq_len = seq_len
-                return output
-
-            @staticmethod
-            def backward(
-                ctx: torch.autograd.function.FunctionCtx, grad_output: torch.Tensor
-            ) -> tuple[
-                torch.Tensor,
-                torch.Tensor,
-                torch.Tensor,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ]:
-                q, k, v, output = ctx.saved_tensors
-                scale = ctx.scale
-                seq_len = ctx.seq_len
-
-                # Reshape from varlen back to batch format for attention computation
-                # Assume uniform sequence lengths (batch_size = total_tokens / seq_len)
-                total_tokens = q.shape[0]
-                num_heads = q.shape[1]
-                num_kv_heads = k.shape[1]
-                head_dim = q.shape[2]
-                batch_size = total_tokens // seq_len
-
-                q_batch = q.reshape(batch_size, seq_len, num_heads, head_dim)
-                k_batch = k.reshape(batch_size, seq_len, num_kv_heads, head_dim)
-                v_batch = v.reshape(batch_size, seq_len, num_kv_heads, head_dim)
-                out_batch = output.reshape(batch_size, seq_len, num_heads, head_dim)
-                grad_out_batch = grad_output.reshape(
-                    batch_size, seq_len, num_heads, head_dim
-                )
-
-                # Transpose to (batch, num_heads, seq_len, head_dim)
-                q_t = q_batch.transpose(1, 2)
-                k_t = k_batch.transpose(1, 2)
-                v_t = v_batch.transpose(1, 2)
-                out_t = out_batch.transpose(1, 2)
-                grad_out_t = grad_out_batch.transpose(1, 2)
-
-                # For GQA, we need to expand K/V to match Q's num_heads
-                # Each KV head serves (num_heads // num_kv_heads) Q heads
-                if num_kv_heads < num_heads:
-                    assert enable_gqa, "GQA requires enable_gqa=True"
-                    assert (
-                        num_heads % num_kv_heads == 0
-                    ), "num_heads must be a multiple of num_kv_heads"
-                    n_rep = num_heads // num_kv_heads
-                    k_t = k_t.repeat_interleave(n_rep, dim=1)
-                    v_t = v_t.repeat_interleave(n_rep, dim=1)
-
-                # Compute attention scores: QK^T
-                # q_t: (B, H, N, D), k_t: (B, H, N, D) -> scores: (B, H, N, N)
-                scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale
-
-                # Apply causal mask
-                causal_mask = torch.triu(
-                    torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool),
-                    diagonal=1,
-                )
-                scores = scores.masked_fill(causal_mask, float("-inf"))
-
-                # Softmax
-                attn_weights = torch.nn.functional.softmax(
-                    scores, dim=-1
-                )  # (B, H, N, N)
-
-                # Backward through attention
-                # out = attn_weights @ v
-                # grad_v = attn_weights^T @ grad_out
-                grad_v_t = torch.matmul(attn_weights.transpose(-2, -1), grad_out_t)
-
-                # grad_attn_weights = grad_out @ v^T
-                grad_attn_weights = torch.matmul(grad_out_t, v_t.transpose(-2, -1))
-
-                # Backward through softmax
-                # d_softmax = attn_weights * (grad_attn_weights - sum(grad_attn_weights * attn_weights))
-                sum_term = (grad_attn_weights * attn_weights).sum(dim=-1, keepdim=True)
-                grad_scores = attn_weights * (grad_attn_weights - sum_term)
-
-                # Apply causal mask to gradients
-                grad_scores = grad_scores.masked_fill(causal_mask, 0.0)
-
-                # Backward through QK^T and scale
-                grad_scores = grad_scores * scale
-
-                # grad_q = grad_scores @ K
-                grad_q_t = torch.matmul(grad_scores, k_t)
-
-                # grad_k = grad_scores^T @ Q
-                grad_k_t = torch.matmul(grad_scores.transpose(-2, -1), q_t)
-
-                # Transpose back and reshape to varlen format
-                grad_q = grad_q_t.transpose(1, 2).reshape(
-                    total_tokens, num_heads, head_dim
-                )
-
-                # For GQA, we need to reduce grad_k and grad_v back to num_kv_heads
-                if num_kv_heads < num_heads:
-                    assert enable_gqa, "GQA requires enable_gqa=True"
-                    assert (
-                        num_heads % num_kv_heads == 0
-                    ), "num_heads must be a multiple of num_kv_heads"
-                    n_rep = num_heads // num_kv_heads
-                    # Reshape and sum over the repeated dimension
-                    grad_k_t = grad_k_t.reshape(
-                        batch_size, num_kv_heads, n_rep, seq_len, head_dim
-                    ).sum(dim=2)
-                    grad_v_t = grad_v_t.reshape(
-                        batch_size, num_kv_heads, n_rep, seq_len, head_dim
-                    ).sum(dim=2)
-
-                grad_k = grad_k_t.transpose(1, 2).reshape(
-                    total_tokens, num_kv_heads, head_dim
-                )
-                grad_v = grad_v_t.transpose(1, 2).reshape(
-                    total_tokens, num_kv_heads, head_dim
-                )
-
-                return grad_q, grad_k, grad_v, None, None, None, None, None, None, None
-
-        # Call Flash Attention varlen with custom backward
-        output_varlen = FlashAttnWithBackward.apply(
+        # Call flash attention custom op (opaque to compiler)
+        output_varlen = torch.ops.vllm_compat.flash_attn(
             q_varlen,
             k_varlen,
             v_varlen,
-            out_varlen,
             cu_seqlens,
             seq_len,
             scale,
-            1 if self.vllm_is_batch_invariant() else 0,
-            self.flash_attn_varlen_func,
-            self.fa_version,
+            self._num_splits,
         )
 
         # Convert back to batch format
-        # (total_tokens, nheads, headdim) -> (batch, seqlen, nheads, headdim)
         output = output_varlen.reshape(batch_size, seq_len, num_heads, head_dim)
 
         # Transpose back to TorchTitan format: (batch, num_heads, seq_len, head_dim)

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -26,9 +26,10 @@ import torch.nn.functional as F
 from huggingface_hub import snapshot_download
 from safetensors.torch import load_file, save_file
 from torch.utils.tensorboard import SummaryWriter
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
 from torchtitan.experiments.rl.metrics import (
     CumulativeMetrics,
+    gpu_timer,
     PhaseMetrics,
     print_step_metrics,
     print_training_summary,

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -950,11 +950,10 @@ def rl_update_step(
             rollout_peak_gib = max(rollout_peak_gib, rollout_mem.max_active_gib)
             rollout_peak_pct = max(rollout_peak_pct, rollout_mem.max_active_pct)
 
-        # --- Train phase ---
+        # Compute loss using current policy
         if enable_profiling:
             device_memory_monitor.reset_peak_stats()
         with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as train_t:
-            # Compute loss using current policy
             loss, loss_metrics = compute_policy_gradient_loss_vllm(
                 model,
                 vllm_token_ids,
@@ -967,8 +966,7 @@ def rl_update_step(
             # Accumulate loss (will be averaged later)
             loss = loss / num_rollout_batches
             loss.backward()
-
-        total_loss += loss.item()
+            total_loss += loss.item()
 
         if enable_profiling:
             train_time_s += train_t.get("elapsed_s", 0.0)
@@ -983,7 +981,6 @@ def rl_update_step(
         batch_metrics.append(loss_metrics)
 
     if enable_profiling:
-        # --- Optimizer phase ---
         device_memory_monitor.reset_peak_stats()
     with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as opt_t:
         # Gradient clipping
@@ -996,7 +993,6 @@ def rl_update_step(
         optimizer_time_s = opt_t["elapsed_s"]
         optimizer_mem = device_memory_monitor.get_peak_stats()
 
-        # --- Weight sync phase ---
         device_memory_monitor.reset_peak_stats()
     with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as wsync_t:
         # Update vLLM weights from current policy (only once per update)


### PR DESCRIPTION
Rewrites batch-invariant ops as torch.library.custom_op (rms_norm, silu_and_mul, flash_attn) so they are opaque to Dynamo/AOT autograd. Adds aten dispatch overrides for matmul/linear backward to use vLLM's deterministic kernels.

Refactors compute_policy_gradient_loss_vllm to use per-sample gradient accumulation: each sample's forward is immediately followed by backward, keeping only one set of activations in memory at a time. This is a prerequisite for torch.compile since the compiled graph processes one sample at a time with fixed-shape inputs.

Changes:
- batch_invariant_backward.py: custom ops rewrite
- models/attention.py: custom op for flash_attn
- simple_rl.py: per-sample backward, loss_scale param, timing metrics
- trainer.py: move zero_grad before loss, remove loss.backward()


Authored with Claude