### PR TITLE
[graph_trainer] Add make_fx_tracer utility and unit tests

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch._subclasses import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.traceback import preserve_node_meta
+from torch.nn.utils import stateless
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+@dataclass
+class SubclassMeta:
+    cls: type
+    attrs: list[str]
+    ctx: Any
+    inner_metas: dict[str, tuple[int, Any]]
+    outer_size: torch.Size
+    outer_stride: tuple[int, ...]
+
+
+@dataclass
+class SubclassLayout:
+    num_tensors: int
+    meta: SubclassMeta | None
+
+
+@dataclass
+class TracedResult:
+    """Holds the traced graph and metadata needed to run it."""
+
+    gm: torch.fx.GraphModule
+    params_len: int
+    params_spec: pytree.TreeSpec
+    input_subclass_layouts: list[SubclassLayout]
+    output_subclass_layouts: list[SubclassLayout]
+
+
+def _unwrap_subclass(t: torch.Tensor) -> tuple[list[torch.Tensor], SubclassMeta | None]:
+    if not is_traceable_wrapper_subclass(t):
+        return [t], None
+    attrs, ctx = t.__tensor_flatten__()
+    all_inner = []
+    inner_metas = {}
+    for attr in attrs:
+        inner_t = getattr(t, attr)
+        tensors, meta = _unwrap_subclass(inner_t)
+        all_inner.extend(tensors)
+        inner_metas[attr] = (len(tensors), meta)
+    meta = SubclassMeta(
+        cls=type(t),
+        attrs=attrs,
+        ctx=ctx,
+        inner_metas=inner_metas,
+        outer_size=t.size(),
+        outer_stride=t.stride(),
+    )
+    return all_inner, meta
+
+
+def _wrap_to_subclass(
+    plain_tensors: list[torch.Tensor], meta: SubclassMeta
+) -> torch.Tensor:
+    inner_dict = {}
+    idx = 0
+    for attr in meta.attrs:
+        num_inner, inner_meta = meta.inner_metas[attr]
+        inner_tensors = plain_tensors[idx : idx + num_inner]
+        idx += num_inner
+        if inner_meta is None:
+            inner_dict[attr] = inner_tensors[0]
+        else:
+            inner_dict[attr] = _wrap_to_subclass(list(inner_tensors), inner_meta)
+    return meta.cls.__tensor_unflatten__(
+        inner_dict, meta.ctx, meta.outer_size, meta.outer_stride
+    )
+
+
+def _wrap_to_subclasses(
+    flat_tensors: tuple[torch.Tensor, ...] | list[torch.Tensor],
+    layouts: list[SubclassLayout],
+) -> list[torch.Tensor]:
+    wrapped = []
+    idx = 0
+    for layout in layouts:
+        tensors = flat_tensors[idx : idx + layout.num_tensors]
+        idx += layout.num_tensors
+        if layout.meta is None:
+            wrapped.append(tensors[0])
+        else:
+            wrapped.append(_wrap_to_subclass(list(tensors), layout.meta))
+    return wrapped
+
+
+def _remove_cpu_shadow_chains(gm: torch.fx.GraphModule) -> None:
+    """Remove dead CPU tensor chains left by DTensor's shadow-op bookkeeping.
+
+    DTensor keeps CPU "shadow" copies of tensor metadata (size, stride) as
+    regular aten ops.  After make_fx tracing these ops end up in the graph but
+    never feed a real GPU computation, so they are pure overhead.  This pass
+    finds every chain rooted at a CPU ``empty_strided`` whose outputs never
+    reach a GPU node with downstream users, and erases the whole chain.
+
+    TODO: figure out a way to avoid tracing them into graph in the first place.
+    """
+    to_remove: set[torch.fx.Node] = set()
+
+    for node in gm.graph.nodes:
+        if node in to_remove:
+            continue
+
+        if not (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.empty_strided.default
+        ):
+            continue
+        device = node.kwargs.get("device")
+        if device is None or device.type != "cpu":
+            continue
+
+        chain: set[torch.fx.Node] = set()
+        queue = [node]
+        feeds_gpu = False
+
+        while queue and not feeds_gpu:
+            current = queue.pop()
+            if current in chain:
+                continue
+            chain.add(current)
+            for user in current.users:
+                val = user.meta.get("val")
+                if isinstance(val, torch.Tensor) and val.device.type != "cpu":
+                    if user.users:
+                        feeds_gpu = True
+                        break
+                    chain.add(user)
+                    continue
+                queue.append(user)
+
+        if not feeds_gpu:
+            to_remove |= chain
+
+    for node in reversed(list(gm.graph.nodes)):
+        if node in to_remove:
+            gm.graph.erase_node(node)
+
+    gm.graph.lint()
+    gm.recompile()
+
+
+def trace_module(
+    mod: nn.Module,
+    args: tuple,
+) -> TracedResult:
+    """Trace ``mod(*args)`` into a flat FX graph, unwrapping tensor subclasses.
+
+    Parameters and buffers are lifted as extra graph inputs so the returned
+    graph is a pure function.  Tensor subclasses (e.g. DTensor) are recursively
+    unwrapped into plain tensors for tracing, and the layouts needed to rewrap
+    them are recorded in the returned :class:`TracedResult`.
+    """
+    named_parameters = dict(mod.named_parameters(remove_duplicate=False))
+    named_buffers = dict(mod.named_buffers(remove_duplicate=False))
+
+    params_and_buffers = {**named_parameters, **named_buffers}
+    params_and_buffers_flat, params_spec = pytree.tree_flatten(params_and_buffers)
+    params_len = len(params_and_buffers_flat)
+
+    def functional_call(*all_args):
+        flat_params = all_args[:params_len]
+        user_args = all_args[params_len:]
+        params = pytree.tree_unflatten(list(flat_params), params_spec)
+        with stateless._reparametrize_module(mod, params):
+            return mod.forward(*user_args)
+
+    user_args_flat, user_args_spec = pytree.tree_flatten(args)
+    full_args = tuple(params_and_buffers_flat) + tuple(user_args_flat)
+
+    unwrapped_args = []
+    input_layouts: list[SubclassLayout] = []
+
+    for arg in full_args:
+        if isinstance(arg, torch.Tensor) and is_traceable_wrapper_subclass(arg):
+            inner_tensors, meta = _unwrap_subclass(arg)
+            unwrapped_args.extend(inner_tensors)
+            input_layouts.append(SubclassLayout(len(inner_tensors), meta))
+        else:
+            unwrapped_args.append(arg)
+            input_layouts.append(SubclassLayout(1, None))
+
+    fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+
+    def to_fake(t):
+        if isinstance(t, torch.Tensor):
+            return fake_mode.from_tensor(t)
+        return t
+
+    fake_args = tuple(to_fake(a) for a in unwrapped_args)
+
+    output_layouts: list[SubclassLayout] = []
+
+    def fn_with_subclass_handling(*plain_args):
+        nonlocal output_layouts
+        output_layouts = []
+
+        wrapped_args = _wrap_to_subclasses(plain_args, input_layouts)
+
+        params_args = wrapped_args[:params_len]
+        user_args_wrapped = wrapped_args[params_len:]
+        user_args_restored = pytree.tree_unflatten(
+            list(user_args_wrapped), user_args_spec
+        )
+
+        outputs = functional_call(*params_args, *user_args_restored)
+
+        flat_outputs, _ = pytree.tree_flatten(outputs)
+        unwrapped_outputs = []
+        for out in flat_outputs:
+            if isinstance(out, torch.Tensor) and is_traceable_wrapper_subclass(out):
+                inner, meta = _unwrap_subclass(out)
+                unwrapped_outputs.extend(inner)
+                output_layouts.append(SubclassLayout(len(inner), meta))
+            else:
+                unwrapped_outputs.append(out)
+                output_layouts.append(SubclassLayout(1, None))
+
+        return unwrapped_outputs
+
+    # preserve_node_meta propagates fx.traceback.annotate metadata to traced nodes
+    with fake_mode, preserve_node_meta():
+        traced = make_fx(fn_with_subclass_handling, record_stack_traces=True)(
+            *fake_args
+        )
+
+    _remove_cpu_shadow_chains(traced)
+
+    return TracedResult(
+        gm=traced,
+        params_len=params_len,
+        params_spec=params_spec,
+        input_subclass_layouts=input_layouts,
+        output_subclass_layouts=output_layouts,
+    )
+
+
+def run_traced_module(
+    traced_result: TracedResult,
+    params_and_buffers: dict[str, torch.Tensor],
+    args: tuple,
+) -> list[torch.Tensor]:
+    """Execute a traced graph and rewrap outputs into their original subclass types.
+
+    Accepts a ``params_and_buffers`` dict (from ``named_parameters`` /
+    ``named_buffers``) instead of the module itself, so callers control exactly
+    which parameter snapshot is used.
+    """
+    params_flat, _ = pytree.tree_flatten(params_and_buffers)
+    user_args_flat, _ = pytree.tree_flatten(args)
+
+    all_args = []
+    for a in itertools.chain(params_flat, user_args_flat):
+        if isinstance(a, torch.Tensor) and is_traceable_wrapper_subclass(a):
+            inner, _ = _unwrap_subclass(a)
+            all_args.extend(inner)
+        else:
+            all_args.append(a)
+
+    flat_outputs = traced_result.gm(*all_args)
+    return _wrap_to_subclasses(flat_outputs, traced_result.output_subclass_layouts)

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -1,0 +1,259 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_module,
+    trace_module,
+)
+
+
+def get_loss(logits, labels):
+    return torch.nn.functional.cross_entropy(
+        logits.flatten(0, 1).float(),
+        labels.flatten(0, 1),
+        reduction="sum",
+    )
+
+
+class TrainStepModule(nn.Module):
+    def __init__(self, model, loss_fn):
+        super().__init__()
+        self.model = model
+        self.loss_fn = loss_fn
+
+    def forward(self, *args):
+        *fwd_args, labels = args
+        logits = self.model(*fwd_args)
+        loss = self.loss_fn(logits, labels)
+        # Must look up params in forward (not __init__) so that
+        # _reparametrize_module's swapped parameters are captured during tracing.
+        params = [p for _, p in self.model.named_parameters(remove_duplicate=False)]
+        grads = torch.autograd.grad(loss, params)
+        return [loss] + list(grads)
+
+
+def _get_params_and_buffers(mod):
+    return {
+        **dict(mod.named_parameters(remove_duplicate=False)),
+        **dict(mod.named_buffers(remove_duplicate=False)),
+    }
+
+
+def create_model(config_cls, model_config, device="cuda", dtype=torch.float32):
+    model = config_cls(model_config)
+    model.to(device=device, dtype=dtype)
+    with torch.no_grad():
+        model.init_weights(buffer_device=torch.device(device))
+    return model
+
+
+class SimpleMLP(nn.Module):
+    def __init__(self, dim=64, hidden=128, vocab_size=256):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, dim)
+        self.fc1 = nn.Linear(dim, hidden)
+        self.fc2 = nn.Linear(hidden, vocab_size)
+
+    def forward(self, x):
+        return self.fc2(torch.relu(self.fc1(self.embed(x))))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestTraceModule(unittest.TestCase):
+    DEVICE = "cuda"
+    DTYPE = torch.float32
+    BATCH_SIZE = 2
+    SEQ_LEN = 128
+    NUM_STEPS = 5
+    LR = 1e-3
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.use_deterministic_algorithms(True)
+
+    def tearDown(self):
+        torch.use_deterministic_algorithms(False)
+
+    def _make_mlp(self):
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        tokens = torch.randint(
+            0, 256, (self.BATCH_SIZE, self.SEQ_LEN), device=self.DEVICE
+        )
+        labels = torch.randint(
+            0, 256, (self.BATCH_SIZE, self.SEQ_LEN), device=self.DEVICE
+        )
+        return model, tokens, labels, get_loss
+
+    def test_mlp_forward(self):
+        model, tokens, labels, loss_fn = self._make_mlp()
+        traced_result = trace_module(model, (tokens,))
+        out_eager = model(tokens)
+        pab = _get_params_and_buffers(model)
+        wrapped = run_traced_module(traced_result, pab, (tokens,))
+        self.assertTrue(torch.equal(out_eager, wrapped[0]))
+
+    def test_mlp_train_step(self):
+        model_ref, tokens, labels, loss_fn = self._make_mlp()
+        model_copy = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        model_copy.load_state_dict(model_ref.state_dict())
+
+        train_step = TrainStepModule(model_ref, loss_fn)
+        traced_result = trace_module(train_step, (tokens, labels))
+
+        logits_ref = model_ref(tokens)
+        loss_ref = loss_fn(logits_ref, labels)
+        loss_ref.backward()
+        grads_ref = [p.grad.clone() for p in model_ref.parameters()]
+
+        train_step_copy = TrainStepModule(model_copy, loss_fn)
+        pab = _get_params_and_buffers(train_step_copy)
+        wrapped = run_traced_module(traced_result, pab, (tokens, labels))
+        loss_tr = wrapped[0]
+        grads_tr = wrapped[1:]
+
+        self.assertTrue(torch.equal(loss_ref, loss_tr))
+        for gr, gt in zip(grads_ref, grads_tr, strict=True):
+            self.assertTrue(torch.equal(gr, gt))
+
+    def test_mlp_multistep_bitwise(self):
+        model_ref, tokens, labels, loss_fn = self._make_mlp()
+        model_copy = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        model_copy.load_state_dict(model_ref.state_dict())
+
+        train_step_ref = TrainStepModule(model_ref, loss_fn)
+        train_step_copy = TrainStepModule(model_copy, loss_fn)
+        traced_result = trace_module(train_step_ref, (tokens, labels))
+
+        opt_ref = torch.optim.Adam(model_ref.parameters(), lr=self.LR)
+        opt_copy = torch.optim.Adam(model_copy.parameters(), lr=self.LR)
+
+        for step in range(1, self.NUM_STEPS + 1):
+            logits_ref = model_ref(tokens)
+            loss_ref = loss_fn(logits_ref, labels)
+            loss_ref.backward()
+            grads_ref = [p.grad.clone() for p in model_ref.parameters()]
+            opt_ref.step()
+            opt_ref.zero_grad()
+
+            pab = _get_params_and_buffers(train_step_copy)
+            wrapped = run_traced_module(traced_result, pab, (tokens, labels))
+            loss_tr = wrapped[0]
+            grads_tr = wrapped[1:]
+            for p, g in zip(model_copy.parameters(), grads_tr, strict=True):
+                p.grad = g
+            opt_copy.step()
+            opt_copy.zero_grad()
+
+            self.assertTrue(
+                torch.equal(loss_ref, loss_tr), f"Step {step}: loss mismatch"
+            )
+            for gr, gt in zip(grads_ref, grads_tr, strict=True):
+                self.assertTrue(torch.equal(gr, gt), f"Step {step}: grad mismatch")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestTraceDTensor(unittest.TestCase):
+    DEVICE = "cuda"
+    DTYPE = torch.float32
+
+    def setUp(self):
+        import torch.distributed as dist
+
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                init_method="tcp://localhost:12357",
+                world_size=1,
+                rank=0,
+            )
+        torch.manual_seed(42)
+        torch.use_deterministic_algorithms(True)
+
+    def tearDown(self):
+        import torch.distributed as dist
+
+        torch.use_deterministic_algorithms(False)
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _distribute_params(self, model, mesh):
+        from torch.distributed._tensor import distribute_tensor, Replicate
+
+        for name, param in list(model.named_parameters()):
+            dt = distribute_tensor(param, mesh, [Replicate()])
+            param_parts = name.split(".")
+            mod = model
+            for part in param_parts[:-1]:
+                mod = getattr(mod, part)
+            setattr(mod, param_parts[-1], nn.Parameter(dt))
+
+    def test_dtensor_forward(self):
+        from torch.distributed._tensor import DTensor, Replicate
+        from torch.distributed.device_mesh import init_device_mesh
+
+        mesh = init_device_mesh(self.DEVICE, (1,))
+
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        self._distribute_params(model, mesh)
+
+        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+        tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
+
+        traced_result = trace_module(model, (tokens_dt,))
+        has_subclass = any(
+            layout.meta is not None for layout in traced_result.input_subclass_layouts
+        )
+        self.assertTrue(has_subclass)
+
+        out_eager = model(tokens_dt)
+        pab = _get_params_and_buffers(model)
+        wrapped = run_traced_module(traced_result, pab, (tokens_dt,))
+        self.assertTrue(torch.equal(out_eager.full_tensor(), wrapped[0].full_tensor()))
+
+    def test_dtensor_train_step(self):
+        from torch.distributed._tensor import DTensor, Replicate
+        from torch.distributed.device_mesh import init_device_mesh
+
+        mesh = init_device_mesh(self.DEVICE, (1,))
+
+        model_ref = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        model_copy = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        model_copy.load_state_dict(model_ref.state_dict())
+
+        self._distribute_params(model_ref, mesh)
+        self._distribute_params(model_copy, mesh)
+
+        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+        labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+        tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
+        labels_dt = DTensor.from_local(labels, mesh, [Replicate()])
+
+        train_step = TrainStepModule(model_ref, get_loss)
+        traced_result = trace_module(train_step, (tokens_dt, labels_dt))
+
+        logits_ref = model_ref(tokens_dt)
+        loss_ref = get_loss(logits_ref, labels_dt)
+        loss_ref.backward()
+        grads_ref = [p.grad.clone() for p in model_ref.parameters()]
+
+        train_step_copy = TrainStepModule(model_copy, get_loss)
+        pab = _get_params_and_buffers(train_step_copy)
+        wrapped = run_traced_module(traced_result, pab, (tokens_dt, labels_dt))
+        loss_tr = wrapped[0]
+        grads_tr = wrapped[1:]
+
+        self.assertTrue(torch.equal(loss_ref.full_tensor(), loss_tr.full_tensor()))
+        for gr, gt in zip(grads_ref, grads_tr, strict=True):
+            self.assertTrue(torch.equal(gr.full_tensor(), gt.full_tensor()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- nonstrict_tracer.py: make_fx-based tracer with subclass handling (trace_module, run_traced_module, SubclassMeta, unwrap/wrap helpers)
- test_trace_module.py: simple MLP tests verifying bitwise-exact eager vs traced execution over multiple training steps

cc @SherlockNoMad 