### PR TITLE
Use Float8TrainingOpConfig instead of removed FP8GroupedMMConfig alias

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -274,7 +274,7 @@ class Float8GroupedMMConverter(QuantizationConverter):
         from torchao.quantization.quant_api import quantize_
 
         try:
-            from torchao.prototype.moe_training.config import FP8GroupedMMConfig
+            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
         except ImportError as e:
             raise ImportError(
                 "torchao installation does not have MoE training support. Please install torchao nightly build."
@@ -293,7 +293,7 @@ class Float8GroupedMMConverter(QuantizationConverter):
             model, ["_init_mean", "_init_std"], nn_module_cls=nn.Linear
         )
 
-        config = FP8GroupedMMConfig()
+        config = Float8TrainingOpConfig()
         quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
         # Re-inject Linear protocol and re-attach attrs


### PR DESCRIPTION
## Summary

`FP8GroupedMMConfig` was a temporary backward-compatibility alias in torchao that has been removed in pytorch/ao#4069. This PR updates torchtitan to use the canonical `Float8TrainingOpConfig` name directly.

## Change

One-line rename in `torchtitan/components/quantization/float8.py`:
- `FP8GroupedMMConfig` → `Float8TrainingOpConfig` (import + usage)

## Test plan
- No behavior change — `FP8GroupedMMConfig` was an alias for `Float8TrainingOpConfig` with identical defaults.
- Existing MoE FP8 training tests cover this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)