### PR TITLE
[graph_trainer] Add core graph PP infrastructure

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -37,6 +37,7 @@ class GraphTrainerCompileConfig(CompileConfig):
     graph before partitioning. Only used in AOT mode."""
 
 
+
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerConfig(Trainer.Config):
     compile: GraphTrainerCompileConfig = field(

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -532,3 +532,415 @@ def get_joint_custom_passes_from_config(
     )
 
     return joint_custom_passes
+
+
+def pp_joint_graph_builder(
+    model: torch.nn.Module,
+    model_args: tuple,
+    model_kwargs: dict,
+    fw_compiler: Callable | None = None,
+    bw_compiler: Callable | None = None,
+    joint_custom_passes: list[Callable] | None = None,
+    dump_folder: str | None = None,
+    compile_config: CompileConfig | None = None,
+    graph_pp_passes: list[str] | None = None,
+    parallel_dims: ParallelDims | None = None,
+):
+    """
+    Build a joint forward-backward graph, partition it, and apply graph PP
+    passes (split_fsdp_collectives, split_dI_dW) to produce subgraphs for
+    graph-based pipeline parallelism execution via GraphPPRunner.
+
+    Args:
+        model: The model to compile
+        model_args: Tuple of model input arguments
+        model_kwargs: Dict of model input keyword arguments
+        fw_compiler: Optional custom forward compiler function
+        bw_compiler: Optional custom backward compiler function
+        joint_custom_passes: list of custom passes to run on the joint graph
+        dump_folder: Optional folder to dump the graph to
+        compile_config: Compile configuration
+        graph_pp_passes: List of graph PP pass names to apply
+        parallel_dims: Parallel dimensions for pipeline configuration
+    """
+    from autoparallel.graph_passes.graph_partition import (
+        partition_joint_with_descriptors,
+    )
+
+    assert isinstance(model_args, tuple)
+    assert graph_pp_passes, "graph_pp_passes must be non-empty"
+    assert parallel_dims is not None and parallel_dims.pp_enabled
+
+    valid_passes = {"split_fsdp_collectives", "split_dI_dW"}
+    for p in graph_pp_passes:
+        if p not in valid_passes:
+            raise ValueError(
+                f"Unknown graph PP pass: {p}. Available: {sorted(valid_passes)}"
+            )
+
+    # Step 1: Export the joint graph
+    joint_with_descriptors, tracing_context = export_joint(
+        model, model_args, model_kwargs, dump_folder=dump_folder
+    )
+
+    # Step 2: Always apply inductor decompositions for graph PP.
+    # The PP subgraphs are compiled with Inductor (compile_fx_inner)
+    # which requires ops to be decomposed first.
+    from torchtitan.experiments.graph_trainer.passes import inductor_decomposition_pass
+
+    decomp_pass = functools.partial(
+        inductor_decomposition_pass,
+        joint_with_descriptors=joint_with_descriptors,
+    )
+    if joint_custom_passes is None:
+        joint_custom_passes = []
+    joint_custom_passes = [decomp_pass] + joint_custom_passes
+
+    # Step 3: Run custom passes on joint graph before partitioning
+    if joint_custom_passes is not None:
+        for joint_custom_pass in joint_custom_passes:
+            joint_with_descriptors.graph_module = joint_custom_pass(
+                joint_with_descriptors.graph_module
+            )
+
+    # Step 4: Partition into fw/bw using autoparallel's partitioner
+    with tracing(tracing_context):
+        (
+            fw_module,
+            bw_module,
+            num_params_buffers,
+            num_user_outputs,
+            num_mutate_inputs,
+            num_fw_outs_saved_for_bw,
+            num_symints_saved_for_bw,
+            _indices_of_inps_to_detach,
+            adjusted_flat_args,
+        ) = partition_joint_with_descriptors(joint_with_descriptors)
+
+    num_params = len(list(model.parameters()))
+    num_buffers = len(list(model.buffers()))
+    assert num_params_buffers == num_params + num_buffers, (
+        f"num_params_buffers: {num_params_buffers}, "
+        f"num_params: {num_params}, num_buffers: {num_buffers}"
+    )
+    num_input_grads = (
+        len(bw_module.graph.find_nodes(op="output")[0].args[0]) - num_params_buffers
+    )
+
+    _dump_gm(dump_folder, fw_module, "pp_fw_module")
+    _dump_gm(dump_folder, bw_module, "pp_bw_module")
+
+    logger.info(
+        f"Partitioned joint graph: {num_params_buffers=}, {num_user_outputs=}, "
+        f"{num_mutate_inputs=}, {num_input_grads=}, "
+        f"{num_fw_outs_saved_for_bw=}, {num_symints_saved_for_bw=}"
+    )
+
+    # Step 5: Apply split_fsdp_collectives if configured
+    unshard_module = None
+    reduce_grad_module = None
+    if "split_fsdp_collectives" in graph_pp_passes:
+        from autoparallel.graph_passes.split_fsdp_collectives import (
+            split_fsdp_prefetch,
+            split_fsdp_reduce_scatters_epilogue,
+        )
+
+        unshard_module, fw_module = split_fsdp_prefetch(fw_module, num_params)
+        bw_module, reduce_grad_module = split_fsdp_reduce_scatters_epilogue(
+            bw_module, num_params
+        )
+        _dump_gm(dump_folder, unshard_module, "pp_unshard_module")
+        _dump_gm(dump_folder, fw_module, "pp_fw_module_no_fsdp")
+        _dump_gm(dump_folder, bw_module, "pp_bw_module_no_fsdp")
+        _dump_gm(dump_folder, reduce_grad_module, "pp_reduce_grad_module")
+        logger.info("Applied split_fsdp_collectives pass")
+
+    # Step 6: Apply split_dI_dW if configured
+    bw_dI_module = None
+    bw_dW_module = None
+    if "split_dI_dW" in graph_pp_passes:
+        from autoparallel.graph_passes.split_di_dw_graph import split_di_dw_graph
+
+        bw_dI_module, bw_dW_module, num_input_grads = split_di_dw_graph(
+            bw_module, num_weight_gradients=num_params_buffers
+        )
+        _dump_gm(dump_folder, bw_dI_module, "pp_bw_dI_module")
+        _dump_gm(dump_folder, bw_dW_module, "pp_bw_dW_module")
+        logger.info("Applied split_dI_dW pass")
+
+    # Step 7: Apply compiler passes to each subgraph
+    subgraphs = {
+        "fw": fw_module,
+        "full_bw": bw_module,
+        "bw_dI": bw_dI_module,
+        "bw_dW": bw_dW_module,
+        "unshard": unshard_module,
+        "reduce_grad": reduce_grad_module,
+    }
+    if fw_compiler is not None:
+        for name, gm in subgraphs.items():
+            if gm is not None:
+                is_fw = name in ("fw", "unshard")
+                compile_fn = fw_compiler if is_fw else bw_compiler
+                example_inputs = [
+                    node.meta.get("val")
+                    for node in gm.graph.find_nodes(op="placeholder")
+                ]
+                subgraphs[name] = compile_fn(gm, example_inputs)
+
+    # Step 8: Build GraphCallables and GraphMeta
+    from autoparallel.graph_passes.graph_pp_runner import GraphCallables, GraphMeta
+
+    graph_callables = GraphCallables(
+        fw=subgraphs["fw"],
+        full_bw=subgraphs["full_bw"],
+        bw_dI=subgraphs["bw_dI"],
+        bw_dW=subgraphs["bw_dW"],
+        unshard=subgraphs["unshard"],
+        reduce_grad=subgraphs["reduce_grad"],
+    )
+    graph_meta = GraphMeta(
+        num_mutate_inputs=num_mutate_inputs,
+        num_user_outputs=num_user_outputs,
+        num_symints_saved_for_bw=num_symints_saved_for_bw,
+        num_params=num_params,
+        num_buffers=num_buffers,
+        num_input_grads=num_input_grads,
+    )
+
+    return graph_callables, graph_meta
+
+
+class CompiledPPModule(Module):
+    """Wraps a model for graph-based pipeline parallelism execution.
+
+    On first forward, builds the PP subgraphs (fw, bw, unshard, reduce_grad,
+    etc.), constructs GraphPipelineStages, and wires them into a
+    GraphPPRunner that executes the pipeline schedule.
+    """
+
+    def __init__(
+        self,
+        inner: torch.nn.Module,
+        parallel_dims: ParallelDims,
+        pp_joint_graph_builder_fn: Callable,
+        parallelize_inputs: Callable,
+        pp_schedule_builder: Callable,
+        **overrides,
+    ) -> None:
+        super().__init__()
+        self.inner = inner
+        self.parallel_dims = parallel_dims
+        self.pp_joint_graph_builder_fn = pp_joint_graph_builder_fn
+        self.parallelize_inputs = parallelize_inputs
+        self.pp_schedule_builder = pp_schedule_builder
+        self._pp_runner = None
+        self._overrides = overrides
+
+    def __getattr__(self, name: str):
+        if "_overrides" in self.__dict__ and name in self._overrides:
+            return self._overrides[name]
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.inner, name)
+
+    def __setattr__(self, name: str, value) -> None:
+        if "_overrides" in self.__dict__ and name in self._overrides:
+            self._overrides[name] = value
+        else:
+            super().__setattr__(name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if "_overrides" in self.__dict__ and name in self._overrides:
+            del self._overrides[name]
+        else:
+            super().__delattr__(name)
+
+    def init_weights(self, **kwargs) -> None:
+        self.inner.init_weights(**kwargs)
+
+    def state_dict(self, *args, **kwargs) -> Any:
+        return self.inner.state_dict(*args, **kwargs)
+
+    def load_state_dict(self, *args, **kwargs) -> Any:
+        return self.inner.load_state_dict(*args, **kwargs)
+
+    def named_parameters(self, *args, **kwargs) -> Any:
+        return self.inner.named_parameters(*args, **kwargs)
+
+    def parameters(self, *args, **kwargs) -> Any:
+        return self.inner.parameters(*args, **kwargs)
+
+    def _build_pp_runner(self, dt_args, dt_kwargs):
+        """Build graph callables and construct the GraphPPRunner."""
+        from autoparallel.graph_passes.graph_pp_runner import (
+            GraphPipelineStage,
+            GraphPPRunner,
+            stage_backward_input,
+            stage_backward_weight,
+            stage_forward,
+            stage_full_backward,
+            stage_reduce_grad,
+            stage_reshard,
+            stage_unshard,
+        )
+        from torch.distributed.pipelining.schedules import (
+            _PipelineScheduleRuntime,
+            BACKWARD_INPUT,
+            BACKWARD_WEIGHT,
+            FORWARD,
+            FULL_BACKWARD,
+            REDUCE_GRAD,
+            RESHARD,
+            UNSHARD,
+        )
+
+        graph_callables, graph_meta = self.pp_joint_graph_builder_fn(
+            self.inner, dt_args, dt_kwargs
+        )
+
+        # Build a single GraphPipelineStage for this rank's stage
+        # (single-stage-per-rank for now)
+        pp_mesh = self.parallel_dims.get_mesh("pp")
+        stage_index = pp_mesh.get_local_rank()
+        num_stages = self.parallel_dims.pp
+
+        # Determine input/output args for the pipeline stage's send/recv
+        # buffer setup. For graph PP, the graph handles the actual computation;
+        # these are only used for P2P communication buffer shapes.
+        fw_gm = graph_callables.fw
+        fw_placeholders = fw_gm.graph.find_nodes(op="placeholder")
+        num_params_buffers = graph_meta.num_params + graph_meta.num_buffers
+        # Activation inputs are fw placeholders after params/buffers
+        activation_placeholders = fw_placeholders[num_params_buffers:]
+        # Get user outputs from the fw graph for output shape inference
+        fw_outputs = fw_gm.graph.find_nodes(op="output")
+        num_inner_fwd_outputs = (
+            graph_meta.num_mutate_inputs + graph_meta.num_user_outputs
+        )
+
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+
+        def _meta_from_val(val):
+            if isinstance(val, torch.Tensor):
+                return torch.empty(val.shape, dtype=val.dtype, device="meta")
+            return val
+
+        # Input args: what this stage receives from prev stage
+        input_args = tuple(
+            _meta_from_val(p.meta["val"])
+            for p in activation_placeholders
+            if "val" in p.meta and isinstance(p.meta["val"], torch.Tensor)
+        )
+        if not input_args:
+            input_args = (torch.empty(1, dtype=torch.bfloat16, device="meta"),)
+
+        # Output args: what this stage sends to next stage
+        if fw_outputs:
+            out_args = fw_outputs[0].args[0]
+            if isinstance(out_args, tuple):
+                user_outs = out_args[
+                    graph_meta.num_mutate_inputs : num_inner_fwd_outputs
+                ]
+                output_args = tuple(
+                    _meta_from_val(o.meta["val"])
+                    for o in user_outs
+                    if hasattr(o, "meta")
+                    and "val" in o.meta
+                    and isinstance(o.meta["val"], torch.Tensor)
+                )
+            else:
+                output_args = None
+        else:
+            output_args = None
+
+        stage = GraphPipelineStage(
+            submodule=self.inner,
+            graph_callables=graph_callables,
+            graph_meta=graph_meta,
+            stage_index=stage_index,
+            num_stages=num_stages,
+            device=device,
+            input_args=input_args,
+            output_args=output_args,
+            group=pp_mesh.get_group(),
+        )
+
+        # Build the schedule via the provided builder.
+        # The builder should return a _PipelineScheduleRuntime which
+        # supports custom action functions needed by GraphPPRunner.
+        schedule = self.pp_schedule_builder(stages=[stage])
+        assert isinstance(schedule, _PipelineScheduleRuntime), (
+            f"Graph PP requires _PipelineScheduleRuntime, got {type(schedule).__name__}. "
+            f"Set --parallelism.pipeline_parallel_schedule_csv to a schedule CSV file."
+        )
+
+        # Register custom action functions
+        schedule.register_custom_function(FORWARD, stage_forward)
+        schedule.register_custom_function(FULL_BACKWARD, stage_full_backward)
+        schedule.register_custom_function(REDUCE_GRAD, stage_reduce_grad)
+        schedule.register_custom_function(RESHARD, stage_reshard)
+        schedule.register_custom_function(UNSHARD, stage_unshard)
+        schedule.register_custom_function(BACKWARD_INPUT, stage_backward_input)
+        schedule.register_custom_function(BACKWARD_WEIGHT, stage_backward_weight)
+
+        return GraphPPRunner(schedule)
+
+    def forward(
+        self,
+        *args,
+        target=None,
+        losses=None,
+        return_outputs=False,
+        **kwargs,
+    ):
+        assert "forward" not in self._overrides, "forward cannot be overridden"
+
+        if self._pp_runner is None:
+            # Lazily build the PP runner on first call.
+            # All ranks need example inputs for graph capture, even
+            # non-first stages that don't receive inputs at runtime.
+            if args:
+                dt_args, dt_kwargs = self.parallelize_inputs(
+                    self.parallel_dims, args, kwargs
+                )
+            else:
+                # Non-first stage: generate example inputs for graph capture
+                capture_args = self._make_capture_args()
+                dt_args, dt_kwargs = self.parallelize_inputs(
+                    self.parallel_dims, capture_args, kwargs
+                )
+            self._pp_runner = self._build_pp_runner(dt_args, dt_kwargs)
+
+        # GraphPPRunner.step() handles both forward and backward
+        if args:
+            dt_args, _ = self.parallelize_inputs(self.parallel_dims, args, kwargs)
+            self._pp_runner.step(
+                *dt_args if isinstance(dt_args, tuple) else (dt_args,),
+                target=target,
+                losses=losses,
+                return_outputs=return_outputs,
+            )
+        else:
+            self._pp_runner.step(
+                target=target,
+                losses=losses,
+                return_outputs=return_outputs,
+            )
+
+        # Return a dummy loss; actual losses are collected via the losses list
+        return torch.tensor(
+            [-1.0], device=torch.device(f"cuda:{torch.cuda.current_device()}")
+        )
+
+    def _make_capture_args(self) -> tuple:
+        """Create example inputs for graph capture on non-first PP stages."""
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        vocab_size = getattr(self, "_capture_vocab_size", 1024)
+        batch_size = getattr(self, "_capture_batch_size", 1)
+        seq_len = getattr(self, "_capture_seq_len", 128)
+        dummy_tokens = torch.randint(
+            0, vocab_size, (batch_size, seq_len), device=device
+        )
+        return (dummy_tokens,)


### PR DESCRIPTION
Stacked PRs:
 * #2708
 * #2707
 * #2706
 * #2705
 * __->__#2704
 * #2703
 * #2702


--- --- ---

[graph_trainer] Add core graph PP infrastructure

Add pp_joint_graph_builder and CompiledPPModule, the core building
blocks for graph-based pipeline parallelism.

pp_joint_graph_builder exports a joint fwd/bwd graph, partitions it,
and applies graph PP passes (split_fsdp_collectives, split_dI_dW) to
produce subgraphs for execution via GraphPPRunner.

CompiledPPModule wraps a model for graph-based PP execution, lazily
building the PP subgraphs on first forward call and delegating to
GraphPPRunner for schedule-driven execution.

Also adds graph_pp_passes config field to GraphTrainerCompileConfig.