### PR TITLE
[Observability 4/7] MetricsProcessor — throughput, memory, validation, log scheduling

### DIFF
--- a/tests/unit_tests/observability/test_aggregation.py
+++ b/tests/unit_tests/observability/test_aggregation.py
@@ -73,7 +73,7 @@ class TestLoggingWorkerBasic:
             kwargs={"queue_timeout_s": 5},
         )
         p.start()
-        queue.put(1)
+        queue.put((1, False))
         queue.put(None)  # shutdown
         p.join(timeout=10)
         assert p.exitcode == 0
@@ -103,7 +103,7 @@ class TestLoggingWorkerBasic:
                 '{"key": "loss", "reduce": "NoOpMetric", "value": 0.5, "step": 51}\n'
             )
 
-        queue.put(51)
+        queue.put((51, False))
         queue.put(None)
         p.join(timeout=10)
         assert p.exitcode == 0
@@ -127,7 +127,7 @@ class TestLoggingWorkerBasic:
             kwargs={"queue_timeout_s": 5},
         )
         p.start()
-        queue.put(1)
+        queue.put((1, False))
         queue.put(None)
         p.join(timeout=10)
         assert p.exitcode == 0

--- a/tests/unit_tests/observability/test_logging_boundary.py
+++ b/tests/unit_tests/observability/test_logging_boundary.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for logging_boundary.py (EveryNSteps schedule)."""
+
+import pytest
+
+from torchtitan.observability.logging_boundary import EveryNSteps
+
+
+class TestEveryNSteps:
+    def test_every_n_basic(self):
+        schedule = EveryNSteps(every_n=5)
+        results = [schedule(s) for s in range(16)]
+        # Step 0: False (excluded), step 5: True, step 10: True, step 15: True
+        assert results == [
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+        ]
+
+    def test_step_0_excluded(self):
+        schedule = EveryNSteps(every_n=1)
+        assert schedule(0) is False
+        assert schedule(1) is True
+
+    def test_additional_steps(self):
+        schedule = EveryNSteps(every_n=5, additional_steps={0, 3})
+        assert schedule(0) is True  # additional
+        assert schedule(3) is True  # additional
+        assert schedule(5) is True  # every_n
+        assert schedule(1) is False
+
+    def test_zero_every_n_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            EveryNSteps(every_n=0)
+
+    def test_negative_every_n_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            EveryNSteps(every_n=-1)
+
+    def test_every_1(self):
+        schedule = EveryNSteps(every_n=1)
+        assert schedule(0) is False
+        assert schedule(1) is True
+        assert schedule(2) is True
+        assert schedule(100) is True

--- a/torchtitan/experiments/observability/tests/test_record_metric.py
+++ b/torchtitan/experiments/observability/tests/test_record_metric.py
@@ -84,3 +84,37 @@ class TestExperimentJSONL:
         assert reduce_by_key.get("training/loss_mean") == "NoOpMetric"
         assert reduce_by_key.get("training/grad_norm_max") == "MaxMetric"
         assert reduce_by_key.get("training/lr") == "NoOpMetric"
+        assert reduce_by_key.get("trainer_throughput/tps_mean") == "MeanMetric"
+        assert reduce_by_key.get("validation/loss_mean") == "NoOpMetric"
+
+    def test_validation_metrics_have_validator_prefix(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        keys = set()
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    keys.add(record.get("key"))
+        assert "validation/loss_mean" in keys, f"Missing validation loss. Found: {keys}"
+
+    def test_log_frequency_not_every_step(self, experiment_logs_dir):
+        """With log_freq=5, loss should not appear on every step."""
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        loss_steps = set()
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    if record.get("key") == "training/loss_mean":
+                        loss_steps.add(record["step"])
+        # With log_freq=5 and 20 steps, loss appears on steps {1, 5, 10, 15, 20}
+        assert loss_steps, "No loss entries found"
+        assert (
+            2 not in loss_steps
+        ), f"Step 2 should not have loss (log_freq=5). Steps: {loss_steps}"

--- a/torchtitan/experiments/observability/toy_rl.py
+++ b/torchtitan/experiments/observability/toy_rl.py
@@ -187,8 +187,9 @@ class TrainerActor(Actor):
         )
         parallel_dims.build_mesh()
         self.dp_rank = parallel_dims.get_mesh("fsdp").get_local_rank()
-        # Controller owns the logging subprocess — trainer has no backends/console.
-        mp_config = MetricsProcessor.Config(enable_wandb=False)
+        # Controller handles flushing — trainer has no backends/console.
+        # log_freq=1 is set because it determines freq to call metrics that need .item() or collectives
+        mp_config = MetricsProcessor.Config(log_freq=1, enable_wandb=False)
         self.trainer = ToyTrainer(
             self.device, parallel_dims, OUTPUT_DIR, mp_config=mp_config
         )
@@ -202,6 +203,7 @@ class TrainerActor(Actor):
     @endpoint
     async def train_step(self, tokens, labels, loss_mask):
         """Train one step on generated completions."""
+        self.trainer.metrics_processor.reset_training_counters()
         # Slice this DP rank's shard from the full batch.
         start = self.dp_rank * BATCH_SIZE
         end = start + BATCH_SIZE
@@ -274,6 +276,8 @@ async def main():
                 "training/loss_mean",
                 "training/grad_norm_max",
                 "training/lr",
+                "trainer_throughput/tps_mean",
+                "trainer_memory/reserved_gib_max",
                 "rl/reward_mean",
                 "rl/completion_len_mean",
             ],
@@ -324,7 +328,8 @@ async def main():
             with record_span("rl_time/training_s", EventType.FWD_BWD):
                 await trainer.train_step.call(tokens, labels, loss_mask)
 
-            log_queue.put(step)
+            is_validation = False
+            log_queue.put((step, is_validation))
 
     await run_training()
 

--- a/torchtitan/experiments/observability/toy_spmd.py
+++ b/torchtitan/experiments/observability/toy_spmd.py
@@ -265,6 +265,8 @@ class ToyTrainer:
 
     def train_step(self, tokens, labels, loss_mask):
         """One training step."""
+        self.metrics_processor.ntokens_since_reset += labels.numel()
+
         with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
             with loss_parallel():
                 logits = self.model(tokens)
@@ -281,21 +283,30 @@ class ToyTrainer:
             grad_norm = clip_grad_norm_(self.model.parameters(), max_norm=1.0)
             self.optimizer.step()
 
-        # Report globally-reduced loss. Each DP rank has
-        # local_loss_sum / global_valid_tokens; SUM gives the global loss.
-        loss_scalar = loss.detach().full_tensor().clone()
-        dist.all_reduce(
-            loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
-        )
-        record_metric("training/loss_mean", NoOpMetric(value=loss_scalar.item()))
-        record_metric("training/grad_norm_max", MaxMetric(value=grad_norm.item()))
         record_metric("training/lr", NoOpMetric(value=LR))
-        record_event(
-            {"train.loss": loss_scalar.item(), "train.grad_norm": grad_norm.item()}
-        )
+
+        # Loss/grad_norm only on log steps (.item() triggers GPU→CPU sync)
+        if self.metrics_processor.should_log(self.step):
+            with record_span("trainer_time/collect_dist_metrics_s"):
+                # Each DP rank has local_loss_sum / global_valid_tokens.
+                # SUM across DP ranks gives global_loss_sum / global_valid_tokens.
+                loss_scalar = loss.detach().full_tensor().clone()
+                dist.all_reduce(
+                    loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
+                )
+                loss_val = loss_scalar.item()
+                grad_norm_val = grad_norm.item()
+                record_metric("training/loss_mean", NoOpMetric(value=loss_val))
+                record_metric("training/grad_norm_max", MaxMetric(value=grad_norm_val))
+                record_event({"train.loss": loss_val, "train.grad_norm": grad_norm_val})
+
+        self.metrics_processor.record_memory()
+        self.metrics_processor.record_throughput()
 
     def validate(self, tokens, labels, loss_mask):
         """Run one forward pass for validation (no backward)."""
+        self.metrics_processor.val_ntokens_since_reset += labels.numel()
+
         with torch.no_grad(), loss_parallel():
             logits = self.model(tokens)
             loss_sum, valid_tokens = self.compute_loss(logits, labels, loss_mask)
@@ -307,6 +318,8 @@ class ToyTrainer:
             val_loss_scalar, op=dist.ReduceOp.SUM, group=self.dp_mesh.get_group()
         )
         record_metric("validation/loss_mean", NoOpMetric(value=val_loss_scalar.item()))
+        self.metrics_processor.record_memory(is_validation=True)
+        self.metrics_processor.record_throughput(is_validation=True)
 
     def train(self, num_steps):
         """Full training loop. Mirrors Trainer.train structure."""
@@ -316,22 +329,27 @@ class ToyTrainer:
 
         for step in range(1, num_steps + 1):
             self.step = step
-            self.metrics_processor.set_step(step)
+            is_validation = step % EVAL_FREQ == 0
+            self.metrics_processor.set_step(step, force_log=is_validation)
 
             # Simulate GC on every 5th step (mirrors gc_handler.run)
             if step % 5 == 0:
                 add_step_tag("gc")
 
+            self.metrics_processor.reset_training_counters()
+
             with record_span("trainer_time/step_s", EventType.STEP):
                 tokens, labels, loss_mask = next(data_iterator)
                 self.train_step(tokens, labels, loss_mask)
 
-            if step % EVAL_FREQ == 0:
+            if is_validation:
                 add_step_tag("eval")
+                self.metrics_processor.reset_val_counters()
                 with record_span("trainer_time/validation_s", EventType.EVAL):
                     self.validate(tokens, labels, loss_mask)
 
-            self.metrics_processor.log(step)
+            if self.metrics_processor.should_log(step):
+                self.metrics_processor.log(step, is_validation=is_validation)
 
     def close(self):
         """Cleanup."""
@@ -370,11 +388,18 @@ def main():
         print(f"Toy SPMD: {world_size} GPUs, 2DPx2TP, {NUM_STEPS} steps")
 
     mp_config = MetricsProcessor.Config(
+        log_freq=5,
         enable_wandb=ENABLE_WANDB,
         console_log_metric_keys=[
             "training/loss_mean",
             "training/grad_norm_max",
-            "training/lr",
+            "trainer_memory/reserved_gib_max",
+            "trainer_throughput/tps_mean",
+        ],
+        console_log_validation_keys=[
+            "validation/loss_mean",
+            "validator_memory/reserved_gib_max",
+            "validator_throughput/tps_mean",
         ],
     )
     trainer = ToyTrainer(device, parallel_dims, OUTPUT_DIR, mp_config=mp_config)

--- a/torchtitan/observability/__init__.py
+++ b/torchtitan/observability/__init__.py
@@ -7,6 +7,7 @@
 """TorchTitan Observability Library."""
 
 from torchtitan.observability.aggregation import aggregate, logging_worker
+from torchtitan.observability.logging_boundary import EveryNSteps
 from torchtitan.observability.metrics import (
     MaxMetric,
     MeanMetric,
@@ -39,4 +40,5 @@ __all__ = [
     "NoOpMetric",
     "aggregate",
     "logging_worker",
+    "EveryNSteps",
 ]

--- a/torchtitan/observability/aggregation.py
+++ b/torchtitan/observability/aggregation.py
@@ -11,6 +11,7 @@ import json
 import logging
 import multiprocessing
 import os
+import sys
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -24,7 +25,7 @@ from torchtitan.components.metrics import (
 )
 from torchtitan.observability.metrics import REDUCE_REGISTRY
 from torchtitan.observability.structured_logging import init_observability
-from torchtitan.tools.utils import Color
+from torchtitan.tools.utils import Color, NoColor
 
 logger = logging.getLogger(__name__)
 
@@ -109,8 +110,10 @@ def _read_new_lines(
 def _flush_step(
     step: int,
     buffer: dict[int, list[dict]],
+    is_validation: bool,
     logger_backend: BaseLogger,
     console_log_metric_keys: list[str],
+    console_log_validation_keys: list[str],
 ) -> tuple[dict[str, float], int]:
     """Aggregate entries for ``step``, write to backends, print to console.
 
