### PR TITLE
Orchestrate runtime and memory profile measurement in simple_rl and simple_rl_multiprocess

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -8,6 +8,7 @@ import os
 import time
 from collections import namedtuple
 from dataclasses import dataclass
+from contextlib import contextmanager
 from datetime import datetime
 from typing import Any
 
@@ -91,6 +92,37 @@ class DeviceMemoryMonitor:
 
     def reset_peak_stats(self):
         device_module.reset_peak_memory_stats()
+
+
+@contextmanager
+def gpu_timer(sync: bool = True, enabled: bool = True):
+    """Context manager that optionally synchronizes the device and measures wall-clock time.
+
+    Yields a dict; on exit it is populated with an ``elapsed_s`` key.
+
+    Args:
+        sync: If True, synchronizes the device before and after timing.
+        enabled: If False, skips all timing/sync overhead and yields an empty dict.
+
+    Usage::
+
+        with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as t:
+            do_work()
+        print(t.get("elapsed_s", 0.0))
+    """
+    result: dict[str, float] = {}
+    if not enabled:
+        yield result
+        return
+    if sync:
+        device_module.synchronize()
+    t0 = time.perf_counter()
+    try:
+        yield result
+    finally:
+        if sync:
+            device_module.synchronize()
+        result["elapsed_s"] = time.perf_counter() - t0
 
 
 def build_device_memory_monitor():

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -94,37 +94,6 @@ class DeviceMemoryMonitor:
         device_module.reset_peak_memory_stats()
 
 
