### PR TITLE
[graph_trainer] Integrate precompile into AOT compilation path

### DIFF
--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -10,8 +10,13 @@ Unified JIT/AOT compilation dispatcher for graph_trainer training.
 Supports two compilation modes via --compile.mode:
 - JIT: standard torch.compile() with custom backend
 - AOT: explicit joint graph export + custom graph passes
+
+Additionally supports pre-compile via --compile.precompile:
+- On first run: compiles with serializable=True, saves the artifact, continues training
+- On subsequent runs: detects existing artifact, loads it, skips compilation
 """
 
+import dataclasses
 import functools
 
 import torch
@@ -36,7 +41,30 @@ from torchtitan.experiments.graph_trainer.graph_utils import (
 from torchtitan.experiments.graph_trainer.jit_backend import (
     get_compile_backend_with_passes,
 )
+from torchtitan.experiments.graph_trainer.storage import (
+    DiskStorageAdapter,
+    StorageAdapter,
+)
 from torchtitan.tools.logging import logger
+
+# Compiler passes whose output supports serialization for precompile.
+# full_inductor_compilation produces OutputCode via compile_fx_inner;
+# regional_inductor produces RegionalOutputCode (an OutputCode subclass).
+_SERIALIZABLE_PASSES: frozenset[str] = frozenset(
+    {"full_inductor_compilation", "regional_inductor"}
+)
+
+
+def _get_precompile_storage_and_key(
+    compile_config: GraphTrainerCompileConfig,
+) -> tuple[StorageAdapter, str]:
+    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+    rank = torch.distributed.get_rank()
+    # Per-rank artifact keys will go away once the Compile on one Rank
+    # (CooR) project lands — at that point we will precompile once and
+    # reuse that artifact across all ranks.
+    artifact_key = f"default_rank{rank}"
+    return storage, artifact_key
 
 
 def _apply_jit_compile(
@@ -60,6 +88,40 @@ def _apply_jit_compile(
     return model
 
 
+def _make_precompile_callback(
+    model: nn.Module,
+    compile_config: GraphTrainerCompileConfig,
+    parallel_dims: ParallelDims,
+):
+    """Build the on_compile callback that saves the compiled artifact to disk."""
+    from torchtitan.experiments.graph_trainer.precompile import (
+        compute_config_fingerprint,
+        precompile_save,
+    )
+
+    storage, artifact_key = _get_precompile_storage_and_key(compile_config)
+    config_fingerprint = compute_config_fingerprint(
+        model, compile_config, parallel_dims
+    )
+
+    # model is read at callback invocation time (synchronous with compilation)
+    def on_compile(compiled_fn, out_spec):
+        precompile_save(
+            model,
+            compiled_fn,
+            storage,
+            artifact_key,
+            out_spec=out_spec,
+            metadata={
+                "world_size": torch.distributed.get_world_size(),
+                "rank": torch.distributed.get_rank(),
+            },
+            config_fingerprint=config_fingerprint,
+        )
+
+    return on_compile
+
+
 def _apply_aot_compile(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -70,6 +132,29 @@ def _apply_aot_compile(
 ) -> CompiledModule:
     """Apply AOT compilation (joint graph export + pass pipeline)."""
     register_blockmask_pytree_node()
+
+    # When precompile is enabled, check if a cached artifact already exists
+    # with a matching config fingerprint. If the fingerprint doesn't match
+    # (e.g. the user changed model shapes or parallelism config), we
+    # discard the stale artifact and fall through to recompile.
+    if compile_config.precompile:
+        storage, artifact_key = _get_precompile_storage_and_key(compile_config)
+
+        if storage.exists(artifact_key):
+            from torchtitan.experiments.graph_trainer.precompile import (
+                compute_config_fingerprint,
+            )
+
+            config_fingerprint = compute_config_fingerprint(
+                model, compile_config, parallel_dims
+            )
+            try:
+                return _apply_aot_compile_load(
+                    model, parallel_dims, storage, artifact_key, config_fingerprint
+                )
+            except ValueError as e:
+                logger.warning(f"Stale precompile artifact detected, recompiling: {e}")
+                storage.delete(artifact_key)
 
     # Get joint custom passes from config
     joint_custom_passes = get_joint_custom_passes_from_config(
@@ -88,6 +173,13 @@ def _apply_aot_compile(
         compiler_passes, dump_folder=dump_folder
     )
 
+    serializable = compile_config.precompile
+    on_compile = (
+        _make_precompile_callback(model, compile_config, parallel_dims)
+        if serializable
+        else None
+    )
+
     # Create custom joint_graph_builder with compilers
     model_joint_graph_builder = functools.partial(
         joint_graph_builder,
@@ -96,13 +188,53 @@ def _apply_aot_compile(
         joint_custom_passes=joint_custom_passes,
         dump_folder=dump_folder,
         compile_config=compile_config,
+        serializable=serializable,
+        on_compile=on_compile,
     )
 
     model = CompiledModule(
         model, parallel_dims, model_joint_graph_builder, parallelize_inputs
     )
-    logger.info("Applied AOT compilation (joint graph export) to the model")
+    msg = "Applied AOT compilation (joint graph export) to the model"
+    if serializable:
+        msg += " with serializable=True (precompile save)"
+    logger.info(msg)
     return model
+
+
+def _apply_aot_compile_load(
+    model: nn.Module,
+    parallel_dims: ParallelDims,
+    storage: StorageAdapter,
+    artifact_key: str,
+    config_fingerprint: str,
+) -> CompiledModule:
+    """Load a precompiled artifact and wrap the model with it."""
+    from torchtitan.experiments.graph_trainer.precompile import precompile_load
+
+    # BlockMask must be registered as a pytree node before unpickling
+    # the artifact, which may contain BlockMask objects in its specs.
+    register_blockmask_pytree_node()
+
+    precompiled_fn = precompile_load(
+        model, storage, artifact_key, expected_fingerprint=config_fingerprint
+    )
+
+    def _unused_graph_builder(*args, **kwargs):
+        raise RuntimeError(
+            "joint_graph_builder should not be called when "
+            "using a precompiled artifact"
+        )
+
+    compiled_model = CompiledModule(
+        model,
+        parallel_dims,
+        joint_graph_builder=_unused_graph_builder,
+        parallelize_inputs=parallelize_inputs,
+        precompiled_fn=precompiled_fn,
+    )
+    logger.info("Applied precompiled artifact (precompile load) to the model")
+    return compiled_model
 
 
 def apply_compile(
@@ -137,6 +269,21 @@ def apply_compile(
     fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
     )
+
+    if compile_config.precompile and mode != "aot":
+        logger.warning(
+            "--compile.precompile is only supported with --compile.mode=aot, "
+            f"but mode is '{mode}'. Ignoring precompile."
+        )
+        compile_config = dataclasses.replace(compile_config, precompile=False)
+
+    if compile_config.precompile and not (
+        _SERIALIZABLE_PASSES & set(compile_config.passes)
+    ):
+        raise ValueError(
+            "--compile.precompile requires at least one serializable pass "
+            f"({', '.join(sorted(_SERIALIZABLE_PASSES))}) in --compile.passes."
+        )
 
     if mode == "jit":
         if "model" not in compile_config.components:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -35,6 +35,21 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Joint graph pass names to apply on the joint forward-backward
     graph before partitioning. Only used in AOT mode."""
 
