### PR TITLE
Temporary fix CI issues

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -127,7 +127,9 @@ class FlexAttentionWrapper(torch.nn.Module):
         flex_attention,
         # This options also encapsulate max-autotune-no-cudagraphs.
         options={
-            "wrap_inductor_compiled_regions": True,
+            # TODO: turn on this after PyTorch fix is landed again
+            # https://github.com/pytorch/pytorch/pull/175733.
+            "wrap_inductor_compiled_regions": False,
             "max_autotune": True,
             "coordinate_descent_tuning": True,
             "triton.cudagraphs": False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2462

https://github.com/pytorch/pytorch/pull/175733 is not in the nightly and is being reverted. This blocks our CI.

This is a temporary fix.