### PR TITLE
[CI] Pin datasets < 4.8.0 to avoid streaming sharding regression

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,5 +1,5 @@
 torchdata >= 0.8.0
-datasets >= 3.6.0
+datasets >= 3.6.0, < 4.8.0
 tensorboard
 wandb
 fsspec


### PR DESCRIPTION
`datasets` 4.8.x introduced a bug in StepExamplesIterable._iter_arrow where single-row Arrow batches cause split_dataset_by_node to yield 0 samples for non-zero ranks when **num_shards < world_size**. This breaks Flux training with the cc12m-test and coco-validation datasets.