### PR TITLE
Add missing top_p to SamplingParams() (fixes #2537)

### DIFF
--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -183,7 +183,7 @@ class VLLMGenerator(Actor, Configurable):
         self.model_path = model_path
         self.max_new_tokens = config.sampling.max_tokens
         self.temperature = config.sampling.temperature
-        self.top_p = config.samling.top_p
+        self.top_p = config.sampling.top_p
         self.num_samples_per_prompt = config.num_samples_per_prompt
 
         # Build vLLM engine


### PR DESCRIPTION
In `torchtitan/experiments/rl/unified/actors/generator.py` we initialize `top_p` in line 98

```python
@dataclass(kw_only=True, slots=True)
class SamplingConfig:
    """Sampling parameters passed to vLLM's SamplingParams."""
    temperature: float = 0.8
    """Sampling temperature. 0.0 = greedy, higher = more random."""
    top_p: float = 0.95
    """Nucleus sampling threshold."""
    max_tokens: int = 100
    """Maximum number of tokens to generate per completion."""
```
and it should probably be used in
```python
sampling_params = SamplingParams(
                temperature=self.temperature,
                top_p=self.top_p,
                max_tokens=self.max_new_tokens,
                n=self.num_samples_per_prompt,
                seed=self.config.seed,
                logprobs=1,
                prompt_logprobs=1,  # Also get prompt log probs to access prompt token IDs
                output_kind=RequestOutputKind.FINAL_ONLY,  # Only return completed outputs
            )
```

(I added it here) like temperature and max_tokens, but it's missing in the original code. (And it also needs to be added here:
```python
self.top_p = config.samling.top_p
```
(IMO)).