### PR TITLE
Fix missing VLLMCompatibleFlashAttention import in `attention.py`

### DIFF
--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -12,6 +12,9 @@ from torch.nn.attention import (
     activate_flash_attention_impl,
     current_flash_attention_impl,
 )
+from torchtitan.experiments.rl.models.vllm_compat_attention import (
+    VLLMCompatibleFlashAttention,
+)
 from torchtitan.protocols.module import Module
 
 from vllm.model_executor.layers.attention import Attention


### PR DESCRIPTION
The import seems to be missing after https://github.com/pytorch/torchtitan/pull/2364, causing `NameError: name 'VLLMCompatibleFlashAttention' is not defined`