+    precompile: bool = False
+    """
+    Enable serializable compilation. On first run, compiles with
+    serializable=True and saves the artifact. On subsequent runs, detects
+    the existing artifact and loads it, skipping compilation entirely.
+    """
+
+    precompile_artifact_dir: str = "/tmp/precompile_artifacts"
+    """
+    Directory where precompile artifacts are stored. The default /tmp
+    is ephemeral on most cluster environments. For multi-node setups
+    or persistence across job restarts, set this to a shared filesystem
+    path (e.g. under the job output directory).
+    """
+
 
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerConfig(Trainer.Config):

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -117,6 +117,8 @@ def joint_graph_builder(
     joint_custom_passes: list[Callable] | None = None,
     dump_folder: str | None = None,
     compile_config: CompileConfig | None = None,
+    serializable: bool = False,
+    on_compile: Callable | None = None,
 ):
     """
     Build a joint forward-backward graph for the model with optional custom compilers.
@@ -129,7 +131,10 @@ def joint_graph_builder(
         bw_compiler: Optional custom backward compiler function
         joint_custom_passes: list of custom passes to run on the joint graph
         dump_folder: Optional folder to dump the graph to
-        job_config: Job configuration
+        compile_config: Compile configuration
+        serializable: If True, compile with serialization support
+        on_compile: Optional callback invoked after compilation with
+            (compiled_fn, out_spec)
     """
     assert isinstance(model_args, tuple)
 
