### PR TITLE
[graph_trainer] Fix graph SAC for DSv3

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -113,12 +113,14 @@ def validate_flex_attn_annotation_pass(
 # where recomputation is expensive.
 DEFAULT_SAC_SAVE_OPS = {
     torch.ops.aten.mm.default,
+    torch.ops.aten.linear.default,
     torch.ops.aten._scaled_dot_product_efficient_attention.default,
     torch.ops.aten._scaled_dot_product_flash_attention.default,
     torch.ops.aten._scaled_dot_product_cudnn_attention.default,
     torch.ops.aten._scaled_dot_product_attention_math.default,
     torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
     torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    torch.ops._c10d_functional.all_to_all_single.default,
     torch.ops.aten.max.default,
     torch._higher_order_ops.flex_attention,
     torch._higher_order_ops.inductor_compiled_code,
@@ -159,11 +161,9 @@ def apply_sac_pass(
     if op_list_to_save is None:
         op_list_to_save = DEFAULT_SAC_SAVE_OPS
 
-    nodes = list(gm.graph.nodes)
-    output_node = nodes[-1].all_input_nodes[0]
     mm_count = 0
 
-    for node in nodes:
+    for node in gm.graph.nodes:
         if node.op != "call_function" or node.target is operator.getitem:
             continue
 
@@ -180,9 +180,6 @@ def apply_sac_pass(
             node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
         else:
             node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
-
-        if node is output_node:
-            break
 
     gm.recompile()
     logger.info(


### PR DESCRIPTION
- Removed early termination at the output node in graph-based SAC which caused some nodes to be skipped and left without SAC annotations.
- Add `aten.linear.default` and `_c10d_functional.all_to_all_single.default` to the default SAC save ops list

Verified on DSv3-16B with FSDP=4, TP=2, EP=2, and local_batch_size=2 
```
MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2 --training.local_batch_size=2 --training.steps 50 --compile.joint_passes apply_sac
```

w/o graph SAC:
```
step: 10  loss: 10.48328  grad_norm: 20.6773  memory: 87.71GiB(92.33%)  tps: 2,530  tflops: 45.80  mfu: 4.63%
step: 20  loss:  8.26837  grad_norm:  4.9812  memory: 88.22GiB(92.87%)  tps: 2,457  tflops: 44.49  mfu: 4.50%
step: 30  loss:  7.29936  grad_norm:  1.1563  memory: 88.22GiB(92.87%)  tps: 2,457  tflops: 44.49  mfu: 4.50%
```

w/ graph SAC: `--compile.joint_passes apply_sac`
```
step: 10  loss: 10.45088  grad_norm: 20.9278  memory: 52.03GiB(54.77%)  tps: 1,908  tflops: 34.55  mfu: 3.49%
step: 20  loss:  8.29953  grad_norm:  6.1690  memory: 52.03GiB(54.77%)  tps: 1,895  tflops: 34.31  mfu: 3.47%
step: 30  loss:  7.33095  grad_norm:  1.4244  memory: 52.03GiB(54.77%)  tps: 1,856  tflops: 33.61  mfu: 3.40%
```