### PR TITLE
[graph_trainer] Add disk storage adapter for precompile artifacts

### DIFF
--- a/torchtitan/experiments/graph_trainer/storage.py
+++ b/torchtitan/experiments/graph_trainer/storage.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class StorageAdapter(ABC):
+    @abstractmethod
+    def save(self, key: str, data: bytes) -> str:
+        """Save data under the given key. Returns the path/URI of the saved artifact."""
+        ...
+
+    @abstractmethod
+    def load(self, key: str) -> bytes:
+        """Load data for the given key."""
+        ...
+
+    @abstractmethod
+    def exists(self, key: str) -> bool:
+        """Check if an artifact exists for the given key."""
+        ...
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Delete an artifact for the given key. No-op if it doesn't exist."""
+        ...
+
+
+class DiskStorageAdapter(StorageAdapter):
+    def __init__(self, base_dir: str | Path) -> None:
+        self.base_dir = Path(base_dir)
+
+    def _path_for(self, key: str) -> Path:
+        return self.base_dir / f"{key}.bin"
+
+    def save(self, key: str, data: bytes) -> str:
+        path = self._path_for(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to a temp file then atomically rename to avoid
+        # leaving partial files if the process crashes mid-write.
+        fd, tmp_path = tempfile.mkstemp(dir=path.parent)
+        try:
+            with open(fd, "wb") as f:
+                f.write(data)
+            Path(tmp_path).replace(path)
+        except BaseException:
+            # open(fd) with closefd=True (the default) closes fd on
+            # success or write failure. But if open() itself fails
+            # before constructing the file object, fd is still open.
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+        return str(path)
+
+    def load(self, key: str) -> bytes:
+        path = self._path_for(key)
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Precompile artifact not found at {path}. "
+                f"Run the precompile save phase first."
+            )
+        return path.read_bytes()
+
+    def exists(self, key: str) -> bool:
+        return self._path_for(key).exists()
+
+    def delete(self, key: str) -> None:
+        self._path_for(key).unlink(missing_ok=True)

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import pickle
+import tempfile
+import unittest
+
+from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+
+
+class TestDiskStorageAdapter(unittest.TestCase):
+    def test_save_load_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            data = pickle.dumps({"hello": "world", "values": [1, 2, 3]})
+
+            path = storage.save("test_key", data)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(storage.exists("test_key"))
+
+            loaded = storage.load("test_key")
+            self.assertEqual(data, loaded)
+
+    def test_load_nonexistent_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            with self.assertRaises(FileNotFoundError):
+                storage.load("nonexistent")
+
+    def test_exists_false_for_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            self.assertFalse(storage.exists("missing"))
+
+    def test_save_creates_subdirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested = os.path.join(tmpdir, "a", "b", "c")
+            storage = DiskStorageAdapter(nested)
+            data = b"test"
+            path = storage.save("key", data)
+            self.assertTrue(os.path.exists(path))
+            self.assertEqual(storage.load("key"), data)
+
+    def test_delete_existing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save("key", b"data")
+            self.assertTrue(storage.exists("key"))
+            storage.delete("key")
+            self.assertFalse(storage.exists("key"))
+
+    def test_delete_nonexistent_noop(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.delete("nonexistent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2659
* #2658
* #2657
* __->__ #2656

Add a StorageAdapter abstraction with a DiskStorageAdapter implementation
for persisting compiled training artifacts to disk. This provides a clean
interface for save/load/exists operations on serialized artifacts, keyed
by a string identifier (e.g. "default_rank0").