### PR TITLE
[EP/graph_trainer] Add PaddedExpertParallel and _local_scalar_dense fallback

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.traceback import annotate_fn
 
@@ -35,6 +36,32 @@ from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
 
 
+def _apply_moe_ep_tp_padded(model: nn.Module, parallel_dims: ParallelDims) -> None:
+    """Apply MoE EP/TP using PaddedExpertParallel for compilation compatibility.
+
+    Calls the standard apply_moe_ep_tp but with PaddedExpertParallel swapped in
+    for ExpertParallel. Uses a temporary monkey-patch on the llama4 parallelize
+    module since apply_moe_ep_tp imports ExpertParallel at module level.
+    """
+    from torchtitan.experiments.graph_trainer.padded_expert_parallel import PaddedExpertParallel
+    from torchtitan.models.llama4 import parallelize as llama4_par
+
+    _orig = llama4_par.ExpertParallel
+    llama4_par.ExpertParallel = PaddedExpertParallel
+    try:
+        apply_moe_ep_tp(
+            model,
+            tp_mesh=parallel_dims.get_optional_mesh("tp"),
+            ep_mesh=parallel_dims.get_optional_mesh("ep"),
+            etp_mesh=parallel_dims.get_optional_mesh("etp"),
+            ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
+        )
+    finally:
+        llama4_par.ExpertParallel = _orig
+
+    logger.info("Using PaddedExpertParallel for graph-compilation-compatible EP")
+
+
 def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
@@ -50,16 +77,24 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
 
     """
     from torchtitan.distributed.expert_parallel import ExpertParallel
+    from torchtitan.experiments.graph_trainer.padded_expert_parallel import (
+        PaddedExpertParallel,
+    )
     from torchtitan.models.common.attention import FlexAttentionWrapper
     from torchtitan.models.common.moe.moe import MoE
 
-    ExpertParallel._token_dispatch = annotate_fn({"EP": "dispatch"})(
+    ExpertParallel._token_dispatch = annotate_fn({"comm_region": "token_dispatch"})(
         ExpertParallel._token_dispatch
     )
-    ExpertParallel._token_combine = annotate_fn({"EP": "combine"})(
+    ExpertParallel._token_combine = annotate_fn({"comm_region": "token_combine"})(
         ExpertParallel._token_combine
     )
-    MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
+    PaddedExpertParallel._token_dispatch = annotate_fn(
+        {"comm_region": "token_dispatch"}
+    )(PaddedExpertParallel._token_dispatch)
+    PaddedExpertParallel._token_combine = annotate_fn(
+        {"comm_region": "token_combine"}
+    )(PaddedExpertParallel._token_combine)
 
     FlexAttentionWrapper.forward = annotate_fn(
         {"compile_with_inductor": "flex_attention"}
@@ -123,13 +158,25 @@ def parallelize_deepseekv3(
         maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
-        apply_moe_ep_tp(
-            model,
-            tp_mesh=parallel_dims.get_optional_mesh("tp"),
-            ep_mesh=parallel_dims.get_optional_mesh("ep"),
-            etp_mesh=parallel_dims.get_optional_mesh("etp"),
-            ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
-        )
+        # Use PaddedExpertParallel when force-balanced routing is enabled.
+        # This avoids data-dependent ops (_local_scalar_dense) in the exported
+        # graph that Inductor cannot compile.
+        if parallel_dims.ep_enabled:
+            # Always use PaddedExpertParallel in graph_trainer to avoid
+            # data-dependent ops that Inductor cannot compile.
+            _apply_moe_ep_tp_padded(model, parallel_dims)
+            # Force balanced routing on all MoE modules for static graph shapes
+            for _, block in model.layers.items():
+                if hasattr(block, "moe") and hasattr(block.moe, "router"):
+                    block.moe.router._debug_force_load_balance = True
+        else:
+            apply_moe_ep_tp(
+                model,
+                tp_mesh=parallel_dims.get_optional_mesh("tp"),
+                ep_mesh=parallel_dims.get_optional_mesh("ep"),
+                etp_mesh=parallel_dims.get_optional_mesh("etp"),
+                ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
+            )
 
     if ac_config.mode != "none":
         apply_graph_ac(compile_config, ac_config)

--- a/torchtitan/experiments/graph_trainer/padded_expert_parallel.py
+++ b/torchtitan/experiments/graph_trainer/padded_expert_parallel.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+PaddedExpertParallel: graph-compilation-compatible Expert Parallel.
+
+Temporary workaround that will be removed when the compiler supports
+non-even routing (data-dependent split sizes in all-to-all).
+"""
+
+import torch
+from torch import Tensor
+from torch.distributed._functional_collectives import all_to_all_single_autograd
+from torch.distributed.tensor import DeviceMesh
+from torch.nn import Module
+
+from torchtitan.distributed.expert_parallel import ExpertParallel
+
+
+class PaddedExpertParallel(ExpertParallel):
+    """Expert Parallel with fixed-size all-to-all for graph compilation compatibility.
+
+    Standard ExpertParallel uses data-dependent split sizes for all-to-all
+    (via .tolist()) and dynamic permutation indices (via generate_permute_indices),
+    both of which introduce _local_scalar_dense ops that Inductor cannot compile.
+
+    This variant:
+    1. Pads routed_input so each rank sends/receives equal-sized chunks
+    2. Uses equal-split all-to-all (split_sizes=None)
+    3. Replaces dynamic _permute with a static reshape+transpose for
+       rank-grouped → expert-grouped reordering
+
+    Requires balanced routing (e.g. _debug_force_load_balance=True) so that
+    each EP rank sends the same number of tokens to every other rank.
+    """
+
+    def _token_dispatch(
+        self, mod: Module, inputs: tuple, device_mesh: DeviceMesh
+    ) -> tuple[Tensor, Tensor]:
+        routed_input, num_tokens_per_expert = inputs
+        ep_degree = device_mesh.shape[0]
+        num_local_experts = num_tokens_per_expert.shape[0] // ep_degree
+
+        total_routed_tokens = routed_input.shape[0]
+        dim = routed_input.shape[1]
+        # Pad to be divisible by ep_degree for equal-split all-to-all
+        tokens_per_rank = (total_routed_tokens + ep_degree - 1) // ep_degree
+        padded_total = tokens_per_rank * ep_degree
+        if padded_total > total_routed_tokens:
+            pad = routed_input.new_zeros(
+                padded_total - total_routed_tokens, dim
+            )
+            routed_input = torch.cat([routed_input, pad], dim=0)
+
+        # Save for combine
+        self._unpadded_total = total_routed_tokens
+        self._tokens_per_rank = tokens_per_rank
+        self._ep_degree = ep_degree
+        self._num_local_experts = num_local_experts
+
+        # Equal-split all-to-all for the actual token data
+        routed_input = all_to_all_single_autograd(
+            routed_input,
+            None,  # equal output splits
+            None,  # equal input splits
+            device_mesh.get_group(),
+        )
+
+        # After all-to-all, tokens are arranged as:
+        #   [rank0_expert0..., rank0_expert1..., rank1_expert0..., rank1_expert1..., ...]
+        # With balanced routing, each (rank, expert) chunk has exactly
+        # tokens_per_rank // num_local_experts tokens.
+        # We want expert-grouped layout:
+        #   [expert0_from_rank0, expert0_from_rank1, ..., expert1_from_rank0, ...]
+        # This is a reshape(ep_degree, num_local_experts, tpe, dim) + transpose(0,1).
+        tpe = tokens_per_rank // num_local_experts  # tokens per expert per rank
+        self._tokens_per_expert_per_rank = tpe
+
+        routed_input = (
+            routed_input.view(ep_degree, num_local_experts, tpe, dim)
+            .transpose(0, 1)
+            .contiguous()
+            .view(-1, dim)
+        )
+
+        # Compute static num_tokens_per_expert for grouped_mm offsets.
+        # Each local expert gets tpe * ep_degree tokens total.
+        # Return pre-computed cumsum offsets (int32) directly.
+        # This avoids an Inductor bug where cumsum(..., dtype=int32) produces
+        # int64 during post-grad fake tensor propagation.
+        # _run_experts_grouped_mm computes cumsum on this; since it's already
+        # the cumsum, we store the per-expert counts but mark them for direct use.
+        tokens_per_expert = tpe * ep_degree
+        num_tokens_per_expert_local = torch.full(
+            (num_local_experts,),
+            tokens_per_expert,
+            dtype=torch.int32,
+            device=routed_input.device,
+        )
+
+        return routed_input, num_tokens_per_expert_local
+
+    def _token_combine(
+        self, mod: Module, routed_output: Tensor, device_mesh: DeviceMesh
+    ) -> Tensor:
+        dim = routed_output.shape[1]
+        ep_degree = self._ep_degree
+        num_local_experts = self._num_local_experts
+        tpe = self._tokens_per_expert_per_rank
+
+        # Reverse the expert-grouped → rank-grouped transpose
+        routed_output = (
+            routed_output.view(num_local_experts, ep_degree, tpe, dim)
+            .transpose(0, 1)
+            .contiguous()
+            .view(-1, dim)
+        )
+
+        # Reverse all-to-all with equal splits
+        routed_output = all_to_all_single_autograd(
+            routed_output,
+            None,  # equal output splits
+            None,  # equal input splits
+            device_mesh.get_group(),
+        )
+
+        # Remove padding added during dispatch
+        if routed_output.shape[0] > self._unpadded_total:
+            routed_output = routed_output[: self._unpadded_total]
+
+        return routed_output

