### PR TITLE
[graph_trainer] Add precompile artifact serialization and loading

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -1,0 +1,226 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import hashlib
+import pickle
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchtitan.distributed import ParallelDims
+    from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+
+import torch
+import torch.utils._pytree as pytree
+from torch._dynamo.aot_compile_types import BundledAOTAutogradSerializableCallable
+
+from torchtitan.experiments.graph_trainer.storage import StorageAdapter
+from torchtitan.tools.logging import logger
+
+
+@dataclass
+class PrecompiledArtifact:
+    serialized_fn: bytes
+    params_spec: list[str]
+    buffers_spec: list[str]
+    out_spec: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+    config_fingerprint: str = ""
+
+
+def compute_config_fingerprint(
+    model: torch.nn.Module,
+    compile_config: GraphTrainerCompileConfig,
+    parallel_dims: ParallelDims,
+) -> str:
+    """
+    Compute a fingerprint that captures everything affecting the compiled output:
+    model parameter/buffer shapes and dtypes, parallelism dimensions, and
+    compile configuration. Returns the first 16 chars of a SHA-256 hex digest.
+    """
+    h = hashlib.sha256()
+
+    for name, param in model.named_parameters():
+        h.update(f"param:{name}:{list(param.shape)}:{param.dtype}\n".encode())
+    for name, buf in model.named_buffers():
+        h.update(f"buffer:{name}:{list(buf.shape)}:{buf.dtype}\n".encode())
+
+    for dim_name in (
+        "world_size",
+        "dp_replicate",
+        "dp_shard",
+        "cp",
+        "tp",
+        "pp",
+        "ep",
+        "etp",
+    ):
+        h.update(f"parallel:{dim_name}:{getattr(parallel_dims, dim_name)}\n".encode())
+
+    h.update(f"compile:mode:{compile_config.mode}\n".encode())
+    h.update(f"compile:backend:{compile_config.backend}\n".encode())
+    h.update(f"compile:passes:{list(compile_config.passes)}\n".encode())
+    h.update(f"compile:joint_passes:{list(compile_config.joint_passes)}\n".encode())
+
+    return h.hexdigest()[:16]
+
+
+def _unwrap_serializable(
+    compiled_fn: Any,
+) -> BundledAOTAutogradSerializableCallable:
+    """
+    Extract the BundledAOTAutogradSerializableCallable from compiled_fn.
+    PyTorch's aot_compile_joint_with_descriptors wraps the serializable
+    callable in a plain function via functools.wraps, so we check both
+    the direct object and the __wrapped__ attribute.
+    """
+    if isinstance(compiled_fn, BundledAOTAutogradSerializableCallable):
+        return compiled_fn
+    wrapped = getattr(compiled_fn, "__wrapped__", None)
+    if isinstance(wrapped, BundledAOTAutogradSerializableCallable):
+        return wrapped
+    raise TypeError(
+        f"precompile_save requires the compiled function to be a "
+        f"BundledAOTAutogradSerializableCallable, but got "
+        f"{type(compiled_fn).__name__}. Ensure your compiler pass "
+        f"pipeline produces serializable output (e.g. by including "
+        f"'full_inductor_compilation' in --compile.passes)."
+    )
+
+
+def precompile_save(
+    model: torch.nn.Module,
+    compiled_fn: BundledAOTAutogradSerializableCallable,
+    storage: StorageAdapter,
+    artifact_key: str,
+    out_spec: Any,
+    metadata: dict[str, Any] | None = None,
+    config_fingerprint: str = "",
+) -> str:
+    """
+    Serialize a compiled function and save it via the storage adapter.
+
+    Returns the path/URI of the saved artifact.
+    """
+    compiled_fn = _unwrap_serializable(compiled_fn)
+    serialized_fn = BundledAOTAutogradSerializableCallable.serialize_compile_artifacts(
+        compiled_fn
+    )
+
+    params_spec = [name for name, _ in model.named_parameters()]
+    buffers_spec = [name for name, _ in model.named_buffers()]
+
+    artifact = PrecompiledArtifact(
+        serialized_fn=serialized_fn,
+        params_spec=params_spec,
+        buffers_spec=buffers_spec,
+        out_spec=out_spec,
+        metadata=metadata or {},
+        config_fingerprint=config_fingerprint,
+    )
+
+    data = pickle.dumps(artifact)
+    path = storage.save(artifact_key, data)
+    logger.info(
+        f"Precompile artifact saved: key={artifact_key}, "
+        f"params={len(params_spec)}, buffers={len(buffers_spec)}, "
+        f"size={len(data)} bytes, fingerprint={config_fingerprint}, "
+        f"path={path}"
+    )
+    return path
+
+
+def precompile_load(
+    model: torch.nn.Module,
+    storage: StorageAdapter,
+    artifact_key: str,
+    expected_fingerprint: str,
+) -> Callable:
+    """
+    Load a precompiled artifact and return a wrapper function that
+    binds model parameters/buffers (same calling convention as
+    joint_graph_builder's wrapper_fn).
+    """
+    data = storage.load(artifact_key)
+    artifact: PrecompiledArtifact = pickle.loads(data)
+
+    current_params = [name for name, _ in model.named_parameters()]
+    current_buffers = [name for name, _ in model.named_buffers()]
+    if current_params != artifact.params_spec:
+        raise ValueError(
+            f"Parameter mismatch between saved artifact and current model. "
+            f"Saved: {artifact.params_spec}, Current: {current_params}"
+        )
+    if current_buffers != artifact.buffers_spec:
+        raise ValueError(
+            f"Buffer mismatch between saved artifact and current model. "
+            f"Saved: {artifact.buffers_spec}, Current: {current_buffers}"
+        )
+
+    if expected_fingerprint and artifact.config_fingerprint:
+        if artifact.config_fingerprint != expected_fingerprint:
+            raise ValueError(
+                f"Config fingerprint mismatch: the precompiled artifact was "
+                f"saved with a different model/parallelism/compile configuration. "
+                f"Artifact fingerprint: {artifact.config_fingerprint}, "
+                f"current fingerprint: {expected_fingerprint}. "
+                f"Delete the stale artifact and re-run with precompile to "
+                f"generate a fresh one."
+            )
+    elif expected_fingerprint and not artifact.config_fingerprint:
+        logger.warning(
+            "Precompiled artifact has no config fingerprint (legacy artifact). "
+            "Skipping fingerprint validation. Re-save the artifact to enable "
+            "fingerprint checks."
+        )
+
+    logger.info(
+        f"Precompile artifact loaded: key={artifact_key}, "
+        f"params={len(artifact.params_spec)}, "
+        f"buffers={len(artifact.buffers_spec)}, "
+        f"fingerprint={artifact.config_fingerprint}, "
+        f"metadata={artifact.metadata}"
+    )
+
+    out_spec = artifact.out_spec
+    serialized_fn_bytes = artifact.serialized_fn
+    compiled_fn: Callable | None = None
+
+    def wrapper_fn(args, kwargs):
+        nonlocal compiled_fn
+        # Defer deserialization to first call so that Triton kernels
+        # are loaded on the correct CUDA device (which is guaranteed
+        # to be set by the time the first forward runs).
+        if compiled_fn is None:
+            logger.info(
+                f"Deserializing compiled fn on device {torch.cuda.current_device()}"
+            )
+            compiled_fn = (
+                BundledAOTAutogradSerializableCallable.deserialize_compile_artifacts(
+                    serialized_fn_bytes
+                )
+            )
+
+        # Build the flat input list: params + buffers + user args.
+        # This mirrors the calling convention in joint_graph_builder's
+        # wrapper_fn (graph_utils.py).
+        inputs = [
+            *model.parameters(),
+            *model.buffers(),
+            *args,
+        ]
+        # The deserialized fn returns flat outputs. We need to
+        # unflatten them using the saved out_spec to match the
+        # original model output structure.
+        flat_outputs = compiled_fn(*inputs, **kwargs)
+        if out_spec is not None:
+            return pytree.tree_unflatten(flat_outputs, out_spec)
+        return flat_outputs
+
+    return wrapper_fn

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -5,16 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import pickle
 import tempfile
 import unittest
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import torch
 
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 
 
 class TestDiskStorageAdapter(unittest.TestCase):
     def test_save_load_roundtrip(self):
