### PR TITLE
[Observability 7/7] Timing spans and step tags across all trainers

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -637,7 +637,7 @@ class CheckpointManager(Configurable):
                 self.states[MODEL].load_state_dict(state_dict)
 
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> None:
+    def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Save the checkpoint for the current step.
 
         This function will save the checkpoint for the current step. If ``last_step`` is
@@ -650,14 +650,14 @@ class CheckpointManager(Configurable):
             last_step (bool, optional): Whether this is the last step of training.
 
         Returns:
-            None
+            True if a checkpoint was saved, False otherwise.
         """
 
         if self.enable_ft_dataloader_checkpoints:
             self._ft_save(curr_step)
 
         if not self._should_save(curr_step, last_step):
-            return
+            return False
 
         begin = time.monotonic()
         if not self.enable_ft_dataloader_checkpoints or (
@@ -673,7 +673,7 @@ class CheckpointManager(Configurable):
             # freed until _async_wait()
             if last_step:
                 self._save_last_step(curr_step)
-                return
+                return True
 
             states = self._flattened_model_states_sd()
             if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
@@ -715,6 +715,7 @@ class CheckpointManager(Configurable):
                 # pyrefly: ignore [missing-attribute]
                 self.ft_manager.participating_rank(),
             )
+        return True
 
     @torch.no_grad()
     def load(self, step: int = -1) -> bool:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -21,6 +21,8 @@ from torchtitan.config import ConfigManager
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.observability import (
+    add_step_tag,
+    EventType,
     init_observability,
     NoOpMetric,
     record_event,
@@ -152,16 +154,16 @@ class Trainer(ForgeEngine):
         self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ) -> Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]:
         """Returns an iterator that processes batches from the data iterator."""
-        device_type = utils.device_type
         data_iterator = iter(data_iterable)
 
         while True:
-            try:
-                batch = next(data_iterator)
-            except StopIteration as ex:
-                # If data runs out during gradient accumulation, that
-                # entire step will not be executed.
-                raise DataloaderExhaustedError() from ex
+            with record_span("trainer_time/data_loading_s", EventType.FETCHING_BATCH):
+                try:
+                    batch = next(data_iterator)
+                except StopIteration as ex:
+                    # If data runs out during gradient accumulation, that
+                    # entire step will not be executed.
+                    raise DataloaderExhaustedError() from ex
             input_dict, labels = batch
             ntokens_batch = labels.numel()
             self.ntokens_seen += ntokens_batch  # cumulative total for the run
@@ -298,31 +300,33 @@ class Trainer(ForgeEngine):
             global_valid_tokens = local_valid_tokens.float()
 
         # Process each microbatch: move to GPU, forward/backward, then free
-        accumulated_losses = []
-        for input_dict, labels in microbatches:
-            # Move tensors to GPU
-            for k, v in input_dict.items():
-                if isinstance(v, torch.Tensor):
-                    input_dict[k] = v.to(self.device)
-            labels = labels.to(self.device)
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            accumulated_losses = []
+            for input_dict, labels in microbatches:
+                # Move tensors to GPU
+                for k, v in input_dict.items():
+                    if isinstance(v, torch.Tensor):
+                        input_dict[k] = v.to(self.device)
+                labels = labels.to(self.device)
 
-            loss = self.forward_backward_step(
-                input_dict=input_dict,
-                labels=labels,
-                global_valid_tokens=global_valid_tokens,
+                loss = self.forward_backward_step(
+                    input_dict=input_dict,
+                    labels=labels,
+                    global_valid_tokens=global_valid_tokens,
+                )
+                accumulated_losses.append(loss.detach())
+
+        with record_span("trainer_time/optimizer_s", EventType.OPTIM):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=parallel_dims.get_optional_mesh("pp"),
+                ep_enabled=parallel_dims.ep_enabled,
             )
-            accumulated_losses.append(loss.detach())
-
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
-            ep_enabled=parallel_dims.ep_enabled,
-        )
-        self.checkpointer.maybe_wait_for_staging()
-        self.optimizers.step()
-        self.lr_schedulers.step()
+            self.checkpointer.maybe_wait_for_staging()
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         # Reduce the data collected over gradient accumulation steps.
         loss = torch.sum(torch.stack(accumulated_losses))
@@ -415,20 +419,29 @@ class Trainer(ForgeEngine):
                 self.metrics_processor.set_step(self.step, force_log=is_validation)
                 self.metrics_processor.reset_training_counters()
 
-                self.gc_handler.run(self.step)
-                try:
-                    self.train_step(data_iterator)
-                except DataloaderExhaustedError:
-                    logger.warning("Ran out of data; last step was canceled.")
-                    break
+                with record_span("trainer_time/gc_collect_s", EventType.GC_COLLECT):
+                    if self.gc_handler.run(self.step):
+                        add_step_tag("gc")
 
-                self.checkpointer.save(
-                    self.step, last_step=(self.step == config.training.steps)
-                )
+                with record_span("trainer_time/step_s", EventType.STEP):
+                    try:
+                        self.train_step(data_iterator)
+                    except DataloaderExhaustedError:
+                        logger.warning("Ran out of data; last step was canceled.")
+                        break
+
+                with record_span("trainer_time/checkpoint_s", EventType.CHECKPOINT):
+                    saved = self.checkpointer.save(
+                        self.step, last_step=(self.step == config.training.steps)
+                    )
+                    if saved:
+                        add_step_tag("checkpoint")
 
                 if is_validation:
+                    add_step_tag("eval")
                     self.metrics_processor.reset_val_counters()
-                    self.validator.validate(self.model_parts, self.step)
+                    with record_span("trainer_time/validation_s", EventType.EVAL):
+                        self.validator.validate(self.model_parts, self.step)
 
                 if self.metrics_processor.should_log(self.step):
                     self.metrics_processor.log(self.step, is_validation=is_validation)

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -24,6 +24,8 @@ from torchtitan.experiments.ft.manager import FTManager, maybe_semi_sync_trainin
 from torchtitan.experiments.ft.optimizer import FTOptimizersContainer
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import (
+    add_step_tag,
+    EventType,
     NoOpMetric,
     record_event,
     record_metric,
@@ -429,32 +431,34 @@ class FaultTolerantTrainer(Trainer):
             global_valid_tokens = local_valid_tokens.float()
 
         # Process each microbatch: move to GPU, forward/backward, then free
-        accumulated_losses = []
-        for input_dict, labels in microbatches:
-            # Move tensors to GPU
-            for k, v in input_dict.items():
-                if isinstance(v, torch.Tensor):
-                    input_dict[k] = v.to(self.device)
-            labels = labels.to(self.device)
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            accumulated_losses = []
+            for input_dict, labels in microbatches:
+                # Move tensors to GPU
+                for k, v in input_dict.items():
+                    if isinstance(v, torch.Tensor):
+                        input_dict[k] = v.to(self.device)
+                labels = labels.to(self.device)
 
-            loss = self.forward_backward_step(
-                input_dict=input_dict,
-                labels=labels,
-                # pyrefly: ignore [bad-argument-type]
-                global_valid_tokens=global_valid_tokens,
+                loss = self.forward_backward_step(
+                    input_dict=input_dict,
+                    labels=labels,
+                    # pyrefly: ignore [bad-argument-type]
+                    global_valid_tokens=global_valid_tokens,
+                )
+                accumulated_losses.append(loss.detach())
+
+        with record_span("trainer_time/optimizer_s", EventType.OPTIM):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=parallel_dims.get_optional_mesh("pp"),
+                ep_enabled=parallel_dims.ep_enabled,
             )
-            accumulated_losses.append(loss.detach())
-
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
-            ep_enabled=parallel_dims.ep_enabled,
-        )
-        self.checkpointer.maybe_wait_for_staging()
-        self.optimizers.step()
-        self.lr_schedulers.step()
+            self.checkpointer.maybe_wait_for_staging()
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         # Reduce the data collected over gradient accumulation steps.
         loss = torch.sum(torch.stack(accumulated_losses))
@@ -575,20 +579,29 @@ class FaultTolerantTrainer(Trainer):
                 self.metrics_processor.set_step(self.step, force_log=is_validation)
                 self.metrics_processor.reset_training_counters()
 
-                self.gc_handler.run(self.step)
-                try:
-                    self.train_step(data_iterator)
-                except DataloaderExhaustedError:
-                    logger.warning("Ran out of data; last step was canceled.")
-                    break
+                with record_span("trainer_time/gc_collect_s", EventType.GC_COLLECT):
+                    if self.gc_handler.run(self.step):
+                        add_step_tag("gc")
 
-                self.checkpointer.save(
-                    self.step, last_step=(self.step == config.training.steps)
-                )
+                with record_span("trainer_time/step_s", EventType.STEP):
+                    try:
+                        self.train_step(data_iterator)
+                    except DataloaderExhaustedError:
+                        logger.warning("Ran out of data; last step was canceled.")
+                        break
+
+                with record_span("trainer_time/checkpoint_s", EventType.CHECKPOINT):
+                    saved = self.checkpointer.save(
+                        self.step, last_step=(self.step == config.training.steps)
+                    )
+                    if saved:
+                        add_step_tag("checkpoint")
 
                 if is_validation:
+                    add_step_tag("eval")
                     self.metrics_processor.reset_val_counters()
-                    self.validator.validate(self.model_parts, self.step)
+                    with record_span("trainer_time/validation_s", EventType.EVAL):
+                        self.validator.validate(self.model_parts, self.step)
 
                 if self.metrics_processor.should_log(self.step):
                     self.metrics_processor.log(self.step, is_validation=is_validation)

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -22,6 +22,7 @@ from torchtitan.models.flux.utils import (
     preprocess_data,
 )
 from torchtitan.observability import (
+    EventType,
     NoOpMetric,
     record_event,
     record_metric,
@@ -241,18 +242,20 @@ class FluxTrainer(Trainer):
         # pyrefly: ignore [no-matching-overload]
         input_dict, labels = next(data_iterator)
 
-        loss = self.forward_backward_step(input_dict=input_dict, labels=labels)
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            loss = self.forward_backward_step(input_dict=input_dict, labels=labels)
 
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
-            ep_enabled=parallel_dims.ep_enabled,
-        )
-        self.checkpointer.maybe_wait_for_staging()
-        self.optimizers.step()
-        self.lr_schedulers.step()
+        with record_span("trainer_time/optimizer_s", EventType.OPTIM):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=parallel_dims.get_optional_mesh("pp"),
+                ep_enabled=parallel_dims.ep_enabled,
+            )
+            self.checkpointer.maybe_wait_for_staging()
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         # log metrics
         if self.metrics_processor.should_log(self.step):

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -56,15 +56,19 @@ class GarbageCollection:
             if torch.distributed.get_rank() == 0:
                 warn_tensor_cycles()
 
-    def run(self, step_count: int):
+    def run(self, step_count: int) -> bool:
+        """Run garbage collection if due. Returns True if GC ran."""
         if self.debug:
             self.collect(
                 "Force GC to perform collection to obtain debug information",
                 generation=2,
             )
             gc.collect()
+            return True
         elif step_count > 1 and step_count % self.gc_freq == 0:
             self.collect("Performing periodic GC collection")
+            return True
+        return False
 
     @staticmethod
     def collect(reason: str, generation: int = 1):

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -9,7 +9,7 @@ import os
 import torch
 
 from torchtitan.config import ConfigManager
-from torchtitan.observability import init_observability
+from torchtitan.observability import EventType, init_observability, record_span
 from torchtitan.tools.logging import init_logger, logger
 from torchtitan.trainer import Trainer
 
@@ -67,7 +67,10 @@ def main() -> None:
     else:
         trainer.close()
         if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+            with record_span(
+                "trainer_time/teardown_s", EventType.TORCH_DISTRIBUTED_TEARDOWN
+            ):
+                torch.distributed.destroy_process_group()
         logger.info("Process group destroyed")
 
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -42,6 +42,7 @@ from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import (
+    add_step_tag,
     EventType,
     NoOpMetric,
     record_event,
@@ -238,44 +239,49 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
 
         # build tokenizer
-        self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
+        with record_span("init/tokenizer_s", EventType.TOKENIZER_INIT):
+            self.tokenizer = config.tokenizer.build(
+                tokenizer_path=config.hf_assets_path
+            )
 
         # build dataloader
-        self.dataloader = config.dataloader.build(
-            dp_world_size=batch_degree,
-            dp_rank=batch_rank,
-            tokenizer=self.tokenizer,
-            seq_len=config.training.seq_len,
-            local_batch_size=config.training.local_batch_size,
-        )
+        with record_span("init/dataloader_s", EventType.DATA_ITERATOR_INIT):
+            self.dataloader = config.dataloader.build(
+                dp_world_size=batch_degree,
+                dp_rank=batch_rank,
+                tokenizer=self.tokenizer,
+                seq_len=config.training.seq_len,
+                local_batch_size=config.training.local_batch_size,
+            )
 
         # build model (using meta init)
-        model_config = model_spec.model
-        # set the model args from training job configs
-        model_config.update_from_config(
-            trainer_config=config,
-        )
-        self.model_config = model_config
+        with record_span("init/model_build_s", EventType.BUILD_MODEL):
+            model_config = model_spec.model
+            # set the model args from training job configs
+            model_config.update_from_config(
+                trainer_config=config,
+            )
+            self.model_config = model_config
 
-        logger.info(
-            f"Building {model_spec.name} {model_spec.flavor} "
-            f"with {json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"
-        )
-        with (
-            torch.device("meta"),
-            utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]),
-        ):
-            model = model_config.build()
+            logger.info(
+                f"Building {model_spec.name} {model_spec.flavor} "
+                f"with {json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"
+            )
+            with (
+                torch.device("meta"),
+                utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]),
+            ):
+                model = model_config.build()
 
-        # Build the collection of model converters. No-op if converters empty
-        model_compile_enabled = (
-            config.compile.enable and "model" in config.compile.components
-        )
-        model_converters = config.model_converters.build(
-            parallel_dims=parallel_dims,
-            model_compile_enabled=model_compile_enabled,
-        )
-        model_converters.convert(model)
+            # Build the collection of model converters. No-op if converters empty
+            model_compile_enabled = (
+                config.compile.enable and "model" in config.compile.components
+            )
+            model_converters = config.model_converters.build(
+                parallel_dims=parallel_dims,
+                model_compile_enabled=model_compile_enabled,
+            )
+            model_converters.convert(model)
 
         # Check if any converter uses quantization (FP8, MX, etc.)
         has_quantization = any(
@@ -340,62 +346,63 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         assert self.gradient_accumulation_steps > 0
 
         # apply parallelisms and initialization
-        if parallel_dims.pp_enabled:
-            if not model_spec.pipelining_fn:
-                raise RuntimeError(
-                    f"Pipeline Parallel is enabled but {model_spec.name} "
-                    f"does not support pipelining"
+        with record_span("init/parallelism_s", EventType.MODEL_PARALLELISM_INIT):
+            if parallel_dims.pp_enabled:
+                if not model_spec.pipelining_fn:
+                    raise RuntimeError(
+                        f"Pipeline Parallel is enabled but {model_spec.name} "
+                        f"does not support pipelining"
+                    )
+
+                # apply both Pipeline Parallel and SPMD-style scaling techniques
+                (
+                    self.pp_schedule,
+                    self.model_parts,
+                    self.pp_has_first_stage,
+                    self.pp_has_last_stage,
+                ) = model_spec.pipelining_fn(
+                    model,
+                    parallel_dims=parallel_dims,
+                    training=config.training,
+                    model_converters=config.model_converters,
+                    parallelism=config.parallelism,
+                    compile_config=config.compile,
+                    ac_config=config.activation_checkpoint,
+                    dump_folder=config.dump_folder,
+                    device=self.device,
+                    model_config=model_config,
+                    parallelize_fn=model_spec.parallelize_fn,
+                    loss_fn=self.loss_fn,
+                )
+                # when PP is enabled, `model` obj is no longer used after this point,
+                # model_parts is used instead
+                del model
+
+                for m in self.model_parts:
+                    m.to_empty(device=init_device)
+                    with torch.no_grad():
+                        cast(Decoder, m).init_weights(buffer_device=buffer_device)
+                    m.train()
+
+            else:
+                # apply Tensor/Context/Expert Parallel, activation checkpointing, torch.compile, Data Parallel
+                model = model_spec.parallelize_fn(
+                    model,
+                    parallel_dims=parallel_dims,
+                    training=config.training,
+                    model_converters=config.model_converters,
+                    parallelism=config.parallelism,
+                    compile_config=config.compile,
+                    ac_config=config.activation_checkpoint,
+                    dump_folder=config.dump_folder,
                 )
 
-            # apply both Pipeline Parallel and SPMD-style scaling techniques
-            (
-                self.pp_schedule,
-                self.model_parts,
-                self.pp_has_first_stage,
-                self.pp_has_last_stage,
-            ) = model_spec.pipelining_fn(
-                model,
-                parallel_dims=parallel_dims,
-                training=config.training,
-                model_converters=config.model_converters,
-                parallelism=config.parallelism,
-                compile_config=config.compile,
-                ac_config=config.activation_checkpoint,
-                dump_folder=config.dump_folder,
-                device=self.device,
-                model_config=model_config,
-                parallelize_fn=model_spec.parallelize_fn,
-                loss_fn=self.loss_fn,
-            )
-            # when PP is enabled, `model` obj is no longer used after this point,
-            # model_parts is used instead
-            del model
-
-            for m in self.model_parts:
-                m.to_empty(device=init_device)
+                model.to_empty(device=init_device)
                 with torch.no_grad():
-                    cast(Decoder, m).init_weights(buffer_device=buffer_device)
-                m.train()
+                    cast(BaseModel, model).init_weights(buffer_device=buffer_device)
+                model.train()
 
-        else:
-            # apply Tensor/Context/Expert Parallel, activation checkpointing, torch.compile, Data Parallel
-            model = model_spec.parallelize_fn(
-                model,
-                parallel_dims=parallel_dims,
-                training=config.training,
-                model_converters=config.model_converters,
-                parallelism=config.parallelism,
-                compile_config=config.compile,
-                ac_config=config.activation_checkpoint,
-                dump_folder=config.dump_folder,
-            )
-
-            model.to_empty(device=init_device)
-            with torch.no_grad():
-                cast(BaseModel, model).init_weights(buffer_device=buffer_device)
-            model.train()
-
-            self.model_parts = [model]
+                self.model_parts = [model]
 
         # initialize device memory monitor and get peak flops for MFU calculation
         device_memory_monitor = self.metrics_processor.device_memory_monitor
@@ -409,11 +416,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
 
         # build optimizer after applying parallelisms to the model
-        self.optimizers = config.optimizer.build(model_parts=self.model_parts)
-        if model_spec.post_optimizer_build_fn is not None:
-            model_spec.post_optimizer_build_fn(
-                self.optimizers, self.model_parts, parallel_dims
-            )
+        with record_span("init/optimizer_s", EventType.OPTIMIZER_INIT):
+            self.optimizers = config.optimizer.build(model_parts=self.model_parts)
+            if model_spec.post_optimizer_build_fn is not None:
+                model_spec.post_optimizer_build_fn(
+                    self.optimizers, self.model_parts, parallel_dims
+                )
         self.lr_schedulers = config.lr_scheduler.build(
             optimizers=self.optimizers,
             training_steps=config.training.steps,
@@ -426,24 +434,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.model_parts
             )
         )
+
         # Initialize trainer states that will be saved in checkpoint.
         # These attributes must be initialized before checkpoint loading.
         self.step = 0
         self.ntokens_seen = 0
 
-        self.checkpointer = config.checkpoint.build(
-            dataloader=self.dataloader,
-            model_parts=self.model_parts,
-            optimizers=self.optimizers,
-            lr_schedulers=self.lr_schedulers,
-            states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
-            base_folder=config.dump_folder,
-        )
+        with record_span("init/checkpoint_s", EventType.CHECKPOINT_INIT):
+            self.checkpointer = config.checkpoint.build(
+                dataloader=self.dataloader,
+                model_parts=self.model_parts,
+                optimizers=self.optimizers,
+                lr_schedulers=self.lr_schedulers,
+                states={"train_state": self},
+                sd_adapter=(
+                    model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+                    if model_spec.state_dict_adapter
+                    else None
+                ),
+                base_folder=config.dump_folder,
+            )
 
         loss_parallel_enabled = (
             parallel_dims.tp_enabled and not config.parallelism.disable_loss_parallel
@@ -708,32 +718,34 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             global_valid_tokens = local_valid_tokens.float()
 
         # Process each microbatch: move to GPU, forward/backward, then free
-        accumulated_losses = []
-        for input_dict, labels in microbatches:
-            # Move tensors to GPU
-            for k, v in input_dict.items():
-                if isinstance(v, torch.Tensor):
-                    input_dict[k] = v.to(self.device)
-            labels = labels.to(self.device)
+        with record_span("trainer_time/forward_backward_s", EventType.FWD_BWD):
+            accumulated_losses = []
+            for input_dict, labels in microbatches:
+                # Move tensors to GPU
+                for k, v in input_dict.items():
+                    if isinstance(v, torch.Tensor):
+                        input_dict[k] = v.to(self.device)
+                labels = labels.to(self.device)
 
-            loss = self.forward_backward_step(
-                input_dict=input_dict,
-                labels=labels,
-                # pyrefly: ignore [bad-argument-type]
-                global_valid_tokens=global_valid_tokens,
+                loss = self.forward_backward_step(
+                    input_dict=input_dict,
+                    labels=labels,
+                    # pyrefly: ignore [bad-argument-type]
+                    global_valid_tokens=global_valid_tokens,
+                )
+                accumulated_losses.append(loss.detach())
+
+        with record_span("trainer_time/optimizer_s", EventType.OPTIM):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=parallel_dims.get_optional_mesh("pp"),
+                ep_enabled=parallel_dims.ep_enabled,
             )
-            accumulated_losses.append(loss.detach())
-
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
-            ep_enabled=parallel_dims.ep_enabled,
-        )
-        self.checkpointer.maybe_wait_for_staging()
-        self.optimizers.step()
-        self.lr_schedulers.step()
+            self.checkpointer.maybe_wait_for_staging()
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         # Reduce the data collected over gradient accumulation steps.
         loss = torch.sum(torch.stack(accumulated_losses))
@@ -801,7 +813,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def train(self):
         config = self.config
 
-        self.checkpointer.load(step=config.checkpoint.load_step)
+        with record_span("trainer_time/checkpoint_load_s", EventType.CHECKPOINT_LOAD):
+            self.checkpointer.load(step=config.checkpoint.load_step)
         logger.info(f"Training starts at step {self.step + 1}")
 
         with (
@@ -828,20 +841,29 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.metrics_processor.set_step(self.step, force_log=is_validation)
                 self.metrics_processor.reset_training_counters()
 
-                self.gc_handler.run(self.step)
-                try:
-                    self.train_step(data_iterator)
-                except DataloaderExhaustedError:
-                    logger.warning("Ran out of data; last step was canceled.")
-                    break
+                with record_span("trainer_time/gc_collect_s", EventType.GC_COLLECT):
+                    if self.gc_handler.run(self.step):
+                        add_step_tag("gc")
 
-                self.checkpointer.save(
-                    self.step, last_step=(self.step == config.training.steps)
-                )
+                with record_span("trainer_time/step_s", EventType.STEP):
+                    try:
+                        self.train_step(data_iterator)
+                    except DataloaderExhaustedError:
+                        logger.warning("Ran out of data; last step was canceled.")
+                        break
+
+                with record_span("trainer_time/checkpoint_s", EventType.CHECKPOINT):
+                    saved = self.checkpointer.save(
+                        self.step, last_step=(self.step == config.training.steps)
+                    )
+                    if saved:
+                        add_step_tag("checkpoint")
 
                 if is_validation:
+                    add_step_tag("eval")
                     self.metrics_processor.reset_val_counters()
-                    self.validator.validate(self.model_parts, self.step)
+                    with record_span("trainer_time/validation_s", EventType.EVAL):
+                        self.validator.validate(self.model_parts, self.step)
 
                 if self.metrics_processor.should_log(self.step):
                     self.metrics_processor.log(self.step, is_validation=is_validation)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2607
* #2606
* #2605
* #2604
* #2603
* #2602
* #2601

## How to review

Understand the changes in trainer.py. The changes in other trainers (Flux, FT, Forge) are exactly the same.

## Summary

Wraps every training phase in `record_span` so the gantt chart shows the full training timeline. Adds `add_step_tag` annotations for GC, validation, and checkpoint events.

[ ] (Previous PR) 1st phase - Focuses on 'experiment metrics' and excludes 'record_span' and 'record_event'.
[x] (This PR) 2nd phase - Adds 'record_span', 'add_step_tag' and 'record_event'.

All four trainers (base, Flux, FT, Forge) have the same span coverage (Trainer, FT, Flux, Forge)

- `checkpoint.save()` and `GarbageCollection.run()` return `bool` for step tagging 

<img width="1499" height="683" alt="image" src="https://github.com/user-attachments/assets/a60a55bf-1daf-4ef3-891d-3e3762dd8880" />

## Test plan

Flux, Forge and Trainer.py were test in main vs this PR. Losses and gradnorm are the same.

```bash
# Base trainer with PP
NGPU=8 LOG_RANK=0 ./run_train.sh --module llama3 --config llama3_debugmodel \
  --training.steps 10 --parallelism.data_parallel_shard_degree=2 \
  --parallelism.tensor_parallel_degree=2 --parallelism.pipeline_parallel_degree=2 \
  --parallelism.pipeline_parallel_schedule=1F1B --debug.seed=42 --debug.deterministic \
  --metrics.enable-wandb

# Base trainer with validation (no PP)
NGPU=8 LOG_RANK=0 ./run_train.sh --module llama3 --config llama3_debugmodel \
  --training.steps 10 --parallelism.data_parallel_shard_degree=4 \
  --parallelism.tensor_parallel_degree=2 --debug.seed=42 --debug.deterministic \
  --validator.enable --validator.freq=5 --validator.steps=2 --metrics.enable-wandb

# Flux (DP=4 CP=2)
NGPU=8 LOG_RANK=0 ./run_train.sh --module flux --config flux_debugmodel \
  --training.steps 5 --debug.seed=42 --metrics.enable-wandb \
  --parallelism.data_parallel_shard_degree=4 --parallelism.context_parallel_degree=2 \
  --tokenizer.test_mode --encoder.random_init \
  --encoder.clip_encoder tests/assets/flux_test_encoders/clip-vit-large-patch14/ \
  --encoder.t5_encoder tests/assets/flux_test_encoders/t5-v1_1-xxl/ \
  --tokenizer.t5_tokenizer_path tests/assets/tokenizer \
  --tokenizer.clip_tokenizer_path tests/assets/tokenizer \
  --hf_assets_path tests/assets/tokenizer

# Forge (DP=2 TP=2 PP=2)
python -m torch.distributed.run --nproc_per_node=8 --local-ranks-filter 0 --role rank --tee 3 \
  -m torchtitan.experiments.forge.example_train --module llama3 --config llama3_debugmodel \
  --training.steps 5 --debug.seed=42 --debug.deterministic --metrics.enable-wandb \
  --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 \
  --parallelism.pipeline_parallel_degree=2 --parallelism.pipeline_parallel_schedule=1F1B

```

- [x] Integration: base trainer PP=2 DP=2 TP=2 loss matches main
- [x] Integration: base trainer with validation shows training + validation console lines
- [x] Integration: Flux DP=4 CP=2 loss matches main
- [x] Integration: Forge DP=2 TP=2 PP=2 loss matches main (real loss, not -2.0)
- [x] Integration: gantt (PP) has span types across all 8 ranks
- [x] Integration: gantt (validation) includes eval spans
- [x] Integration: checkpoint tag only appears on steps where checkpoint was saved

### Console output — Base trainer with PP (PP=2 DP=2 TP=2)

```
[rank0]:[titan] 2026-03-16 08:57:13,807 - torchtitan.observability.aggregation - INFO - step:  1  training/loss_mean: 8.028  training/grad_norm_max: 50810.5  trainer_memory/reserved_gib_max: 0.19  trainer_throughput/tps_mean: 361.4  trainer_throughput/tflops_mean: 0.026  trainer_throughput/mfu_pct_mean: 0.0026
[rank0]:[titan] 2026-03-16 08:57:15,323 - torchtitan.observability.aggregation - INFO - step:  5  training/loss_mean: 5.021  training/grad_norm_max: 81269.6  trainer_memory/reserved_gib_max: 0.20  trainer_throughput/tps_mean: 10177.9  trainer_throughput/tflops_mean: 0.73  trainer_throughput/mfu_pct_mean: 0.074
[rank0]:[titan] 2026-03-16 08:57:17,135 - torchtitan.observability.aggregation - INFO - step: 10  training/loss_mean: 3.90  training/grad_norm_max: 52873.5  trainer_memory/reserved_gib_max: 0.20  trainer_throughput/tps_mean: 11729.9  trainer_throughput/tflops_mean: 0.84  trainer_throughput/mfu_pct_mean: 0.085
```

### Console output — Base trainer with validation (DP=4 TP=2)

```
[rank0]:[titan] 2026-03-16 08:58:05,206 - torchtitan.observability.aggregation - INFO - step:  1  training/loss_mean: 8.13  training/grad_norm_max: 1.54  trainer_memory/reserved_gib_max: 0.64  trainer_throughput/tps_mean: 1409.4  trainer_throughput/tflops_mean: 0.10  trainer_throughput/mfu_pct_mean: 0.010
[rank0]:[titan] 2026-03-16 08:58:05,207 - torchtitan.observability.aggregation - INFO - validate step:  1  validation/loss_mean: 7.81  validator_memory/reserved_gib_max: 0.64  validator_throughput/tps_mean: 11233.7
[rank0]:[titan] 2026-03-16 08:58:06,075 - torchtitan.observability.aggregation - INFO - step:  5  training/loss_mean: 5.32  training/grad_norm_max: 2.51  trainer_memory/reserved_gib_max: 0.67  trainer_throughput/tps_mean: 71439.5  trainer_throughput/tflops_mean: 5.11  trainer_throughput/mfu_pct_mean: 0.52
[rank0]:[titan] 2026-03-16 08:58:06,075 - torchtitan.observability.aggregation - INFO - validate step:  5  validation/loss_mean: 4.78  validator_memory/reserved_gib_max: 0.67  validator_throughput/tps_mean: 42884.5
[rank0]:[titan] 2026-03-16 08:58:07,045 - torchtitan.observability.aggregation - INFO - step: 10  training/loss_mean: 4.022  training/grad_norm_max: 1.88  trainer_memory/reserved_gib_max: 0.67  trainer_throughput/tps_mean: 66496.5  trainer_throughput/tflops_mean: 4.76  trainer_throughput/mfu_pct_mean: 0.48
[rank0]:[titan] 2026-03-16 08:58:07,046 - torchtitan.observability.aggregation - INFO - validate step: 10  validation/loss_mean: 4.034  validator_memory/reserved_gib_max: 0.67  validator_throughput/tps_mean: 45510.2
```

### WandB runs

| | Main | PR7c |
|---|------|------|
| Base (PP=2 DP=2 TP=2) | https://wandb.ai/cabernet-team/torchtitan/runs/9ltdu69z | https://wandb.ai/cabernet-team/torchtitan/runs/uxcx428m |
| Base (validation) | — | https://wandb.ai/cabernet-team/torchtitan/runs/rsq5vxlx |
| Flux (DP=4 CP=2) | https://wandb.ai/cabernet-team/torchtitan/runs/twfvo2ys | https://wandb.ai/cabernet-team/torchtitan/runs/iua7gyq5 |
| Forge (DP=2 TP=2 PP=2) | https://wandb.ai/cabernet-team/torchtitan/runs/35ztpneg | https://wandb.ai/cabernet-team/torchtitan/runs/o1pqmpeb |