@@ -127,9 +130,15 @@ def _flush_step(
         # Write all metrics to WandB/TensorBoard
         logger_backend.log(aggregated, step)
 
-        # Log selected metrics to console
+        # Log training console line
         if console_log_metric_keys:
             _log_to_console(step, aggregated, console_log_metric_keys)
+
+        # Log validation console line (only on validation steps)
+        if is_validation and console_log_validation_keys:
+            _log_to_console(
+                step, aggregated, console_log_validation_keys, prefix="validate "
+            )
 
     return aggregated, len(entries)
 
@@ -186,22 +195,30 @@ def _fmt_value(value: Any) -> str:
 def _log_to_console(
     step: int,
     aggregated: dict[str, float],
-    console_log_metric_keys: list[str],
+    keys: list[str],
+    prefix: str = "",
 ) -> None:
     """Log one console line with the configured metric keys.
 
     Colors cycle by position in the key list. Missing metrics show '--'.
+    Color is auto-detected (disabled when stdout is piped to file/CI).
+
+    Args:
+        step: Training step number.
+        aggregated: All aggregated metrics for this step.
+        keys: Which metric keys to print (in order).
+        prefix: Optional label before "step:" (e.g., "validate ").
 
     Example:
 
         aggregated = {"training/loss": 2.5, "training/lr": 0.001, "memory/peak": 14.2}
         _log_to_console(step=5, aggregated=aggregated,
-                        console_log_metric_keys=["training/loss", "memory/peak"])
+                        keys=["training/loss", "memory/peak"])
         # Output: "step:  5  training/loss: 2.5  memory/peak: 14.2"
     """
-    color = Color()
-    parts = [f"{color.red}step: {step:2}"]
-    for i, key in enumerate(console_log_metric_keys):
+    color = Color() if sys.stdout.isatty() else NoColor()
+    parts = [f"{color.red}{prefix}step: {step:2}"]
+    for i, key in enumerate(keys):
         c = getattr(color, _COLORS[i % len(_COLORS)])
         val = aggregated.get(key)
         if val is None:
@@ -255,6 +272,7 @@ def logging_worker(
     config_dict: dict[str, Any] | None = None,
     tag: str | None = None,
     console_log_metric_keys: list[str] | None = None,
+    console_log_validation_keys: list[str] | None = None,
     queue_timeout_s: float = _QUEUE_TIMEOUT_S,
 ) -> None:
     """Background process that reads experiment JSONL, aggregates across
@@ -270,19 +288,21 @@ def logging_worker(
             kwargs={"enable_wandb": True, "console_log_metric_keys": ["training/loss"]},
         )
         p.start()
-        queue.put(step)   # signal to read + aggregate + flush
-        queue.put(None)   # shutdown
+        queue.put((step, is_validation))  # signal to read + aggregate + flush
+        queue.put(None)                   # shutdown
 
     Args:
-        queue: Receives ``step`` (int), or ``None`` to shut down.
+        queue: Receives ``(step, is_validation)`` tuple, or ``None`` to
+            shut down.
         dump_folder: Root output directory containing ``experiment_logs/``.
         enable_wandb: Whether to log to WandB.
         enable_tensorboard: Whether to log to TensorBoard.
         save_tb_folder: Subfolder for TensorBoard files.
         config_dict: Full config for ``wandb.init(config=...)``.
         tag: Prefix for TB/WandB scalar keys.
-        console_log_metric_keys: Metric keys to print to console each step.
-            If empty or None, console output is disabled.
+        console_log_metric_keys: Training metric keys for console each step.
+        console_log_validation_keys: Validation metric keys for console
+            (only printed on validation steps).
         queue_timeout_s: Seconds to wait for a signal before assuming
             training crashed. Default 600 (10 min).
     """
@@ -321,7 +341,8 @@ def logging_worker(
         if msg is None:
             break
 
-        step = msg
+        # Training process sends (step, is_validation) after barrier
+        step, is_validation = msg
         time.sleep(0.02)  # let filesystem propagate writes
 
         # Read new JSONL lines from all rank files
@@ -333,8 +354,10 @@ def logging_worker(
         aggregated, num_entries = _flush_step(
             step,
             buffer,
+            is_validation,
             logger_backend,
             console_log_metric_keys or [],
+            console_log_validation_keys or [],
         )
 
         logger.debug(

--- a/torchtitan/observability/logging_boundary.py
+++ b/torchtitan/observability/logging_boundary.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class EveryNSteps:
+    """Returns True every N steps, with optional additional steps.
+
+    Step 0 is excluded by default — use additional_steps={0} to include it.
+
+    Args:
+        every_n: Returns True if step > 0 and step % every_n == 0.
+        additional_steps: Optional set of steps where action is also taken.
+
+    Raises:
+        ValueError: If every_n <= 0.
+    """
+
+    def __init__(self, every_n: int, additional_steps: set[int] | None = None) -> None:
+        if every_n <= 0:
+            raise ValueError("every_n must be positive")
+        self.every_n = every_n
+        self.additional_steps = additional_steps
+
+    def __call__(self, step: int) -> bool:
+        return (step > 0 and step % self.every_n == 0) or (
+            self.additional_steps is not None and step in self.additional_steps
+        )

--- a/torchtitan/observability/metrics_processor.py
+++ b/torchtitan/observability/metrics_processor.py
@@ -7,30 +7,48 @@
 """MetricsProcessor: step context, derived metrics, and logging subprocess."""
 
 import multiprocessing
+import time
 from dataclasses import dataclass, field
 
 import torch
 
+from torchtitan.components.metrics import build_device_memory_monitor
 from torchtitan.config import Configurable
 from torchtitan.distributed import ParallelDims
 from torchtitan.observability.aggregation import logging_worker
+from torchtitan.observability.logging_boundary import EveryNSteps
+from torchtitan.observability.metrics import (
+    MaxMetric,
+    MeanMetric,
+    record_metric,
+    SumMetric,
+)
 from torchtitan.observability.step_state import set_step
 from torchtitan.observability.structured_logging import record_event
+from torchtitan.tools import utils
 
 
 class MetricsProcessor(Configurable):
-    """Step context and logging subprocess.
+    """Step context, derived metrics, and logging subprocess.
 
     Records training metrics to experiment JSONL via record_metric.
     A non-blocking background subprocess reads JSONL, aggregates across ranks,
     and writes to WandB/TB/console.
     """
 
+    # Prefix for throughput and memory metric keys (e.g., "trainer_memory/...")
+    _TRAIN_PREFIX = "trainer"
+    _VAL_PREFIX = "validator"
+
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
+        log_freq: int = 10
+        """How often to log to backends (e.g. wandb). Also gates expensive
+        metrics computation (.item(), collectives)."""
         enable_wandb: bool = True
         enable_tensorboard: bool = False
         console_log_metric_keys: list[str] = field(default_factory=list)
+        console_log_validation_keys: list[str] = field(default_factory=list)
 
     def __init__(
         self,
@@ -39,8 +57,25 @@ class MetricsProcessor(Configurable):
         parallel_dims: ParallelDims,
         dump_folder: str,
     ):
+        self.config = config
         self._step: int = 0
         self.parallel_dims = parallel_dims
+        self._force_log = False
+
+        # Schedule: log on step 1 + every log_freq steps
+        self._log_schedule = EveryNSteps(every_n=config.log_freq, additional_steps={1})
+
+        # Device memory monitor
+        self.device_memory_monitor = build_device_memory_monitor()
+
+        # TFLOPS/MFU: set by trainer after construction (-1 = skip)
+        self.num_flops_per_token: int = -1
+        self._gpu_peak_flops = utils.get_peak_flops(
+            self.device_memory_monitor.device_name
+        )
+
+        self.reset_training_counters()
+        self.reset_val_counters()
 
         # Rank 0 runs a background process that reads experiment JSONL
         # from all ranks, reduces metrics, and logs to WandB/TB/console.
@@ -60,18 +95,99 @@ class MetricsProcessor(Configurable):
                     "enable_wandb": config.enable_wandb,
                     "enable_tensorboard": config.enable_tensorboard,
                     "console_log_metric_keys": config.console_log_metric_keys,
+                    "console_log_validation_keys": config.console_log_validation_keys,
                 },
                 daemon=True,
             )
             self._log_process.start()
 
-    def set_step(self, step: int) -> None:
-        """Set the current training step."""
+    # ----
+    # Step management
+    # ----
+
+    def set_step(self, step: int, force_log: bool = False) -> None:
+        """Set current step. Call before train_step().
+
+        force_log: For example, can be used to ensure loss is computed
+        on validation steps.
+        """
         self._step = step
+        self._force_log = force_log
         set_step(step)
         record_event({"train.step": step})
 
-    def log(self, step: int) -> None:
+    # ----
+    # Schedule queries
+    # ----
+
+    def should_log(self, step: int) -> bool:
+        """Returns True on log steps or when force_log was set."""
+        return self._log_schedule(step) or self._force_log
+
+    # ----
+    # Counter resets
+    # ----
+
+    def reset_training_counters(self) -> None:
+        """Reset throughput/memory counters for a new training measurement."""
+        self._time_at_reset = time.perf_counter()
+        self.ntokens_since_reset = 0
+        self.device_memory_monitor.reset_peak_stats()
+
+    def reset_val_counters(self) -> None:
+        """Reset throughput/memory counters for a new validation measurement."""
+        self._val_time_at_reset = time.perf_counter()
+        self.val_ntokens_since_reset = 0
+        self.device_memory_monitor.reset_peak_stats()
+
+    # ----
+    # Derived metrics (called every step, outside should_log gate)
+    # ----
+
+    def record_throughput(self, is_validation: bool = False) -> None:
+        """Compute and record throughput from tokens since last reset."""
+        if is_validation:
+            time_delta = time.perf_counter() - self._val_time_at_reset
+            ntokens = self.val_ntokens_since_reset
+            prefix = self._VAL_PREFIX
+        else:
+            time_delta = time.perf_counter() - self._time_at_reset
+            ntokens = self.ntokens_since_reset
+            prefix = self._TRAIN_PREFIX
+
+        ndp = self.parallel_dims.non_data_parallel_size
+        tps = ntokens / (time_delta * ndp) if time_delta > 0 else 0
+        record_metric(f"{prefix}_throughput/tps_mean", MeanMetric(sum=tps))
+
+        if self.num_flops_per_token > 0:
+            tflops = self.num_flops_per_token * tps / 1e12
+            record_metric(f"{prefix}_throughput/tflops_mean", MeanMetric(sum=tflops))
+            if self._gpu_peak_flops > 0:
+                mfu = 100 * self.num_flops_per_token * tps / self._gpu_peak_flops
+                record_metric(f"{prefix}_throughput/mfu_pct_mean", MeanMetric(sum=mfu))
+
+    def record_memory(self, is_validation: bool = False) -> None:
+        """Record GPU memory peak stats since last reset."""
+        prefix = self._VAL_PREFIX if is_validation else self._TRAIN_PREFIX
+        mem = self.device_memory_monitor.get_peak_stats()
+        record_metric(
+            f"{prefix}_memory/reserved_gib_max",
+            MaxMetric(value=mem.max_reserved_gib),
+        )
+        record_metric(
+            f"{prefix}_memory/active_gib_max",
+            MaxMetric(value=mem.max_active_gib),
+        )
+        record_metric(
+            f"{prefix}_memory/alloc_retries_sum",
+            SumMetric(value=mem.num_alloc_retries),
+        )
+
+    # ----
+    # Flush
+    # ----
+
+    def log(self, step: int, is_validation: bool = False) -> None:
         """Signal the logging subprocess to aggregate and write.
 
         All ranks participate in the barrier so the subprocess can read
@@ -79,7 +195,7 @@ class MetricsProcessor(Configurable):
         """
         torch.distributed.barrier()
         if self._log_queue is not None:
-            self._log_queue.put(step)
+            self._log_queue.put((step, is_validation))
 
     def close(self) -> None:
         """Shut down the logging subprocess."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2607
* #2606
* #2605
* __->__ #2604
* #2603
* #2602
* #2601

## How to review

Prioritize the files under /observability. Check how they are used in the toy example.
No need to nitpick the toy example. Real implementation in trainer are in PRs 6 and 7.

## Summary

(Almost) Full `MetricsProcessor` for the toy trainer. This is the reference implementation that we will mirror for the real Trainer in PRs 6 and 7.

### APIs

- `should_log(step)` — returns True every N steps, on step 1, or when `force_log` is set (for validation).
- `reset_training_counters()` / `reset_val_counters()` — reset timing and token counts.
- `record_throughput()` — computes tokens/sec/device, TFLOPS, and MFU from tokens since last reset.
- `record_memory()` — records GPU peak stats (reserved/active GiB, pct, alloc retries, OOMs).
- `log(step, is_validation)` — signals the logging subprocess to aggregate and flush.

### Validation support

`MetricsProcessor.Config` adds `console_log_validation_keys`.  When `is_validation=True` is passed to `log()`, the subprocess prints a separate validation console line.

## Test plan

Run toy_spmd: `python -m torch.distributed.run --nproc_per_node=4 -m torchtitan.experiments.observability.toy_spmd`
Run toy_rl: `python -m torchtitan.experiments.observability.toy_rl`

- [x] 13 new unit tests for EveryNSteps + logging boundary (80 cumulative)
- [x] Integration: toy_spmd with log_freq=5 only logs on steps {1, 5, 10, 15, 20}
- [x] Integration: validation console line appears on eval steps
- [x] Integration: throughput and memory metrics appear in WandB

### Console output (toy_spmd)

With `log_freq=5`, metrics only appear on steps {1, 5, 10, 15, 20}.
Validation runs on steps 10 and 20 (every 10 steps):

```
[titan] 2026-03-15 14:50:51,749 - torchtitan.observability.aggregation - INFO - step:  1  training/loss_mean: 3.66  training/grad_norm_max: 0.49  trainer_memory/reserved_gib_max: 0.068  trainer_throughput/tps_mean: 11.86  
[titan] 2026-03-15 14:50:51,876 - torchtitan.observability.aggregation - INFO - step:  5  training/loss_mean: 3.053  training/grad_norm_max: 0.41  trainer_memory/reserved_gib_max: 0.068  trainer_throughput/tps_mean: 2166.4  
[titan] 2026-03-15 14:50:52,470 - torchtitan.observability.aggregation - INFO - step: 10  training/loss_mean: 2.54  training/grad_norm_max: 0.32  trainer_memory/reserved_gib_max: 0.068  trainer_throughput/tps_mean: 2094.1  
[titan] 2026-03-15 14:50:52,470 - torchtitan.observability.aggregation - INFO - validate step: 10  validation/loss_mean: 2.46  validator_memory/reserved_gib_max: 0.068  validator_throughput/tps_mean: 144.6  
[titan] 2026-03-15 14:50:52,622 - torchtitan.observability.aggregation - INFO - step: 15  training/loss_mean: 2.23  training/grad_norm_max: 0.26  trainer_memory/reserved_gib_max: 0.068  trainer_throughput/tps_mean: 2193.8  
[titan] 2026-03-15 14:50:52,782 - torchtitan.observability.aggregation - INFO - step: 20  training/loss_mean: 2.026  training/grad_norm_max: 0.22  trainer_memory/reserved_gib_max: 0.068  trainer_throughput/tps_mean: 2213.7  
[titan] 2026-03-15 14:50:52,782 - torchtitan.observability.aggregation - INFO - validate step: 20  validation/loss_mean: 1.99  validator_memory/reserved_gib_max: 0.068  validator_throughput/tps_mean: 7884.4  
[titan] 2026-03-15 14:50:52,782 - torchtitan.observability.aggregation - INFO - [logging process] shutting down
```

### WandB

toy_spmd: https://wandb.ai/cabernet-team/torchtitan/runs/owcdodsg


