### PR TITLE
[graph_trainer] Add Qwen3

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -62,9 +62,10 @@ jobs:
 
         python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_default --gpu_arch_type cuda $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 
-        # Run the numerics unit tests (Llama3 only; DeepSeek tests run in the H100 workflow)
+
+        # Run the numerics unit tests (dense models only; MoE tests run in the H100 workflow)
         pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestSimpleFSDP -v
-        pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "not dsv3"
+        pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "dense"
 
         # Run the graph passes unit tests
         torchrun --nproc-per-node=8 -m pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestReassignToPgPass -v

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -64,8 +64,8 @@ jobs:
         # NVLS according to several CI runs.
         NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_h100 --gpu_arch_type cuda $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 
-        # Run the DeepSeek numerics tests
-        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "dsv3"
+        # Run the MoE numerics tests
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "moe"
 
         # Run bitwise deterministic guardrail test (includes H100-only hardcoded-hash tests)
         pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -8,6 +8,7 @@ _supported_experiments = frozenset(
     [
         "graph_trainer.llama3",
         "graph_trainer.deepseek_v3",
+        "graph_trainer.qwen3",
         "vlm",
         "transformers_modeling_backend",
         "autoparallel.llama3",

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -197,8 +197,9 @@ def joint_graph_builder(
         on_compile(fn, joint_with_descriptors.out_spec)
 
     def wrapper_fn(args, kwargs):
+        params = [p for _, p in model.named_parameters(remove_duplicate=False)]
         inputs = [
-            *model.parameters(),
+            *params,
             *model.buffers(),
             *args,
         ]

--- a/torchtitan/experiments/graph_trainer/qwen3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import fields
+
+from torchtitan.components.loss import build_cross_entropy_loss
+from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.models.qwen3 import qwen3_configs
+from torchtitan.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
+from torchtitan.protocols.model_spec import ModelSpec
+
+from .model import GraphTrainerQwen3Model
+from .parallelize import parallelize_qwen3
+
+
+def model_registry(flavor: str) -> ModelSpec:
+    base = qwen3_configs[flavor]()
+    config = GraphTrainerQwen3Model.Config(
+        **{f.name: getattr(base, f.name) for f in fields(base)}
+    )
+    return ModelSpec(
+        name="graph_trainer/qwen3",
+        flavor=flavor,
+        model=config,
+        parallelize_fn=parallelize_qwen3,
+        pipelining_fn=pipeline_llm,
+        build_loss_fn=build_cross_entropy_loss,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=Qwen3StateDictAdapter,
+    )

--- a/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.graph_trainer.configs import (
+    GraphTrainerCompileConfig,
+    to_graph_trainer_config,
+)
+from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+from torchtitan.models.qwen3.config_registry import (
+    qwen3_debugmodel,
+    qwen3_debugmodel_flex,
+    qwen3_moe_debug,
+)
+
+from . import model_registry
+
+
+def graph_trainer_qwen3_debugmodel() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(qwen3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_qwen3_debugmodel_flex_attn() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(qwen3_debugmodel_flex(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_qwen3_debugmodel_moe() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(qwen3_moe_debug(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config

--- a/torchtitan/experiments/graph_trainer/qwen3/model.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/model.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+import torch
+
+from torchtitan.models.qwen3 import Qwen3Model
+
+from ..simple_fsdp import disable_active_parametrization
+
+
+class GraphTrainerQwen3Model(Qwen3Model):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Qwen3Model.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+
+    def init_states(
+        self,
+        *,
+        buffer_device: torch.device | None = None,
+    ) -> None:
+        with disable_active_parametrization():
+            super().init_states(buffer_device=buffer_device)

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch.distributed.device_mesh import DeviceMesh
+from torch.fx.traceback import annotate_fn
+
+from torchtitan.components.quantization.float8 import find_float8_linear_config
+from torchtitan.config import (
+    ActivationCheckpointConfig,
+    CompileConfig,
+    ParallelismConfig,
+    TORCH_DTYPE_MAP,
+    TrainingConfig,
+)
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_ac_regions,
+    apply_graph_ac,
+)
+from torchtitan.experiments.graph_trainer.compile import apply_compile
+from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
+
+from torchtitan.experiments.graph_trainer.simple_fsdp import (
+    data_parallel,
+    MixedPrecisionPolicy,
+)
+from torchtitan.models.llama4.parallelize import apply_moe_ep_tp
+from torchtitan.models.qwen3.parallelize import apply_non_moe_tp
+from torchtitan.protocols.model_converter import ModelConvertersContainer
+from torchtitan.tools.logging import logger
+
+
+def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
+    """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
+
+    - Expert Parallel (EP) annotations: Tags "dispatch", "combine", and "compute"
+      regions in MoE for debugging purposes (only if MoE layers exist).
+    - Flex attention annotation: Tags FlexAttention.forward with
+      {"compile_with_inductor": "flex_attention"} so the compiler can apply
+      regional inductor pass based on the annotation. Regional inductor is now only
+      supported in AOT mode.
+    - AC region annotation: Tags each transformer block's forward with a unique
+      ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
+      boundaries for the min-cut partitioner.
+    """
+    from torchtitan.models.common.attention import FlexAttention
+
+    # Annotate MoE EP regions if any layer has MoE enabled
+    if any(layer.moe is not None for layer in model.config.layers):
+        from torchtitan.distributed.expert_parallel import ExpertParallel
+        from torchtitan.models.common.moe import MoE
+
+        ExpertParallel._token_dispatch = annotate_fn({"EP": "dispatch"})(
+            ExpertParallel._token_dispatch
+        )
+        ExpertParallel._token_combine = annotate_fn({"EP": "combine"})(
+            ExpertParallel._token_combine
+        )
+        MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
+
+    FlexAttention.forward = annotate_fn({"compile_with_inductor": "flex_attention"})(
+        FlexAttention.forward
+    )
+
+    annotate_ac_regions(model)
+
+
+def parallelize_qwen3(
+    model: GraphTrainerQwen3Model,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    model_converters: ModelConvertersContainer.Config,
+    parallelism: ParallelismConfig,
+    compile_config: CompileConfig,
+    ac_config: ActivationCheckpointConfig,
+    dump_folder: str,
+):
+    """
+    Apply annotation, parallelization, activation checkpointing, and full graph
+    capture to the model.
+
+    NOTE: The passed-in model preferably should be on meta device. Otherwise,
+    the model must fit on GPU or CPU memory.
+    """
+    assert (
+        training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
+        Sequence length {training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}), i.e. {parallel_dims.seq_len_divisor}.
+        """
+
+    annotate_qwen3(model)
+
+    if parallel_dims.tp_enabled:
+        float8_config = find_float8_linear_config(model_converters.converters)
+        enable_float8_linear = float8_config is not None
+        float8_is_rowwise = float8_config is not None and float8_config.recipe_name in (
+            "rowwise",
+            "rowwise_with_gw_hp",
+        )
+
+        enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
+
+        tp_mesh = parallel_dims.get_mesh("tp")
+        apply_non_moe_tp(
+            model,
+            tp_mesh,
+            enable_loss_parallel=not parallelism.disable_loss_parallel,
+            enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+            enable_async_tp=parallelism.enable_async_tensor_parallel,
+            enable_cp=parallel_dims.cp_enabled,
+            enable_sp=parallelism.enable_sequence_parallel,
+        )
+        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+
+    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+        from torchtitan.components.quantization import find_pad_multiple
+
+        pad_multiple = find_pad_multiple(model_converters.converters)
+
+        apply_moe_ep_tp(
+            model,
+            tp_mesh=parallel_dims.get_optional_mesh("tp"),
+            ep_mesh=parallel_dims.get_optional_mesh("ep"),
+            etp_mesh=parallel_dims.get_optional_mesh("etp"),
+            ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
+            pad_multiple=pad_multiple,
+        )
+
+    if ac_config.mode != "none":
+        apply_graph_ac(compile_config, ac_config)
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
+    )
+
+    # apply data parallel
+    dp_mesh: DeviceMesh | None = None
+    if (
+        parallel_dims.fsdp_enabled
+        or parallel_dims.ep_enabled
+        or parallel_dims.dp_replicate_enabled
+    ):
+        if parallel_dims.dp_replicate_enabled:
+            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
+                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
+                dp_mode = "hybrid_shard"
+            else:
+                dp_mesh_dim_names = ["dp_replicate"]
+                dp_mode = "replicate"
+        else:
+            dp_mesh_dim_names = ["fsdp"]
+            dp_mode = "fully_shard"
+
+        dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
+
+        # the mesh dim names of which the MoE params are sharded on via FSDP/HSDP
+        edp_mesh_names = (
+            ["dp_replicate", "efsdp"]
+            if parallel_dims.dp_replicate_enabled
+            else ["efsdp"]
+        )
+        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+
+        for _, transformer_block in model.layers.items():
+            if transformer_block.moe_enabled and parallel_dims.ep_enabled:
+                experts_shard_dim = 0
+                assert edp_mesh is not None
+                assert hasattr(transformer_block, "moe")
+                if (
+                    edp_mesh["efsdp"].size() * parallel_dims.ep
+                    > transformer_block.moe.experts.num_experts
+                ):
+                    experts_shard_dim = 1
+
+                transformer_block.moe.experts = data_parallel(
+                    transformer_block.moe.experts,
+                    edp_mesh,
+                    dp_mode,
+                    mp_policy=mp_policy,
+                    shard_dim=experts_shard_dim,
+                )
+
+        model = data_parallel(
+            model,
+            dp_mesh,
+            dp_mode,
+            mp_policy=mp_policy,
+        )
+
+        logger.info(
+            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
+        )
+
+    # Apply compilation based on mode
+    model = apply_compile(
+        model,
+        compile_config=compile_config,
+        parallelism=parallelism,
+        parallel_dims=parallel_dims,
+        dump_folder=dump_folder,
+    )
+
+    return model

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -468,9 +468,45 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
     ]
 
 
+def _build_qwen3_tests() -> list[OverrideDefinitions]:
+    """Qwen3-based integration tests (dense + MoE)."""
+    return [
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.qwen3",
+                    "--config graph_trainer_qwen3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace qwen3 FSDP+TP",
+            "aot_fx_trace_qwen3_fsdp_tp",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.qwen3",
+                    "--config graph_trainer_qwen3_debugmodel_moe",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                ],
+            ],
+            "aot_fx_trace qwen3 MoE FSDP+TP+EP",
+            "aot_fx_trace_qwen3_moe_fsdp_tp_ep",
+            ngpu=8,
+        ),
+    ]
+
+
 def build_graph_trainer_test_list() -> list[OverrideDefinitions]:
-    """All graph_trainer integration tests (Llama3 + DeepSeek-v3)."""
-    return _build_llama3_tests() + _build_deepseek_v3_tests()
+    """All graph_trainer integration tests (Llama3 + DeepSeek-v3 + Qwen3)."""
+    return _build_llama3_tests() + _build_deepseek_v3_tests() + _build_qwen3_tests()
 
 
 def build_graph_trainer_default_test_list() -> list[OverrideDefinitions]:
@@ -479,8 +515,8 @@ def build_graph_trainer_default_test_list() -> list[OverrideDefinitions]:
 
 
 def build_graph_trainer_h100_test_list() -> list[OverrideDefinitions]:
-    """DeepSeek-v3 tests only (for H100 machines)."""
-    return _build_deepseek_v3_tests()
+    """DeepSeek-v3 + Qwen3 tests (for H100 machines)."""
+    return _build_deepseek_v3_tests() + _build_qwen3_tests()
 
 
 _TEST_SUITES_FUNCTION = {

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -109,87 +109,142 @@ def _run_deepseek_v3_loss_compare(test_options_extra: str = "") -> bool:
     )
 
 
+QWEN3_PARALLELISM = (
+    "--parallelism.tensor_parallel_degree=2"
+    " --parallelism.data_parallel_shard_degree=4"
+)
+
+
+def _run_qwen3_loss_compare(test_options_extra: str = "") -> bool:
+    """Run loss_compare for qwen3 vs graph_trainer.qwen3 with FSDP+TP."""
+    test_options = QWEN3_PARALLELISM
+    if test_options_extra:
+        test_options += f" {test_options_extra}"
+    return run_loss_compare(
+        baseline_module="qwen3",
+        baseline_config="qwen3_debugmodel",
+        test_module="graph_trainer.qwen3",
+        test_config="graph_trainer_qwen3_debugmodel",
+        baseline_options=QWEN3_PARALLELISM,
+        test_options=test_options,
+    )
+
+
+QWEN3_MOE_PARALLELISM = (
+    "--parallelism.data_parallel_shard_degree=4"
+    " --parallelism.tensor_parallel_degree=2"
+    " --parallelism.expert_parallel_degree=2"
+)
+
+
+def _run_qwen3_moe_loss_compare(test_options_extra: str = "") -> bool:
+    """Run loss_compare for qwen3 MoE vs graph_trainer.qwen3 MoE."""
+    test_options = QWEN3_MOE_PARALLELISM
+    if test_options_extra:
+        test_options += f" {test_options_extra}"
+    return run_loss_compare(
+        baseline_module="qwen3",
+        baseline_config="qwen3_moe_debug",
+        test_module="graph_trainer.qwen3",
+        test_config="graph_trainer_qwen3_debugmodel_moe",
+        baseline_options=QWEN3_MOE_PARALLELISM,
+        test_options=test_options,
+    )
+
+
 class TestGraphTrainerNumerics(unittest.TestCase):
     """Test numerics equivalence between graph_trainer and FSDP2 eager."""
 
-    def test_llama3_aot_vs_eager(self):
+    def test_dense_llama3_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode aot"),
         )
 
-    def test_llama3_auto_bucketing_aot_vs_eager(self):
+    def test_dense_llama3_auto_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
                 test_options_extra="--compile.mode aot --compile.passes auto_bucketing"
             ),
         )
 
-    def test_llama3_manual_bucketing_aot_vs_eager(self):
+    def test_dense_llama3_manual_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
                 test_options_extra="--compile.mode aot --compile.passes transformer_block_bucketing"
             ),
         )
 
-    def test_llama3_cudagraph_aot_vs_eager(self):
+    def test_dense_llama3_cudagraph_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
                 test_options_extra="--compile.mode aot --compile.passes cudagraph"
             ),
         )
 
-    def test_dsv3_aot_vs_eager(self):
+    def test_moe_dsv3_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode aot"),
         )
 
-    def test_dsv3_manual_bucketing_aot_vs_eager(self):
+    def test_moe_dsv3_manual_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
                 test_options_extra="--compile.mode aot --compile.passes transformer_block_bucketing"
             ),
         )
 
-    def test_llama3_aot_fx_trace_vs_eager(self):
+    def test_dense_llama3_aot_fx_trace_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode aot_fx_trace"),
         )
 
-    def test_llama3_jit_vs_eager(self):
+    def test_dense_llama3_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode jit"),
         )
 
-    def test_llama3_auto_bucketing_jit_vs_eager(self):
+    def test_dense_llama3_auto_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
                 test_options_extra="--compile.mode jit --compile.passes auto_bucketing"
             ),
         )
 
-    def test_llama3_manual_bucketing_jit_vs_eager(self):
+    def test_dense_llama3_manual_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
                 test_options_extra="--compile.mode jit --compile.passes transformer_block_bucketing"
             ),
         )
 
-    def test_dsv3_jit_vs_eager(self):
+    def test_moe_dsv3_jit_vs_eager(self):
         """Test graph_trainer.deepseek_v3 matches deepseek_v3 (JIT)."""
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode jit"),
         )
 
-    def test_dsv3_manual_bucketing_jit_vs_eager(self):
+    def test_moe_dsv3_manual_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
                 test_options_extra="--compile.mode jit --compile.passes transformer_block_bucketing"
             ),
         )
 
-    def test_dsv3_aot_fx_trace_vs_eager(self):
+    def test_moe_dsv3_aot_fx_trace_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
+                test_options_extra="--compile.mode aot_fx_trace"
+            ),
+        )
+
+    def test_dense_qwen3_aot_fx_trace_vs_eager(self):
+        self.assertTrue(
+            _run_qwen3_loss_compare(test_options_extra="--compile.mode aot_fx_trace"),
+        )
+
+    def test_moe_qwen3_aot_fx_trace_vs_eager(self):
+        self.assertTrue(
+            _run_qwen3_moe_loss_compare(
                 test_options_extra="--compile.mode aot_fx_trace"
             ),
         )

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -38,7 +38,11 @@ def make_fwd_bwd_step(loss_fn):
     ):
         pred = model(inputs, **extra_inputs, **extra_kwargs)
         loss = loss_fn(pred, labels) / global_valid_tokens
-        params = [p for p in model.parameters() if p.requires_grad]
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
         grads = torch.autograd.grad(loss, params)
         return [loss] + list(grads)
 
@@ -83,8 +87,13 @@ class GraphTrainer(Trainer):
         inputs, labels, extra_inputs, extra_kwargs = self.post_dataloading_process(
             input_dict, labels
         )
-
-        params = [p for p in model.parameters() if p.requires_grad]
+        # remove_duplicate=False to preserve duplicate parameter entries
+        # from weight tying (e.g. shared embedding/output weights).
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
         return self._make_fx_forward_backward_step(
             model,
             inputs,


### PR DESCRIPTION
Add Qwen3 (dense + MoE) to the graph_trainer experiment.

Files added
- `torchtitan/experiments/graph_trainer/qwen3/__init__.py` -- Model registry
- `torchtitan/experiments/graph_trainer/qwen3/config_registry.py` -- Debug model configs (dense, flex_attn, MoE)
- `torchtitan/experiments/graph_trainer/qwen3/model.py` -- GraphTrainerQwen3Model
- `torchtitan/experiments/graph_trainer/qwen3/parallelize.py` -- Parallelization function

Handles two Qwen3-specific issues:

- Weight tying: Qwen3 ties `tok_embeddings.weight` and `output.weight`, which means `model.parameters()` returns duplicates. Therefore, we need to use `named_parameters(remove_duplicate=False)`.

- cos_sin RoPE backend: Unlike Llama3/DeepSeek which use a complex backend, Qwen3 uses a cos_sin backend that stores cos/sin caches as float32 buffers. It causes numerics issues but was fixed in #2881

Test Plan:

Since we are making `aot_fx_trace` the default mode. I only added tests for this mode
