### PR TITLE
Fix Qwen3 TP + CP composition using local_map for DTensor conversion

### DIFF
--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -12,6 +12,7 @@ import torch._inductor.config
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard
+from torch.distributed.tensor.experimental import local_map
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     parallelize_module,
@@ -40,7 +41,37 @@ from torchtitan.models.llama4.parallelize import (
 )
 from torchtitan.models.qwen3.model import Qwen3Model
 from torchtitan.protocols.model_converter import ModelConvertersContainer
+
 from torchtitan.tools.logging import logger
+
+
+class _LocalMapInnerAttention(nn.Module):
+    """Wraps inner_attention with local_map for TP + CP composition.
+
+    When TP uses use_local_output=False, q/k/v arrive at inner_attention as
+    DTensors on the TP mesh (Shard on heads dim). The CP hooks expect plain
+    tensors. This wrapper uses local_map to properly convert DTensors to local
+    tensors (with correct grad_placements for backward) before calling the
+    wrapped module (which has CP hooks), and wraps the output back to DTensor.
+    """
+
+    def __init__(self, inner_attn: nn.Module, tp_mesh: DeviceMesh):
+        super().__init__()
+        self._inner = inner_attn
+        # q, k, v are sharded on heads dim (dim=1 after transpose in GQAttention)
+        # Each PlacementType is a Sequence[Placement], e.g. (Shard(1),)
+        shard_heads = (Shard(1),)
+        self._local_map_fn = local_map(
+            inner_attn,
+            # Single output: wrap in tuple so local_map sees Tuple[PlacementType]
+            out_placements=(shard_heads,),
+            in_placements=(shard_heads, shard_heads, shard_heads),
+            in_grad_placements=(shard_heads, shard_heads, shard_heads),
+            device_mesh=tp_mesh,
+        )
+
+    def forward(self, *args, **kwargs):
+        return self._local_map_fn(*args, **kwargs)
 
 
 # for selective op activation checkpointing
@@ -138,6 +169,20 @@ def parallelize_qwen3(
             parallel_dims.get_mesh("cp"),
             attn_backend,
         )
+
+    # When both TP and CP are enabled, wrap inner_attention with local_map
+    # to properly handle DTensor <-> local tensor conversion at the TP/CP
+    # boundary. TP's use_local_output=False produces DTensor q/k/v, but CP
+    # hooks expect plain tensors. local_map handles this with correct
+    # grad_placements for backward pass.
+    if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+        tp_mesh = parallel_dims.get_mesh("tp")
+        # pyrefly: ignore [missing-attribute, not-callable]
+        for block in model.layers.values():
+            attn = block.attention  # pyrefly: ignore [missing-attribute]
+            attn.inner_attention = _LocalMapInnerAttention(
+                attn.inner_attention, tp_mesh
+            )
 
     if ac_config.mode != "none":
         apply_ac(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #2481

Use local_map to properly handle DTensor <-> local tensor conversion at
the TP/CP boundary instead of raw .to_local() calls. This ensures
correct grad_placements for backward pass.