### PR TITLE
[compiler toolkit] Fix CompiledModule.forward to use DTensor inputs

### DIFF
--- a/torchtitan/experiments/compiler_toolkit/graph_utils.py
+++ b/torchtitan/experiments/compiler_toolkit/graph_utils.py
@@ -254,7 +254,7 @@ class CompiledModule(torch.nn.Module):
 
         # calling the line below returns control to torchtitan's runner
         # letting it call the backward, and optimizer.
-        return self.joint_graph_module(args, kwargs)
+        return self.joint_graph_module(dt_args, dt_kwargs)
 
 
 # Default compiler pass configuration - no passes by default


### PR DESCRIPTION
CompiledModule.forward was passing the original (args, kwargs) to
joint_graph_module instead of the parallelized (dt_args, dt_kwargs).
This meant the compiled graph, which was traced against DTensor inputs,
was being called with non-DTensor tensors.

This doesn't cause an error today because PyTorch doesn't enforce the
inputs to the AOT wrapper, but that will change in the future.
