### PR TITLE
[BE] Migrate torch.compile calls to `.compile()`

### DIFF
--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -6,6 +6,7 @@
 
 import torch
 import torch.nn as nn
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointWrapper,
 )
@@ -13,6 +14,14 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 from torchtitan.config import CompileConfig
 from torchtitan.models.common.moe import moe as moe_module
 from torchtitan.tools.logging import logger
+
+
+# TODO: Remove this monkeypatch once FakeTensorMode.__init__ is decorated with
+# @torch.compiler.disable(recursive=True) upstream.
+# See https://github.com/pytorch/pytorch/issues/178887
+FakeTensorMode.__init__ = torch.compiler.disable(  # type: ignore[method-assign]
+    FakeTensorMode.__init__, recursive=True
+)
 
 
 def apply_compile_dense(model: nn.Module, compile_config: CompileConfig) -> None:
@@ -33,9 +42,7 @@ def apply_compile_dense(model: nn.Module, compile_config: CompileConfig) -> None
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
-        transformer_block = torch.compile(
-            transformer_block, backend=compile_config.backend, fullgraph=True
-        )
+        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
         # pyrefly: ignore [missing-attribute]
         model.layers.register_module(layer_id, transformer_block)
 
@@ -93,27 +100,13 @@ def apply_compile_sparse(
                             # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
                             # https://github.com/pytorch/torchtitan/issues/1940
                             continue
-                        setattr(
-                            moe,
-                            attr_name,
-                            torch.compile(
-                                submod, backend=compile_config.backend, fullgraph=True
-                            ),
-                        )
+                        submod.compile(backend=compile_config.backend, fullgraph=True)
                 else:
-                    setattr(
-                        block,
-                        attr_name,
-                        torch.compile(
-                            submod, backend=compile_config.backend, fullgraph=True
-                        ),
-                    )
-
+                    submod.compile(backend=compile_config.backend, fullgraph=True)
         else:
             # If it's not a MoE layer, there is no FSDP(GroupedExperts)
             # So we can compile the whole block
-            transformer_block = torch.compile(
-                transformer_block,
+            transformer_block.compile(
                 backend=compile_config.backend,
                 fullgraph=True,
             )
@@ -154,26 +147,3 @@ def apply_compile_sparse(
     # https://github.com/pytorch/pytorch/issues/166460
 
     logger.info("Compiling each TransformerBlock with torch.compile")
-
-
-def apply_compile_dense_rl(model: nn.Module, compile_config: CompileConfig) -> None:
-    """Apply torch.compile in-place to each TransformerBlock for RL training.
-
-    Uses ``Module.compile()`` (in-place) instead of ``torch.compile()`` +
-    ``register_module()`` to preserve weight naming compatibility between
-    the trainer and vLLM generator (avoids ``_orig_mod`` prefix that
-    ``OptimizedModule`` wrapping introduces).
-
-    Also fixes some numeric issues we have observed with ``torch.compile()``.
-    See https://github.com/pytorch/torchtitan/issues/2673 for more details.
-    """
-    # pyrefly: ignore [missing-attribute, not-callable]
-    for _, transformer_block in model.layers.named_children():
-        # pyrefly: ignore [missing-attribute]
-        transformer_block.compile(
-            backend=compile_config.backend,
-            fullgraph=True,
-            dynamic=True,
-        )
-
-    logger.info("Compiled each TransformerBlock with torch.compile (RL in-place)")

--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -80,8 +80,7 @@ def _apply_jit_compile(
         fsdp_reshard_after_forward,
         transformer_block_buckets,
     )
-    model = torch.compile(
-        model,
+    model.compile(
         backend=backend,
         fullgraph=True,
     )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -80,6 +80,13 @@ class PolicyTrainer(Actor, Configurable):
         requested = TORCH_DTYPE_MAP[transfer_dtype] if transfer_dtype else None
         self._transfer_dtype = requested if requested != training_dtype else None
 
+        # The policy and ref models share code objects, so dynamo's
+        # per-code-object cache must hold entries for both grad modes
+        # (grad for policy, no_grad for ref). The default limit of 8
+        # is not enough; 16 accommodates both without recompile storms.
+        # TODO: @Lucaskabela fix recompiles in general as these increase startup
+        torch._dynamo.config.cache_size_limit = 16
+
         # Device setup
         device_module, device_type = utils.device_module, utils.device_type
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")

--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor.parallel import (
 from torchtitan.config import ParallelismConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.compile import apply_compile_dense_rl
+from torchtitan.distributed.compile import apply_compile_dense
 from torchtitan.distributed.tensor_parallel import NoParallel
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ def parallelize_qwen3(
         and compile_config.enable
         and "model" in compile_config.components
     ):
-        apply_compile_dense_rl(model, compile_config)
+        apply_compile_dense(model, compile_config)
 
     return model
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -29,7 +29,6 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
 )
 from torch.nn.attention.varlen import varlen_attn
-from torch.types import Number
 
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
@@ -64,8 +63,8 @@ class VarlenMetadata(NamedTuple):
 
     cu_seq_q: torch.Tensor
     cu_seq_k: torch.Tensor
-    max_q: Number
-    max_k: Number
+    max_q: int
+    max_k: int
 
 
 AttentionMasksType = dict[str, BlockMask] | BlockMask | VarlenMetadata
@@ -187,7 +186,8 @@ class VarlenAttentionWrapper(LocalMapAttention):
         xk_packed = xk_packed.to(torch.bfloat16)
         xv_packed = xv_packed.to(torch.bfloat16)
 
-        return varlen_attn(
+        # pyrefly: ignore [bad-assignment]
+        res: torch.Tensor = varlen_attn(
             xq_packed,
             xk_packed,
             xv_packed,
@@ -207,7 +207,8 @@ class VarlenAttentionWrapper(LocalMapAttention):
             #               is_causal=False.
             #   - (W, 0): Sliding window causal - attend to at most W previous tokens.
             window_size=(-1, 0),
-        ).to(xq.dtype)
+        )
+        return res.to(xq.dtype)
 
 
 class FlexAttentionWrapper(LocalMapAttention):
@@ -488,10 +489,11 @@ def create_varlen_metadata_for_document(
         cu_seqlens_list + [torch.tensor([offset], dtype=torch.int32, device=device)]
     )
 
-    max_seqlen = 0
+    max_seqlen: int = 0
     if len(all_seq_lengths) > 0:
         all_seq_lengths = torch.cat(all_seq_lengths)
         # device to host sync but only done once per model forward
+        # pyrefly: ignore[bad-assignment]
         max_seqlen = all_seq_lengths.max().item()
 
     return VarlenMetadata(


### PR DESCRIPTION
## Summary
Prerequisite: https://github.com/pytorch/pytorch/pull/178330


We migrate calls from `torch.compile` to `.compile` instead.  This is preferred under [PT2 programming model](https://github.com/pytorch/pytorch/blob/e074024e5883f186a1f3c84f690cc8479a56e707/docs/source/user_guide/torch_compiler/compile/programming_model.where_to_apply_compile.md?plain=1#L55) and has benifits that:

1) We modify the module in place (no need for assignment)
2) We retain the original naming (torch.compile prefixes with `._orig_mod`), which may cause issues with weight transfer in RL or AC for instance 
3) We compile 

Fixes https://github.com/pytorch/torchtitan/issues/2622 
Fixes https://github.com/pytorch/torchtitan/issues/2673

## Testing

```bash
pytest tests/unit_tests/test_compile_moe.py
```

```bash
1 passed
```