### PR TITLE
[graph_trainer] Only validate flex_attn annotations when regional_inductor is used

### DIFF
--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -486,7 +486,12 @@ def get_joint_custom_passes_from_config(
     )
 
     joint_custom_passes = []
-    joint_custom_passes.append(validate_flex_attn_annotation_pass)
+
+    # Only validate flex_attention annotations when regional_inductor is used,
+    # since that's the only pass that relies on them.
+    pass_names = getattr(compile_config, "passes", [])
+    if "regional_inductor" in pass_names:
+        joint_custom_passes.append(validate_flex_attn_annotation_pass)
 
     # Handle joint passes from config (excluding inductor_decomposition)
     joint_pass_names = getattr(compile_config, "joint_passes", [])


### PR DESCRIPTION
Stacked PRs:
 * #2548
 * __->__#2547
 * #2546


--- --- ---

[graph_trainer] Only validate flex_attn annotations when regional_inductor is used

The validate_flex_attn_annotation_pass asserts that all flex_attention
nodes have compile_with_inductor annotations. This is only needed for
the regional_inductor pass. Running it unconditionally causes assertion
failures when using full_inductor_compilation or other pass
configurations where these annotations are irrelevant.

Tested with DSv3 16B, 8xH100, EP=8, batch=1, seq=4096, dataset=c4_test:
  step: 20  loss: 7.305  tps: 7,835  tflops: 141.86  mfu: 14.34%  memory: 48.99GiB