### PR TITLE
[Reland] Remove dead create_context_parallel_ctx function from distributed/utils.py

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -197,31 +197,6 @@ def set_determinism(
         torch.distributed.tensor._random.manual_seed(seed, parallel_dims.world_mesh)
 
 
-def create_context_parallel_ctx(
-    cp_mesh: DeviceMesh,
-    cp_buffers: list[torch.Tensor],
-    cp_seq_dims: list[int],
-    cp_no_restore_buffers: set[torch.Tensor],
-    cp_rotate_method: str,
-):
-    try:
-        from torch.distributed.tensor.experimental import context_parallel
-        from torch.distributed.tensor.experimental._attention import set_rotate_method
-    except ImportError as e:
-        raise ValueError(
-            f"PyTorch version {torch.__version__} does not include the experimental "
-            "Context Parallel API. Please update to a newer version."
-        ) from e
-
-    set_rotate_method(cp_rotate_method)
-    return context_parallel(
-        cp_mesh,
-        buffers=cp_buffers,
-        buffer_seq_dims=cp_seq_dims,
-        no_restore_buffers=cp_no_restore_buffers,
-    )
-
-
 class TrainContext(Protocol):
     @abstractmethod
     def __call__(self) -> contextlib.AbstractContextManager[None]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2555

This function has no callers — context parallel functionality is now
provided by torchtitan/distributed/context_parallel.py.


**Safe to merge, already change the base to main**.