### PR TITLE
[rl] non-colocated trainer / generator

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 
 import torch
 from monarch.actor import Actor, endpoint
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import distribute_tensor, DTensor
 from torchtitan.config import Configurable
 from torchtitan.config.configs import ParallelismConfig
 from torchtitan.experiments.rl.unified.plugin import (
@@ -76,7 +76,7 @@ class VLLMGenerator(Actor, Configurable):
         model_dtype: str = "bfloat16"
         """Data type for model weights, passed directly to vLLM (auto, float16, bfloat16, float32)."""
 
-        gpu_memory_limit: float = 0.5
+        gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
         enforce_eager: bool = True
@@ -233,29 +233,22 @@ class VLLMGenerator(Actor, Configurable):
 
         Args:
             version: New policy version number
-            state_dict: Per-rank state dicts keyed by GPU index,
-                e.g. {0: state_dict_gpu0, 1: state_dict_gpu1}
+            state_dict: Full (unsharded) state dict with plain tensors.
         """
-        # Extract this rank's state dict from the per-rank dict
-        rank = int(os.environ.get("LOCAL_RANK", 0))
-        local_state_dict = state_dict[rank]
-
-        # Convert plain local tensors (TP shards from trainer) to DTensors
-        # matching the vLLM model's sharding layout. The trainer exports
-        # weights via to_local() which strips DTensor metadata.
+        # Reshard full tensors to match this generator's DTensor layout
         model_state_dict = dict(self._get_model().model.state_dict())
-        for name, tensor in local_state_dict.items():
+        for name, tensor in state_dict.items():
             if name in model_state_dict and isinstance(model_state_dict[name], DTensor):
                 if isinstance(tensor, DTensor):
                     continue
                 target_dtensor = model_state_dict[name]
-                local_state_dict[name] = DTensor.from_local(
+                state_dict[name] = distribute_tensor(
                     tensor.to(target_dtensor.device_mesh.device_type),
                     device_mesh=target_dtensor.device_mesh,
                     placements=target_dtensor.placements,
                 )
 
-        load_weights = self._get_model().load_weights_from_state_dict(local_state_dict)
+        load_weights = self._get_model().load_weights_from_state_dict(state_dict)
         self.policy_version = version
         logger.debug(
             f"Updated weights into vLLM engine model. "

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 from monarch.actor import Actor, endpoint
 from torch.distributed._tensor import DTensor
@@ -131,7 +132,14 @@ class PolicyTrainer(Actor, Configurable):
         self.policy_version = 0
         self.generator: Any | None = None
 
-        logger.debug("PolicyTrainer initialized")
+        # Data parallelism: determine this rank's shard of the batch.
+        self.dp_size = self.parallel_dims.dp_replicate * self.parallel_dims.dp_shard
+        self.dp_rank = dist.get_rank() // self.parallel_dims.non_data_parallel_size
+        self.dp_enabled = self.parallel_dims.dp_enabled
+
+        logger.debug(
+            f"PolicyTrainer initialized (dp_rank={self.dp_rank}, dp_size={self.dp_size})"
+        )
 
     def _load_initial_hf_weights(self, model, checkpoint_path: str) -> None:
         """Load model weights from HF checkpoint using DCP and state_dict_adapter.
@@ -219,13 +227,8 @@ class PolicyTrainer(Actor, Configurable):
         """
         titan_state = self.model.state_dict()
 
-        # Unwrap DTensors to plain local tensors and clone to break shared storage.
-        # Without clone, to_local() returns a view of the trainer's parameter data.
-        # Since trainer and generator are collocated (same process), Monarch passes
-        # by reference, so the generator's set_model_state_dict can corrupt the
-        # trainer's Replicate params (norm weights) via in-place redistribution.
         return {
-            k: v.to_local().clone() if isinstance(v, DTensor) else v.clone()
+            k: v.full_tensor() if isinstance(v, DTensor) else v
             for k, v in titan_state.items()
         }
 
@@ -233,7 +236,9 @@ class PolicyTrainer(Actor, Configurable):
     async def step(self, episodes: list[Episode]) -> dict:
         """Perform one training step.
 
-        Computes advantages from rewards, then updates the policy.
+        Computes advantages from rewards on the full batch (GRPO normalizes
+        within each prompt group), then shards completions across DP ranks
+        so each rank processes a unique slice of the data.
 
         Args:
             episodes: List of Episode data (one per prompt) with rewards filled by Grader
@@ -245,7 +250,8 @@ class PolicyTrainer(Actor, Configurable):
             f"{os.getpid()=} PolicyTrainer starting step {self.policy_version} "
         )
 
-        # Compute advantages.
+        # Compute GRPO advantages on the full batch (group normalization
+        # requires seeing all completions per prompt).
         all_token_ids: list[list[int]] = []
         all_prompt_token_ids: list[list[int]] = []
         all_token_log_probs: list[list[float]] = []
