### PR TITLE
[graph_trainer] Address code review comments on precompile stack

### DIFF
--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -40,7 +40,20 @@ from torchtitan.experiments.graph_trainer.graph_utils import (
 from torchtitan.experiments.graph_trainer.jit_backend import (
     get_compile_backend_with_passes,
 )
+from torchtitan.experiments.graph_trainer.storage import (
+    DiskStorageAdapter,
+    StorageAdapter,
+)
 from torchtitan.tools.logging import logger
+
+
+def _get_precompile_storage_and_key(
+    compile_config: GraphTrainerCompileConfig,
+) -> tuple[StorageAdapter, str]:
+    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+    rank = torch.distributed.get_rank()
+    artifact_key = f"default_rank{rank}"
+    return storage, artifact_key
 
 
 def _apply_jit_compile(
@@ -74,8 +87,7 @@ def _make_precompile_callback(
     which is required for serializable compilation (it's the only pass that
     produces Inductor OutputCode via compile_fx_inner).
     """
-    pass_names = getattr(compile_config, "passes", [])
-    if "full_inductor_compilation" not in pass_names:
+    if "full_inductor_compilation" not in compile_config.passes:
         raise ValueError(
             "precompile requires 'full_inductor_compilation' "
             "in --compile.passes because the serialization machinery "
@@ -85,11 +97,8 @@ def _make_precompile_callback(
         )
 
     from torchtitan.experiments.graph_trainer.precompile import precompile_save
-    from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 
-    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
-    rank = torch.distributed.get_rank()
-    artifact_key = f"default_rank{rank}"
+    storage, artifact_key = _get_precompile_storage_and_key(compile_config)
 
     def on_compile(compiled_fn, in_spec, out_spec):
         precompile_save(
@@ -101,7 +110,7 @@ def _make_precompile_callback(
             out_spec=out_spec,
             metadata={
                 "world_size": torch.distributed.get_world_size(),
-                "rank": rank,
+                "rank": torch.distributed.get_rank(),
             },
         )
 
@@ -122,11 +131,7 @@ def _apply_aot_compile(
     # When precompile is enabled, check if a cached artifact already exists.
     # If so, skip compilation entirely and load the artifact.
     if compile_config.precompile:
-        from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
-
-        storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
-        rank = torch.distributed.get_rank()
-        artifact_key = f"default_rank{rank}"
+        storage, artifact_key = _get_precompile_storage_and_key(compile_config)
 
         if storage.exists(artifact_key):
             return _apply_aot_compile_load(model, parallel_dims, storage, artifact_key)
@@ -168,17 +173,17 @@ def _apply_aot_compile(
     model = CompiledModule(
         model, parallel_dims, model_joint_graph_builder, parallelize_inputs
     )
-    logger.info(
-        f"Applied AOT compilation (joint graph export) to the model"
-        f"{' with serializable=True (precompile save)' if serializable else ''}"
-    )
+    msg = "Applied AOT compilation (joint graph export) to the model"
+    if serializable:
+        msg += " with serializable=True (precompile save)"
+    logger.info(msg)
     return model
 
 
 def _apply_aot_compile_load(
     model: nn.Module,
     parallel_dims: ParallelDims,
-    storage: object,
+    storage: StorageAdapter,
     artifact_key: str,
 ) -> CompiledModule:
     """Load a precompiled artifact and wrap the model with it."""
@@ -188,10 +193,16 @@ def _apply_aot_compile_load(
 
     precompiled_fn = precompile_load(model, storage, artifact_key)
 
+    def _unused_graph_builder(*args, **kwargs):
+        raise RuntimeError(
+            "joint_graph_builder should not be called when "
+            "using a precompiled artifact"
+        )
+
     compiled_model = CompiledModule(
         model,
         parallel_dims,
-        joint_graph_builder=lambda *a, **kw: None,
+        joint_graph_builder=_unused_graph_builder,
         parallelize_inputs=parallelize_inputs,
         precompiled_fn=precompiled_fn,
     )
@@ -231,6 +242,12 @@ def apply_compile(
     fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
     )
+
+    if compile_config.precompile and mode != "aot":
+        logger.warning(
+            f"--compile.precompile is only supported with --compile.mode=aot, "
+            f"but mode is '{mode}'. Precompile will have no effect."
+        )
 
     if mode == "jit":
         if "model" not in compile_config.components:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -43,7 +43,12 @@ class GraphTrainerCompileConfig(CompileConfig):
     """
 
     precompile_artifact_dir: str = "/tmp/precompile_artifacts"
-    """Directory where precompile artifacts are stored."""
+    """
+    Directory where precompile artifacts are stored. The default /tmp
+    is ephemeral on most cluster environments. For multi-node setups
+    or persistence across job restarts, set this to a shared filesystem
+    path (e.g. under the job output directory).
+    """
 
     fake_tensors: bool = False
     """

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -82,6 +82,19 @@ def precompile_load(
     data = storage.load(artifact_key)
     artifact: PrecompiledArtifact = pickle.loads(data)
 
+    current_params = [name for name, _ in model.named_parameters()]
+    current_buffers = [name for name, _ in model.named_buffers()]
+    if current_params != artifact.params_spec:
+        raise ValueError(
+            f"Parameter mismatch between saved artifact and current model. "
+            f"Saved: {artifact.params_spec}, Current: {current_params}"
+        )
+    if current_buffers != artifact.buffers_spec:
+        raise ValueError(
+            f"Buffer mismatch between saved artifact and current model. "
+            f"Saved: {artifact.buffers_spec}, Current: {current_buffers}"
+        )
+
     logger.info(
         f"Precompile artifact loaded: key={artifact_key}, "
         f"params={len(artifact.params_spec)}, "
@@ -99,7 +112,7 @@ def precompile_load(
         # to be set by the time the first forward runs).
         if not compiled_fn_holder:
             logger.info(
-                f"Deserializing compiled fn on device " f"{torch.cuda.current_device()}"
+                f"Deserializing compiled fn on device {torch.cuda.current_device()}"
             )
             compiled_fn_holder.append(
                 BundledAOTAutogradSerializableCallable.deserialize_compile_artifacts(

--- a/torchtitan/experiments/graph_trainer/storage.py
+++ b/torchtitan/experiments/graph_trainer/storage.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -28,7 +29,7 @@ class StorageAdapter(ABC):
 
 
 class DiskStorageAdapter(StorageAdapter):
-    def __init__(self, base_dir: str) -> None:
+    def __init__(self, base_dir: str | Path) -> None:
         self.base_dir = Path(base_dir)
 
     def _path_for(self, key: str) -> Path:
@@ -37,7 +38,16 @@ class DiskStorageAdapter(StorageAdapter):
     def save(self, key: str, data: bytes) -> str:
         path = self._path_for(key)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(data)
+        # Write to a temp file then atomically rename to avoid
+        # leaving partial files if the process crashes mid-write.
+        fd, tmp_path = tempfile.mkstemp(dir=path.parent)
+        try:
+            with open(fd, "wb") as f:
+                f.write(data)
+            Path(tmp_path).replace(path)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
         return str(path)
 
     def load(self, key: str) -> bytes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2648
* __->__ #2647
* #2646
* #2645
* #2644
* #2643
* #2642

----

- storage.py: Accept Path|str for base_dir, use atomic write-to-temp-
  then-rename pattern to avoid partial files on crash
- precompile.py: Validate params/buffers spec on load against current
  model (raise ValueError on mismatch), fix unnecessary f-string concat
- compile.py: Extract _get_precompile_storage_and_key helper to DRY up
  duplicated storage/rank/key construction, fix storage type annotation
  (object -> StorageAdapter), replace silent None lambda with defensive
  RuntimeError for unused joint_graph_builder, add warning when
  precompile is used with non-AOT mode, use direct attribute access
  instead of getattr for passes, fix f-string without interpolation
- configs.py: Expand precompile_artifact_dir docstring to note /tmp is
  ephemeral and users should use a persistent/shared path