### PR TITLE
Performance Improvement: Implement custom op for MoE token combination

### DIFF
--- a/tests/unit_tests/test_moe_token_combine.py
+++ b/tests/unit_tests/test_moe_token_combine.py
@@ -1,0 +1,48 @@
+import pytest
+import torch
+from torchtitan.models.common.moe.moe import ExpertCombineFunction
+
+NUM_TOKENS = 42
+# Use some Qwen3-30B-A3B dimensions for testing.
+DIM = 2048
+NUM_EXPERTS = 128
+TOP_K = 8
+
+def original_token_combine(s: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
+    """Original token combine implementation using bmm, for testing against the custom autograd function."""
+    return torch.bmm(s.unsqueeze(1), R.float()).squeeze(1).to(torch.bfloat16)
+
+@pytest.mark.gpu
+def test_token_combine_fwd():
+    routed_expert_activations = torch.randn(NUM_TOKENS, TOP_K, DIM, device="cuda", dtype=torch.bfloat16)
+    router_scores = torch.randn(NUM_TOKENS, TOP_K, device="cuda", dtype=torch.float32)
+
+    combined_output_ground_truth = original_token_combine(router_scores, routed_expert_activations)
+    combined_output = ExpertCombineFunction.apply(router_scores, routed_expert_activations, torch.bfloat16)
+
+    assert combined_output.dtype == torch.bfloat16, "Expected combined output to be bfloat16"
+    assert combined_output.shape == (NUM_TOKENS, DIM), f"Expected combined output shape to be {(NUM_TOKENS, DIM)}"
+    assert torch.allclose(combined_output, combined_output_ground_truth, rtol=1e-4, atol=1e-4), "Combined output does not match ground truth"
+
+
+@pytest.mark.gpu
+def test_token_combine_bwd():
+    routed_expert_activations = torch.randn(NUM_TOKENS, TOP_K, DIM, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    router_scores = torch.randn(NUM_TOKENS, TOP_K, device="cuda", dtype=torch.float32, requires_grad=True)
+
+    routed_expert_activations2 = routed_expert_activations.clone().detach().requires_grad_(True)
+    router_scores2 = router_scores.clone().detach().requires_grad_(True)
+
+    combined_output = ExpertCombineFunction.apply(router_scores, routed_expert_activations, torch.bfloat16)
+    loss = combined_output.sum()
+    loss.backward()
+
+    combined_output2 = original_token_combine(router_scores2, routed_expert_activations2)
+    loss2 = combined_output2.sum()
+    loss2.backward()
+
+    assert router_scores.grad is not None, "Expected gradient w.r.t. router scores"
+    assert routed_expert_activations.grad is not None, "Expected gradient w.r.t. routed expert activations"
+
+    assert torch.allclose(router_scores.grad, router_scores2.grad, rtol=1e-4, atol=1e-4), "Gradient w.r.t. router scores does not match ground truth"
+    assert torch.allclose(routed_expert_activations.grad, routed_expert_activations2.grad, rtol=1e-4, atol=1e-4), "Gradient w.r.t. routed expert activations does not match ground truth"

--- a/torchtitan/models/common/moe/moe.py
+++ b/torchtitan/models/common/moe/moe.py
@@ -365,6 +365,58 @@ class TokenReorderer(nn.Module):
             num_tokens_per_expert,
         )
 
+class ExpertCombineFunction(torch.autograd.Function):
+    """Custom autograd Function that computes the expert combination
+    y_{n,:} = sum_k s_{n,k} * R_{n,k,:}
+    Inputs expected:
+    - `s` : shape (N, K) (router scores)
+    - `R`  : shape (N, K, D) (routed experts outputs)
+    Returns:
+    - y : shape (N, D)
+    """
+
+    @staticmethod
+    def forward(ctx, s, R, out_dtype=None):
+        assert s.dtype == torch.float32, "Expect router scores to be float32"
+        assert R.dtype == torch.bfloat16, "Expect routed experts outputs to be bfloat16"
+
+        # Ensure expectations about input shapes are met
+        assert s.dim() == 2, "Expect s to have shape (N, K)"
+        assert R.dim() == 3, "R is expected to be a 3D tensor"
+        assert s.shape[0] == R.shape[0], "Batch size of s and R must match"
+        assert s.shape[1] == R.shape[1], "Number of experts in s and R must match"
+
+        ctx.save_for_backward(s, R)
+        ctx.out_dtype = out_dtype
+
+        R_f = R.to(torch.float32)
+        y = torch.bmm(s.unsqueeze(1), R_f).squeeze(1)
+
+        if out_dtype is not None:
+            return y.to(out_dtype)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        s, R = ctx.saved_tensors
+        assert s.dtype == torch.float32, "Expect router scores to be float32"
+        assert R.dtype == torch.bfloat16, "Expect routed experts outputs to be bfloat16"
+
+        # Forward bmm is in float, so we also compute the gradients in float.
+
+        # grad_output: (N, D)
+        grad_y = grad_output.unsqueeze(1)  # (N,1,D)
+
+        # grad w.r.t. s: (N,1,K) = (N,1,D) @ (N,D,K).  (batched sgemv)
+        Rt = R.transpose(1, 2)  # R^T along the non-batch dims
+        grad_s = torch.bmm(grad_y.to(torch.float32), Rt.to(torch.float32)).to(s.dtype).squeeze(1)
+
+        # grad w.r.t. R: (N,K,D) = (N,K,1) @ (N,1,D) = (N,1,D) * (N,K,1).  (batched outer product)
+        grad_R = (grad_y.to(torch.float32) * s.unsqueeze(2)).to(R.dtype)
+
+        return grad_s, grad_R, None
+
+
 
 class MoE(Module):
     @dataclass(kw_only=True, slots=True)
@@ -516,13 +568,18 @@ class MoE(Module):
             -1, self.router.top_k, dim
         )
         if not self.score_before_experts:
