### PR TITLE
[graph_trainer] Add graph PP documentation to README

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -69,6 +69,39 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode jit --compile.backend inductor
 ```
 
+### Graph-based Pipeline Parallelism
+
+Graph PP captures the joint forward/backward graph per pipeline stage, then applies
+graph passes to partition FSDP collectives and enable zero-bubble scheduling. It
+requires AOT mode (`--compile.mode aot`, the default).
+
+Graph PP passes are auto-inferred from the parallelism config:
+- `split_fsdp_collectives` is enabled when FSDP is active
+- `split_dI_dW` is enabled for V-schedules (DualPipeV, ZBV)
+
+> **Note:** Graph PP currently requires balanced MoE routing
+> (`_debug_force_load_balance=True`) to avoid data-dependent ops
+> (`_local_scalar_dense`) that Inductor cannot compile. The `16B_sdpa_balanced`
+> and `debugmodel_balanced` configs have this enabled. This requirement is
+> temporary and will be removed once Inductor supports non-even routing.
+
+#### Training DeepSeek-v3-16B with graph PP (PP=2, FSDP=4, EP=4)
+```bash
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b_sdpa_balanced ./run_train.sh \
+  --parallelism.pipeline_parallel_degree 2 \
+  --parallelism.data_parallel_shard_degree 4 \
+  --parallelism.expert_parallel_degree 4
+```
+
+#### Training DeepSeek-v3-16B with graph PP and DualPipeV schedule
+```bash
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b_sdpa_balanced ./run_train.sh \
+  --parallelism.pipeline_parallel_degree 2 \
+  --parallelism.data_parallel_shard_degree 4 \
+  --parallelism.expert_parallel_degree 4 \
+  --parallelism.pipeline_parallel_schedule DualPipeV
+```
+
 ### Composability Support
 
 Some of the features require the updates from PyTorch, with which we are working on providing composability support for the following features:
@@ -87,8 +120,8 @@ Some of the features require the updates from PyTorch, with which we are working
 |Float8 Training| ✅ |
 |Expert Parallelism| ✅ |
 |Expert Parallelism + Activation Checkpointing| 🚧 |
-|Expert Parallelism + Pipeline Parallelism| 🚧 |
-|Graph-based Pipeline Parallelism| 🚧 |
+|Expert Parallelism + Pipeline Parallelism| ✅ (AOT mode, balanced routing only) |
+|Graph-based Pipeline Parallelism| ✅ (AOT mode, balanced routing only) |
 |Micro-batch overlap| 🚧 |
 |Pre-compile| 🚧 |
 


### PR DESCRIPTION
[graph_trainer] Add graph PP documentation to README

Add Graph-based Pipeline Parallelism section with run commands for
DeepSeek-v3-16B with Interleaved1F1B and DualPipeV schedules. Note
that balanced routing is temporarily required until Inductor supports
non-even routing. Update composability table accordingly.