-@contextmanager
-def gpu_timer(sync: bool = True, enabled: bool = True):
-    """Context manager that optionally synchronizes the device and measures wall-clock time.
-
-    Yields a dict; on exit it is populated with an ``elapsed_s`` key.
-
-    Args:
-        sync: If True, synchronizes the device before and after timing.
-        enabled: If False, skips all timing/sync overhead and yields an empty dict.
-
-    Usage::
-
-        with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as t:
-            do_work()
-        print(t.get("elapsed_s", 0.0))
-    """
-    result: dict[str, float] = {}
-    if not enabled:
-        yield result
-        return
-    if sync:
-        device_module.synchronize()
-    t0 = time.perf_counter()
-    try:
-        yield result
-    finally:
-        if sync:
-            device_module.synchronize()
-        result["elapsed_s"] = time.perf_counter() - t0
-
-
 def build_device_memory_monitor():
     device_memory_monitor = DeviceMemoryMonitor(device_type)
     logger.info(

--- a/torchtitan/experiments/rl/metrics.py
+++ b/torchtitan/experiments/rl/metrics.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Shared metrics utilities for RL training loops.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CumulativeMetrics:
+    """Accumulator for timing and memory metrics across training steps."""
+
+    rollout_s: float = 0.0
+    train_s: float = 0.0
+    optimizer_s: float = 0.0
+    weight_sync_s: float = 0.0
+    total_s: float = 0.0
+    peak_rollout_gib: float = 0.0
+    peak_train_gib: float = 0.0
+    peak_optimizer_gib: float = 0.0
+    peak_weight_sync_gib: float = 0.0
+    completed_steps: int = 0
+
+
+@dataclass(frozen=True)
+class PhaseMetrics:
+    """Metrics for a single phase of a RL step."""
+
+    name: str
+    time_s: float
+    peak_mem_gib: float = 0.0
+    peak_mem_pct: float = 0.0
+    note: str | None = None
+
+
+def update_cumulative_metrics(
+    cumulative: CumulativeMetrics,
+    rollout_time_s: float,
+    train_time_s: float,
+    optimizer_time_s: float,
+    weight_sync_time_s: float,
+    total_time_s: float,
+    rollout_peak_gib: float = 0.0,
+    train_peak_gib: float = 0.0,
+    optimizer_peak_gib: float = 0.0,
+    weight_sync_peak_gib: float = 0.0,
+) -> None:
+    """Update cumulative metrics with data from a single RL step.
+
+    Args:
+        cumulative: The CumulativeMetrics instance to update.
+        rollout_time_s: Time spent in rollout phase (seconds).
+        train_time_s: Time spent in training phase (seconds).
+        optimizer_time_s: Time spent in optimizer step (seconds).
+        weight_sync_time_s: Time spent syncing weights (seconds).
+        total_time_s: Total step time (seconds).
+        rollout_peak_gib: Peak memory during rollout phase (GiB).
+        train_peak_gib: Peak memory during train phase (GiB).
+        optimizer_peak_gib: Peak memory during optimizer step (GiB).
+        weight_sync_peak_gib: Peak memory during weight sync phase (GiB).
+    """
+    cumulative.rollout_s += rollout_time_s
+    cumulative.train_s += train_time_s
+    cumulative.optimizer_s += optimizer_time_s
+    cumulative.weight_sync_s += weight_sync_time_s
+    cumulative.total_s += total_time_s
+    cumulative.completed_steps += 1
+    cumulative.peak_rollout_gib = max(cumulative.peak_rollout_gib, rollout_peak_gib)
+    cumulative.peak_train_gib = max(cumulative.peak_train_gib, train_peak_gib)
+    cumulative.peak_optimizer_gib = max(
+        cumulative.peak_optimizer_gib, optimizer_peak_gib
+    )
+    cumulative.peak_weight_sync_gib = max(
+        cumulative.peak_weight_sync_gib, weight_sync_peak_gib
+    )
+
+
+def print_step_metrics(
+    phases: list[PhaseMetrics],
+    total_time_s: float,
+    include_mem_pct: bool = False,
+) -> None:
+    """Print per-phase timing and memory breakdown for a training step.
+
+    Args:
+        phases: List of PhaseMetrics for each phase in the step.
+        total_time_s: Total time for the step (seconds).
+        include_mem_pct: If True, include memory percentage in output.
+    """
+    print(f"  {'Phase':<16s} {'Time':>8s}  {'Peak Mem':>10s}")
+    print(f"  {'-' * 38}")
+
+    for phase in phases:
+        line = f"  {phase.name + ':':<16s} {phase.time_s:>7.2f}s"
+        if phase.peak_mem_gib > 0:
+            line += f",  {phase.peak_mem_gib:>5.2f} GiB"
+            if include_mem_pct and phase.peak_mem_pct > 0:
+                line += f"  ({phase.peak_mem_pct:.1f}%)"
+            if phase.note:
+                line += f"  {phase.note}"
+        elif phase.note:
+            line += f"  {phase.note}"
+        print(line)
+
+    print(f"  {'total:':<16s} {total_time_s:>7.2f}s")
+
+
+def print_training_summary(
+    cumulative: CumulativeMetrics,
+    only_print_memory_if_nonzero: bool = False,
+) -> None:
+    """Print a formatted training summary.
+
+    Args:
+        cumulative: The CumulativeMetrics instance containing accumulated data.
+        only_print_memory_if_nonzero: If True, only print memory stats when > 0.
+            If False, always print memory stats.
+    """
+    if cumulative.completed_steps == 0:
+        return
+
+    print("\n" + "=" * 80)
+    print(f"Training Summary ({cumulative.completed_steps} steps):")
+    print(f"  {'Total wall-clock:':<28s} {cumulative.total_s:>9.2f}s")
+
+    for label, val in [
+        ("Cumul. rollout:", cumulative.rollout_s),
+        ("Cumul. train:", cumulative.train_s),
+        ("Cumul. optimizer:", cumulative.optimizer_s),
+        ("Cumul. weight_sync:", cumulative.weight_sync_s),
+    ]:
+        pct = 100 * val / cumulative.total_s
+        print(f"  {label:<28s} {val:>9.2f}s  ({pct:>5.1f}%)")
+
+    should_print_rollout_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_rollout_gib > 0
+    )
+    should_print_train_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_train_gib > 0
+    )
+    should_print_optimizer_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_optimizer_gib > 0
+    )
+    should_print_weight_sync_mem = (
+        not only_print_memory_if_nonzero or cumulative.peak_weight_sync_gib > 0
+    )
+
+    if should_print_rollout_mem:
+        print(
+            f"  {'Peak mem (rollout):':<28s} "
+            f"{cumulative.peak_rollout_gib:>8.2f} GiB"
+        )
+    if should_print_train_mem:
+        print(f"  {'Peak mem (train):':<28s} " f"{cumulative.peak_train_gib:>8.2f} GiB")
+    if should_print_optimizer_mem:
+        print(
+            f"  {'Peak mem (optimizer):':<28s} "
+            f"{cumulative.peak_optimizer_gib:>8.2f} GiB"
+        )
+    if should_print_weight_sync_mem:
+        print(
+            f"  {'Peak mem (weight_sync):':<28s} "
+            f"{cumulative.peak_weight_sync_gib:>8.2f} GiB"
+        )
+
+    print("=" * 80)

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -13,11 +13,12 @@ import torch
 from monarch.actor import Actor, endpoint
 from safetensors.torch import save_file
 from torchtitan.config import CommConfig
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
 from torchtitan.distributed import utils as dist_utils
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
+from torchtitan.experiments.rl.metrics import gpu_timer
 from torchtitan.experiments.rl.vllm_compat.simple_rl import (
     compute_grpo_advantages,
     compute_grpo_advantages_stable,

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -7,18 +7,17 @@
 import asyncio
 import logging
 import os
-
 from dataclasses import dataclass
 
 import torch
 from monarch.actor import Actor, endpoint
 from safetensors.torch import save_file
 from torchtitan.config import CommConfig
+from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
 from torchtitan.distributed import utils as dist_utils
 
 # Import unified module - this automatically registers TorchTitan models with vLLM
 from torchtitan.experiments.rl import unified  # noqa: F401
-
 from torchtitan.experiments.rl.vllm_compat.simple_rl import (
     compute_grpo_advantages,
     compute_grpo_advantages_stable,
@@ -46,6 +45,10 @@ class TrajectoryData:
         prompt_token_ids: List of prompt token ID lists
         rewards: Computed rewards for each completion
         advantages: Computed advantages for each completion
+        gen_time_s: Generation wall-clock time in seconds
+        gen_peak_active_gib: Peak active GPU memory during generation (GiB)
+        gen_peak_active_pct: Peak active GPU memory as percentage of capacity
+        gen_peak_reserved_gib: Peak reserved GPU memory during generation (GiB)
     """
 
     policy_version: int
@@ -55,6 +58,10 @@ class TrajectoryData:
     prompt_token_ids: list[list[int]]
     rewards: torch.Tensor
     advantages: torch.Tensor
+    gen_time_s: float = 0.0
+    gen_peak_active_gib: float = 0.0
+    gen_peak_active_pct: float = 0.0
+    gen_peak_reserved_gib: float = 0.0
 
 
 class VLLMRolloutEngine:
@@ -373,6 +380,8 @@ class Generator(Actor):
         grpo_beta: float = 0.1,
         use_stable_grpo: bool = False,
         tp_size: int = 1,
+        cuda_sync_for_metrics: bool = True,
+        enable_profiling: bool = True,
     ):
         self.model_path = model_path
         self.prompt_texts = prompt_texts
@@ -384,6 +393,8 @@ class Generator(Actor):
         self.grpo_beta = grpo_beta
         self.use_stable_grpo = use_stable_grpo
         self.tp_size = tp_size
+        self.cuda_sync_for_metrics = cuda_sync_for_metrics
+        self.enable_profiling = enable_profiling
 
         # Initialize distributed environment for SPMD generator
         world_size = dist_utils.init_distributed(
@@ -391,6 +402,9 @@ class Generator(Actor):
         )
         # Initialize vLLM engine
         self.vllm_engine = VLLMRolloutEngine(model_path, tp_size=self.tp_size)
+
+        if enable_profiling:
+            self.device_memory_monitor = DeviceMemoryMonitor()
 
         # State machine
         self.state = GeneratorState.READY_TO_UPDATE
@@ -416,42 +430,60 @@ class Generator(Actor):
                 lambda: self.state == GeneratorState.READY_TO_GENERATE
             )
 
-            # Generate samples using vLLM
-            (
-                completions,
-                vllm_log_probs,
-                vllm_token_ids,
-                vllm_token_log_probs,
-                prompt_token_ids,
-            ) = self.vllm_engine.generate(
-                self.prompt_texts,
-                self.max_new_tokens,
-                self.temperature,
-                n_samples_per_prompt=self.group_size,
-            )
+            if self.enable_profiling:
+                self.device_memory_monitor.reset_peak_stats()
 
-            # Compute rewards
-            rewards = self.reward_fn(
-                completions, self.expected_answers, self.group_size
-            )
-
-            # Normalize rewards
-            reward_mean = rewards.mean()
-            reward_std = rewards.std()
-            if reward_std > 1e-8:
-                rewards_normalized = (rewards - reward_mean) / reward_std
-            else:
-                rewards_normalized = rewards - reward_mean
-
-            # Compute advantages using GRPO
-            if self.use_stable_grpo:
-                advantages = compute_grpo_advantages_stable(
-                    rewards_normalized, self.group_size
+            with gpu_timer(
+                sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+            ) as gen_t:
+                # Generate samples using vLLM
+                (
+                    completions,
+                    vllm_log_probs,
+                    vllm_token_ids,
+                    vllm_token_log_probs,
+                    prompt_token_ids,
+                ) = self.vllm_engine.generate(
+                    self.prompt_texts,
+                    self.max_new_tokens,
+                    self.temperature,
+                    n_samples_per_prompt=self.group_size,
                 )
-            else:
-                advantages = compute_grpo_advantages(
-                    rewards_normalized, self.group_size, beta=self.grpo_beta
+
+                # Compute rewards
+                rewards = self.reward_fn(
+                    completions, self.expected_answers, self.group_size
                 )
+
+                # Normalize rewards
+                reward_mean = rewards.mean()
+                reward_std = rewards.std()
+                if reward_std > 1e-8:
+                    rewards_normalized = (rewards - reward_mean) / reward_std
+                else:
+                    rewards_normalized = rewards - reward_mean
+
+                # Compute advantages using GRPO
+                if self.use_stable_grpo:
+                    advantages = compute_grpo_advantages_stable(
+                        rewards_normalized, self.group_size
+                    )
+                else:
+                    advantages = compute_grpo_advantages(
+                        rewards_normalized, self.group_size, beta=self.grpo_beta
+                    )
+
+            if self.enable_profiling:
+                mem_stats = self.device_memory_monitor.get_peak_stats()
+                gen_time_s = gen_t.get("elapsed_s", 0.0)
+                gen_peak_active_gib = mem_stats.max_active_gib
+                gen_peak_active_pct = mem_stats.max_active_pct
+                gen_peak_reserved_gib = mem_stats.max_reserved_gib
+            else:
+                gen_time_s = 0.0
+                gen_peak_active_gib = 0.0
+                gen_peak_active_pct = 0.0
+                gen_peak_reserved_gib = 0.0
 
             # Create trajectory data
             trajectory = TrajectoryData(
@@ -462,6 +494,10 @@ class Generator(Actor):
                 prompt_token_ids=prompt_token_ids,
                 rewards=rewards,
                 advantages=advantages,
+                gen_time_s=gen_time_s,
+                gen_peak_active_gib=gen_peak_active_gib,
+                gen_peak_active_pct=gen_peak_active_pct,
+                gen_peak_reserved_gib=gen_peak_reserved_gib,
             )
 
             # Signal ready for update

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -10,7 +10,8 @@ from typing import Any, Optional
 
 import torch
 from monarch.actor import Actor, endpoint
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
+from torchtitan.experiments.rl.metrics import gpu_timer
 from torchtitan.experiments.rl.unified.actors.generator import TrajectoryData
 from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_trainer_parallel_dims,

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 from monarch.actor import Actor, endpoint
+from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
 from torchtitan.experiments.rl.unified.actors.generator import TrajectoryData
 from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
     create_trainer_parallel_dims,
@@ -37,6 +38,7 @@ class Trainer(Actor):
         learning_rate: Learning rate for optimizer
         model_mode: Indicates which model to use. Train inferece unified model, batch invariant Torchtitan model,
             or plain Torchtitan model
+        enable_profiling: If True, track timing and memory metrics
     """
 
     def __init__(
@@ -47,11 +49,18 @@ class Trainer(Actor):
         model_mode: str = ModelMode.VLLM_COMPAT,
         ddp_size: int = 1,
         tp_size: int = 1,
+        cuda_sync_for_metrics: bool = True,
+        enable_profiling: bool = True,
     ):
         # Explicitly set cuda device for each trainer, otherwise different processes will use the same CUDA device
         local_rank = int(os.environ["LOCAL_RANK"])
         device = torch.device(f"cuda:{local_rank}")
         torch.cuda.set_device(local_rank)
+
+        self.cuda_sync_for_metrics = cuda_sync_for_metrics
+        self.enable_profiling = enable_profiling
+        if enable_profiling:
+            self.device_memory_monitor = DeviceMemoryMonitor(f"cuda:{local_rank}")
 
         self.model = load_model(
             titan_checkpoint_path, model_path, model_mode=model_mode
@@ -101,21 +110,41 @@ class Trainer(Actor):
         logger.info(
             f"{os.getpid()=} Trainer starts to train {self.policy_version} on traj:"
         )
-        # Compute loss
-        loss, loss_metrics = compute_policy_gradient_loss_vllm(
-            self.model,
-            trajectory.vllm_token_ids,
-            trajectory.vllm_token_log_probs,
-            trajectory.prompt_token_ids,
-            trajectory.advantages,
-            kl_coef=0.1,
-        )
 
-        # Update weights
-        self.optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
-        self.optimizer.step()
+        if self.enable_profiling:
+            self.device_memory_monitor.reset_peak_stats()
+        with gpu_timer(
+            sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+        ) as train_t:
+            # Compute loss
+            loss, loss_metrics = compute_policy_gradient_loss_vllm(
+                self.model,
+                trajectory.vllm_token_ids,
+                trajectory.vllm_token_log_probs,
+                trajectory.prompt_token_ids,
+                trajectory.advantages,
+                kl_coef=0.1,
+            )
+
+            # Backward pass
+            self.optimizer.zero_grad()
+            loss.backward()
+
+        if self.enable_profiling:
+            train_time_s = train_t["elapsed_s"]
+            train_mem = self.device_memory_monitor.get_peak_stats()
+            self.device_memory_monitor.reset_peak_stats()
+
+        with gpu_timer(
+            sync=self.cuda_sync_for_metrics, enabled=self.enable_profiling
+        ) as opt_t:
+            # Gradient clipping + optimizer step
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+            self.optimizer.step()
+
+        if self.enable_profiling:
+            optimizer_time_s = opt_t["elapsed_s"]
+            optimizer_mem = self.device_memory_monitor.get_peak_stats()
 
         self.policy_version += 1
 
@@ -132,5 +161,18 @@ class Trainer(Actor):
             "policy_version": self.policy_version,
             **loss_metrics,
         }
+        if self.enable_profiling:
+            metrics.update(
+                {
+                    "train_time_s": train_time_s,
+                    "train_peak_active_gib": train_mem.max_active_gib,
+                    "train_peak_active_pct": train_mem.max_active_pct,
+                    "train_peak_reserved_gib": train_mem.max_reserved_gib,
+                    "optimizer_time_s": optimizer_time_s,
+                    "optimizer_peak_active_gib": optimizer_mem.max_active_gib,
+                    "optimizer_peak_active_pct": optimizer_mem.max_active_pct,
+                    "optimizer_peak_reserved_gib": optimizer_mem.max_reserved_gib,
+                }
+            )
         logger.info(f"{os.getpid()=} Trainer finish step {self.policy_version}")
         return metrics

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -26,9 +26,10 @@ import torch.nn.functional as F
 from huggingface_hub import snapshot_download
 from safetensors.torch import load_file, save_file
 from torch.utils.tensorboard import SummaryWriter
-from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.components.metrics import DeviceMemoryMonitor
 from torchtitan.experiments.rl.metrics import (
     CumulativeMetrics,
+    gpu_timer,
     PhaseMetrics,
     print_step_metrics,
     print_training_summary,

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -19,13 +19,21 @@ This demonstrates:
 
 import os
 import re
+import time
 
 import torch
 import torch.nn.functional as F
 from huggingface_hub import snapshot_download
 from safetensors.torch import load_file, save_file
 from torch.utils.tensorboard import SummaryWriter
-
+from torchtitan.components.metrics import DeviceMemoryMonitor, gpu_timer
+from torchtitan.experiments.rl.metrics import (
+    CumulativeMetrics,
+    PhaseMetrics,
+    print_step_metrics,
+    print_training_summary,
+    update_cumulative_metrics,
+)
 from torchtitan.experiments.rl.vllm_compat.weights.converter import (
     torchtitan_to_vllm,
     vllm_to_torchtitan,
@@ -33,10 +41,8 @@ from torchtitan.experiments.rl.vllm_compat.weights.converter import (
 from torchtitan.experiments.rl.vllm_compat.weights_vllm_compat import (
     torchtitan_to_vllm_compat,
 )
-
 from torchtitan.models.qwen3.model import Qwen3Model
 from transformers import AutoConfig, AutoTokenizer
-
 from vllm import LLM, SamplingParams
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -835,6 +841,9 @@ def rl_update_step(
     reward_fn=None,
     grpo_beta: float = 0.1,
     use_stable_grpo: bool = False,
+    cuda_sync_for_metrics: bool = True,
+    device_memory_monitor: DeviceMemoryMonitor | None = None,
+    enable_profiling: bool = True,
 ) -> dict:
     """
     Perform one RL update step using vLLM for rollouts.
@@ -854,10 +863,13 @@ def rl_update_step(
         reward_fn: Reward function (defaults to trivial_reward_function)
         grpo_beta: Beta parameter for GRPO exponential weighting (lower = more unstable)
         use_stable_grpo: If True, use stable GRPO (mean-centering) instead of exponential
+        cuda_sync_for_metrics: If True, synchronize CUDA before timing for accurate GPU measurements
+        device_memory_monitor: Reusable memory monitor (created once to avoid per-step cache clears)
 
     Returns:
         metrics: Dict of training metrics
     """
+
     # Default reward function
     if reward_fn is None:
         reward_fn = trivial_reward_function
@@ -867,6 +879,13 @@ def rl_update_step(
     vllm_compat_state = torchtitan_to_vllm_compat(titan_state)
     vllm_engine.update_weights(vllm_compat_state)
 
+    if device_memory_monitor is None:
+        device_memory_monitor = DeviceMemoryMonitor()
+
+    if enable_profiling:
+        total_t0 = time.perf_counter()
+
+    # --- Rollout + training batch loop ---
     # Accumulate gradients over multiple rollout batches
     optimizer.zero_grad()
 
@@ -875,55 +894,86 @@ def rl_update_step(
     all_advantages = []
     total_loss = 0.0
     batch_metrics = []
+    rollout_time_s = 0.0
+    train_time_s = 0.0
+    rollout_peak_gib = 0.0
+    rollout_peak_pct = 0.0
+    train_peak_gib = 0.0
+    train_peak_pct = 0.0
 
     for batch_idx in range(num_rollout_batches):
-        # Generate samples using vLLM
-        (
-            completions,
-            vllm_log_probs,
-            vllm_token_ids,
-            vllm_token_log_probs,
-            prompt_token_ids,
-        ) = vllm_engine.generate(
-            prompt_texts,
-            max_new_tokens,
-            temperature,
-            n_samples_per_prompt=group_size,
-        )
-
-        # Compute rewards using provided reward function
-        rewards = reward_fn(completions, expected_answers, group_size)
-
-        # Normalize rewards for stability (mean=0, std=1)
-        reward_mean = rewards.mean()
-        reward_std = rewards.std()
-        if reward_std > 1e-8:
-            rewards_normalized = (rewards - reward_mean) / reward_std
-        else:
-            rewards_normalized = rewards - reward_mean
-
-        # Compute advantages using GRPO
-        if use_stable_grpo:
-            advantages = compute_grpo_advantages_stable(rewards_normalized, group_size)
-        else:
-            advantages = compute_grpo_advantages(
-                rewards_normalized, group_size, beta=grpo_beta
+        # --- Rollout phase ---
+        if enable_profiling:
+            device_memory_monitor.reset_peak_stats()
+        with gpu_timer(
+            sync=cuda_sync_for_metrics, enabled=enable_profiling
+        ) as rollout_t:
+            # Generate samples using vLLM
+            (
+                completions,
+                vllm_log_probs,
+                vllm_token_ids,
+                vllm_token_log_probs,
+                prompt_token_ids,
+            ) = vllm_engine.generate(
+                prompt_texts,
+                max_new_tokens,
+                temperature,
+                n_samples_per_prompt=group_size,
             )
 
-        # Compute loss using current policy
-        loss, loss_metrics = compute_policy_gradient_loss_vllm(
-            model,
-            vllm_token_ids,
-            vllm_token_log_probs,
-            prompt_token_ids,
-            advantages,
-            kl_coef=0.1,
-        )
+            # Compute rewards using provided reward function
+            rewards = reward_fn(completions, expected_answers, group_size)
 
-        # Accumulate loss (will be averaged later)
-        loss = loss / num_rollout_batches
-        loss.backward()
+            # Normalize rewards for stability (mean=0, std=1)
+            reward_mean = rewards.mean()
+            reward_std = rewards.std()
+            if reward_std > 1e-8:
+                rewards_normalized = (rewards - reward_mean) / reward_std
+            else:
+                rewards_normalized = rewards - reward_mean
+
+            # Compute advantages using GRPO
+            if use_stable_grpo:
+                advantages = compute_grpo_advantages_stable(
+                    rewards_normalized, group_size
+                )
+            else:
+                advantages = compute_grpo_advantages(
+                    rewards_normalized, group_size, beta=grpo_beta
+                )
+
+        if enable_profiling:
+            rollout_time_s += rollout_t.get("elapsed_s", 0.0)
+            rollout_mem = device_memory_monitor.get_peak_stats()
+            rollout_peak_gib = max(rollout_peak_gib, rollout_mem.max_active_gib)
+            rollout_peak_pct = max(rollout_peak_pct, rollout_mem.max_active_pct)
+
+        # --- Train phase ---
+        if enable_profiling:
+            device_memory_monitor.reset_peak_stats()
+        with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as train_t:
+            # Compute loss using current policy
+            loss, loss_metrics = compute_policy_gradient_loss_vllm(
+                model,
+                vllm_token_ids,
+                vllm_token_log_probs,
+                prompt_token_ids,
+                advantages,
+                kl_coef=0.1,
+            )
+
+            # Accumulate loss (will be averaged later)
+            loss = loss / num_rollout_batches
+            loss.backward()
+
         total_loss += loss.item()
+
+        if enable_profiling:
+            train_time_s += train_t.get("elapsed_s", 0.0)
+            train_mem = device_memory_monitor.get_peak_stats()
+            train_peak_gib = max(train_peak_gib, train_mem.max_active_gib)
+            train_peak_pct = max(train_peak_pct, train_mem.max_active_pct)
 
         # Track metrics
         all_completions.extend(completions[:2])  # Sample 2 from each batch
@@ -931,11 +981,32 @@ def rl_update_step(
         all_advantages.append(advantages.mean().item())
         batch_metrics.append(loss_metrics)
 
-    # Gradient clipping
-    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+    if enable_profiling:
+        # --- Optimizer phase ---
+        device_memory_monitor.reset_peak_stats()
+    with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as opt_t:
+        # Gradient clipping
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
 
-    # Update weights
-    optimizer.step()
+        # Update weights
+        optimizer.step()
+
+    if enable_profiling:
+        optimizer_time_s = opt_t["elapsed_s"]
+        optimizer_mem = device_memory_monitor.get_peak_stats()
+
+        # --- Weight sync phase ---
+        device_memory_monitor.reset_peak_stats()
+    with gpu_timer(sync=cuda_sync_for_metrics, enabled=enable_profiling) as wsync_t:
+        # Update vLLM weights from current policy (only once per update)
+        titan_state = model.state_dict()
+        vllm_compat_state = torchtitan_to_vllm_compat(titan_state)
+        vllm_engine.update_weights(vllm_compat_state)
+
+    if enable_profiling:
+        weight_sync_time_s = wsync_t["elapsed_s"]
+        wsync_mem = device_memory_monitor.get_peak_stats()
+        total_time_s = time.perf_counter() - total_t0
 
     # Aggregate metrics across batches
     avg_reward = sum(all_rewards) / len(all_rewards)
@@ -956,6 +1027,30 @@ def rl_update_step(
         "total_samples": len(prompt_texts) * group_size * num_rollout_batches,
         **final_metrics,  # Include final batch metrics
     }
+
+    # Add timing/memory metrics only if profiling is enabled
+    if enable_profiling:
+        metrics.update(
+            {
+                # Timing metrics
+                "time/total_s": total_time_s,
+                "time/weight_sync_s": weight_sync_time_s,
+                "time/rollout_s": rollout_time_s,
+                "time/train_s": train_time_s,
+                "time/optimizer_s": optimizer_time_s,
+                # Memory metrics
+                "memory/weight_sync_peak_active_gib": wsync_mem.max_active_gib,
+                "memory/weight_sync_peak_active_pct": wsync_mem.max_active_pct,
+                "memory/weight_sync_peak_reserved_gib": wsync_mem.max_reserved_gib,
+                "memory/rollout_peak_active_gib": rollout_peak_gib,
+                "memory/rollout_peak_active_pct": rollout_peak_pct,
+                "memory/train_peak_active_gib": train_peak_gib,
+                "memory/train_peak_active_pct": train_peak_pct,
+                "memory/optimizer_peak_active_gib": optimizer_mem.max_active_gib,
+                "memory/optimizer_peak_active_pct": optimizer_mem.max_active_pct,
+                "memory/optimizer_peak_reserved_gib": optimizer_mem.max_reserved_gib,
+            }
+        )
 
     return metrics
 
@@ -1030,7 +1125,7 @@ def main():
     # Training config
     group_size = 8  # Samples per prompt for GRPO (increased from 4)
     num_rollout_batches = 2  # Multiple rollout batches per update (NEW!)
-    num_steps = 100
+    num_steps = 5
     learning_rate = 1e-5
 
     # GRPO config
@@ -1093,6 +1188,12 @@ def main():
     print("\nInitializing vLLM engine for rollouts...")
     vllm_engine = VLLMRolloutEngine(model_path)
 
+    # Initial weight sync to vLLM engine
+    print("Performing initial weight sync to vLLM...")
+    titan_state = model.state_dict()
+    vllm_compat_state = torchtitan_to_vllm_compat(titan_state)
+    vllm_engine.update_weights(vllm_compat_state)
+
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
@@ -1140,6 +1241,11 @@ def main():
     print("TensorBoard logging enabled at: ./outputs/rl_training")
     print("=" * 80)
 
+    # Metrics config
+    cuda_sync_for_metrics = True
+    enable_profiling = True  # Set to False to disable timing/memory output
+    device_memory_monitor = DeviceMemoryMonitor()
+
     # Training loop
     print(f"\nStarting RL training for {num_steps} steps...")
     print(f"  Prompts: {len(prompt_texts)}")
@@ -1152,6 +1258,8 @@ def main():
         f"  GRPO mode: {'Stable (mean-centering)' if use_stable_grpo else f'Exponential (beta={grpo_beta})'}"
     )
     print("=" * 80)
+
+    cumulative = CumulativeMetrics()
 
     for step in range(num_steps):
         metrics = rl_update_step(
@@ -1169,7 +1277,25 @@ def main():
             reward_fn=reward_fn,
             grpo_beta=grpo_beta,
             use_stable_grpo=use_stable_grpo,
+            cuda_sync_for_metrics=cuda_sync_for_metrics,
+            device_memory_monitor=device_memory_monitor,
+            enable_profiling=enable_profiling,
         )
+
+        # Accumulate timing using helper function (only if profiling is enabled)
+        if enable_profiling:
+            update_cumulative_metrics(
+                cumulative,
+                metrics["time/rollout_s"],
+                metrics["time/train_s"],
+                metrics["time/optimizer_s"],
+                metrics["time/weight_sync_s"],
+                metrics["time/total_s"],
+                rollout_peak_gib=metrics["memory/rollout_peak_active_gib"],
+                train_peak_gib=metrics["memory/train_peak_active_gib"],
+                optimizer_peak_gib=metrics["memory/optimizer_peak_active_gib"],
+                weight_sync_peak_gib=metrics["memory/weight_sync_peak_active_gib"],
+            )
 
         # Compute weight deltas from initial state
         weight_deltas = compute_weight_deltas(model, initial_state)
@@ -1187,6 +1313,11 @@ def main():
         writer.add_scalar("rl/advantage_std", metrics.get("advantage_std", 0.0), step)
         writer.add_scalar("rl/total_samples", metrics["total_samples"], step)
 
+        # Log timing and memory metrics to TensorBoard
+        for key in metrics:
+            if key.startswith(("time/", "memory/")):
+                writer.add_scalar(f"rl/{key}", metrics[key], step)
+
         # Log weight deltas
         for key, value in weight_deltas.items():
             writer.add_scalar(key, value, step)
@@ -1196,6 +1327,39 @@ def main():
             f"Reward: {metrics['reward_mean']:+.3f} | "
             f"Samples: {metrics['total_samples']}"
         )
+        # Per-phase timing and memory breakdown (only if profiling enabled)
+        if enable_profiling:
+            m = metrics
+            print_step_metrics(
+                [
+                    PhaseMetrics(
+                        "rollout",
+                        m["time/rollout_s"],
+                        m["memory/rollout_peak_active_gib"],
+                        m["memory/rollout_peak_active_pct"],
+                    ),
+                    PhaseMetrics(
+                        "train",
+                        m["time/train_s"],
+                        m["memory/train_peak_active_gib"],
+                        m["memory/train_peak_active_pct"],
+                    ),
+                    PhaseMetrics(
+                        "optimizer",
+                        m["time/optimizer_s"],
+                        m["memory/optimizer_peak_active_gib"],
+                        m["memory/optimizer_peak_active_pct"],
+                    ),
+                    PhaseMetrics(
+                        "weight_sync",
+                        m["time/weight_sync_s"],
+                        m["memory/weight_sync_peak_active_gib"],
+                        m["memory/weight_sync_peak_active_pct"],
+                    ),
+                ],
+                m["time/total_s"],
+                include_mem_pct=True,
+            )
         print(f"  Sample: {metrics['sample_completions'][0][:80]}...")
 
         # Check for NaN/Inf (sign of instability)
@@ -1208,6 +1372,10 @@ def main():
             print("Try setting use_stable_grpo=True or enabling batch invariance mode.")
             print("!" * 80)
             break
+
+    # Training summary
+    if enable_profiling:
+        print_training_summary(cumulative)
 
     print("\n" + "=" * 80)
     print("Training complete!")


### PR DESCRIPTION
## Summary
This PR instruments the RL code with timing and memory logging in order to evaluate subsequent changes (compile enablement) in an apples to apples manner

## Test

### vllm_compat - Simple RL
Execute `CUDA_VISIBLE_DEVICES=7 with-proxy VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 torchtitan/experiments/rl/vllm_compat/simple_rl.py`

```bash
Step   0 | Loss: -0.0036 | Reward: +0.075 | Samples: 160
  Phase                Time    Peak Mem
  --------------------------------------
  rollout:            6.35s,  14.00 GiB  (14.7%)
  train:             26.85s,  51.70 GiB  (54.4%)
  optimizer:          0.10s,  23.62 GiB  (24.8%)
  weight_sync:        8.13s,  24.20 GiB  (25.5%)
  total:             41.44s
  Sample:  48 + 24 = 72.
Let me check the reasoning.
...
================================================================================
Training Summary (5 steps):
  Total wall-clock:               196.29s
  Cumul. rollout:                  31.32s  ( 16.0%)
  Cumul. train:                   126.13s  ( 64.3%)
  Cumul. optimizer:                 0.39s  (  0.2%)
  Cumul. weight_sync:              38.38s  ( 19.6%)
  Peak mem (rollout):             20.41 GiB
  Peak mem (train):               58.13 GiB
  Peak mem (optimizer):           23.62 GiB
  Peak mem (weight_sync):         24.20 GiB
================================================================================
```

### unified - Simple multiprocess RL

Execute `VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 torchtitan/experiments/rl/unified/simple_rl_multiprocess.py`

```bash
Step   0 | Loss: -0.0196 | Reward: +1.177
  Phase                Time    Peak Mem
  --------------------------------------
  rollout:            1.49s,   4.09 GiB  (4.3%)
  train:              6.04s,   6.78 GiB  (7.1%)
  optimizer:          0.06s,   8.43 GiB  (8.9%)
  weight_sync:        7.30s
  total:             14.83s
...
Step   9 | Loss: 0.1330 | Reward: +1.177
  Phase                Time    Peak Mem
  --------------------------------------
  rollout:            0.74s,   4.09 GiB  (4.3%)
  train:              4.60s,   9.58 GiB  (10.1%)
  optimizer:          0.03s,   8.44 GiB  (8.9%)
  weight_sync:        7.61s
  total:             12.95s
...
================================================================================
Training Summary (10 steps):
  Total wall-clock:               136.32s
  Cumul. rollout:                   8.29s  (  6.1%)
  Cumul. train:                    48.24s  ( 35.4%)
  Cumul. optimizer:                 0.32s  (  0.2%)
  Cumul. weight_sync:              79.79s  ( 58.5%)
  Peak mem (rollout):              4.09 GiB
  Peak mem (train):                9.58 GiB
  Peak mem (optimizer):            8.44 GiB
================================================
```