### PR TITLE
[graph_trainer] Propagate forward metadata to backward nodes in make_fx_tracer

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -5,9 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Generator
+from typing import Any
 
 import torch
 import torch.nn as nn

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -351,5 +351,6 @@ class TestMetadataPropagation(unittest.TestCase):
         self.assertIs(torch.autograd.graph._engine_run_backward, orig_fn)
         self.assertIs(torch.autograd._engine_run_backward, orig_fn)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Patch the autograd engine during make_fx tracing to preserve seq_nr on
    backward FX nodes, then copy forward-node custom/nn_module_stack metadata
    to corresponding backward nodes via seq_nr matching.