### PR TITLE
[BE] Apply pep604 and turn on flake8 rule so no regressions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Suggested config from pytorch that we can adapt
-select = B,C,E,F,N,P,T4,W,B9,TOR0,TOR1,TOR2
+select = B,C,E,F,N,NU,P,T4,W,B9,TOR0,TOR1,TOR2
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
           - pep8-naming == 0.12.1
           - torchfix
           - flake8-pep585
+          - flake8-new-union-types == 0.4.1
         args: ['--config=.flake8']
 
 -   repo: https://github.com/omnilib/ufmt

--- a/scripts/checkpoint_conversion/numerical_tests_example.py
+++ b/scripts/checkpoint_conversion/numerical_tests_example.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import torch
 
 import torch.distributed.checkpoint as dcp
@@ -30,7 +28,7 @@ def loss_fn(logits1, logits2):
 
 
 @torch.no_grad
-def forward_hf(model_name, model_path: Optional[str], input_ids):
+def forward_hf(model_name, model_path: str | None, input_ids):
     # Load the tokenizer and model
     model_path = model_path if model_path else model_name
     model = AutoModelForCausalLM.from_pretrained(model_path)

--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from fnmatch import fnmatch
-from typing import Optional
 
 from requests.exceptions import HTTPError
 from tqdm import tqdm
@@ -16,8 +15,8 @@ def download_hf_assets(
     local_dir: str,
     asset_types: str | list[str],
     download_all: bool = False,
-    hf_token: Optional[str] = None,
-    additional_patterns: Optional[list] = None,
+    hf_token: str | None = None,
+    additional_patterns: list | None = None,
 ) -> None:
     """
     Download relevant files from HuggingFace Hub repository.

--- a/scripts/generate/_generation.py
+++ b/scripts/generate/_generation.py
@@ -4,13 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import torch
 
 
 def multinomial_sample_one(
-    probs: torch.Tensor, rng: Optional[torch.Generator] = None
+    probs: torch.Tensor, rng: torch.Generator | None = None
 ) -> torch.Tensor:
     q = torch.empty_like(probs).exponential_(1, generator=rng)
     return torch.argmax(probs / q, dim=-1, keepdim=True).to(dtype=torch.long)
@@ -19,7 +17,7 @@ def multinomial_sample_one(
 def logits_to_probs(
     logits: torch.Tensor,
     temperature: float = 1.0,
-    top_k: Optional[int] = None,
+    top_k: int | None = None,
 ) -> torch.Tensor:
     logits = logits / max(temperature, 1e-5)
 
@@ -37,8 +35,8 @@ def generate_next_token(
     x: torch.Tensor,
     *,
     temperature: float = 1.0,
-    top_k: Optional[int] = None,
-    rng: Optional[torch.Generator] = None,
+    top_k: int | None = None,
+    rng: torch.Generator | None = None,
 ) -> torch.Tensor:
     logits = model(x)  # (B, T, vocab_size)
     probs = logits_to_probs(logits[:, -1, :], temperature, top_k)
@@ -53,8 +51,8 @@ def generate(
     *,
     max_new_tokens: int,
     temperature: float = 1.0,
-    top_k: Optional[int] = None,
-    seed: Optional[int] = None,
+    top_k: int | None = None,
+    seed: int | None = None,
 ) -> torch.Tensor:
     # ensure batch dimension (T,) --> (B, T)
     if input_ids.ndim == 1:

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -10,7 +10,6 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional
 
 import torch
 import torch.distributed.checkpoint as dcp
@@ -78,8 +77,8 @@ def test_generate(
     temperature: float = 1.0,
     max_new_tokens: int = 32,
     batch_size: int = 1,
-    top_k: Optional[int] = None,
-    seed: Optional[int] = None,
+    top_k: int | None = None,
+    seed: int | None = None,
     deterministic: bool = False,
 ):
     init_logger()

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -9,7 +9,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from tokenizers import AddedToken, Tokenizer
 from torchtitan.config import Configurable
@@ -85,7 +85,7 @@ class HuggingFaceTokenizer(BaseTokenizer):
         self._infer_special_tokens()
         self._infer_should_add_bos_eos()
 
-    def _load_config(self, config_path: str) -> Optional[dict]:
+    def _load_config(self, config_path: str) -> dict | None:
         """Load configuration from JSON file if it exists."""
         if os.path.exists(config_path):
             with open(config_path, "r") as f:
@@ -189,7 +189,7 @@ class HuggingFaceTokenizer(BaseTokenizer):
                 "Looking for: tokenizer.json, vocab.txt+merges.txt, or vocab.json+merges.txt"
             )
 
-    def _get_token_from_config(self, config: dict[str, Any], key: str) -> Optional[str]:
+    def _get_token_from_config(self, config: dict[str, Any], key: str) -> str | None:
         """
         Parse special tokens from config that can be either strings or dicts.
         HF tokens are stored as either {'bos_token': '<bos>'} or {'bos_token': {'content': '<bos>', ...}}.
