### PR TITLE
Add aten.linear to selective activation checkpointing op policy

### DIFF
--- a/tests/unit_tests/test_activation_checkpoint.py
+++ b/tests/unit_tests/test_activation_checkpoint.py
@@ -18,6 +18,7 @@ from torchtitan.distributed.activation_checkpoint import apply_ac
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -73,6 +73,9 @@ def _apply_op_sac(
         create_selective_checkpoint_contexts,
     )
 
+    # Collect weight shapes to force-recompute, stored as mm RHS shape
+    # (in_f, out_f). For aten.linear we transpose args[1].shape at lookup
+    # time to match, since linear's weight is (out_f, in_f).
     mm_recompute_shapes = set()
     if len(ac_config.per_op_sac_force_recompute_mm_shapes_by_fqns) > 0:
         for module_fqn, submod in module.named_modules():
@@ -95,6 +98,10 @@ def _apply_op_sac(
             f"Selective op AC force recomputing mms with rhs shapes {mm_recompute_shapes}"
         )
 
+    # Some backends (e.g. PrivateUse1) register aten.linear as a leaf op
+    # instead of decomposing it into aten.mm, so we must handle both.
+    mm_ops = (torch.ops.aten.mm.default, torch.ops.aten.linear.default)
+
     def _get_custom_policy(meta):
         def _custom_policy(ctx, func, *args, **kwargs):
             if (
@@ -107,13 +114,17 @@ def _apply_op_sac(
 
             mode = "recompute" if ctx.is_recompute else "forward"
             mm_count_key = f"{mode}_mm_count"
-            if func == torch.ops.aten.mm.default:
-                if args[1].shape in mm_recompute_shapes:
+            if func in mm_ops:
+                weight_shape = args[1].shape
+                # linear weight is (out, in); normalize to (in, out) to match mm
+                if func == torch.ops.aten.linear.default:
+                    weight_shape = torch.Size((weight_shape[1], weight_shape[0]))
+                if weight_shape in mm_recompute_shapes:
                     return CheckpointPolicy.PREFER_RECOMPUTE
                 meta[mm_count_key] += 1
-            # Saves output of all compute ops, except every second mm
+            # Saves output of all compute ops, except every second mm/linear
             to_save = func in op_sac_save_list and not (
-                func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0
+                func in mm_ops and meta[mm_count_key] % 2 == 0
             )
             return (
                 CheckpointPolicy.MUST_SAVE

--- a/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
+++ b/torchtitan/experiments/simple_fsdp/llama3/parallelize.py
@@ -28,6 +28,7 @@ from ..simple_fsdp import data_parallel, MixedPrecisionPolicy
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -42,6 +42,7 @@ from torchtitan.tools.logging import logger
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -49,6 +49,7 @@ from .expert_parallel import GptossExpertTensorParallel, GptossTensorParallel
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -42,6 +42,7 @@ from torchtitan.tools.logging import logger
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -59,6 +59,7 @@ from torchtitan.tools.logging import logger
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -46,6 +46,7 @@ from torchtitan.tools.logging import logger
 # for selective op activation checkpointing
 _op_sac_save_list = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,


### PR DESCRIPTION
Backends that implement `aten.linear` as a leaf op rather than decomposing it into `aten.mm` (e.g. PrivateUse1) bypass the selective AC policy entirely, since only `aten.mm` was recognized by the save list and alternating-save logic. This results in all linear outputs being unconditionally recomputed.

This PR extends the per-op SAC policy to handle `aten.linear.default` alongside `aten.mm.default`:

- Linear and mm share the same alternating counter for the "save every other" policy
- Force-recompute shape matching normalizes linear's weight shape `(out_f, in_f)` to mm convention `(in_f, out_f)` at lookup time
- All per-model `_op_sac_save_list` sets include `aten.linear.default`

On backends where `aten.linear` decomposes into `aten.mm`, this change is a no-op as `aten.linear` does not reach `__torch_dispatch__`.