### PR TITLE
[mxfp8 training] add TP warning

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -84,6 +84,12 @@ class MXFP8Converter(QuantizationConverter):
                 "torch.compile enablement is required for highest performance of MXFP8 dynamic quantization."
             )
 
+        if parallel_dims.tp > 1:
+            logger.warning(
+                "TP support for MXFP8 linears is still in progress. "
+                "Any linear layers with TP applied will use default precision, not MXFP8."
+            )
+
         self.config = config
         self.enabled = True
         logger.info("MXFP8 MoE training enabled")


### PR DESCRIPTION
## Summary
- We are doing a refactor of how Dtensor + MXFP8WeightWrapperTensor subclass compose, reversing the wrapping order to `MXFP8WeightWrapperTensor(Dtensor(...))` (https://github.com/pytorch/ao/pull/4010) and landing Dtensor scaled_mm sharding strategy fixes (https://github.com/pytorch/pytorch/pull/177234). 
- In the meantime, while the wrapping order is `Dtensor(MXFP8WeightWrapperTensor(..))`, we need to warn that linears using TP will use default precision, not MXFP8. 

## Optional extra details 
- Due to how Dtensor linear uses "composite implicit autograd" it decomposes linear ops into `aten.t` + `aten.mm`, going straight through `__torch_dispatch__` instead of first going through `__torch_function__`. This prevents our subclass from intercepting the linear op to dispatch to `_to_mxfp8_then_scaled_mm` autograd func. We cannot intercept at the `__torch_dispatch__` level because then autograd would not capture the backward for our autograd func we dispatch to.
- In contrast, grouped_mm does not have this problem, as it has an explicitly registered backward (compose explicit autograd) so we always see `aten._grouped_mm` in `__torch_function__` and can intercept.
- thanks @pianpwk for the help with this! 