### PR TITLE
[Bugfix] Fix missing attribute from compile

### DIFF
--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -167,8 +167,9 @@ def apply_compile_dense_rl(model: nn.Module, compile_config: CompileConfig) -> N
     Also fixes some numeric issues we have observed with ``torch.compile()``.
     See https://github.com/pytorch/torchtitan/issues/2673 for more details.
     """
-    # pyrefly: ignore [missing-attribute]
-    for transformer_block in model.layers.named_children.values():
+    # pyrefly: ignore [missing-attribute, not-callable]
+    for _, transformer_block in model.layers.named_children():
+        # pyrefly: ignore [missing-attribute]
         transformer_block.compile(
             backend=compile_config.backend,
             fullgraph=True,


### PR DESCRIPTION
Minor fix in https://github.com/pytorch/torchtitan/pull/2568 to move apply_compile to distributed/compile caused a bug due to missing `.named_children()` in this integration.  So, update to fix (avoid crashing) for compile on the trainer

