### PR TITLE
[RL] Turn compile for generator back on

### DIFF
--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -13,7 +13,7 @@ Each function returns a complete ``RLTrainer.Config`` and is discoverable by
 
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
-from torchtitan.config.configs import ParallelismConfig, TrainingConfig
+from torchtitan.config.configs import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.experiments.rl.actors.generator import (
     GeneratorCompileConfig,
     SamplingConfig,
@@ -41,13 +41,13 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=4,
@@ -81,13 +81,13 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=4,
@@ -121,12 +121,12 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=1,


### PR DESCRIPTION
## Summary

We turned the compile for generator off in https://github.com/pytorch/torchtitan/pull/2638 due to conflict with DTensor and symbolic propogation

We fix this in https://github.com/pytorch/pytorch/pull/178210 so reenable this config (once landed in nightly)

## Test
```bash
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```