### PR TITLE
Remove dead create_context_parallel_ctx function from distributed/utils.py

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -196,6 +196,7 @@ def set_determinism(
         # this API uses.
         torch.distributed.tensor._random.manual_seed(seed, parallel_dims.world_mesh)
 
+
 class TrainContext(Protocol):
     @abstractmethod
     def __call__(self) -> contextlib.AbstractContextManager[None]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2554

This function has no callers — context parallel functionality is now
provided by torchtitan/distributed/context_parallel.py.