### PR TITLE
[simple_fsdp] Add CUDAGraph support for SimpleFSDP via --compile.use_cudagraph

### DIFF
--- a/torchtitan/experiments/simple_fsdp/README.md
+++ b/torchtitan/experiments/simple_fsdp/README.md
@@ -39,6 +39,7 @@ Some of the features require the updates from PyTorch, with which we are working
 |Context Parallelism| ✅ |
 |Pipeline Parallelism| ✅ |
 |Distributed Checkpointing| ✅ |
+|CUDA Graphs| ✅ |
 |Float8 Training| 🚧 |
 |Expert Parallelism | ✅ |
 |Expert Parallelism + Activation Checkpointing| 🚧 |
@@ -62,6 +63,12 @@ SimpleFSDP relies on compiler backend to perform optimizations (i.e., bucketing 
       ```bash
       --compile.backend "aot_eager" --compile.graph_passes "transformer_block_bucketing"
       ```
+
+4. CUDA Graphs: wrap compiled fw/bw graphs with `CUDAGraphWrapper` from `compiler_toolkit` for reduced kernel launch overhead. Compatible with both `auto_bucketing` and `transformer_block_bucketing` passes, and both `aot_eager` and `inductor` backends.
+      ```bash
+      NCCL_GRAPH_REGISTER=0 torchrun ... --compile.use_cudagraph --compile.graph_passes "transformer_block_bucketing"
+      ```
+    **Note:** `NCCL_GRAPH_REGISTER=0` env var is required when NCCL collectives are captured inside CUDA graphs.
 
 ### Citation
 

--- a/torchtitan/experiments/simple_fsdp/backend.py
+++ b/torchtitan/experiments/simple_fsdp/backend.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -15,11 +16,91 @@ from .configs import SimpleFSDPCompileConfig as CompileConfig
 from .reshard_after_forward import annotate_fsdp_all_gather
 
 
+def _wrap_compiler_with_cudagraph(compiler_fn: Callable, is_forward: bool) -> Callable:
+    """Wrap a fw/bw compiler to apply CUDAGraphWrapper after compilation.
+
+    Uses compiler_toolkit's CUDAGraphWrapper (warmup -> record -> replay)
+    with a shared memory pool across all captured graphs.
+    """
+    from torchtitan.experiments.compiler_toolkit.cudagraph import (
+        CUDAGraphWrapper,
+        get_static_input_indices,
+    )
+
+    def wrapped(gm: torch.fx.GraphModule, example_inputs):
+        compiled = compiler_fn(gm, example_inputs)
+        static_indices = get_static_input_indices(gm, is_forward)
+        # compile_fx_inner returns CompiledFxGraph(list) -> out,
+        # adapt to CUDAGraphWrapper's (*args) -> out convention
+        inner = compiled
+        return CUDAGraphWrapper(
+            lambda *args: inner(list(args)), example_inputs, static_indices
+        )
+
+    return wrapped
+
+
+def _build_inductor_cg_backend(bucketing_pass_fn: Callable) -> Callable:
+    """Build an aot_autograd backend for inductor + CUDAGraph.
+
+    Applies: bucketing_pass -> compile_fx_inner -> CUDAGraphWrapper.
+    """
+    from torch._dynamo.backends.common import aot_autograd as aot_autograd_backend
+    from torch._inductor.compile_fx import compile_fx_inner
+    from torch._inductor.decomposition import select_decomp_table
+
+    def compiler(gm: torch.fx.GraphModule, example_inputs: Any) -> Any:
+        bucketing_pass_fn(gm)
+        gm.recompile()
+        return compile_fx_inner(gm, example_inputs)
+
+    torch._inductor.config.reorder_for_peak_memory = False
+    torch._inductor.config.reorder_for_compute_comm_overlap = False
+
+    return aot_autograd_backend(
+        fw_compiler=_wrap_compiler_with_cudagraph(compiler, is_forward=True),
+        bw_compiler=_wrap_compiler_with_cudagraph(compiler, is_forward=False),
+        keep_inference_input_mutations=True,
+        decompositions=select_decomp_table(),
+    )
+
+
+def _build_aot_eager_cg_backend(bucketing_pass_fn: Callable) -> Callable:
+    """Build an aot_autograd backend for aot_eager + CUDAGraph.
+
+    Applies: bucketing_pass -> CUDAGraphWrapper wrapping the GraphModule.
+    Returns CUDAGraphWrapper directly (not gm with replaced forward) to avoid
+    recursion through LazyGraphModule's self-call in _lazy_forward.
+    """
+    from torch._dynamo.backends.common import aot_autograd as aot_autograd_backend
+    from torchtitan.experiments.compiler_toolkit.cudagraph import (
+        CUDAGraphWrapper,
+        get_static_input_indices,
+    )
+
+    def _cg_compiler(is_forward: bool) -> Callable:
+        def compiler(
+            gm: torch.fx.GraphModule, example_inputs: Any
+        ) -> CUDAGraphWrapper:
+            bucketing_pass_fn(gm)
+            gm.recompile()
+            static_indices = get_static_input_indices(gm, is_forward)
+            return CUDAGraphWrapper(gm, example_inputs, static_indices)
+
+        return compiler
+
+    return aot_autograd_backend(
+        fw_compiler=_cg_compiler(is_forward=True),
+        bw_compiler=_cg_compiler(is_forward=False),
+        keep_inference_input_mutations=True,
+    )
+
+
 def get_compile_backend_with_passes(
     compile_config: CompileConfig,
     fsdp_reshard_after_forward: bool,
     fsdp_manual_buckets: list[list[str] | str] | None,
-) -> callable:
+) -> Callable:
     """
     Apply compile backend and additional graph passes.
     Args:
@@ -30,6 +111,19 @@ def get_compile_backend_with_passes(
     Returns:
         compile backend with applied graph passes.
     """
