### PR TITLE
[Bugfix] Workaround CI failure in flexattention compilation from Triton3.7 bump

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
+# TODO: Re-enable once we have closed
+# https://github.com/pytorch/torchtitan/issues/2722
+os.environ.setdefault("DISABLE_LLVM_OPT", "1")
+
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary 

From nightly bump, we notice CI started failing.  This seems to be caused by Triton bump breaking llvm build for flexattention

For now, disable so that we can workaround

### Rootcause

 Workaround for Triton 3.7 LLVM SLP vectorizer crash on flex attention kernels. The Triton pin update (pytorch/pytorch#174896) ships an LLVM build whose SLP vectorizer hits an assertion (FromIdx <= ToIdx, "Bad index") when compiling certain flex attention Triton kernels. The crash occurs in llvm.optimize_module() during make_llir, which runs the LLVM O3 pipeline including SLP vectorization. There is no Python-level API to disable only the SLP vectorizer pass (optimize_module ignores its flags parameter, and DISABLE_LLVM_OPT=<name> only sets flags to true). Setting DISABLE_LLVM_OPT=1 skips the LLVM O3 pipeline entirely; the MLIR-level optimizations still run, so GPU kernel performance impact is minimal.

## Test plan

```bash
NGPU=4 LOG_RANK=0,1,2,3 ./run_train.sh  --module llama3 --config llama3_debugmodel_flex_attn --parallelism.data_parallel_shard_degree=4 --activation_checkpoint.mode='full'
```

Passes now!