### PR TITLE
[graph_trainer] Wire graph PP into DeepSeek V3 and trainer

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
@@ -9,6 +9,8 @@ from dataclasses import fields
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.compile import graph_pp_pipeline_llm
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -30,13 +32,20 @@ def _to_graph_trainer_configs(base_configs):
 _graph_trainer_configs = _to_graph_trainer_configs(deepseekv3_configs)
 
 
+def _pipelining_fn(model, *, compile_config, **kwargs):
+    """Dispatch to graph PP when using GraphTrainerCompileConfig, else standard PP."""
+    if isinstance(compile_config, GraphTrainerCompileConfig):
+        return graph_pp_pipeline_llm(model, compile_config=compile_config, **kwargs)
+    return pipeline_llm(model, compile_config=compile_config, **kwargs)
+
+
 def model_registry(flavor: str) -> ModelSpec:
     return ModelSpec(
         name="graph_trainer/deepseek_v3",
         flavor=flavor,
         model=_graph_trainer_configs[flavor],
         parallelize_fn=parallelize_deepseekv3,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=_pipelining_fn,
         build_loss_fn=build_cross_entropy_loss,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -18,6 +18,38 @@ class GraphTrainer(Trainer):
             default_factory=GraphTrainerCompileConfig
         )
 
+    def train_step(self, *args, **kwargs):
+        """Override to handle SymFloat grad_norm from fx.Interpreter execution.
+
+        When graph PP executes subgraphs via fx.Interpreter, gradient
+        operations may return SymFloat instead of regular Tensor. The
+        base trainer's clip_grad_norm_ can return SymFloat which breaks
+        metrics formatting. This override calls the parent and lets it
+        handle the error, then the metrics log converts appropriately.
+        """
+        # Temporarily patch metrics_processor.log to convert grad_norm
+        original_log = self.metrics_processor.log
+
+        def patched_log(step, avg_loss, max_loss, grad_norm, **kw):
+            # Handle SymFloat/SymInt from fx.Interpreter backward execution
+            import torch
+
+            if isinstance(grad_norm, (torch.SymFloat, torch.SymInt)):
+                grad_norm = torch.sym_float(grad_norm)
+                # Try to get the concrete hint value
+                if hasattr(grad_norm, "node") and hasattr(grad_norm.node, "hint"):
+                    hint = grad_norm.node.hint
+                    grad_norm = hint if hint is not None else float("inf")
+                else:
+                    grad_norm = float("inf")
+            return original_log(step, avg_loss, max_loss, grad_norm, **kw)
+
+        self.metrics_processor.log = patched_log
+        try:
+            super().train_step(*args, **kwargs)
+        finally:
+            self.metrics_processor.log = original_log
+
     def close(self) -> None:
         super().close()
 


### PR DESCRIPTION
[graph_trainer] Wire graph PP into DeepSeek V3 and trainer

Add _pipelining_fn to graph_trainer's DeepSeek V3 model_registry that
dispatches to graph_pp_pipeline_llm when graph_pp_passes are configured,
falling back to standard pipeline_llm otherwise.

Add train_step override to GraphTrainer that handles SymFloat grad_norm
values from fx.Interpreter execution. When graph PP executes subgraphs
via the interpreter, gradient operations may return SymFloat instead of
regular Tensor, which breaks metrics formatting.