@@ -206,7 +206,7 @@ class HuggingFaceTokenizer(BaseTokenizer):
         return token
 
     def _process_special_token(
-        self, token_str: str, token_config: dict, token_id: Optional[int] = None
+        self, token_str: str, token_config: dict, token_id: int | None = None
     ) -> AddedToken:
         """
         Process a special token and update BOS/EOS attributes if applicable.
@@ -417,10 +417,10 @@ class HuggingFaceTokenizer(BaseTokenizer):
         """Get the vocabulary as a dictionary."""
         return self.tokenizer.get_vocab()
 
-    def token_to_id(self, token: str) -> Optional[int]:
+    def token_to_id(self, token: str) -> int | None:
         """Convert token to ID."""
         return self.tokenizer.token_to_id(token)
 
-    def id_to_token(self, token_id: int) -> Optional[str]:
+    def id_to_token(self, token_id: int) -> str | None:
         """Convert ID to token."""
         return self.tokenizer.id_to_token(token_id)

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -12,7 +12,6 @@ Used by DeepEPExpertParallel in expert_parallel.py.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 from torch.distributed import ProcessGroup
@@ -44,7 +43,7 @@ _handle_counter: int = 0
 # shared_experts computation with combine communication.
 # This is process-local state (each GPU process has its own Python interpreter),
 # and execution is single-threaded, so a simple module variable suffices.
-_pending_combine_event: Optional[EventOverlap] = None
+_pending_combine_event: EventOverlap | None = None
 
 
 def _get_next_handle_id() -> torch.Tensor:
@@ -387,7 +386,7 @@ class DispatchState:
     handle_id: torch.Tensor  # CPU tensor used to retrieve cached handle
     permuted_indices: torch.Tensor
     num_recv_tokens: int
-    permuted_scores: Optional[torch.Tensor] = None
+    permuted_scores: torch.Tensor | None = None
 
 
 def dispatch_tokens(

--- a/torchtitan/distributed/dual_pipe_v.py
+++ b/torchtitan/distributed/dual_pipe_v.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import threading
-from typing import cast, Optional
+from typing import cast
 
 import torch
 import torch.nn as nn
@@ -124,7 +124,7 @@ class HookCoordinator:
         except threading.BrokenBarrierError:
             pass
 
-    def enable_coordination(self, num_layers: Optional[int] = None):
+    def enable_coordination(self, num_layers: int | None = None):
         if num_layers is not None and num_layers > 0:
             self._coordination_enabled = True
             self._cycle_count = 0

--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -7,7 +7,6 @@
 import time
 import types
 from collections.abc import Callable
-from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -85,7 +84,7 @@ def create_functional_router_forward(
 def _moe_forward(
     x: torch.Tensor,
     router_gate_weight: torch.nn.Parameter,
-    expert_bias: Optional[torch.Tensor],
+    expert_bias: torch.Tensor | None,
     experts_w1: torch.Tensor,
     experts_w3: torch.Tensor,
     experts_w2: torch.Tensor,

--- a/torchtitan/experiments/compiler_toolkit/cudagraph.py
+++ b/torchtitan/experiments/compiler_toolkit/cudagraph.py
@@ -13,7 +13,7 @@ during compilation.
 
 import warnings
 from collections.abc import Callable, Sequence
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
@@ -62,7 +62,7 @@ class CUDAGraphWrapper:
         self,
         runnable: Callable,
         example_inputs: Sequence[Any],
-        static_input_indices: Optional[tuple[int]] = None,
+        static_input_indices: tuple[int] | None = None,
         should_check_address: bool = False,
     ):
         self.runnable = runnable
@@ -76,7 +76,7 @@ class CUDAGraphWrapper:
             for i, inp in enumerate(example_inputs)
             if isinstance(inp, torch.Tensor) and i not in self.static_input_indices
         ]
-        self.cudagraph: Optional[torch.cuda.CUDAGraph] = None
+        self.cudagraph: torch.cuda.CUDAGraph | None = None
         self.has_warmup = False
 
         self.args = None

--- a/torchtitan/experiments/compiler_toolkit/graph_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/graph_utils.py
@@ -4,11 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import contextlib
 import functools
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
@@ -109,11 +111,11 @@ def joint_graph_builder(
     model: torch.nn.Module,
     model_args: tuple,
     model_kwargs: dict,
-    fw_compiler: Optional[Callable] = None,
-    bw_compiler: Optional[Callable] = None,
-    joint_custom_passes: Optional[list[Callable]] = None,
+    fw_compiler: Callable | None = None,
+    bw_compiler: Callable | None = None,
+    joint_custom_passes: list[Callable] | None = None,
     dump_folder: str | None = None,
-    compile_config: Optional[CompileConfig] = None,
+    compile_config: CompileConfig | None = None,
 ):
     """
     Build a joint forward-backward graph for the model with optional custom compilers.