@@ -253,7 +259,6 @@ class PolicyTrainer(Actor, Configurable):
         all_rewards: list[float] = []
         for episode in episodes:
             rewards = torch.tensor([c.reward for c in episode.completions])
-            # GRPO advantage: computed relative to the mean reward within the group
             advantages = rewards - rewards.mean()
             all_advantages.append(advantages)
             all_rewards.extend(c.reward for c in episode.completions)
@@ -265,31 +270,38 @@ class PolicyTrainer(Actor, Configurable):
         advantages = torch.cat(all_advantages)
         all_rewards_tensor = torch.tensor(all_rewards)
 
-        # Compute reference log probs using frozen ref_model
+        # Shard flattened completions across DP ranks so each rank processes
+        # a unique subset of the data.
+        total_samples = len(all_token_ids)
+        my_indices = list(range(self.dp_rank, total_samples, self.dp_size))
+        my_token_ids = [all_token_ids[i] for i in my_indices]
+        my_prompt_token_ids = [all_prompt_token_ids[i] for i in my_indices]
+        my_token_log_probs = [all_token_log_probs[i] for i in my_indices]
+        my_advantages = advantages[my_indices]
+
+        # Compute reference log probs using frozen ref_model (local shard only)
         ref_token_log_probs = []
         device = next(self.model.parameters()).device
         with torch.no_grad():
-            for prompt_toks, gen_toks in zip(all_prompt_token_ids, all_token_ids):
+            for prompt_toks, gen_toks in zip(my_prompt_token_ids, my_token_ids):
                 token_lps = compute_token_log_probs(
                     self.ref_model, prompt_toks, gen_toks, device
                 )
                 ref_token_log_probs.append(token_lps)
 
-        # Compute loss.
-        # TODO: compute the forward_backward first and then pass this to the loss to
-        # keep the loss function only computing the loss itself
+        # Compute loss on this rank's shard
         loss, loss_metrics, batch_token_log_probs = compute_policy_gradient_loss(
             self.model,
-            all_token_ids,
-            all_prompt_token_ids,
-            advantages,
+            my_token_ids,
+            my_prompt_token_ids,
+            my_advantages,
             ref_token_log_probs,
             kl_coef=0.1,
         )
 
-        # Verify logprob identity and compute log ratio (train/generator)
+        # Verify logprob identity (local shard)
         verification_result = verify_logprob_identity(
-            all_token_log_probs,
+            my_token_log_probs,
             batch_token_log_probs,
         )
         logger.debug(
@@ -300,9 +312,16 @@ class PolicyTrainer(Actor, Configurable):
             f"tokens_checked={verification_result['total_tokens_checked']}"
         )
 
-        # Update weights using torchtitan optimizers
+        # Update weights
         self.optimizers.zero_grad()
         loss.backward()
