### PR TITLE
[Perf] Add model compile support to gpt oss

### DIFF
--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -238,14 +238,6 @@ def apply_non_moe_tp(
             "attention.wq": ColwiseParallel(use_local_output=False),
             "attention.wk": ColwiseParallel(use_local_output=False),
             "attention.wv": ColwiseParallel(use_local_output=False),
-            "attention.inner_attention": PrepareModuleInputOutput(
-                input_layouts=(Shard(1), Shard(1), Shard(1)),
-                desired_input_layouts=(Shard(1), Shard(1), Shard(1)),
-                use_local_input=True,
-                output_layouts=(Shard(1), Shard(1)),
-                desired_output_layouts=(Shard(1), Shard(1)),
-                use_local_output=False,
-            ),
             "attention.wo": rowwise_output_plan,
             "ffn_norm": norm_plan,
         }


### PR DESCRIPTION
Blocked by #2684 

After the above 2 PRs are merged full graph compilation is supported for gpt_oss!

Results:

I ran this code on 8xH100 for gpt_oss_20b using this command for both runs:

```
torchrun --nproc_per_node=8 \
    -m torchtitan.train \
    --module gpt_oss \
    --config gpt_oss_20b \
    --metrics.log_freq 1 \
    --training.steps 10 \
    --compile.enable
```
[compile-gpt-oss.log](https://github.com/user-attachments/files/26222535/compile-gpt-oss.log)


| | main branch | #2686 | this pr + #2684 | this pr + #2686 + #2684 |
| --- | --- | --- | --- | --- |
| MFU | 16.50% | 18.68% | 17.10% |  19.49% |