### PR TITLE
[Observability 5/7] RolloutLogger for RL rollout JSONL with filtering

### DIFF
--- a/tests/unit_tests/observability/test_rollout_logger.py
+++ b/tests/unit_tests/observability/test_rollout_logger.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for rollout_logger.py."""
+
+import json
+import os
+
+from torchtitan.observability.rollout_logger import RolloutLogger
+
+
+class TestRolloutLogger:
+    def test_writes_jsonl(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        logger.log(
+            [{"prompt": "hello", "reward": 0.5}, {"prompt": "world", "reward": 0.3}],
+            metadata={"step": 1},
+        )
+        logger.close()
+
+        with open(tmp_path / "rollouts.jsonl") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 2
+        assert lines[0]["prompt"] == "hello"
+        assert lines[0]["__metadata__"]["step"] == 1
+
+    def test_metadata_nested_under_key(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        logger.log([{"x": 1}], metadata={"step": 42, "epoch": 3})
+        logger.close()
+
+        with open(tmp_path / "rollouts.jsonl") as f:
+            record = json.loads(f.readline())
+        assert record["__metadata__"]["step"] == 42
+        assert record["__metadata__"]["epoch"] == 3
+        assert record["x"] == 1
+        # metadata doesn't pollute top-level keys
+        assert "step" not in record
+        assert "epoch" not in record
+
+    def test_no_metadata(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        logger.log([{"x": 1}])
+        logger.close()
+
+        with open(tmp_path / "rollouts.jsonl") as f:
+            record = json.loads(f.readline())
+        assert record == {"x": 1}
+        assert "__metadata__" not in record
+
+    def test_empty_records_noop(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        logger.log([], metadata={"step": 1})
+        logger.close()
+
+        filepath = tmp_path / "rollouts.jsonl"
+        assert filepath.stat().st_size == 0
+
+    def test_filter_fn_applied(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        records = [{"id": i, "reward": i * 0.1} for i in range(10)]
+        logger.log(records, metadata={"step": 1}, filter_fn=lambda r: r[:3])
+        logger.close()
+
+        with open(tmp_path / "rollouts.jsonl") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 3
+
+    def test_custom_filename(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path), filename="custom.jsonl")
+        logger.log([{"x": 1}], metadata={"step": 1})
+        logger.close()
+
+        assert os.path.exists(tmp_path / "custom.jsonl")
+
+    def test_append_across_calls(self, tmp_path):
+        logger = RolloutLogger(output_dir=str(tmp_path))
+        logger.log([{"step_data": "a"}], metadata={"step": 1})
+        logger.log([{"step_data": "b"}], metadata={"step": 2})
+        logger.close()
+
+        with open(tmp_path / "rollouts.jsonl") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 2

--- a/torchtitan/experiments/observability/tests/test_toy_rl.py
+++ b/torchtitan/experiments/observability/tests/test_toy_rl.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Integration tests for toy_rl output.
+
+Run toy_rl first to generate output files.
+"""
+
+import json
+import os
+from glob import glob
+
+import pytest
+
+OUTPUT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "outputs", "toy_rl"
+)
+
+
+@pytest.fixture
+def experiment_logs_dir():
+    path = os.path.join(OUTPUT_DIR, "experiment_logs")
+    if not os.path.isdir(path):
+        pytest.fail(
+            f"No experiment_logs at {path}. Run toy_rl first to generate outputs."
+        )
+    return path
+
+
+@pytest.fixture
+def rollout_dir():
+    path = os.path.join(OUTPUT_DIR, "rollouts")
+    if not os.path.isdir(path):
+        pytest.fail(f"No rollouts at {path}. Run toy_rl first to generate outputs.")
+    return path
+
+
+class TestRLExperimentJSONL:
+    def test_experiment_jsonl_has_training_metrics(self, experiment_logs_dir):
+        files = glob(os.path.join(experiment_logs_dir, "*.jsonl"))
+        keys = set()
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    keys.add(record.get("key"))
+
+        assert "training/loss_mean" in keys, f"Missing loss. Found: {keys}"
+        assert "training/grad_norm_max" in keys, f"Missing grad_norm. Found: {keys}"
+        assert "training/lr" in keys, f"Missing lr. Found: {keys}"
+        assert "trainer_throughput/tps_mean" in keys, f"Missing tps. Found: {keys}"
+
+
+class TestRolloutLogger:
+    def test_rollout_file_exists(self, rollout_dir):
+        files = glob(os.path.join(rollout_dir, "*.jsonl"))
+        assert len(files) >= 1, f"No rollout JSONL files in {rollout_dir}"
+
+    def test_rollout_has_expected_fields(self, rollout_dir):
+        files = glob(os.path.join(rollout_dir, "*.jsonl"))
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    assert "reward" in record, f"Missing reward in rollout: {record}"
+                    assert "prompt" in record, f"Missing prompt in rollout: {record}"
+                    assert (
+                        "completion" in record
+                    ), f"Missing completion in rollout: {record}"
+                    assert (
+                        "__metadata__" in record
+                    ), f"Missing __metadata__ in rollout: {record}"
+                    assert (
+                        "step" in record["__metadata__"]
+                    ), f"Missing step in __metadata__: {record}"
+                    return  # One record is enough
+
+    def test_rollout_filter_applied(self, rollout_dir):
+        """With filter_top_bottom(k=2), each step should have at most 4 records."""
+        files = glob(os.path.join(rollout_dir, "*.jsonl"))
+        records_per_step: dict[int, int] = {}
+        for fp in files:
+            with open(fp) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    step = record["__metadata__"]["step"]
+                    records_per_step[step] = records_per_step.get(step, 0) + 1
+
+        for step, count in records_per_step.items():
+            assert (
+                count <= 4
+            ), f"Step {step} has {count} records (expected <=4 with k=2)"