+
+        # All-reduce gradients across DP ranks so all ranks have consistent
+        # weight updates despite processing different data shards.
+        if self.dp_enabled:
+            for param in self.model.parameters():
+                if param.grad is not None:
+                    dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
 
         # Gradient clipping
         grad_norm = dist_utils.clip_grad_norm_(

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -24,7 +24,7 @@ from torchtitan.models.qwen3 import model_registry
 
 
 def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
-    """GRPO training config for Qwen3-0.6B."""
+    """GRPO training config for Qwen3-0.6B (4 GPUs: 2 gen + 2 train)."""
     return RLTrainer.Config(
         model_spec=model_registry("0.6B"),
         hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
@@ -42,15 +42,14 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
-                data_parallel_replicate_degree=1,
             ),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
-            gpu_memory_limit=0.5,
             enforce_eager=True,
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
+                data_parallel_replicate_degree=1,
             ),
             num_samples_per_prompt=8,
             sampling=SamplingConfig(
@@ -64,7 +63,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
 
 
 def rl_grpo_qwen3_debug() -> RLTrainer.Config:
-    """Debug config for quick iteration — small model, few steps."""
+    """Debug config for quick iteration -- small model, few steps (2 GPUs: 1 gen + 1 train)."""
     return RLTrainer.Config(
         model_spec=model_registry("debugmodel"),
         num_steps=5,
@@ -85,10 +84,10 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
             ),
         ),
         generator=VLLMGenerator.Config(
-            gpu_memory_limit=0.3,
             enforce_eager=True,
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=1,
+                data_parallel_replicate_degree=1,
             ),
             num_samples_per_prompt=4,
             sampling=SamplingConfig(

--- a/torchtitan/experiments/rl/unified/simple_grpo.py
+++ b/torchtitan/experiments/rl/unified/simple_grpo.py
@@ -5,12 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Multiprocess RL training loop using Monarch Actors.
+RL training loop using Monarch Actors.
 
 This demonstrates:
-1. Distributed actor architecture with VLLMGenerator (vLLM) and PolicyTrainer (TorchTitan) components
-2. Weight synchronization between trainer and generator by unwrapping and
-    rewrap DTensor. We have strong assumption that trainer and generator has same parallelism
+1. Distributed actor architecture with VLLMGenerator (vLLM) and PolicyTrainer (TorchTitan)
+   running on separate GPU meshes
+2. Weight synchronization across meshes: trainer gathers full (unsharded) weights,
+   generator reshards to match its own parallelism layout via distribute_tensor
 3. Separate scoring component for reward and advantage computation
 
 The architecture mirrors monarch's grpo_actor.py but adapted for vLLM rollouts + TorchTitan training.
@@ -23,7 +24,9 @@ python3 torchtitan/experiments/rl/unified/simple_grpo.py \
 
 import asyncio
 import logging
+import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import torch
@@ -38,6 +41,40 @@ from torchtitan.experiments.rl.unified.sum_digits import extract_answer, SumDigi
 from torchtitan.protocols.model_spec import ModelSpec
 
 logger = logging.getLogger(__name__)
+
+
+class Provisioner:
+    """Allocates non-overlapping GPU ranges for Monarch proc meshes.
+
+    In non-colocated mode, the trainer and generator run on separate GPU
+    meshes (e.g. GPUs 0-3 for training, GPUs 4-7 for generation). Each
+    call to ``allocate(n)`` reserves the next *n* GPUs and returns a
+    bootstrap callable that sets ``CUDA_VISIBLE_DEVICES`` before CUDA
+    initializes in the spawned process, ensuring each mesh only sees its
+    own devices.
+    """
+
+    def __init__(self, total_gpus: int = 8):
+        self.total_gpus = total_gpus
+        self.next_gpu = 0
+
+    @property
+    def available(self) -> int:
+        return self.total_gpus - self.next_gpu
+
+    def allocate(self, num_gpus: int) -> Callable[[], None]:
+        if num_gpus > self.available:
+            raise RuntimeError(
+                f"Requested {num_gpus} GPUs but only {self.available} "
+                f"available (total={self.total_gpus}, allocated={self.next_gpu})"
+            )
+        gpu_ids = list(range(self.next_gpu, self.next_gpu + num_gpus))
+        self.next_gpu += num_gpus
+
+        def _bootstrap():
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
+
+        return _bootstrap
 
 
 class RLTrainer(Configurable):
@@ -89,45 +126,59 @@ class RLTrainer(Configurable):
 
         self.task = SumDigitsTask(seed=42)
 
-    async def setup(self):
-        """Spawn Monarch actors and initialize weights.
+    @staticmethod
+    def _compute_world_size(p: "ParallelismConfig") -> int:
+        """Compute world size from all parallel dimensions."""
+        dp_shard = max(p.data_parallel_shard_degree, 1)
+        return (
+            p.data_parallel_replicate_degree
+            * dp_shard
+            * p.tensor_parallel_degree
+            * p.pipeline_parallel_degree
+            * p.context_parallel_degree
+        )
 
-        Creates the process mesh, spawns trainer/generator/grader actors,
-        and synchronizes initial weights from trainer to generator.
+    async def setup(self):
+        """Spawn Monarch actors on separate meshes and initialize weights.
+
+        Creates separate GPU meshes for trainer and generator, a CPU mesh for
+        the grader, and synchronizes initial weights from trainer to generator.
         Must be called before :meth:`train`.
         """
         config = self.config
 
-        # Validate that trainer and generator have the same parallel plan
-        # since they are collocated on the same mesh (our strong assumption now)
-        assert config.trainer.parallelism == config.generator.parallelism, (
-            f"Trainer and generator must use the same parallel plan.\n"
-            f"  Trainer:   {config.trainer.parallelism}\n"
-            f"  VLLMGenerator: {config.generator.vllm_engine.parallelism}"
+        self.trainer_world_size = self._compute_world_size(config.trainer.parallelism)
+        self.generator_world_size = self._compute_world_size(
+            config.generator.parallelism
         )
 
-        self.trainer_world_size = (
-            config.trainer.parallelism.data_parallel_replicate_degree
-            * config.trainer.parallelism.tensor_parallel_degree
+        total_gpus = self.trainer_world_size + self.generator_world_size
+        logger.info(
+            f"{self.generator_world_size} generator GPUs + "
+            f"{self.trainer_world_size} trainer GPUs = {total_gpus} total"
         )
 
         self.system_prompt = self.task.get_system_prompt()
 
-        # Create process mesh for trainer (generator is collocated on same mesh)
-        # TODO: Make the world size according to parallel degrees
+        # Allocate non-overlapping GPU ranges for each mesh
+        provisioner = Provisioner(total_gpus=total_gpus)
+
+        # Spawn separate meshes for trainer, generator, and grader
         trainer_mesh = this_host().spawn_procs(
-            per_host={"gpus": self.trainer_world_size}
+            per_host={"gpus": self.trainer_world_size},
+            bootstrap=provisioner.allocate(self.trainer_world_size),
         )
-
-        # Set up distributed env vars so that actors are connected via c10d
-        await setup_env_for_distributed(
-            trainer_mesh,
-            master_addr="localhost",  # TODO: figure out what to set
-            master_port=29501,  # TODO: figure out what to set
+        generator_mesh = this_host().spawn_procs(
+            per_host={"gpus": self.generator_world_size},
+            bootstrap=provisioner.allocate(self.generator_world_size),
         )
+        grader_mesh = this_host().spawn_procs()
 
-        # Spawn trainer first
-        self.trainer_actor = trainer_mesh.spawn(
+        await setup_env_for_distributed(trainer_mesh)
+        await setup_env_for_distributed(generator_mesh)
+
+        # Spawn actors on their respective meshes
+        self.trainer = trainer_mesh.spawn(
             "trainer",
             PolicyTrainer,
             config.trainer,
@@ -135,22 +186,7 @@ class RLTrainer(Configurable):
             batch_invariant_mode=config.batch_invariant_mode,
             hf_assets_path=config.hf_assets_path,
         )
-
-        # Spawn grader on trainer mesh
-        self.grader = trainer_mesh.spawn(
-            "grader",
-            Grader,
-            self.task.reward_function,
-        )
-
-        # Wait for trainer to be fully initialized on all ranks then collect weights
-        initial_weight_mesh = self.trainer_actor.get_weights.call().get()
-        initial_weights = {
-            gpu: initial_weight_mesh.item(gpus=gpu)
-            for gpu in range(self.trainer_world_size)
-        }
-
-        self.generator = trainer_mesh.spawn(
+        self.generator = generator_mesh.spawn(
             "generator",
             VLLMGenerator,
             config.generator,
@@ -158,8 +194,17 @@ class RLTrainer(Configurable):
             model_path=config.hf_assets_path,
             batch_invariant_mode=config.batch_invariant_mode,
         )
+        self.grader = grader_mesh.spawn(
+            "grader",
+            Grader,
+            self.task.reward_function,
+        )
 
-        # Initialize generator with trainer weights.
+        # Trainer gathers full (unsharded) weights on every rank. We only
+        # need to collect from one rank since they're all identical.
+        initial_weights = self.trainer.get_weights.call().get().item(gpus=0)
+
+        # Initialize generator with trainer weights
         self.generator.update.call(0, initial_weights).get()
 
     async def evaluate(self, num_samples: int = 20) -> dict:
@@ -252,7 +297,7 @@ class RLTrainer(Configurable):
                 episode.expected_answer = answer
 
             # 2. Grader computes rewards per episode
-            scored_episodes = self.grader.score.call(episodes).get().item(gpus=0)
+            scored_episodes = self.grader.score.call(episodes).get().item()
 
             if self.config.log_samples:
                 for ep, question, answer in zip(
@@ -272,14 +317,9 @@ class RLTrainer(Configurable):
                     )
 
             # 3. Trainer computes advantages and updates policy
-            metrics = self.trainer_actor.step.call(scored_episodes).get().item(gpus=0)
-
-            # 4. Sync weights back to generator (all TP ranks)
-            weight_mesh = self.trainer_actor.get_weights.call().get()
-            weights = {
-                gpu: weight_mesh.item(gpus=gpu)
-                for gpu in range(self.trainer_world_size)
-            }
+            metrics = self.trainer.step.call(scored_episodes).get().item(gpus=0)
+            # 4. Sync full weights to generator (each rank reshards locally)
+            weights = self.trainer.get_weights.call().get().item(gpus=0)
             self.generator.update.call(metrics["policy_version"], weights).get()
 
             all_token_lens = [


### PR DESCRIPTION
As title - this is the schema we want to target

**What does this PR do?**
* Creates a ToyProvisioner that splits trainer and generator on different GPUs (within the same node)
* Updates the weight sync to gather full state dict
* Spawns all three actors on different meshes

**Why non-colocated?** While it's true that colocated trainer/generator is the fastest because you can drop and reload weights in the same memory, it requires smaller models and usually necessitates that the sharding strategy between trainer and generator is the same. These are significant limitations for training RL at scale, so we should pursue the harder and more realistic option: non-colocated. 

**Why do we need a ToyProvisioner?** This is truly as simple as possible. You can see a more complex provisioner system in forge but this is all we need for now. Monarch doesn't automatically stop you from allocating as many things as you want starting from rank 0, so this plugs into the mechanism to block that from happening.

**Why do you gather full state dict now?** This allows us to have different sharding patterns. The resharding is very naive but this is where torchstore will plug in soon.