### PR TITLE
[graph_trainer] Add precompile artifact serialization and loading

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -201,22 +201,22 @@ def precompile_load(
 
     out_spec = artifact.out_spec
     serialized_fn_bytes = artifact.serialized_fn
-    compiled_fn_holder: list[Callable] = []
+    compiled_fn: Callable | None = None
 
     def wrapper_fn(args, kwargs):
+        nonlocal compiled_fn
         # Defer deserialization to first call so that Triton kernels
         # are loaded on the correct CUDA device (which is guaranteed
         # to be set by the time the first forward runs).
-        if not compiled_fn_holder:
+        if compiled_fn is None:
             logger.info(
                 f"Deserializing compiled fn on device {torch.cuda.current_device()}"
             )
-            compiled_fn_holder.append(
+            compiled_fn = (
                 BundledAOTAutogradSerializableCallable.deserialize_compile_artifacts(
                     serialized_fn_bytes
                 )
             )
-        compiled_fn = compiled_fn_holder[0]
 
         # Build the flat input list: params + buffers + user args.
         # This mirrors the calling convention in joint_graph_builder's

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -119,6 +119,9 @@ def _make_stub_model(params=None, buffers=None):
         buffers = [("running_mean", torch.zeros(4))]
 
     model = MagicMock()
+    # Use side_effect (not return_value) so each call produces a
+    # fresh iterator — just like real nn.Module methods. A single
+    # return_value=iter(...) would be exhausted after the first call.
     model.named_parameters.side_effect = lambda: iter(params)
     model.named_buffers.side_effect = lambda: iter(buffers)
     return model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2646
* #2650
* #2644
* __->__ #2643
* #2642

Add precompile_save() and precompile_load() functions that serialize and
deserialize compiled AOT graphs using BundledAOTAutogradSerializableCallable.
Artifacts include the serialized compiled function, parameter/buffer specs,
input/output tree specs, and metadata. Deserialization is deferred to first
call so Triton kernels load on the correct CUDA device.

Includes config fingerprint validation: `compute_config_fingerprint()` hashes
model param/buffer names+shapes+dtypes, parallelism dimensions (world_size,
dp_replicate, dp_shard, cp, tp, pp, ep, etp), and compile config (mode,
backend, passes, joint_passes) into a 16-char SHA-256 digest. The fingerprint
is stored in the artifact on save and validated on load — mismatches produce
a clear error, and legacy artifacts without fingerprints log a warning.

@claude