### PR TITLE
[RL] Fix vLLM wrapper crash with configurable Embedding

### DIFF
--- a/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
@@ -129,7 +129,7 @@ class TorchTitanVLLMModelWrapper(nn.Module):
 
         # Use TorchTitan model config directly (no HF config mapping)
         self.config = model_spec.model
-        logger.debug(f"Creating model with config: {self.config}")
+        logger.debug(f"Creating model with config: {self.config.to_dict()}")
 
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()


### PR DESCRIPTION
After https://github.com/pytorch/torchtitan/pull/2428/ RL training is hanging on main; with a try-except the error is revealed to be `AttributeError: 'Config' object has no attribute 'num_embeddings'`

The root cause is the logger.debug line in `vllm_wrapper.py` calls repr() on the model config, which fails because Embedding.Config has `field(init=False)` slots (num_embeddings, embedding_dim) that aren't set until build() time. Calling `config.to_dict()` instead of `repr()` safely skips unset fields, and resolves the hang.