### PR TITLE
Remove device to host synchronizations from repeat_interleave and tail_slack

### DIFF
--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -153,27 +153,27 @@ def _run_experts_grouped_mm(
     tp_degree: int = 1,
 ) -> torch.Tensor:
     offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-    num_tokens_per_expert_long = num_tokens_per_expert.to(torch.long)
+    # Pad num_tokens_per_expert with tail slack so that repeat_interleave
+    # with output_size=x.shape[0] directly produces a static-shaped output,
+    # avoiding the D2H sync that repeat_interleave incurs without output_size.
+    tail_slack = (x.shape[0] - offsets[-1]).unsqueeze(0).to(num_tokens_per_expert.dtype)
+    num_tokens_per_expert_long = torch.cat([num_tokens_per_expert, tail_slack]).long()
 
     h = torch._grouped_mm(
         x.bfloat16(), mlp1_weight.transpose(-2, -1).bfloat16(), offs=offsets
     )
 
-    b1 = mlp1_bias.repeat_interleave(num_tokens_per_expert_long, dim=0)
-    tail_slack = x.shape[0] - int(offsets[-1])
-    if tail_slack:
-        b1 = torch.cat([b1, b1.new_zeros((tail_slack, b1.shape[-1]))], dim=0)
+    b1 = torch.cat([mlp1_bias, mlp1_bias.new_zeros(1, mlp1_bias.shape[-1])])
+    b1 = b1.repeat_interleave(num_tokens_per_expert_long, dim=0, output_size=x.shape[0])
     h = h + b1.to(h.dtype)
 
     h = swiglu(h, limit=swiglu_limit)
     h = torch._grouped_mm(h, mlp2_weight.transpose(-2, -1).bfloat16(), offs=offsets)
 
     # Apply custom autograd function to scale bias in forward but not in backward
-    b2_base = mlp2_bias.repeat_interleave(num_tokens_per_expert_long, dim=0)
-    b2 = ScaleBiasForward.apply(b2_base, tp_degree)
-    tail_slack = x.shape[0] - int(offsets[-1])
-    if tail_slack:  # padding
-        b2 = torch.cat([b2, b2.new_zeros((tail_slack, b2.shape[-1]))], dim=0)
+    b2 = torch.cat([mlp2_bias, mlp2_bias.new_zeros(1, mlp2_bias.shape[-1])])
+    b2 = b2.repeat_interleave(num_tokens_per_expert_long, dim=0, output_size=x.shape[0])
+    b2 = ScaleBiasForward.apply(b2, tp_degree)
     h = h + b2.to(h.dtype)
 
     return h


### PR DESCRIPTION
The current approach for the bias in expert gate/up/down projection uses `repeat_interleave` which produces a dynamic shape and then uses `tail_slack` to pad to a static shape. This incurs multiple device to host synchronizations: `repeat_interleave` without the `output_size` parameter and the `.item` call from `int(offsets[-1])`. Specifically, the `repeat_interleave` and `tail_slack` output allocation size both depend on the data in `num_tokens_per_expert`, but when they are concatenated the output has a statically known shape.

We can solve this problem by reordering operations slightly. In particular, we can pad first and then run `repeat_interleave` with the `output_size` parameter to directly produce a tensor of static shape with the correct amount of padding without relying on multiple device to host sync. This should be mathematically equivalent.