### PR TITLE
[BE] Apply pep585 and turn on flake8 rule so no regressions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
           - flake8-bugbear == 22.4.25
           - pep8-naming == 0.12.1
           - torchfix
+          - flake8-pep585
         args: ['--config=.flake8']
 
 -   repo: https://github.com/omnilib/ufmt

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 __all__ = [
     "OverrideDefinitions",

--- a/tests/unit_tests/test_permute_indices_kernel.py
+++ b/tests/unit_tests/test_permute_indices_kernel.py
@@ -6,7 +6,6 @@
 
 
 import unittest
-from typing import Tuple
 
 import numpy as np
 import torch
@@ -71,9 +70,9 @@ class TestOptimizedKernel(unittest.TestCase):
         self,
         experts_per_rank: int,
         num_ranks: int,
-        token_range: Tuple[int, int] = (1, 16),
+        token_range: tuple[int, int] = (1, 16),
         alignment: int = 32,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
         """Create test data"""
         # Create token counts
         tokens_per_expert_group = torch.randint(

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -9,8 +9,9 @@
 import inspect
 import pickle
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any
 
 import torch
 

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, TypeAlias
+from collections.abc import Callable
+from typing import TypeAlias
 
 import torch
 

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -7,8 +7,9 @@
 import copy
 import functools
 import math
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Any, Callable, Iterator, Literal
+from typing import Any
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.optim.lr_scheduler import LambdaLR, LRScheduler

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -9,7 +9,7 @@ import functools
 import math
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.optim.lr_scheduler import LambdaLR, LRScheduler

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Generic, Iterator, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 import torch
 import torch.distributed.tensor

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -9,7 +9,7 @@ import os
 import sys
 import warnings
 from dataclasses import field, fields, is_dataclass, make_dataclass
-from typing import Type
+from typing import Any
 
 import tyro
 
@@ -135,7 +135,7 @@ class ConfigManager:
         return loaded_config, filtered_args
 
     @staticmethod
-    def _merge_configs(base, custom) -> Type:
+    def _merge_configs(base, custom) -> type:
         """
         Merges a base config class with user-defined extensions.
         """

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -12,7 +12,7 @@ Used by DeepEPExpertParallel in expert_parallel.py.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 from torch.distributed import ProcessGroup
@@ -81,7 +81,7 @@ def _dispatch_op_impl(
     num_tokens_per_rdma_rank: torch.Tensor,
     is_token_in_rank: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Execute DeepEP dispatch."""
     global _buffer
 
@@ -321,7 +321,7 @@ def _permute_tokens(
     hidden_states: torch.Tensor,
     dispatched_indices: torch.Tensor,
     dispatched_scores: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Convert dispatch output to grouped_mm format with permutation and token expansion.
 
     Each token may be routed to multiple experts (top-k), so tokens are expanded and sorted
@@ -398,7 +398,7 @@ def dispatch_tokens(
     num_experts: int,
     group: ProcessGroup,
     score_before_experts: bool = True,
-) -> Tuple[torch.Tensor, torch.Tensor, DispatchState]:
+) -> tuple[torch.Tensor, torch.Tensor, DispatchState]:
     """Dispatch tokens to experts via DeepEP.
 
     Args:

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -6,7 +6,7 @@
 import copy
 import math
 import os
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn

--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -6,7 +6,8 @@
 
 import time
 import types
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 import torch
 import torch.nn as nn

--- a/torchtitan/experiments/compiler_toolkit/common_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/common_utils.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Callable
 
 import torch
 import torch.distributed as dist

--- a/torchtitan/experiments/compiler_toolkit/cudagraph.py
+++ b/torchtitan/experiments/compiler_toolkit/cudagraph.py
@@ -12,7 +12,8 @@ during compilation.
 """
 
 import warnings
-from typing import Any, Callable, Optional, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any, Optional
 
 import torch
 from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager

--- a/torchtitan/experiments/compiler_toolkit/graph_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/graph_utils.py
@@ -6,8 +6,9 @@
 
 import contextlib
 import functools
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Optional
 
 import torch
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
@@ -110,7 +111,7 @@ def joint_graph_builder(
     model_kwargs: dict,
     fw_compiler: Optional[Callable] = None,
     bw_compiler: Optional[Callable] = None,
-    joint_custom_passes: Optional[List[Callable]] = None,
+    joint_custom_passes: Optional[list[Callable]] = None,
     dump_folder: str | None = None,
     compile_config: Optional[CompileConfig] = None,
 ):
@@ -262,7 +263,7 @@ def compiler(
     name: str,
     gm: torch.fx.GraphModule,
     example_inputs,
-    passes: List[Callable] = None,
+    passes: list[Callable] = None,
     dump_folder: str | None = None,
     is_forward: bool = True,
 ):
@@ -322,7 +323,7 @@ def compiler(
 
 
 def make_compiler_with_passes(
-    passes: List[Callable] = None,
+    passes: list[Callable] = None,
     dump_folder: str | None = None,
 ):
     """

--- a/torchtitan/experiments/compiler_toolkit/passes.py
+++ b/torchtitan/experiments/compiler_toolkit/passes.py
@@ -15,7 +15,8 @@ Pass Types:
 - Compiler passes: Applied to the partitioned forward/backward graphs
 """
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import torch
 from torch._functorch.aot_autograd import JointWithDescriptors

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from collections.abc import Generator
 from dataclasses import asdict, dataclass, field
-from typing import Any, Generator
+from typing import Any
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import time
+from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any, Iterable
+from typing import Any
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record

--- a/torchtitan/experiments/ft/manager.py
+++ b/torchtitan/experiments/ft/manager.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib.util
-from contextlib import nullcontext
+from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable, cast, ContextManager, Optional, TYPE_CHECKING, Union
+from typing import cast, Optional, TYPE_CHECKING, Union
 
 import torch
 import torch.distributed as dist
@@ -157,7 +158,7 @@ def maybe_semi_sync_training(
     n_layers: int,
     optimizer: torch.optim.Optimizer,
     fragment_fn: Optional[Callable[..., list[nn.Module]]] = None,
-) -> ContextManager[Union["local_sgd.DiLoCo", "local_sgd.LocalSGD", None]]:
+) -> AbstractContextManager[Union["local_sgd.DiLoCo", "local_sgd.LocalSGD", None]]:
     """
     If TorchFT is enabled and the config is set, use semi_sync_method
     """

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -8,9 +8,10 @@ import dataclasses
 import json
 import os
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import cast, Iterator
+from typing import cast
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -9,7 +9,6 @@ import logging
 import os
 
 from dataclasses import dataclass
-from typing import List
 
 import torch
 from monarch.actor import Actor, endpoint
@@ -50,10 +49,10 @@ class TrajectoryData:
     """
 
     policy_version: int
-    completions: List[str]
-    vllm_token_ids: List[List[int]]
-    vllm_token_log_probs: List[List[float]]
-    prompt_token_ids: List[List[int]]
+    completions: list[str]
+    vllm_token_ids: list[list[int]]
+    vllm_token_log_probs: list[list[float]]
+    prompt_token_ids: list[list[int]]
     rewards: torch.Tensor
     advantages: torch.Tensor
 
@@ -365,8 +364,8 @@ class Generator(Actor):
     def __init__(
         self,
         model_path: str,
-        prompt_texts: List[str],
-        expected_answers: List[str],
+        prompt_texts: list[str],
+        expected_answers: list[str],
         group_size: int = 8,
         max_new_tokens: int = 20,
         temperature: float = 1.0,

--- a/torchtitan/experiments/rl/vllm_compat/weights_vllm_compat.py
+++ b/torchtitan/experiments/rl/vllm_compat/weights_vllm_compat.py
@@ -12,14 +12,12 @@ Converts between:
 - vLLM compat format (merged gate_up_proj = [w1; w3])
 """
 
-from typing import Dict
-
 import torch
 
 
 def torchtitan_to_vllm_compat(
-    torchtitan_state_dict: Dict[str, torch.Tensor]
-) -> Dict[str, torch.Tensor]:
+    torchtitan_state_dict: dict[str, torch.Tensor]
+) -> dict[str, torch.Tensor]:
     """
     Convert TorchTitan Qwen3 state dict to vLLM-compatible format.
 
@@ -68,8 +66,8 @@ def torchtitan_to_vllm_compat(
 
 
 def vllm_compat_to_torchtitan(
-    vllm_compat_state_dict: Dict[str, torch.Tensor]
-) -> Dict[str, torch.Tensor]:
+    vllm_compat_state_dict: dict[str, torch.Tensor]
+) -> dict[str, torch.Tensor]:
     """
     Convert vLLM-compatible state dict back to TorchTitan format.
 

--- a/torchtitan/experiments/torchcomms/parallel_dims.py
+++ b/torchtitan/experiments/torchcomms/parallel_dims.py
@@ -6,7 +6,6 @@
 
 import os
 from dataclasses import dataclass
-from typing import Dict, List
 
 import torch
 import torchcomms
@@ -21,11 +20,11 @@ __all__ = ["TorchCommsParallelDims"]
 
 
 def _calculate_ranks_per_dimension(
-    meshes: List[torch.Tensor],
-    dim_names: List[str],
-    dim_sizes: List[int],
+    meshes: list[torch.Tensor],
+    dim_names: list[str],
+    dim_sizes: list[int],
     cur_rank: int,
-) -> Dict[str, List[int]]:
+) -> dict[str, list[int]]:
     """Util function to calculate global ranks mapping for each mesh dimension.
 
     Args:
@@ -52,8 +51,8 @@ def _calculate_ranks_per_dimension(
 def _create_device_mesh(
     world_size: int,
     mesh_shape: tuple,
-    mesh_dim_names: List[str],
-) -> Dict:
+    mesh_dim_names: list[str],
+) -> dict:
     """Util function to create device mesh with communicators for each dimension.
 
     Args:
@@ -117,11 +116,11 @@ def _create_device_mesh(
 
 
 def _flatten_comms(
-    flatten_ranks_per_dim: Dict[str, List[int]],
+    flatten_ranks_per_dim: dict[str, list[int]],
     comm,
-    flatten_mesh_dim_names: Dict[str, List[str]],
+    flatten_mesh_dim_names: dict[str, list[str]],
     device_mesh: DeviceMesh,
-    comm_per_dim: Dict[str, any],
+    comm_per_dim: dict[str, any],
 ) -> None:
     """Util function to flatten mesh dimensions and create corresponding communicators.
 

--- a/torchtitan/experiments/vlm/datasets/mm_datasets.py
+++ b/torchtitan/experiments/vlm/datasets/mm_datasets.py
@@ -11,8 +11,9 @@ including images and text. Images are interleaved with text at native aspect rat
 It supports both streaming and non-streaming datasets from HuggingFace.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from datasets import Dataset, load_dataset

--- a/torchtitan/hf_datasets/__init__.py
+++ b/torchtitan/hf_datasets/__init__.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 
 __all__ = ["DatasetConfig"]

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from datasets import Dataset, load_dataset

--- a/torchtitan/models/common/moe/utils.py
+++ b/torchtitan/models/common/moe/utils.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 import torch
 

--- a/torchtitan/models/flux/flux_datasets.py
+++ b/torchtitan/models/flux/flux_datasets.py
@@ -6,8 +6,9 @@
 
 import itertools
 import math
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import numpy as np
 import PIL.Image

--- a/torchtitan/models/flux/inference/sampling.py
+++ b/torchtitan/models/flux/inference/sampling.py
@@ -6,7 +6,7 @@
 
 import math
 import os
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 from einops import rearrange

--- a/torchtitan/models/flux/tokenizer.py
+++ b/torchtitan/models/flux/tokenizer.py
@@ -8,8 +8,6 @@
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
 
-from typing import List
-
 import torch
 from transformers import CLIPTokenizer, T5Tokenizer
 
@@ -30,8 +28,8 @@ class FluxTestTokenizer(BaseTokenizer):
         self.pad_id = 0
 
     def _pad_and_chunk_tokens(
-        self, tokens: List[int], max_length: int, pad_token: int
-    ) -> List[int]:
+        self, tokens: list[int], max_length: int, pad_token: int
+    ) -> list[int]:
         # Pad the token sequence to max_length
         if len(tokens) < max_length:
             # If tokens are shorter than max_length, pad with pad_id or eos_id if pad_id is not defined
@@ -75,7 +73,7 @@ class FluxTestTokenizer(BaseTokenizer):
             return torch.tensor(tokens)
 
     # pyrefly: ignore [bad-override]
-    def decode(self, t: List[int]) -> str:
+    def decode(self, t: list[int]) -> str:
         """
         Decode function. This function will not be called.
         """
@@ -127,7 +125,7 @@ class FluxTokenizer(BaseTokenizer):
             return_length=False,
             return_overflowing_tokens=False,
             padding="max_length",
-            return_tensors="pt",  # return pytorch tensors, default return List[int]
+            return_tensors="pt",  # return pytorch tensors, default return list[int]
         )["input_ids"]
         return tokens
 

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
-from typing import Iterable
+from collections.abc import Iterable
 
 import torch
 

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, field
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 
 import torch
 

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 from torch import nn

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -7,8 +7,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from collections.abc import Callable
+
+from dataclasses import dataclass
 
 import torch
 from torch import nn

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 from dataclasses import dataclass, field
-from typing import List, Protocol, Union
+from typing import Protocol, Union
 
 import torch.nn as nn
 
@@ -26,7 +26,7 @@ class ModelConverter(Protocol):
         """Inplace conversion of the model."""
         ...
 
-    def post_optimizer_hook(self, model: Union[nn.Module, List[nn.Module]]):
+    def post_optimizer_hook(self, model: Union[nn.Module, list[nn.Module]]):
         """Post-optimizer (optional) hook (e.g. compute weights statistics)."""
         ...
 
@@ -75,7 +75,7 @@ class ModelConvertersContainer(Configurable, ModelConverter):
         if self.print_after_conversion:
             logger.info(f"Model definition after conversion:\n\n{model}\n\n")
 
-    def post_optimizer_hook(self, model: Union[nn.Module, List[nn.Module]]):
+    def post_optimizer_hook(self, model: Union[nn.Module, list[nn.Module]]):
         for mh in self.converters:
             mh.post_optimizer_hook(model)
 

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 
@@ -27,7 +27,7 @@ class BaseStateDictAdapter(ABC):
         hf_assets_path: path to HF assets folder containing tokenizer, model weights, etc.
     """
 
-    fqn_to_index_mapping: Dict[Any, int] | None
+    fqn_to_index_mapping: dict[Any, int] | None
     hf_assets_path: str | None
 
     @abstractmethod

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -8,9 +8,10 @@ import contextlib
 import gc
 import subprocess
 import time
+from collections.abc import Generator
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Generator, Optional
+from typing import Optional
 
 import torch
 from torch._utils import _get_available_device_type, _get_device_module

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -8,9 +8,10 @@ import dataclasses
 import json
 import os
 import time
+from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
-from typing import Annotated, Any, cast, Iterable, Iterator
+from typing import Annotated, Any, cast
 
 import torch
 import torch.distributed.checkpoint.stateful


### PR DESCRIPTION
Since python>=3.10 is defined in the pyproject.toml, we can enable [pep585](https://peps.python.org/pep-0585/) (in python >=3.9)

Why? 

1) Fewer imports making code simpler
2) Standardization - prior to this change, we could have `List` and `list` intermixed in the codebase
3) Future proof for direction of python type system

### Test 
Ran 
```
 python -m flake8 --pep585-activation=always .
```
Explicitly