-            out_experts = (
-                torch.bmm(
-                    top_scores.reshape(-1, 1, self.router.top_k),
-                    routed_output_unsorted.float(),
-                )
-                .to(x.dtype)
-                .squeeze(1)
+            # out_experts = (
+            #     torch.bmm(
+            #         top_scores.reshape(-1, 1, self.router.top_k),
+            #         routed_output_unsorted.float(),
+            #     )
+            #     .to(x.dtype)
+            #     .squeeze(1)
+            # )
+            out_experts = ExpertCombineFunction.apply(
+                top_scores,  # (bs*slen, top_k)
+                routed_output_unsorted,
+                x.dtype,
             )
         else:
             out_experts = routed_output_unsorted.sum(dim=1)


### PR DESCRIPTION
In Qwen3-30B-A3B, we get a large Magma SGEMM or Cutlass SIMT kernel on B200 for the token combination bmm backward from the Autograd.
This kernel seems to be very inefficient, taking ~6-9ms for local_batch_size=16, where a memory-bound kernel should take something like 1ms. The Torch Inductor is not able to remove this kernel by default.

This commit reformulates the problem into an explicit outer product, which seems to lower to a much better kernel for B200s than the one produced by the Autograd. Together with torch.compile enabled for MoE (which is not the default), this change saves about 4.5 ms per backward layer.


Before:
<img width="829" height="400" alt="grafik" src="https://github.com/user-attachments/assets/e453514c-e269-4503-a99a-401399ca5438" />

After:
<img width="940" height="411" alt="grafik" src="https://github.com/user-attachments/assets/c488b895-3813-4ab6-b1a5-2a17dfbf7b3b" />

Average duration of the backwards CompiledFxGraph (this is not the whole backward, FSDP communication is missing):
Before: 62.6875 ms
After: 56.167 ms

Averages generated with:
```
select avg(dur/1000/1000) as avg_ms from slices
 where category = 'gpu_user_annotation'
   and name = '## Call CompiledFxGraph None ##'
   and ts >= <timestamp-where-backward-pass-begins>;
```

*This commit does not change the performance of Qwen3-30B-A3B in eager mode or in the current default Torch Titan setting, where the grouped_gemms in MoE are exempt from compilation (the called kernels are different, but the runtime is practically the same).*