### PR TITLE
[DRAFT][Not4Review] vLLM Native support

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -7,6 +7,7 @@
 import logging
 import os
 from dataclasses import dataclass, field
+from typing import Literal
 
 import torch
 from monarch.actor import Actor, endpoint
@@ -20,12 +21,60 @@ from torchtitan.experiments.rl.unified.plugin import (
 from torchtitan.experiments.rl.unified.types import Episode
 from torchtitan.protocols.model_spec import ModelSpec
 from vllm import EngineArgs, LLMEngine, SamplingParams
-from vllm.config import AttentionConfig
+from vllm.config import AttentionConfig, CompilationConfig
 from vllm.model_executor.layers.batch_invariant import init_batch_invariance
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True, slots=True)
+class GeneratorCompileConfig:
+    """Compilation and CUDA graph settings for the vLLM generator."""
+
+    backend: Literal["none", "eager", "inductor"] = "eager"
+    """torch.compile backend for vLLM
+    When set to a value other than "none", enables compilation with the specified backend.
+    See https://docs.vllm.ai/en/stable/api/vllm/config/#vllm.config.CompilationConfig.backend
+    NOTE: "eager" means compile with dynamo backend (like torch.compile(backend="eager"))
+    NOTE: inductor will offer the best performance, but will impact numerics - use eager for
+    bitwise identical results."""
+
+    cudagraph_mode: Literal[
+        "none", "piecewise", "full", "full_and_piecewise"
+    ] = "piecewise"
+    """CUDA graph capture mode for vLLM.
+    NOTE: Piecewise graph capture requires torch.compile for graph capture and splitting
+    See https://docs.vllm.ai/en/latest/design/v1/torch_compile.html#cuda-graph for more details."""
+
+    def __post_init__(self) -> None:
+        if self.backend == "none" and self.cudagraph_mode in (
+            "piecewise",
+            "full_and_piecewise",
+        ):
+            raise ValueError(
+                f"cudagraph_mode='{self.cudagraph_mode}' requires piecewise graph "
+                "capture which depends on torch.compile. Set backend "
+                "to 'eager' or 'inductor'."
+            )
+
+    @property
+    def is_eager(self) -> bool:
+        """Inferred from backend and cudagraph_mode."""
+        return self.backend == "none" and self.cudagraph_mode == "none"
+
+    def get_vllm_compilation_config(self) -> CompilationConfig | None:
+        """Build a vLLM ``CompilationConfig``, or return ``None`` when both
+        compilation and CUDA graphs are disabled.
+        """
+        if self.is_eager:
+            return None
+
+        return CompilationConfig(
+            backend=self.backend,
+            cudagraph_mode=self.cudagraph_mode,
+        )
 
 
 @dataclass(kw_only=True, slots=True)
@@ -79,8 +128,8 @@ class VLLMGenerator(Actor, Configurable):
         gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
-        enforce_eager: bool = True
-        """Disable CUDA graphs in vLLM (use eager execution)."""
+        compile: GeneratorCompileConfig = field(default_factory=GeneratorCompileConfig)
+        """Compilation and CUDA graph settings for the vLLM engine."""
 
         num_samples_per_prompt: int = 8
         """Number of completions to generate per prompt."""
@@ -135,14 +184,16 @@ class VLLMGenerator(Actor, Configurable):
             # tells vLLM to run one worker per process (no subprocess spawning)
             distributed_executor_backend="external_launcher",
             gpu_memory_utilization=config.gpu_memory_limit,
-            enforce_eager=config.enforce_eager,
-            # Disable vLLM logging to avoid noisy logs on every step
-            disable_log_stats=True,
+            enforce_eager=config.compile.is_eager,
             hf_overrides={"architectures": [VLLM_MODEL_NAME]},
             attention_config=AttentionConfig(
                 backend=AttentionBackendEnum[config.attention_backend],
             ),
+            disable_log_stats=True,
         )
