### PR TITLE
[DTensor Bugfix] Explicitly specify grad_placements in to_local to ensure necessary all reduce takes place 

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -187,8 +187,12 @@ class ReplicateComputation(torch.nn.Module):
             dp_mesh = self.device_mesh
 
             # Compute grad placements for non-DP mesh dims so that
-            # backward properly reduces gradients (e.g., Replicate -> Partial
-            # for RMSNorm weights on the TP mesh that see Shard inputs).
+            # backward properly reduces gradients.
+            # TODO: We assume Replicate -> Partial here, which is correct
+            # when using Sequence Parallel (Shard inputs produce partial
+            # gradients). Without SP, the grad placement depends on
+            # downstream operations and may not be Partial. This could be
+            # fixed by enforcing spmd_types.
             non_dp_placements = tuple(x._spec.placements[-non_dp_mesh_dims:])
             non_dp_grad_placements = tuple(
                 Partial() if isinstance(p, Replicate) else p for p in non_dp_placements


### PR DESCRIPTION
Solved #2217 by @alpemreacar
 ## Problem: 
`x.to_local()` was called on a multi-dimensional DTensor (e.g., on a `(dp, tp)` mesh with placements like `(Shard(0), Replicate())`). The bare `to_local()` strips all mesh dimensions and loses gradient placement info for the non-DP (TP) dimensions. For a `Replicate()` RMSNorm weight on the TP mesh, the backward should produce `Partial()` gradients (requiring all-reduce), but this information was lost.

 ## Fix: 
  1. Extract the non-DP placements from `x`
  2. Compute the corresponding grad placements — Replicate → Partial(), others stay as-is
  3. Pass the full grad placements (DP dims + non-DP dims) to to_local()

This ensures that in the backward pass, gradients flowing back through `to_local()` are properly wrapped as a DTensor with `Partial()` on the TP mesh dimension, which will trigger the necessary all-reduce across TP ranks.

**Note that this changes the numerics when using simple FSDP so I updated the test loss value for the GraphTrainer tests.** 

Authored with Claude. 