### PR TITLE
Fix qwen3 varlen RMSNorm upcast under AMP

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -88,7 +88,7 @@ class VarlenAttentionWrapper(torch.nn.Module):
         )  # (bs * seqlen, n_kv_heads, head_dim)
 
         # Some operators can upcast under AMP, but varlen attention currently only
-        # supports bf16/fp16 inputs. If this changes, or fp16 training support 
+        # supports bf16/fp16 inputs. If this changes, or fp16 training support
         # is added, this may need to be revisited.
         xq_packed = xq_packed.to(torch.bfloat16)
         xk_packed = xk_packed.to(torch.bfloat16)


### PR DESCRIPTION
When using varlen attention with Qwen3 on a single device (no FSDP, so using `autocast`), it looks like the `RMSNorm` output is being upcast to fp32 during bf16 training, breaking varlen attention:

```
RuntimeError: FlashAttention only support fp16 and bf16 data type
```

Not sure if my fix is the right way to go about it (contract that inp dtype is out dtype in `RMSNorm`).

Can reproduce with:
```python
from dataclasses import replace

import torch
from torchtitan.models.common.attention import VarlenMetadata
from torchtitan.models.qwen3 import qwen3_configs

cfg = qwen3_configs["debugmodel"]
cfg = replace(
    cfg,
    layer=replace(
        cfg.layer,
        attention=replace(
            cfg.layer.attention,
            attn_backend="varlen",
            attn_mask_type="block_causal",
        ),
    ),
)

model = cfg.build().cuda()

tokens = torch.randint(0, cfg.vocab_size, (1, 8), device="cuda")
positions = torch.arange(8, device="cuda", dtype=torch.long).unsqueeze(0)
masks = VarlenMetadata(
    cu_seq_q=torch.tensor([0, 8], device="cuda", dtype=torch.int32),
    cu_seq_k=torch.tensor([0, 8], device="cuda", dtype=torch.int32),
    max_q=8,
    max_k=8,
)

with torch.autocast("cuda", dtype=torch.bfloat16):
    out = model(tokens, attention_masks=masks, positions=positions)
    print(out.shape, out.dtype)
```