### PR TITLE
[RL] Fix `hf_assets_path` in inference_example.py

### DIFF
--- a/torchtitan/experiments/rl/unified/inference_example.py
+++ b/torchtitan/experiments/rl/unified/inference_example.py
@@ -34,7 +34,7 @@ def generate():
 
     config = rl_grpo_qwen3_0_6b()
     gen_config = config.generator
-    model_path = config.trainer.hf_assets_path
+    model_path = config.hf_assets_path
 
     # Patch model_spec to use the RL-specific parallelize function.
     # TODO: Switch to canonical Qwen3 parallel plan


### PR DESCRIPTION
This was changed in https://github.com/pytorch/torchtitan/pull/2482, requires a small update in `inference_example.py`