-        import pickle
-
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
             data = pickle.dumps({"hello": "world", "values": [1, 2, 3]})
@@ -58,6 +61,329 @@ class TestDiskStorageAdapter(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
             storage.delete("nonexistent")
+
+
+class TestPrecompiledArtifact(unittest.TestCase):
+    def test_artifact_pickle_roundtrip(self):
+        from torchtitan.experiments.graph_trainer.precompile import PrecompiledArtifact
+
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake_serialized_data",
+            params_spec=["layer.weight", "layer.bias"],
+            buffers_spec=["running_mean"],
+            out_spec=None,
+            metadata={"world_size": 8, "model_name": "test"},
+        )
+
+        data = pickle.dumps(artifact)
+        loaded = pickle.loads(data)
+
+        self.assertEqual(loaded.serialized_fn, artifact.serialized_fn)
+        self.assertEqual(loaded.params_spec, artifact.params_spec)
+        self.assertEqual(loaded.buffers_spec, artifact.buffers_spec)
+        self.assertEqual(loaded.metadata, artifact.metadata)
+
+
+@dataclass
+class _StubCompileConfig:
+    mode: str = "aot"
+    backend: str = "aot_eager"
+    passes: list = field(default_factory=list)
+    joint_passes: list = field(default_factory=list)
+
+
+@dataclass
+class _StubParallelDims:
+    world_size: int = 8
+    dp_replicate: int = 1
+    dp_shard: int = 2
+    cp: int = 1
+    tp: int = 2
+    pp: int = 2
+    ep: int = 1
+    etp: int = 1
+
+
+def _make_stub_model(params=None, buffers=None):
+    """
+    Build a mock model with controlled named_parameters() and
+    named_buffers() for deterministic fingerprint testing.
+    """
+    if params is None:
+        params = [
+            ("layer.weight", torch.zeros(4, 4)),
+            ("layer.bias", torch.zeros(4)),
+        ]
+    if buffers is None:
+        buffers = [("running_mean", torch.zeros(4))]
+
+    model = MagicMock()
+    # Use side_effect (not return_value) so each call produces a
+    # fresh iterator — just like real nn.Module methods. A single
+    # return_value=iter(...) would be exhausted after the first call.
+    model.named_parameters.side_effect = lambda: iter(params)
+    model.named_buffers.side_effect = lambda: iter(buffers)
+    return model
+
+
+class TestPrecompileSaveLoad(unittest.TestCase):
+    def test_save_load_roundtrip(self):
+        from torch._dynamo.aot_compile_types import (
+            BundledAOTAutogradSerializableCallable,
+        )
+
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            precompile_save,
+        )
+
+        model = torch.nn.Linear(4, 4)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            compiled_fn = MagicMock(spec=BundledAOTAutogradSerializableCallable)
+            with patch.object(
+                BundledAOTAutogradSerializableCallable,
+                "serialize_compile_artifacts",
+                return_value=b"fake_serialized",
+            ):
+                precompile_save(
+                    model,
+                    compiled_fn,
+                    storage,
+                    "test_key",
+                    out_spec=None,
+                    config_fingerprint="abc123",
+                )
+
+            self.assertTrue(storage.exists("test_key"))
+
+            # Load should succeed with matching model
+            wrapper = precompile_load(
+                model, storage, "test_key", expected_fingerprint="abc123"
+            )
+            self.assertTrue(callable(wrapper))
+
+    def test_load_param_mismatch(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            PrecompiledArtifact,
+        )
+
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake",
+            params_spec=["layer.weight", "layer.bias"],
+            buffers_spec=[],
+            out_spec=None,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", pickle.dumps(artifact))
+
+            # Model with different params should fail
+            model = torch.nn.Linear(8, 8)
+            model.extra = torch.nn.Parameter(torch.zeros(1))
+            with self.assertRaises(ValueError, msg="Parameter mismatch"):
+                precompile_load(model, storage, "key", expected_fingerprint="")
+
+    def test_load_buffer_mismatch(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            PrecompiledArtifact,
+        )
+
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake",
+            params_spec=["weight", "bias"],
+            buffers_spec=["running_mean"],
+            out_spec=None,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", pickle.dumps(artifact))
+
+            # nn.Linear has no buffers, so buffers_spec won't match
+            model = torch.nn.Linear(4, 4)
+            with self.assertRaises(ValueError, msg="Buffer mismatch"):
+                precompile_load(model, storage, "key", expected_fingerprint="")
+
+    def test_load_fingerprint_mismatch(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            PrecompiledArtifact,
+        )
+
+        model = torch.nn.Linear(4, 4)
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake",
+            params_spec=[n for n, _ in model.named_parameters()],
+            buffers_spec=[n for n, _ in model.named_buffers()],
+            out_spec=None,
+            config_fingerprint="old_fingerprint",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", pickle.dumps(artifact))
+
+            with self.assertRaises(ValueError, msg="fingerprint mismatch"):
+                precompile_load(
+                    model, storage, "key", expected_fingerprint="new_fingerprint"
+                )
+
+    def test_load_with_out_spec_unflattens(self):
+        from torch._dynamo.aot_compile_types import (
+            BundledAOTAutogradSerializableCallable,
+        )
+
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            PrecompiledArtifact,
+        )
+
+        model = torch.nn.Linear(4, 4)
+        # Build an out_spec from a dict so we can verify unflattening
+        example_output = {"loss": torch.tensor(1.0), "logits": torch.tensor(2.0)}
+        flat_values, out_spec = torch.utils._pytree.tree_flatten(example_output)
+
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake",
+            params_spec=[n for n, _ in model.named_parameters()],
+            buffers_spec=[n for n, _ in model.named_buffers()],
+            out_spec=out_spec,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", pickle.dumps(artifact))
+
+            # Mock deserialize to return a fn that returns flat outputs
+            def fake_compiled_fn(*args, **kwargs):
+                return flat_values
+
+            with patch.object(
+                BundledAOTAutogradSerializableCallable,
+                "deserialize_compile_artifacts",
+                return_value=fake_compiled_fn,
+            ):
+                wrapper = precompile_load(
+                    model, storage, "key", expected_fingerprint=""
+                )
+                result = wrapper((), {})
+
+            self.assertIsInstance(result, dict)
+            self.assertIn("loss", result)
+            self.assertIn("logits", result)
+            self.assertEqual(result["loss"].item(), 1.0)
+            self.assertEqual(result["logits"].item(), 2.0)
+
+    def test_load_legacy_artifact_warns(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_load,
+            PrecompiledArtifact,
+        )
+
+        model = torch.nn.Linear(4, 4)
+        artifact = PrecompiledArtifact(
+            serialized_fn=b"fake",
+            params_spec=[n for n, _ in model.named_parameters()],
+            buffers_spec=[n for n, _ in model.named_buffers()],
+            out_spec=None,
+            config_fingerprint="",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", pickle.dumps(artifact))
+
+            with self.assertLogs(level="WARNING") as cm:
+                precompile_load(model, storage, "key", expected_fingerprint="some_fp")
+            self.assertTrue(any("legacy artifact" in msg for msg in cm.output))
+
+
+class TestPrecompileSaveValidation(unittest.TestCase):
+    def test_non_serializable_compiled_fn_raises(self):
+        from torchtitan.experiments.graph_trainer.precompile import precompile_save
+
+        model = torch.nn.Linear(4, 4)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            not_serializable = lambda *args: None
+            with self.assertRaises(
+                TypeError, msg="BundledAOTAutogradSerializableCallable"
+            ):
+                precompile_save(
+                    model,
+                    not_serializable,
+                    storage,
+                    "test_key",
+                    out_spec=None,
+                )
+
+
+class TestConfigFingerprint(unittest.TestCase):
+    def test_deterministic(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        cfg = _StubCompileConfig()
+        dims = _StubParallelDims()
+
+        fp1 = compute_config_fingerprint(_make_stub_model(), cfg, dims)
+        fp2 = compute_config_fingerprint(_make_stub_model(), cfg, dims)
+        self.assertEqual(fp1, fp2)
+        self.assertEqual(len(fp1), 16)
+
+    def test_model_shape_sensitivity(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        cfg = _StubCompileConfig()
+        dims = _StubParallelDims()
+
+        model_a = _make_stub_model(params=[("w", torch.zeros(4, 4))], buffers=[])
+        model_b = _make_stub_model(params=[("w", torch.zeros(8, 8))], buffers=[])
+        fp_a = compute_config_fingerprint(model_a, cfg, dims)
+        fp_b = compute_config_fingerprint(model_b, cfg, dims)
+        self.assertNotEqual(fp_a, fp_b)
+
+    def test_parallelism_sensitivity(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        cfg = _StubCompileConfig()
+        model = _make_stub_model()
+
+        dims_tp2 = _StubParallelDims(tp=2)
+        dims_tp4 = _StubParallelDims(tp=4)
+        fp_tp2 = compute_config_fingerprint(model, cfg, dims_tp2)
+        fp_tp4 = compute_config_fingerprint(_make_stub_model(), cfg, dims_tp4)
+        self.assertNotEqual(fp_tp2, fp_tp4)
+
+    def test_compile_config_sensitivity(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        dims = _StubParallelDims()
+
+        cfg_a = _StubCompileConfig(passes=["pass_a"])
+        cfg_b = _StubCompileConfig(passes=["pass_a", "pass_b"])
+        fp_a = compute_config_fingerprint(_make_stub_model(), cfg_a, dims)
+        fp_b = compute_config_fingerprint(_make_stub_model(), cfg_b, dims)
+        self.assertNotEqual(fp_a, fp_b)
+
+    def test_pass_order_sensitive(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        dims = _StubParallelDims()
+
+        cfg_ab = _StubCompileConfig(passes=["a", "b"])
+        cfg_ba = _StubCompileConfig(passes=["b", "a"])
+        fp_ab = compute_config_fingerprint(_make_stub_model(), cfg_ab, dims)
+        fp_ba = compute_config_fingerprint(_make_stub_model(), cfg_ba, dims)
+        self.assertNotEqual(fp_ab, fp_ba)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2655
* #2654
* #2653
* __->__ #2652
* #2651

Add precompile_save() and precompile_load() functions that serialize and
deserialize compiled AOT graphs using BundledAOTAutogradSerializableCallable.
Artifacts include the serialized compiled function, parameter/buffer specs,
input/output tree specs, and metadata. Deserialization is deferred to first
call so Triton kernels load on the correct CUDA device.

Pull-Request: https://github.com/pytorch/torchtitan/pull/2643