@@ -169,8 +174,20 @@ def joint_graph_builder(
 
     with tracing(tracing_context):
         fn = aot_compile_joint_with_descriptors(
-            joint_with_descriptors, fw_compiler=fw_compiler, bw_compiler=bw_compiler
+            joint_with_descriptors,
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            serializable=serializable,
         )
+
+    if on_compile is not None:
+        on_compile(fn, joint_with_descriptors.out_spec)
+
+    # Note: when serializable=True, PyTorch's aot_compile_joint_with_descriptors
+    # already wraps the compiled function in unflattened_compiled_fn which
+    # unflattens outputs using out_spec internally. We must NOT unflatten
+    # again here. The out_spec is only used in precompile_load where we call
+    # the raw deserialized compiled_fn which returns flat outputs.
 
     def wrapper_fn(args, kwargs):
         inputs = [
@@ -190,6 +207,7 @@ class CompiledModule(Module):
         parallel_dims: ParallelDims,
         joint_graph_builder: Callable,
         parallelize_inputs: Callable,
+        precompiled_fn: Callable | None = None,
         **overrides,
     ) -> None:
         super().__init__()
@@ -198,6 +216,7 @@ class CompiledModule(Module):
 
         self.joint_graph_builder = joint_graph_builder
         self.joint_graph_module = None
+        self.precompiled_fn = precompiled_fn
 
         self.parallelize_inputs = parallelize_inputs
 
@@ -252,9 +271,12 @@ class CompiledModule(Module):
         dt_args, dt_kwargs = self.parallelize_inputs(self.parallel_dims, args, kwargs)
 
         if self.joint_graph_module is None:
-            self.joint_graph_module = self.joint_graph_builder(
-                self.inner, dt_args, dt_kwargs
-            )
+            if self.precompiled_fn is not None:
+                self.joint_graph_module = self.precompiled_fn
+            else:
+                self.joint_graph_module = self.joint_graph_builder(
+                    self.inner, dt_args, dt_kwargs
+                )
 
         # calling the line below returns control to torchtitan's runner
         # letting it call the backward, and optimizer.
@@ -466,6 +488,13 @@ def get_compiler_passes_from_config(
                 functools.partial(
                     AVAILABLE_COMPILER_PASSES[pass_name],
                     fsdp_manual_buckets=get_transformer_block_buckets(model),
+                )
+            )
+        elif pass_name == "regional_inductor" and compile_config.precompile:
+            compiler_passes.append(
+                functools.partial(
+                    AVAILABLE_COMPILER_PASSES[pass_name],
+                    serializable=True,
                 )
             )
         else:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -62,12 +62,45 @@ def transformer_block_bucketing_reordering_pass(
     return gm
 
 
+def _ops_filter_with_distributed(name: str) -> bool:
+    """Ops filter that allows distributed collective ops for serialization.
+
+    The default GraphPickler ops filter only allows aten and fbgemm ops.
+    SimpleFSDP uses _c10d_functional collectives that must also be
+    allowed for the graph to serialize correctly.
+    """
+    return name.startswith(
+        (
+            "torch.ops.aten",
+            "torch.ops.fbgemm",
+            "torch.ops._c10d_functional",
+        )
+    )
+
+
 def regional_inductor_pass(
-    gm: torch.fx.GraphModule, example_inputs
+    gm: torch.fx.GraphModule, example_inputs, *, serializable: bool = False
 ) -> torch.fx.GraphModule:
     """
     Apply regional inductor compilation based on user annotation.
+
+    When serializable=True (precompile mode), sets force_autograd_cache
+    so that regional_inductor wraps its output in RegionalOutputCode,
+    and overrides the ops filter to allow distributed collective ops.
     """
+    if serializable:
+        with torch._functorch.config.patch("force_autograd_cache", True):
+            result = regional_inductor(gm, example_inputs)
+        from torch._inductor.output_code import RegionalOutputCode
+
+        if isinstance(result, RegionalOutputCode):
+            result._ops_filter = _ops_filter_with_distributed
+        else:
+            logger.warning(
+                "regional_inductor with serializable=True did not produce "
+                "RegionalOutputCode; distributed ops may not serialize correctly."
+            )
+        return result
     return regional_inductor(gm, example_inputs)
 
 

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -128,6 +129,9 @@ def _distribute_dtensor(
     )
 
 
+_wrap_class_counter = 0
+
+
 def _register_parametrization(
     module: nn.Module, param_names: list[str], parametrization: nn.Module
 ) -> None:
@@ -138,6 +142,8 @@ def _register_parametrization(
     TODO: In checkpoint saving/loading, avoid parametrization calls when calling
     get_model_state_dict func in torchtitan's torchtitan/components/checkpoint.py.
     """
+    global _wrap_class_counter
+    _wrap_class_counter += 1
     param_name_to_property = {
         param_name: property(
             lambda self, pn=param_name: parametrization(self._parameters[pn])
@@ -145,11 +151,14 @@ def _register_parametrization(
         for param_name in param_names
     }
     module_cls = type(
-        f"SimpleFSDP{module.__class__.__name__}",
+        f"SimpleFSDP{module.__class__.__name__}_{_wrap_class_counter}",
         (module.__class__,),
         param_name_to_property,
     )
     module.__class__ = module_cls
+    # Expose the dynamically created class as a real, importable symbol
+    # so that pickle/GraphPickler can resolve it during serialization.
+    sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
 
 
 class ReplicateComputation(Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2662
* __->__ #2661
* #2657
* #2660

Add precompile and precompile_artifact_dir config fields to
GraphTrainerCompileConfig, and wire serializable compilation through
joint_graph_builder and the AOT compile dispatcher:

- joint_graph_builder: add serializable and on_compile params. When
  serializable=True, passes it to aot_compile_joint_with_descriptors.
  Calls on_compile callback after compilation with the compiled fn and
  tree specs.

- CompiledModule: add precompiled_fn param. When set, uses the
  precompiled function directly instead of calling joint_graph_builder.

- _apply_aot_compile: when precompile=True, checks for existing
  artifacts and loads them (skipping compilation). Otherwise compiles
  with serializable=True and saves the artifact via on_compile callback.

- _make_precompile_callback: builds the on_compile callback that saves
  the compiled artifact to disk.

- regional_inductor_pass: add serializable mode that sets
  force_autograd_cache and overrides the ops filter to allow
  _c10d_functional distributed collective ops.

- simple_fsdp: make dynamically generated SimpleFSDP* classes
  picklable by registering them in sys.modules with unique names.