### PR TITLE
[rl] Add varlen attention for trainer.

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -200,6 +200,12 @@ class PolicyTrainer(Actor, Configurable):
         Returns:
             Initialized model with weights loaded from checkpoint.
         """
+
+        # TODO Also support flex attention backend later.
+        assert (
+            model_spec.model.layer.attention.attn_backend == "varlen"
+        ), "Only varlen attention backend is allowed."
+
         with torch.device("meta"):
             with utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]):
                 model = model_spec.model.build()
@@ -285,7 +291,10 @@ class PolicyTrainer(Actor, Configurable):
         with torch.no_grad():
             for prompt_toks, gen_toks in zip(my_prompt_token_ids, my_token_ids):
                 token_lps = compute_token_log_probs(
-                    self.ref_model, prompt_toks, gen_toks, device
+                    self.ref_model,
+                    prompt_toks,
+                    gen_toks,
+                    device,
                 )
                 ref_token_log_probs.append(token_lps)
 

--- a/torchtitan/experiments/rl/actors/utils.py
+++ b/torchtitan/experiments/rl/actors/utils.py
@@ -7,29 +7,55 @@
 import torch
 import torch.nn.functional as F
 
+from torchtitan.models.common.attention import VarlenMetadata
+
+
+# TODO We should either unify all the mask creation for RL, or move them to a
+#      single file.
+def build_varlen_metadata(
+    input_sequences: list[tuple[torch.Tensor, int, int]], device: torch.device
+) -> VarlenMetadata:
+    """Build VarlenMetadata for all sequences in a batch."""
+    cu_seqs = torch.cumsum(
+        torch.tensor(
+            [0] + [token_ids.shape[0] for token_ids, _, _ in input_sequences],
+            dtype=torch.int32,
+            device=device,
+        ),
+        0,
+        dtype=torch.int32,
+    )
+    max_len = max(token_ids.shape[0] for token_ids, _, _ in input_sequences)
+    return VarlenMetadata(
+        cu_seq_q=cu_seqs, cu_seq_k=cu_seqs, max_q=max_len, max_k=max_len
+    )
+
 
 def compute_token_log_probs(
     model: torch.nn.Module,
-    prompt_token_ids: list[int],
-    gen_token_ids: list[int],
+    prompt_ids: list[int],
+    gen_ids: list[int],
     device: torch.device,
 ) -> torch.Tensor:
     """
     Compute per-token log probabilities for generated tokens.
+    TODO Only batch size 1 is supported for now.
 
     Args:
         model: The model to use for computing logits
-        prompt_token_ids: Token IDs for the prompt
-        gen_token_ids: Token IDs for the generated completion
+        prompt_ids: Prompt token IDs
+        gen_ids: Generated token IDs
         device: Device to run computation on
 
     Returns:
         Per-token log probabilities for the generated tokens
     """
-    full_sequence = prompt_token_ids + gen_token_ids
-    full_tensor = torch.tensor(
-        full_sequence, dtype=torch.long, device=device
-    ).unsqueeze(0)
+    token_ids = torch.tensor(prompt_ids + gen_ids, dtype=torch.long, device=device)
+    prompt_len = len(prompt_ids)
+    gen_len = len(gen_ids)
+    attention_masks = build_varlen_metadata([(token_ids, prompt_len, gen_len)], device)
+
+    full_tensor = token_ids.unsqueeze(0)
 
     # NOTE: We should move towards batching to improve efficiency here
     # See https://github.com/pytorch/torchtitan/issues/2674
@@ -38,7 +64,7 @@ def compute_token_log_probs(
     seq_len = full_tensor.shape[1]
     positions = torch.arange(seq_len, device=device).unsqueeze(0)
 
-    logits = model(full_tensor, attention_masks=None, positions=positions)
+    logits = model(full_tensor, attention_masks=attention_masks, positions=positions)
 
     # Convert to float32 for numerical stability
     logits_f32 = logits[:, :-1, :].to(torch.float32)
@@ -46,9 +72,8 @@ def compute_token_log_probs(
     target_tokens = full_tensor[:, 1:]
 
     # Extract log probs for generated tokens only
-    prompt_len = len(prompt_token_ids)
     gen_start_idx = prompt_len - 1
-    gen_end_idx = gen_start_idx + len(gen_token_ids)
+    gen_end_idx = gen_start_idx + gen_len
 
     gen_token_logprobs = log_probs[0, gen_start_idx:gen_end_idx, :]
     gen_token_ids_tensor = target_tokens[0, gen_start_idx:gen_end_idx]
@@ -97,7 +122,12 @@ def compute_policy_gradient_loss(
     batch_token_log_probs = []
 
     for prompt_toks, gen_toks in zip(prompt_token_ids, vllm_token_ids):
-        token_lps = compute_token_log_probs(model, prompt_toks, gen_toks, device)
+        token_lps = compute_token_log_probs(
+            model,
+            prompt_toks,
+            gen_toks,
+            device,
+        )
         batch_token_log_probs.append(token_lps)
 
     # Per-token log ratios and KL, averaged across tokens per sample

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -26,8 +26,9 @@ from torchtitan.models.qwen3 import model_registry
 
 def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-0.6B (6 GPUs: 4 gen + 2 train)."""
