### PR TITLE
[script] Print baseline losses on assert-equal failure in loss_compare.py

### DIFF
--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -801,6 +801,19 @@ def assert_losses_equal(
 
     if not result.wasSuccessful():
         log_print("Loss assertion failed!")
+        log_print()
+        log_print(
+            "Actual baseline losses (can be used to update import file if "
+            "the loss curve change is expected):"
+        )
+        log_print(
+            "Note that you should verify the loss curve change is not a "
+            "regression first!!!"
+        )
+        for step in sorted(baseline_losses.keys()):
+            loss = baseline_losses[step]
+            print(f"{step} {loss}")
+        log_print()
         sys.exit(1)
     else:
         if test_log and import_result:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2473

**Summary:**
When --assert-equal fails in loss_compare.py, the script now prints the actual baseline losses in {step} {loss} format before exiting. This saves users from having to re-launch CI with --export-result, just to see the new losses directly from the CI log to update their import file.

**Note:**
Users should only update the import file when the loss curve change is expected.