### PR TITLE
[DeepEP] Centralize DeepEP backend selection in MoE.Config.build()

### DIFF
--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -284,7 +284,6 @@ class DeepSeekV3Model(Decoder):
 
             self.layer.moe._debug_force_load_balance = debug.moe_force_load_balance
 
-            # Configure expert parallel communication backend from config
             if parallelism.expert_parallel_comm_backend == "deepep":
                 from torchtitan.models.common.moe.moe_deepep import DeepEPMoE
 

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -190,6 +190,11 @@ class Llama4Model(Decoder):
 
             self.layer.moe._debug_force_load_balance = debug.moe_force_load_balance
 
+            if parallelism.expert_parallel_comm_backend == "deepep":
+                from torchtitan.models.common.moe.moe_deepep import DeepEPMoE
+
+                self.layer.moe = DeepEPMoE.Config(**dataclasses.asdict(self.layer.moe))
+
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:


### PR DESCRIPTION
## Summary

**Cause:** With DeepEP, the parallelization path applies `DeepEPExpertParallel` and its `_token_dispatch` hook expects 5 inputs (hidden_states, …, selected_experts_indices, top_scores, num_experts). The standard `MoE` forwards only 2 arguments to `self.experts()` (routed_input, num_tokens_per_expert). DeepSeek V3 already fixes this by swapping the MoE config for `DeepEPMoE.Config` in `update_from_config`, so at build time the MoE layer is a `DeepEPMoE` instance, which forwards the 5 arguments DeepEP expects. Llama4 was missing this swap.

**Change:** Align Llama4 with DeepSeek V3 by adding the same logic in `Llama4Model.Config.update_from_config`: when `parallelism.expert_parallel_comm_backend == "deepep"`, set `self.layer.moe = DeepEPMoE.Config(**dataclasses.asdict(self.layer.moe))`. 