--- a/torchtitan/experiments/observability/toy_rl.py
+++ b/torchtitan/experiments/observability/toy_rl.py
@@ -48,6 +48,7 @@ from torchtitan.observability import (
     MeanMetric,
     record_metric,
     record_span,
+    RolloutLogger,
     set_step,
 )
 from torchtitan.observability.analysis import generate_gantt_trace
@@ -108,6 +109,20 @@ def rollouts_to_train_batch(
         torch.stack([r.labels for r in rollouts]),
         torch.stack([r.loss_mask for r in rollouts]),
     )
+
+
+def filter_top_bottom(
+    records: list[dict], key: str = "reward", k: int = 1
+) -> list[dict]:
+    """Keep top-k and bottom-k records by a key.
+
+    If fewer than 2*k records, returns all records.
+    """
+    sorted_recs = sorted(records, key=lambda r: r.get(key, 0))
+    k = min(k, len(sorted_recs) // 2) if sorted_recs else 0
+    if k == 0:
+        return sorted_recs
+    return sorted_recs[:k] + sorted_recs[-k:]
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +319,12 @@ async def main():
     actors = [rollouter, trainer, reward_actor]
     logger.info("Actors spawned.")
 
+    rollout_dir = os.path.join(OUTPUT_DIR, "rollouts")
+    rollout_logger = RolloutLogger(
+        output_dir=rollout_dir,
+        filter_fn=lambda records: filter_top_bottom(records, key="reward", k=2),
+    )
+
     # Dummy prompts for the rollouter.
     prompts = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN))
 
@@ -322,6 +343,13 @@ async def main():
                 result = await reward_actor.score.call(rollouts)
                 rollouts = next(iter(result.values()))
 
+            # Logging is synchronous here but could be overlapped with
+            # the train_step call below since it's just file I/O.
+            rollout_logger.log(
+                [r.to_logging_dict() for r in rollouts],
+                metadata={"step": step},
+            )
+
             with record_span("rl_time/rollouts_to_train_batch_s"):
                 tokens, labels, loss_mask = rollouts_to_train_batch(rollouts)
 
@@ -334,6 +362,7 @@ async def main():
     await run_training()
 
     # ---- Cleanup ----
+    rollout_logger.close()
     log_queue.put(None)
     log_process.join(timeout=10)
     await trainer.teardown.call()

--- a/torchtitan/observability/__init__.py
+++ b/torchtitan/observability/__init__.py
@@ -16,6 +16,7 @@ from torchtitan.observability.metrics import (
     record_metric,
     SumMetric,
 )