+        vllm_compilation_config = config.compile.get_vllm_compilation_config()
+        if vllm_compilation_config is not None:
+            engine_kwargs["compilation_config"] = vllm_compilation_config
         if config.seed is not None:
             engine_kwargs["seed"] = config.seed
         engine_args = EngineArgs(**engine_kwargs)

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -137,6 +137,12 @@ class VLLMGenerator(Actor, Configurable):
         seed: int | None = None
         """Random seed for vLLM engine and sampling. None for non-deterministic."""
 
+        use_native_vllm_model: bool = False
+        """When True, use vLLM's own native model (e.g. Qwen3ForCausalLM) instead
+        of wrapping the torchtitan model. Weight sync reconstructs full tensors
+        from the trainer's TP shards and converts names to HF format so that
+        vLLM's ``load_weights()`` can re-shard them natively."""
+
         def __post_init__(self):
             assert self.parallelism.data_parallel_shard_degree in (1, -1), (
                 f"Generator does not support data parallel sharding, "
@@ -157,9 +163,11 @@ class VLLMGenerator(Actor, Configurable):
     ):
         self.config = config
         self.model_spec = model_spec
+        self.use_native_vllm_model = config.use_native_vllm_model
 
-        # Register TorchTitan model with vLLM before any engine creation
-        register_model_to_vllm_model_registry(model_spec)
+        if not self.use_native_vllm_model:
+            # Register TorchTitan model with vLLM before any engine creation
+            register_model_to_vllm_model_registry(model_spec)
 
         # Set vLLM environment variables from config before any vLLM initialization
         os.environ["VLLM_ATTENTION_BACKEND"] = config.attention_backend
@@ -185,12 +193,14 @@ class VLLMGenerator(Actor, Configurable):
             distributed_executor_backend="external_launcher",
             gpu_memory_utilization=config.gpu_memory_limit,
             enforce_eager=config.compile.is_eager,
-            hf_overrides={"architectures": [VLLM_MODEL_NAME]},
             attention_config=AttentionConfig(
                 backend=AttentionBackendEnum[config.attention_backend],
             ),
             disable_log_stats=True,
         )
+        if not self.use_native_vllm_model:
+            # Override architecture so vLLM loads our TorchTitan wrapper model
+            engine_kwargs["hf_overrides"] = {"architectures": [VLLM_MODEL_NAME]}
         vllm_compilation_config = config.compile.get_vllm_compilation_config()
         if vllm_compilation_config is not None:
             engine_kwargs["compilation_config"] = vllm_compilation_config
