### PR TITLE
[Observability 2/7] Structured system logging and gantt chart generation

### DIFF
--- a/tests/unit_tests/observability/__init__.py
+++ b/tests/unit_tests/observability/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/unit_tests/observability/conftest.py
+++ b/tests/unit_tests/observability/conftest.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared fixtures for observability tests."""
+
+import pytest
+
+
+@pytest.fixture
+def tmp_output_dir(tmp_path):
+    """Provides a temp directory for JSONL output, cleaned up after test."""
+    output_dir = tmp_path / "observability_test_output"
+    output_dir.mkdir()
+    return str(output_dir)

--- a/tests/unit_tests/observability/test_structured_logging.py
+++ b/tests/unit_tests/observability/test_structured_logging.py
@@ -1,0 +1,598 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for torchtitan.observability.structured_logging."""
+
+import json
+import logging
+import os
+import time
+
+import pytest
+
+from torchtitan.observability import step_state
+from torchtitan.observability._constants import SYSTEM_LOGGER_NAME
+from torchtitan.observability.analysis import generate_gantt_trace
+from torchtitan.observability.step_state import (
+    add_step_tag,
+    clear_step_tags,
+    get_step,
+    get_step_tags,
+    set_step,
+)
+from torchtitan.observability.structured_logging import (
+    event_extra,
+    EventsOnlyFilter,
+    EventType,
+    ExtraFields,
+    InflightEventTrackingHandler,
+    init_observability,
+    LogType,
+    MAX_MESSAGE_SIZE,
+    record_event,
+    record_span,
+    StructuredJSONFormatter,
+    StructuredLoggingHandler,
+    to_structured_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_context():
+    """Reset step state before each test."""
+    step_state._STEP = None
+    step_state._STEP_TAGS = ()
+    yield
+    step_state._STEP = None
+    step_state._STEP_TAGS = ()
+
+
+@pytest.fixture
+def system_logger():
+    """Provide a clean system logger for testing."""
+    logger = logging.getLogger(SYSTEM_LOGGER_NAME)
+    original_handlers = logger.handlers[:]
+    original_level = logger.level
+    original_propagate = logger.propagate
+    yield logger
+    # Restore
+    logger.handlers = original_handlers
+    logger.level = original_level
+    logger.propagate = original_propagate
+
+
+# ---------------------------------------------------------------------------
+# Step context tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetStep:
+    def test_set_step_stores_value(self):
+        set_step(42)
+        assert get_step() == 42
+
+    def test_set_step_overwrites(self):
+        set_step(1)
+        set_step(2)
+        assert get_step() == 2
+
+    def test_step_default_is_none(self):
+        assert get_step() is None
+
+
+class TestStepTags:
+    def test_add_step_tag_adds_tag(self):
+        set_step(1)
+        add_step_tag("gc")
+        assert get_step_tags() == ("gc",)
+
+    def test_add_step_tag_deduplicates(self):
+        add_step_tag("gc")
+        add_step_tag("gc")
+        assert get_step_tags() == ("gc",)
+
+    def test_add_step_tag_multiple_tags(self):
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        add_step_tag("checkpoint")
+        assert get_step_tags() == ("gc", "profiling", "checkpoint")
+
+    def test_clear_step_tags_clears_all(self):
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        clear_step_tags()
+        assert get_step_tags() == ()
+
+    def test_clear_step_tags_on_empty(self):
+        clear_step_tags()
+        assert get_step_tags() == ()
+
+    def test_step_tags_are_tuples(self):
+        """Step tags are tuples (immutable) to avoid shared-reference issues."""
+        add_step_tag("a")
+        tags = get_step_tags()
+        assert isinstance(tags, tuple)
+
+
+# ---------------------------------------------------------------------------
+# event_extra
+# ---------------------------------------------------------------------------
+
+
+class TestEventExtra:
+    def test_basic_event(self):
+        extra = event_extra(EventType.FWD_BWD)
+        assert extra[str(ExtraFields.LOG_TYPE)] == str(LogType.EVENT)
+        assert extra[str(ExtraFields.LOG_TYPE_NAME)] == str(EventType.FWD_BWD)
+
+    def test_with_step_and_value(self):
+        extra = event_extra(EventType.STEP, step=10, value=42.0)
+        assert extra[str(ExtraFields.STEP)] == 10
+        assert extra[str(ExtraFields.VALUE)] == 42.0
+
+
+# ---------------------------------------------------------------------------
+# to_structured_json
+# ---------------------------------------------------------------------------
+
+
+class TestToStructuredJson:
+    def test_int_field(self):
+        result = json.loads(to_structured_json({"rank": 0}))
+        assert result["int"]["rank"] == 0
+
+    def test_float_field(self):
+        result = json.loads(to_structured_json({"value": 3.14}))
+        assert result["double"]["value"] == pytest.approx(3.14)
+
+    def test_string_field(self):
+        result = json.loads(to_structured_json({"source": "trainer"}))
+        assert result["normal"]["source"] == "trainer"
+
+    def test_list_field(self):
+        result = json.loads(to_structured_json({"tags": ["a", "b"]}))
+        assert result["normvector"]["tags"] == ["a", "b"]
+
+    def test_none_values_skipped(self):
+        result = json.loads(to_structured_json({"a": None, "b": 1}))
+        assert "a" not in result["int"]
+        assert "a" not in result["normal"]
+        assert result["int"]["b"] == 1
+
+    def test_bool_becomes_int(self):
+        result = json.loads(to_structured_json({"flag": True}))
+        assert result["int"]["flag"] == 1
+
+    def test_empty_dict(self):
+        result = json.loads(to_structured_json({}))
+        assert result == {"int": {}, "normal": {}, "double": {}, "normvector": {}}
+
+
+# ---------------------------------------------------------------------------
+# StructuredJSONFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredJSONFormatter:
+    def test_format_produces_valid_json(self):
+        fmt = StructuredJSONFormatter(rank=0, source="trainer")
+        set_step(5)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello",
+            args=None,
+            exc_info=None,
+        )
+        # Add event extra fields
+        for k, v in event_extra(str(EventType.FWD_BWD) + "_start", step=5).items():
+            setattr(record, k, v)
+
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert "int" in parsed
+        assert "normal" in parsed
+        assert parsed["int"]["rank"] == 0
+        assert parsed["normal"]["source"] == "trainer"
+        assert parsed["int"]["step"] == 5
+
+    def test_rank_and_source_from_self(self):
+        fmt = StructuredJSONFormatter(rank=3, source="generator")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra(EventType.STEP).items():
+            setattr(record, k, v)
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert parsed["int"]["rank"] == 3
+        assert parsed["normal"]["source"] == "generator"
+
+    def test_step_from_global(self):
+        fmt = StructuredJSONFormatter(rank=0, source="test")
+        set_step(42)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra(EventType.STEP).items():
+            setattr(record, k, v)
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert parsed["int"]["step"] == 42
+
+    def test_message_truncation(self):
+        fmt = StructuredJSONFormatter(rank=0, source="test")
+        long_msg = "x" * (MAX_MESSAGE_SIZE + 100)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg=long_msg,
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra(EventType.STEP).items():
+            setattr(record, k, v)
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert "..." in parsed["normal"]["message"]
+        assert len(parsed["normal"]["message"]) < len(long_msg)
+
+    def test_step_tags_in_output(self):
+        fmt = StructuredJSONFormatter(rank=0, source="test")
+        set_step(1)
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra(EventType.STEP).items():
+            setattr(record, k, v)
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert "step_tags" in parsed["normvector"]
+        assert set(parsed["normvector"]["step_tags"]) == {"gc", "profiling"}
+
+    def test_seq_id_increments(self):
+        fmt = StructuredJSONFormatter(rank=0, source="test")
+        records = []
+        for i in range(3):
+            r = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="test.py",
+                lineno=1,
+                msg=f"msg{i}",
+                args=None,
+                exc_info=None,
+            )
+            for k, v in event_extra(EventType.STEP).items():
+                setattr(r, k, v)
+            records.append(r)
+
+        seq_ids = []
+        for r in records:
+            parsed = json.loads(fmt.format(r))
+            seq_ids.append(parsed["int"]["seq_id"])
+        assert seq_ids == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# EventsOnlyFilter
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOnlyFilter:
+    def test_passes_event_records(self):
+        f = EventsOnlyFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        setattr(record, str(ExtraFields.LOG_TYPE_NAME), str(EventType.STEP))
+        assert f.filter(record) is True
+
+    def test_blocks_non_event_records(self):
+        f = EventsOnlyFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="just text",
+            args=None,
+            exc_info=None,
+        )
+        assert f.filter(record) is False
+
+
+# ---------------------------------------------------------------------------
+# InflightEventTrackingHandler
+# ---------------------------------------------------------------------------
+
+
+class TestInflightEventTrackingHandler:
+    def test_tracks_last_event(self):
+        handler = InflightEventTrackingHandler()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        setattr(
+            record, str(ExtraFields.LOG_TYPE_NAME), str(EventType.FWD_BWD) + "_start"
+        )
+        handler.emit(record)
+        assert handler.last_event == str(EventType.FWD_BWD) + "_start"
+        assert handler.last_event_time is not None
+
+    def test_ignores_non_event_records(self):
+        handler = InflightEventTrackingHandler()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="plain text",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        assert handler.last_event is None
+
+
+# ---------------------------------------------------------------------------
+# init_observability
+# ---------------------------------------------------------------------------
+
+
+class TestInitObservability:
+    def test_creates_system_jsonl(self, tmp_path, system_logger):
+        output_dir = str(tmp_path)
+        init_observability(rank=0, source="trainer", output_dir=output_dir)
+
+        # Logger should have handlers
+        assert any(
+            isinstance(h, StructuredLoggingHandler) for h in system_logger.handlers
+        )
+
+        # File should exist after we log something
+        set_step(1)
+        system_logger.info(
+            "test event",
+            extra=event_extra(EventType.STEP, step=1),
+        )
+
+        expected_path = os.path.join(
+            output_dir, "system_logs", "trainer_rank_0_system.jsonl"
+        )
+        assert os.path.exists(expected_path)
+
+        with open(expected_path) as f:
+            line = f.readline().strip()
+        parsed = json.loads(line)
+        assert parsed["int"]["rank"] == 0
+        assert parsed["normal"]["source"] == "trainer"
+
+    def test_idempotent(self, tmp_path, system_logger):
+        output_dir = str(tmp_path)
+        init_observability(rank=0, source="trainer", output_dir=output_dir)
+        handler_count = len(system_logger.handlers)
+        init_observability(rank=0, source="trainer", output_dir=output_dir)
+        assert len(system_logger.handlers) == handler_count
+
+    def test_creates_inflight_handler(self, tmp_path, system_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        assert any(
+            isinstance(h, InflightEventTrackingHandler) for h in system_logger.handlers
+        )
+
+
+# ---------------------------------------------------------------------------
+# record_event
+# ---------------------------------------------------------------------------
+
+
+class TestRecordEvent:
+    def test_writes_metric_events(self, tmp_path, system_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(10)
+        record_event({"train.loss": 2.5, "train.lr": 1e-4})
+
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "trainer_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+        # Check that event names are present
+        event_names = {line["normal"].get("event_name") for line in lines}
+        assert "train.loss" in event_names
+        assert "train.lr" in event_names
+        # Verify step appears in output
+        assert all(line["int"].get("step") == 10 for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# record_span
+# ---------------------------------------------------------------------------
+
+
+class TestRecordSpan:
+    def test_logs_start_and_end(self, tmp_path, system_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(5)
+
+        with record_span("Forward/Backward", EventType.FWD_BWD):
+            time.sleep(0.01)
+
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "trainer_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+        assert lines[0]["normal"]["log_type_name"] == str(EventType.FWD_BWD) + "_start"
+        assert lines[1]["normal"]["log_type_name"] == str(EventType.FWD_BWD) + "_end"
+        # End event should have duration in value
+        assert lines[1]["double"]["value"] > 0
+        # Both events should have step=5
+        assert lines[0]["int"]["step"] == 5
+        assert lines[1]["int"]["step"] == 5
+
+    def test_works_as_decorator(self, tmp_path, system_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+
+        @record_span("Optimizer", EventType.OPTIM)
+        def optimizer_step():
+            pass
+
+        optimizer_step()
+
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "trainer_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+        assert lines[0]["normal"]["log_type_name"] == str(EventType.OPTIM) + "_start"
+        assert lines[1]["normal"]["log_type_name"] == str(EventType.OPTIM) + "_end"
+
+    def test_does_not_suppress_exceptions(self, tmp_path, system_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+
+        with pytest.raises(ValueError, match="test error"):
+            with record_span("Test", EventType.STEP):
+                raise ValueError("test error")
+
+    def test_no_event_type_uses_description(self, tmp_path, system_logger):
+        """When event_type is omitted, description is used as the base name."""
+        init_observability(rank=0, source="reward", output_dir=str(tmp_path))
+        set_step(1)
+        with record_span("rl_time/scoring_s"):
+            pass
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "reward_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["normal"]["log_type_name"] == "rl_time/scoring_s_start"
+        assert lines[1]["normal"]["log_type_name"] == "rl_time/scoring_s_end"
+
+    def test_string_event_type(self, tmp_path, system_logger):
+        """event_type can be a plain string."""
+        init_observability(rank=0, source="reward", output_dir=str(tmp_path))
+        set_step(1)
+        with record_span("Grading", "rl_grading"):
+            pass
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "reward_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["normal"]["log_type_name"] == "rl_grading_start"
+        assert lines[1]["normal"]["log_type_name"] == "rl_grading_end"
+
+    def test_event_name_field_populated(self, tmp_path, system_logger):
+        """record_span stores description in event_name field."""
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            pass
+        jsonl_path = os.path.join(
+            str(tmp_path), "system_logs", "trainer_rank_0_system.jsonl"
+        )
+        with open(jsonl_path) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        # event_name should be the description, not the EventType
+        assert lines[0]["normal"]["event_name"] == "trainer_time/forward_backward_s"
+        assert lines[1]["normal"]["event_name"] == "trainer_time/forward_backward_s"
+
+
+class TestChromeTrace:
+    """Tests for generate_gantt_trace in analysis.py."""
+
+    def test_same_event_type_different_descriptions(self, tmp_path, system_logger):
+        """Two sequential spans with the same EventType must both appear
+        in the chrome trace (no key collision). Display name shows
+        EventType when provided, description otherwise.
+
+        This is a regression test: previously, pending_starts used
+        EventType as the key, so the second span's start overwrote the
+        first, losing one span from the output.
+        """
+        init_observability(rank=0, source="controller", output_dir=str(tmp_path))
+        set_step(1)
+        with record_span("rl_time/training_s", EventType.FWD_BWD):
+            pass
+        with record_span("rl_time/rollouts_to_train_batch_s"):
+            pass
+        with record_span("rl_time/scoring_s", EventType.FWD_BWD):
+            pass
+
+        log_dir = os.path.join(str(tmp_path), "system_logs")
+        trace_path = os.path.join(str(tmp_path), "trace.json")
+        trace = generate_gantt_trace(log_dir, trace_path)
+
+        span_names = [e["name"] for e in trace["traceEvents"] if e.get("ph") == "X"]
+        # Spans with EventType show the EventType name; without show description
+        assert span_names.count("fwd_bwd") == 2
+        assert "rl_time/rollouts_to_train_batch_s" in span_names
+        assert len(span_names) == 3
+
+    def test_no_event_type_uses_description_in_trace(self, tmp_path, system_logger):
+        """Spans without EventType use description as the trace name."""
+        init_observability(rank=0, source="test", output_dir=str(tmp_path))
+        set_step(1)
+        with record_span("my_custom/span_s"):
+            pass
+
+        log_dir = os.path.join(str(tmp_path), "system_logs")
+        trace_path = os.path.join(str(tmp_path), "trace.json")
+        trace = generate_gantt_trace(log_dir, trace_path)
+
+        span_names = [e["name"] for e in trace["traceEvents"] if e.get("ph") == "X"]
+        assert "my_custom/span_s" in span_names

--- a/torchtitan/experiments/observability/tests/__init__.py
+++ b/torchtitan/experiments/observability/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/observability/tests/test_structured_logging.py
+++ b/torchtitan/experiments/observability/tests/test_structured_logging.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Integration tests for structured logging in toy_spmd.
+
+Verifies system JSONL output from a toy_spmd run. These tests inspect
+output files — they do not import internal modules.
+
+Prerequisites: run toy_spmd first to generate output files.
+"""
+
+import json
+import os
+from glob import glob
+
+import pytest
+
+OUTPUT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "outputs", "toy_spmd"
+)
+
+
+@pytest.fixture
+def system_logs_dir():
+    """Path to system_logs from a prior toy_spmd run."""
+    path = os.path.join(OUTPUT_DIR, "system_logs")
+    if not os.path.isdir(path):
+        pytest.fail(
+            f"No system_logs at {path}. Run toy_spmd first to generate outputs."
+        )
+    return path
+
+
+class TestSystemJSONL:
+    def test_system_jsonl_files_exist(self, system_logs_dir):
+        files = glob(os.path.join(system_logs_dir, "*.jsonl"))
+        assert len(files) >= 1, "Expected at least one system JSONL file"
+
+    def test_system_jsonl_has_valid_structure(self, system_logs_dir):
+        files = glob(os.path.join(system_logs_dir, "*.jsonl"))
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    assert "int" in record
+                    assert "normal" in record
+                    assert "double" in record
+                    assert "normvector" in record
+                    assert "rank" in record["int"]
+
+    def test_system_jsonl_has_step_events(self, system_logs_dir):
+        files = glob(os.path.join(system_logs_dir, "*.jsonl"))
+        event_types = set()
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    et = record.get("normal", {}).get("log_type_name")
+                    if et:
+                        event_types.add(et)
+        assert "step_start" in event_types, f"Missing step_start in {event_types}"
+        assert "step_end" in event_types, f"Missing step_end in {event_types}"
+
+    def test_system_jsonl_has_caller_field(self, system_logs_dir):
+        files = glob(os.path.join(system_logs_dir, "*.jsonl"))
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    caller = record.get("normal", {}).get("caller")
+                    assert caller is not None, "Missing caller field"
+                    assert ":" in caller, f"caller field missing colon: {caller}"
+                    return  # One check is enough
+
+
+class TestChromeTrace:
+    def test_trace_json_exists(self):
+        trace_path = os.path.join(OUTPUT_DIR, "analysis", "system_metrics_gantt.json")
+        if not os.path.exists(trace_path):
+            pytest.fail("No analysis/system_metrics_gantt.json. Run toy_spmd first.")
+        with open(trace_path) as f:
+            trace = json.load(f)
+        assert "traceEvents" in trace
+        assert len(trace["traceEvents"]) > 0

--- a/torchtitan/experiments/observability/toy_rl.py
+++ b/torchtitan/experiments/observability/toy_rl.py
@@ -39,6 +39,14 @@ from torchtitan.experiments.observability.toy_spmd import (
     ToyTrainer,
     VOCAB_SIZE,
 )
+from torchtitan.observability import (
+    EventType,
+    init_observability,
+    record_span,
+    set_step,
+)
+from torchtitan.observability.analysis import generate_gantt_trace
+from torchtitan.tools.logging import init_logger
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -106,13 +114,16 @@ class RollouterActor(Actor):
 
     @endpoint
     async def setup(self):
+        rank = current_rank().rank
+        init_logger()
+        init_observability(source="rollouter", output_dir=OUTPUT_DIR, rank=rank)
         dataset = setup_data(batch_size=DP_SIZE * BATCH_SIZE)
         self.dataset = dataset
 
     @endpoint
     async def set_step(self, step: int):
         """Receive step from controller."""
-        pass
+        set_step(step)
 
     @endpoint
     async def do_rollouts(self, prompts: torch.Tensor) -> list[RolloutOutput]:
@@ -122,18 +133,19 @@ class RollouterActor(Actor):
         the model would generate completions and the tokenizer would
         decode them into text.
         """
-        rollouts = [
-            RolloutOutput(
-                prompt_tokens=self.dataset.tokens[i].tolist(),
-                completion_tokens=self.dataset.tokens[i].tolist(),
-                prompt_text=f"What is {i}+{i}?",
-                completion_text=f"The answer is {i + i}.",
-                tokens=self.dataset.tokens[i],
-                labels=self.dataset.labels[i],
-                loss_mask=self.dataset.loss_mask[i],
-            )
-            for i in range(len(self.dataset.tokens))
-        ]
+        with record_span("rollouter_time/generate_s"):
+            rollouts = [
+                RolloutOutput(
+                    prompt_tokens=self.dataset.tokens[i].tolist(),
+                    completion_tokens=self.dataset.tokens[i].tolist(),
+                    prompt_text=f"What is {i}+{i}?",
+                    completion_text=f"The answer is {i + i}.",
+                    tokens=self.dataset.tokens[i],
+                    labels=self.dataset.labels[i],
+                    loss_mask=self.dataset.loss_mask[i],
+                )
+                for i in range(len(self.dataset.tokens))
+            ]
         return rollouts
 
 
@@ -150,6 +162,8 @@ class TrainerActor(Actor):
             torch.distributed.init_process_group(
                 backend="nccl", rank=rank, world_size=world_size
             )
+        init_logger()
+        init_observability(source="trainer", output_dir=OUTPUT_DIR, rank=rank)
         parallel_dims = ParallelDims(
             dp_replicate=1,
             dp_shard=DP_SIZE,
@@ -166,8 +180,9 @@ class TrainerActor(Actor):
 
     @endpoint
     async def set_step(self, step: int):
-        """Receive step from controller."""
+        """Receive step from controller. Sets step on trainer."""
         self.trainer.step = step
+        self.trainer.metrics_processor.set_step(step)
 
     @endpoint
     async def train_step(self, tokens, labels, loss_mask):
@@ -195,18 +210,21 @@ class RewardActor(Actor):
 
     @endpoint
     async def setup(self):
-        pass
+        rank = current_rank().rank
+        init_logger()
+        init_observability(source="reward", output_dir=OUTPUT_DIR, rank=rank)
 
     @endpoint
     async def set_step(self, step: int):
         """Receive step from controller."""
-        pass
+        set_step(step)
 
     @endpoint
     async def score(self, rollouts: list[RolloutOutput]) -> list[RolloutOutput]:
         """Score rollouts. Fills in reward field and returns them."""
-        for rollout in rollouts:
-            rollout.reward = 1.0  # dummy constant reward
+        with record_span("reward_time/scoring_s"):
+            for rollout in rollouts:
+                rollout.reward = 1.0  # dummy constant reward
         return rollouts
 
 
@@ -221,6 +239,9 @@ async def main():
     if os.path.exists(OUTPUT_DIR):
         shutil.rmtree(OUTPUT_DIR)
     os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    init_logger()
+    init_observability(source="controller", output_dir=OUTPUT_DIR, rank=0)
 
     # ---- Setup ----
     host = this_host()
@@ -246,18 +267,23 @@ async def main():
     # ---- Training loop ----
     async def run_training():
         for step in range(1, NUM_STEPS + 1):
+            set_step(step)
             for actor in actors:
                 await actor.set_step.call(step)
 
-            result = await rollouter.do_rollouts.call(prompts)
-            rollouts = next(iter(result.values()))
+            with record_span("rl_time/rollout_s", EventType.RL_ROLLOUT):
+                result = await rollouter.do_rollouts.call(prompts)
+                rollouts = next(iter(result.values()))
 
-            result = await reward_actor.score.call(rollouts)
-            rollouts = next(iter(result.values()))
+            with record_span("rl_time/scoring_s", EventType.RL_GRADING):
+                result = await reward_actor.score.call(rollouts)
+                rollouts = next(iter(result.values()))
 
-            tokens, labels, loss_mask = rollouts_to_train_batch(rollouts)
+            with record_span("rl_time/rollouts_to_train_batch_s"):
+                tokens, labels, loss_mask = rollouts_to_train_batch(rollouts)
 
-            await trainer.train_step.call(tokens, labels, loss_mask)
+            with record_span("rl_time/training_s", EventType.FWD_BWD):
+                await trainer.train_step.call(tokens, labels, loss_mask)
 
             rewards = [r.reward for r in rollouts]
             reward_mean = sum(rewards) / len(rewards)
@@ -267,6 +293,11 @@ async def main():
 
     # ---- Cleanup ----
     await trainer.teardown.call()
+
+    sys_logs = os.path.join(OUTPUT_DIR, "system_logs")
+    trace_path = os.path.join(OUTPUT_DIR, "analysis", "system_metrics_gantt.json")
+    generate_gantt_trace(sys_logs, trace_path)
+
     logger.info(f"Done in {time.time() - t0:.1f}s. Output: {OUTPUT_DIR}")
 
 

--- a/torchtitan/experiments/observability/toy_spmd.py
+++ b/torchtitan/experiments/observability/toy_spmd.py
@@ -34,6 +34,16 @@ from torch.distributed.tensor.parallel import (
 
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.utils import clip_grad_norm_
+from torchtitan.observability import (
+    add_step_tag,
+    EventType,
+    init_observability,
+    record_event,
+    record_span,
+)
+from torchtitan.observability.analysis import generate_gantt_trace
+from torchtitan.observability.metrics_processor import MetricsProcessor
+from torchtitan.tools.logging import init_logger
 
 # ---- Config ----
 NUM_STEPS = 20
@@ -155,11 +165,14 @@ class ToyTrainer:
         self.output_dir = output_dir
         self.step = 0
 
+        self.metrics_processor = MetricsProcessor()
+
         torch.manual_seed(0)
-        model = TinyModel().to(device)
-        self._apply_tp(model, tp_mesh)
-        self._apply_compile(model)
-        self._apply_fsdp(model, dp_mesh)
+        with record_span("setup/model_build", EventType.BUILD_MODEL):
+            model = TinyModel().to(device)
+            self._apply_tp(model, tp_mesh)
+            self._apply_compile(model)
+            self._apply_fsdp(model, dp_mesh)
         self.model = model
         self.optimizer = torch.optim.AdamW(model.parameters(), lr=LR)
 
@@ -220,7 +233,9 @@ class ToyTrainer:
         """Wraps a dataloader into an iterator."""
         data_iterator = iter(data_iterable)
         while True:
-            yield next(data_iterator)
+            with record_span("trainer_time/data_loading_s", EventType.FETCHING_BATCH):
+                batch = next(data_iterator)
+            yield batch
 
     def compute_loss(self, logits, labels, loss_mask):
         """Compute cross-entropy loss with masking under loss_parallel.
@@ -240,25 +255,30 @@ class ToyTrainer:
 
     def train_step(self, tokens, labels, loss_mask):
         """One training step."""
-        with loss_parallel():
-            logits = self.model(tokens)
-            loss_sum, valid_tokens = self.compute_loss(logits, labels, loss_mask)
-            # Globally-normalized loss: each token contributes equally to
-            # gradients regardless of which DP rank it's on (matches titan).
-            global_valid_tokens = valid_tokens.detach().clone().float()
-            dist.all_reduce(global_valid_tokens, group=self.dp_mesh.get_group())
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            with loss_parallel():
+                logits = self.model(tokens)
+                loss_sum, valid_tokens = self.compute_loss(logits, labels, loss_mask)
+                # Globally-normalized loss: each token contributes equally to
+                # gradients regardless of which DP rank it's on (matches titan).
+                global_valid_tokens = valid_tokens.detach().clone().float()
+                dist.all_reduce(global_valid_tokens, group=self.dp_mesh.get_group())
+                loss = loss_sum / global_valid_tokens
+                self.optimizer.zero_grad()
+                loss.backward()
 
-            loss = loss_sum / global_valid_tokens
-            self.optimizer.zero_grad()
-            loss.backward()
-        grad_norm = clip_grad_norm_(self.model.parameters(), max_norm=1.0)
-        self.optimizer.step()
+        with record_span("trainer_time/optimizer_s", EventType.OPTIM):
+            grad_norm = clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+            self.optimizer.step()
 
         # Report globally-reduced loss. Each DP rank has
         # local_loss_sum / global_valid_tokens; SUM gives the global loss.
         loss_scalar = loss.detach().full_tensor().clone()
         dist.all_reduce(
             loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
+        )
+        record_event(
+            {"train.loss": loss_scalar.item(), "train.grad_norm": grad_norm.item()}
         )
         if self.rank == 0:
             print(
@@ -289,15 +309,24 @@ class ToyTrainer:
 
         for step in range(1, num_steps + 1):
             self.step = step
-            tokens, labels, loss_mask = next(data_iterator)
-            self.train_step(tokens, labels, loss_mask)
+            self.metrics_processor.set_step(step)
+
+            # Simulate GC on every 5th step (mirrors gc_handler.run)
+            if step % 5 == 0:
+                add_step_tag("gc")
+
+            with record_span("trainer_time/step_s", EventType.STEP):
+                tokens, labels, loss_mask = next(data_iterator)
+                self.train_step(tokens, labels, loss_mask)
 
             if step % EVAL_FREQ == 0:
-                self.validate(tokens, labels, loss_mask)
+                add_step_tag("eval")
+                with record_span("trainer_time/validation_s", EventType.EVAL):
+                    self.validate(tokens, labels, loss_mask)
 
     def close(self):
-        """Cleanup. Subclasses override to close writers, profilers, etc."""
-        pass
+        """Cleanup."""
+        self.metrics_processor.close()
 
 
 def main():
@@ -312,6 +341,9 @@ def main():
         shutil.rmtree(OUTPUT_DIR)
     dist.barrier()
     os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    init_logger()
+    init_observability(source="trainer", output_dir=OUTPUT_DIR, rank=rank)
 
     parallel_dims = ParallelDims(
         dp_replicate=1,
@@ -333,7 +365,10 @@ def main():
     trainer.close()
 
     if rank == 0:
-        print(f"Done. Output: {OUTPUT_DIR}")
+        sys_logs = os.path.join(OUTPUT_DIR, "system_logs")
+        trace_path = os.path.join(OUTPUT_DIR, "analysis", "system_metrics_gantt.json")
+        generate_gantt_trace(sys_logs, trace_path)
+        print(f"\nDone. Output: {OUTPUT_DIR}")
     dist.destroy_process_group()
 
 

--- a/torchtitan/observability/__init__.py
+++ b/torchtitan/observability/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+TorchTitan Observability Library
+
+System metrics: init_observability, set_step, record_span, record_event, EventType
+"""
+
+from torchtitan.observability.step_state import add_step_tag, clear_step_tags, set_step
+from torchtitan.observability.structured_logging import (
+    EventType,
+    init_observability,
+    record_event,
+    record_span,
+)
+
+__all__ = [
+    "init_observability",
+    "set_step",
+    "add_step_tag",
+    "clear_step_tags",
+    "record_span",
+    "record_event",
+    "EventType",
+]

--- a/torchtitan/observability/_constants.py
+++ b/torchtitan/observability/_constants.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Logger names and markers shared by multiple functions in observability.
+Added here to avoid circular dependencies."""
+
+# Separate loggers so system events (phase timing) and experiment metrics
+# (loss, reward) go to independent JSONL files with independent formatters.
+SYSTEM_LOGGER_NAME = "torchtitan.observability.system"
+EXPERIMENT_LOGGER_NAME = "torchtitan.observability.experiment"
+
+# Key set on LogRecord.extra to distinguish record_metric entries in
+# ExperimentJSONFormatter.
+_METRIC_ENTRY = "_metric_entry"

--- a/torchtitan/observability/analysis.py
+++ b/torchtitan/observability/analysis.py
@@ -1,0 +1,138 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Post-training analysis tools for system JSONL."""
+
+import json
+import os
+from glob import glob
+from typing import Any
+
+from torchtitan.tools.logging import logger
+
+
+def load_all_records(log_dir: str) -> list[dict]:
+    """Load all JSONL records from a system_logs directory."""
+    records = []
+    for path in sorted(glob(os.path.join(log_dir, "*.jsonl"))):
+        source = os.path.basename(path).replace(".jsonl", "")
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    r = json.loads(line)
+                    r["_source_file"] = source
+                    records.append(r)
+    return records
+
+
+def generate_gantt_trace(log_dir: str, output_path: str) -> dict:
+    """Convert system_logs/*.jsonl (from record_span) to Chrome Trace JSON.
+
+    Reads system JSONL files only — NOT experiment JSONL. For experiment
+    metrics, read experiment_logs/*.jsonl directly.
+
+    Each source file becomes a process, each rank a thread. Start/end
+    events become duration spans visible as a Gantt chart in Perfetto
+    (https://ui.perfetto.dev) or chrome://tracing.
+
+    Args:
+        log_dir: Path to the system_logs/ directory.
+        output_path: Where to write the Chrome Trace JSON file.
+
+    Returns:
+        The trace dict (also written to output_path).
+    """
+    records = load_all_records(log_dir)
+    if not records:
+        logger.info(f"No records found in {log_dir}")
+        return {"traceEvents": []}
+
+    # Map source files to process IDs
+    sources = sorted(set(r["_source_file"] for r in records))
+    source_to_pid = {s: i for i, s in enumerate(sources)}
+
+    events: list[dict[str, Any]] = []
+
+    # Process name metadata
+    for source, pid in source_to_pid.items():
+        events.append(
+            {
+                "name": "process_name",
+                "ph": "M",
+                "pid": pid,
+                "tid": 0,
+                "args": {"name": source},
+            }
+        )
+
+    # Collect start events to pair with their end events for "X" (complete) format.
+    # Key: (name, pid, tid) → start timestamp
+    pending_starts: dict[tuple, dict] = {}
+
+    for r in records:
+        normal = r.get("normal", {})
+        event_type = normal.get("log_type_name", "")
+        # Prefer microsecond timestamps; fall back to milliseconds for older logs
+        int_fields = r.get("int", {})
+        time_us = int_fields.get("time_us", int_fields.get("time_ms", 0) * 1000)
+        pid = source_to_pid[r["_source_file"]]
+        rank = r.get("int", {}).get("rank", 0)
+        step = r.get("int", {}).get("step")
+
+        if event_type.endswith("_start"):
+            type_name = event_type.removesuffix("_start")
+            display_name = type_name or normal.get("event_name", type_name)
+            pending_starts[(type_name, pid, rank)] = {
+                "ts": time_us,
+                "step": step,
+                "display_name": display_name,
+            }
+        elif event_type.endswith("_end"):
+            type_name = event_type.removesuffix("_end")
+            duration_ms = r.get("double", {}).get("value", 0)
+            duration_us = duration_ms * 1000
+            start = pending_starts.pop((type_name, pid, rank), None)
+            start_ts = start["ts"] if start else time_us
+            display_name = (start or {}).get("display_name", type_name)
+            events.append(
+                {
+                    "name": display_name,
+                    "ph": "X",
+                    "ts": start_ts,
+                    "dur": duration_us,
+                    "pid": pid,
+                    "tid": rank,
+                    "args": {
+                        **({"step": step} if step is not None else {}),
+                        "duration_ms": f"{duration_ms:.2f}",
+                    },
+                }
+            )
+        elif event_type == "metric_value":
+            event_name = normal.get("event_name", "metric")
+            value = r.get("double", {}).get("value", 0)
+            events.append(
+                {
+                    "name": f"{event_name}={value:.4f}",
+                    "ph": "i",
+                    "ts": time_us,
+                    "pid": pid,
+                    "tid": rank,
+                    "s": "t",
+                    "args": {"step": step},
+                }
+            )
+
+    trace = {"traceEvents": events}
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(trace, f, indent=2)
+
+    logger.info(f"Chrome Trace: {output_path}")
+    logger.info(f"  {len(events)} events from {len(sources)} sources")
+    logger.info("  View in: chrome://tracing or https://ui.perfetto.dev")
+    return trace

--- a/torchtitan/observability/metrics_processor.py
+++ b/torchtitan/observability/metrics_processor.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Toy MetricsProcessor for the observability experiment."""
+
+from torchtitan.observability import record_event
+from torchtitan.observability.step_state import set_step
+
+
+class MetricsProcessor:
+    """Step context manager for the toy trainer.
+
+    Mirrors the method order of components/metrics.py MetricsProcessor
+    so the toy and production versions are easy to compare.
+    """
+
+    def __init__(self):
+        self._step: int = 0
+
+    def set_step(self, step: int) -> None:
+        """Set the current training step."""
+        self._step = step
+        set_step(step)
+        record_event({"train.step": step})
+
+    def close(self) -> None:
+        """Shutdown. Extended with subprocess cleanup when logging is added."""
+        pass

--- a/torchtitan/observability/step_state.py
+++ b/torchtitan/observability/step_state.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Per-step context: current step number and step tags."""
+
+_STEP: int | None = None
+_STEP_TAGS: tuple[str, ...] = ()
+
+
+def set_step(step: int) -> None:
+    """Set the current training step. All subsequent JSONL records will
+    include this step number. Clears step tags from the previous step.
+
+    Example::
+
+        for step in range(1, num_steps + 1):
+            set_step(step)
+            train_step(...)
+    """
+    global _STEP
+    _STEP = step
+    clear_step_tags()
+
+
+def get_step() -> int | None:
+    """Return the current step, or None if not set."""
+    return _STEP
+
+
+def get_step_tags() -> tuple[str, ...]:
+    """Return the current step tags."""
+    return _STEP_TAGS
+
+
+def add_step_tag(tag: str) -> None:
+    """Annotate the current step. Tags appear in system JSONL for filtering.
+
+    Example::
+
+        if gc_happened:
+            add_step_tag("gc")
+        if is_validation:
+            add_step_tag("eval")
+        # system JSONL: {"normvector": {"step_tags": ["gc", "eval"]}}
+    """
+    global _STEP_TAGS
+    if tag not in _STEP_TAGS:
+        _STEP_TAGS = _STEP_TAGS + (tag,)
+
+
+def clear_step_tags() -> None:
+    """Reset step tags."""
+    global _STEP_TAGS
+    _STEP_TAGS = ()

--- a/torchtitan/observability/structured_logging.py
+++ b/torchtitan/observability/structured_logging.py
@@ -1,0 +1,459 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""System JSONL logging: init_observability, record_span, record_event."""
+
+import enum
+import itertools
+import json
+import logging
+import os
+import socket
+import threading
+import time
+from contextlib import ContextDecorator
+from timeit import default_timer as timer
+from typing import Any
+
+from torchtitan.observability._constants import SYSTEM_LOGGER_NAME
+from torchtitan.observability.step_state import get_step, get_step_tags
+
+MAX_MESSAGE_SIZE: int = 1000
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class StrEnum(enum.Enum):
+    """String-valued enum. str(member) returns the value, not 'Class.name'."""
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class EventType(StrEnum):
+    """Standardized phase identifiers for structured JSONL events.
+    Used for categorization and analysis.
+    """
+
+    TORCH_DISTRIBUTED_INIT = "torch_distributed_init"
+    TORCH_DISTRIBUTED_TEARDOWN = "torch_distributed_teardown"
+    MODEL_PARALLELISM_INIT = "model_parallelism_init"
+    TOKENIZER_INIT = "tokenizer_init"
+    DATA_ITERATOR_INIT = "data_iterator_init"
+    RELOAD_DATA_LOADER_STATE = "reload_data_loader_state"
+    BUILD_MODEL = "build_model"
+    BUILD_LEARNER = "build_learner"
+    OPTIMIZER_INIT = "optimizer_init"
+    TRAINING_START = "training_start"
+    STEP = "step"
+    FETCHING_BATCH = "fetching_batch"
+    FWD_BWD = "fwd_bwd"
+    OPTIM = "optim"
+    CHECKPOINT = "checkpoint"
+    CHECKPOINT_INIT = "checkpoint_init"
+    CHECKPOINT_STAGE = "checkpoint_stage"
+    CHECKPOINT_LOAD = "checkpoint_load"
+    EVAL_LAUNCH = "eval_launch"
+    EVAL = "eval"
+    SUMMARY_WRITER = "summary_writer"
+    TORCH_MEMORY_BREAKDOWN = "torch_memory_breakdown"
+    GC_COLLECT = "gc_collect"
+    METRIC_VALUE = "metric_value"
+    STATE_DICT_INIT = "state_dict_init"
+    STATE_DICT_LOAD = "state_dict_load"
+
+    # RL
+    RL_GRADING = "rl_grading"
+    RL_ROLLOUT = "rl_rollout"
+    RL_GENERATE = "rl_generate"
+    RL_ENV = "rl_env"
+
+
+class LogType(StrEnum):
+    """Distinguishes event records from free-text log records in JSONL."""
+
+    EVENT = "event"
+    TEXT = "text"
+
+
+class ExtraFields(StrEnum):
+    """Keys for the `extra` dict passed to logging calls."""
+
+    LOG_TYPE = "log_type"
+    LOG_TYPE_NAME = "log_type_name"
+    EVENT_NAME = "event_name"
+    STEP = "step"
+    VALUE = "value"
+
+
+# ---------------------------------------------------------------------------
+# Event helpers
+# ---------------------------------------------------------------------------
+
+
+def event_extra(
+    event_type: EventType | str,
+    event_name: str | None = None,
+    step: int | None = None,
+    value: float | int | None = None,
+) -> dict[str, Any]:
+    """Build the extra dict for a structured JSONL event record."""
+    return {
+        str(ExtraFields.LOG_TYPE): str(LogType.EVENT),
+        str(ExtraFields.LOG_TYPE_NAME): str(event_type),
+        str(ExtraFields.EVENT_NAME): event_name,
+        str(ExtraFields.STEP): step,
+        str(ExtraFields.VALUE): value,
+    }
+
+
+# ---------------------------------------------------------------------------
+# JSONL formatting
+# ---------------------------------------------------------------------------
+
+
+def to_structured_json(log_dict: dict[str, Any]) -> str:
+    """Convert a log dict to 4-column JSON (int/normal/double/normvector)."""
+    int_dict: dict[str, int] = {}
+    str_dict: dict[str, str] = {}
+    float_dict: dict[str, float] = {}
+    vector_str_dict: dict[str, list[str]] = {}
+
+    for k, v in log_dict.items():
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            int_dict[k] = int(v)
+        elif isinstance(v, int):
+            int_dict[k] = v
+        elif isinstance(v, str):
+            str_dict[k] = v
+        elif isinstance(v, float):
+            float_dict[k] = v
+        elif isinstance(v, (list, tuple)):
+            vector_str_dict[k] = [str(e) for e in v]
+
+    structured_dict = {
+        "int": int_dict,
+        "normal": str_dict,
+        "double": float_dict,
+        "normvector": vector_str_dict,
+    }
+    return json.dumps(structured_dict)
+
+
+# ---------------------------------------------------------------------------
+# StructuredJSONFormatter
+# ---------------------------------------------------------------------------
+
+
+class StructuredJSONFormatter(logging.Formatter):
+    """Formats system log records as structured JSONL (4-column format).
+
+    Each record becomes a JSON line with int/normal/double/normvector columns.
+    Rank and source are constants (set once). Step and step_tags come from
+    globals so each process has its own step.
+
+    Example output (one JSON line):
+        {"int": {"rank": 0, "step": 5, "time": 1709500000, "seq_id": 42},
+         "normal": {"source": "trainer", "log_type_name": "fwd_bwd_end", ...},
+         "double": {"value": 12.5, "delta_ms": 0.3},
+         "normvector": {}}
+
+    Usage:
+        formatter = StructuredJSONFormatter(rank=0, source="trainer")
+        handler.setFormatter(formatter)
+    """
+
+    _thread_local = threading.local()
+
+    def __init__(self, rank: int, source: str):
+        super().__init__()
+        self.rank = rank
+        self.source = source
+        self._seq_counter = itertools.count()
+
+    def format(self, record: logging.LogRecord) -> str:
+        return to_structured_json(self._log_dict(record))
+
+    def _log_dict(self, record: logging.LogRecord) -> dict[str, Any]:
+        """Build the flat dict that to_structured_json splits into 4 columns.
+
+        Example output (before to_structured_json splits by type)::
+
+            {"rank": 0, "source": "trainer", "step": 5,
+             "log_type_name": "fwd_bwd_end", "value": 12.5, ...}
+        """
+        log_dict: dict[str, Any] = {}
+
+        log_dict["delta_ms"] = self._refresh_event_delta()
+        log_dict["tid"] = threading.get_native_id()
+        log_dict["thread_time_ns"] = time.thread_time_ns()
+
+        # Rank/source from self (constants, set once in init_observability)
+        log_dict["rank"] = self.rank
+        log_dict["source"] = self.source
+        log_dict["host_name"] = socket.gethostname()
+        log_dict["pid"] = os.getpid()
+
+        # Step/step_tags from step_state globals (mutable, changes every step)
+        step = get_step()
+        if step is not None:
+            log_dict["step"] = step
+        step_tags = get_step_tags()
+        if step_tags:
+            log_dict["step_tags"] = list(step_tags)
+
+        log_dict["time"] = int(record.created)
+        log_dict["time_ms"] = int(record.created * 1000)
+        log_dict["time_us"] = int(record.created * 1_000_000)
+
+        log_dict["log_type"] = getattr(
+            record, str(ExtraFields.LOG_TYPE), str(LogType.TEXT)
+        )
+        log_dict["log_type_name"] = getattr(
+            record, str(ExtraFields.LOG_TYPE_NAME), None
+        )
+
+        # Per-record step override (from event_extra)
+        record_step = getattr(record, str(ExtraFields.STEP), None)
+        if record_step is not None:
+            log_dict["step"] = record_step
+
+        log_dict["event_name"] = getattr(record, str(ExtraFields.EVENT_NAME), None)
+
+        value = getattr(record, str(ExtraFields.VALUE), None)
+        if isinstance(value, (float, int)):
+            log_dict["value"] = float(value)
+
+        # Caller field for source traceability (file:line:function)
+        log_dict[
+            "caller"
+        ] = f"{os.path.relpath(record.pathname)}:{record.lineno}:{record.funcName}"
+        log_dict["log_file"] = record.filename
+        log_dict["log_function"] = record.funcName
+        log_dict["log_level"] = record.levelname
+        log_dict["logger_name"] = record.name
+        log_dict["stack_info"] = record.stack_info
+
+        log_dict["seq_id"] = next(self._seq_counter)
+
+        message = record.getMessage()
+        if message is not None:
+            if len(message) <= MAX_MESSAGE_SIZE:
+                log_dict["message"] = message
+            else:
+                half = MAX_MESSAGE_SIZE // 2
+                log_dict["message"] = message[:half] + "..." + message[-half:]
+
+        return log_dict
+
+    def _refresh_event_delta(self) -> float:
+        if not hasattr(self._thread_local, "last_event_time"):
+            self._thread_local.last_event_time = timer()
+        event_delta = (timer() - self._thread_local.last_event_time) * 1000
+        self._thread_local.last_event_time = timer()
+        return event_delta
+
+
+# ---------------------------------------------------------------------------
+# Filters and handlers
+# ---------------------------------------------------------------------------
+
+
+class EventsOnlyFilter(logging.Filter):
+    """Filters logs, only passing events with LOG_TYPE_NAME set."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return getattr(record, str(ExtraFields.LOG_TYPE_NAME), None) is not None
+
+
+class StructuredLoggingHandler(logging.FileHandler):
+    """Writes structured JSONL events to per-rank files.
+
+    Creates the output directory if needed. Only passes events
+    (records with LOG_TYPE_NAME set) — free-text logs are filtered out.
+    """
+
+    def __init__(self, filepath: str):
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        super().__init__(filename=filepath)
+        self.addFilter(EventsOnlyFilter())
+
+
+# ---------------------------------------------------------------------------
+# Crash forensics
+# ---------------------------------------------------------------------------
+
+
+class InflightEventTrackingHandler(logging.Handler):
+    """Tracks the last structured event for crash forensics.
+
+    On crash, ``handler.last_event`` tells you what phase the process was in::
+
+        handler = InflightEventTrackingHandler()
+        sys_logger.addHandler(handler)
+        # ... training runs, then crashes during forward pass ...
+        print(handler.last_event)  # "fwd_bwd_start"
+        print(handler.last_event_time)  # 1708200121.5
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_event: str | None = None
+        self.last_event_time: float | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            event_name = getattr(record, str(ExtraFields.LOG_TYPE_NAME), None)
+            if event_name is not None:
+                self.last_event = str(event_name)
+                self.last_event_time = time.time()
+        except Exception:
+            return  # Crash forensics handler must never itself crash
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+_system_logger = logging.getLogger(SYSTEM_LOGGER_NAME)
+
+
+def init_observability(source: str, output_dir: str, rank: int | None = None) -> None:
+    """Initialize observability JSONL file handlers.
+
+    Adds per-rank system and experiment JSONL handlers for structured
+    logging. Does NOT set up console logging — call ``init_logger()``
+    from ``torchtitan.tools.logging`` for that.
+
+    Idempotent: safe to call multiple times (skips existing handlers).
+    Can be called before torch.distributed init — rank defaults to the
+    RANK environment variable (set by torchrun).
+
+    Example:
+
+        init_logger()  # console
+        init_observability(source="trainer", output_dir="./outputs")
+        # Creates: ./outputs/system_logs/trainer_rank_0_system.jsonl
+
+    Args:
+        source: Component name (e.g., "trainer", "generator").
+        output_dir: Root output directory.
+        rank: Global rank. If None, reads from RANK env var (default 0).
+    """
+    if rank is None:
+        rank = int(os.environ.get("RANK", 0))
+
+    # --- System handler ---
+    sys_logger = logging.getLogger(SYSTEM_LOGGER_NAME)
+    if not any(isinstance(h, StructuredLoggingHandler) for h in sys_logger.handlers):
+        sys_path = os.path.join(
+            output_dir, "system_logs", f"{source}_rank_{rank}_system.jsonl"
+        )
+        handler = StructuredLoggingHandler(filepath=sys_path)
+        handler.setFormatter(StructuredJSONFormatter(rank=rank, source=source))
+        sys_logger.addHandler(handler)
+        sys_logger.addHandler(InflightEventTrackingHandler())
+        # propagate=False prevents events from bubbling to the root logger
+        # (which would duplicate them in stderr). Level ensures INFO records
+        # are captured even if the root logger has a higher threshold.
+        sys_logger.propagate = False
+        if sys_logger.level == logging.NOTSET or sys_logger.level > logging.INFO:
+            sys_logger.setLevel(logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+# Public API: record_event, record_span
+# ---------------------------------------------------------------------------
+
+
+def record_event(metrics: dict[str, float | int]) -> None:
+    """Log point-in-time scalars to system JSONL.
+
+    Each key-value pair becomes a separate METRIC_VALUE event.
+    Step is read from the global set by ``set_step()``.
+
+    Example:
+
+        record_event({"train.loss": 2.5, "train.tflops": 45.6})
+        # system JSONL: {"normal": {"event_name": "train.loss"}, "double": {"value": 2.5}, ...}
+    """
+    step = get_step()
+    for name, value in metrics.items():
+        _system_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {name}={value}",
+            extra=event_extra(
+                EventType.METRIC_VALUE, event_name=name, value=value, step=step
+            ),
+            stacklevel=2,
+        )
+
+
+class record_span(ContextDecorator):  # noqa: N801
+    """Context manager/decorator for timing phases.
+
+    Logs START event on enter, END event (with duration) on exit to system
+    JSONL. Step is read from the global set by ``set_step()``.
+
+    Args:
+        description (str): Human-readable label for log messages and metric key.
+            Free-form string (e.g., "trainer_time/forward_backward_s").
+            Appears in system JSONL messages and, when metrics are enabled,
+            as the experiment metric key.
+        event_type Optional([EventType,str]): Optional categorization for analysis tools. Can be an
+            ``EventType`` enum for standardized phases, or any string.
+            When omitted, the description is used as the event type.
+
+    Usage::
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            output = model(batch)
+            loss.backward()
+
+        # Without EventType (description used as event type):
+        with record_span("rl_time/rollout_s"):
+            rollouts = generate(prompts)
+    """
+
+    def __init__(self, description: str, event_type: EventType | str | None = None):
+        self.description = description
+        self.start_time: float = 0.0
+
+        # Derive _start/_end type names from event_type or description.
+        base_name = str(event_type) if event_type is not None else description
+        self.start_type_name = base_name + "_start"
+        self.end_type_name = base_name + "_end"
+
+    def __enter__(self):
+        self.start_time = timer()
+        step = get_step()
+        _system_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {self.description} {self.start_type_name}",
+            extra=event_extra(
+                self.start_type_name, event_name=self.description, step=step
+            ),
+            stacklevel=2,
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        end_time = timer()
+        step = get_step()
+        duration_s = end_time - self.start_time
+        delta_ms = duration_s * 1000
+        _system_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {self.description} {self.end_type_name} took {delta_ms:.2f} ms",
+            extra=event_extra(
+                self.end_type_name,
+                event_name=self.description,
+                value=delta_ms,
+                step=step,
+            ),
+            stacklevel=2,
+        )
+        return False  # Don't suppress exceptions


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2607
* #2606
* #2605
* #2604
* #2603
* __->__ #2602
* #2601

## How to review

Prioritize the files under /observability. Check how they are used in the toy example.
No need to nitpick the toy example. Real implementation in trainer are in PRs 6 and 7.

## Summary

The system logging layer. Every process writes structured JSONL to disk via Python's logging module.

Two APIs:
- `record_span(description, event_type)` — context manager that writes START/END events with wall-clock duration. Used for timing training phases (forward/backward, optimizer, data loading, etc).
- `record_event({"key": value, ...})` — point-in-time scalar snapshots for per-rank diagnostics.

## Example

```python
from torchtitan.observability import (
    init_observability, set_step, add_step_tag,
    record_span, record_event, EventType,
)
from torchtitan.tools.logging import init_logger

# Console logging (stdout with [titan] format)
init_logger()

# JSONL file handlers for structured logging
init_observability(source="trainer", output_dir="./outputs")

for step in range(steps):
    # Stamp all subsequent JSONL entries with step=step
    set_step(step)

    if should_garbage_collect:
        add_step_tag("gc")
        with record_span("trainer_time/gc_s", EventType.GC_COLLECT):
            run_gc()

    with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
        reduced_loss = model.fwd_bwd(batch)
        record_event({"loss": reduced_loss.item()})
```

```json
// dump_dir/system_logs/trainer_rank_0_system.jsonl
{"int": {"step": 42, "rank": 0, "time_us": 1708200121724000},
 "normal": {"log_type_name": "fwd_bwd_end", "source": "trainer",
            "message": "[step 42] trainer_time/forward_backward_s fwd_bwd_end took 123.45 ms",
            "caller": "torchtitan/trainer.py:730:train_step"},
 "double": {"value": 123.45},
 "normvector": {"step_tags": ["gc"]}}
```

### Output folder (from toy_spmd on this PR)

```
outputs/toy_spmd/
├── analysis/
│   └── system_metrics_gantt.json      ← generate_gantt_trace output
└── system_logs/
    ├── trainer_rank_0_system.jsonl
    ├── trainer_rank_1_system.jsonl
    ├── trainer_rank_2_system.jsonl
    └── trainer_rank_3_system.jsonl
```

### Gantt chart

**toy_rl**
<img width="1595" height="362" alt="gantt_rl" src="https://github.com/user-attachments/assets/37f01bdf-f4c9-4022-b727-17a23a87dd7d" />

**toy_spmd**
<img width="1699" height="310" alt="ganttspmd" src="https://github.com/user-attachments/assets/405d8197-edda-4905-9b6f-1d7d4759bb5b" />

## Others

`init_observability(source, output_dir)` sets up the JSONL file handlers. Each rank gets its own file: `{output_dir}/system_logs/{source}_rank_{rank}_system.jsonl`.

The JSONL format uses four typed columns (`int`, `normal`, `double`, `normvector`) for easy ingestion into Grafana, DuckDB, etc.

`generate_gantt_trace(log_dir, output_path)` reads all system JSONL files and produces a Chrome Trace JSON. Open in Perfetto to see a gantt chart of every `record_span` across all ranks.

Also includes:
 - `EventType` enum for categorizing spans,
 - `set_step`/`add_step_tag` for step context,
 - `InflightEventTrackingHandler` for crash forensics

## Test plan

Run toy_spmd: `python -m torch.distributed.run --nproc_per_node=4 -m torchtitan.experiments.observability.toy_spmd`
Run toy_rl: `python -m torchtitan.experiments.observability.toy_rl`

- [x] 44 new unit tests for record_span, record_event, init_observability, gantt generation, step state
- [x] Integration: toy_spmd produces system JSONL with record_span start/end events
- [x] Integration: toy_rl produces system JSONL from 4 actor types
- [x] Integration: generate_gantt_trace produces Chrome Trace JSON from system JSONL

### Console output (toy_spmd)
```
step: 1  loss: 3.65555  grad_norm: 0.49419
step: 5  loss: 3.05283  grad_norm: 0.40876
step: 10  loss: 2.53639  grad_norm: 0.31771
  val loss: 2.4611
step: 20  loss: 2.02626  grad_norm: 0.22093
  val loss: 1.9949
Chrome Trace: outputs/toy_spmd/analysis/system_metrics_gantt.json
  576 events from 4 sources
```

### Console output (toy_rl)
```
step: 1  loss: 3.65156  grad_norm: 0.49804
step: 1  reward_mean: 1.00000
step: 3  loss: 3.32657  grad_norm: 0.44708
step: 3  reward_mean: 1.00000
step: 6  loss: 2.93530  grad_norm: 0.36988
step: 6  reward_mean: 1.00000
Chrome Trace: outputs/toy_rl/analysis/system_metrics_gantt.json
Done in 13.8s.
```

Sample of generated logs
```json
{"int": {"tid": 1056731, "thread_time_ns": 3325664547, "rank": 0, "pid": 1056731, "time": 1773610642, "time_ms": 1773610642167, "time_us": 1773610642167603, "seq_id": 0}, "normal": {"source": "trainer", "host_name": "devgpu011.ldc3.facebook.com", "log_type": "event", "log_type_name": "build_model_start", "event_name": "setup/model_build", "caller": "torchtitan/experiments/observability/toy_spmd.py:168:__init__", "log_file": "toy_spmd.py", "log_function": "__init__", "log_level": "INFO", "logger_name": "torchtitan.observability.system", "message": "[step N/A] setup/model_build build_model_start"}, "double": {"delta_ms": 0.00051083043217659}, "normvector": {}}
{"int": {"tid": 1056731, "thread_time_ns": 3998473694, "rank": 0, "pid": 1056731, "time": 1773610642, "time_ms": 1773610642858, "time_us": 1773610642858849, "seq_id": 1}, "normal": {"source": "trainer", "host_name": "devgpu011.ldc3.facebook.com", "log_type": "event", "log_type_name": "build_model_end", "event_name": "setup/model_build", "caller": "torchtitan/experiments/observability/toy_spmd.py:168:__init__", "log_file": "toy_spmd.py", "log_function": "__init__", "log_level": "INFO", "logger_name": "torchtitan.observability.system", "message": "[step N/A] setup/model_build build_model_end took 691.24 ms"}, "double": {"delta_ms": 691.2433146499097, "value": 691.238438244909}, "normvector": {}}
```
