### PR TITLE
[graph_trainer] Graph-based SAC with default policy

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -108,23 +108,43 @@ def validate_flex_attn_annotation_pass(
     return gm
 
 
-# Default set of ops whose outputs should be saved (not recomputed) during
-# activation checkpointing. These are compute-intensive or communication ops
-# where recomputation is expensive.
-DEFAULT_SAC_SAVE_OPS = {
-    torch.ops.aten.mm.default,
-    torch.ops.aten.linear.default,
-    torch.ops.aten._scaled_dot_product_efficient_attention.default,
-    torch.ops.aten._scaled_dot_product_flash_attention.default,
-    torch.ops.aten._scaled_dot_product_cudnn_attention.default,
-    torch.ops.aten._scaled_dot_product_attention_math.default,
-    torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
-    torch.ops._c10d_functional.reduce_scatter_tensor.default,
-    torch.ops._c10d_functional.all_to_all_single.default,
-    torch.ops.aten.max.default,
-    torch._higher_order_ops.flex_attention,
-    torch._higher_order_ops.inductor_compiled_code,
-}
+def _get_default_sac_save_ops() -> set:
+    """Build the default set of ops whose outputs should be saved (not recomputed)
+    during activation checkpointing.
+
+    Compute-intensive ops are obtained dynamically from PyTorch's partitioner
+    (``get_default_op_list``) so the list stays in sync with upstream changes.
+    """
+    from torch._functorch.partitioners import get_default_op_list
+
+    # Compute-intensive ops from PyTorch's partitioner
+    compute_intensive_ops = {
+        op.default for op in get_default_op_list().compute_intensive_ops
+    }
+
+    # attention variants
+    scaled_dot_product_attention_ops = {
+        torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+        torch.ops.aten._scaled_dot_product_attention_math.default,
+        torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
+    }
+
+    higher_order_ops = {
+        torch._higher_order_ops.flex_attention,
+        torch._higher_order_ops.inductor_compiled_code,
+    }
+
+    communication_intensive_ops = {
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        torch.ops._c10d_functional.all_to_all_single.default,
+    }
+
+    return (
+        compute_intensive_ops
+        | scaled_dot_product_attention_ops
+        | higher_order_ops
+        | communication_intensive_ops
+    )
 
 
 def apply_sac_pass(
@@ -153,18 +173,36 @@ def apply_sac_pass(
     Args:
         gm: The joint forward-backward graph module
         op_list_to_save: Set of op targets whose outputs should be saved.
-            Defaults to DEFAULT_SAC_SAVE_OPS if None.
+            Defaults to ``_get_default_sac_save_ops()`` if None.
 
     Returns:
         The annotated graph module
     """
     if op_list_to_save is None:
-        op_list_to_save = DEFAULT_SAC_SAVE_OPS
+        op_list_to_save = _get_default_sac_save_ops()
 
     mm_count = 0
 
     for node in gm.graph.nodes:
-        if node.op != "call_function" or node.target is operator.getitem:
+        if node.op != "call_function":
+            continue
+
+        if node.target in (
+            operator.getitem,
+            torch.ops._c10d_functional.wait_tensor.default,
+        ):
+            # Propagate recompute tag from the parent node:
+            # - getitem: When a node returns a tuple/list (e.g., rmsnorm, sdpa),
+            #   it is followed by getitem nodes that extract individual elements.
+            #   They inherit the parent's recompute tag, otherwise they will be
+            #   exposed as graph outputs and saved for backwards unnecessarily.
+            # - wait_tensor: Semantically tied to its parent async collective
+            #   (e.g., reduce_scatter_tensor, all_gather_into_tensor) and must
+            #   share the same save/recompute decision.
+            parent = node.args[0]
+            if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
+                node.meta["recompute"] = parent.meta["recompute"]
+                node.meta["ac_graph_id"] = parent.meta.get("ac_graph_id", 0)
             continue
 
         node.meta["ac_graph_id"] = 0

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -196,6 +196,21 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
                     "--compile.mode aot",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
+                    "--compile.joint_passes apply_sac",
+                ],
+            ],
+            "AOT llama3 FSDP+TP graph SAC",
+            "aot_llama3_fsdp_tp_graph_sac",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
                     "--compile.passes auto_bucketing",
                 ],
             ],
@@ -376,6 +391,23 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "AOT deepseek_v3 FSDP+TP+EP",
             "aot_deepseekv3_fsdp_tp_ep",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                    "--compile.joint_passes apply_sac",
+                ],
+            ],
+            "AOT deepseek_v3 FSDP+TP+EP Graph SAC",
+            "aot_deepseekv3_fsdp_tp_ep_graph_sac",
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -248,8 +248,8 @@ class TestApplySACPass(TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].meta["recompute"], CheckpointPolicy.MUST_SAVE)
 
-    def test_getitem_nodes_skipped(self):
-        """operator.getitem nodes should not receive any annotation."""
+    def test_getitem_propagates_parent_tag(self):
+        """operator.getitem nodes should inherit the parent's recompute tag."""
         gm = self._build_gm(
             [
                 torch.ops.aten.add.Tensor,
@@ -258,10 +258,28 @@ class TestApplySACPass(TestCase):
             ]
         )
         apply_sac_pass(gm)
-        for node in self._get_call_function_nodes(gm):
-            if node.target is operator.getitem:
-                self.assertNotIn("recompute", node.meta)
-                self.assertNotIn("ac_graph_id", node.meta)
+        nodes = self._get_call_function_nodes(gm)
+        add_node = nodes[0]
+        getitem_node = nodes[1]
+        self.assertEqual(add_node.target, torch.ops.aten.add.Tensor)
+        self.assertEqual(getitem_node.target, operator.getitem)
+        self.assertEqual(getitem_node.meta["recompute"], add_node.meta["recompute"])
+
+    def test_wait_tensor_propagates_parent_tag(self):
+        """wait_tensor nodes should inherit the parent's recompute tag."""
+        custom_save = {torch.ops._c10d_functional.reduce_scatter_tensor.default}
+        gm = self._build_gm(
+            [
+                torch.ops._c10d_functional.reduce_scatter_tensor.default,
+                torch.ops._c10d_functional.wait_tensor.default,
+            ]
+        )
+        apply_sac_pass(gm, op_list_to_save=custom_save)
+        nodes = self._get_call_function_nodes(gm)
+        rs_node = nodes[0]
+        wait_node = nodes[1]
+        self.assertEqual(rs_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertEqual(wait_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
 
     def test_ac_graph_id_set(self):
         """All annotated nodes should have ac_graph_id = 0."""


### PR DESCRIPTION
- Replace hardcoded SAC save-ops list with a dynamic default policy that pulls compute-intensive ops from PyTorch's upstream get_default_op_list() partitioner.
- Propagate recompute tags to getitem and wait_tensor nodes so that tuple-unpacking nodes (e.g. from rmsnorm, sdpa) and async collective wait nodes inherit their parent's save/recompute decision, preventing them from being unnecessarily saved as graph outputs.
- Add integration tests for graph SAC with FSDP+TP on Llama3 and FSDP+TP+EP on DeepSeek V3.

Llama3-8B FSDP=4, TP=2
no AC: `memory: 49.65GiB(52.27%)  tps: 4,878  tflops: 282.50  mfu: 28.56%`
eager SAC: `memory: 28.54GiB(30.04%)  tps: 4,463  tflops: 258.44  mfu: 26.13%`
graph SAC: `memory: 28.09GiB(29.57%)  tps: 4,523  tflops: 261.95  mfu: 26.49%`

Deepseek-v3-16B FSDP=4, TP=2, EP=2, and local_batch_size=2 
no AC: `memory: 87.71GiB(92.33%)  tps: 2,530  tflops: 45.80  mfu: 4.63%`
eager SAC: doesn't work with full graph capture (due to AC HOP mutation issue #1935)
graph SAC: `memory: 52.03GiB(54.77%)  tps: 1,908  tflops: 34.55  mfu: 3.49%`