### PR TITLE
[RL] Some cleanups around `hf_assets_path`

### DIFF
--- a/torchtitan/experiments/rl/unified/README.md
+++ b/torchtitan/experiments/rl/unified/README.md
@@ -56,8 +56,11 @@ torchrun --nproc_per_node=2 torchtitan/experiments/rl/unified/inference_example.
 
 6. Run simple GRPO RL loop
 ```bash
-python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b --hf_assets_path=<path_to_model_checkpoint>
+python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b
 ```
+
+**NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
+
 We use a unified model definition for the trainer and generator, ensuring bitwise-identical models to address a class of subtle correctness bugs in RL for LLMs.
 
 ## TODO

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -63,8 +63,6 @@ class PolicyTrainer(Actor, Configurable):
         parallelism: ParallelismConfig = field(default_factory=ParallelismConfig)
         comm: CommConfig = field(default_factory=CommConfig)
         """Communication configuration for distributed initialization."""
-        hf_assets_path: str = ""
-        """Path to the HF model checkpoint for initial weight loading."""
 
     def __init__(
         self,

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -27,7 +27,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-0.6B."""
     return RLTrainer.Config(
         model_spec=model_registry("0.6B"),
-        hf_assets_path="/data/users/jianiw/model/qwen3-0.6b",
+        hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
         num_steps=10,
         batch_invariant_mode=True,
         trainer=PolicyTrainer.Config(
@@ -44,7 +44,6 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
             ),
-            hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",


### PR DESCRIPTION
* The `hf_assets_path` arg on the PolicyTrainer config was not used; removing
* In the config_registry `hf_assets_path` on the RLTrainer config was set to `/data/users/jianiw/model/qwen3-0.6b`; changing to set it to the path in the README (`torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B`)
* In the README remove `--hf_assets_path=<path_to_model_checkpoint>` from the command in step 6 to reduce some friction for the user having to find the correct path; in step 4 we tell the user in which path to store the checkpoint. Include a note in case someone wants to store the checkpoint in a different path