### PR TITLE
[RL] Fix rl on main

### DIFF
--- a/torchtitan/experiments/rl/unified/models/utils.py
+++ b/torchtitan/experiments/rl/unified/models/utils.py
@@ -17,7 +17,8 @@ from torchtitan.experiments.rl.vllm_compat.models.attention import (
 from torchtitan.experiments.rl.vllm_compat.weights_vllm_compat import (
     torchtitan_to_vllm_compat,
 )
-from torchtitan.models.qwen3.model import Qwen3Model
+from torchtitan.models.common import FeedForward, GQAttention, RoPE
+from torchtitan.models.qwen3.model import Qwen3Model, Qwen3TransformerBlock
 from transformers import AutoConfig
 
 logger = logging.getLogger(__name__)
@@ -70,13 +71,14 @@ def replace_with_vllm_attention(model, tp_degree=1):
             raise ValueError(f"Layer {layer_name} must have .attention attribute")
 
         # GQA
+        head_dim = model_args.layer.attention.head_dim
         vllm_attn = VLLMAttention(
             hidden_size=model_args.dim,
             num_heads=model_args.layer.attention.n_heads // tp_degree,
             num_kv_heads=num_kv_heads,
-            head_dim=model_args.head_dim,
+            head_dim=head_dim,
             layer_name=layer_name,
-            scale=model_args.head_dim**-0.5,
+            scale=head_dim**-0.5,
         )
 
         layer.attention.inner_attention = vllm_attn
@@ -131,26 +133,41 @@ def load_model(
     # TODO: do not depend on transformers.AutoConfig, use qwen_args directly
     hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
-    # Create model args
+    # Create model args using the nested dataclass config structure
+    head_dim = getattr(
+        hf_config,
+        "head_dim",
+        hf_config.hidden_size // hf_config.num_attention_heads,
+    )
+    max_seq_len = getattr(hf_config, "max_position_embeddings", 32768)
+    rope_theta = hf_config.rope_theta
+
     model_args = Qwen3Model.Config(
         dim=hf_config.hidden_size,
         n_layers=hf_config.num_hidden_layers,
-        n_heads=hf_config.num_attention_heads,
-        n_kv_heads=hf_config.num_key_value_heads,
         vocab_size=hf_config.vocab_size,
-        head_dim=getattr(
-            hf_config,
-            "head_dim",
-            hf_config.hidden_size // hf_config.num_attention_heads,
-        ),
-        hidden_dim=hf_config.intermediate_size,
         norm_eps=hf_config.rms_norm_eps,
-        rope_theta=hf_config.rope_theta,
-        max_seq_len=getattr(hf_config, "max_position_embeddings", 32768),
-        qk_norm=True,
-        depth_init=True,
-        eos_id=getattr(hf_config, "eos_token_id", 151645),
         enable_weight_tying=getattr(hf_config, "tie_word_embeddings", False),
+        layer=Qwen3TransformerBlock.Config(
+            norm_eps=hf_config.rms_norm_eps,
+            depth_init=True,
+            feed_forward=FeedForward.Config(hidden_dim=hf_config.intermediate_size),
+            attention=GQAttention.Config(
+                n_heads=hf_config.num_attention_heads,
+                n_kv_heads=hf_config.num_key_value_heads,
+                head_dim=head_dim,
+                qk_norm=True,
+                norm_eps=hf_config.rms_norm_eps,
+                attn_backend="sdpa",
+                rope_backend="cos_sin",
+            ),
+        ),
+        rope=RoPE.Config(
+            dim=head_dim,
+            max_seq_len=max_seq_len,
+            theta=rope_theta,
+            backend="cos_sin",
+        ),
     )
 
     # state_dict is in standard TorchTitan format (w1, w2, w3)
@@ -163,8 +180,6 @@ def load_model(
         state_dict["output.weight"] = state_dict["tok_embeddings.weight"]
 
     if model_mode == ModelMode.UNIFIED:
-        from torchtitan.models.qwen3 import Qwen3Model
-
         model = Qwen3Model(model_args)
         # Set global default dtype to bfloat16. This is needed because vLLM's Attention
         # layer uses torch.get_default_dtype() and it doesn't support float32
@@ -187,8 +202,6 @@ def load_model(
         model.load_state_dict(vllm_compat_state, strict=False)
     else:
         # Use standard TorchTitan model
-        from torchtitan.models.qwen3 import Qwen3Model
-
         model = Qwen3Model(model_args)
         # Load standard TorchTitan format directly
         model.load_state_dict(state_dict, strict=False)

--- a/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
@@ -11,7 +11,7 @@ This module provides TorchTitanVLLMModel: Core model class that adapts
 TorchTitan models for vLLM.
 """
 
-from functools import partial
+from dataclasses import replace as dataclass_replace
 
 import torch
 import torch.nn as nn
@@ -27,7 +27,7 @@ from torchtitan.experiments.rl.unified.infra.parallelism_utils import (
 )
 
 from torchtitan.experiments.rl.unified.models.utils import replace_with_vllm_attention
-from torchtitan.models.qwen3.model import precompute_rope_cache
+from torchtitan.models.common import RoPE
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.model_spec import ParallelizeFunction
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
@@ -80,12 +80,11 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         logger.info(f"Creating model with config: {model_config}")
         self.model = model_config.build()
 
-        # Setup RoPE cache extension function if provided
-        self.rope_cache_extension_fn = partial(
-            precompute_rope_cache,
-            dim=self.config.head_dim,
-            base=self.config.rope_theta,
-        )
+        # Setup RoPE cache extension function
+        rope_config = self.config.rope
+        self.rope_cache_extension_fn = lambda max_seq_len: RoPE(
+            dataclass_replace(rope_config, max_seq_len=max_seq_len)
+        ).cache
 
         # Create ParallelDims and JobConfig from vLLM config at runtime
         # vLLM config contains the tensor_parallel_size from command-line args
@@ -109,7 +108,12 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         self.model = parallelize_fn(
             model=self.model,
             parallel_dims=self.parallel_dims,
-            job_config=self.parallel_config,
+            training=self.parallel_config.training,
+            model_converters=self.parallel_config.model_converters,
+            parallelism=self.parallel_config.parallelism,
+            compile_config=self.parallel_config.compile,
+            ac_config=self.parallel_config.activation_checkpoint,
+            dump_folder=self.parallel_config.dump_folder,
         )
 
     def _extend_rope_cache_if_needed(
@@ -131,15 +135,6 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         if required_len <= rope_cache.shape[0]:
             return rope_cache
 
-        # If no extension function provided, return original cache
-        if self.rope_cache_extension_fn is None:
-            logger.warning(
-                f"RoPE cache extension needed (required_len={required_len}, "
-                f"current_len={rope_cache.shape[0]}) but no rope_cache_extension_fn provided. "
-                "Returning original cache."
-            )
-            return rope_cache
-
         # Handle DTensor case
         is_dtensor = isinstance(rope_cache, DTensor)
         if is_dtensor:
@@ -153,7 +148,7 @@ class TorchTitanVLLMModelWrapper(nn.Module):
 
         # Use provided extension function
         try:
-            extended_cache = self.rope_cache_extension_fn(self.config, required_len)
+            extended_cache = self.rope_cache_extension_fn(max_seq_len=required_len)
             extended_cache = extended_cache.to(device=device, dtype=dtype)
         except Exception as e:
             logger.warning(
@@ -214,14 +209,8 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         # Get embeddings
         h = self.model.tok_embeddings(tokens_2d)
 
-        # Get RoPE cache (handle model-specific attribute names)
-        # Use hasattr to avoid ambiguous boolean value error with tensors
-        if hasattr(self.model, "rope_cache"):
-            rope_attr = self.model.rope_cache
-        elif hasattr(self.model, "freqs_cis"):
-            rope_attr = self.model.freqs_cis
-        else:
-            rope_attr = None
+        # Get RoPE cache - TorchTitan models always have rope.cache
+        rope_attr = self.model.rope.cache
 
         # Extend RoPE cache if needed (vLLM profiling may use 2x max_seq_len)
         if positions is not None:

--- a/torchtitan/experiments/rl/vllm_compat/models/qwen3/model_vllm_compat.py
+++ b/torchtitan/experiments/rl/vllm_compat/models/qwen3/model_vllm_compat.py
@@ -18,8 +18,9 @@ from torchtitan.experiments.rl.vllm_compat.batch_invariant_backward import (
     silu_and_mul_with_gradients,
 )
 
-from torchtitan.models.common import trunc_normal_
+from torchtitan.models.common import RoPE, trunc_normal_
 from torchtitan.models.common.attention import AttentionMasksType
+from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
 
 # Import from main torchtitan
 from torchtitan.models.qwen3.model import Qwen3Model
@@ -27,48 +28,6 @@ from torchtitan.protocols.model import BaseModel
 
 # Import from local experiment's models
 from ..attention import VLLMCompatibleFlashAttention
-
-
-# RoPE functions (same as original)
-def precompute_rope_cache(
-    dim: int, max_seq_len: int, base: float = 1_000_000.0
-) -> torch.Tensor:
-    freqs = 1.0 / (base ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(max_seq_len, dtype=freqs.dtype, device=freqs.device)
-    idx_theta = torch.outer(t, freqs).float()
-    freqs = torch.cat([idx_theta, idx_theta], dim=-1)
-    rope_cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
-    return rope_cache
-
-
-def rotate_half(x: torch.Tensor) -> torch.Tensor:
-    """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-def reshape_for_broadcast(rope_cache: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-    """Reshape frequency tensor for broadcasting."""
-    ndim = x.ndim
-    assert ndim > 1
-    _, seqlen, _, head_dim = x.shape
-    rope_cache = rope_cache[0:seqlen]
-    assert rope_cache.shape == (seqlen, head_dim * 2)
-    shape = [-1, seqlen, 1, head_dim * 2]
-    return rope_cache.view(*shape)
-
-
-def apply_rotary_emb(
-    xq: torch.Tensor, xk: torch.Tensor, rope_cache: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    head_dim = xq.shape[-1]
-    rope_cache = reshape_for_broadcast(rope_cache, xq)
-    cos = rope_cache[..., :head_dim].to(dtype=xq.dtype, device=xq.device)
-    sin = rope_cache[..., head_dim:].to(dtype=xq.dtype, device=xq.device)
-    xq_out = (xq * cos) + (rotate_half(xq) * sin)
-    xk_out = (xk * cos) + (rotate_half(xk) * sin)
-    return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
 def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -146,33 +105,30 @@ class Attention(nn.Module):
 
     def __init__(self, model_args: Qwen3Model.Config):
         super().__init__()
-        self.n_heads = model_args.n_heads
+        attn_config = model_args.layer.attention
+        self.n_heads = attn_config.n_heads
         self.n_kv_heads = (
-            model_args.n_heads
-            if model_args.n_kv_heads is None
-            else model_args.n_kv_heads
+            attn_config.n_heads
+            if attn_config.n_kv_heads is None
+            else attn_config.n_kv_heads
         )
         self.n_rep = self.n_heads // self.n_kv_heads
-        self.head_dim = model_args.head_dim
+        self.head_dim = attn_config.head_dim
         self.scaling = self.head_dim**-0.5
 
         # QK norm (Qwen3 specific) - use vLLM's RMSNorm
-        if model_args.qk_norm:
-            self.q_norm = VLLMRMSNorm(self.head_dim, eps=model_args.norm_eps)
-            self.k_norm = VLLMRMSNorm(self.head_dim, eps=model_args.norm_eps)
+        if attn_config.qk_norm:
+            self.q_norm = VLLMRMSNorm(self.head_dim, eps=attn_config.norm_eps)
+            self.k_norm = VLLMRMSNorm(self.head_dim, eps=attn_config.norm_eps)
         else:
             self.q_norm = None
             self.k_norm = None
 
         # QKV projections
-        self.wq = nn.Linear(
-            model_args.dim, model_args.n_heads * self.head_dim, bias=False
-        )
+        self.wq = nn.Linear(model_args.dim, self.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
         self.wv = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=False)
-        self.wo = nn.Linear(
-            model_args.n_heads * self.head_dim, model_args.dim, bias=False
-        )
+        self.wo = nn.Linear(self.n_heads * self.head_dim, model_args.dim, bias=False)
 
         # Always use vLLM compatible flash attention
         self.inner_attention = VLLMCompatibleFlashAttention()
@@ -207,7 +163,7 @@ class Attention(nn.Module):
             xk = self.k_norm(xk)
 
         # Apply rotary embedding
-        xq, xk = apply_rotary_emb(xq, xk, rope_cache)
+        xq, xk = apply_rotary_emb_cos_sin(xq, xk, rope_cache)
 
         # Repeat k/v heads if needed
         keys = repeat_kv(xk, self.n_rep)
@@ -238,20 +194,20 @@ class TransformerBlock(nn.Module):
 
     def __init__(self, layer_id: int, model_args: Qwen3Model.Config):
         super().__init__()
-        self.n_heads = model_args.n_heads
+        self.n_heads = model_args.layer.attention.n_heads
         self.dim = model_args.dim
 
         self.attention = Attention(model_args)
 
         # Use vLLM-compatible FFN with merged projections
         self.feed_forward = FeedForwardVLLMCompat(
-            dim=model_args.dim, hidden_dim=model_args.hidden_dim
+            dim=model_args.dim, hidden_dim=model_args.layer.feed_forward.hidden_dim
         )
 
         self.attention_norm = VLLMRMSNorm(model_args.dim, eps=model_args.norm_eps)
         self.ffn_norm = VLLMRMSNorm(model_args.dim, eps=model_args.norm_eps)
 
-        if model_args.depth_init:
+        if model_args.layer.depth_init:
             self.weight_init_std = 0.02 / (2 * (layer_id + 1)) ** 0.5
         else:
             self.weight_init_std = 0.02 / (2 * model_args.n_layers) ** 0.5
@@ -290,14 +246,11 @@ class Qwen3VLLMCompatModel(BaseModel):
         self.config = model_args
         self.vocab_size = model_args.vocab_size
         self.n_layers = model_args.n_layers
-        self.eos_id = model_args.eos_id
-        self.head_dim = model_args.head_dim
+        self.head_dim = model_args.layer.attention.head_dim
 
         self.tok_embeddings = nn.Embedding(model_args.vocab_size, model_args.dim)
 
-        self.register_buffer(
-            "rope_cache", self._precompute_rope_cache(), persistent=False
-        )
+        self.rope = RoPE(model_args.rope)
 
         self.layers = torch.nn.ModuleDict()
         for layer_id in range(model_args.n_layers):
@@ -316,9 +269,8 @@ class Qwen3VLLMCompatModel(BaseModel):
         self,
         buffer_device: torch.device | None = None,
     ):
-        buffer_device = buffer_device or self.rope_cache.device
-        with torch.device(buffer_device):
-            self.rope_cache = self._precompute_rope_cache()
+        buffer_device = buffer_device or self.rope.cache.device
+        self.rope.init_weights(buffer_device=buffer_device)
         if self.tok_embeddings is not None:
             nn.init.normal_(self.tok_embeddings.weight)
         for layer in self.layers.values():
@@ -338,13 +290,6 @@ class Qwen3VLLMCompatModel(BaseModel):
                 b=cutoff_factor * final_out_std,
             )
 
-    def _precompute_rope_cache(self) -> torch.Tensor:
-        return precompute_rope_cache(
-            self.config.head_dim,
-            self.config.max_seq_len,
-            self.config.rope_theta,
-        )
-
     def get_attention_masks(
         self,
         input_batch: torch.Tensor,
@@ -362,7 +307,7 @@ class Qwen3VLLMCompatModel(BaseModel):
         h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
 
         for layer in self.layers.values():
-            h = layer(h, self.rope_cache, attention_masks)
+            h = layer(h, self.rope.cache, attention_masks)
 
         h = self.norm(h) if self.norm else h
         output = self.output(h) if self.output else h

--- a/torchtitan/experiments/rl/vllm_compat/simple_rl.py
+++ b/torchtitan/experiments/rl/vllm_compat/simple_rl.py
@@ -34,7 +34,8 @@ from torchtitan.experiments.rl.vllm_compat.weights_vllm_compat import (
     torchtitan_to_vllm_compat,
 )
 
-from torchtitan.models.qwen3.model import Qwen3Model
+from torchtitan.models.common import FeedForward, GQAttention, RoPE
+from torchtitan.models.qwen3.model import Qwen3Model, Qwen3TransformerBlock
 from transformers import AutoConfig, AutoTokenizer
 
 from vllm import LLM, SamplingParams
@@ -317,25 +318,40 @@ def load_model(checkpoint_path: str, model_path: str, use_vllm_compat: bool = Tr
     # Load HuggingFace config
     hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
-    # Create model args
+    # Create model args using the nested dataclass config structure
+    head_dim = getattr(
+        hf_config,
+        "head_dim",
+        hf_config.hidden_size // hf_config.num_attention_heads,
+    )
+    max_seq_len = getattr(hf_config, "max_position_embeddings", 32768)
+    rope_theta = hf_config.rope_theta
+
     model_args = Qwen3Model.Config(
         dim=hf_config.hidden_size,
         n_layers=hf_config.num_hidden_layers,
-        n_heads=hf_config.num_attention_heads,
-        n_kv_heads=hf_config.num_key_value_heads,
         vocab_size=hf_config.vocab_size,
-        head_dim=getattr(
-            hf_config,
-            "head_dim",
-            hf_config.hidden_size // hf_config.num_attention_heads,
-        ),
-        hidden_dim=hf_config.intermediate_size,
         norm_eps=hf_config.rms_norm_eps,
-        rope_theta=hf_config.rope_theta,
-        max_seq_len=getattr(hf_config, "max_position_embeddings", 32768),
-        qk_norm=True,
-        depth_init=True,
-        eos_id=getattr(hf_config, "eos_token_id", 151645),
+        layer=Qwen3TransformerBlock.Config(
+            norm_eps=hf_config.rms_norm_eps,
+            depth_init=True,
+            feed_forward=FeedForward.Config(hidden_dim=hf_config.intermediate_size),
+            attention=GQAttention.Config(
+                n_heads=hf_config.num_attention_heads,
+                n_kv_heads=hf_config.num_key_value_heads,
+                head_dim=head_dim,
+                qk_norm=True,
+                norm_eps=hf_config.rms_norm_eps,
+                attn_backend="sdpa",
+                rope_backend="cos_sin",
+            ),
+        ),
+        rope=RoPE.Config(
+            dim=head_dim,
+            max_seq_len=max_seq_len,
+            theta=rope_theta,
+            backend="cos_sin",
+        ),
     )
 
     # state_dict is in standard TorchTitan format (w1, w2, w3)
@@ -353,8 +369,6 @@ def load_model(checkpoint_path: str, model_path: str, use_vllm_compat: bool = Tr
         model.load_state_dict(vllm_compat_state, strict=False)
     else:
         # Use standard TorchTitan model
-        from torchtitan.models.qwen3 import Qwen3Model
-
         model = Qwen3Model(model_args)
         # Load standard TorchTitan format directly
         model.load_state_dict(state_dict, strict=False)


### PR DESCRIPTION
Following the config changes in https://github.com/pytorch/torchtitan/pull/2386 the scripts for RL fail on main.  

This PR modifies the code to restore them

## Test Plan

### Simple RL

```bash
VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 torchtitan/experiments/rl/vllm_compat/simple_rl.py
```

output:
```bash
Step   0 | Loss: -0.0036 | Reward: +0.075 | Samples: 160
  Sample:  48 + 24 = 72.
Let me check the reasoning.
Okay, so Natalia sold clips to 48 of ...
...
```

### Simple Multiprocess RL
```bash
VLLM_BATCH_INVARIANT=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN python3 torchtitan/experiments/rl/unified/simple_rl_multiprocess.py
```

```
[2026-02-23 15:03:25] INFO trainer.py:114: [actor=<root>.<torchtitan.experiments.rl.unified.actors.trainer.Trainer trainer{'gpus': 0/2}>] os.getpid()=3548191 Trainer starts to train 1 on traj:
  ✓ vLLM-TorchTitan bitwise determinism verified: 20 tokens match exactly
  ✓ vLLM-TorchTitan bitwise determinism verified: 20 tokens match exactly
```