### PR TITLE
[graph_trainer] Address review: validate fake_tensors requires precompile

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -54,10 +54,17 @@ class GraphTrainerCompileConfig(CompileConfig):
     """
     Use FakeTensorMode during precompilation. Model weights and inputs are
     fake tensors — no GPU memory allocated. Requires real torchrun (real PGs)
-    so compiled artifacts have correct process group names. Implies
+    so compiled artifacts have correct process group names. Requires
     precompile=True. After compilation completes, the process exits since
     training cannot proceed with fake tensors.
     """
+
+    def __post_init__(self):
+        if self.fake_tensors and not self.precompile:
+            raise ValueError(
+                "--compile.fake-tensors requires --compile.precompile. "
+                "fake_tensors only makes sense during precompilation."
+            )
 
 
 @dataclass(kw_only=True, slots=True)

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -99,7 +99,15 @@ class TestGraphTrainerCompileConfig(unittest.TestCase):
         config = GraphTrainerCompileConfig()
         self.assertFalse(config.fake_tensors)
 
-    def test_fake_tensors_config_custom(self):
+    def test_fake_tensors_config_requires_precompile(self):
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+
+        with self.assertRaises(ValueError):
+            GraphTrainerCompileConfig(enable=True, fake_tensors=True)
+
+    def test_fake_tensors_config_with_precompile(self):
         from torchtitan.experiments.graph_trainer.configs import (
             GraphTrainerCompileConfig,
         )
@@ -107,8 +115,10 @@ class TestGraphTrainerCompileConfig(unittest.TestCase):
         config = GraphTrainerCompileConfig(
             enable=True,
             fake_tensors=True,
+            precompile=True,
         )
         self.assertTrue(config.fake_tensors)
+        self.assertTrue(config.precompile)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -26,7 +26,6 @@ class GraphTrainer(Trainer):
 
     def __init__(self, config: Config):
         if config.compile.fake_tensors:
-            config.compile.precompile = True
             self._fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
 
             original_to_empty = torch.nn.Module.to_empty
@@ -48,12 +47,12 @@ class GraphTrainer(Trainer):
             super().__init__(config)
 
     def train(self):
-        if self._fake_mode is not None:
-            self._precompile_and_exit()
+        if self.config.compile.precompile and self._fake_mode is not None:
+            self._precompile_with_fake_tensors()
         else:
             super().train()
 
-    def _precompile_and_exit(self):
+    def _precompile_with_fake_tensors(self):
         """
         Trigger AOT compilation with fake tensors and save the artifact.
         We call the joint_graph_builder directly (not the full forward)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2648
* #2647
* #2646
* #2645
* #2644
* #2643
* #2642

----

- Error in __post_init__ if fake_tensors=True without precompile=True
  instead of silently coercing precompile
- Rename _precompile_and_exit to _precompile_with_fake_tensors and
  branch on config.compile.precompile in train() so precompile is the
  top-level condition, not fake_mode
- Update docstring: "Implies" -> "Requires"
- Update tests to verify ValueError on invalid config