@@ -286,7 +296,41 @@ class VLLMGenerator(Actor, Configurable):
             version: New policy version number
             state_dict: Full (unsharded) state dict with plain tensors.
         """
-        # Reshard full tensors to match this generator's DTensor layout
+        if self.use_native_vllm_model:
+            self._update_native(version, state_dict)
+        else:
+            self._update_wrapper(version, state_dict)
+
+    def _update_native(self, version: int, state_dict: dict) -> None:
+        """Weight update path for native vLLM model.
+
+        Converts torchtitan parameter names to HF format and calls vLLM's
+        ``load_weights()`` which handles sharding internally.  The incoming
+        ``state_dict`` already contains full (unsharded) tensors produced by
+        ``get_weights()`` in the trainer.
+        """
+        from torchtitan.experiments.rl.unified.models.native_vllm_weights import (
+            convert_to_hf,
+        )
+
+        hf_weights = convert_to_hf(state_dict)
+        self._get_model().load_weights(hf_weights)
+        self.policy_version = version
+        logger.debug(
+            f"Updated native vLLM model weights. "
+            f"Number of weight entries: {len(hf_weights)}. "
+            f"{os.getpid()=} Generator updating weights to policy v{version}..."
+        )
+
+    def _update_wrapper(self, version: int, state_dict: dict) -> None:
+        """Weight update path for TorchTitan wrapper model.
+
+        Re-wraps plain tensors as DTensors matching the wrapper model's
+        sharding layout, and loads them directly.
+        """
+        # Convert plain local tensors (TP shards from trainer) to DTensors
+        # matching the vLLM model's sharding layout. The trainer exports
+        # weights via to_local() which strips DTensor metadata.
         model_state_dict = dict(self._get_model().model.state_dict())
         for name, tensor in state_dict.items():
             if name in model_state_dict and isinstance(model_state_dict[name], DTensor):

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -15,6 +15,7 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config.configs import ParallelismConfig, TrainingConfig
 from torchtitan.experiments.rl.unified.actors.generator import (
+    GeneratorCompileConfig,
     SamplingConfig,
     VLLMGenerator,
 )
@@ -43,7 +44,11 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
-            enforce_eager=True,
+            gpu_memory_limit=0.5,
+            compile=GeneratorCompileConfig(
+                backend="eager",
+                cudagraph_mode="piecewise",
+            ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
@@ -78,7 +83,11 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
             ),
         ),
         generator=VLLMGenerator.Config(
-            enforce_eager=True,
+            gpu_memory_limit=0.3,
+            compile=GeneratorCompileConfig(
+                backend="eager",
+                cudagraph_mode="piecewise",
+            ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -64,6 +64,50 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     )
 
 
+def rl_grpo_qwen3_0_6b_native() -> RLTrainer.Config:
+    """GRPO training config for Qwen3-0.6B using vLLM's native model."""
+    return RLTrainer.Config(
+        model_spec=model_registry("0.6B"),
+        hf_assets_path="/data/users/jianiw/model/qwen3-0.6b",
+        num_steps=10,
+        batch_invariant_mode=True,
+        trainer=PolicyTrainer.Config(
+            optimizer=OptimizersContainer.Config(lr=1e-6),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=2,
+                decay_type="linear",
+            ),
+            training=TrainingConfig(
+                local_batch_size=4,
+                seq_len=4096,
+            ),
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=2,
+                data_parallel_replicate_degree=1,
+            ),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            gpu_memory_limit=0.5,
+            compile=GeneratorCompileConfig(
+                backend="eager",
+                cudagraph_mode="piecewise",
+            ),
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=2,
+            ),
+            num_samples_per_prompt=8,
+            sampling=SamplingConfig(
+                temperature=0.8,
+                top_p=0.95,
+                max_tokens=100,
+            ),
+            attention_backend="FLASH_ATTN",
+            use_native_vllm_model=True,
+        ),
+    )
+
+
 def rl_grpo_qwen3_debug() -> RLTrainer.Config:
     """Debug config for quick iteration -- small model, few steps (2 GPUs: 1 gen + 1 train)."""
     return RLTrainer.Config(

--- a/torchtitan/experiments/rl/unified/inference_example.py
+++ b/torchtitan/experiments/rl/unified/inference_example.py
@@ -11,7 +11,7 @@ Example inference script using TorchTitan models with vLLM LLMEngine.
 This script uses the RL unified config_registry to configure both
 the vLLM engine and sampling parameters.
 
-Run: torchrun --nproc_per_node=<world_size> \
+Run: torchrun --nproc_per_node=2 \
       torchtitan/experiments/rl/unified/infer.py
 """
 import os
@@ -70,10 +70,13 @@ def generate():
         distributed_executor_backend=("external_launcher"),
         # Memory and performance
         gpu_memory_utilization=gen_config.gpu_memory_limit,
-        enforce_eager=gen_config.enforce_eager,
+        enforce_eager=gen_config.compile.is_eager,
         # HuggingFace overrides
         hf_overrides={"architectures": [VLLM_MODEL_NAME]},
     )
+    vllm_compilation_config = gen_config.compile.get_vllm_compilation_config()
+    if vllm_compilation_config is not None:
+        engine_kwargs["compilation_config"] = vllm_compilation_config
     if gen_config.seed is not None:
         engine_kwargs["seed"] = gen_config.seed
     engine_args = EngineArgs(**engine_kwargs)

--- a/torchtitan/experiments/rl/unified/models/attention.py
+++ b/torchtitan/experiments/rl/unified/models/attention.py
@@ -89,6 +89,11 @@ class VLLMAttention(torch.nn.Module):
         Returns:
             ``(batch, num_heads, seq_len, head_dim)``
         """
+        # Capture the original symbolic seq_len from the input BEFORE
+        # to_local() so that the symbol is the same one GQAttention uses
+        # in its .view(bs, seqlen, -1) call.
+        batch_size, _, seq_len, head_dim = q.shape
+
         # Unwrap DTensor inputs to local tensors for attention computation
         device_mesh = None
         placements = None
@@ -99,33 +104,28 @@ class VLLMAttention(torch.nn.Module):
             k = k.to_local()
             v = v.to_local()
 
-        # Input is (batch, num_heads, seq_len, head_dim)
         # TODO: may be good to use einops in future as we can explicitly reshape
         # with dimension names - see https://github.com/arogozhnikov/einops
-        batch_size, num_heads, seq_len, head_dim = q.shape
-        _, num_kv_heads, _, _ = k.shape
+        # Convert from (batch, num_heads, seq_len, head_dim)
+        #   to (batch*seq_len, num_heads (or num_kv_heads), head_dim) for vLLM Attn
+        q = q.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
+        k = k.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
+        v = v.transpose(1, 2).reshape(batch_size * seq_len, -1, head_dim)
 
-        # Transpose to (batch, seq_len, num_heads, head_dim) for vLLM
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-
-        # TODO: reimplement as a 4d tensor once vLLM fix has landed
-        # Then flatten batch and seq_len: (batch * seq_len, num_heads, head_dim)
-        q = q.reshape(batch_size * seq_len, num_heads, head_dim)
-        k = k.reshape(batch_size * seq_len, num_kv_heads, head_dim)
-        v = v.reshape(batch_size * seq_len, num_kv_heads, head_dim)
-
-        # vLLM attention returns (num_tokens, hidden_size) where hidden_size = num_heads * head_dim
+        # vLLM attention returns (num_tokens, num_heads/num_kv_heads * head_dim)
         output_flat = self.vllm_attn(q, k, v)
 
-        # Output is (batch * seq_len, num_heads * head_dim), reshape to (batch, seq_len, num_heads, head_dim)
-        output = output_flat.view(batch_size, seq_len, num_heads, head_dim)
+        # vLLM's flash attention backend may pad the token count (e.g.
+        # round up to an even number), which introduces a new symbolic
+        # shape under torch.compile.  Narrow to trim this padding
+        # NOTE: this error only happens when batch_size and seq_len are 1
+        # which happens with cudagraph capture for dummy input
+        output_flat = output_flat.narrow(0, 0, batch_size * seq_len)
 
-        # Transpose back to TorchTitan format: (batch, num_heads, seq_len, head_dim)
+        # Reshape back to titan: (batch, num_heads_local, seq_len, head_dim)
+        output = output_flat.view(batch_size, seq_len, -1, head_dim)
         output = output.transpose(1, 2)
 
-        # Wrap output back as DTensor if inputs were DTensors
         if device_mesh is not None:
             output = DTensor.from_local(
                 output, device_mesh=device_mesh, placements=placements

--- a/torchtitan/experiments/rl/unified/models/native_vllm_weights.py
+++ b/torchtitan/experiments/rl/unified/models/native_vllm_weights.py
@@ -1,0 +1,173 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Weight reconstruction and name conversion for native vLLM model updates.
+
+Reconstructs full (unsharded) tensors from per-rank TP shards produced by
+the torchtitan trainer, then converts parameter names from torchtitan
+format to HuggingFace format suitable for vLLM's ``load_weights()``.
+"""
+
+import torch
+
+# TorchTitan parameter name suffixes and their TP shard reconstruction strategy.
+#
+# ColwiseParallel: each rank holds a slice along dim 0 -> cat on dim 0
+# RowwiseParallel: each rank holds a slice along dim 1 -> cat on dim 1
+# Replicated (norms): all ranks hold identical copies -> take rank 0
+
+_COLWISE_SUFFIXES = (
+    "attention.wq.weight",
+    "attention.wk.weight",
+    "attention.wv.weight",
+    "feed_forward.w1.weight",
+    "feed_forward.w3.weight",
+    "output.weight",
+)
+
+_ROWWISE_SUFFIXES = (
+    "tok_embeddings.weight",
+    "attention.wo.weight",
+    "feed_forward.w2.weight",
+)
+
+# Name mapping: torchtitan -> HuggingFace.
+# Derived by inverting VLLM_TO_TITAN_MAP from
+# torchtitan/experiments/rl/vllm_compat/weights/converter.py.
+# Layer-indexed entries use ``{}`` as a placeholder for the layer number.
+_TITAN_TO_HF_MAP = {
+    "tok_embeddings.weight": "model.embed_tokens.weight",
+    "layers.{}.attention.wq.weight": "model.layers.{}.self_attn.q_proj.weight",
+    "layers.{}.attention.wk.weight": "model.layers.{}.self_attn.k_proj.weight",
+    "layers.{}.attention.wv.weight": "model.layers.{}.self_attn.v_proj.weight",
+    "layers.{}.attention.wo.weight": "model.layers.{}.self_attn.o_proj.weight",
+    "layers.{}.attention.q_norm.weight": "model.layers.{}.self_attn.q_norm.weight",
+    "layers.{}.attention.k_norm.weight": "model.layers.{}.self_attn.k_norm.weight",
+    "layers.{}.feed_forward.w1.weight": "model.layers.{}.mlp.gate_proj.weight",
+    "layers.{}.feed_forward.w3.weight": "model.layers.{}.mlp.up_proj.weight",
+    "layers.{}.feed_forward.w2.weight": "model.layers.{}.mlp.down_proj.weight",
+    "layers.{}.attention_norm.weight": "model.layers.{}.input_layernorm.weight",
+    "layers.{}.ffn_norm.weight": "model.layers.{}.post_attention_layernorm.weight",
+    "norm.weight": "model.norm.weight",
+    "output.weight": "lm_head.weight",
+}
+
+
+def _get_cat_dim(param_name: str) -> int | None:
+    """Return the concatenation dimension for a sharded parameter.
+
+    Returns 0 for ColwiseParallel, 1 for RowwiseParallel, or ``None`` for
+    replicated parameters (norms).
+    """
+    for suffix in _COLWISE_SUFFIXES:
+        if param_name.endswith(suffix):
+            return 0
+    for suffix in _ROWWISE_SUFFIXES:
+        if param_name.endswith(suffix):
+            return 1
+    return None
+
+
+def _titan_name_to_hf(titan_name: str) -> str:
+    """Convert a torchtitan parameter name to HuggingFace format."""
+    if "layers." in titan_name:
+        parts = titan_name.split(".")
+        layer_idx = parts[1]
+        abstract_key = titan_name.replace(f".{layer_idx}.", ".{}.")
+        if abstract_key in _TITAN_TO_HF_MAP:
+            return _TITAN_TO_HF_MAP[abstract_key].format(layer_idx)
+    else:
+        if titan_name in _TITAN_TO_HF_MAP:
+            return _TITAN_TO_HF_MAP[titan_name]
+    raise ValueError(f"No HF name mapping for torchtitan param: {titan_name}")
+
+
+def _detect_weight_tying(
+    rank_0_sd: dict[str, torch.Tensor],
+) -> bool:
+    """Detect whether tok_embeddings and output share the same weight (tying).
+
+    When weight tying is active, ``parallelize_module`` converts the shared
+    parameter to ``Shard(0)`` (from ``output``'s ColwiseParallel, which runs
+    after ``tok_embeddings``'s RowwiseParallel).  Both state-dict entries
+    then have the **same** local shape ``[V/tp, H]``.
+
+    Without tying the shapes differ: ``tok_embeddings`` is ``[V, H/tp]``
+    (RowwiseParallel) while ``output`` is ``[V/tp, H]`` (ColwiseParallel).
+    Since ``V != H`` for all practical language models, a shape comparison
+    reliably distinguishes the two cases.
+    """
+    tok = rank_0_sd.get("tok_embeddings.weight")
+    out = rank_0_sd.get("output.weight")
+    if tok is None or out is None:
+        return False
+    # Fast path: same storage after Monarch transfer (not always preserved)
+    if tok.data_ptr() == out.data_ptr():
+        return True
+    # Fallback: identical shapes imply shared Shard(0) placement
+    return tok.shape == out.shape
+
+
+def convert_to_hf(
+    state_dict: dict[str, torch.Tensor],
+) -> list[tuple[str, torch.Tensor]]:
+    """Convert torchtitan parameter names to HF format.
+
+    Unlike ``reconstruct_and_convert_to_hf``, this assumes the tensors are
+    already full (unsharded) — as produced by ``get_weights()`` which calls
+    ``.full_tensor()`` on DTensors.
+
+    Args:
+        state_dict: Flat mapping of torchtitan param names to full tensors.
+
+    Returns:
+        List of ``(hf_name, full_tensor)`` pairs suitable for passing to
+        vLLM's ``model.load_weights()``.
+    """
+    return [(_titan_name_to_hf(name), tensor) for name, tensor in state_dict.items()]
+
+
+def reconstruct_and_convert_to_hf(
+    per_rank_state_dicts: dict[int, dict[str, torch.Tensor]],
+    tp_degree: int,
+) -> list[tuple[str, torch.Tensor]]:
+    """Reconstruct full tensors from TP shards and convert names to HF format.
+
+    Args:
+        per_rank_state_dicts: Mapping from rank index to that rank's state dict
+            (local tensors exported by the trainer via ``to_local()``).
+        tp_degree: Tensor parallel degree (number of TP ranks).
+
+    Returns:
+        List of ``(hf_name, full_tensor)`` pairs suitable for passing to
+        vLLM's ``model.load_weights()``.
+    """
+    rank_0_sd = per_rank_state_dicts[0]
+    results: list[tuple[str, torch.Tensor]] = []
+
+    # When weight tying is active, tok_embeddings.weight shares storage with
+    # output.weight and ends up with Shard(0) placement (ColwiseParallel from
+    # ``output``).  We must cat on dim 0 instead of the usual dim 1.
+    tied_embeddings = _detect_weight_tying(rank_0_sd)
+
+    for param_name in rank_0_sd:
+        cat_dim = _get_cat_dim(param_name)
+
+        if tied_embeddings and param_name == "tok_embeddings.weight":
+            cat_dim = 0
+
+        if cat_dim is not None:
+            shards = [per_rank_state_dicts[r][param_name] for r in range(tp_degree)]
+            full_tensor = torch.cat(shards, dim=cat_dim)
+        else:
+            # Replicated: all ranks hold identical copies
+            full_tensor = rank_0_sd[param_name]
+
+        hf_name = _titan_name_to_hf(param_name)
+        results.append((hf_name, full_tensor))
+
+    return results

--- a/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/unified/models/vllm_wrapper.py
@@ -29,12 +29,31 @@ from torchtitan.experiments.rl.unified.models.attention import (
     replace_with_vllm_attention,
 )
 from torchtitan.protocols.model_spec import ModelSpec
-
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.utils import torch_utils as _torch_utils
 
 
 logger = init_logger(__name__)
+
+# NOTE: Monkeypatch vLLM's weak_ref_tensor to handle DTensor
+# This is because piecewise CUDA-graph capture calls weak_ref_tensor()
+# on every subgraphoutput (see vllm/compilation/cuda_graph.py).
+# When TP is active some of those outputs are DTensors which fail with
+# ("The specified pointer resides on host memory").  to_local
+# converts the DTensor to a plain tensor. which succeeds with this
+# cudagraph implementation.
+_original_weak_ref_tensor = _torch_utils.weak_ref_tensor
+
+
+def _dtensor_safe_weak_ref_tensor(tensor):
+    if isinstance(tensor, DTensor):
+        tensor = tensor.to_local()
+    return _original_weak_ref_tensor(tensor)
+
+
+_torch_utils.weak_ref_tensor = _dtensor_safe_weak_ref_tensor
 
 
 def create_torchtitan_config_from_vllm_config(
@@ -93,6 +112,12 @@ def create_torchtitan_config_from_vllm_config(
     return parallel_dims, parallelism
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+    }
+)
 class TorchTitanVLLMModelWrapper(nn.Module):
     """
     Generic vLLM-compatible model wrapper for TorchTitan models. Implemented
@@ -158,28 +183,32 @@ class TorchTitanVLLMModelWrapper(nn.Module):
             has_position_id=True,  # vLLM always passes positions explicitly
         )
 
+        # Pre-extend RoPE cache to cover vLLM's max model length (profiling
+        # may use up to 2x max_seq_len, so use max_model_len which already
+        # accounts for this).  This avoids data-dependent control flow in
+        # forward() which is incompatible with torch.compile.
+        max_model_len = vllm_config.model_config.max_model_len
+        if self.model.freqs_cis.shape[0] < max_model_len:
+            self.model.freqs_cis = self._extend_rope_cache(
+                self.model.freqs_cis, max_model_len
+            )
+
         # Initial load model weights from HuggingFace checkpoint path
         self._initial_load_weights(checkpoint_path=vllm_config.model_config.model)
 
-    def _extend_rope_cache_if_needed(
-        self, rope_cache: torch.Tensor, max_position: int
+    def _extend_rope_cache(
+        self, rope_cache: torch.Tensor, required_len: int
     ) -> torch.Tensor:
         """
-        Extend RoPE cache if needed during vLLM profiling stage.
+        Build an extended RoPE cache of at least ``required_len`` positions.
 
         Args:
             rope_cache: Current RoPE cache tensor
-            max_position: Maximum position index needed
+            required_len: Minimum number of positions the cache must cover
 
         Returns:
-            Extended RoPE cache if needed, otherwise original cache
+            Extended RoPE cache tensor
         """
-        required_len = max_position + 1
-
-        # No extension needed
-        if required_len <= rope_cache.shape[0]:
-            return rope_cache
-
         # Handle DTensor case
         is_dtensor = isinstance(rope_cache, DTensor)
         if is_dtensor:
@@ -253,15 +282,7 @@ class TorchTitanVLLMModelWrapper(nn.Module):
         # Get embeddings
         h = self.model.tok_embeddings(tokens_2d)
 
-        # Extend RoPE cache if needed (vLLM profiling may use 2x max_seq_len)
-        if positions is not None:
-            max_position = positions.max().item()
-        else:
-            max_position = 0
-
-        rope_cache = self._extend_rope_cache_if_needed(
-            self.model.freqs_cis, max_position
-        )
+        rope_cache = self.model.freqs_cis
         positions = positions.unsqueeze(0)
 
         # Pass through transformer layers
@@ -275,9 +296,8 @@ class TorchTitanVLLMModelWrapper(nn.Module):
 
         # Convert to vLLM format: [total_tokens, hidden_size]
         if h.dim() == 3:
-            batch_size, seq_len, hidden_size = h.shape
-            h = h.view(batch_size * seq_len, hidden_size)
-
+            hidden_size = h.size(-1)
+            h = h.view(-1, hidden_size)
         return h
 
     def compute_logits(

--- a/torchtitan/experiments/rl/unified/simple_grpo.py
+++ b/torchtitan/experiments/rl/unified/simple_grpo.py
@@ -26,6 +26,7 @@ import asyncio
 import logging
 import os
 import re
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -202,10 +203,15 @@ class RLTrainer(Configurable):
 
         # Trainer gathers full (unsharded) weights on every rank. We only
         # need to collect from one rank since they're all identical.
+        t0 = time.perf_counter()
         initial_weights = self.trainer.get_weights.call().get().item(gpus=0)
 
         # Initialize generator with trainer weights
         self.generator.update.call(0, initial_weights).get()
+        self.generator_init_time = time.perf_counter() - t0
+        logger.info(
+            f"Generator init + weight sync took {self.generator_init_time:.2f}s"
+        )
 
     async def evaluate(self, num_samples: int = 20) -> dict:
         """Run evaluation on held-out prompts.
@@ -276,6 +282,11 @@ class RLTrainer(Configurable):
         logger.info(f"Starting RL training for {num_steps} steps")
         logger.info("=" * 80)
 
+        total_generate = 0.0
+        total_grade = 0.0
+        total_train = 0.0
+        total_sync = 0.0
+
         for step in range(num_steps):
             # Generate prompts for this step
             train_prompts = []
@@ -287,17 +298,23 @@ class RLTrainer(Configurable):
                 train_answers.append(answer)
                 train_questions.append(question)
 
+            step_start = time.perf_counter()
+
             # Fully sync RL loop with separate scoring step
             # 1. VLLMGenerator produces episodes (one per prompt, without rewards)
             # TODO: Create a queue to use all episode from all GPUs
+            t0 = time.perf_counter()
             episodes = self.generator.generate.call(train_prompts).get().item(gpus=0)
+            t_generate = time.perf_counter() - t0
 
             # Attach expected answers to each episode
             for episode, answer in zip(episodes, train_answers):
                 episode.expected_answer = answer
 
             # 2. Grader computes rewards per episode
+            t0 = time.perf_counter()
             scored_episodes = self.grader.score.call(episodes).get().item()
+            t_grade = time.perf_counter() - t0
 
             if self.config.log_samples:
                 for ep, question, answer in zip(
@@ -317,10 +334,21 @@ class RLTrainer(Configurable):
                     )
 
             # 3. Trainer computes advantages and updates policy
+            t0 = time.perf_counter()
             metrics = self.trainer.step.call(scored_episodes).get().item(gpus=0)
+            t_train = time.perf_counter() - t0
+
             # 4. Sync full weights to generator (each rank reshards locally)
+            t0 = time.perf_counter()
             weights = self.trainer.get_weights.call().get().item(gpus=0)
             self.generator.update.call(metrics["policy_version"], weights).get()
+            t_sync = time.perf_counter() - t0
+
+            t_step = time.perf_counter() - step_start
+            total_generate += t_generate
+            total_grade += t_grade
+            total_train += t_train
+            total_sync += t_sync
 
             all_token_lens = [
                 len(c.token_ids) for ep in scored_episodes for c in ep.completions
@@ -339,6 +367,10 @@ class RLTrainer(Configurable):
                 f"Logprob diff: mean={metrics['logprob_diff_mean']:.4e}, "
                 f"max={metrics['logprob_diff_max']:.4e}"
             )
+            logger.info(
+                f"  Timing: generate={t_generate:.2f}s grade={t_grade:.2f}s "
+                f"train={t_train:.2f}s sync={t_sync:.2f}s total={t_step:.2f}s"
+            )
 
             # Check for divergence
             if not torch.isfinite(torch.tensor(metrics["loss"])):
@@ -346,6 +378,18 @@ class RLTrainer(Configurable):
                 logger.info("ERROR: Loss is NaN/Inf! Training diverged.")
                 logger.info("!" * 80)
                 break
+
+        # Timing summary
+        total_loop = total_generate + total_grade + total_train + total_sync
+        logger.info("=" * 80)
+        logger.info("Timing Summary")
+        logger.info(f"  Generator init + weight sync: {self.generator_init_time:.2f}s")
+        logger.info(f"  Generate (total): {total_generate:.2f}s")
+        logger.info(f"  Grade    (total): {total_grade:.2f}s")
+        logger.info(f"  Train    (total): {total_train:.2f}s")
+        logger.info(f"  Sync     (total): {total_sync:.2f}s")
+        logger.info(f"  Loop     (total): {total_loop:.2f}s")
+        logger.info("=" * 80)
 
         # Post-training evaluation
         logger.info("RL Training complete")
@@ -370,7 +414,9 @@ async def main():
     """Run the distributed RL training loop using Monarch."""
     config = ConfigManager().parse_args()
     rl_trainer = RLTrainer(config)
+    t_setup_start = time.perf_counter()
     await rl_trainer.setup()
+    logger.info(f"Total setup time: {time.perf_counter() - t_setup_start:.2f}s")
     await rl_trainer.train()
 
 


### PR DESCRIPTION
To run baseline compile for vLLM, use 
```bash
python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B 
```
For this, I get `Generate (total): 22.13s`

To run vLLM native, use 
```bash
python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b_native --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B 
```

For this, I get `Generate (total): 10.66s`