+    use_cg = compile_config.use_cudagraph
+
+    if use_cg:
+        if compile_config.backend not in ("inductor", "aot_eager"):
+            raise ValueError(
+                "use_cudagraph requires backend='inductor' or 'aot_eager', "
+                f"got '{compile_config.backend}'"
+            )
+        if compile_config.backend == "inductor":
+            # Disable inductor's built-in cudagraph; we use CUDAGraphWrapper instead
+            torch._inductor.config.triton.cudagraphs = False
+        logger.info("CUDAGraph enabled via compiler_toolkit CUDAGraphWrapper")
+
     backend = torch._dynamo.lookup_backend(compile_config.backend)
 
     # Apply bucketing and overlapping pass on fwd and bwd graph separately
@@ -44,12 +138,16 @@ def get_compile_backend_with_passes(
         dist_opts.collective_bucketing = True
         torch._inductor.config.allow_buffer_reuse = False
 
-        if compile_config.backend == "aot_eager":
+        if compile_config.backend == "aot_eager" and use_cg:
+            dist_opts.insert_overlap_deps = False
+            backend = _build_aot_eager_cg_backend(schedule_overlap_bucketing)
+
+        elif compile_config.backend == "aot_eager":
             from torch._dynamo.backends.common import (
                 aot_autograd as aot_autograd_backend,
             )
 
-            def aot_eager_autobucketing_reordering_pass(
+            def aot_eager_autobucketing_pass(
                 gm: torch.fx.GraphModule, example_inputs: Any
             ) -> torch.fx.GraphModule:
                 schedule_overlap_bucketing(gm)
@@ -58,10 +156,14 @@ def get_compile_backend_with_passes(
 
             dist_opts.insert_overlap_deps = False
             backend = aot_autograd_backend(
-                fw_compiler=aot_eager_autobucketing_reordering_pass,
-                bw_compiler=aot_eager_autobucketing_reordering_pass,
+                fw_compiler=aot_eager_autobucketing_pass,
+                bw_compiler=aot_eager_autobucketing_pass,
                 keep_inference_input_mutations=True,
             )
+        elif compile_config.backend == "inductor" and use_cg:
+            dist_opts.insert_overlap_deps = True
+            backend = _build_inductor_cg_backend(schedule_overlap_bucketing)
+
         elif compile_config.backend == "inductor":
 
             def inductor_autobucketing_reordering_pass(
@@ -97,22 +199,32 @@ def get_compile_backend_with_passes(
             module_bucket_plans=fsdp_manual_buckets,
         )
 
-        if compile_config.backend == "aot_eager":
+        if compile_config.backend == "aot_eager" and use_cg:
+            backend = _build_aot_eager_cg_backend(
+                lambda gm: manual_overlap_bucketing(gm, insert_overlap_deps=False)
+            )
 
-            def aot_eager_transformer_block_bucketing_reordering_pass(
+        elif compile_config.backend == "aot_eager":
+
+            def aot_eager_manual_bucketing_pass(
                 gm: torch.fx.GraphModule, example_inputs: Any
             ) -> torch.fx.GraphModule:
                 manual_overlap_bucketing(gm, insert_overlap_deps=False)
                 return gm
 
             backend = aot_autograd_backend(
-                fw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
-                bw_compiler=aot_eager_transformer_block_bucketing_reordering_pass,
+                fw_compiler=aot_eager_manual_bucketing_pass,
+                bw_compiler=aot_eager_manual_bucketing_pass,
                 keep_inference_input_mutations=True,
             )
+        elif compile_config.backend == "inductor" and use_cg:
+            backend = _build_inductor_cg_backend(
+                lambda gm: manual_overlap_bucketing(gm, insert_overlap_deps=False)
+            )
+
         elif compile_config.backend == "inductor":
 
-            def inductor_transformer_block_bucketing_reordering_pass(
+            def inductor_manual_bucketing_reordering_pass(
                 gm: torch.fx.Graph,
             ) -> torch.fx.GraphModule:
                 return manual_overlap_bucketing(
@@ -122,7 +234,7 @@ def get_compile_backend_with_passes(
             torch._inductor.config.reorder_for_peak_memory = False
             torch._inductor.config.reorder_for_compute_comm_overlap = False
             torch._inductor.config.post_grad_custom_post_pass = (
-                inductor_transformer_block_bucketing_reordering_pass
+                inductor_manual_bucketing_reordering_pass
             )
         else:
             raise ValueError(

--- a/torchtitan/experiments/simple_fsdp/configs.py
+++ b/torchtitan/experiments/simple_fsdp/configs.py
@@ -19,6 +19,15 @@ class SimpleFSDPCompileConfig(CompileConfig):
         auto_bucketing, transformer_block_bucketing
     """
 
+    use_cudagraph: bool = False
+    """
+    Enable CUDA Graphs via compiler_toolkit.cudagraph.CUDAGraphWrapper.
+    Captures compiled fw/bw graphs into CUDA graphs (warmup -> record -> replay)
+    with a shared memory pool, reducing kernel launch overhead.
+    Supported with backend='inductor' and 'aot_eager'.
+    Requires NCCL_GRAPH_REGISTER=0 env var when NCCL collectives are present.
+    """
+
 
 @dataclass(kw_only=True, slots=True)
 class SimpleFSDPConfig(Trainer.Config):


### PR DESCRIPTION
Reuse compiler_toolkit's CUDAGraphWrapper (warmup -> record -> replay lifecycle with shared memory pool) to capture NCCL collectives inside CUDA graphs. Inductor's built-in cudagraph integration cannot handle NCCL ops, so we disable it and wrap fw/bw compiled graphs externally.

For inductor + CG: use aot_autograd with custom compilers that apply bucketing pass -> compile_fx_inner -> CUDAGraphWrapper. This gives us Triton-compiled kernels with CUDA graph capture around the full graph.

Only supported with backend='inductor' (aot_eager has CUDA graph memory pool conflicts between forward and backward recording).

Usage:
  NCCL_GRAPH_REGISTER=0 torchrun ... --compile.use_cudagraph