### PR TITLE
[graph_trainer] Remove eager AC

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -145,20 +145,25 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     return module_fqns
 
 
-def maybe_disable_eager_ac(
+def apply_graph_ac(
     compile_config: CompileConfig,
     ac_config: "ActivationCheckpointConfig",
 ) -> None:
-    """Disable eager AC when apply_sac graph pass is enabled.
+    """Add apply_sac to compile joint passes for graph-based selective AC.
 
-    When apply_sac is used as a joint graph pass, eager activation checkpointing
-    must be disabled to avoid double-checkpointing. This must be called before
-    the model parallelization step that applies eager AC.
+    Must be called only when ac_config.mode != "none". Only "selective" mode
+    is supported; other modes raise ValueError.
     """
+    if ac_config.mode != "selective":
+        raise ValueError(
+            f"graph_trainer only supports activation_checkpoint.mode 'selective' or "
+            f"'none', got '{ac_config.mode}'. Use 'selective' for graph-based SAC."
+        )
+
     joint_pass_names = getattr(compile_config, "joint_passes", [])
-    if "apply_sac" in joint_pass_names:
-        if ac_config.mode != "none":
-            logger.info(
-                "apply_sac graph pass is enabled, overriding eager AC mode to none"
-            )
-            ac_config.mode = "none"
+    if "apply_sac" not in joint_pass_names:
+        compile_config.joint_passes = list(joint_pass_names) + ["apply_sac"]
+        logger.info(
+            "activation_checkpoint.mode is 'selective', added apply_sac to "
+            "compile.joint_passes"
+        )

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, fields
 from typing import Literal
 
+from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
@@ -58,5 +59,11 @@ def to_graph_trainer_config(
     d = {f.name: getattr(base_config, f.name) for f in fields(base_config)}
     d["model_spec"] = model_registry(base_config.model_spec.flavor)
     d.pop("compile")
+
+    # graph_trainer uses graph-based SAC instead of eager AC. Override any
+    # non-"none" AC mode to "selective" so callers don't need per-config fixups.
+    ac = d.get("activation_checkpoint")
+    if ac is not None and ac.mode != "none":
+        d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
 
     return GraphTrainer.Config(**d)

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -22,27 +21,23 @@ from . import model_registry
 
 def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
-    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
 
 def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> (GraphTrainer.Config):
     config = to_graph_trainer_config(deepseek_v3_debugmodel_flex_attn(), model_registry)
-    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
 
 def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_16b(), model_registry)
-    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
 
 def graph_trainer_deepseek_v3_671b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_671b(), model_registry)
-    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -17,11 +17,10 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 
-from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
-    maybe_disable_eager_ac,
+    apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
@@ -99,8 +98,6 @@ def parallelize_deepseekv3(
 
     annotate_deepseekv3(model)
 
-    maybe_disable_eager_ac(compile_config, ac_config)
-
     if parallel_dims.tp_enabled:
         float8_config = find_float8_linear_config(model_converters.converters)
         enable_float8_linear = float8_config is not None
@@ -135,7 +132,7 @@ def parallelize_deepseekv3(
         )
 
     if ac_config.mode != "none":
-        apply_ac(model, ac_config)
+        apply_graph_ac(compile_config, ac_config)
 
     mp_policy = MixedPrecisionPolicy(
         param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.components.quantization.float8 import find_float8_linear_config
@@ -16,11 +15,10 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
-    maybe_disable_eager_ac,
+    apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
@@ -31,25 +29,6 @@ from torchtitan.experiments.graph_trainer.simple_fsdp import (
 from torchtitan.models.llama3.parallelize import apply_tp
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
-
-# for selective op activation checkpointing
-_op_sac_save_list = {
-    torch.ops.aten.mm.default,
-    torch.ops.aten.linear.default,
-    torch.ops.aten._scaled_dot_product_efficient_attention.default,
-    torch.ops.aten._scaled_dot_product_flash_attention.default,
-    torch.ops.aten._scaled_dot_product_cudnn_attention.default,
-    torch.ops.aten._scaled_dot_product_attention_math.default,
-    torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
-    torch.ops._c10d_functional.reduce_scatter_tensor.default,
-    # for low precision training, it's useful to always save
-    # the result of max, since the absolute maximum is
-    # used to compute the scaling factor for quantization.
-    torch.ops.aten.max.default,
-    torch._higher_order_ops.flex_attention,
-    torch.ops.torch_attn._varlen_attn.default,
-    torch._higher_order_ops.inductor_compiled_code,
-}
 
 
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
@@ -103,8 +82,6 @@ def parallelize_llama(
 
     annotate_llama(model)
 
-    maybe_disable_eager_ac(compile_config, ac_config)
-
     if parallel_dims.tp_enabled:
         float8_config = find_float8_linear_config(model_converters.converters)
         enable_float8_linear = float8_config is not None
@@ -128,16 +105,7 @@ def parallelize_llama(
         maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
 
     if ac_config.mode != "none":
-        model_compile_enabled = (
-            compile_config.enable and "model" in compile_config.components
-        )
-        apply_ac(
-            model,
-            ac_config,
-            model_compile_enabled=model_compile_enabled,
-            op_sac_save_list=_op_sac_save_list,
-            base_folder=dump_folder,
-        )
+        apply_graph_ac(compile_config, ac_config)
 
     # apply data parallel
     if (

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -41,31 +41,6 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT 1D+transformer_block_bucketing",
             "jit_1d_transformer_block_bucketing",
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module graph_trainer.llama3",
-                    "--config graph_trainer_llama3_debugmodel",
-                    "--compile.mode jit",
-                    "--activation_checkpoint.mode selective",
-                    "--activation_checkpoint.selective_ac_option op",
-                ],
-            ],
-            "JIT 1D with selective op AC",
-            "jit_1d_sac_op",
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module graph_trainer.llama3",
-                    "--config graph_trainer_llama3_debugmodel",
-                    "--compile.mode jit",
-                    "--activation_checkpoint.mode full",
-                ],
-            ],
-            "JIT 1D with full AC",
-            "jit_1d_full_ac",
-        ),
         # TODO: re-enable this test once the async TP issue is fixed
         OverrideDefinitions(
             [
@@ -196,11 +171,10 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
                     "--compile.mode aot",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
-                    "--compile.joint_passes apply_sac",
                 ],
             ],
-            "AOT llama3 FSDP+TP graph SAC",
-            "aot_llama3_fsdp_tp_graph_sac",
+            "AOT llama3 FSDP+TP",
+            "aot_llama3_fsdp_tp",
             ngpu=8,
         ),
         OverrideDefinitions(
@@ -386,28 +360,10 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.expert_parallel_degree 4",
                     "--parallelism.expert_tensor_parallel_degree 1",
-                    "--activation_checkpoint.mode none",
                 ],
             ],
             "AOT deepseek_v3 FSDP+TP+EP",
             "aot_deepseekv3_fsdp_tp_ep",
-            ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module graph_trainer.deepseek_v3",
-                    "--config graph_trainer_deepseek_v3_debugmodel",
-                    "--compile.mode aot",
-                    "--parallelism.data_parallel_shard_degree 4",
-                    "--parallelism.tensor_parallel_degree 2",
-                    "--parallelism.expert_parallel_degree 4",
-                    "--parallelism.expert_tensor_parallel_degree 1",
-                    "--compile.joint_passes apply_sac",
-                ],
-            ],
-            "AOT deepseek_v3 FSDP+TP+EP Graph SAC",
-            "aot_deepseekv3_fsdp_tp_ep_graph_sac",
             ngpu=8,
         ),
         OverrideDefinitions(
@@ -420,7 +376,6 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.expert_parallel_degree 4",
                     "--parallelism.expert_tensor_parallel_degree 1",
-                    "--activation_checkpoint.mode none",
                 ],
             ],
             "AOT deepseek_v3 FSDP+TP+EP+FlexAttention",
@@ -438,7 +393,6 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--parallelism.expert_parallel_degree 4",
                     "--parallelism.expert_tensor_parallel_degree 1",
                     "--compile.joint_passes inductor_decomposition",
-                    "--activation_checkpoint.mode none",
                 ],
             ],
             "AOT deepseek_v3 inductor_decomposition",


### PR DESCRIPTION
Eager AC via `torch.utils.checkpoint` could break graph capture. Since we have graph-based AC support, this PR removes eager AC entirely in `graph_trainer` experiment and uses graph-based SAC exclusively.