--- a/torchtitan/experiments/ft/manager.py
+++ b/torchtitan/experiments/ft/manager.py
@@ -4,12 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import importlib.util
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import cast, Optional, TYPE_CHECKING, Union
+from typing import cast, TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
@@ -143,7 +145,7 @@ class FTManager(Configurable):
     @property
     def loss_sync_pg(
         self,
-    ) -> Optional["ft.process_group.ManagedProcessGroup"]:
+    ) -> "ft.process_group.ManagedProcessGroup" | None:
         if self.enabled and self.use_async_quorum:
             return self.replicate_pg
         else:
@@ -157,8 +159,8 @@ def maybe_semi_sync_training(
     model: torch.nn.Module,
     n_layers: int,
     optimizer: torch.optim.Optimizer,
-    fragment_fn: Optional[Callable[..., list[nn.Module]]] = None,
-) -> AbstractContextManager[Union["local_sgd.DiLoCo", "local_sgd.LocalSGD", None]]:
+    fragment_fn: Callable[..., list[nn.Module]] | None = None,
+) -> AbstractContextManager["local_sgd.DiLoCo" | "local_sgd.LocalSGD" | None]:
     """
     If TorchFT is enabled and the config is set, use semi_sync_method
     """

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from monarch.actor import Actor, endpoint
@@ -76,7 +76,7 @@ class Trainer(Actor):
         # Optimizer
         self.optimizer = torch.optim.AdamW(self.model.parameters(), lr=learning_rate)
         self.policy_version = 0
-        self.generator: Optional[Any] = None
+        self.generator: Any | None = None
 
         logger.info("Trainer initialized with TorchTitan model")
 

