### PR TITLE
[Observability 1/7] Toy trainers for observability development

### DIFF
--- a/torchtitan/experiments/observability/__init__.py
+++ b/torchtitan/experiments/observability/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/observability/toy_rl.py
+++ b/torchtitan/experiments/observability/toy_rl.py
@@ -1,0 +1,264 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This is not a production training recipe. It is just dummy incomplete code
+to demonstrate observability APIs.
+
+Toy RL with Monarch actors: RollouterActor produces completions,
+RewardActor scores them, TrainerActor trains on them. Controller
+orchestrates the loop.
+
+Run (requires 4 GPUs):
+    python -m torchtitan.experiments.observability.toy_rl
+
+Do NOT use torch.distributed.run / torchrun — the controller is a single
+process that spawns GPU workers via Monarch's this_host().spawn_procs().
+"""
+
+import asyncio
+import logging
+import os
+import shutil
+import socket
+import time
+from dataclasses import dataclass
+
+import torch
+from monarch.actor import Actor, current_rank, endpoint, this_host
+from torch.distributed.device_mesh import init_device_mesh
+
+from torchtitan.experiments.observability.toy_spmd import (
+    BATCH_SIZE,
+    DP_SIZE,
+    SEQ_LEN,
+    setup_data,
+    ToyTrainer,
+    VOCAB_SIZE,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    logger.addHandler(logging.StreamHandler())
+
+NUM_STEPS = 6
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "outputs", "toy_rl")
+
+
+# ---------------------------------------------------------------------------
+# RolloutOutput
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RolloutOutput:
+    """One prompt+completion pair from a rollout.
+
+    Token fields and training tensors are used for training.
+    Text fields are for logging and human inspection only — in a real
+    pipeline they would be populated by tokenizer.decode().
+    """
+
+    prompt_tokens: list[int]
+    completion_tokens: list[int]
+    prompt_text: str
+    completion_text: str
+    reward: float | None = None
+    # Training tensors (one sample, not batched)
+    tokens: torch.Tensor | None = None
+    labels: torch.Tensor | None = None
+    loss_mask: torch.Tensor | None = None
+
+    def to_logging_dict(self) -> dict:
+        """Convert to a dict for logging. Only text + reward."""
+        d = {"prompt": self.prompt_text, "completion": self.completion_text}
+        if self.reward is not None:
+            d["reward"] = self.reward
+        return d
+
+
+def rollouts_to_train_batch(
+    rollouts: list[RolloutOutput],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Stack individual rollout tensors into a training batch.
+
+    Returns:
+        (tokens, labels, loss_mask), each of shape (batch_size, seq_len).
+    """
+    return (
+        torch.stack([r.tokens for r in rollouts]),
+        torch.stack([r.labels for r in rollouts]),
+        torch.stack([r.loss_mask for r in rollouts]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Actors
+# ---------------------------------------------------------------------------
+
+
+class RollouterActor(Actor):
+    """Dummy rollouter that returns fixed data as if it were generated."""
+
+    @endpoint
+    async def setup(self):
+        dataset = setup_data(batch_size=DP_SIZE * BATCH_SIZE)
+        self.dataset = dataset
+
+    @endpoint
+    async def set_step(self, step: int):
+        """Receive step from controller."""
+        pass
+
+    @endpoint
+    async def do_rollouts(self, prompts: torch.Tensor) -> list[RolloutOutput]:
+        """Produce rollouts. Each carries one sample's tensors and dummy text.
+
+        This is a dummy — not a real generation loop. In a real pipeline,
+        the model would generate completions and the tokenizer would
+        decode them into text.
+        """
+        rollouts = [
+            RolloutOutput(
+                prompt_tokens=self.dataset.tokens[i].tolist(),
+                completion_tokens=self.dataset.tokens[i].tolist(),
+                prompt_text=f"What is {i}+{i}?",
+                completion_text=f"The answer is {i + i}.",
+                tokens=self.dataset.tokens[i],
+                labels=self.dataset.labels[i],
+                loss_mask=self.dataset.loss_mask[i],
+            )
+            for i in range(len(self.dataset.tokens))
+        ]
+        return rollouts
+
+
+class TrainerActor(Actor):
+    @endpoint
+    async def setup(self):
+        rank = current_rank().rank
+        self.device = f"cuda:{rank}"
+        torch.cuda.set_device(self.device)
+        if not torch.distributed.is_initialized():
+            os.environ.setdefault("MASTER_ADDR", socket.gethostname())
+            os.environ.setdefault("MASTER_PORT", "29500")
+            world_size = int(os.environ.get("WORLD_SIZE", 4))
+            torch.distributed.init_process_group(
+                backend="nccl", rank=rank, world_size=world_size
+            )
+        mesh = init_device_mesh("cuda", (2, 2), mesh_dim_names=("dp", "tp"))
+        self.dp_rank = mesh["dp"].get_local_rank()
+        self.trainer = ToyTrainer(self.device, mesh["dp"], mesh["tp"], OUTPUT_DIR)
+
+    @endpoint
+    async def set_step(self, step: int):
+        """Receive step from controller."""
+        self.trainer.step = step
+
+    @endpoint
+    async def train_step(self, tokens, labels, loss_mask):
+        """Train one step on generated completions."""
+        # Slice this DP rank's shard from the full batch.
+        start = self.dp_rank * BATCH_SIZE
+        end = start + BATCH_SIZE
+        tokens = tokens[start:end].to(self.device)
+        labels = labels[start:end].to(self.device)
+        loss_mask = loss_mask[start:end].to(self.device)
+
+        # Train step (loss is logged inside via logger.info)
+        self.trainer.train_step(tokens, labels, loss_mask)
+
+    @endpoint
+    async def teardown(self):
+        self.trainer.close()
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+class RewardActor(Actor):
+    """Dummy reward actor. Scores are not used by the trainer — this actor
+    exists to demonstrate multi-actor observability patterns."""
+
+    @endpoint
+    async def setup(self):
+        pass
+
+    @endpoint
+    async def set_step(self, step: int):
+        """Receive step from controller."""
+        pass
+
+    @endpoint
+    async def score(self, rollouts: list[RolloutOutput]) -> list[RolloutOutput]:
+        """Score rollouts. Fills in reward field and returns them."""
+        for rollout in rollouts:
+            rollout.reward = 1.0  # dummy constant reward
+        return rollouts
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    t0 = time.time()
+    logger.info(f"Toy RL: {NUM_STEPS} steps")
+    if os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # ---- Setup ----
+    host = this_host()
+
+    rollouter_mesh = host.spawn_procs(per_host={"procs": 1}, name="rollouter")
+    rollouter = rollouter_mesh.spawn("rollouter", RollouterActor)
+    await rollouter.setup.call()
+
+    trainer_mesh = host.spawn_procs(per_host={"gpus": 4}, name="trainer")
+    trainer = trainer_mesh.spawn("trainer", TrainerActor)
+    await trainer.setup.call()
+
+    reward_mesh = host.spawn_procs(per_host={"procs": 1}, name="reward")
+    reward_actor = reward_mesh.spawn("reward", RewardActor)
+    await reward_actor.setup.call()
+
+    actors = [rollouter, trainer, reward_actor]
+    logger.info("Actors spawned.")
+
+    # Dummy prompts for the rollouter.
+    prompts = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN))
+
+    # ---- Training loop ----
+    async def run_training():
+        for step in range(1, NUM_STEPS + 1):
+            for actor in actors:
+                await actor.set_step.call(step)
+
+            result = await rollouter.do_rollouts.call(prompts)
+            rollouts = next(iter(result.values()))
+
+            result = await reward_actor.score.call(rollouts)
+            rollouts = next(iter(result.values()))
+
+            tokens, labels, loss_mask = rollouts_to_train_batch(rollouts)
+
+            await trainer.train_step.call(tokens, labels, loss_mask)
+
+            rewards = [r.reward for r in rollouts]
+            reward_mean = sum(rewards) / len(rewards)
+            logger.info(f"step: {step}  reward_mean: {reward_mean:.5f}")
+
+    await run_training()
+
+    # ---- Cleanup ----
+    await trainer.teardown.call()
+    logger.info(f"Done in {time.time() - t0:.1f}s. Output: {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/torchtitan/experiments/observability/toy_spmd.py
+++ b/torchtitan/experiments/observability/toy_spmd.py
@@ -1,0 +1,325 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This is not a production training recipe. It is just dummy incomplete code
+to demonstrate observability APIs.
+
+Toy SPMD training with TP + FSDP2 + per-layer compile on 4 GPUs.
+Each rank gets different valid token counts (via loss_mask) to exercise
+weighted metric reduction.
+
+Run:
+    torchrun --nproc_per_node=4 -m torchtitan.experiments.observability.toy_spmd
+"""
+
+import os
+import shutil
+import time
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    loss_parallel,
+    parallelize_module,
+    RowwiseParallel,
+)
+
+from torchtitan.distributed.utils import clip_grad_norm_
+
+# ---- Config ----
+NUM_STEPS = 20
+EVAL_FREQ = 10
+D_MODEL = 64
+HIDDEN_DIM = 128
+N_HEADS = 3
+VOCAB_SIZE = 32
+SEQ_LEN = 16
+BATCH_SIZE = 8
+DP_SIZE = 2
+LR = 1e-3
+IGNORE_INDEX = -100
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "outputs", "toy_spmd")
+
+
+# ---- Data ----
+class RepeatDataset:
+    """Yields the same batch every step so we can overfit and see loss decrease."""
+
+    def __init__(
+        self, tokens: torch.Tensor, labels: torch.Tensor, loss_mask: torch.Tensor
+    ):
+        self.tokens = tokens
+        self.labels = labels
+        self.loss_mask = loss_mask
+
+    def __iter__(self):
+        while True:
+            yield self.tokens, self.labels, self.loss_mask
+
+
+def setup_data(
+    device: torch.device = torch.device("cpu"),
+    *,
+    dp_rank: int = 0,
+    batch_size: int = BATCH_SIZE,
+    seq_len: int = SEQ_LEN,
+    vocab_size: int = VOCAB_SIZE,
+) -> RepeatDataset:
+    """Create fixed training data for overfitting.
+
+    Each DP rank gets a different seed so loss_mask (and thus valid token
+    count) differs across ranks, exercising weighted metric reduction.
+    """
+    torch.manual_seed(42 + dp_rank)
+    tokens = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+    labels = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+    loss_mask = torch.randint(0, 2, (batch_size, seq_len), device=device).float()
+    return RepeatDataset(tokens, labels, loss_mask)
+
+
+# ---- Model ----
+class MLPBlock(nn.Module):
+    """MLP block with multiple projections (heads) for testing per-head
+    observability within compiled regions."""
+
+    def __init__(self, d_model: int, hidden_dim: int, n_heads: int = N_HEADS):
+        super().__init__()
+        self.norm = nn.LayerNorm(d_model)
+        self.heads = nn.ModuleDict(
+            {str(i): nn.Linear(d_model, hidden_dim, bias=False) for i in range(n_heads)}
+        )
+        self.out_proj = nn.Linear(hidden_dim, d_model, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.norm(x)
+        parts = []
+        for head in self.heads.values():
+            parts.append(F.silu(head(h)))
+        return x + self.out_proj(sum(parts))
+
+
+class TinyModel(nn.Module):
+    """3-layer model with embedding, MLP blocks, and output head."""
+
+    def __init__(
+        self,
+        vocab_size: int = VOCAB_SIZE,
+        d_model: int = D_MODEL,
+        hidden_dim: int = HIDDEN_DIM,
+        n_layers: int = 3,
+    ):
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(vocab_size, d_model)
+        self.layers = nn.ModuleDict(
+            {str(i): MLPBlock(d_model, hidden_dim) for i in range(n_layers)}
+        )
+        self.norm = nn.LayerNorm(d_model)
+        self.output = nn.Linear(d_model, vocab_size, bias=False)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        h = self.tok_embeddings(tokens)
+        for layer in self.layers.values():
+            h = layer(h)
+        h = self.norm(h)
+        return self.output(h)
+
+
+# ---- Trainer ----
+class ToyTrainer:
+    """Minimal trainer with TP + compile + FSDP.
+
+    Mirrors the structure of torchtitan/trainer.py:
+    - __init__: build model, apply parallelism, create optimizer
+    - batch_generator: wraps dataloader, yields batches
+    - train_step: one forward/backward/optimizer step
+    - validate: one forward pass (no backward)
+    - train: owns the training loop
+    """
+
+    def __init__(self, device, dp_mesh, tp_mesh, output_dir):
+        self.device = device
+        self.dp_mesh = dp_mesh
+        self.rank = dist.get_rank()
+        self.output_dir = output_dir
+        self.step = 0
+
+        torch.manual_seed(0)
+        model = TinyModel().to(device)
+        self._apply_tp(model, tp_mesh)
+        self._apply_compile(model)
+        self._apply_fsdp(model, dp_mesh)
+        self.model = model
+        self.optimizer = torch.optim.AdamW(model.parameters(), lr=LR)
+
+    @staticmethod
+    def _replicate_params(module: nn.Module, tp_mesh) -> None:
+        """Wrap non-TP-parallelized params as Replicate DTensors on the TP
+        mesh so they work with FSDP."""
+        for p_name, param in module.named_parameters():
+            replicated = nn.Parameter(
+                DTensor.from_local(param, tp_mesh, [Replicate()], run_check=False)
+            )
+            module.register_parameter(p_name, replicated)
+
+    def _apply_tp(self, model, tp_mesh):
+        """Apply tensor parallelism. Embeddings and output use TP plans;
+        remaining params are wrapped as Replicate DTensors."""
+        parallelize_module(
+            model,
+            tp_mesh,
+            {
+                "tok_embeddings": RowwiseParallel(
+                    input_layouts=Replicate(), use_local_output=False
+                ),
+                "output": ColwiseParallel(
+                    output_layouts=Shard(-1), use_local_output=False
+                ),
+            },
+        )
+        self._replicate_params(model.norm, tp_mesh)
+        for layer in model.layers.values():
+            parallelize_module(
+                layer,
+                tp_mesh,
+                {"out_proj": RowwiseParallel(use_local_output=False)},
+            )
+            for head_name in layer.heads:
+                parallelize_module(
+                    layer,
+                    tp_mesh,
+                    {f"heads.{head_name}": ColwiseParallel(use_local_output=False)},
+                )
+            self._replicate_params(layer.norm, tp_mesh)
+
+    def _apply_compile(self, model):
+        """Per-layer torch.compile."""
+        for layer_id, block in model.layers.named_children():
+            model.layers.register_module(layer_id, torch.compile(block, fullgraph=True))
+
+    def _apply_fsdp(self, model, dp_mesh):
+        """FSDP2 wrapping. Applied last (after TP and compile)."""
+        fully_shard(model.tok_embeddings, mesh=dp_mesh)
+        for layer in model.layers.values():
+            fully_shard(layer, mesh=dp_mesh)
+        fully_shard([model.norm, model.output], mesh=dp_mesh)
+        fully_shard(model, mesh=dp_mesh)
+
+    def batch_generator(self, data_iterable):
+        """Wraps a dataloader into an iterator."""
+        data_iterator = iter(data_iterable)
+        while True:
+            yield next(data_iterator)
+
+    def compute_loss(self, logits, labels, loss_mask):
+        """Compute cross-entropy loss with masking under loss_parallel.
+
+        Returns (loss_sum, valid_tokens). The caller divides for backward.
+        """
+        masked_labels = labels.clone().flatten()
+        masked_labels[loss_mask.flatten() == 0] = IGNORE_INDEX
+        loss_sum = F.cross_entropy(
+            logits.flatten(0, 1).float(),
+            masked_labels,
+            reduction="sum",
+            ignore_index=IGNORE_INDEX,
+        )
+        valid_tokens = (masked_labels != IGNORE_INDEX).sum()
+        return loss_sum, valid_tokens
+
+    def train_step(self, tokens, labels, loss_mask):
+        """One training step."""
+        with loss_parallel():
+            logits = self.model(tokens)
+            loss_sum, valid_tokens = self.compute_loss(logits, labels, loss_mask)
+            # Globally-normalized loss: each token contributes equally to
+            # gradients regardless of which DP rank it's on (matches titan).
+            global_valid_tokens = valid_tokens.detach().clone().float()
+            dist.all_reduce(global_valid_tokens, group=self.dp_mesh.get_group())
+
+            loss = loss_sum / global_valid_tokens
+            self.optimizer.zero_grad()
+            loss.backward()
+        grad_norm = clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+        self.optimizer.step()
+
+        # Report globally-reduced loss. Each DP rank has
+        # local_loss_sum / global_valid_tokens; SUM gives the global loss.
+        loss_scalar = loss.detach().full_tensor().clone()
+        dist.all_reduce(loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group())
+        if self.rank == 0:
+            print(
+                f"step: {self.step}  loss: {loss_scalar.item():.5f}  "
+                f"grad_norm: {grad_norm.item():.5f}"
+            )
+
+    def validate(self, tokens, labels, loss_mask):
+        """Run one forward pass for validation (no backward)."""
+        with torch.no_grad(), loss_parallel():
+            logits = self.model(tokens)
+            loss_sum, valid_tokens = self.compute_loss(logits, labels, loss_mask)
+            global_valid_tokens = valid_tokens.detach().clone().float()
+            dist.all_reduce(global_valid_tokens, group=self.dp_mesh.get_group())
+            val_loss = loss_sum / global_valid_tokens
+        val_loss_scalar = val_loss.detach().full_tensor().clone()
+        dist.all_reduce(val_loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group())
+        if self.rank == 0:
+            print(f"  val loss: {val_loss_scalar.item():.4f}")
+
+    def train(self, num_steps):
+        """Full training loop. Mirrors Trainer.train structure."""
+        dp_rank = self.dp_mesh.get_local_rank()
+        dataloader = setup_data(self.device, dp_rank=dp_rank)
+        data_iterator = self.batch_generator(dataloader)
+
+        for step in range(1, num_steps + 1):
+            self.step = step
+            tokens, labels, loss_mask = next(data_iterator)
+            self.train_step(tokens, labels, loss_mask)
+
+            if step % EVAL_FREQ == 0:
+                self.validate(tokens, labels, loss_mask)
+
+    def close(self):
+        """Cleanup. Subclasses override to close writers, profilers, etc."""
+        pass
+
+
+def main():
+    rank = int(os.environ.get("RANK", 0))
+    device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(backend="nccl", device_id=device)
+    world_size = dist.get_world_size()
+    assert world_size == 4, f"Requires 4 GPUs, got {world_size}"
+
+    if rank == 0 and os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
+    dist.barrier()
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    mesh = init_device_mesh("cuda", (2, 2), mesh_dim_names=("dp", "tp"))
+
+    if rank == 0:
+        print(f"Toy SPMD: {world_size} GPUs, 2DPx2TP, {NUM_STEPS} steps")
+
+    trainer = ToyTrainer(device, mesh["dp"], mesh["tp"], OUTPUT_DIR)
+    trainer.train(NUM_STEPS)
+    trainer.close()
+
+    if rank == 0:
+        print(f"Done. Output: {OUTPUT_DIR}")
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/observability/README.md
+++ b/torchtitan/observability/README.md
@@ -1,0 +1,426 @@
+# TorchTitan Observability
+
+Structured logging and metrics for distributed training. Works for both
+SPMD pretraining and RL with multiple actors (no shared process group).
+
+## Overview
+
+Mental model: Every metric first goes to structured JSONL using python's stdout logger. Then, a background subprocess collects and aggregates for dashboards.
+
+There are two types of metrics:
+- **Experiment metrics** — training values (loss, throughput, memory) that get
+  aggregated across ranks and sent to WandB/TB/console.
+- **System metrics** — per-rank timing and scalar snapshots for debugging tools
+  (Perfetto, DuckDB, LLM agents).
+
+```
+Experiment: record_metric(key, Metric) → logger → experiment.jsonl → logging subprocess → aggregate → WandB/TB/console
+
+System:     record_span / record_event → logger → system.jsonl     → analysis tools (Perfetto, DuckDB, LLM agents)
+```
+
+This JSONL-first design gives us two advantages:
+
+1. **No metric plumbing.** Each process calls `record_metric(key, value)`
+   locally. No passing dicts between functions or actors. The logging
+   subprocess reads all JSONL files in the background.
+
+2. **Debuggability.** Every rank's raw metrics are preserved as JSONL on disk.
+   An LLM agent or DuckDB query can answer "what happened on rank 47 at step
+   3000?"
+
+### Quickstart
+
+```python
+from torchtitan.observability import (
+    init_observability, set_step, add_step_tag,
+    record_span, record_event, record_metric,
+    EventType, MeanMetric, NoOpMetric,
+)
+from torchtitan.tools.logging import init_logger
+
+# Console logging (stdout with [titan] format)
+init_logger()
+
+# JSONL file handlers for structured logging
+init_observability(source="trainer", output_dir="./outputs")
+
+for step in range(steps):
+    # Stamp all subsequent JSONL entries with step=step
+    set_step(step)
+
+    if should_garbage_collect:
+        add_step_tag("gc")
+        with record_span("trainer_time/gc_s", EventType.GC_COLLECT):
+            run_gc()
+
+    with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+        reduced_loss = model.fwd_bwd(batch)
+        record_metric("training/loss_mean", NoOpMetric(value=reduced_loss))
+```
+
+## Setup
+
+```python
+from torchtitan.tools.logging import init_logger
+from torchtitan.observability import init_observability
+
+init_logger()  # console StreamHandler (stdout, [titan] prefix)
+init_observability(source="trainer", output_dir="./outputs")  # JSONL file handlers
+```
+
+Call once per process, before any logging calls. `init_logger()` sets up
+console output. `init_observability()` adds JSONL file handlers, which can be modified to
+a different backend (e.g. Grafana).
+
+```
+                    ┌─ Console StreamHandler (stdout, [titan] format)
+Root Logger ────────┤    set up by init_logger()
+                    │
+                    │         ┌─ StructuredLoggingHandler → system.jsonl
+System Logger ──────┤─────────┤─ StructuredJSONFormatter (rank, source, caller, timestamp)
+                    │         └─ InflightEventTrackingHandler (tracks open spans for crash forensics)
+                    │
+                    │         ┌─ ExperimentLoggingHandler → experiment.jsonl
+Experiment Logger ──┤─────────┤─ ExperimentJSONFormatter (rank, source, caller, timestamp)
+```
+
+Rank and source are baked into the formatters at init time. Every JSONL entry
+automatically includes `rank`, `source`, `caller` (file:line:function), and
+`timestamp`.
+
+
+
+<<<<<<< Updated upstream
+set_step(42)              # stamps all subsequent JSONL entries with step=42
+add_step_tag("gc")        # annotate: GC ran this step
+add_step_tag("eval")      # annotate: validation ran this step
+clear_step_tags()         # reset tags (called at the start of each step)
+```
+
+Step and tags are stored as `ContextVar`s — isolated between concurrent asyncio
+tasks (for Monarch actor endpoints in RL) with no overhead in SPMD. These tags and steps
+could be used for custom aggregation, e.g. in RL aggregate scores per policy version.
+
+## 4. Experiment Metrics: record_metric
+
+```python
+from torchtitan.observability.metrics import (
+    record_metric, MeanMetric, MaxMetric, SumMetric, MinMetric, NoOpMetric,
+)
+
+record_metric("trainer_throughput/tps_mean", MeanMetric(sum=1234.5, weight=262))
+record_metric("trainer_gradient/norm_max", MaxMetric(value=12.3))
+record_metric("trainer_memory/ooms_sum", SumMetric(value=0))
+record_metric("loss/trainer_loss_mean", NoOpMetric(value=0.038))  # already all_reduced
+record_metric("trainer_schedule/lr", NoOpMetric(value=3e-4))      # same on all ranks
+```
+=======
+## Experiment Metrics: record_metric
+>>>>>>> Stashed changes
+
+Each call serializes to experiment JSONL immediately. Step comes from
+`set_step()`. Rank, source, caller, and timestamp are added automatically.
+
+Example: two ranks log the same metric on the same step, then the subprocess
+aggregates them:
+
+```python
+record_metric("trainer_throughput/tps_mean", MeanMetric(sum=tps))
+```
+
+```json
+// dump_dir/experiment_logs/trainer_rank_0_experiment.jsonl
+{"key": "trainer_throughput/tps_mean", "reduce": "MeanMetric",
+ "sum": 1234.5, "weight": 1.0,
+ "step": 42, "rank": 0, "source": "trainer",
+ "caller": "torchtitan/trainer.py:542:train_step", "timestamp": 1708200121.724}
+
+// dump_dir/experiment_logs/trainer_rank_1_experiment.jsonl
+{"key": "trainer_throughput/tps_mean", "reduce": "MeanMetric",
+ "sum": 1180.2, "weight": 1.0,
+ "step": 42, "rank": 1, "source": "trainer",
+ "caller": "torchtitan/trainer.py:542:train_step", "timestamp": 1708200121.725}
+
+// After aggregation: (1234.5 + 1180.2) / (1.0 + 1.0) = 1207.35
+```
+
+### Reduce types
+
+| Type | Constructor | Aggregation |
+|------|------------|-------------|
+| `MeanMetric` | `MeanMetric(sum=x, weight=1)` | `sum(sums) / sum(weights)` |
+| `MaxMetric` | `MaxMetric(value=x)` | `max(values)` |
+| `MinMetric` | `MinMetric(value=x)` | `min(values)` |
+| `SumMetric` | `SumMetric(value=x)` | `sum(values)` |
+| `NoOpMetric` | `NoOpMetric(value=x)` | Pass through (in aggregation, selects random row) |
+
+Custom reduce types can be registered in `REDUCE_REGISTRY`.
+
+### Known limitations
+
+- Does not work with tensors on accelerators (GPU) or inside `torch.compile`
+  regions. All values must be Python floats/ints (call `.item()` first).
+  The choice is who does the cross-rank reduction:
+
+  a) **You reduce, then log.** Call `all_reduce` + `.item()` yourself, then
+  record with `NoOpMetric` (the subprocess takes the value as-is):
+  ```python
+  dist.all_reduce(my_tensor, op=dist.ReduceOp.SUM, group=dp_mesh.get_group())
+  record_metric("my_metric", NoOpMetric(value=my_tensor.item()))
+  ```
+
+  b) **Log per-rank, let the subprocess reduce.** Each rank logs its local
+  value and the subprocess aggregates across all rank JSONL files:
+  ```python
+  if rank in dp_mesh.get_group():
+    record_metric("my_metric", SumMetric(value=my_tensor.item()))
+  ```
+
+An API that is compile-safe and friendly for distributed tensors is planned.
+
+## System Metrics: record_span and record_event
+
+### record_span — timing a code region
+
+On enter: writes a START event to system JSONL.
+On exit: writes an END event with duration in milliseconds.
+
+```python
+from torchtitan.observability import record_span, EventType
+
+with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+    output = model(batch)
+    loss.backward()
+```
+
+### System JSONL format
+
+Values are grouped into four typed columns (`int`, `normal`, `double`,
+`normvector`) for easy ingestion into Grafana, DuckDB, or Scuba:
+
+```json
+{"int": {"step": 42, "rank": 0, "time_us": 1708200121724000},
+ "normal": {"log_type_name": "fwd_bwd_end", "source": "trainer",
+            "message": "[step 42] trainer_time/forward_backward_s fwd_bwd_end took 123.45 ms",
+            "caller": "torchtitan/trainer.py:730:train_step"},
+ "double": {"value": 123.45},
+ "normvector": {"step_tags": ["gc"]}}
+```
+
+EventType is optional — description is used as the event type if omitted:
+```python
+with record_span("trainer_time/forward_backward_s"):
+    rollouts = generate(prompts)
+```
+
+By default `log_to_metrics=True`, the exit also calls `record_metric` with
+the duration in **seconds** as a `MeanMetric`, so timing data flows to
+WandB/TB alongside other experiment metrics.
+
+To disable:
+```python
+with record_span("rl_time/rollout_s", log_to_metrics=False):
+    rollouts = generate(prompts)
+```
+
+
+### record_event — point-in-time scalars
+
+```python
+from torchtitan.observability import record_event
+
+record_event({"train.step": 42, "train.tflops": 45.6})
+```
+
+Writes to system JSONL only. Does NOT flow to experiment JSONL or WandB.
+Used for per-rank diagnostic data (TFLOPS, loss, grad_norm every step).
+
+
+
+## Aggregation (Logging Subprocess)
+
+The training process never reads JSONL or writes to backends directly.
+A background subprocess on rank 0 handles all aggregation and output:
+
+```
+                  Training Process (all ranks)
+                  ┌─────────────────────────────────┐
+                  │  record_metric("loss", ...)     │──→ experiment.jsonl (per rank)
+                  │  record_span("fwd_bwd", ...)    │──→ system.jsonl (per rank)
+                  │                                 │
+                  │  # on log steps:                │
+                  │  barrier()                      │
+                  │  log_queue.put(step) ───────────│──┐  (~0.1ms, non-blocking)
+                  └─────────────────────────────────┘  │
+                                                       │
+                  Logging Subprocess (rank 0 only)     │
+                  ┌─────────────────────────────────┐  │
+                  │  step = queue.get() ◄───────────│──┘
+                  │  read all experiment.jsonl files│
+                  │  aggregate by key (reduce)      │
+                  │  write to WandB / TensorBoard   │
+                  │  print to console               │
+                  └─────────────────────────────────┘
+```
+
+The subprocess is spawned via `logging_worker` from `aggregation.py`. Here's
+the RL pattern where the controller owns the subprocess directly:
+
+```python
+import multiprocessing
+from torchtitan.observability import logging_worker
+
+# Spawn the logging subprocess
+log_queue = multiprocessing.Queue()
+log_process = multiprocessing.Process(
+    target=logging_worker,
+    args=(log_queue, OUTPUT_DIR),
+    kwargs={
+        "enable_wandb": True,
+        "enable_tensorboard": False,
+        "console_log_metric_keys": [
+            "training/loss_mean",
+            "training/grad_norm_max",
+            "rl/reward_mean",
+            "trainer_throughput/tps_mean",
+        ],
+    },
+    daemon=True,
+)
+log_process.start()
+
+# Each actor calls record_metric locally — writes go to JSONL
+# ...
+
+# After each step, signal the subprocess to read + aggregate + flush
+log_queue.put((step, False))  # (step, is_validation)
+
+# Shutdown
+log_queue.put(None)
+log_process.join()
+```
+
+For SPMD training, `MetricsProcessor` wraps this lifecycle automatically —
+see `observability/metrics_processor.py`.
+
+`aggregate()` groups entries by key and delegates reduction to the
+`REDUCE_REGISTRY` based on each entry's `"reduce"` field. Console output
+also comes from the subprocess (not from `logger.info` in the training process).
+
+**Timing (local filesystem, 100 metrics/rank):**
+
+Aggregation benchmarks are measured on local filesystem. NFS will be slower
+for the read, but shouldn't be an issue since it is non-blocking.
+
+| Scale | Read | Aggregate | Total |
+|-------|------|-----------|-------|
+| 10 files (1K entries) | 9ms | 0.5ms | 10ms |
+| 100 files (10K entries) | 88ms | 6ms | 94ms |
+| 500 files (50K entries) | 333ms | 35ms | 368ms |
+
+None of this blocks training. Training pays only the signal cost (~0.1ms).
+
+## Analysis Tools
+
+### Gantt chart from system JSONL
+
+```python
+from torchtitan.observability.analysis import generate_gantt_trace
+
+generate_gantt_trace("outputs/system_logs/", "outputs/analysis/gantt.json")
+```
+
+Reads all system JSONL files (all ranks), produces a Chrome Trace JSON.
+Open in `chrome://tracing` or Perfetto to see a Gantt chart of every
+`record_span` across all ranks.
+
+Example output from toy_rl (view in chrome://tracing or https://ui.perfetto.dev):
+
+```
+<<<<<<< Updated upstream
+observability/
+    __init__.py             # Public API re-exports
+    step_state.py           # ContextVars: _STEP, _STEP_TAGS, set_step, add_step_tag, clear_step_tags
+    _constants.py           # Logger names, metric entry markers (import cycle breaker)
+    structured_logging.py   # System pipeline: init_observability, record_span, record_event, EventType
+    metrics.py              # Experiment pipeline: record_metric, MetricValue types, REDUCE_REGISTRY
+    aggregation.py          # aggregate() + logging_worker subprocess + JSONL readers
+    logging_boundary.py     # EveryNSteps schedule
+    rollout_logger.py       # RL: RolloutLogger, filter_top_bottom
+    analysis.py             # Post-training: generate_gantt_trace (Gantt chart from system JSONL)
+    README.md               # This file
+=======
+                       step 1                              step 2
+                  ┌──────────────────────────┐       ┌───────────────────────────┐
+trainer rank 0    │ ▓▓ fwd_bwd ▓▓  ▓ optim ▓ │       │ ▓ fwd_bwd ▓▓ ▓▓ optim ▓   │
+trainer rank 1    │  ▓▓ fwd_bwd ▓ ▓ optim ▓  │       │  ▓▓ fwd_bwd ▓▓ ▓ optim ▓  │
+trainer rank 2    │ ▓ fwd_bwd ▓▓ ▓ optim ▓▓  │       │  ▓ fwd_bwd ▓▓▓ ▓ optim ▓▓ │
+trainer rank 3    │  ▓▓ fwd_bwd ▓▓▓ ▓ optim ▓│       │ ▓ fwd_bwd ▓▓ ▓ optim ▓    │
+                  └──────────────────────────┘       └───────────────────────────┘
+controller        ▓▓▓▓▓▓ training_s ▓▓▓▓▓▓▓ ▓ scoring ▓ ▓▓▓▓▓▓ training_s ▓▓▓▓▓▓
+rollouter         ▓▓▓                                     ▓▓▓
+reward                                       ▓▓▓                              ▓▓▓
+                  ├──────────────────────────┼───────────┼──────────────────────┤
+                  0s                         3s          4s                     7s
+```
+
+Each `record_span` becomes a bar. Every actor type is a separate process
+row in Perfetto, with threads per rank — stragglers and idle gaps are
+immediately visible.
+
+## RL: RolloutLogger
+
+Logs RL rollouts to JSONL with optional filtering:
+
+```python
+from torchtitan.observability import RolloutLogger
+
+rollout_logger = RolloutLogger(
+    output_dir="outputs/rollouts",
+    filter_fn=lambda records: filter_top_bottom(records, key="reward", k=2),
+)
+
+rollouts = [
+     {"prompt": "what is 2+2?", "response": "4", "reward": 0.95},
+     {"prompt": "write a poem", "response": "roses...", "reward": 0.3}
+     ]
+
+# Log rollout dicts with optional metadata
+rollout_logger.log(
+    rollouts,
+    metadata={"step": 42, "batch_size": 64},
+)
+rollout_logger.close()
+```
+
+Output JSONL (metadata stored under `__metadata__` to avoid key collisions):
+```json
+{"prompt": "what is 2+2?", "response": "4", "reward": 0.95, "__metadata__": {"step": 42, "batch_size": 64}}
+{"prompt": "write a poem", "response": "roses...", "reward": 0.3, "__metadata__": {"step": 42, "batch_size": 64}}
+```
+
+`RolloutLogger.log(records, metadata=None, filter_fn=None)` takes a
+`list[dict]` — no schema enforced. Metadata is stored under `__metadata__`
+in each record to avoid key collisions.
+
+## Output and File Layout
+
+### Output folder
+
+```
+{dump_folder}/
+├── system_logs/                       ← record_span + record_event
+│   ├── trainer_rank_0_system.jsonl
+│   ├── trainer_rank_1_system.jsonl
+│   └── ...
+├── experiment_logs/                   ← record_metric
+│   ├── trainer_rank_0_experiment.jsonl
+│   └── ...
+├── rollouts/                          ← RolloutLogger (RL only)
+│   └── rollouts.jsonl
+├── analysis/
+│   └── system_metrics_gantt.json      ← analysis.py:generate_gantt_trace output
+└── tb/                                ← TensorBoard logs (when enabled)
+>>>>>>> Stashed changes
+```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2591
* #2590
* #2589
* #2588
* #2587
* #2586
* __->__ #2585

## Summary

Two toy training scripts that serve as development sandboxes for the observability APIs. They're minimal but exercise the same patterns as a real workflow.

**toy_spmd.py** — 4-GPU SPMD trainer with 2D parallelism (DP=2, TP=2). Runs with `torch.distributed.run`.

**toy_rl.py** — Multi-actor RL loop using Monarch. A controller orchestrates a rollouter, reward scorer, and trainer.

## Test plan

Overfitting to the same batch to show training.

### Console output toy_spmd
```
step: 1  loss: 3.65555  grad_norm: 0.49419
step: 5  loss: 3.05283  grad_norm: 0.40876
step: 10  loss: 2.53639  grad_norm: 0.31771
  val loss: 2.4611
step: 20  loss: 2.02626  grad_norm: 0.22093
  val loss: 1.9949
Done. Output: outputs/toy_spmd
```

### Console output toy_rl

```
step: 1  loss: 3.65156  grad_norm: 0.49804
step: 1  reward_mean: 1.00000
step: 2  loss: 3.48354  grad_norm: 0.47334
step: 2  reward_mean: 1.00000
step: 3  loss: 3.32657  grad_norm: 0.44708
step: 3  reward_mean: 1.00000
step: 6  loss: 2.93530  grad_norm: 0.36988
step: 6  reward_mean: 1.00000
Done in 14.4s. Output: outputs/toy_rl
```

Each step logs both training loss and RL reward.

Run toy_spmd: `python -m torch.distributed.run --nproc_per_node=4 -m torchtitan.experiments.observability.toy_spmd`
Run toy_rl: `python -m torchtitan.experiments.observability.toy_rl`
