### PR TITLE
Refactor pipeline parallel helpers for graph PP reuse

### DIFF
--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -36,12 +36,9 @@ from torchtitan.protocols.model_spec import ParallelizeFunction
 from torchtitan.protocols.module import ModuleDict, ModuleList
 from torchtitan.tools.logging import logger
 
-__all__ = [
-    "pipeline_llm",
-    "build_pipeline_schedule",
-    "generate_llm_fqn_per_model_part",
-    "pipeline_module_split",
-]
+# pipeline_llm is the public entrypoint for model-specific PP setup. Helpers in
+# this module are implementation details and should stay private.
+__all__ = ["pipeline_llm"]
 
 
 def _build_get_mesh_callback(
@@ -84,6 +81,79 @@ def pipeline_llm(
 ) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
     pp_mesh = parallel_dims.get_mesh("pp")
 
+    (
+        num_virtual_stages,
+        num_layers,
+        input_weight,
+        output_weight,
+    ) = _get_pipeline_metadata(parallel_dims, parallelism, model_config)
+
+    module_names_per_stage = parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = _generate_llm_fqn_per_model_part(
+            num_virtual_stages, num_layers, input_weight, output_weight
+        )
+    for i, stage_ms in enumerate(module_names_per_stage):
+        logger.debug(f"Stage {i}: {stage_ms}")
+
+    get_mesh_cb = _build_get_mesh_callback(parallel_dims)
+    stages, model_parts = _pipeline_module_split(
+        model,
+        pp_mesh,
+        parallelism.pipeline_parallel_schedule,
+        device,
+        module_names_per_stage,
+        get_mesh=get_mesh_cb,
+    )
+
+    # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
+    # We need to iterate through model_parts to apply SPMD parallelisms, compilation,
+    # optimizer, and checkpointing
+    for i, m in enumerate(model_parts):
+        # apply SPMD-style PT-D techniques
+        m = parallelize_fn(
+            m,
+            parallel_dims=parallel_dims,
+            training=training,
+            parallelism=parallelism,
+            compile_config=compile_config,
+            ac_config=ac_config,
+            dump_folder=dump_folder,
+        )
+        model_parts[i] = m
+        # NOTE: this is to update the model in the stage
+        #       in case the model is modified e.g. by torch.compile
+        stages[i].submod = m
+
+    pp_schedule = _build_pipeline_schedule(
+        parallelism=parallelism,
+        local_batch_size=training.local_batch_size,
+        stages=stages,
+        loss_fn=loss_fn,
+    )
+
+    # This is used in the train loop to determine whether to pass in the input_ids and labels
+    has_first_stage = False
+    has_last_stage = False
+    for stage in stages:
+        if stage.is_first:
+            has_first_stage = True
+        if stage.is_last:
+            has_last_stage = True
+
+    return pp_schedule, model_parts, has_first_stage, has_last_stage
+
+
+def _get_pipeline_metadata(
+    parallel_dims: ParallelDims,
+    parallelism: ParallelismConfig,
+    model_config: BaseModel.Config,
+) -> tuple[int, int, int, int]:
+    """Determine the number of virtual stages and the number of layers in the model.
+
+    Extracted from ``pipeline_llm`` so that Graph PP can compute stage
+    metadata without running the full eager pipeline setup.
+    """
     # Determine the number of virtual stages based on schedule type
     schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
     is_single_stage_schedule = issubclass(schedule_class, PipelineScheduleSingle)
@@ -144,71 +214,22 @@ def pipeline_llm(
         # For single-stage schedules, default is 1 virtual stage per rank
         stages_per_rank = 1 if is_single_stage_schedule else 2
         num_virtual_stages = parallel_dims.pp * stages_per_rank
-
-    module_names_per_stage = parallelism.module_fqns_per_model_part
-    if module_names_per_stage is None:
-        module_names_per_stage = generate_llm_fqn_per_model_part(
-            num_virtual_stages, num_layers, input_weight, output_weight
-        )
-    for i, stage_ms in enumerate(module_names_per_stage):
-        logger.debug(f"Stage {i}: {stage_ms}")
-
-    get_mesh_cb = _build_get_mesh_callback(parallel_dims)
-    stages, model_parts = pipeline_module_split(
-        model,
-        pp_mesh,
-        parallelism.pipeline_parallel_schedule,
-        device,
-        module_names_per_stage,
-        get_mesh=get_mesh_cb,
-    )
-
-    # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
-    # We need to iterate through model_parts to apply SPMD parallelisms, compilation,
-    # optimizer, and checkpointing
-    for i, m in enumerate(model_parts):
-        # apply SPMD-style PT-D techniques
-        m = parallelize_fn(
-            m,
-            parallel_dims=parallel_dims,
-            training=training,
-            parallelism=parallelism,
-            compile_config=compile_config,
-            ac_config=ac_config,
-            dump_folder=dump_folder,
-        )
-        model_parts[i] = m
-        # NOTE: this is to update the model in the stage
-        #       in case the model is modified e.g. by torch.compile
-        stages[i].submod = m
-
-    pp_schedule = build_pipeline_schedule(
-        parallelism=parallelism,
-        local_batch_size=training.local_batch_size,
-        stages=stages,
-        loss_fn=loss_fn,
-    )
-
-    # This is used in the train loop to determine whether to pass in the input_ids and labels
-    has_first_stage = False
-    has_last_stage = False
-    for stage in stages:
-        if stage.is_first:
-            has_first_stage = True
-        if stage.is_last:
-            has_last_stage = True
-
-    return pp_schedule, model_parts, has_first_stage, has_last_stage
+    return num_virtual_stages, num_layers, input_weight, output_weight
 
 
-def build_pipeline_schedule(
+def _build_pipeline_schedule(
     *,
     parallelism: ParallelismConfig,
     local_batch_size: int,
     stages: list[PipelineStage],
     loss_fn: Callable,
+    # Graph PP runs explicit backward graphs instead of autograd
+    backward_requires_autograd: bool = True,
 ) -> _PipelineSchedule:
     """Builds a pipeline schedule for the given job configuration and stages.
+
+    Also used by Graph PP, which passes ``backward_requires_autograd=False``
+    because it runs explicit backward graphs instead of autograd.
 
     Args:
         parallelism (ParallelismConfig): The parallelism configuration.
@@ -249,14 +270,26 @@ def build_pipeline_schedule(
             f"of stages ({num_total_stages}) which may result in a bubble in the pipeline."
         )
 
-    # pyrefly: ignore [bad-instantiation]
-    schedule = schedule_class(
-        # pyrefly: ignore [bad-argument-type]
-        stages if looped_schedule else stages[0],
-        n_microbatches=n_microbatches,
-        loss_fn=loss_fn,
-        scale_grads=False,
-    )
+    if schedule_class is PipelineScheduleSingle:
+        raise ValueError(
+            "PipelineScheduleSingle is an abstract base class. "
+            "Use a concrete single-stage schedule such as GPipe or 1F1B."
+        )
+    if looped_schedule:
+        schedule = schedule_class(
+            stages,  # pyrefly: ignore [bad-argument-type]
+            n_microbatches=n_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+            backward_requires_autograd=backward_requires_autograd,
+        )
+    else:
+        schedule = schedule_class(
+            stages[0],
+            n_microbatches=n_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+        )
     logger.info(
         f"Using pipeline schedule {parallelism.pipeline_parallel_schedule} "
         f"with {n_microbatches} microbatches and {num_total_stages} stages."
@@ -277,14 +310,16 @@ def build_pipeline_schedule(
     return schedule
 
 
-def generate_llm_fqn_per_model_part(
+def _generate_llm_fqn_per_model_part(
     num_stages: int,
     num_layers: int,
     input_weight: int = 1,
     output_weight: int = 1,
 ) -> list[list[str]]:
-    """
-    Programmatically generates module names model part, focused on LLMs models.
+    """Programmatically generates module names per model part, focused on LLM models.
+
+    Also used by Graph PP to compute per-stage module splits independently
+    of the full ``pipeline_llm`` setup.
 
     Args:
         num_stages: Number of pipeline stages
@@ -296,7 +331,7 @@ def generate_llm_fqn_per_model_part(
         List of lists containing module names for each model part
 
     Example:
-        generate_llm_fqn_per_model_part(2, 3, input_weight=2, output_weight=2)
+        _generate_llm_fqn_per_model_part(2, 3, input_weight=2, output_weight=2)
         treats embeddings as 2 layers and norm+output as 2 layers for distribution
     """
     if num_stages < 1:
@@ -388,7 +423,109 @@ def generate_llm_fqn_per_model_part(
     return module_names_per_stage
 
 
-def pipeline_module_split(
+def _split_module(
+    whole_model: nn.Module,
+    module_names: list[str],
+) -> nn.Module:
+    """
+    Splits a whole model into a module based on the specified module names.
+
+    Args:
+        whole_model: The complete model to be split
+        module_names: List of module names to include in the split
+
+    Returns:
+        The split module
+
+    Example usage:
+        module_names = ["tok_embeddings", "layers.0", "layers.1", "norm", "output"]
+        split_module(whole_model, module_names)
+    """
+    model = copy.deepcopy(whole_model)
+    # Create a set of modules to keep for faster lookup
+    modules_to_keep = set(module_names)
+    for module_name, module_value in model.named_children():
+        # Handle layer-like structures (e.g., "layers.0", "layers.1")
+        if isinstance(
+            module_value, (nn.ModuleDict, nn.ModuleList, ModuleDict, ModuleList)
+        ):
+            layers_to_keep = {
+                name.split(".", 1)[1]
+                for name in modules_to_keep
+                if name.startswith(f"{module_name}.")
+            }
+            if layers_to_keep:
+                # Keep only specified layers
+                if isinstance(module_value, nn.ModuleDict):
+                    for layer_name in list(module_value.keys()):
+                        if layer_name not in layers_to_keep:
+                            del module_value[layer_name]
+                elif isinstance(module_value, nn.ModuleList):
+                    indices_to_keep = {
+                        int(idx) for idx in layers_to_keep if idx.isdigit()
+                    }
+                    new_layers = ModuleList(
+                        [
+                            layer
+                            for i, layer in enumerate(module_value)
+                            if i in indices_to_keep
+                        ]
+                    )
+                    setattr(model, module_name, new_layers)
+            else:
+                # No layers from this structure needed, set to empty structure
+                if isinstance(module_value, (nn.ModuleDict, ModuleDict)):
+                    setattr(model, module_name, ModuleDict())
+                elif isinstance(module_value, (nn.ModuleList, ModuleList)):
+                    setattr(model, module_name, ModuleList())
+        # Handle simple module attributes (e.g., "linear", "norm")
+        elif module_name not in modules_to_keep:
+            # Replace with None
+            setattr(model, module_name, None)
+    return model
+
+
+def _get_pp_rank_to_stage_indices_mapping(
+    pp_rank: int,
+    pp_degree,
+    pp_schedule: str,
+    num_stages: int,
+) -> tuple[int, ...]:
+    """
+    Returns a mapping from PP rank to stage indices for the given pipeline schedule.
+
+    Args:
+        pp_rank: Pipeline parallel rank
+        pp_degree: Number of pipeline parallel ranks
+        pp_schedule: Name of pipeline parallelism schedule
+        num_stages: Number of pipeline stages
+
+    Returns:
+        Mapping from PP rank to stage indices
+    """
+    schedule_class = get_schedule_class(pp_schedule)
+    style = (
+        "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
+    )
+    assert (
+        num_stages % pp_degree == 0
+    ), f"num_stages {num_stages} must be evenly divisible by pp_degree {pp_degree}"
+    stages_per_rank = num_stages // pp_degree
+    if style == "loop":
+        return tuple(pp_rank + s * pp_degree for s in range(stages_per_rank))
+    elif style == "v":
+        assert (
+            stages_per_rank == 2
+        ), f"v schedules assume 2 stages per rank, got {stages_per_rank}"
+        stage_v_pairs = list(
+            zip(range(pp_degree), range(num_stages - 1, pp_degree - 1, -1))
+        )
+        return tuple(stage_v_pairs[pp_rank])
+    else:
+        raise ValueError(f"Unknown style {style}")
+
+
+def _pipeline_module_split(
     whole_model: nn.Module,
     pp_mesh: DeviceMesh,
     pp_schedule: str,
@@ -396,8 +533,10 @@ def pipeline_module_split(
     module_names_per_stage: list[list[str]],
     get_mesh: Callable | None = None,
 ) -> tuple[list[PipelineStage], list[nn.Module]]:
-    """
-    This API creates pipeline stages based on specified module names for each stage.
+    """Create pipeline stages based on specified module names for each stage.
+
+    Also used by Graph PP to split the model into per-stage chunks before
+    exporting joint forward/backward graphs for each stage.
 
     Some model restrictions include:
     - forward() method should tolerate deleted layers
@@ -430,98 +569,22 @@ def pipeline_module_split(
     """
     pp_rank = pp_mesh.get_local_rank()
     pp_degree = pp_mesh.size()
-
-    def _build_stage_from_modules(
-        stage_idx: int, module_names: list[str], num_stages: int
-    ) -> tuple[PipelineStage, nn.Module]:
-        model = copy.deepcopy(whole_model)
-
-        # Create a set of modules to keep for faster lookup
-        modules_to_keep = set(module_names)
-        for module_name, module_value in model.named_children():
-            # Handle layer-like structures (e.g., "layers.0", "layers.1")
-            if isinstance(module_value, (nn.ModuleDict, nn.ModuleList)):
-                layers_to_keep = {
-                    name.split(".", 1)[1]
-                    for name in modules_to_keep
-                    if name.startswith(f"{module_name}.")
-                }
-                if layers_to_keep:
-                    # Keep only specified layers
-                    if isinstance(module_value, nn.ModuleDict):
-                        for layer_name in list(module_value.keys()):
-                            if layer_name not in layers_to_keep:
-                                del module_value[layer_name]
-                    elif isinstance(module_value, nn.ModuleList):
-                        indices_to_keep = {
-                            int(idx) for idx in layers_to_keep if idx.isdigit()
-                        }
-                        new_layers = ModuleList(
-                            [
-                                layer
-                                for i, layer in enumerate(module_value)
-                                if i in indices_to_keep
-                            ]
-                        )
-                        setattr(model, module_name, new_layers)
-                else:
-                    # No layers from this structure needed, set to empty structure
-                    if isinstance(module_value, nn.ModuleDict):
-                        setattr(model, module_name, ModuleDict())
-                    elif isinstance(module_value, nn.ModuleList):
-                        setattr(model, module_name, ModuleList())
-            # Handle simple module attributes (e.g., "linear", "norm")
-            elif module_name not in modules_to_keep:
-                # Replace with None
-                setattr(model, module_name, None)
-
+    num_stages = len(module_names_per_stage)
+    stages = []
+    models = []
+    pp_rank_to_stage_indices = _get_pp_rank_to_stage_indices_mapping(
+        pp_rank, pp_degree, pp_schedule, num_stages
+    )
+    for stage_idx in pp_rank_to_stage_indices:
+        module_names = module_names_per_stage[stage_idx]
+        model_chunk = _split_module(whole_model, module_names)
         stage = PipelineStage(
-            model,
+            model_chunk,
             stage_idx,
             num_stages,
             device,
             group=pp_mesh.get_group("pp"),
             get_mesh=get_mesh,
-        )
-        return stage, model
-
-    num_stages = len(module_names_per_stage)
-    stages = []
-    models = []
-
-    schedule_class = get_schedule_class(pp_schedule)
-    style = (
-        "v" if schedule_class in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else "loop"
-    )
-
-    def _get_stage_indices() -> tuple[int, ...]:
-        """
-        Compute the stage ids for the stages that will run on this pp rank
-        for either a looped or V style schedule
-        """
-        assert (
-            num_stages % pp_degree == 0
-        ), f"num_stages {num_stages} must be evenly divisible by pp_degree {pp_degree}"
-        stages_per_rank = num_stages // pp_degree
-        if style == "loop":
-            return tuple(pp_rank + s * pp_degree for s in range(stages_per_rank))
-        elif style == "v":
-            assert (
-                stages_per_rank == 2
-            ), f"v schedules assume 2 stages per rank, got {stages_per_rank}"
-            stage_v_pairs = list(
-                zip(range(pp_degree), range(num_stages - 1, pp_degree - 1, -1))
-            )
-            return stage_v_pairs[pp_rank]
-        else:
-            raise ValueError(f"Unknown style {style}")
-
-    for stage_idx in _get_stage_indices():
-        module_names = module_names_per_stage[stage_idx]
-        stage, model_chunk = _build_stage_from_modules(
-            stage_idx,
-            module_names,
-            num_stages,
         )
         logger.info(
             f"PP rank {pp_rank} is building stage_idx {stage_idx} "

--- a/torchtitan/experiments/ft/diloco/utils.py
+++ b/torchtitan/experiments/ft/diloco/utils.py
@@ -6,7 +6,7 @@
 
 import torch.nn as nn
 
-from torchtitan.distributed.pipeline_parallel import generate_llm_fqn_per_model_part
+from torchtitan.distributed.pipeline_parallel import _generate_llm_fqn_per_model_part
 from torchtitan.experiments.ft.config import FaultTolerance as FTConfig
 from torchtitan.protocols.module import ModuleList
 from torchtitan.tools.logging import logger
@@ -126,7 +126,7 @@ def fragment_llm(
             logger.info("Created 1 model fragments")
             return [model]
 
-        module_fqns_per_model_fragment = generate_llm_fqn_per_model_part(
+        module_fqns_per_model_fragment = _generate_llm_fqn_per_model_part(
             ft_config.num_fragments, n_layers, input_weight, output_weight
         )
 

--- a/torchtitan/experiments/transformers_modeling_backend/pipeline.py
+++ b/torchtitan/experiments/transformers_modeling_backend/pipeline.py
@@ -26,7 +26,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.pipeline_parallel import build_pipeline_schedule
+from torchtitan.distributed.pipeline_parallel import _build_pipeline_schedule
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.model_spec import ParallelizeFunction
 from torchtitan.protocols.module import Module, ModuleDict, ModuleList
@@ -398,7 +398,7 @@ def pipeline_hf_transformers(
         #       in case the model is modified e.g. by torch.compile
         stages[i].submod = m
 
-    pp_schedule = build_pipeline_schedule(
+    pp_schedule = _build_pipeline_schedule(
         parallelism=parallelism,
         local_batch_size=training.local_batch_size,
         stages=stages,


### PR DESCRIPTION
Stacked PRs:
 * #3090
 * #3089
 * #3088
 * #2727
 * #2726
 * #2725
 * __->__#2724


--- --- ---

### Refactor pipeline parallel helpers for graph PP reuse

Extract pipeline metadata, module splitting, and PP rank-to-stage mapping from pipeline_llm so graph PP can reuse the underlying setup logic without duplicating it. Add backward_requires_autograd to the schedule builder for graph PP, which runs explicit backward graphs instead of autograd. Existing eager PP behavior is unchanged.

How does this refactoring help?

This is the call chain:
  pipeline_llm
    -> _get_pipeline_metadata
    -> _generate_llm_fqn_per_model_part
    -> _build_get_mesh_callback
    -> _pipeline_module_split
         -> _get_pp_rank_to_stage_indices_mapping
         -> _split_module
         -> PipelineStage
    -> parallelize_fn
    -> _build_pipeline_schedule
    
 GraphPP will define:
   **graph_pipeline_llm**
    -> _get_pipeline_metadata
    -> _generate_llm_fqn_per_model_part
    -> _build_get_mesh_callback
    -> _pipeline_module_split
         -> _get_pp_rank_to_stage_indices_mapping
         -> _split_module
         -> **GraphPipelineStage**
    -> parallelize_fn
    -> _build_pipeline_schedule
    -> **GraphPPRunner**

So by just overriding  _pipeline_module_split but by reusing all the other helpers, we minimize code redundancy and maximize code reuse.

Keep pipeline_llm as the only public entrypoint exported by torchtitan.distributed.pipeline_parallel. Make build_pipeline_schedule, generate_llm_fqn_per_model_part, and pipeline_module_split private because they are implementation details with narrower contracts: schedule construction depends on the current PP config shape, LLM FQN generation encodes TorchTitan-specific module naming heuristics, and module splitting assumes models tolerate deleted or empty layer containers.

Update internal and experiment callsites to use the private helper names directly where reuse is still needed. This keeps the reusable code centralized while avoiding accidentally blessing those helpers as stable public API.
