### PR TITLE
[RL] Load weights in trainer with `strict=True`

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -154,7 +154,7 @@ class PolicyTrainer(Actor, Configurable):
         set_model_state_dict(
             model=model,
             model_state_dict=torchtitan_state_dict,
-            options=StateDictOptions(strict=False),
+            options=StateDictOptions(strict=True),
         )
         logger.info(
             f"Loaded initial weights from {checkpoint_path} "


### PR DESCRIPTION
Pass `strict=True` to `set_model_state_dict` since this doesn't error and is safer for the future