### PR TITLE
Fix compiler toolkit CI by removing duplicated buffer registration

### DIFF
--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -50,8 +50,7 @@ class RoPE(Module):
     def __init__(self, config: Config):
         super().__init__()
         self.config = config
-        # Buffer registered later in init_weights
-        self.register_buffer("cache", self._precompute(), persistent=False)
+        self.cache: torch.Tensor = self._precompute()
 
     def _precompute(self) -> torch.Tensor:
         cfg = self.config


### PR DESCRIPTION
`self.rope.cache` and `self.freqs_cis` are the same tensor object registered as buffers on two different modules. Tracing would see them as two distinct graph inputs for the same underlying data.

This PR removes the `register_buffer` from RoPE and just store cache as a plain tensor attribute there, keeping only the Decoder-level `register_buffer("freqs_cis", ...)`.

This fixes the compiler toolkit CI:

```
NGPU=4 TRAIN_FILE=torchtitan.experiments.compiler_toolkit.train MODULE=compiler_toolkit.llama3 CONFIG=compiler_toolkit_llama3_debugmodel ./run_train.sh --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2
```