### PR TITLE
[RL] Turn on vllm `support_torch_compile` in RL speeding up training

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -7,6 +7,7 @@
 import logging
 import os
 from dataclasses import dataclass, field
+from typing import Literal
 
 import torch
 from monarch.actor import Actor, endpoint
@@ -20,12 +21,71 @@ from torchtitan.experiments.rl.unified.plugin import (
 from torchtitan.experiments.rl.unified.types import Episode
 from torchtitan.protocols.model_spec import ModelSpec
 from vllm import EngineArgs, LLMEngine, SamplingParams
-from vllm.config import AttentionConfig
+from vllm.config import AttentionConfig, CompilationConfig
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True, slots=True)
+class GeneratorCompileConfig:
+    """Compilation and CUDA graph settings for the vLLM generator."""
+
+    backend: Literal["none", "eager", "inductor"] = "eager"
+    """torch.compile backend for vLLM
+    When set to a value other than "none", enables compilation with the specified backend.
+    See https://docs.vllm.ai/en/stable/api/vllm/config/#vllm.config.CompilationConfig.backend
+    NOTE: "eager" means compile with dynamo backend (like torch.compile(backend="eager"))
+    NOTE: inductor will offer the best performance, but will impact numerics - use eager for
+    bitwise identical results."""
+
+    cudagraph_mode: Literal[
+        "none", "piecewise", "full", "full_and_piecewise"
+    ] = "piecewise"
+    """CUDA graph capture mode for vLLM.
+    Piecewise capture supports dynamic sizes and splits cudagraphs around non capturable
+      ops like attention
+    Full capture captures one graph at the expense of less dynamism and requires full
+      capturability
+    full_and_piecewise does both and selects which to use based on dynamism
+    NOTE: Piecewise graph capture requires torch.compile for graph capture and splitting
+    See https://docs.vllm.ai/en/latest/design/cuda_graphs/#cudagraphmodes for more details."""
+
+    def __post_init__(self) -> None:
+        if self.backend == "none" and self.cudagraph_mode in (
+            "piecewise",
+            "full_and_piecewise",
+        ):
+            raise ValueError(
+                f"cudagraph_mode='{self.cudagraph_mode}' requires piecewise graph "
+                "capture which depends on torch.compile. Set backend "
+                "to 'eager' or 'inductor'."
+            )
+
+    @property
+    def is_eager(self) -> bool:
+        """Inferred from backend and cudagraph_mode."""
+        return self.backend == "none" and self.cudagraph_mode == "none"
+
+    def get_vllm_compilation_config(self) -> CompilationConfig | None:
+        """Build a vLLM ``CompilationConfig``, or return ``None`` when both
+        compilation and CUDA graphs are disabled.
+        """
+        if self.is_eager:
+            return None
+
+        kwargs: dict = dict(cudagraph_mode=self.cudagraph_mode)
+        if self.backend == "none":
+            # Disable torch.compile but keep CUDA graphs (e.g. full mode).
+            # mode=0 (CompilationMode.NONE) prevents vLLM from inferring
+            # VLLM_COMPILE based on the default optimization level.
+            kwargs["mode"] = 0
+        else:
+            kwargs["backend"] = self.backend
+
+        return CompilationConfig(**kwargs)
 
 
 @dataclass(kw_only=True, slots=True)
@@ -79,8 +139,8 @@ class VLLMGenerator(Actor, Configurable):
         gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
-        enforce_eager: bool = True
-        """Disable CUDA graphs in vLLM (use eager execution)."""
+        compile: GeneratorCompileConfig = field(default_factory=GeneratorCompileConfig)
+        """Compilation and CUDA graph settings for the vLLM engine."""
 
         num_samples_per_prompt: int = 8
         """Number of completions to generate per prompt."""
@@ -135,14 +195,16 @@ class VLLMGenerator(Actor, Configurable):
             # tells vLLM to run one worker per process (no subprocess spawning)
             distributed_executor_backend="external_launcher",
             gpu_memory_utilization=config.gpu_memory_limit,
-            enforce_eager=config.enforce_eager,
-            # Disable vLLM logging to avoid noisy logs on every step
-            disable_log_stats=True,
+            enforce_eager=config.compile.is_eager,
             hf_overrides={"architectures": [VLLM_MODEL_NAME]},
             attention_config=AttentionConfig(
                 backend=AttentionBackendEnum[config.attention_backend],
             ),
+            disable_log_stats=True,
         )