--- a/torchtitan/models/flux/flux_datasets.py
+++ b/torchtitan/models/flux/flux_datasets.py
@@ -8,7 +8,7 @@ import itertools
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import PIL.Image
@@ -30,7 +30,7 @@ from .configs import Encoder
 def _process_cc12m_image(
     img: PIL.Image.Image,
     output_size: int = 256,
-) -> Optional[torch.Tensor]:
+) -> torch.Tensor | None:
     """Process CC12M image to the desired size."""
 
     width, height = img.size
@@ -158,7 +158,7 @@ DATASETS = {
 
 
 def _validate_dataset(
-    dataset_name: str, dataset_path: Optional[str] = None
+    dataset_name: str, dataset_path: str | None = None
 ) -> tuple[str, Callable, Callable]:
     """Validate dataset name and path."""
     if dataset_name not in DATASETS:
@@ -188,7 +188,7 @@ class FluxDataset(IterableDataset, Stateful):
     def __init__(
         self,
         dataset_name: str,
-        dataset_path: Optional[str],
+        dataset_path: str | None,
         t5_tokenizer: BaseTokenizer,
         clip_tokenizer: BaseTokenizer,
         classifier_free_guidance_prob: float,
@@ -320,7 +320,7 @@ class FluxValidationDataset(FluxDataset):
     def __init__(
         self,
         dataset_name: str,
-        dataset_path: Optional[str],
+        dataset_path: str | None,
         t5_tokenizer: BaseTokenizer,
         clip_tokenizer: BaseTokenizer,
         classifier_free_guidance_prob: float,

--- a/torchtitan/models/flux/utils.py
+++ b/torchtitan/models/flux/utils.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import torch
 
 from torch import Tensor
@@ -20,7 +18,7 @@ def preprocess_data(
     dtype: torch.dtype,
     *,
     # arguments from the config
-    autoencoder: Optional[AutoEncoder],
+    autoencoder: AutoEncoder | None,
     clip_encoder: FluxEmbedder,
     t5_encoder: FluxEmbedder,
     batch: dict[str, Tensor],

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 from dataclasses import dataclass, field
-from typing import Protocol, Union
+from typing import Protocol
 
 import torch.nn as nn
 
@@ -26,7 +26,7 @@ class ModelConverter(Protocol):
         """Inplace conversion of the model."""
         ...
 
-    def post_optimizer_hook(self, model: Union[nn.Module, list[nn.Module]]):
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
         """Post-optimizer (optional) hook (e.g. compute weights statistics)."""
         ...
 
@@ -75,7 +75,7 @@ class ModelConvertersContainer(Configurable, ModelConverter):
         if self.print_after_conversion:
             logger.info(f"Model definition after conversion:\n\n{model}\n\n")
 
-    def post_optimizer_hook(self, model: Union[nn.Module, list[nn.Module]]):
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
         for mh in self.converters:
             mh.post_optimizer_hook(model)
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -11,7 +11,6 @@ import time
 from collections.abc import Generator
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Optional
 
 import torch
 from torch._utils import _get_available_device_type, _get_device_module
@@ -183,7 +182,7 @@ assert set(NoColor.__dataclass_fields__.keys()) == set(
 def check_if_feature_in_pytorch(
     feature_name: str,
     pull_request: str,
-    min_nightly_version: Optional[str] = None,
+    min_nightly_version: str | None = None,
 ) -> None:
     if "git" in torch.__version__:  # pytorch is built from source
         # notify users to check if the pull request is included in their pytorch


### PR DESCRIPTION
Since python>=3.10 is defined in the pyproject.toml, we can enable [pep604](https://peps.python.org/pep-0604/) (in python >=3.10)

Why? 

1) Fewer imports making code simpler
2) Standardization - prior to this change, we could have `Optional` or the  `| None` intermixed in the codebase
3) Future proof for direction of python type system

### Test 
Ran 
```
 python -m flake8 --pep604-activation=always .
```
Explicitly

