### PR TITLE
[graph_trainer] Add precompile artifact serialization and loading

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -76,6 +76,13 @@ def compute_config_fingerprint(
     # different PyTorch versions.
     h.update(f"torch_version:{torch.__version__}\n".encode())
 
+    # Compiled Triton kernels are architecture-specific (e.g. SM80 vs
+    # SM90), so artifacts saved on one GPU type may not work on another.
+    # Include the GPU capability to catch cross-machine mismatches.
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability()
+        h.update(f"cuda_capability:{capability}\n".encode())
+
     return h.hexdigest()[:16]
 
 
@@ -229,7 +236,9 @@ def precompile_load(
         ]
         # The deserialized fn returns flat outputs. We need to
         # unflatten them using the saved out_spec to match the
-        # original model output structure.
+        # original model output structure. See also graph_utils.py:wrapper_fn
+        # which does NOT unflatten because the live-compiled fn already
+        # handles it via unflattened_compiled_fn.
         flat_outputs = compiled_fn(*inputs, **kwargs)
         if out_spec is not None:
             return pytree.tree_unflatten(flat_outputs, out_spec)

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -188,7 +188,7 @@ class TestPrecompileSaveLoad(unittest.TestCase):
             # Model with different params should fail
             model = torch.nn.Linear(8, 8)
             model.extra = torch.nn.Parameter(torch.zeros(1))
-            with self.assertRaises(ValueError, msg="Parameter mismatch"):
+            with self.assertRaisesRegex(ValueError, "Parameter mismatch"):
                 precompile_load(model, storage, "key", expected_fingerprint="")
 
     def test_load_buffer_mismatch(self):
@@ -209,7 +209,7 @@ class TestPrecompileSaveLoad(unittest.TestCase):
 
             # nn.Linear has no buffers, so buffers_spec won't match
             model = torch.nn.Linear(4, 4)
-            with self.assertRaises(ValueError, msg="Buffer mismatch"):
+            with self.assertRaisesRegex(ValueError, "Buffer mismatch"):
                 precompile_load(model, storage, "key", expected_fingerprint="")
 
     def test_load_fingerprint_mismatch(self):
@@ -230,7 +230,7 @@ class TestPrecompileSaveLoad(unittest.TestCase):
             storage = DiskStorageAdapter(tmpdir)
             storage.save("key", pickle.dumps(artifact))
 
-            with self.assertRaises(ValueError, msg="fingerprint mismatch"):
+            with self.assertRaisesRegex(ValueError, "fingerprint mismatch"):
                 precompile_load(
                     model, storage, "key", expected_fingerprint="new_fingerprint"
                 )
@@ -311,8 +311,8 @@ class TestPrecompileSaveValidation(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
             not_serializable = lambda *args: None
-            with self.assertRaises(
-                TypeError, msg="BundledAOTAutogradSerializableCallable"
+            with self.assertRaisesRegex(
+                TypeError, "BundledAOTAutogradSerializableCallable"
             ):
                 precompile_save(
                     model,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2667
* #2665
* __->__ #2664
* #2663

Add precompile_save() and precompile_load() functions that serialize and
deserialize compiled AOT graphs using BundledAOTAutogradSerializableCallable.
Artifacts include the serialized compiled function, parameter/buffer specs,
input/output tree specs, and metadata. Deserialization is deferred to first
call so Triton kernels load on the correct CUDA device.