+        vllm_compilation_config = config.compile.get_vllm_compilation_config()
+        if vllm_compilation_config is not None:
+            engine_kwargs["compilation_config"] = vllm_compilation_config
         if config.seed is not None:
             engine_kwargs["seed"] = config.seed
         engine_args = EngineArgs(**engine_kwargs)

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -15,6 +15,7 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config.configs import ParallelismConfig, TrainingConfig
 from torchtitan.experiments.rl.unified.actors.generator import (
+    GeneratorCompileConfig,
     SamplingConfig,
     VLLMGenerator,
 )
@@ -43,7 +44,10 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
-            enforce_eager=True,
+            compile=GeneratorCompileConfig(
+                backend="eager",
+                cudagraph_mode="piecewise",
+            ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
@@ -78,7 +82,10 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
             ),
         ),
         generator=VLLMGenerator.Config(
-            enforce_eager=True,
+            compile=GeneratorCompileConfig(
+                backend="eager",
+                cudagraph_mode="piecewise",
+            ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,

--- a/torchtitan/experiments/rl/unified/inference_example.py
+++ b/torchtitan/experiments/rl/unified/inference_example.py
@@ -11,7 +11,7 @@ Example inference script using TorchTitan models with vLLM LLMEngine.
 This script uses the RL unified config_registry to configure both
 the vLLM engine and sampling parameters.
 
-Run: torchrun --nproc_per_node=<world_size> \
+Run: torchrun --nproc_per_node=2 \
       torchtitan/experiments/rl/unified/infer.py
 """
 import os
@@ -70,10 +70,13 @@ def generate():
         distributed_executor_backend=("external_launcher"),
         # Memory and performance
         gpu_memory_utilization=gen_config.gpu_memory_limit,
-        enforce_eager=gen_config.enforce_eager,
+        enforce_eager=gen_config.compile.is_eager,
         # HuggingFace overrides
         hf_overrides={"architectures": [VLLM_MODEL_NAME]},
     )
+    vllm_compilation_config = gen_config.compile.get_vllm_compilation_config()
+    if vllm_compilation_config is not None:
+        engine_kwargs["compilation_config"] = vllm_compilation_config
     if gen_config.seed is not None:
         engine_kwargs["seed"] = gen_config.seed
     engine_args = EngineArgs(**engine_kwargs)

--- a/torchtitan/experiments/rl/unified/models/attention.py
+++ b/torchtitan/experiments/rl/unified/models/attention.py
@@ -89,6 +89,11 @@ class VLLMAttention(torch.nn.Module):
         Returns:
             ``(batch, num_heads, seq_len, head_dim)``
         """
+        # Capture the original symbolic seq_len from the input BEFORE
+        # to_local() so that the symbol is the same one GQAttention uses
+        # in its .view(bs, seqlen, -1) call.
+        batch_size, _, seq_len, head_dim = q.shape
+
         # Unwrap DTensor inputs to local tensors for attention computation
         device_mesh = None
         placements = None
@@ -99,33 +104,28 @@ class VLLMAttention(torch.nn.Module):
             k = k.to_local()
             v = v.to_local()
 
-        # Input is (batch, num_heads, seq_len, head_dim)
         # TODO: may be good to use einops in future as we can explicitly reshape
         # with dimension names - see https://github.com/arogozhnikov/einops
-        batch_size, num_heads, seq_len, head_dim = q.shape
-        _, num_kv_heads, _, _ = k.shape
+        # Convert from (batch, num_heads, seq_len, head_dim)
+        #   to (batch*seq_len, num_heads (or num_kv_heads), head_dim) for vLLM Attn
+        q = q.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
+        k = k.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
+        v = v.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
 
-        # Transpose to (batch, seq_len, num_heads, head_dim) for vLLM
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-
-        # TODO: reimplement as a 4d tensor once vLLM fix has landed
-        # Then flatten batch and seq_len: (batch * seq_len, num_heads, head_dim)
-        q = q.reshape(batch_size * seq_len, num_heads, head_dim)
-        k = k.reshape(batch_size * seq_len, num_kv_heads, head_dim)
-        v = v.reshape(batch_size * seq_len, num_kv_heads, head_dim)
-
-        # vLLM attention returns (num_tokens, hidden_size) where hidden_size = num_heads * head_dim
+        # vLLM attention returns (num_tokens, num_heads/num_kv_heads * head_dim)
         output_flat = self.vllm_attn(q, k, v)
 
-        # Output is (batch * seq_len, num_heads * head_dim), reshape to (batch, seq_len, num_heads, head_dim)
-        output = output_flat.view(batch_size, seq_len, num_heads, head_dim)
+        # vLLM's flash attention backend may pad the token count (e.g.
+        # round up to an even number), which introduces a new symbolic
+        # shape under torch.compile.  Narrow to trim this padding
+        # NOTE: this error only happens when batch_size and seq_len are 1
+        # which happens with cudagraph capture for dummy input
+        output_flat = output_flat.narrow(0, 0, batch_size * seq_len)
 
-        # Transpose back to TorchTitan format: (batch, num_heads, seq_len, head_dim)
+        # Reshape back to titan: (batch, num_heads_local, seq_len, head_dim)
+        output = output_flat.view(batch_size, seq_len, -1, head_dim)
         output = output.transpose(1, 2)
 
-        # Wrap output back as DTensor if inputs were DTensors
         if device_mesh is not None:
             output = DTensor.from_local(
                 output, device_mesh=device_mesh, placements=placements

--- a/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
@@ -29,12 +29,31 @@ from torchtitan.experiments.rl.unified.models.attention import (
     replace_with_vllm_attention,
 )
 from torchtitan.protocols.model_spec import ModelSpec
-
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.utils import torch_utils as _torch_utils
 
 
 logger = init_logger(__name__)
+
+# NOTE: Monkeypatch vLLM's weak_ref_tensor to handle DTensor
+# This is because piecewise CUDA-graph capture calls weak_ref_tensor()
+# on every subgraphoutput (see vllm/compilation/cuda_graph.py).
+# When TP is active some of those outputs are DTensors which fail with
+# ("The specified pointer resides on host memory").  to_local
+# converts the DTensor to a plain tensor. which succeeds with this
+# cudagraph implementation.
+_original_weak_ref_tensor = _torch_utils.weak_ref_tensor
+
+
+def _dtensor_safe_weak_ref_tensor(tensor):
+    if isinstance(tensor, DTensor):
+        tensor = tensor._local_tensor
+    return _original_weak_ref_tensor(tensor)
+
+
+_torch_utils.weak_ref_tensor = _dtensor_safe_weak_ref_tensor
 
 
 def create_torchtitan_config_from_vllm_config(
@@ -93,6 +112,12 @@ def create_torchtitan_config_from_vllm_config(
     return parallel_dims, parallelism
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+    }
+)
 class TorchTitanVLLMModelWrapper(nn.Module):
     """
     Generic vLLM-compatible model wrapper for TorchTitan models. Implemented
@@ -158,28 +183,32 @@ class TorchTitanVLLMModelWrapper(nn.Module):
             has_position_id=True,  # vLLM always passes positions explicitly
         )
 
+        # Pre-extend RoPE cache to cover vLLM's max model length (profiling
+        # may use up to 2x max_seq_len, so use max_model_len which already
+        # accounts for this).  This avoids data-dependent control flow in
+        # forward() which is incompatible with torch.compile.
+        max_model_len = vllm_config.model_config.max_model_len
+        if self.model.freqs_cis.shape[0] < max_model_len:
+            self.model.freqs_cis = self._extend_rope_cache(
+                self.model.freqs_cis, max_model_len
+            )
+
         # Initial load model weights from HuggingFace checkpoint path
         self._initial_load_weights(checkpoint_path=vllm_config.model_config.model)
 
-    def _extend_rope_cache_if_needed(
-        self, rope_cache: torch.Tensor, max_position: int
+    def _extend_rope_cache(
+        self, rope_cache: torch.Tensor, required_len: int
     ) -> torch.Tensor:
         """
-        Extend RoPE cache if needed during vLLM profiling stage.
+        Build an extended RoPE cache of at least ``required_len`` positions.
 
         Args:
             rope_cache: Current RoPE cache tensor
-            max_position: Maximum position index needed
+            required_len: Minimum number of positions the cache must cover
 
         Returns:
-            Extended RoPE cache if needed, otherwise original cache
+            Extended RoPE cache tensor
         """
-        required_len = max_position + 1
-
-        # No extension needed
-        if required_len <= rope_cache.shape[0]:
-            return rope_cache
-
         # Handle DTensor case
         is_dtensor = isinstance(rope_cache, DTensor)
         if is_dtensor:
@@ -253,15 +282,7 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         # Get embeddings
         h = self.model.tok_embeddings(tokens_2d)
 
-        # Extend RoPE cache if needed (vLLM profiling may use 2x max_seq_len)
-        if positions is not None:
-            max_position = positions.max().item()
-        else:
-            max_position = 0
-
-        rope_cache = self._extend_rope_cache_if_needed(
-            self.model.freqs_cis, max_position
-        )
+        rope_cache = self.model.freqs_cis
         positions = positions.unsqueeze(0)
 
         # Pass through transformer layers
@@ -275,9 +296,8 @@ class TorchTitanVLLMModelWrapper(nn.Module):
 
         # Convert to vLLM format: [total_tokens, hidden_size]
         if h.dim() == 3:
-            batch_size, seq_len, hidden_size = h.shape
-            h = h.view(batch_size * seq_len, hidden_size)
-
+            hidden_size = h.size(-1)
+            h = h.view(-1, hidden_size)
         return h
 
     def compute_logits(


### PR DESCRIPTION
## Summary

Implements the changes necessary for vllm enablement.  These are:
* Support weak_ref capture of DTensors in vLLM required for cudagraph
* Rewrite vllm_wrapper to avoid graph break (extending rope cache, .max().item())
* Rewrite attention for simplicity (fold reshape operations)
* Narrow output of vLLM Attention for correct symbolic shape propogation (can be resolved with https://github.com/pytorch/pytorch/issues/175690 fix but not clear the scope/necessity due to dropping guards in vLLM)

For more context, this is a reimplementation of https://github.com/pytorch/torchtitan/pull/2393 post rebase

We then test with **eager backend (dynamo/torch compile) and piecewise cudagraphs** and verify there is no numeric difference.  We observe ~1.85x speedup end to end, and 15x speedup in generator time.  That said, there is additional overhead (~50s) of compiling and capturing cudagraphs, but considering we save ~200s in runtime, the net benefit is ~150s or 3 minutes

## Test 
Running
```bash
python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```
with simple instrumentation for timing (just wrapping call() in grpo with perf counters) 
                                         
  ### Startup                                                                                                                                                                
                                                                                                                                                                             
  |                          | Baseline (eager) | Compile+CUDAGraph | Delta    |                                                                                             
  |--------------------------|------------------|-------------------|----------|                                                                                             
  | Generator init + sync    | 10.21s           | 60.92s            | +50.71s  |

  Compile overhead: torch.compile 16.35s + CUDA graph capture 33s

  ### Per-Step Comparison

  | Step | Generate (eager) | Generate (compile eager + piecwise) | Speedup | Logprob diff match? |
  |------|------------------|--------------------|---------|---------------------|
  | 0    | 24.09s           | 2.95s              | **8.2x** | Yes (mean=7.30e-06, max=2.19e-01) |
  | 1    | 23.08s           | 1.39s              | **16.6x** | Yes (mean=-1.41e-03, max=2.43e-01) |
  | 2    | 24.03s           | 1.44s              | **16.7x** | Yes (mean=-2.31e-03, max=6.65e-01) |
  | 3    | 23.96s           | 1.48s              | **16.2x** | Yes (mean=-1.51e-03, max=9.60e-01) |
  | 4    | 25.58s           | 1.40s              | **18.3x** | Yes (mean=-3.98e-03, max=1.17e+00) |
  | 5    | 24.16s           | 1.35s              | **17.9x** | Yes (mean=-8.51e-03, max=2.32e+00) |
  | 6    | 24.69s           | 1.25s              | **19.8x** | Yes (mean=-4.18e-03, max=2.08e+00) |
  | 7    | 22.53s           | 1.39s              | **16.2x** | Yes (mean=-7.42e-03, max=1.74e+00) |
  | 8    | 23.51s           | 1.54s              | **15.3x** | Yes (mean=-5.23e-03, max=2.25e+00) |
  | 9    | 24.39s           | 1.67s              | **14.6x** | Yes (mean=-8.91e-03, max=2.10e+00) |

  ### Totals

  |              | Baseline | Compile+CUDAGraph | Speedup |
  |--------------|----------|--------------------|---------|
  | Generate     | 240.03s  | 15.87s             | **15.1x** |
  | Train        | 151.02s  | 152.50s            | ~1.0x   |
  | Sync         | 88.66s   | 93.26s             | ~1.0x   |
  | **Total**    | **479.87s** | **261.71s**     | **1.83x** |

  Loss, reward, and logprob diffs are **identical** across all steps -- compile+cudagraph is numerically equivalent