### PR TITLE
Add CLAUDE.md and path-specific rules for code review conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,101 @@
+# TorchTitan Development Guide
+
+## Build & Test
+
+```bash
+# Install dev dependencies
+pip install -r requirements.txt -r requirements-dev.txt
+
+# Lint and format (required before any PR)
+pre-commit run --all-files
+
+# Run unit tests
+pytest tests/ -x
+```
+
+### Run GPU integration tests (requires GPUs)
+Integration tests override default config for Llama 3 debug model.
+See tests/integration_tests/ for `OverrideDefinitions`.
+
+### Validating Numerics
+Non-computation changes (e.g. activation checkpointing, refactoring) must produce
+**identical loss** before vs. after with fixed `training.seed` and `training.deterministic`.
+Computation changes require loss convergence on representative datasets (e.g. C4).
+
+## Core Principles
+
+1. **PyTorch-native training techniques.** Core torchtitan's training infrastructure
+   and parallelism code must not depend on non-PyTorch libraries. Techniques with
+   moderate-to-large complexity belong in their proper upstream repo (pytorch/pytorch
+   for parallelisms, pytorch/data for data loaders, etc.).
+
+2. **Investigate root cause before patching.** Don't land band-aid fixes. Understand
+   *why* something fails before proposing a solution. If a change seems to help but
+   you can't explain why, dig deeper.
+
+3. **Reuse over duplication.** Before writing new code, check if existing implementations
+   already handle the case. Unify similar code paths across models rather than creating
+   per-model wrappers. If upstream (torchao, PyTorch) already provides functionality,
+   use it.
+
+4. **Don't leak experiments into core.** The `torchtitan/experiments/` folder exists for
+   a reason. Don't modify core torchtitan code to accommodate experiment-specific needs
+   (e.g. don't add `if experiment_x:` branches to core files). Deprecated files should
+   be removed, not updated.
+
+5. **Protect battle-tested code paths.** Be cautious changing converged behavior. Flag
+   potential silent breakage of existing user code or checkpoints. When in doubt, ask.
+
+6. **Audit all callsites.** When changing shared code (common model components, config
+   fields, distributed utilities), check and update every callsite. This includes all
+   model variants: llama3, llama4, qwen3, deepseek_v3, gpt_oss, flux, etc.
+
+## Code Style
+
+### Naming
+- Names must be **accurate, descriptive, and reflect actual scope**. Don't use
+  "toy/test/temp" in production names — put that context in docstrings instead.
+- Follow upstream conventions: match torchao and PyTorch naming where applicable.
+  E.g. if torchao calls it `Float8Linear`, use `Float8Linear` not `Float8Config`.
+- Use `num_` prefix for counts (e.g. `num_expert_groups` not `n_expert_groups`)
+  when not directly matching an upstream API.
+
+### Code Placement
+- Put code in the **most general applicable location**:
+  - Model-agnostic parallelism helpers → `torchtitan/distributed/`
+  - Shared model components (attention, MoE, embeddings) → `torchtitan/models/common/`
+  - Model-specific code → the specific model folder
+- Don't put model-agnostic functionality in model-specific files just because
+  that's where you first needed it.
+
+### Assertions and Error Handling
+- **`ValueError`** for user-facing errors (bad config, invalid input).
+- **`assert`** only for internal invariants that indicate programmer error.
+- Always validate mesh dimensions, tensor placements, and config values explicitly
+  in distributed code — don't assume 1D mesh or specific placements.
+- When a code path silently skips user configuration, **emit a warning**.
+
+### Parameters and Config
+- Important parameters first; less important ones later.
+- Prefer keyword-only arguments after the first positional arg.
+- No `None` defaults for required config fields.
+- `dataclasses.replace()` is a shallow copy: nested dataclasses and list/dict
+  fields are shared by reference. Be explicit when deep copies are needed.
+
+### Comments and Documentation
+- Add comments only for genuinely non-obvious things: dimension semantics,
+  parallelism gradient placements, why a workaround exists.
+- Use TODO comments for known limitations with a brief explanation.
+- Put descriptions in docstrings, not in names.
+
+## PR Expectations
+
+1. **Lint first.** Run `pre-commit run --all-files` and fix all issues before
+   requesting review. CI linting failures waste everyone's time.
+2. **Show numerical proof.** Include loss comparison for any non-trivial change.
+3. **Explain "why" not just "what"** in the PR description.
+4. **Add tests.** New features need CPU unit tests at minimum; GPU integration
+   tests when involving parallelism. Verify CI actually runs the intended test
+   config (check `--model.name` and other flags).
+5. **Keep model code minimal.** After model changes, ensure original checkpoints
+   still load correctly. Document reasons for model changes.

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -1,0 +1,29 @@
+---
+description: Rules for the config system
+globs: torchtitan/**
+---
+
+# Config System Rules
+
+## No None Defaults for Required Fields
+If a config field is required, don't give it a `None` default. Either set a
+meaningful default or make it a required argument with no default.
+
+## Parameter Ordering
+- Put important, commonly-used fields first.
+- Less important or rarely-changed fields go later.
+- Prefer keyword-only arguments after the first positional arg to prevent
+  positional mistakes.
+
+## Naming Conventions
+- Use descriptive names that reflect what the config controls.
+- Use `num_` prefix for count fields.
+- Prefer strings as config names when they benefit extensibility (e.g. model
+  selection, dataset selection).
+
+## Safety
+- When config values are passed through to external APIs (e.g. DataLoader kwargs),
+  ensure all values are safe for all code paths (e.g. what happens when
+  `num_workers == 0`?).
+- When a config option silently doesn't take effect in certain code paths,
+  emit a warning to the user.

--- a/.claude/rules/distributed.md
+++ b/.claude/rules/distributed.md
@@ -1,0 +1,34 @@
+---
+description: Rules for distributed training code
+globs: torchtitan/distributed/**
+---
+
+# Distributed Code Rules
+
+## Assert Mesh and Placements Explicitly
+- Never assume a 1D mesh. Always assert on mesh dimensions before using them.
+- Validate tensor placements (Replicate, Shard, Partial) explicitly.
+- When enforcing a field is not None for plain tensor inputs, do so with a clear
+  error message.
+
+## Document Parallelism Semantics
+For any usage of `DTensor.to_local`, specify explicitly the `grad_placements`, especially when the original DTensor placement has `Replicate` or `Partial`. This includes the indirect calls from `local_map` (`in_grad_placements`), and `full_tensor` (`grad_placements`).
+
+## Consider All Parallelism Combinations
+When adding or modifying distributed code, think through how it interacts with
+every parallelism dimension. A fix for one configuration may break another.
+Include the parallelism configuration in bug reports and test descriptions.
+
+## Model-Agnostic Code Lives Here
+Helper functions that apply to any model (e.g. `maybe_enable_async_tp`,
+`NoParallel`, tensor parallel utilities) belong in `torchtitan/distributed/`,
+not in model-specific infrastructure files.
+
+## Be Conservative with Changes
+Distributed training code is hard to test exhaustively. When modifying existing
+behavior:
+- Verify numerics match before and after across multiple parallelism configs.
+- Watch for silent correctness issues (wrong gradient placements, identity
+  operations that break DCP).
+- If changing something that's been converged and validated, provide strong
+  justification and thorough testing.

--- a/.claude/rules/experiments.md
+++ b/.claude/rules/experiments.md
@@ -1,0 +1,24 @@
+---
+description: Rules for the experiments folder
+globs: torchtitan/experiments/**
+---
+
+# Experiments Folder Rules
+
+## Looser Standards, Still Linted
+Code in experiments has more flexibility than core, but must still pass
+`pre-commit run --all-files`. No exceptions for linting.
+
+## Don't Modify Core for Experiments
+If an experiment needs behavior that core doesn't provide, work around it in the
+experiment folder. Don't change core torchtitan code to accommodate experiment needs
+(e.g. don't add `if experiment_x:` branches to `train.py` or core modules).
+The experiments folder is "more-or-less a hack" by design.
+
+## Use TorchTitan's Config System
+Use torchtitan's existing config and job config infrastructure. Don't introduce
+custom argument parsing or parallel config systems.
+
+## Separate Concerns
+Keep distinct features in separate folders (e.g. inference code separate from RL
+work). Don't bundle unrelated functionality just because it's all "experimental."

--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -1,0 +1,50 @@
+---
+description: Rules for model implementations
+globs: torchtitan/models/**
+---
+
+# Model Code Rules
+
+## Keep Models Minimal and Readable
+- Model files should contain model architecture, not training infrastructure.
+- Weight initialization belongs in the config or a dedicated init function, not
+  scattered through `Module.__init__`.
+- After any model change, ensure original checkpoints still load correctly.
+
+## Audit All Variants
+When changing shared components (attention, normalization, MoE routing), check and
+update **all** model variants: llama3, llama4, qwen3, deepseek_v3, gpt_oss, flux,
+and any others present. Don't leave stale patterns in sibling models.
+
+## Unify Across Models
+- Don't create per-model wrappers for the same functionality. Aim for at most one
+  general wrapper shared by all models.
+- If multiple models have near-identical code (e.g. `apply_fsdp`, `apply_ac`,
+  `apply_compile`), consolidate into `torchtitan/models/common/` or
+  `torchtitan/distributed/`.
+- Before adding a new rotary embedding, MoE router, or similar component, check if
+  an existing implementation already supports the use case.
+
+## Standard Model Folder Structure
+Each model folder follows a consistent pattern:
+- `config_registry.py` — registers model configs (sizes, hyperparameters)
+- `parallelize.py` — defines parallelism strategy for the model
+- Model definition files (architecture, layers)
+
+## Shared Components
+Components used by multiple models belong in `torchtitan/models/common/`:
+- Attention mechanisms (`attention.py`)
+- Feed-forward layers (`feed_forward.py`)
+- Decoder blocks (`decoder.py`)
+- MoE routing and expert implementations (`moe/`)
+- Rotary/positional embeddings (`rope.py`)
+- Normalization layers (`rmsnorm.py`)
+
+## Don't Over-Specialize
+If a feature is only needed by one model (e.g. HFTransformerModel), implement it
+in that model's folder. Don't modify shared infrastructure or base classes to
+accommodate a single model's needs.
+
+## Control Flow in Forward
+Keep control flow (routing decisions, conditional logic) in the `forward` method.
+Don't bury important branching logic inside helper methods where it's hard to trace.


### PR DESCRIPTION
Encode maintainer review patterns into Claude Code configuration so contributors using Claude automatically follow project conventions. Covers naming, code placement, assertions, config safety, distributed semantics, and experiment boundaries.

NOTE: authored with claude, who distilled from my actual GitHub review history (~40+ PRs over 7 months, Aug 2025 - Mar 2026) — into Claude Code configuration so that contributors using Claude automatically follow conventions.