### PR TITLE
[rl] Refactor Episode definition to be a single completion instead of a group (#2529)

### DIFF
--- a/torchtitan/experiments/rl/unified/README.md
+++ b/torchtitan/experiments/rl/unified/README.md
@@ -56,27 +56,15 @@ torchrun --nproc_per_node=2 torchtitan/experiments/rl/unified/inference_example.
 
 **NOTE:**: Set `--nproc_per_node` to the world size, which should match the `tensor_parallel_degree` in the `VLLMGenerator` config.
 
-6. Run simple GRPO RL loop
+6. Run simple GRPO RL loop for model to learn sum digits task
 ```bash
-python torchtitan/experiments/rl/unified/simple_grpo.py --module rl.unified --config rl_grpo_qwen3_0_6b
+python torchtitan/experiments/rl/unified/simple_grpo_sum_digits.py --module rl.unified --config rl_grpo_qwen3_0_6b
 ```
 
 **NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
 
 We use a unified model definition for the trainer and generator, ensuring bitwise-identical models to address a class of subtle correctness bugs in RL for LLMs.
 
-## TODO
-Work on batch invariance:
-1. Integrate with simple_rl_multiprocess.py to run end-to-end RL with one canonical model definition(UNIFIED mode).
-2. Rewrite attention part to use vllm.Attention() with backward as the only attention path.
-3. Leverage batch-invariant kernels into model definition.
 
-Work on the RL loop:
-1. Design trainer API and integrate with [train.py](https://github.com/pytorch/torchtitan/blob/main/torchtitan/train.py#L475)
-2. Remove hardcoded configs and dependency on Qwen3 Model. Use torchtitan's config/TrainSpec instead, to work with any model.
-3. Need to load the gsm8k dataset using TorchTitan dataset.
-4. Need to properly implement weight saving and loading using TorchTitan's checkpoint mechanism, or use TorchStore. Also need to
-    replace `vllm_to_torchtitan` and `torchtitan_to_vllm` calls to TorchTitan [state dict adaptor](https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/qwen3/model/state_dict_adapter.py).
-5. Right now we only support trainer run on multiple processes using DDP, and generator using TP, need to onboard more parallelism.
-6. Right now we only support VLLM_COMPAT mode to achieve batch invariance and bitwise determinism, need to support UNIFIED mode.
-7. In the longer term, need to add episode queue to achieve async, right now trainer and generator are running synchronously.
+
+**Current status:** Batch invariance is only supported for single-GPU configurations (TP=1) for both the trainer and generator. When tensor parallelism is enabled (TP > 1), batch-invariant mode is not yet supported.

--- a/torchtitan/experiments/rl/unified/actors/generator.py
+++ b/torchtitan/experiments/rl/unified/actors/generator.py
@@ -225,12 +225,22 @@ class VLLMGenerator(Actor, Configurable):
         return self._engine.model_executor.driver_worker.get_model()
 
     @endpoint
-    async def generate(self, prompt_texts: list[str]) -> list[Episode]:
-        """Generate episodes and return list of Episode (one per prompt).
-        Called by the orchestrator (simple_grpo.py). The Grader fills in rewards.
+    async def generate(
+        self,
+        prompt_texts: list[str],
+        expected_answers: list[str],
+    ) -> list[Episode]:
+        """Generate completions and return a flat list of Episodes.
+
+        Each prompt produces ``num_samples_per_prompt`` Episodes. Episodes
+        from the same prompt share a ``group_id`` so the controller can
+        compute group-level advantages later.
 
         Args:
             prompt_texts: List of prompt strings for which to generate completions.
+            expected_answers: List of expected answers, one per prompt.
+                They are copied into each Episode so downstream graders can use them
+                for reward computation and generator doesn't use this field.
         """
         logger.debug(
             f"{os.getpid()=} Generating start generate (policy v{self.policy_version})..."
@@ -258,32 +268,36 @@ class VLLMGenerator(Actor, Configurable):
                 request_outputs = self._engine.step()
                 all_outputs.extend(request_outputs)
 
-            # Build one Episode per prompt
-            episodes = []
-            for output in all_outputs:
-                prompt_token_ids = output.prompt_token_ids
+            # Sort outputs by request_id to guarantee prompt ordering,
+            # since vLLM may return completed requests out of order.
+            all_outputs.sort(key=lambda o: int(o.request_id))
 
-                completions = []
+            # Build flat list of Episodes; assign a group_id per prompt.
+            # TODO: Assigning group_id here is GRPO-specific and should be
+            # decoupled from the generator in the future.
+            episodes: list[Episode] = []
+            for idx, output in enumerate(all_outputs):
+                prompt_token_ids = output.prompt_token_ids
+                gid = f"{os.getpid()}_{self.policy_version}_{idx}"
+
                 for sample in output.outputs:
                     per_token_log_probs = [
                         list(logprob_dict.values())[0].logprob
                         for logprob_dict in sample.logprobs
                     ]
-                    completions.append(
-                        Episode.Completion(
+                    episodes.append(
+                        Episode(
+                            policy_version=self.policy_version,
+                            prompt_token_ids=prompt_token_ids,
                             text=sample.text,
                             token_ids=sample.token_ids,
                             token_log_probs=per_token_log_probs,
+                            expected_answer=expected_answers[idx]
+                            if expected_answers
+                            else "",
+                            group_id=gid,
                         )
                     )
-
-                episodes.append(
-                    Episode(
-                        policy_version=self.policy_version,
-                        prompt_token_ids=prompt_token_ids,
-                        completions=completions,
-                    )
-                )
 
         logger.debug(
             f"{os.getpid()=} Generating finish generate (policy v{self.policy_version})..."
@@ -293,7 +307,7 @@ class VLLMGenerator(Actor, Configurable):
     @endpoint
     async def update(self, version: int, state_dict: dict) -> None:
         """Update generator weights.
-        Called by the orchestrator (simple_grpo.py).
+        Called by the orchestrator.
 
         Args:
             version: New policy version number

--- a/torchtitan/experiments/rl/unified/actors/grader.py
+++ b/torchtitan/experiments/rl/unified/actors/grader.py
@@ -16,11 +16,10 @@ logger = logging.getLogger(__name__)
 
 class Grader(Actor):
     """
-    Evaluates completions and assigns rewards to episode data.
+    Evaluates completions and assigns rewards to episodes.
 
-    The Grader receives episode data from the Generator
-    and computes rewards using a reward function. Advantage computation
-    is done by the Trainer.
+    The Grader receives a flat list of Episodes and computes rewards
+    using a reward function. It scores each episode independently.
 
     Args:
         reward_fn: Reward function that takes (completions: list[str], expected_answer: str)
@@ -40,32 +39,27 @@ class Grader(Actor):
         """
         Score episodes by computing rewards.
 
+        Calls the reward_fn with each episode's completion text and
+        expected answer, then sets the reward on each episode.
+
         Args:
-            episodes: List of Episode data (one per prompt, with completions)
+            episodes: Flat list of Episodes to score.
 
         Returns:
-            Episodes with computed rewards
+            Episodes with rewards filled in.
         """
-        logger.debug(
-            f"Grader scoring {len(episodes)} episodes "
-            f"(policy v{episodes[0].policy_version})..."
-        )
+        logger.debug(f"Grader scoring {len(episodes)} episodes...")
 
-        all_rewards = []
-        for episode in episodes:
-            completion_texts = [c.text for c in episode.completions]
-            rewards = self.reward_fn(completion_texts, episode.expected_answer)
-            for completion, reward in zip(episode.completions, rewards):
-                completion.reward = reward.item()
-            all_rewards.append(rewards)
+        # Score each episode individually
+        for ep in episodes:
+            rewards = self.reward_fn([ep.text], ep.expected_answer)
+            ep.reward = rewards[0].item()
 
-        all_rewards_cat = torch.cat(all_rewards)
-        reward_mean = all_rewards_cat.mean()
-        reward_std = all_rewards_cat.std()
-
+        all_rewards = torch.tensor([ep.reward for ep in episodes])
         logger.debug(
             f"Grader finished scoring: "
-            f"reward_mean={reward_mean.item():.4f}, reward_std={reward_std.item():.4f}"
+            f"reward_mean={all_rewards.mean().item():.4f}, "
+            f"reward_std={all_rewards.std().item():.4f}"
         )
 
         return episodes

--- a/torchtitan/experiments/rl/unified/actors/trainer.py
+++ b/torchtitan/experiments/rl/unified/actors/trainer.py
@@ -242,12 +242,12 @@ class PolicyTrainer(Actor, Configurable):
     async def step(self, episodes: list[Episode]) -> dict:
         """Perform one training step.
 
-        Computes advantages from rewards on the full batch (GRPO normalizes
-        within each prompt group), then shards completions across DP ranks
-        so each rank processes a unique slice of the data.
+        Expects a flat list of Episodes with ``advantage`` already computed
+        by the controller. Shards episodes across DP ranks so each rank
+        processes a unique slice of the data.
 
         Args:
-            episodes: List of Episode data (one per prompt) with rewards filled by Grader
+            episodes: Flat list of Episodes with advantages set.
 
         Returns:
             Training metrics
@@ -256,25 +256,13 @@ class PolicyTrainer(Actor, Configurable):
             f"{os.getpid()=} PolicyTrainer starting step {self.policy_version} "
         )
 
-        # Compute GRPO advantages on the full batch (group normalization
-        # requires seeing all completions per prompt).
-        all_token_ids: list[list[int]] = []
-        all_prompt_token_ids: list[list[int]] = []
-        all_token_log_probs: list[list[float]] = []
-        all_advantages: list[torch.Tensor] = []
-        all_rewards: list[float] = []
-        for episode in episodes:
-            rewards = torch.tensor([c.reward for c in episode.completions])
-            advantages = rewards - rewards.mean()
-            all_advantages.append(advantages)
-            all_rewards.extend(c.reward for c in episode.completions)
-            for completion in episode.completions:
-                all_token_ids.append(completion.token_ids)
-                all_prompt_token_ids.append(episode.prompt_token_ids)
-                all_token_log_probs.append(completion.token_log_probs)
+        advantages = torch.tensor([ep.advantage for ep in episodes])
 
-        advantages = torch.cat(all_advantages)
-        all_rewards_tensor = torch.tensor(all_rewards)
+        all_token_ids: list[list[int]] = [ep.token_ids for ep in episodes]
+        all_prompt_token_ids: list[list[int]] = [ep.prompt_token_ids for ep in episodes]
+        all_token_log_probs: list[list[float]] = [ep.token_log_probs for ep in episodes]
+
+        all_rewards_tensor = torch.tensor([ep.reward for ep in episodes])
 
         # Shard flattened completions across DP ranks so each rank processes
         # a unique subset of the data.
@@ -349,7 +337,7 @@ class PolicyTrainer(Actor, Configurable):
             "reward_std": all_rewards_tensor.std().item(),
             "advantage_mean": advantages.mean().item(),
             "advantage_std": advantages.std().item(),
-            "sample_completion": episodes[0].completions[0].text[:80],
+            "sample_completion": episodes[0].text[:80],
             "policy_version": self.policy_version,
             "grad_norm": grad_norm.item() if hasattr(grad_norm, "item") else grad_norm,
             # Trainer vs generator log prob divergence

--- a/torchtitan/experiments/rl/unified/config_registry.py
+++ b/torchtitan/experiments/rl/unified/config_registry.py
@@ -20,7 +20,7 @@ from torchtitan.experiments.rl.unified.actors.generator import (
     VLLMGenerator,
 )
 from torchtitan.experiments.rl.unified.actors.trainer import PolicyTrainer
-from torchtitan.experiments.rl.unified.simple_grpo import RLTrainer
+from torchtitan.experiments.rl.unified.simple_grpo_sum_digits import RLTrainer
 from torchtitan.models.qwen3 import model_registry
 
 

--- a/torchtitan/experiments/rl/unified/simple_grpo_sum_digits.py
+++ b/torchtitan/experiments/rl/unified/simple_grpo_sum_digits.py
@@ -17,7 +17,7 @@ This demonstrates:
 The architecture mirrors monarch's grpo_actor.py but adapted for vLLM rollouts + TorchTitan training.
 
 Command to run:
-python3 torchtitan/experiments/rl/unified/simple_grpo.py \
+python3 torchtitan/experiments/rl/unified/simple_grpo_sum_digits.py \
     --module rl.unified --config rl_grpo_qwen3_0_6b \
     --hf_assets_path=<path_to_model_checkpoint>
 """
@@ -27,6 +27,7 @@ import logging
 import os
 import re
 import time
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -39,6 +40,7 @@ from torchtitan.experiments.rl.unified.actors.generator import VLLMGenerator
 from torchtitan.experiments.rl.unified.actors.grader import Grader
 from torchtitan.experiments.rl.unified.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.unified.sum_digits import extract_answer, SumDigitsTask
+from torchtitan.experiments.rl.unified.types import Episode
 from torchtitan.protocols.model_spec import ModelSpec
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,25 @@ class Provisioner:
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
 
         return _bootstrap
+
+
+def _log_samples(episodes: list[Episode]) -> None:
+    """Log the first completion per group for debugging."""
+    seen_groups: set[str] = set()
+    for ep in episodes:
+        if ep.group_id in seen_groups:
+            continue
+        seen_groups.add(ep.group_id)
+        extracted = extract_answer(ep.text)
+        is_correct = (
+            extracted == int(ep.expected_answer) if ep.expected_answer else None
+        )
+        mark = "+" if is_correct else "-"
+        logger.info(
+            f"  [{mark}] expected={ep.expected_answer} extracted={extracted} "
+            f"reward={ep.reward:+.1f}"
+        )
+        logger.info(f"       A: {ep.text[:300].replace(chr(10), ' ').strip()}")
 
 
 class RLTrainer(Configurable):
@@ -230,24 +251,24 @@ class RLTrainer(Configurable):
             eval_questions.append(question)
 
         # Generate on eval prompts
-        episodes = self.generator.generate.call(eval_prompts).get().item(gpus=0)
+        episodes = (
+            self.generator.generate.call(eval_prompts, eval_answers).get().item(gpus=0)
+        )
 
-        # Score: check first completion per episode
+        # Score: check first episode per prompt (episodes are ordered by prompt)
         correct = 0
         format_ok = 0
-        for episode, question, answer in zip(episodes, eval_questions, eval_answers):
-            text = episode.completions[0].text
-            extracted = extract_answer(text)
+        samples_per_prompt = self.config.generator.num_samples_per_prompt
+        for i, (question, answer) in enumerate(zip(eval_questions, eval_answers)):
+            ep = episodes[i * samples_per_prompt]
+            extracted = extract_answer(ep.text)
             is_correct = extracted == int(answer)
-            has_tag = bool(re.search(r"\[ANSWER\]", text))
+            has_tag = bool(re.search(r"\[ANSWER\]", ep.text))
             correct += int(is_correct)
             format_ok += int(has_tag)
 
-            if self.config.log_samples:
-                mark = "+" if is_correct else "-"
-                logger.info(f"  [{mark}] expected={answer} extracted={extracted}")
-                logger.info(f"       Q: {question}")
-                logger.info(f"       A: {text[:300].replace(chr(10), ' ').strip()}")
+        if self.config.log_samples:
+            _log_samples(episodes)
 
         result = {
             "accuracy": correct / num_samples,
@@ -278,7 +299,7 @@ class RLTrainer(Configurable):
         logger.info("=" * 80)
 
         for step in range(num_steps):
-            # Generate prompts for this step
+            # Generate data sample for this step
             train_prompts = []
             train_answers = []
             train_questions = []
@@ -288,51 +309,45 @@ class RLTrainer(Configurable):
                 train_answers.append(answer)
                 train_questions.append(question)
 
-            step_start = time.perf_counter()
+            step_start: float = time.perf_counter()
 
-            # Fully sync RL loop with separate scoring step
-            # 1. VLLMGenerator produces episodes (one per prompt, without rewards)
-            # TODO: Create a queue to use all episode from all GPUs
-            episodes = self.generator.generate.call(train_prompts).get().item(gpus=0)
-
-            # Attach expected answers to each episode
-            for episode, answer in zip(episodes, train_answers):
-                episode.expected_answer = answer
+            # Fully sync RL loop (GRPO)
+            # 1. Generator produces flat list of Episodes with group_id
+            # TODO: Create a queue to use all episodes from all GPUs
+            episodes = (
+                self.generator.generate.call(train_prompts, train_answers)
+                .get()
+                .item(gpus=0)
+            )
 
             # 2. Grader computes rewards per episode
-            scored_episodes = self.grader.score.call(episodes).get().item()
+            episodes = self.grader.score.call(episodes).get().item()
+
+            # 3. Controller computes GRPO advantages (normalize within group)
+            groups: dict[str, list[int]] = defaultdict(list)
+            for idx, ep in enumerate(episodes):
+                groups[ep.group_id].append(idx)
+            for indices in groups.values():
+                rewards = torch.tensor([episodes[i].reward for i in indices])
+                mean_reward = rewards.mean().item()
+                for i in indices:
+                    episodes[i].advantage = episodes[i].reward - mean_reward
 
             if self.config.log_samples:
-                for ep, question, answer in zip(
-                    scored_episodes, train_questions, train_answers
-                ):
-                    # Log first completion per prompt
-                    comp = ep.completions[0]
-                    extracted = extract_answer(comp.text)
-                    mark = "+" if comp.reward > 0 else "-"
-                    logger.info(
-                        f"  [{mark}] expected={answer} extracted={extracted} "
-                        f"reward={comp.reward:+.1f}"
-                    )
-                    logger.info(f"       Q: {question}")
-                    logger.info(
-                        f"       A: {comp.text[:300].replace(chr(10), ' ').strip()}"
-                    )
+                _log_samples(episodes)
 
-            # 3. Trainer computes advantages and updates policy
-            metrics = self.trainer.step.call(scored_episodes).get().item(gpus=0)
-            # 4. Sync full weights to generator (each rank reshards locally)
+            # 4. Trainer updates policy using episodes with advantages
+            metrics = self.trainer.step.call(episodes).get().item(gpus=0)
+            # 5. Sync full weights to generator (each rank reshards locally)
             weights = self.trainer.get_weights.call().get().item(gpus=0)
             self.generator.update.call(metrics["policy_version"], weights).get()
 
             t_step = time.perf_counter() - step_start
 
-            all_token_lens = [
-                len(c.token_ids) for ep in scored_episodes for c in ep.completions
-            ]
+            all_token_lens = [len(ep.token_ids) for ep in episodes]
             avg_len = sum(all_token_lens) / len(all_token_lens)
 
-            all_rewards = [c.reward for ep in scored_episodes for c in ep.completions]
+            all_rewards = [ep.reward for ep in episodes]
             correct_count = sum(1 for r in all_rewards if r > 0)
             total_count = len(all_rewards)
 

--- a/torchtitan/experiments/rl/unified/types.py
+++ b/torchtitan/experiments/rl/unified/types.py
@@ -4,32 +4,42 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
 class Episode:
     """
-    Data from one prompt in a generation batch.
-    Each Episode holds a single prompt and its group of completions.
+    A single prompt + completion pair with reward and advantage.
+
+    The generator creates Episodes (with group_id, no reward yet).
+    The grader fills in the reward.
+    The controller computes advantages across episodes sharing a group_id.
+    The trainer consumes the final Episodes with advantages set.
 
     Attributes:
-        policy_version: Version of policy that produced this episode
-        prompt_token_ids: Token IDs for this prompt (no duplication)
-        expected_answer: Expected answer for reward computation
-        completions: List of Completion objects (len=num_samples_per_prompt)
+        policy_version: Version of policy that produced this episode.
+        prompt_token_ids: Token IDs for the prompt.
+        text: Decoded completion text.
+        token_ids: Completion token IDs.
+        token_log_probs: Per-token log probabilities from the generator.
+        expected_answer: Expected answer for reward computation.
+            Passed to Episode by the generator — the generator
+            does not read this field.
+        reward: Scalar reward assigned by the grader.
+        group_id: Identifies which group this episode belongs to.
+            Episodes with the same group_id share a prompt and have
+            their advantages normalized together.
+        advantage: Advantage value computed by the controller (GRPO:
+            reward minus group mean reward).
     """
-
-    @dataclass
-    class Completion:
-        """A single completion for a prompt."""
-
-        text: str
-        token_ids: list[int]
-        token_log_probs: list[float]
-        reward: float = 0.0
 
     policy_version: int
     prompt_token_ids: list[int]
+    text: str
+    token_ids: list[int]
+    token_log_probs: list[float]
     expected_answer: str = ""
-    completions: list[Completion] = field(default_factory=list)
+    reward: float = 0.0
+    group_id: str = ""
+    advantage: float = 0.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2567

- Previously we use `Episode` to represent a group of completion in
GRPO, which requires several places to flatten the list.
- Flatten the Episode concept and introduce `group_id` field to identify
the group