+from torchtitan.observability.rollout_logger import RolloutLogger
 from torchtitan.observability.step_state import add_step_tag, clear_step_tags, set_step
 from torchtitan.observability.structured_logging import (
     EventType,
@@ -41,4 +42,5 @@ __all__ = [
     "aggregate",
     "logging_worker",
     "EveryNSteps",
+    "RolloutLogger",
 ]

--- a/torchtitan/observability/rollout_logger.py
+++ b/torchtitan/observability/rollout_logger.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+from collections.abc import Callable
+
+
+class RolloutLogger:
+    """Logs rollout data as JSONL for offline analysis.
+
+    Takes any list[dict] and writes one JSON line per record. An optional
+    ``filter_fn`` selects which records to keep (e.g. top/bottom by reward).
+
+    Args:
+        output_dir: Directory for rollout files.
+        filename: Name of the JSONL file (default: rollouts.jsonl).
+        filter_fn: Optional default filter applied to every log() call.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        filename: str = "rollouts.jsonl",
+        filter_fn: Callable[[list[dict]], list[dict]] | None = None,
+    ):
+        os.makedirs(output_dir, exist_ok=True)
+        self._filepath = os.path.join(output_dir, filename)
+        self._file = open(self._filepath, "a")  # kept open for lifetime
+        self._filter_fn = filter_fn
+
+    def log(
+        self,
+        records: list[dict],
+        metadata: dict | None = None,
+        filter_fn: Callable[[list[dict]], list[dict]] | None = None,
+    ) -> None:
+        """Write rollout dicts as JSON lines.
+
+        Args:
+            records: List of rollout dicts. No schema enforced.
+            metadata: Stored under ``__metadata__`` in each record to avoid
+                key collisions (e.g. ``{"step": 1}``).
+            filter_fn: Override the default filter for this call.
+        """
+        if not records:
+            return
+        fn = filter_fn if filter_fn is not None else self._filter_fn
+        if fn is not None:
+            records = fn(records)
+        extra = {"__metadata__": metadata} if metadata else {}
+        self._file.write("\n".join(json.dumps({**r, **extra}) for r in records) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        self._file.close()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2607
* #2606
* __->__ #2605
* #2604
* #2603
* #2602
* #2601

## How to review

Prioritize the files under /observability. Check how they are used in the toy example. No need to nitpick the toy example.

## Summary

`RolloutLogger` writes RL rollouts to JSONL with optional filtering. Takes a `list[dict]` with no enforced schema — users pass whatever fields their rollouts have (prompt, response, reward, etc). Metadata is nested under `__metadata__` to avoid key collisions.

Optional `filter_fn` for selecting which rollouts to log, e.g. `filter_top_bottom(records, key, k)` keeps the top-k and bottom-k by a given key — useful for logging only the best and worst rollouts per batch.

Integrated into toy_rl: the controller logs filtered rollouts after each RL step.

## Example

```python
from torchtitan.observability import RolloutLogger

rollout_logger = RolloutLogger(
    output_dir="outputs/rollouts",
    filter_fn=lambda records: filter_top_bottom(records, key="reward", k=2),
)

rollouts = [
     {"prompt": "what is 2+2?", "response": "4", "reward": 0.95},
     {"prompt": "write a poem", "response": "roses...", "reward": 0.3}
     ]

# Log rollout dicts with optional metadata
rollout_logger.log(
    rollouts,
    metadata={"step": 42, "batch_size": 64},
)
rollout_logger.close()
```

Output JSONL (metadata stored under `__metadata__` to avoid key collisions):
```json
{"prompt": "what is 2+2?", "response": "4", "reward": 0.95, "__metadata__": {"step": 42, "batch_size": 64}}
{"prompt": "write a poem", "response": "roses...", "reward": 0.3, "__metadata__": {"step": 42, "batch_size": 64}}
```

## Test plan

Run toy_rl: `python -m torchtitan.experiments.observability.toy_rl`

- [x] New unit tests for RolloutLogger: write, filter, metadata nesting, close
- [x] Integration: toy_rl produces rollouts.jsonl with filtered entries
- [x] Integration: rollouts have __metadata__ nesting with step info

### Output folder (toy_rl on PR6 — note rollouts/ directory)

```
outputs/toy_rl/
├── analysis/
│   └── system_metrics_gantt.json
├── experiment_logs/
│   ├── controller_rank_0_experiment.jsonl
│   ├── reward_rank_0_experiment.jsonl
│   ├── rollouter_rank_0_experiment.jsonl
│   └── trainer_rank_{0-3}_experiment.jsonl
├── rollouts/                               ← NEW
│   └── rollouts.jsonl
├── system_logs/
│   ├── controller_rank_0_system.jsonl
│   ├── reward_rank_0_system.jsonl
│   ├── rollouter_rank_0_system.jsonl
│   └── trainer_rank_{0-3}_system.jsonl
└── wandb/
```