### PR TITLE
[RL][BE] Reapply Compilation in RL

### DIFF
--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -13,7 +13,7 @@ Each function returns a complete ``RLTrainer.Config`` and is discoverable by
 
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
-from torchtitan.config.configs import ParallelismConfig, TrainingConfig
+from torchtitan.config.configs import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.experiments.rl.actors.generator import (
     GeneratorCompileConfig,
     SamplingConfig,
@@ -41,13 +41,13 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=4,
@@ -80,13 +80,13 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=4,
@@ -119,12 +119,12 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
             ),
-            # compile=CompileConfig(enable=True, backend="aot_eager"),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             compile=GeneratorCompileConfig(
-                backend="none",
-                cudagraph_mode="none",
+                backend="eager",
+                cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=1,

--- a/torchtitan/experiments/rl/tests/test_bitwise_identity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_identity.py
@@ -40,7 +40,7 @@ from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from torchtitan.config import CommConfig, TORCH_DTYPE_MAP
-from torchtitan.config.configs import ParallelismConfig
+from torchtitan.config.configs import CompileConfig, ParallelismConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.experiments.rl.actors.generator import (
     GeneratorCompileConfig,
@@ -239,6 +239,7 @@ def _test_config() -> RLTrainer.Config:
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
             ),
+            compile=CompileConfig(enable=True, backend="aot_eager"),
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
@@ -246,10 +247,7 @@ def _test_config() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 tensor_parallel_degree=2,
             ),
-            # compile=GeneratorCompileConfig(
-            #     backend="eager", cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE
-            # ),
-            compile=GeneratorCompileConfig(backend="none", cudagraph_mode="none"),
+            compile=GeneratorCompileConfig(backend="eager", cudagraph_mode="piecewise"),
             num_samples_per_prompt=1,
             sampling=SamplingConfig(
                 temperature=0.0,


### PR DESCRIPTION
## Summary
This PR 
1) Reapplies https://github.com/pytorch/torchtitan/pull/2710

## Test plan
PREREQ: ensure https://github.com/pytorch/pytorch/pull/178210 is in your torch version
```bash
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```
With both compiles on, we expect a 4x speedup over eager (timed from ~400s e2e to ~100s for 10 steps)

```bash
torchrun --nproc_per_node=2 \
      torchtitan/experiments/rl/tests/test_bitwise_identity.py
```

For numerics results in:
```
Trainer computed 30 token log-probs
  vLLM   log-probs[:5]: [-4.129570484161377, -1.795021891593933, -0.71578049659729, -0.2110116183757782, -0.9374725222587585]
  Trainer log-probs[:5]: [-4.129570484161377, -1.795021891593933, -0.71578049659729, -0.2110116183757782, -0.9374725222587585]
============================================================
LOGPROB COMPARISON RESULTS
============================================================
  Bitwise identical : True
  Tokens checked    : 30
  Tokens different  : 0
  Max delta         : 0.000000e+00
  Avg delta         : 0.000000e+00
  Diff mean         : 0.000000e+00
  Diff max          : 0.000000e+00
============================================================
PASS: vLLM and trainer log-probs are bitwise identical.
/home/lucaskabela/.conda/envs/pytorch_build/lib/python3.10
```