+    model_spec = model_registry("0.6B", attn_backend_override="varlen")
     return RLTrainer.Config(
-        model_spec=model_registry("0.6B"),
+        model_spec=model_spec,
         hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
         num_steps=10,
         batch_invariant_mode=True,
@@ -65,8 +66,9 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
 
 def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-1.7B (6 GPUs: 4 gen + 2 train)."""
+    model_spec = model_registry("1.7B", attn_backend_override="varlen")
     return RLTrainer.Config(
-        model_spec=model_registry("1.7B"),
+        model_spec=model_spec,
         hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-1.7B",
         num_steps=10,
         batch_invariant_mode=True,
@@ -104,8 +106,9 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
 
 def rl_grpo_qwen3_debug() -> RLTrainer.Config:
     """Debug config for quick iteration -- small model, few steps (2 GPUs: 1 gen + 1 train)."""
+    model_spec = model_registry("debugmodel", attn_backend_override="varlen")
     return RLTrainer.Config(
-        model_spec=model_registry("debugmodel"),
+        model_spec=model_spec,
         num_steps=5,
         batch_invariant_mode=False,
         trainer=PolicyTrainer.Config(

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -247,6 +247,7 @@ class VLLMAttention(LocalMapAttention):
         *,
         scale: float | None = None,
         enable_gqa: bool = False,
+        attention_masks: None = None,  # Unused but needed for GQA varlen inference.
     ) -> torch.Tensor:
         """Run vLLM paged attention on local (non-DTensor) tensors.
 
@@ -284,9 +285,9 @@ class VLLMAttention(LocalMapAttention):
         # which happens with cudagraph capture for dummy input
         output_flat = output_flat.narrow(0, 0, batch_size * seq_len)
 
-        # Reshape back to titan: (batch, num_heads_local, seq_len, head_dim)
-        output = output_flat.view(batch_size, seq_len, -1, head_dim)
-        output = output.transpose(1, 2)
+        # Reshape back to the format expected by GQAttention.forward()
+        # varlen path expects (bs*seqlen, n_heads, head_dim)
+        output = output_flat.view(batch_size * seq_len, -1, head_dim)
 
         return output
 
@@ -329,6 +330,11 @@ def replace_with_vllm_attention(model, tp_degree=1):
 
         # GQA
         head_dim = model_args.layer.attention.head_dim
+
+        # TODO Support flex attention backend later as well.
+        assert (
+            layer.attention.attn_backend == "varlen"
+        ), "Only varlen attention backend is allowed."
         vllm_attn = VLLMAttention(
             hidden_size=model_args.dim,
             num_heads=model_args.layer.attention.n_heads // tp_degree,

--- a/torchtitan/experiments/rl/tests/test_bitwise_identity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_identity.py
@@ -79,7 +79,7 @@ def _log_attention_module(model, label):
 # ---------------------------------------------------------------------------
 
 
-def create_vllm_engine(config):
+def create_vllm_engine(config: RLTrainer.Config) -> LLMEngine:
     """Create a vLLM LLMEngine from the RL config."""
     gen_config = config.generator
     model_path = config.hf_assets_path
@@ -113,7 +113,9 @@ def create_vllm_engine(config):
     return engine
 
 
-def generate_with_vllm(engine, prompt, gen_config):
+def generate_with_vllm(
+    engine: LLMEngine, prompt: str, gen_config: VLLMGenerator.Config
+) -> tuple[list[int], list[int], list[float]]:
     """Generate tokens from *prompt*, return IDs + log-probs."""
     sampling = gen_config.sampling
     sampling_params = SamplingParams(
@@ -135,6 +137,7 @@ def generate_with_vllm(engine, prompt, gen_config):
     assert len(outputs) == 1, f"Expected 1 output, got {len(outputs)}"
     output = outputs[0]
 
+    logger.info('vLLM text output: "%s"', output.outputs[0].text)
     prompt_token_ids = list(output.prompt_token_ids)
     sample = output.outputs[0]
     generated_token_ids = list(sample.token_ids)
@@ -158,8 +161,6 @@ def build_trainer_model(config):
 
     Mirrors PolicyTrainer._build_model() but without the Monarch actor
     framework.
-
-    TODO(zhxchen17) Switch trainer model to use varlen backend with batch-invariant mode.
     """
     model_spec = config.model_spec
     model_config = model_spec.model
@@ -230,8 +231,9 @@ def build_trainer_model(config):
 
 def _test_config() -> RLTrainer.Config:
     """Test-specific config: greedy sampling, fewer tokens, single sample."""
+    model_spec = model_registry("0.6B", attn_backend_override="varlen")
     return RLTrainer.Config(
-        model_spec=model_registry("0.6B"),
+        model_spec=model_spec,
         hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
         batch_invariant_mode=True,
         trainer=PolicyTrainer.Config(
@@ -297,7 +299,10 @@ def main():
 
     with torch.no_grad():
         trainer_token_log_probs = compute_token_log_probs(
-            trainer_model, prompt_token_ids, generated_token_ids, device
+            trainer_model,
+            prompt_token_ids,
+            generated_token_ids,
+            device,
         )
 
     if dist.get_rank() == 0:

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -164,6 +164,9 @@ class VarlenAttentionWrapper(LocalMapAttention):
         attention_masks: VarlenMetadata,
         scale: float | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert isinstance(
+            attention_masks, VarlenMetadata
+        ), f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
 
         cu_seq_q = attention_masks.cu_seq_q
         cu_seq_k = attention_masks.cu_seq_k
@@ -249,6 +252,10 @@ class FlexAttentionWrapper(LocalMapAttention):
         return_lse: bool = False,
         enable_gqa: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert isinstance(
+            block_mask, (BlockMask, type(None))
+        ), f"block_mask must instance of BlockMask or None, got {type(block_mask)}"
+
         # 1. _compiled_flex_attn has to be a class variable, otherwise there will
         #    be multiple compiled flex_attention instances, which can be slow.
         # 2. `self._compiled_flex_attn` is not correct, `self` will be passed in
@@ -643,7 +650,6 @@ class GQAttention(BaseAttention):
                     mask_key = "rope" if self.use_rope else "nope"
                     block_mask = attention_masks[mask_key]
                 else:
-                    assert isinstance(attention_masks, BlockMask), attention_masks
                     block_mask = attention_masks
                 output = (
                     self.inner_attention(
@@ -658,7 +664,6 @@ class GQAttention(BaseAttention):
                     .contiguous()
                 )
             case "varlen":
-                assert isinstance(attention_masks, VarlenMetadata), attention_masks
                 output = self.inner_attention(
                     xq, xk, xv, attention_masks=attention_masks, **scale_kwargs
                 )

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -6,6 +6,8 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
+import copy
+
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, FeedForward, GQAttention, Linear, RoPE
@@ -399,11 +401,21 @@ qwen3_configs = {
 }
 
 
-def model_registry(flavor: str) -> ModelSpec:
+def model_registry(flavor: str, attn_backend_override: str | None = None) -> ModelSpec:
+    model = copy.deepcopy(qwen3_configs[flavor])
+    if attn_backend_override is not None:
+        assert attn_backend_override in [
+            "sdpa",
+            "flex",
+            "varlen",
+        ], f"Invalid attn_backend_override: {attn_backend_override}"
+        model.layer.attention.attn_backend = attn_backend_override
+        if attn_backend_override == "varlen":
+            model.layer.attention.attn_mask_type = "block_causal"
     return ModelSpec(
         name="qwen3",
         flavor=flavor,
-        model=qwen3_configs[flavor],
+        model=model,
         parallelize_fn=parallelize_qwen3,
         pipelining_fn=pipeline_llm,
         build_loss_fn=build_cross_entropy_loss,


### PR DESCRIPTION
Summary:

We previously added varlen attention kernel for generator(vllm) by registering
a CUSTOM backend and using it in Generator Config. In this PR, we added a new
model config with attention_backend set to "varlen".

In the test_attn_numerics.py we are now testing against Qwen variant "0.6B_varlen"
instead of "0.6B" now, which means the generator and trainer should both use varlen
kernel now.

Test Plan:

torchrun --nproc_per_node=2 torchtitan/experiments/rl/tests/test_attn_numerics.py

Reviewers:

Subscribers:

Tasks:

Tags:
