### PR TITLE
Add stable CI entrypoint for PyTorch CI

### DIFF
--- a/scripts/ci/pytorch_ci_test_runner.sh
+++ b/scripts/ci/pytorch_ci_test_runner.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Stable entrypoint for PyTorch CI to run torchtitan integration tests.
+# PyTorch CI calls this script so that torchtitan maintainers can adjust
+# test configuration without modifying the PyTorch repo.
+
+set -euo pipefail
+
+OUTPUT_DIR="${OUTPUT_DIR:-artifacts-to-be-uploaded}"
+NGPU="${NGPU:-8}"
+
+usage() {
+    echo "Usage: $0 <command>"
+    echo ""
+    echo "Commands:"
+    echo "  feature_tests   Run feature integration tests"
+    echo "  model_tests     Run model integration tests"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+COMMAND="$1"
+shift
+
+case "$COMMAND" in
+    feature_tests)
+        python -m tests.integration_tests.run_tests \
+            --test_suite features \
+            --exclude "cpu_offload+opt_in_bwd+TP+DP+CP" \
+            --ngpu "$NGPU" \
+            "$OUTPUT_DIR"
+        ;;
+    model_tests)
+        python -m tests.integration_tests.run_tests \
+            --test_suite models \
+            --ngpu "$NGPU" \
+            "$OUTPUT_DIR"
+        ;;
+    *)
+        echo "Unknown command: $COMMAND"
+        usage
+        ;;
+esac

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -78,13 +78,17 @@ def run_single_test(
 def run_tests(args, test_list: list[OverrideDefinitions], module=None, config=None):
     """Run all integration tests to test the core features of TorchTitan"""
 
+    exclude_set = set()
+    if hasattr(args, "exclude") and args.exclude:
+        exclude_set = {name.strip() for name in args.exclude.split(",")}
+
     ran_any_test = False
     for test_flavor in test_list:
         # Filter by test_name if specified
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
             continue
 
-        if test_flavor.disabled:
+        if test_flavor.disabled or test_flavor.test_name in exclude_set:
             continue
 
         # Skip the test for ROCm
@@ -154,6 +158,11 @@ def main():
     )
     parser.add_argument(
         "--ngpu", default=8, type=int, help="Maximum number of GPUs to use"
+    )
+    parser.add_argument(
+        "--exclude",
+        default=None,
+        help="Comma-separated list of test names to skip",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2492

Add an --exclude flag to run_tests.py and a scripts/ci/pytorch_ci_test_runner.sh
script that PyTorch CI calls. This lets torchtitan maintainers control which
tests run (and which are excluded) without modifying PyTorch CI configuration.

Authored with Claude.