### PR TITLE
[graph_trainer] Add Llama3 precompile config, tests, and docs

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -69,6 +69,45 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode jit --compile.backend inductor
 ```
 
+### Pre-compile (Serializable Compilation)
+
+Pre-compile lets you save compiled AOT graphs to disk on the first run and
+reload them on subsequent runs, skipping compilation entirely. This is useful
+for large models where compilation time is significant.
+
+```bash
+# First run: compiles with serializable=True, saves artifacts, then trains
+torchrun --nproc_per_node=8 --virtual-local-rank \
+    -m torchtitan.train \
+    --module graph_trainer.llama3 \
+    --config graph_trainer_llama3_precompile \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.tensor_parallel_degree 2
+
+# Subsequent runs: detects existing artifacts, loads them, skips compilation
+torchrun --nproc_per_node=8 --virtual-local-rank \
+    -m torchtitan.train \
+    --module graph_trainer.llama3 \
+    --config graph_trainer_llama3_precompile \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.tensor_parallel_degree 2
+```
+
+Pre-compile requires AOT mode with `full_inductor_compilation` and
+`inductor_decomposition` passes — these are already set in the `_precompile`
+config variants. Artifacts are stored in `/tmp/precompile_artifacts/` by
+default (configurable via `--compile.precompile_artifact_dir`).
+
+The `--virtual-local-rank` flag is required so that each rank sees its GPU as
+device 0, matching the device the Triton kernels were compiled for.
+
+#### Validation
+
+Pre-compile has been validated for bitwise equivalence on Llama3 debugmodel
+with 2D parallelism (FSDP dp=4, TP=2) on 8 GPUs. The three paths — baseline
+(no precompile), precompile-save (first run), and precompile-load (subsequent
+run) — produce identical loss values across all training steps.
+
 ### Composability Support
 
 Some of the features require the updates from PyTorch, with which we are working on providing composability support for the following features:

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -48,3 +48,15 @@ def graph_trainer_llama3_405b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_405b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
+
+
+def graph_trainer_llama3_precompile() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        mode="aot",
+        passes=["full_inductor_compilation"],
+        joint_passes=["inductor_decomposition"],
+        precompile=True,
+    )
+    return config

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -84,6 +84,30 @@ class TestPrecompiledArtifact(unittest.TestCase):
         self.assertEqual(loaded.metadata, artifact.metadata)
 
 
+class TestGraphTrainerCompileConfig(unittest.TestCase):
+    def test_precompile_config_defaults(self):
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+
+        config = GraphTrainerCompileConfig()
+        self.assertFalse(config.precompile)
+        self.assertEqual(config.precompile_artifact_dir, "/tmp/precompile_artifacts")
+
+    def test_precompile_config_custom(self):
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            precompile=True,
+            precompile_artifact_dir="/tmp/test_artifacts",
+        )
+        self.assertTrue(config.precompile)
+        self.assertEqual(config.precompile_artifact_dir, "/tmp/test_artifacts")
+
+
 @dataclass
 class _StubCompileConfig:
     mode: str = "aot"
@@ -315,6 +339,27 @@ class TestPrecompileSaveValidation(unittest.TestCase):
                     "test_key",
                     out_spec=None,
                 )
+
+    def test_unwrap_from_wrapped_attribute(self):
+        """Test that precompile_save can unwrap a plain function whose
+        __wrapped__ attribute is a BundledAOTAutogradSerializableCallable,
+        matching PyTorch's aot_compile_joint_with_descriptors behavior."""
+        from functools import wraps
+
+        from torch._dynamo.aot_compile_types import (
+            BundledAOTAutogradSerializableCallable,
+        )
+
+        from torchtitan.experiments.graph_trainer.precompile import _unwrap_serializable
+
+        inner = MagicMock(spec=BundledAOTAutogradSerializableCallable)
+
+        @wraps(inner)
+        def wrapper(*args, **kwargs):
+            return inner(*args, **kwargs)
+
+        result = _unwrap_serializable(wrapper)
+        self.assertIs(result, inner)
 
 
 class TestConfigFingerprint(unittest.TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2655
* __->__ #2654
* #2653
* #2652
* #2651

- Add llama3_precompile config registry entry for precompilation
- Add TestGraphTrainerCompileConfig unit tests for precompile config fields
- Document precompilation workflow in README

## Validation

Validated on Llama3 debugmodel with AOT + inductor passes (DP=2, TP=2,
PP=2) on 8x H100 GPUs using --debug.deterministic --debug.seed=42 for
10 steps.

Three runs compared, all using the same compile passes
(full_inductor_compilation + inductor_decomposition):
1. AOT baseline: same passes, precompile=false
2. Cold run: precompile=true — compiles, saves artifact, trains
3. Warm run: precompile=true — loads saved artifact, trains

All three produce bitwise-identical loss curves (max |diff| = 0.0).
Verified by extracting full-precision loss values from TensorBoard
event files (loss_metrics/global_avg_loss tag) at every step and
comparing with exact floating-point equality (no epsilon).

Loss comparison plot:
https://github.com/pytorch/torchtitan/releases/download/untagged-f74d367d36dd5650f5be/precompile_bitwise_comparison.png

Test script and full results:
https://gist.github.com/bobrenjc93/f10a064e64babae5b07c9e217f6eed83

Pull-Request: https://github.com/pytorch/torchtitan/pull/2650