### PR TITLE
[graph_trainer] Add Llama3 precompile config, tests, and docs

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -69,6 +69,49 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode jit --compile.backend inductor
 ```
 
+### Pre-compile (Serializable Compilation)
+
+Pre-compile lets you save compiled AOT graphs to disk on the first run and
+reload them on subsequent runs, skipping compilation entirely. This is useful
+for large models where compilation time is significant.
+
+```bash
+# First run: compiles with serializable=True, saves artifacts, then trains
+torchrun --nproc_per_node=8 --virtual-local-rank \
+    -m torchtitan.train \
+    --module graph_trainer.llama3 \
+    --config graph_trainer_llama3_precompile \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.tensor_parallel_degree 2
+
+# Subsequent runs: detects existing artifacts, loads them, skips compilation
+torchrun --nproc_per_node=8 --virtual-local-rank \
+    -m torchtitan.train \
+    --module graph_trainer.llama3 \
+    --config graph_trainer_llama3_precompile \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.tensor_parallel_degree 2
+```
+
+Pre-compile works with any compiler pass that produces serializable output,
+including `full_inductor_compilation` and `regional_inductor`. Two config
+variants are provided:
+
+- `graph_trainer_llama3_precompile` — full Inductor compilation
+- `graph_trainer_llama3_precompile_regional` — regional Inductor compilation
+
+Artifacts are stored in `/tmp/precompile_artifacts/` by default (configurable
+via `--compile.precompile_artifact_dir`).
+
+#### Validation
+
+Pre-compile has been validated for bitwise equivalence on Llama3
+with 2D parallelism (FSDP dp=4, TP=2) on 8 GPUs for both
+`full_inductor_compilation` and `regional_inductor` passes. The three
+paths — baseline (no precompile), precompile-save (first run), and
+precompile-load (subsequent run) — produce identical loss values across all
+training steps.
+
 ### Composability Support
 
 Some of the features require the updates from PyTorch, with which we are working on providing composability support for the following features:

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -48,3 +48,26 @@ def graph_trainer_llama3_405b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_405b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
+
+
+def graph_trainer_llama3_precompile() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        mode="aot",
+        passes=["full_inductor_compilation"],
+        joint_passes=["inductor_decomposition"],
+        precompile=True,
+    )
+    return config
+
+
+def graph_trainer_llama3_precompile_regional() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        mode="aot",
+        passes=["regional_inductor"],
+        precompile=True,
+    )
+    return config

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -294,6 +294,33 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor",
             ngpu=8,
         ),
+        # === Precompile tests ===
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_precompile",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "AOT llama3 precompile full_inductor_compilation",
+            "aot_llama3_precompile_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_precompile_regional",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "AOT llama3 precompile regional_inductor",
+            "aot_llama3_precompile_regional_inductor",
+            ngpu=8,
+        ),
     ]
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -90,6 +90,30 @@ class TestPrecompiledArtifact(unittest.TestCase):
         self.assertEqual(loaded.metadata, artifact.metadata)
 
 
+class TestGraphTrainerCompileConfig(unittest.TestCase):
+    def test_precompile_config_defaults(self):
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+
+        config = GraphTrainerCompileConfig()
+        self.assertFalse(config.precompile)
+        self.assertEqual(config.precompile_artifact_dir, "/tmp/precompile_artifacts")
+
+    def test_precompile_config_custom(self):
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            precompile=True,
+            precompile_artifact_dir="/tmp/test_artifacts",
+        )
+        self.assertTrue(config.precompile)
+        self.assertEqual(config.precompile_artifact_dir, "/tmp/test_artifacts")
+
+
 @dataclass
 class _StubCompileConfig:
     mode: str = "aot"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2666
* #2665
* #2664
* #2663

----

- Add llama3_precompile and llama3_precompile_regional config registry
  entries for precompilation with full_inductor_compilation and
  regional_inductor passes respectively
- Add integration tests for both precompile variants
- Document precompilation workflow in README

## Validation

Validated on Llama3 debugmodel with AOT compilation (FSDP dp=4, TP=2)
on 8 GPUs using --debug.deterministic --debug.seed=42 for 10 steps.

Three runs compared for each pass (full_inductor_compilation and
regional_inductor):
1. AOT baseline: same passes, precompile=false
2. Cold run: precompile=true — compiles, saves artifact, trains
3. Warm run: precompile=true — loads saved artifact, trains

All three produce bitwise-identical loss curves (max |diff| = 0.0).

### full_inductor_compilation
![full_inductor_compilation precompile comparison](https://github.com/pytorch/torchtitan/releases/download/precompile-loss-v1/precompile_full_inductor_comparison.png)

### regional_inductor
![regional_inductor precompile comparison](https://github.com/pytorch/torchtitan/releases/download/precompile-loss-v1/precompile_regional_inductor_comparison.png)

Test scripts and plotting code:
https://gist.github.com/bobrenjc93/192ea9e481422d68117ef3f1add1892b