### PR TITLE
[deepseek_v3/graph_trainer] Add 16B_sdpa and debugmodel_balanced configs

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -11,8 +11,10 @@ from torchtitan.experiments.graph_trainer.configs import (
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
+    deepseek_v3_16b_sdpa_balanced,
     deepseek_v3_671b,
     deepseek_v3_debugmodel,
+    deepseek_v3_debugmodel_balanced,
     deepseek_v3_debugmodel_flex_attn,
 )
 
@@ -25,6 +27,12 @@ def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_debugmodel_balanced() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(deepseek_v3_debugmodel_balanced(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
 def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> (GraphTrainer.Config):
     config = to_graph_trainer_config(deepseek_v3_debugmodel_flex_attn(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
@@ -33,6 +41,12 @@ def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> (GraphTrainer.Config):
 
 def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_16b(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_16b_sdpa_balanced() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(deepseek_v3_16b_sdpa_balanced(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
+
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
@@ -284,6 +286,34 @@ deepseekv3_configs = {
         ),
     ),
 }
+
+
+# debugmodel_balanced: debugmodel with force-balanced MoE routing (for debugging purposes)
+_dm = deepseekv3_configs["debugmodel"]
+_dm_router = dataclasses.replace(
+    _dm.layer.moe.router, _debug_force_load_balance=True
+)
+_dm_moe = dataclasses.replace(_dm.layer.moe, router=_dm_router)
+_dm_layer = dataclasses.replace(_dm.layer, moe=_dm_moe)
+deepseekv3_configs["debugmodel_balanced"] = dataclasses.replace(
+    _dm, layer=_dm_layer
+)
+
+# 16B_sdpa_balanced: 16B with sdpa attention and force-balanced MoE routing
+_16b = deepseekv3_configs["16B"]
+_16b_sdpa_attn = dataclasses.replace(
+    _16b.layer.attention, attn_backend="sdpa", attn_mask_type="causal"
+)
+_16b_sdpa_router = dataclasses.replace(
+    _16b.layer.moe.router, _debug_force_load_balance=True
+)
+_16b_sdpa_moe = dataclasses.replace(_16b.layer.moe, router=_16b_sdpa_router)
+_16b_sdpa_layer = dataclasses.replace(
+    _16b.layer, attention=_16b_sdpa_attn, moe=_16b_sdpa_moe
+)
+deepseekv3_configs["16B_sdpa_balanced"] = dataclasses.replace(
+    _16b, layer=_16b_sdpa_layer
+)
 
 
 def model_registry(flavor: str) -> ModelSpec:

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -96,6 +96,20 @@ def deepseek_v3_16b() -> Trainer.Config:
     )
 
 
+def deepseek_v3_debugmodel_balanced() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.model_spec = model_registry("debugmodel_balanced")
+    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
+    return config
+
+
+def deepseek_v3_16b_sdpa_balanced() -> Trainer.Config:
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry("16B_sdpa_balanced")
+    config.activation_checkpoint = ActivationCheckpointConfig(mode="none")
+    return config
+
+
 def deepseek_v3_671b() -> Trainer.Config:
     return Trainer.Config(
         hf_assets_path="./assets/hf/DeepSeek-V3.1-Base",


### PR DESCRIPTION
Stacked PRs:
 * #2708
 * #2707
 * #2706
 * #2705
 * #2704
 * #2703
 * __->__#2702


--- --- ---

[deepseek_v3/graph_trainer] Add 16B_sdpa and debugmodel_balanced configs

Add model config variants for graph-compilation-compatible benchmarking:
- 16B_sdpa: 16B with sdpa attention (instead of flex) and balanced routing
- debugmodel_balanced: debugmodel with force-balanced MoE routing

These variants avoid flex attention and data-dependent routing ops that
Inductor cannot compile, enabling end-to-end graph compilation.