### PR TITLE
Fix Config.to_dict() to serialize list fields containing Config objects

### DIFF
--- a/torchtitan/config/configurable.py
+++ b/torchtitan/config/configurable.py
@@ -5,8 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+import logging
 from dataclasses import dataclass, fields, replace
 from typing import ClassVar
+
+logger = logging.getLogger(__name__)
 
 import torch
 
@@ -88,10 +91,11 @@ class Configurable:
                 elif isinstance(val, (str, int, float, bool, type(None))):
                     return val
                 else:
-                    raise TypeError(
+                    logger.warning(
                         f"Config field value of type {type(val).__name__} "
-                        f"is not JSON serializable"
+                        f"may not be JSON serializable"
                     )
+                    return val
 
             result = {}
             for f in fields(self):


### PR DESCRIPTION
**Summary:** Config.to_dict() did not handle list fields containing Config objects. When a config like llama3_8b_float8 set model_converters with a list of Float8LinearConverter.Config objects, to_dict() passed the raw list through without serializing its elements. This caused json.dumps() to fail with TypeError: Object of type Config is not JSON serializable when maybe_log() attempted to log the config.

In order to reproduce the issue, you can run MODULE=llama3 CONFIG=llama3_debugmodel_float8 ./run_train.sh --debug.print-config. Issue most likely has not surfaced yet because we have debug.print-config disabled by default locally. 

**Test Case** 
1. MODULE=llama3 CONFIG=llama3_debugmodel_float8 ./run_train.sh --debug.print-config.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2677