--- a/torchtitan/models/common/moe/moe.py
+++ b/torchtitan/models/common/moe/moe.py
@@ -63,7 +63,10 @@ def _run_experts_grouped_mm(
     x: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
 ) -> torch.Tensor:
-    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+    # Two-step cumsum to work around Inductor lowering bug where
+    # cumsum(..., dtype=torch.int32) produces int64 in post-grad passes.
+    offsets = torch.cumsum(num_tokens_per_expert.to(torch.int32), dim=0)
+    offsets = offsets.to(torch.int32)
 
     h = F.silu(
         torch._grouped_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets)


### PR DESCRIPTION
[EP/graph_trainer] Add PaddedExpertParallel and _local_scalar_dense fallback

Add PaddedExpertParallel, a graph-compilation-compatible alternative to
ExpertParallel that avoids data-dependent ops (_local_scalar_dense).

Standard ExpertParallel uses dynamic split sizes for all-to-all and
dynamic permutation indices, both of which introduce _local_scalar_dense
ops that Inductor cannot compile. PaddedExpertParallel instead:
1. Pads routed_input so each rank sends/receives equal-sized chunks
2. Uses equal-split all-to-all (split_sizes=None)
3. Replaces dynamic _permute with static reshape+transpose

Also updates the graph_trainer DeepSeek V3 parallelize to use
PaddedExpertParallel when EP is enabled, force-balance routing on
all MoE modules, and annotate PaddedExpertParallel for FX tracing.

This is temporary infrastructure that will be removed when non-even
routing support lands in the compiler.