### PR TITLE
[Module relative path] Adds support for module path for configs in addition to the hardcoded supported module values

### DIFF
--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -50,9 +50,9 @@ class TestConfigManager(unittest.TestCase):
             config_manager.parse_args([])
 
     def test_invalid_model_errors(self):
-        """--module with unknown module name raises ValueError."""
+        """--module with unknown module name raises ImportError."""
         config_manager = ConfigManager()
-        with pytest.raises(ValueError, match="Unknown module"):
+        with pytest.raises(ImportError, match="Cannot import module"):
             config_manager.parse_args(["--module", "nonexistent", "--config", "foo"])
 
     def test_invalid_config_errors(self):
@@ -173,6 +173,47 @@ class TestConfigManager(unittest.TestCase):
         )
         assert config.model_spec.name == "deepseek_v3"
         assert config.model_spec.flavor == "debugmodel"
+
+    def test_fqn_module_with_config_registry(self):
+        """--module torchtitan.models.llama3.config_registry works."""
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "torchtitan.models.llama3.config_registry",
+                "--config",
+                "llama3_debugmodel",
+            ]
+        )
+        assert config.model_spec.name == "llama3"
+        assert config.model_spec.flavor == "debugmodel"
+
+    def test_fqn_module_without_config_registry(self):
+        """--module torchtitan.models.llama3 (auto-appends .config_registry)."""
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "torchtitan.models.llama3",
+                "--config",
+                "llama3_debugmodel",
+            ]
+        )
+        assert config.model_spec.name == "llama3"
+        assert config.model_spec.flavor == "debugmodel"
+
+    def test_fqn_module_invalid_errors(self):
+        """--module with invalid FQN raises ImportError."""
+        config_manager = ConfigManager()
+        with pytest.raises(ImportError, match="Cannot import module"):
+            config_manager.parse_args(
+                [
+                    "--module",
+                    "torchtitan.models.nonexistent",
+                    "--config",
+                    "foo",
+                ]
+            )
 
 
 if __name__ == "__main__":

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -95,26 +95,42 @@ class ConfigManager:
         from torchtitan.models import _supported_models
 
         all_supported = _supported_models | _supported_experiments
-        if module_name not in all_supported:
-            raise ValueError(
-                f"Unknown module '{module_name}'. "
-                f"Supported modules: {sorted(all_supported)}"
-            )
 
-        # Import config_registry module (search models first, then experiments)
         module = None
-        for prefix in ("torchtitan.models", "torchtitan.experiments"):
-            module_path = f"{prefix}.{module_name}.config_registry"
-            try:
-                module = importlib.import_module(module_path)
-                break
-            except ImportError:
-                continue
-        if module is None:
-            raise ImportError(
-                f"Cannot import config_registry for module '{module_name}' "
-                f"from torchtitan.models or torchtitan.experiments"
-            )
+        module_path = None
+
+        # Import config_registry from module based on module specification
+        if module_name in all_supported:
+            # short module from supported module list  (search models first, then experiments)
+            for prefix in ("torchtitan.models", "torchtitan.experiments"):
+                module_path = f"{prefix}.{module_name}.config_registry"
+                try:
+                    module = importlib.import_module(module_path)
+                    break
+                except ImportError:
+                    continue
+            if module is None:
+                raise ImportError(
+                    f"Cannot import config_registry for module '{module_name}' "
+                    f"from torchtitan.models or torchtitan.experiments"
+                )
+        else:
+            # Fully qualified module path: try appending .config_registry first,
+            # then fall back to importing directly (e.g., torchtitan.models.llama3
+            # -> torchtitan.models.llama3.config_registry)
+            for candidate in (f"{module_name}.config_registry", module_name):
+                try:
+                    module = importlib.import_module(candidate)
+                    module_path = candidate
+                    break
+                except ImportError:
+                    continue
+            if module is None:
+                raise ImportError(
+                    f"Cannot import module '{module_name}' or "
+                    f"'{module_name}.config_registry'. "
+                    f"For shorthands, supported modules are: {sorted(all_supported)}"
+                )
 
         # Get the config function
         config_fn = getattr(module, config_name, None)


### PR DESCRIPTION
Summary:
This change updates the `--module` argument across the codebase to use fully qualified dotted module paths (e.g., `torchtitan.experiments.simple_fsdp.llama3.config_registry`)in addition to the short model names (e.g., `simple_fsdp.llama3`).
Specificallyt adding:

```
--module llama3 search in torchtitan/models/ or torchtitan/experiments/ (today)
--module torchtitan.models.llama3.config_registry where config_registry has the target config
--module torchtitan.models.llama3 where llama3 has a config_registry.py which has the target config
```

Example usage change in `run_train.sh`:
```
# Before
MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh
```

```
# After 2 more ways
MODULE=torchtitan.models.llama3.config_registry CONFIG=llama3_debugmodel ./run_train.sh

MODULE=torchtitan.models.llama3 CONFIG=llama3_debugmodel ./run_train.sh
```

Differential Revision: D95111856


