### PR TITLE
[Observability 3/7] Experiment metrics with background aggregation subprocess

### DIFF
--- a/tests/unit_tests/observability/test_aggregation.py
+++ b/tests/unit_tests/observability/test_aggregation.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for aggregation.py: aggregate() and logging_worker."""
+
+import multiprocessing
+
+import pytest
+
+from torchtitan.observability.aggregation import aggregate, logging_worker
+
+
+class TestAggregate:
+    def test_empty(self):
+        assert aggregate([]) == {}
+
+    def test_mean_metric(self):
+        entries = [
+            {"key": "tps", "reduce": "MeanMetric", "sum": 1000, "weight": 1},
+            {"key": "tps", "reduce": "MeanMetric", "sum": 1200, "weight": 1},
+        ]
+        result = aggregate(entries)
+        assert result["tps"] == pytest.approx(1100.0)
+
+    def test_max_metric(self):
+        entries = [
+            {"key": "mem", "reduce": "MaxMetric", "value": 14.0},
+            {"key": "mem", "reduce": "MaxMetric", "value": 15.5},
+        ]
+        result = aggregate(entries)
+        assert result["mem"] == pytest.approx(15.5)
+
+    def test_noop_metric(self):
+        entries = [
+            {"key": "loss", "reduce": "NoOpMetric", "value": 0.5},
+            {"key": "loss", "reduce": "NoOpMetric", "value": 0.6},
+        ]
+        result = aggregate(entries)
+        assert result["loss"] == pytest.approx(0.5)  # takes first
+
+    def test_mixed_keys(self):
+        entries = [
+            {"key": "loss", "reduce": "NoOpMetric", "value": 0.5},
+            {"key": "tps", "reduce": "MeanMetric", "sum": 1000, "weight": 1},
+            {"key": "mem", "reduce": "MaxMetric", "value": 14.0},
+        ]
+        result = aggregate(entries)
+        assert len(result) == 3
+        assert result["loss"] == 0.5
+        assert result["tps"] == 1000.0
+        assert result["mem"] == 14.0
+
+
+class TestLoggingWorkerBasic:
+    def test_reads_jsonl_and_shuts_down(self, tmp_path):
+        """Logging worker reads JSONL, aggregates, and shuts down cleanly."""
+        log_dir = tmp_path / "experiment_logs"
+        log_dir.mkdir()
+
+        fp = log_dir / "rank_0.jsonl"
+        fp.write_text(
+            '{"key": "loss", "reduce": "NoOpMetric", "value": 0.5, "step": 1}\n'
+            '{"key": "tps", "reduce": "MeanMetric", "sum": 1000, "weight": 1, "step": 1}\n'
+        )
+
+        queue = multiprocessing.Queue()
+        p = multiprocessing.Process(
+            target=logging_worker,
+            args=(queue, str(tmp_path)),
+            kwargs={"queue_timeout_s": 5},
+        )
+        p.start()
+        queue.put(1)
+        queue.put(None)  # shutdown
+        p.join(timeout=10)
+        assert p.exitcode == 0
+
+    def test_skip_historical_data(self, tmp_path):
+        """On startup, worker skips existing JSONL data (checkpoint resume)."""
+        log_dir = tmp_path / "experiment_logs"
+        log_dir.mkdir()
+
+        fp = log_dir / "rank_0.jsonl"
+        # Write old data before worker starts
+        fp.write_text(
+            '{"key": "loss", "reduce": "NoOpMetric", "value": 99.0, "step": 50}\n'
+        )
+
+        queue = multiprocessing.Queue()
+        p = multiprocessing.Process(
+            target=logging_worker,
+            args=(queue, str(tmp_path)),
+            kwargs={"queue_timeout_s": 5},
+        )
+        p.start()
+
+        # Write new data after worker started
+        with open(fp, "a") as f:
+            f.write(
+                '{"key": "loss", "reduce": "NoOpMetric", "value": 0.5, "step": 51}\n'
+            )
+
+        queue.put(51)
+        queue.put(None)
+        p.join(timeout=10)
+        assert p.exitcode == 0
+
+    def test_multi_rank_aggregation(self, tmp_path):
+        """Worker aggregates metrics from multiple rank files."""
+        log_dir = tmp_path / "experiment_logs"
+        log_dir.mkdir()
+
+        for rank in range(4):
+            fp = log_dir / f"rank_{rank}.jsonl"
+            tps = 1000 + rank * 100
+            fp.write_text(
+                f'{{"key": "tps", "reduce": "MeanMetric", "sum": {tps}, "weight": 1, "step": 1}}\n'
+            )
+
+        queue = multiprocessing.Queue()
+        p = multiprocessing.Process(
+            target=logging_worker,
+            args=(queue, str(tmp_path)),
+            kwargs={"queue_timeout_s": 5},
+        )
+        p.start()
+        queue.put(1)
+        queue.put(None)
+        p.join(timeout=10)
+        assert p.exitcode == 0

--- a/tests/unit_tests/observability/test_metrics.py
+++ b/tests/unit_tests/observability/test_metrics.py
@@ -1,0 +1,202 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for metrics.py: MetricValue types, record_metric, ExperimentJSONFormatter."""
+
+import json
+import logging
+
+import pytest
+from torchtitan.observability import step_state
+
+from torchtitan.observability._constants import (
+    EXPERIMENT_LOGGER_NAME,
+    SYSTEM_LOGGER_NAME,
+)
+from torchtitan.observability.metrics import (
+    ExperimentJSONFormatter,
+    MaxMetric,
+    MeanMetric,
+    MinMetric,
+    NoOpMetric,
+    record_metric,
+    REDUCE_REGISTRY,
+    SumMetric,
+)
+from torchtitan.observability.step_state import set_step
+from torchtitan.observability.structured_logging import init_observability
+
+
+@pytest.fixture(autouse=True)
+def reset_step():
+    step_state._STEP = None
+    yield
+    step_state._STEP = None
+
+
+@pytest.fixture
+def exp_logger():
+    """Provide clean experiment + system loggers for testing."""
+    exp_log = logging.getLogger(EXPERIMENT_LOGGER_NAME)
+    sys_log = logging.getLogger(SYSTEM_LOGGER_NAME)
+    exp_orig = (exp_log.handlers[:], exp_log.level, exp_log.propagate)
+    sys_orig = (sys_log.handlers[:], sys_log.level, sys_log.propagate)
+    yield exp_log
+    exp_log.handlers, exp_log.level, exp_log.propagate = exp_orig
+    sys_log.handlers, sys_log.level, sys_log.propagate = sys_orig
+
+
+# ---------------------------------------------------------------------------
+# MetricValue types
+# ---------------------------------------------------------------------------
+
+
+class TestMeanMetric:
+    def test_from_value(self):
+        m = MeanMetric(sum=2.5)
+        state = m.get_state()
+        assert state["reduce"] == "MeanMetric"
+        assert state["sum"] == 2.5
+        assert state["weight"] == 1.0
+
+    def test_from_sum_weight(self):
+        m = MeanMetric(sum=10.0, weight=4.0)
+        state = m.get_state()
+        assert state["sum"] == 10.0
+        assert state["weight"] == 4.0
+
+    def test_reduce(self):
+        states = [
+            {"sum": 6.0, "weight": 3.0},
+            {"sum": 4.0, "weight": 2.0},
+        ]
+        result = MeanMetric.get_reduced_value_from_states(states)
+        assert result == pytest.approx(2.0)  # 10/5
+
+    def test_default_weight(self):
+        m = MeanMetric(sum=5.0)
+        assert m._weight == 1.0
+
+
+class TestMaxMetric:
+    def test_basic(self):
+        assert MaxMetric(5.0).get_state()["value"] == 5.0
+
+    def test_reduce(self):
+        states = [{"value": 3.0}, {"value": 7.0}, {"value": 1.0}]
+        assert MaxMetric.get_reduced_value_from_states(states) == 7.0
+
+
+class TestMinMetric:
+    def test_reduce(self):
+        states = [{"value": 3.0}, {"value": 7.0}, {"value": 1.0}]
+        assert MinMetric.get_reduced_value_from_states(states) == 1.0
+
+
+class TestSumMetric:
+    def test_reduce(self):
+        states = [{"value": 3.0}, {"value": 7.0}, {"value": 1.0}]
+        assert SumMetric.get_reduced_value_from_states(states) == 11.0
+
+
+class TestNoOpMetric:
+    def test_basic(self):
+        m = NoOpMetric(value=0.038)
+        state = m.get_state()
+        assert state["reduce"] == "NoOpMetric"
+        assert state["value"] == 0.038
+
+    def test_reduce_takes_first(self):
+        states = [{"value": 0.5}, {"value": 0.6}, {"value": 0.7}]
+        assert NoOpMetric.get_reduced_value_from_states(states) == 0.5
+
+
+class TestReduceRegistry:
+    def test_all_types_registered(self):
+        assert "MeanMetric" in REDUCE_REGISTRY
+        assert "MaxMetric" in REDUCE_REGISTRY
+        assert "MinMetric" in REDUCE_REGISTRY
+        assert "SumMetric" in REDUCE_REGISTRY
+        assert "NoOpMetric" in REDUCE_REGISTRY
+
+
+# ---------------------------------------------------------------------------
+# ExperimentJSONFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentJSONFormatter:
+    def test_formats_metric_entry(self):
+        fmt = ExperimentJSONFormatter(rank=0, source="trainer")
+        set_step(5)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=42,
+            msg="experiment_metric",
+            args=None,
+            exc_info=None,
+        )
+        record._metric_entry = {
+            "key": "reward",
+            "reduce": "MaxMetric",
+            "value": 0.95,
+        }
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        assert parsed["key"] == "reward"
+        assert parsed["step"] == 5
+        assert parsed["rank"] == 0
+        assert parsed["source"] == "trainer"
+        assert "caller" in parsed
+        assert "timestamp" in parsed
+
+    def test_raises_without_step(self):
+        fmt = ExperimentJSONFormatter(rank=0, source="trainer")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        record._metric_entry = {"key": "x", "reduce": "MaxMetric", "value": 1.0}
+        with pytest.raises(ValueError, match="No step"):
+            fmt.format(record)
+
+
+# ---------------------------------------------------------------------------
+# record_metric end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestRecordMetricEndToEnd:
+    def test_writes_to_experiment_jsonl(self, tmp_path, exp_logger):
+        init_observability(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(42)
+
+        record_metric("reward", MaxMetric(0.95))
+        record_metric("lr", MeanMetric(sum=1e-4))
+
+        for h in exp_logger.handlers:
+            h.flush()
+
+        exp_dir = tmp_path / "experiment_logs"
+        jsonl_files = list(exp_dir.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+
+        with open(jsonl_files[0]) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 2
+        keys = {line["key"] for line in lines}
+        assert keys == {"reward", "lr"}
+
+    def test_raises_without_step(self):
+        with pytest.raises(ValueError, match="No step"):
+            record_metric("x", MaxMetric(1.0))

--- a/tests/unit_tests/observability/test_structured_logging.py
+++ b/tests/unit_tests/observability/test_structured_logging.py
@@ -14,7 +14,10 @@ import time
 import pytest
 
 from torchtitan.observability import step_state
-from torchtitan.observability._constants import SYSTEM_LOGGER_NAME
+from torchtitan.observability._constants import (
+    EXPERIMENT_LOGGER_NAME,
+    SYSTEM_LOGGER_NAME,
+)
 from torchtitan.observability.analysis import generate_gantt_trace
 from torchtitan.observability.step_state import (
     add_step_tag,
@@ -58,15 +61,13 @@ def reset_context():
 @pytest.fixture
 def system_logger():
     """Provide a clean system logger for testing."""
-    logger = logging.getLogger(SYSTEM_LOGGER_NAME)
-    original_handlers = logger.handlers[:]
-    original_level = logger.level
-    original_propagate = logger.propagate
-    yield logger
-    # Restore
-    logger.handlers = original_handlers
-    logger.level = original_level
-    logger.propagate = original_propagate
+    sys_log = logging.getLogger(SYSTEM_LOGGER_NAME)
+    exp_log = logging.getLogger(EXPERIMENT_LOGGER_NAME)
+    sys_orig = (sys_log.handlers[:], sys_log.level, sys_log.propagate)
+    exp_orig = (exp_log.handlers[:], exp_log.level, exp_log.propagate)
+    yield sys_log
+    sys_log.handlers, sys_log.level, sys_log.propagate = sys_orig
+    exp_log.handlers, exp_log.level, exp_log.propagate = exp_orig
 
 
 # ---------------------------------------------------------------------------

--- a/torchtitan/experiments/observability/tests/test_record_metric.py
+++ b/torchtitan/experiments/observability/tests/test_record_metric.py
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Integration tests for experiment JSONL from toy_spmd.
+
+Verifies record_metric output. Run toy_spmd first to generate output files.
+"""
+
+import json
+import os
+from glob import glob
+
+import pytest
+
+OUTPUT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "outputs", "toy_spmd"
+)
+
+
+@pytest.fixture
+def experiment_logs_dir():
+    """Path to experiment_logs from a prior toy_spmd run."""
+    path = os.path.join(OUTPUT_DIR, "experiment_logs")
+    if not os.path.isdir(path):
+        pytest.fail(
+            f"No experiment_logs at {path}. Run toy_spmd first to generate outputs."
+        )
+    return path
+
+
+class TestExperimentJSONL:
+    def test_experiment_jsonl_files_exist(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        assert len(files) >= 1
+
+    def test_experiment_jsonl_has_expected_keys(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        keys = set()
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    keys.add(record.get("key"))
+
+        assert "training/loss_mean" in keys, f"Missing loss metric. Found: {keys}"
+        assert "training/grad_norm_max" in keys, f"Missing grad_norm. Found: {keys}"
+        assert "training/lr" in keys, f"Missing lr. Found: {keys}"
+
+    def test_experiment_jsonl_has_required_fields(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    assert "key" in record
+                    assert "reduce" in record
+                    assert "step" in record
+                    assert "rank" in record
+                    assert "caller" in record
+                    assert "timestamp" in record
+                    return  # One record is enough
+
+    def test_experiment_jsonl_reduce_types_correct(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        reduce_by_key: dict[str, str] = {}
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    reduce_by_key[record["key"]] = record["reduce"]
+
+        assert reduce_by_key.get("training/loss_mean") == "NoOpMetric"
+        assert reduce_by_key.get("training/grad_norm_max") == "MaxMetric"
+        assert reduce_by_key.get("training/lr") == "NoOpMetric"

--- a/torchtitan/experiments/observability/toy_rl.py
+++ b/torchtitan/experiments/observability/toy_rl.py
@@ -21,6 +21,7 @@ process that spawns GPU workers via Monarch's this_host().spawn_procs().
 
 import asyncio
 import logging
+import multiprocessing
 import os
 import shutil
 import socket
@@ -31,6 +32,7 @@ import torch
 from monarch.actor import Actor, current_rank, endpoint, this_host
 
 from torchtitan.distributed import ParallelDims
+
 from torchtitan.experiments.observability.toy_spmd import (
     BATCH_SIZE,
     DP_SIZE,
@@ -42,10 +44,14 @@ from torchtitan.experiments.observability.toy_spmd import (
 from torchtitan.observability import (
     EventType,
     init_observability,
+    logging_worker,
+    MeanMetric,
+    record_metric,
     record_span,
     set_step,
 )
 from torchtitan.observability.analysis import generate_gantt_trace
+from torchtitan.observability.metrics_processor import MetricsProcessor
 from torchtitan.tools.logging import init_logger
 
 logger = logging.getLogger(__name__)
@@ -146,6 +152,11 @@ class RollouterActor(Actor):
                 )
                 for i in range(len(self.dataset.tokens))
             ]
+        total_completion_len = sum(len(r.completion_text) for r in rollouts)
+        record_metric(
+            "rl/completion_len_mean",
+            MeanMetric(sum=total_completion_len, weight=len(rollouts)),
+        )
         return rollouts
 
 
@@ -176,7 +187,11 @@ class TrainerActor(Actor):
         )
         parallel_dims.build_mesh()
         self.dp_rank = parallel_dims.get_mesh("fsdp").get_local_rank()
-        self.trainer = ToyTrainer(self.device, parallel_dims, OUTPUT_DIR)
+        # Controller owns the logging subprocess — trainer has no backends/console.
+        mp_config = MetricsProcessor.Config(enable_wandb=False)
+        self.trainer = ToyTrainer(
+            self.device, parallel_dims, OUTPUT_DIR, mp_config=mp_config
+        )
 
     @endpoint
     async def set_step(self, step: int):
@@ -225,6 +240,10 @@ class RewardActor(Actor):
         with record_span("reward_time/scoring_s"):
             for rollout in rollouts:
                 rollout.reward = 1.0  # dummy constant reward
+        reward_sum = sum(r.reward for r in rollouts)
+        record_metric(
+            "rl/reward_mean", MeanMetric(sum=reward_sum, weight=len(rollouts))
+        )
         return rollouts
 
 
@@ -242,6 +261,26 @@ async def main():
 
     init_logger()
     init_observability(source="controller", output_dir=OUTPUT_DIR, rank=0)
+
+    # logging_worker reads experiment JSONL from all actors, aggregates
+    # metrics, and flushes to WandB/TB/console. Runs in a separate process.
+    log_queue = multiprocessing.Queue()
+    log_process = multiprocessing.Process(
+        target=logging_worker,
+        args=(log_queue, OUTPUT_DIR),
+        kwargs={
+            "enable_wandb": True,
+            "console_log_metric_keys": [
+                "training/loss_mean",
+                "training/grad_norm_max",
+                "training/lr",
+                "rl/reward_mean",
+                "rl/completion_len_mean",
+            ],
+        },
+        daemon=True,
+    )
+    log_process.start()
 
     # ---- Setup ----
     host = this_host()
@@ -285,13 +324,13 @@ async def main():
             with record_span("rl_time/training_s", EventType.FWD_BWD):
                 await trainer.train_step.call(tokens, labels, loss_mask)
 
-            rewards = [r.reward for r in rollouts]
-            reward_mean = sum(rewards) / len(rewards)
-            logger.info(f"step: {step}  reward_mean: {reward_mean:.5f}")
+            log_queue.put(step)
 
     await run_training()
 
     # ---- Cleanup ----
+    log_queue.put(None)
+    log_process.join(timeout=10)
     await trainer.teardown.call()
 
     sys_logs = os.path.join(OUTPUT_DIR, "system_logs")

--- a/torchtitan/experiments/observability/toy_spmd.py
+++ b/torchtitan/experiments/observability/toy_spmd.py
@@ -38,7 +38,10 @@ from torchtitan.observability import (
     add_step_tag,
     EventType,
     init_observability,
+    MaxMetric,
+    NoOpMetric,
     record_event,
+    record_metric,
     record_span,
 )
 from torchtitan.observability.analysis import generate_gantt_trace
@@ -57,6 +60,7 @@ BATCH_SIZE = 8
 DP_SIZE = 2
 LR = 1e-3
 IGNORE_INDEX = -100
+ENABLE_WANDB = True
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "outputs", "toy_spmd")
 
 
@@ -155,7 +159,9 @@ class ToyTrainer:
     - train: owns the training loop
     """
 
-    def __init__(self, device, parallel_dims: ParallelDims, output_dir):
+    def __init__(
+        self, device, parallel_dims: ParallelDims, output_dir, *, mp_config=None
+    ):
         self.device = device
         self.parallel_dims = parallel_dims
         dp_mesh = parallel_dims.get_mesh("fsdp")
@@ -165,7 +171,11 @@ class ToyTrainer:
         self.output_dir = output_dir
         self.step = 0
 
-        self.metrics_processor = MetricsProcessor()
+        if mp_config is None:
+            mp_config = MetricsProcessor.Config()
+        self.metrics_processor = mp_config.build(
+            parallel_dims=parallel_dims, dump_folder=output_dir
+        )
 
         torch.manual_seed(0)
         with record_span("setup/model_build", EventType.BUILD_MODEL):
@@ -277,14 +287,12 @@ class ToyTrainer:
         dist.all_reduce(
             loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
         )
+        record_metric("training/loss_mean", NoOpMetric(value=loss_scalar.item()))
+        record_metric("training/grad_norm_max", MaxMetric(value=grad_norm.item()))
+        record_metric("training/lr", NoOpMetric(value=LR))
         record_event(
             {"train.loss": loss_scalar.item(), "train.grad_norm": grad_norm.item()}
         )
-        if self.rank == 0:
-            print(
-                f"step: {self.step}  loss: {loss_scalar.item():.5f}  "
-                f"grad_norm: {grad_norm.item():.5f}"
-            )
 
     def validate(self, tokens, labels, loss_mask):
         """Run one forward pass for validation (no backward)."""
@@ -298,8 +306,7 @@ class ToyTrainer:
         dist.all_reduce(
             val_loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
         )
-        if self.rank == 0:
-            print(f"  val loss: {val_loss_scalar.item():.4f}")
+        record_metric("validation/loss_mean", NoOpMetric(value=val_loss_scalar.item()))
 
     def train(self, num_steps):
         """Full training loop. Mirrors Trainer.train structure."""
@@ -323,6 +330,8 @@ class ToyTrainer:
                 add_step_tag("eval")
                 with record_span("trainer_time/validation_s", EventType.EVAL):
                     self.validate(tokens, labels, loss_mask)
+
+            self.metrics_processor.log(step)
 
     def close(self):
         """Cleanup."""
@@ -360,7 +369,15 @@ def main():
     if rank == 0:
         print(f"Toy SPMD: {world_size} GPUs, 2DPx2TP, {NUM_STEPS} steps")
 
-    trainer = ToyTrainer(device, parallel_dims, OUTPUT_DIR)
+    mp_config = MetricsProcessor.Config(
+        enable_wandb=ENABLE_WANDB,
+        console_log_metric_keys=[
+            "training/loss_mean",
+            "training/grad_norm_max",
+            "training/lr",
+        ],
+    )
+    trainer = ToyTrainer(device, parallel_dims, OUTPUT_DIR, mp_config=mp_config)
     trainer.train(NUM_STEPS)
     trainer.close()
 

--- a/torchtitan/observability/__init__.py
+++ b/torchtitan/observability/__init__.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""
-TorchTitan Observability Library
+"""TorchTitan Observability Library."""
 
-System metrics: init_observability, set_step, record_span, record_event, EventType
-"""
-
+from torchtitan.observability.aggregation import aggregate, logging_worker
+from torchtitan.observability.metrics import (
+    MaxMetric,
+    MeanMetric,
+    MinMetric,
+    NoOpMetric,
+    record_metric,
+    SumMetric,
+)
 from torchtitan.observability.step_state import add_step_tag, clear_step_tags, set_step
 from torchtitan.observability.structured_logging import (
     EventType,
@@ -26,4 +31,12 @@ __all__ = [
     "record_span",
     "record_event",
     "EventType",
+    "record_metric",
+    "MeanMetric",
+    "MaxMetric",
+    "MinMetric",
+    "SumMetric",
+    "NoOpMetric",
+    "aggregate",
+    "logging_worker",
 ]

--- a/torchtitan/observability/aggregation.py
+++ b/torchtitan/observability/aggregation.py
@@ -1,0 +1,348 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Aggregation: reduce experiment metrics from JSONL + logging subprocess."""
+
+import glob
+import json
+import logging
+import multiprocessing
+import os
+import time
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from torchtitan.components.metrics import (
+    BaseLogger,
+    LoggerContainer,
+    TensorBoardLogger,
+    WandBLogger,
+)
+from torchtitan.observability.metrics import REDUCE_REGISTRY
+from torchtitan.observability.structured_logging import init_observability
+from torchtitan.tools.utils import Color
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_TIMEOUT_S = 600  # 10 minutes — if no signal, assume training crashed
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate(entries: list[dict]) -> dict[str, float]:
+    """Reduce a list of metric entries to a single dict.
+
+    Groups entries by key and delegates to REDUCE_REGISTRY.
+
+    Example:
+
+        entries = [
+            {"key": "loss", "reduce": "MeanMetric", "sum": 6.0, "weight": 3.0},
+            {"key": "loss", "reduce": "MeanMetric", "sum": 4.0, "weight": 2.0},
+        ]
+        aggregate(entries)  # {"loss": 2.0}
+    """
+    if not entries:
+        return {}
+
+    # Group entries by metric key
+    by_key: dict[str, list[dict]] = defaultdict(list)
+    for entry in entries:
+        by_key[entry["key"]].append(entry)
+
+    # Reduce each key using its registered reduce type
+    result: dict[str, float] = {}
+    for key, key_entries in by_key.items():
+        cls = REDUCE_REGISTRY[key_entries[0]["reduce"]]
+        result[key] = cls.get_reduced_value_from_states(key_entries)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# JSONL reader
+# ---------------------------------------------------------------------------
+
+
+def _read_new_lines(
+    log_dir: str,
+    offsets: dict[str, int],
+    buffer: dict[int, list[dict]],
+) -> None:
+    """Read new JSONL lines into buffer, grouped by step.
+
+    Tracks file offsets to avoid re-reading old lines.
+    """
+    for fp in sorted(glob.glob(os.path.join(log_dir, "*.jsonl"))):
+        with open(fp) as f:
+            f.seek(offsets.get(fp, 0))
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                step = entry.get("step")
+                if step is not None:
+                    buffer[step].append(entry)
+                else:
+                    logger.warning(
+                        "Skipping experiment entry without step: %s",
+                        entry.get("key", "?"),
+                    )
+            offsets[fp] = f.tell()
+
+
+# ---------------------------------------------------------------------------
+# Flush: aggregate + write to backends + console
+# ---------------------------------------------------------------------------
+
+
+def _flush_step(
+    step: int,
+    buffer: dict[int, list[dict]],
+    logger_backend: BaseLogger,
+    console_log_metric_keys: list[str],
+) -> tuple[dict[str, float], int]:
+    """Aggregate entries for ``step``, write to backends, print to console.
+
+    Also purges entries for older steps to prevent memory leaks.
+    """
+    # Pop this step's entries and discard older steps
+    entries = buffer.pop(step, [])
+    for s in [s for s in buffer if s < step]:
+        del buffer[s]
+
+    aggregated = aggregate(entries)
+
+    if aggregated:
+        # Write all metrics to WandB/TensorBoard
+        logger_backend.log(aggregated, step)
+
+        # Log selected metrics to console
+        if console_log_metric_keys:
+            _log_to_console(step, aggregated, console_log_metric_keys)
+
+    return aggregated, len(entries)
+
+
+# ---------------------------------------------------------------------------
+# Console output
+# ---------------------------------------------------------------------------
+
+# Available colors from Color, excluding reset/black/white.
+_COLORS = [
+    k
+    for k in vars(Color)
+    if not k.startswith("_") and k not in ("reset", "black", "white")
+]
+
+
+def _fmt_value(value: Any) -> str:
+    """Format a value for console display.
+
+    Numbers: show at least 2 non-zero decimals, up to 5 decimal places.
+    Other types (bool, str): converted to string as-is.
+
+    Examples:
+
+        _fmt_value(3.67060)   → '3.67'
+        _fmt_value(0.00123)   → '0.0012'
+        _fmt_value(1234.5)    → '1234.5'
+        _fmt_value(True)      → 'True'
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return str(value)
+    if value == 0:
+        return "0"
+    if isinstance(value, int) or abs(value) >= 100:
+        return f"{value:.1f}"
+
+    # e.g. value=3.67 → frac=0.67
+    frac = abs(value) - int(abs(value))
+    if frac == 0:
+        return f"{value:.1f}"
+
+    # Walk decimal digits until we've seen 2 non-zero ones.
+    # e.g. 0.00123: digit 1→0, digit 2→0, digit 3→1(first!), digit 4→2(second!) → 4 decimals
+    n_decimals, n_nonzero = 0, 0
+    temp = frac
+    while n_decimals < 5 and n_nonzero < 2:
+        n_decimals += 1
+        temp *= 10  # e.g. 0.00123 → 0.0123 → 0.123 → 1.23
+        if int(temp) % 10 != 0 or n_nonzero > 0:
+            n_nonzero += 1
+    return f"{value:.{max(n_decimals, 2)}f}"
+
+
+def _log_to_console(
+    step: int,
+    aggregated: dict[str, float],
+    console_log_metric_keys: list[str],
+) -> None:
+    """Log one console line with the configured metric keys.
+
+    Colors cycle by position in the key list. Missing metrics show '--'.
+
+    Example:
+
+        aggregated = {"training/loss": 2.5, "training/lr": 0.001, "memory/peak": 14.2}
+        _log_to_console(step=5, aggregated=aggregated,
+                        console_log_metric_keys=["training/loss", "memory/peak"])
+        # Output: "step:  5  training/loss: 2.5  memory/peak: 14.2"
+    """
+    color = Color()
+    parts = [f"{color.red}step: {step:2}"]
+    for i, key in enumerate(console_log_metric_keys):
+        c = getattr(color, _COLORS[i % len(_COLORS)])
+        val = aggregated.get(key)
+        if val is None:
+            parts.append(f"{c}{key}: --")
+        else:
+            parts.append(f"{c}{key}: {_fmt_value(val)}")
+    parts.append(color.reset)
+    logger.info("  ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# Backend logger builder
+# ---------------------------------------------------------------------------
+
+
+def _build_metric_logger(
+    dump_folder: str,
+    *,
+    enable_wandb: bool = False,
+    enable_tensorboard: bool = False,
+    save_tb_folder: str = "tb",
+    config_dict: dict[str, Any] | None = None,
+    tag: str | None = None,
+) -> BaseLogger:
+    """Build WandB/TB logger."""
+    container = LoggerContainer()
+    if enable_tensorboard:
+        tb_dir = os.path.join(
+            dump_folder, save_tb_folder, datetime.now().strftime("%Y%m%d-%H%M")
+        )
+        container.add_logger(TensorBoardLogger(log_dir=tb_dir, tag=tag))
+    if enable_wandb:
+        container.add_logger(
+            WandBLogger(log_dir=dump_folder, config_dict=config_dict, tag=tag)
+        )
+    return container
+
+
+# ---------------------------------------------------------------------------
+# Logging subprocess
+# ---------------------------------------------------------------------------
+
+
+def logging_worker(
+    queue: multiprocessing.Queue,
+    dump_folder: str,
+    *,
+    enable_wandb: bool = False,
+    enable_tensorboard: bool = False,
+    save_tb_folder: str = "tb",
+    config_dict: dict[str, Any] | None = None,
+    tag: str | None = None,
+    console_log_metric_keys: list[str] | None = None,
+    queue_timeout_s: float = _QUEUE_TIMEOUT_S,
+) -> None:
+    """Background process that reads experiment JSONL, aggregates across
+    ranks, and writes to WandB/TB/console. Shuts down on ``None`` sentinel
+    or queue timeout.
+
+    Example:
+
+        queue = multiprocessing.Queue()
+        p = multiprocessing.Process(
+            target=logging_worker,
+            args=(queue, "./outputs"),
+            kwargs={"enable_wandb": True, "console_log_metric_keys": ["training/loss"]},
+        )
+        p.start()
+        queue.put(step)   # signal to read + aggregate + flush
+        queue.put(None)   # shutdown
+
+    Args:
+        queue: Receives ``step`` (int), or ``None`` to shut down.
+        dump_folder: Root output directory containing ``experiment_logs/``.
+        enable_wandb: Whether to log to WandB.
+        enable_tensorboard: Whether to log to TensorBoard.
+        save_tb_folder: Subfolder for TensorBoard files.
+        config_dict: Full config for ``wandb.init(config=...)``.
+        tag: Prefix for TB/WandB scalar keys.
+        console_log_metric_keys: Metric keys to print to console each step.
+            If empty or None, console output is disabled.
+        queue_timeout_s: Seconds to wait for a signal before assuming
+            training crashed. Default 600 (10 min).
+    """
+    init_observability(source="logging_worker", output_dir=dump_folder, rank=0)
+
+    log_dir = os.path.join(dump_folder, "experiment_logs")
+    buffer: dict[int, list[dict]] = defaultdict(list)
+
+    # Skip historical data from previous runs / checkpoint resume.
+    offsets: dict[str, int] = {}
+    for fp in glob.glob(os.path.join(log_dir, "*.jsonl")):
+        offsets[fp] = os.path.getsize(fp)
+
+    # Build backend loggers (WandB, TensorBoard)
+    logger_backend = _build_metric_logger(
+        dump_folder,
+        enable_wandb=enable_wandb,
+        enable_tensorboard=enable_tensorboard,
+        save_tb_folder=save_tb_folder,
+        config_dict=config_dict,
+        tag=tag,
+    )
+    logger.info("[logging process] started, reading from %s", log_dir)
+
+    # Main loop: wait for signals, read JSONL, aggregate, flush
+    while True:
+        try:
+            msg = queue.get(timeout=queue_timeout_s)
+        except Exception:
+            logger.warning(
+                "[logging process] no signal in %ds, assuming training crashed",
+                queue_timeout_s,
+            )
+            break
+
+        if msg is None:
+            break
+
+        step = msg
+        time.sleep(0.02)  # let filesystem propagate writes
+
+        # Read new JSONL lines from all rank files
+        t_read_start = time.perf_counter()
+        _read_new_lines(log_dir, offsets, buffer)
+        t_read_end = time.perf_counter()
+
+        # Aggregate and flush to backends + console
+        aggregated, num_entries = _flush_step(
+            step,
+            buffer,
+            logger_backend,
+            console_log_metric_keys or [],
+        )
+
+        logger.debug(
+            "[obs] step %d: read=%.1fms entries=%d",
+            step,
+            (t_read_end - t_read_start) * 1000,
+            num_entries,
+        )
+
+    logger.info("[logging process] shutting down")
+    logger_backend.close()

--- a/torchtitan/observability/metrics.py
+++ b/torchtitan/observability/metrics.py
@@ -1,0 +1,264 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Experiment metrics: record_metric, MetricValue types, JSONL formatter."""
+
+import json
+import logging
+import os
+import time
+from abc import ABC, abstractmethod
+from typing import Any
+
+from torchtitan.observability._constants import _METRIC_ENTRY, EXPERIMENT_LOGGER_NAME
+from torchtitan.observability.step_state import get_step
+
+_experiment_logger = logging.getLogger(EXPERIMENT_LOGGER_NAME)
+
+
+# ---------------------------------------------------------------------------
+# MetricValue types
+# ---------------------------------------------------------------------------
+
+
+class MetricValue(ABC):
+    """Base for metric types.
+
+    Each subclass defines how to serialize its state to JSONL (``get_state``)
+    and how the aggregator should combine entries from multiple ranks
+    (``get_reduced_value_from_states``).
+
+    Example: ``MeanMetric(sum=7.2, weight=10)`` serializes to JSONL as:
+
+        {"key": "reward", "reduce": "MeanMetric", "sum": 7.2, "weight": 10, ...}
+
+    and aggregates as ``(Σsum) / (Σweight)`` across ranks.
+    """
+
+    reduce_name: str
+
+    @abstractmethod
+    def get_state(self) -> dict[str, Any]:
+        """Return serializable state dict for JSONL. Must include 'reduce' key."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        """Reduce multiple states (from multiple ranks/calls) to a single float."""
+        ...
+
+
+class MeanMetric(MetricValue):
+    """Weighted mean: (Σsum) / (Σweight).
+
+    When aggregating entries from multiple ranks, sums and weights are
+    accumulated separately, then divided:
+
+        # Rank 0: MeanMetric(sum=6.0, weight=3.0)
+        # Rank 1: MeanMetric(sum=4.0, weight=2.0)
+        # Aggregated: (6.0 + 4.0) / (3.0 + 2.0) = 2.0
+    """
+
+    reduce_name = "MeanMetric"
+
+    def __init__(self, *, sum: float, weight: float = 1.0) -> None:  # noqa: A002
+        self._sum = sum
+        self._weight = weight
+
+    def get_state(self) -> dict[str, Any]:
+        return {"reduce": self.reduce_name, "sum": self._sum, "weight": self._weight}
+
+    @classmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        total_sum = sum(s["sum"] for s in states)
+        total_weight = sum(s["weight"] for s in states)
+        return total_sum / total_weight if total_weight > 0 else 0.0
+
+
+class MaxMetric(MetricValue):
+    """Maximum value across all entries."""
+
+    reduce_name = "MaxMetric"
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def get_state(self) -> dict[str, Any]:
+        return {"reduce": self.reduce_name, "value": self._value}
+
+    @classmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        return max(s["value"] for s in states)
+
+
+class MinMetric(MetricValue):
+    """Minimum value across all entries."""
+
+    reduce_name = "MinMetric"
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def get_state(self) -> dict[str, Any]:
+        return {"reduce": self.reduce_name, "value": self._value}
+
+    @classmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        return min(s["value"] for s in states)
+
+
+class SumMetric(MetricValue):
+    """Sum of values across all entries."""
+
+    reduce_name = "SumMetric"
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def get_state(self) -> dict[str, Any]:
+        return {"reduce": self.reduce_name, "value": self._value}
+
+    @classmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        return sum(s["value"] for s in states)
+
+
+class NoOpMetric(MetricValue):
+    """No reduction — returns the first entry's value, ignoring the rest.
+
+    Use for values that are already reduced (e.g., loss after ``dist_sum``)
+    or identical across ranks (e.g., learning rate).
+
+    Example:
+
+        record_metric("training/loss_mean", NoOpMetric(value=0.038))
+        # Rank 0: NoOpMetric(value=0.038)
+        # Rank 1: NoOpMetric(value=0.038)
+        # Aggregated: 0.038 (entries[0], rest ignored)
+    """
+
+    reduce_name = "NoOpMetric"
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def get_state(self) -> dict[str, Any]:
+        return {"reduce": self.reduce_name, "value": self._value}
+
+    @classmethod
+    def get_reduced_value_from_states(cls, states: list[dict[str, Any]]) -> float:
+        return states[0]["value"]
+
+
+# ---------------------------------------------------------------------------
+# REDUCE_REGISTRY — extensible type registry for aggregation
+# ---------------------------------------------------------------------------
+
+REDUCE_REGISTRY: dict[str, type[MetricValue]] = {
+    cls.reduce_name: cls
+    for cls in (MeanMetric, MaxMetric, MinMetric, SumMetric, NoOpMetric)
+}
+
+
+# ---------------------------------------------------------------------------
+# record_metric — fire-and-forget public API
+# ---------------------------------------------------------------------------
+
+
+def record_metric(key: str, value: MetricValue, _stacklevel: int = 2) -> None:
+    """Record a metric to experiment JSONL.
+
+    Step, rank, source, caller, and timestamp are added automatically by
+    the JSONL handler configured in ``init_observability``.
+
+    Example:
+
+        record_metric("trainer_gradient/norm_max", MaxMetric(value=12.3))
+
+    Args:
+        key: Metric name (e.g., "loss/trainer_loss_mean").
+        value: MetricValue instance (MeanMetric, MaxMetric, NoOpMetric, etc.).
+        _stacklevel: Controls which call site appears in the ``caller``
+            field (e.g., "trainer.py:541:train_step"). Default 2 (the
+            direct caller). Pass 3 from wrapper functions so the logged
+            caller shows the wrapper's caller instead.
+    """
+    if get_step() is None:
+        raise ValueError("No step in context. Call set_step() before record_metric().")
+
+    # Serialize all metric state (sum, weight, value, etc.) so the JSONL
+    # handler can write it and the aggregator can reconstruct the reduction.
+    state = value.get_state()
+    state["key"] = key
+    _experiment_logger.info(
+        "experiment_metric",
+        extra={_METRIC_ENTRY: state},  # marker to distinguish metrics from stdout
+        stacklevel=_stacklevel,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ExperimentJSONFormatter + Handler
+# ---------------------------------------------------------------------------
+
+
+class ExperimentJSONFormatter(logging.Formatter):
+    """Formats experiment metric records as flat JSONL.
+
+    Input (from record_metric via LogRecord.extra):
+
+        LogRecord with extra={"_metric_entry": {"key": "reward", "reduce": "MeanMetric",
+                                                 "sum": 7.2, "weight": 10}}
+
+    Output (one JSON line per record):
+
+        {"key": "reward", "reduce": "MeanMetric", "sum": 7.2, "weight": 10,
+         "step": 42, "rank": 0, "source": "reward",
+         "caller": "torchtitan/trainer.py:542:train_step", "timestamp": 1708200121.7}
+    """
+
+    def __init__(self, rank: int, source: str):
+        super().__init__()
+        self.rank = rank
+        self.source = source
+
+    def format(self, record: logging.LogRecord) -> str:
+        step = get_step()
+        if step is None:
+            raise ValueError(
+                "No step in context. Call set_step() before record_metric()."
+            )
+
+        raw_state = getattr(record, _METRIC_ENTRY, None)
+        if raw_state is not None:
+            state: dict[str, Any] = dict(raw_state)
+            state["step"] = step
+            state["rank"] = self.rank
+            state["source"] = self.source
+            state[
+                "caller"
+            ] = f"{os.path.relpath(record.pathname)}:{record.lineno}:{record.funcName}"
+            state["timestamp"] = time.time()
+            return json.dumps(state)
+
+        return ""
+
+
+class ExperimentMetricsFilter(logging.Filter):
+    """Only pass records with metric data."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return hasattr(record, _METRIC_ENTRY)
+
+
+class ExperimentLoggingHandler(logging.FileHandler):
+    """Writes experiment metrics to per-rank JSONL files."""
+
+    def __init__(self, filepath: str):
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        super().__init__(filename=filepath)
+        self.addFilter(ExperimentMetricsFilter())

--- a/torchtitan/observability/metrics_processor.py
+++ b/torchtitan/observability/metrics_processor.py
@@ -4,21 +4,66 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Toy MetricsProcessor for the observability experiment."""
+"""MetricsProcessor: step context, derived metrics, and logging subprocess."""
 
-from torchtitan.observability import record_event
+import multiprocessing
+from dataclasses import dataclass, field
+
+import torch
+
+from torchtitan.config import Configurable
+from torchtitan.distributed import ParallelDims
+from torchtitan.observability.aggregation import logging_worker
 from torchtitan.observability.step_state import set_step
+from torchtitan.observability.structured_logging import record_event
 
 
-class MetricsProcessor:
-    """Step context manager for the toy trainer.
+class MetricsProcessor(Configurable):
+    """Step context and logging subprocess.
 
-    Mirrors the method order of components/metrics.py MetricsProcessor
-    so the toy and production versions are easy to compare.
+    Records training metrics to experiment JSONL via record_metric.
+    A non-blocking background subprocess reads JSONL, aggregates across ranks,
+    and writes to WandB/TB/console.
     """
 
-    def __init__(self):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        enable_wandb: bool = True
+        enable_tensorboard: bool = False
+        console_log_metric_keys: list[str] = field(default_factory=list)
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        parallel_dims: ParallelDims,
+        dump_folder: str,
+    ):
         self._step: int = 0
+        self.parallel_dims = parallel_dims
+
+        # Rank 0 runs a background process that reads experiment JSONL
+        # from all ranks, reduces metrics, and logs to WandB/TB/console.
+        needs_subprocess = (
+            config.enable_wandb
+            or config.enable_tensorboard
+            or config.console_log_metric_keys
+        )
+        self._log_queue: multiprocessing.Queue | None = None
+        self._log_process: multiprocessing.Process | None = None
+        if torch.distributed.get_rank() == 0 and needs_subprocess:
+            self._log_queue = multiprocessing.Queue()
+            self._log_process = multiprocessing.Process(
+                target=logging_worker,
+                args=(self._log_queue, dump_folder),
+                kwargs={
+                    "enable_wandb": config.enable_wandb,
+                    "enable_tensorboard": config.enable_tensorboard,
+                    "console_log_metric_keys": config.console_log_metric_keys,
+                },
+                daemon=True,
+            )
+            self._log_process.start()
 
     def set_step(self, step: int) -> None:
         """Set the current training step."""
@@ -26,6 +71,21 @@ class MetricsProcessor:
         set_step(step)
         record_event({"train.step": step})
 
+    def log(self, step: int) -> None:
+        """Signal the logging subprocess to aggregate and write.
+
+        All ranks participate in the barrier so the subprocess can read
+        all JSONL files. Non-blocking after barrier (~0.1ms).
+        """
+        torch.distributed.barrier()
+        if self._log_queue is not None:
+            self._log_queue.put(step)
+
     def close(self) -> None:
-        """Shutdown. Extended with subprocess cleanup when logging is added."""
-        pass
+        """Shut down the logging subprocess."""
+        if self._log_queue is not None:
+            self._log_queue.put(None)
+        if self._log_process is not None:
+            self._log_process.join(timeout=10)
+            if self._log_process.is_alive():
+                self._log_process.terminate()

--- a/torchtitan/observability/step_state.py
+++ b/torchtitan/observability/step_state.py
@@ -14,7 +14,7 @@ def set_step(step: int) -> None:
     """Set the current training step. All subsequent JSONL records will
     include this step number. Clears step tags from the previous step.
 
-    Example::
+    Example:
 
         for step in range(1, num_steps + 1):
             set_step(step)
@@ -38,7 +38,7 @@ def get_step_tags() -> tuple[str, ...]:
 def add_step_tag(tag: str) -> None:
     """Annotate the current step. Tags appear in system JSONL for filtering.
 
-    Example::
+    Example:
 
         if gc_happened:
             add_step_tag("gc")

--- a/torchtitan/observability/structured_logging.py
+++ b/torchtitan/observability/structured_logging.py
@@ -18,7 +18,16 @@ from contextlib import ContextDecorator
 from timeit import default_timer as timer
 from typing import Any
 
-from torchtitan.observability._constants import SYSTEM_LOGGER_NAME
+from torchtitan.observability._constants import (
+    EXPERIMENT_LOGGER_NAME,
+    SYSTEM_LOGGER_NAME,
+)
+from torchtitan.observability.metrics import (
+    ExperimentJSONFormatter,
+    ExperimentLoggingHandler,
+    MeanMetric,
+    record_metric,
+)
 from torchtitan.observability.step_state import get_step, get_step_tags
 
 MAX_MESSAGE_SIZE: int = 1000
@@ -294,7 +303,7 @@ class StructuredLoggingHandler(logging.FileHandler):
 class InflightEventTrackingHandler(logging.Handler):
     """Tracks the last structured event for crash forensics.
 
-    On crash, ``handler.last_event`` tells you what phase the process was in::
+    On crash, ``handler.last_event`` tells you what phase the process was in:
 
         handler = InflightEventTrackingHandler()
         sys_logger.addHandler(handler)
@@ -367,6 +376,23 @@ def init_observability(source: str, output_dir: str, rank: int | None = None) ->
         if sys_logger.level == logging.NOTSET or sys_logger.level > logging.INFO:
             sys_logger.setLevel(logging.INFO)
 
+    # --- Experiment handler (record_metric → per-rank JSONL) ---
+    exp_logger = logging.getLogger(EXPERIMENT_LOGGER_NAME)
+    # Skip if already initialized (idempotent)
+    if not any(isinstance(h, ExperimentLoggingHandler) for h in exp_logger.handlers):
+        exp_path = os.path.join(
+            output_dir,
+            "experiment_logs",
+            f"{source}_rank_{rank}_experiment.jsonl",
+        )
+        handler = ExperimentLoggingHandler(filepath=exp_path)
+        handler.setFormatter(ExperimentJSONFormatter(rank=rank, source=source))
+        exp_logger.addHandler(handler)
+    # Don't propagate to root logger (avoids duplicate console output)
+    exp_logger.propagate = False
+    if exp_logger.level == logging.NOTSET or exp_logger.level > logging.INFO:
+        exp_logger.setLevel(logging.INFO)
+
 
 # ---------------------------------------------------------------------------
 # Public API: record_event, record_span
@@ -398,8 +424,9 @@ def record_event(metrics: dict[str, float | int]) -> None:
 class record_span(ContextDecorator):  # noqa: N801
     """Context manager/decorator for timing phases.
 
-    Logs START event on enter, END event (with duration) on exit to system
-    JSONL. Step is read from the global set by ``set_step()``.
+    Logs START/END events to system JSONL. When ``log_to_metrics=True``
+    (default), also records the duration as a MeanMetric (seconds) to
+    experiment JSONL via ``record_metric``.
 
     Args:
         description (str): Human-readable label for log messages and metric key.
@@ -409,6 +436,8 @@ class record_span(ContextDecorator):  # noqa: N801
         event_type Optional([EventType,str]): Optional categorization for analysis tools. Can be an
             ``EventType`` enum for standardized phases, or any string.
             When omitted, the description is used as the event type.
+        log_to_metrics: If True, record duration to experiment JSONL.
+            Default True.
 
     Usage::
         with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
@@ -420,8 +449,15 @@ class record_span(ContextDecorator):  # noqa: N801
             rollouts = generate(prompts)
     """
 
-    def __init__(self, description: str, event_type: EventType | str | None = None):
+    def __init__(
+        self,
+        description: str,
+        event_type: EventType | str | None = None,
+        *,
+        log_to_metrics: bool = True,
+    ):
         self.description = description
+        self.log_to_metrics = log_to_metrics
         self.start_time: float = 0.0
 
         # Derive _start/_end type names from event_type or description.
@@ -456,4 +492,7 @@ class record_span(ContextDecorator):  # noqa: N801
             ),
             stacklevel=2,
         )
+        if self.log_to_metrics and step is not None:
+            # stacklevel=3 adds to the metadata the actual call site, e.g. trainer.py:537
+            record_metric(self.description, MeanMetric(sum=duration_s), _stacklevel=3)
         return False  # Don't suppress exceptions


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2607
* #2606
* #2605
* #2604
* __->__ #2603
* #2602
* #2601
## How to review

Prioritize the files under /observability. Check how they are used in the toy example.
No need to nitpick the toy example. Real implementation in trainer are in PRs 7 and 8.

## Summary

The experiment metrics layer. Each rank calls `record_metric(key, MetricValue)` which serializes to per-rank experiment JSONL. Five metric types: `MeanMetric`, `MaxMetric`, `MinMetric`, `SumMetric`, `NoOpMetric`.

The logging subprocess (`logging_worker` in `aggregation.py`) runs as a `multiprocessing.Process`. The training process signals it via `queue.put((step, is_validation))` after each log step.

## Example

```python
record_metric("trainer_throughput/tps_mean", MeanMetric(sum=tps))
```

```json
// dump_dir/experiment_logs/trainer_rank_0_experiment.jsonl
{"key": "trainer_throughput/tps_mean", "reduce": "MeanMetric",
 "sum": 1234.5, "weight": 1.0,
 "step": 42, "rank": 0, "source": "trainer",
 "caller": "torchtitan/trainer.py:542:train_step", "timestamp": 1708200121.724}

// dump_dir/experiment_logs/trainer_rank_1_experiment.jsonl
{"key": "trainer_throughput/tps_mean", "reduce": "MeanMetric",
 "sum": 1180.2, "weight": 1.0,
 "step": 42, "rank": 1, "source": "trainer",
 "caller": "torchtitan/trainer.py:542:train_step", "timestamp": 1708200121.725}

// After aggregation: (1234.5 + 1180.2) / (1.0 + 1.0) = 1207.35
```

## Aggregation (Logging Subprocess)

The training process never reads JSONL or writes to backends directly.
A background subprocess on rank 0 handles all aggregation and output:

```
                  Training Process (all ranks)
                  ┌─────────────────────────────────┐
                  │  record_metric("loss", ...)     │──→ experiment.jsonl (per rank)
                  │                                 │
                  │                                 │
                  │  # on log steps:                │
                  │  barrier()                      │
                  │  log_queue.put(step) ───────────│──┐  (~0.1ms, non-blocking)
                  └─────────────────────────────────┘  │
                                                       │
                  Logging Subprocess (rank 0 only)     │
                  ┌─────────────────────────────────┐  │
                  │  step = queue.get() ◄───────────│──┘
                  │  read all experiment.jsonl files│
                  │  aggregate by key (reduce)      │
                  │  write to WandB / TensorBoard   │
                  │  print to console               │
                  └─────────────────────────────────┘
```

The subprocess is spawned via `logging_worker` from `aggregation.py`. Here's
the RL pattern where the controller owns the subprocess directly:

```python
import multiprocessing
from torchtitan.observability import logging_worker

# Spawn the logging subprocess
log_queue = multiprocessing.Queue()
log_process = multiprocessing.Process(
    target=logging_worker,
    args=(log_queue, OUTPUT_DIR),
    kwargs={
        "enable_wandb": True,
        "enable_tensorboard": False,
        "console_log_metric_keys": [
            "training/loss_mean",
            "training/grad_norm_max",
            "rl/reward_mean",
            "trainer_throughput/tps_mean",
        ],
    },
    daemon=True,
)
log_process.start()

# Each actor calls record_metric locally — writes go to JSONL
# ...

# After each step, signal the subprocess to read + aggregate + flush
log_queue.put((step, False))  # (step, is_validation)

# Shutdown
log_queue.put(None)
log_process.join()
```

`console_log_metric_keys` controls which metrics appear in the console output.
The subprocess prints one line per step with only the keys listed.

## Perf

**Timing (local filesystem, 100 metrics/rank):**

Aggregation benchmarks are measured on local filesystem without multithreading. NFS will be slower for the read, but shouldn't be an issue since it is non-blocking + multithreading.

| Scale | Read | Aggregate | Total |
|-------|------|-----------|-------|
| 10 files (1K entries) | 9ms | 0.5ms | 10ms |
| 100 files (10K entries) | 88ms | 6ms | 94ms |
| 500 files (50K entries) | 333ms | 35ms | 368ms |

None of this blocks training. Training pays only the signal cost (~0.1ms).

## Test plan

Run toy_spmd: `python -m torch.distributed.run --nproc_per_node=4 -m torchtitan.experiments.observability.toy_spmd`
Run toy_rl: `python -m torchtitan.experiments.observability.toy_rl`

- [x] 23 new unit tests for aggregation + metrics (67 cumulative)
- [x] Integration: toy_spmd produces experiment JSONL with aggregated loss/grad_norm/lr
- [x] Integration: toy_rl produces experiment JSONL from 4 actor types (controller, rollouter, reward, trainer)
- [x] Integration: logging subprocess writes to WandB and prints console output

**Sample**

```json
{"reduce": "MeanMetric", "sum": 5.5534299463033676e-05, "weight": 1.0, "key": "trainer_time/data_loading_s", "step": 1, "rank": 0, "source": "trainer", "caller": "torchtitan/experiments/observability/toy_spmd.py:240:batch_generator", "timestamp": 1773611398.1511042}
{"reduce": "MeanMetric", "sum": 3.14233530825004, "weight": 1.0, "key": "trainer_time/forward_backward_s", "step": 1, "rank": 0, "source": "trainer", "caller": "torchtitan/experiments/observability/toy_spmd.py:262:train_step", "timestamp": 1773611401.293699}
{"reduce": "MeanMetric", "sum": 0.15071861585602164, "weight": 1.0, "key": "trainer_time/optimizer_s", "step": 1, "rank": 0, "source": "trainer", "caller": "torchtitan/experiments/observability/toy_spmd.py:274:train_step", "timestamp": 1773611401.444696}
```

**Console output (toy_spmd 4 GPUs, 20 steps)**

```
[titan] 2026-03-15 14:50:01,477 - torchtitan.observability.aggregation - INFO - [31mstep:  1  [31mtraining/loss_mean: 3.66  [32mtraining/grad_norm_max: 0.49  [33mtraining/lr: 0.0010  [39m
[titan] 2026-03-15 14:50:01,602 - torchtitan.observability.aggregation - INFO - [31mstep:  5  [31mtraining/loss_mean: 3.053  [32mtraining/grad_norm_max: 0.41  [33mtraining/lr: 0.0010  [39m
[titan] 2026-03-15 14:50:02,196 - torchtitan.observability.aggregation - INFO - [31mstep: 10  [31mtraining/loss_mean: 2.54  [32mtraining/grad_norm_max: 0.32  [33mtraining/lr: 0.0010  [39m
[titan] 2026-03-15 14:50:02,360 - torchtitan.observability.aggregation - INFO - [31mstep: 15  [31mtraining/loss_mean: 2.23  [32mtraining/grad_norm_max: 0.26  [33mtraining/lr: 0.0010  [39m
[titan] 2026-03-15 14:50:02,523 - torchtitan.observability.aggregation - INFO - [31mstep: 20  [31mtraining/loss_mean: 2.026  [32mtraining/grad_norm_max: 0.22  [33mtraining/lr: 0.0010  [39m
[titan] 2026-03-15 14:50:02,523 - torchtitan.observability.aggregation - INFO - [logging process] shutting down
```

**Console output - toy_rl**

```
[titan] 2026-03-15 14:52:58,085 - torchtitan.observability.aggregation - INFO - [31mstep:  1  [31mtraining/loss_mean: 3.65  [32mtraining/grad_norm_max: 0.50  [33mtraining/lr: 0.0010  [34mrl/reward_mean: 1.0  [35mrl/completion_len_mean: 16.69  [39m
[titan] 2026-03-15 14:52:58,221 - torchtitan.observability.aggregation - INFO - [31mstep:  3  [31mtraining/loss_mean: 3.33  [32mtraining/grad_norm_max: 0.45  [33mtraining/lr: 0.0010  [34mrl/reward_mean: 1.0  [35mrl/completion_len_mean: 16.69  [39m
[titan] 2026-03-15 14:52:58,354 - torchtitan.observability.aggregation - INFO - [31mstep:  5  [31mtraining/loss_mean: 3.052  [32mtraining/grad_norm_max: 0.39  [33mtraining/lr: 0.0010  [34mrl/reward_mean: 1.0  [35mrl/completion_len_mean: 16.69  [39m
[titan] 2026-03-15 14:52:58,417 - torchtitan.observability.aggregation - INFO - [logging process] shutting down
```

### Output folder (adds experiment_logs/)

```
outputs/toy_spmd/
├── analysis/
│   └── system_metrics_gantt.json
├── experiment_logs/                    ← NEW in PR3
│   ├── trainer_rank_0_experiment.jsonl
│   ├── trainer_rank_1_experiment.jsonl
│   ├── trainer_rank_2_experiment.jsonl
│   └── trainer_rank_3_experiment.jsonl
├── system_logs/
│   └── trainer_rank_{0-3}_system.jsonl
└── wandb/
```

### WandB

toy_spmd: https://wandb.ai/cabernet-team/torchtitan/runs/pi8sosf6
toy_rl: https://wandb.ai/cabernet-team/torchtitan/runs/zcl58f75

