### PR TITLE
Temporarily disable CPU offload CI tests to unblock

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -45,7 +45,7 @@ jobs:
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 60
+      timeout: 45
       script: |
         set -eux
 

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -528,27 +528,28 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=4,
             skip_rocm_test=True,
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module llama3 --config llama3_debugmodel_opt_in_bwd",
-                    "--checkpoint.enable",
-                    "--parallelism.tensor_parallel_degree=2",
-                    "--parallelism.context_parallel_degree=2",
-                    "--training.enable_cpu_offload",
-                ],
-                [
-                    "--module llama3 --config llama3_debugmodel_opt_in_bwd",
-                    "--parallelism.tensor_parallel_degree=2",
-                    "--parallelism.context_parallel_degree=2",
-                    "--parallelism.data_parallel_replicate_degree=2",
-                    "--training.enable_cpu_offload",
-                ],
-            ],
-            "Enable CPU Offload, Optimizer in backward with TP, DP, CP",
-            "cpu_offload+opt_in_bwd+TP+DP+CP",
-            ngpu=8,
-        ),
+        # NOTE: temporarily disable due to test hanging in CI
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--module llama3 --config llama3_debugmodel_opt_in_bwd",
+        #             "--checkpoint.enable",
+        #             "--parallelism.tensor_parallel_degree=2",
+        #             "--parallelism.context_parallel_degree=2",
+        #             "--training.enable_cpu_offload",
+        #         ],
+        #         [
+        #             "--module llama3 --config llama3_debugmodel_opt_in_bwd",
+        #             "--parallelism.tensor_parallel_degree=2",
+        #             "--parallelism.context_parallel_degree=2",
+        #             "--parallelism.data_parallel_replicate_degree=2",
+        #             "--training.enable_cpu_offload",
+        #         ],
+        #     ],
+        #     "Enable CPU Offload, Optimizer in backward with TP, DP, CP",
+        #     "cpu_offload+opt_in_bwd+TP+DP+CP",
+        #     ngpu=8,
+        # ),
         OverrideDefinitions(
             [
                 [


### PR DESCRIPTION
- "Enable CPU Offload, Optimizer in backward with TP, DP, CP" test takes ~19mins. Even if I change the timeout time to be 60min, the CI timeout on the same test.
<img width="2174" height="690" alt="image" src="https://github.com/user-attachments/assets/e6c935d5-f8cb-4622-b1fc-b797d30756a4" />
