### PR TITLE
[Config] Overwrite _replace for HFTransformerModel.Config

### DIFF
--- a/torchtitan/config/configurable.py
+++ b/torchtitan/config/configurable.py
@@ -4,9 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 import dataclasses
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, replace
 from typing import ClassVar
 
 import torch
@@ -73,14 +72,14 @@ class Configurable:
             return result
 
         def _replace(self, **overrides):
-            """Copy this config via ``copy.copy()``, apply *overrides* to every
+            """Copy this config via ``replace()``, apply *overrides* to every
             ``field(init=False)`` slot, and validate that every
             ``field(init=False)`` slot has been set.
 
             Raises ``TypeError`` if any ``init=False`` field is neither
             pre-set on *self* nor supplied in *overrides*.
             """
-            clone = copy.copy(self)
+            clone = replace(self)
             for f in fields(self):
                 if f.init:
                     continue

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import importlib
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 import torch
 from torch import nn
@@ -105,6 +106,29 @@ class HFTransformerModel(BaseModel):
             self._configure_hf_attention(attn_implementation)
 
             self._initialize_dense_attributes(titan_dense_config)
+
+        def _replace(self, **overrides):
+            """Override to use ``copy.copy()`` instead of ``dataclasses.replace()``.
+
+            ``dataclasses.replace()`` re-invokes ``__init__``, which is
+            incompatible with the custom ``__init__`` here (it expects
+            ``titan_dense_config`` and calls ``PretrainedConfig.__init__``).
+            A shallow copy preserves all dynamically-set HF attributes.
+            """
+            clone = copy.copy(self)
+            for f in fields(self):
+                if f.init:
+                    continue
+                if f.name in overrides:
+                    setattr(clone, f.name, overrides[f.name])
+                elif hasattr(self, f.name):
+                    setattr(clone, f.name, getattr(self, f.name))
+                else:
+                    raise TypeError(
+                        f"{type(self).__name__} field '{f.name}' "
+                        f"(init=False) was not provided via build()"
+                    )
+            return clone
 
         def _initialize_dense_attributes(self, titan_dense_config):
             """Initialize all dense model attributes."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2512

```
torchrun --nproc_per_node=8 --rdzv_backend c10d --rdzv_endpoint=localhost:0   --tee 3 -m torchtitan.train --module llama3 --config llama3_debugmodel --module transformers_modeling_backend --config transformers_modeling_backend_debugmodel --hf_model Qwen/Qwen2.5-7B --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.pipeline_parallel_degree 2 --parallelism.pipeline_parallel_schedule 1F1B
```

This command is broken. This PR fixes it. Basically, `HFTransformerModel` does two things 1) titan_dense_config is not defined in the dataclass but in __init__. 2) update_from_config will dynamically create some fields.