### PR TITLE
[graph_trainer] Trace forward loss backward step with make_fx

### DIFF
--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -317,5 +317,14 @@ def apply_compile(
             fsdp_reshard_after_forward,
             joint_passes=[],
         )
+    elif mode == "aot_fx_trace":
+        # aot_fx_trace traces fwd+loss+bwd together inside forward_backward_step,
+        # so no model-level wrapping is needed here.
+        logger.info(
+            "aot_fx_trace compile mode: graph capture will happen at training time"
+        )
+        return model
     else:
-        raise ValueError(f"Unknown compile mode: {mode}. Must be 'jit' or 'aot'.")
+        raise ValueError(
+            f"Unknown compile mode: {mode}. Must be 'jit', 'aot', or 'aot_fx_trace'."
+        )

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -16,11 +16,12 @@ from torchtitan.trainer import Trainer
 
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerCompileConfig(CompileConfig):
-    mode: Literal["jit", "aot"] | None = "aot"
+    mode: Literal["jit", "aot", "aot_fx_trace"] | None = "aot"
     """
     Compilation mode. Options:
         jit: standard torch.compile() with custom backend
         aot: explicit joint graph export + custom graph passes
+        aot_fx_trace: non-strict tracing of fwd+loss+bwd via make_fx
     """
 
     backend: str = "aot_eager"

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -262,6 +262,10 @@ def trace_module(
     graph is a pure function.  Tensor subclasses (e.g. DTensor) are recursively
     unwrapped into plain tensors for tracing, and the layouts needed to rewrap
     them are recorded in the returned :class:`TracedResult`.
+
+    Args:
+        mod: The module to trace.
+        args: The user arguments to trace with.
     """
     named_parameters = dict(mod.named_parameters(remove_duplicate=False))
     named_buffers = dict(mod.named_buffers(remove_duplicate=False))

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -283,6 +283,35 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor",
             ngpu=8,
         ),
+        # === aot_fx_trace mode tests ===
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP",
+            "aot_fx_trace_llama3_fsdp_tp",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_flex_attn",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+FlexAttn",
+            "aot_fx_trace_llama3_fsdp_tp_flexattn",
+            ngpu=8,
+        ),
     ]
 
 
@@ -397,6 +426,39 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "AOT deepseek_v3 inductor_decomposition",
             "aot_deepseekv3_inductor_decomposition",
+            ngpu=8,
+        ),
+        # === aot_fx_trace mode tests ===
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel_flex_attn",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
             ngpu=8,
         ),
     ]

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -150,6 +150,11 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    def test_llama3_aot_fx_trace_vs_eager(self):
+        self.assertTrue(
+            _run_llama3_loss_compare(test_options_extra="--compile.mode aot_fx_trace"),
+        )
+
     def test_llama3_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode jit"),
@@ -179,6 +184,13 @@ class TestGraphTrainerNumerics(unittest.TestCase):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
                 test_options_extra="--compile.mode jit --compile.passes transformer_block_bucketing"
+            ),
+        )
+
+    def test_dsv3_aot_fx_trace_vs_eager(self):
+        self.assertTrue(
+            _run_deepseek_v3_loss_compare(
+                test_options_extra="--compile.mode aot_fx_trace"
             ),
         )
 

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -5,10 +5,38 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn as nn
 
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_module,
+    trace_module,
+    TracedResult,
+)
 from torchtitan.trainer import Trainer
+
+
+class FwdBwdStepModule(nn.Module):
+    """Wraps model + loss_fn + autograd.grad into a single traceable forward.
+
+    This allows make_fx to trace through the entire fwd+loss+bwd as one graph.
+    """
+
+    def __init__(self, model, loss_fn):
+        super().__init__()
+        self.model = model
+        self.loss_fn = loss_fn
+
+    def forward(self, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs):
+        pred = self.model(inputs, **extra_inputs, **extra_kwargs)
+        loss = self.loss_fn(pred, labels) / global_valid_tokens
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        grads = torch.autograd.grad(loss, params)
+        return [loss] + list(grads)
 
 
 class GraphTrainer(Trainer):
@@ -17,6 +45,90 @@ class GraphTrainer(Trainer):
         compile: GraphTrainerCompileConfig = field(
             default_factory=GraphTrainerCompileConfig
         )
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if self.config.compile.mode == "aot_fx_trace" and self.parallel_dims.pp_enabled:
+            raise ValueError(
+                "aot_fx_trace compile mode does not support Pipeline Parallel"
+            )
+
+        # Lazy state for aot_fx_trace mode
+        self._fwd_bwd_step_module: FwdBwdStepModule | None = None
+        self._traced_step: TracedResult | None = None
+
+    def forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.config.compile.mode != "aot_fx_trace":
+            return super().forward_backward_step(
+                input_dict=input_dict,
+                labels=labels,
+                global_valid_tokens=global_valid_tokens,
+            )
+
+        assert len(self.model_parts) == 1
+        model = self.model_parts[0]
+
+        inputs, labels, extra_inputs, extra_kwargs = self.post_dataloading_process(
+            input_dict, labels
+        )
+
+        params = [p for p in model.parameters() if p.requires_grad]
+        return self._make_fx_forward_backward_step(
+            model,
+            inputs,
+            labels,
+            global_valid_tokens,
+            params,
+            extra_inputs,
+            extra_kwargs,
+        )
+
+    def _make_fx_forward_backward_step(
+        self,
+        model: nn.Module,
+        inputs: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        params: list[torch.Tensor],
+        extra_inputs: dict[str, torch.Tensor],
+        extra_kwargs: dict[str, Any],
+    ) -> torch.Tensor:
+        if self._traced_step is None:
+            self._fwd_bwd_step_module = FwdBwdStepModule(model, self.loss_fn)
+
+            with self.train_context(), self.maybe_enable_amp:
+                self._traced_step = trace_module(
+                    self._fwd_bwd_step_module,
+                    (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+                )
+
+        params_and_buffers = {
+            **dict(self._fwd_bwd_step_module.named_parameters(remove_duplicate=False)),
+            **dict(self._fwd_bwd_step_module.named_buffers(remove_duplicate=False)),
+        }
+        with self.train_context(), self.maybe_enable_amp:
+            outputs = run_traced_module(
+                self._traced_step,
+                params_and_buffers,
+                (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+            )
+        loss = outputs[0]
+        grads = outputs[1:]
+
+        for param, grad in zip(params, grads):
+            if param.grad is None:
+                param.grad = grad
+            else:
+                param.grad += grad
+
+        return loss
 
     def close(self) -> None:
         super().close()


### PR DESCRIPTION
This PR adds a new `aot_fx_trace` compilation mode to the graph_trainer experiment that uses `make_fx_tracer` to trace the entire forward pass, loss computation, and backward pass as a single unified graph.

It introduces `FwdBwdStepModule` that composes `model(inputs)` → `loss_fn(pred, labels)` → `autograd.grad(loss, params)` into a single traceable forward. Overrides `forward_backward_step` in `GraphTrainer` to use this path when `compile.mode == "aot_fx_trace"`, with lazy tracing on the first step.

