### PR TITLE
tied parameters in the fsdp group

### DIFF
--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -393,7 +393,7 @@ def apply_fsdp(
                 f"Invalid reshard_after_forward_policy: {reshard_after_forward_policy}."
             )
 
-    if getattr(model.enable_weight_tying, "enable_weight_tying", False):
+    if getattr(model, "enable_weight_tying", False):
         modules = [
             m for m in (model.tok_embeddings, model.norm, model.output) if m is not None
         ]


### PR DESCRIPTION
This PR addresses https://github.com/pytorch/torchtitan/issues/2495

Briefly, since tied parameters are supposed to be put in the same FSDP group (see https://github.com/pytorch/pytorch/pull/176225#discussion_r2874905548), I changed `torchtitan/models/llama4/parallelize.py` to group `molde.output, model.norm`, and `model.tok_embeddings` in the case `model.enable_weight_tying` is set to true