### PR TITLE
Fix repr() crash on Config with unset field(init=False) slots

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -3,7 +3,7 @@ datasets >= 3.6.0
 tensorboard
 wandb
 fsspec
-tyro
+tyro >= 1.0.5
 tokenizers >= 0.15.0
 safetensors
 einops

--- a/tests/unit_tests/test_configurable.py
+++ b/tests/unit_tests/test_configurable.py
@@ -200,6 +200,30 @@ class TestConfigurable(unittest.TestCase):
         self.assertEqual(d2["inner"]["a"], 1)
         self.assertEqual(d2["inner"]["b"], 256)
 
+    def test_repr_with_unset_init_false(self):
+        """repr() must not crash when field(init=False) slots are unset."""
+        cfg = self.NewStyleComponent.Config(x=10)
+        # Before build: dim and hidden are unset
+        r = repr(cfg)
+        self.assertIn("x=10", r)
+        self.assertIn("dim=<UNSET>", r)
+        self.assertIn("hidden=<UNSET>", r)
+
+        # After build: all fields set
+        obj = cfg.build(dim=64, hidden=128)
+        r2 = repr(obj.config)
+        self.assertIn("x=10", r2)
+        self.assertIn("dim=64", r2)
+        self.assertIn("hidden=128", r2)
+        self.assertNotIn("UNSET", r2)
+
+    def test_repr_no_init_false_fields(self):
+        """repr() works normally when there are no field(init=False) fields."""
+        cfg = self.NoKwargsComponent.Config(x=42)
+        r = repr(cfg)
+        self.assertIn("x=42", r)
+        self.assertNotIn("UNSET", r)
+
     def test_init_false_with_inheritance(self):
         """Child config can redeclare field with default."""
 

--- a/torchtitan/config/configurable.py
+++ b/torchtitan/config/configurable.py
@@ -54,6 +54,25 @@ class Configurable:
 
         _owner: ClassVar[type | None] = None
 
+        def __repr__(self) -> str:
+            """Safe repr that handles unset ``field(init=False)`` slots.
+
+            The default dataclass ``__repr__`` raises ``AttributeError`` when
+            ``field(init=False)`` slots have not been set yet.  This override
+            shows ``<UNSET>`` for those fields instead of crashing, which lets
+            external libraries (e.g. tyro) safely print configs.
+            """
+            cls_name = type(self).__name__
+            parts: list[str] = []
+            for f in fields(self):
+                try:
+                    val = getattr(self, f.name)
+                except AttributeError:
+                    parts.append(f"{f.name}=<UNSET>")
+                    continue
+                parts.append(f"{f.name}={val!r}")
+            return f"{cls_name}({', '.join(parts)})"
+
         def to_dict(self) -> dict:
             """Serialize to a dict, safely handling unset ``field(init=False)`` slots."""
             result = {}
@@ -154,5 +173,8 @@ class Configurable:
                             f"{cls.__name__}.Config field '{f.name}' "
                             "must be keyword-only"
                         )
+                # Override @dataclass-generated __repr__ with our safe
+                # version that handles unset field(init=False) slots.
+                config_cls.__repr__ = Configurable.Config.__repr__
                 # Auto-wire build() to construct this class
                 config_cls._owner = cls


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2563

Since we introduce field(init=False) for sharing fields, people have encountered the issue that config.__repr__() may fail if some fields are not set yet -- build() is not called. This PR fixes the issue and also bumps tyro version, which will avoid call repr when building configs.


**Safe to land**