### PR TITLE
Use return_aux in FlexAttention to avoid graph breaking warnings.warn

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -152,7 +152,7 @@ class FlexAttentionWrapper(torch.nn.Module):
         # 2. `self._compiled_flex_attn` is not correct, `self` will be passed in
         #    as the first argument, which will cause an error.
         #    `FlexAttentionWrapper._compiled_flex_attn` is correct.
-        out = FlexAttentionWrapper._compiled_flex_attn(
+        out, aux = FlexAttentionWrapper._compiled_flex_attn(
             q,
             k,
             v,
@@ -164,7 +164,7 @@ class FlexAttentionWrapper(torch.nn.Module):
         # Note: return a tuple of Tensor to make converting `lse`
         # to DTensor easier with TP module notation.
         if return_lse:
-            return out[0], out[1].lse
+            return out, aux.lse
         return out
 
 


### PR DESCRIPTION
Using return_lse currently triggers a warning that breaks graph compilation even if you add warnings.warn to exemptions. The warning is triggered here: https://github.com/pytorch/pytorch/blob/v2.10.0/torch/nn/attention/flex_attention.py#L1559

This PR just swaps to using the newer return_aux, with the addition of pulling out the `aux.lse` so the outputs are easily addressable with TP. This unblocks torch.compile with gpt_oss.

Tested on 8xh100 with gpt_oss 20b
