### PR TITLE
Add RL artifacts directories to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,9 @@ Sessionx.vim
 # env files
 .env
 
-# Local checkpoints/models
-converted/
-models/
+# Downloaded HF models and converted checkpoints (RL experiments)
+/models/
+/converted/
 
 # Vibe coding
 .claude

--- a/torchtitan/experiments/rl/.gitignore
+++ b/torchtitan/experiments/rl/.gitignore
@@ -1,5 +1,1 @@
 example_checkpoint/
-
-# Downloaded HF models and converted checkpoints (only at root level)
-/models/
-/converted/


### PR DESCRIPTION
These two directories (converted/ and models/) are created when running:
```
python torchtitan/experiments/rl/unified/simple_rl_multiprocess.py
```

We don't want to commit these so adding them to `.gitignore`.