### PR TITLE
[Just Test][ROCm] Switch CI runners from MI300X (gfx942) to MI355X (gfx950)

### DIFF
--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      runner-rocm: linux.rocm.gpu.gfx950.8
+      runner-rocm: linux.rocm.gpu.gfx950.4
       runner-cuda: linux.aws.h100.8
 
   # Step 2: Use the dynamic matrix in the build-test job

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      runner-rocm: linux.rocm.gpu.gfx942.8
+      runner-rocm: linux.rocm.gpu.gfx950.8
       runner-cuda: linux.aws.h100.8
 
   # Step 2: Use the dynamic matrix in the build-test job

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runner-rocm:
-        description: 'Override default (linux.rocm.gpu.gfx950.8) ROCm runner label'
+        description: 'Override default (linux.rocm.gpu.gfx950.4) ROCm runner label'
         required: false
         type: string
       runner-cuda:
@@ -29,7 +29,7 @@ jobs:
       TRIGGERED_8GPU_LABEL: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
 
       # Default CUDA & ROCm runners
-      DEFAULT_ROCM_RUNNER: linux.rocm.gpu.gfx950.8
+      DEFAULT_ROCM_RUNNER: linux.rocm.gpu.gfx950.4
       DEFAULT_CUDA_RUNNER: linux.g5.48xlarge.nvidia.gpu
 
       # Input CUDA & ROCm runners

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runner-rocm:
-        description: 'Override default (linux.rocm.gpu.gfx942.8) ROCm runner label'
+        description: 'Override default (linux.rocm.gpu.gfx950.8) ROCm runner label'
         required: false
         type: string
       runner-cuda:
@@ -29,7 +29,7 @@ jobs:
       TRIGGERED_8GPU_LABEL: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
 
       # Default CUDA & ROCm runners
-      DEFAULT_ROCM_RUNNER: linux.rocm.gpu.gfx942.8
+      DEFAULT_ROCM_RUNNER: linux.rocm.gpu.gfx950.8
       DEFAULT_CUDA_RUNNER: linux.g5.48xlarge.nvidia.gpu
 
       # Input CUDA & ROCm runners


### PR DESCRIPTION
## Summary
- Switch ROCm CI runner label from `linux.rocm.gpu.gfx942.8` to `linux.rocm.gpu.gfx950.8`
- The gfx942 (MI300X) 8-GPU runner pool has been offline since ~Mar 4, causing all ROCm CI jobs to be permanently stuck in QUEUED state across every PR
- The gfx950 (MI355X) runners align with pytorch/pytorch's trunk CI, which has already migrated to gfx950

## Test plan
- [ ] Verify that ROCm CI jobs get picked up by gfx950 runners instead of being stuck in queue
- [ ] Confirm ROCm integration tests pass on MI355X hardware