### PR TITLE
Add async logging

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -258,6 +258,24 @@ def _get_metrics_rank(
     return (world_size // pp_size) * (pp_size - 1)
 
 
+@dataclass
+class PendingMetrics:
+    """Bundles all metric tensors from a single logging step with one CUDA event.
+
+    A single event guards all non-blocking D2H copies so we pay for one
+    synchronization point rather than one per metric. Used by
+    ``MetricsProcessor.log_async`` / ``flush`` to defer the GPU-CPU sync
+    until the next train step, where the event has already completed.
+    """
+
+    step: int
+    global_avg_loss: torch.Tensor
+    global_max_loss: torch.Tensor
+    grad_norm: torch.Tensor
+    extra_metrics: dict[str, Any]
+    event: torch.cuda.Event
+
+
 class MetricsProcessor(Configurable):
     """Metrics processor to processes the metrics and log metrics.
 
@@ -361,6 +379,7 @@ class MetricsProcessor(Configurable):
         self.optimizers = None
         self.lr_schedulers = None
         self.model_parts = None
+        self._pending: PendingMetrics | None = None
 
     def should_log(self, step: int) -> bool:
         return step == 1 or step % self.config.log_freq == 0
@@ -492,7 +511,11 @@ class MetricsProcessor(Configurable):
             mfu = 100 * self.num_flops_per_token * tps / self.gpu_peak_flops
 
         time_end_to_end = time_delta / self.config.log_freq
-        time_data_loading = sum(self.data_loading_times) / len(self.data_loading_times)
+        time_data_loading = (
+            sum(self.data_loading_times) / len(self.data_loading_times)
+            if self.data_loading_times
+            else 0.0
+        )
         time_data_loading_pct = 100 * sum(self.data_loading_times) / time_delta
 
         device_mem_stats = self.device_memory_monitor.get_peak_stats()
@@ -578,5 +601,44 @@ class MetricsProcessor(Configurable):
         self.time_last_log = time.perf_counter()
         self.device_memory_monitor.reset_peak_stats()
 
+    def log_async(
+        self,
+        step: int,
+        global_avg_loss: torch.Tensor,
+        global_max_loss: torch.Tensor,
+        grad_norm: torch.Tensor,
+        extra_metrics: dict[str, Any] | None = None,
+    ) -> None:
+        """Initiate non-blocking D2H copies and stash for later flush.
+
+        Accepts GPU tensors instead of floats. A CUDA event is recorded so
+        ``flush`` can synchronize before reading the values.
+        """
+        self._pending = PendingMetrics(
+            step=step,
+            global_avg_loss=global_avg_loss.to("cpu", non_blocking=True),
+            global_max_loss=global_max_loss.to("cpu", non_blocking=True),
+            grad_norm=grad_norm.to("cpu", non_blocking=True),
+            extra_metrics=extra_metrics or {},
+            event=torch.cuda.Event(),
+        )
+        self._pending.event.record()
+
+    def flush(self) -> None:
+        """Flush any pending async metrics. No-op if nothing is pending."""
+        if self._pending is None:
+            return
+        pm = self._pending
+        self._pending = None
+        pm.event.synchronize()
+        self.log(
+            pm.step,
+            float(pm.global_avg_loss.item()),
+            float(pm.global_max_loss.item()),
+            float(pm.grad_norm.item()),
+            extra_metrics=pm.extra_metrics,
+        )
+
     def close(self):
+        self.flush()
         self.logger.close()

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -27,35 +27,47 @@ from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 
 
-def _dist_reduce(
+def _dist_reduce_tensor(
     x: torch.Tensor,
     reduceOp: str,
     mesh: DeviceMesh | None,
     extra_pg: dist.ProcessGroup | None,
-) -> float:
-    """Perform distributed reduction on a tensor.
+) -> torch.Tensor:
+    """Perform distributed reduction, returning the result as a device tensor.
+
+    This is the no-sync primitive: it runs the collective but does NOT call
+    ``.item()``, so no device-to-host synchronization occurs.
 
     Args:
         x (torch.Tensor): Input tensor.
         reduceOp (str): Reduce operation to perform.
         mesh (DeviceMesh | None): Device mesh to use for reduction.
-            If None, no reduction is performed but simply convert the tensor to a float.
+            If None, no reduction is performed and the tensor is returned as-is.
         extra_pg (dist.ProcessGroup, optional): Extra process group to use for reduction.
             Defaults to None. If provided, this all_reduce will be called for the extra
             process group, and then the result will be all_reduced for the mesh.
     """
     if isinstance(x, DTensor):
-        # functional collectives do not support DTensor inputs
         x = x.full_tensor()
 
     if extra_pg is not None:
         x = funcol.all_reduce(x, reduceOp=reduceOp, group=extra_pg)
 
     if mesh is None:
-        return float(x.item())
+        return x
 
-    assert x.numel() == 1  # required by `.item()`
-    return float(funcol.all_reduce(x, reduceOp=reduceOp, group=mesh).item())
+    assert x.numel() == 1
+    return funcol.all_reduce(x, reduceOp=reduceOp, group=mesh)
+
+
+def _dist_reduce(
+    x: torch.Tensor,
+    reduceOp: str,
+    mesh: DeviceMesh | None,
+    extra_pg: dist.ProcessGroup | None,
+) -> float:
+    """Perform distributed reduction and synchronously return a Python float."""
+    return float(_dist_reduce_tensor(x, reduceOp, mesh, extra_pg).item())
 
 
 # TODO: rename this to maybe_dist_max
@@ -69,12 +81,32 @@ def dist_max(
     )
 
 
+def dist_max_tensor(
+    x: torch.Tensor,
+    mesh: DeviceMesh | None = None,
+    extra_pg: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    return _dist_reduce_tensor(
+        x, reduceOp=c10d.ReduceOp.MAX.name, mesh=mesh, extra_pg=extra_pg
+    )
+
+
 def dist_sum(
     x: torch.Tensor,
     mesh: DeviceMesh | None = None,
     extra_pg: dist.ProcessGroup | None = None,
 ) -> float:
     return _dist_reduce(
+        x, reduceOp=c10d.ReduceOp.SUM.name, mesh=mesh, extra_pg=extra_pg
+    )
+
+
+def dist_sum_tensor(
+    x: torch.Tensor,
+    mesh: DeviceMesh | None = None,
+    extra_pg: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    return _dist_reduce_tensor(
         x, reduceOp=c10d.ReduceOp.SUM.name, mesh=mesh, extra_pg=extra_pg
     )
 

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -250,7 +250,8 @@ class FluxTrainer(Trainer):
         self.optimizers.step()
         self.lr_schedulers.step()
 
-        # log metrics
+        self.metrics_processor.flush()
+
         if not self.metrics_processor.should_log(self.step):
             return
 
@@ -258,29 +259,21 @@ class FluxTrainer(Trainer):
             loss = loss.detach()
             loss_mesh = parallel_dims.get_optional_mesh("loss")
 
-            # NOTE: the loss returned by train
-            global_avg_loss, global_max_loss, global_ntokens_seen = (
-                dist_utils.dist_sum(loss, loss_mesh),
-                dist_utils.dist_max(loss, loss_mesh),
-                dist_utils.dist_sum(
-                    torch.tensor(
-                        self.ntokens_seen, dtype=torch.int64, device=self.device
-                    ),
-                    loss_mesh,
-                ),
+            global_avg_loss = dist_utils.dist_sum_tensor(loss, loss_mesh)
+            global_max_loss = dist_utils.dist_max_tensor(loss, loss_mesh)
+            global_ntokens_seen = dist_utils.dist_sum(
+                torch.tensor(self.ntokens_seen, dtype=torch.int64, device=self.device),
+                loss_mesh,
             )
         else:
-            global_avg_loss = global_max_loss = float(loss.detach().item())
+            global_avg_loss = loss.detach()
+            global_max_loss = global_avg_loss
             global_ntokens_seen = self.ntokens_seen
 
-        extra_metrics = {
-            "n_tokens_seen": global_ntokens_seen,
-            "lr": lr,
-        }
-        self.metrics_processor.log(
+        self.metrics_processor.log_async(
             self.step,
             global_avg_loss,
             global_max_loss,
-            float(grad_norm.item()),
-            extra_metrics=extra_metrics,
+            grad_norm,
+            extra_metrics={"n_tokens_seen": global_ntokens_seen, "lr": lr},
         )

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -756,7 +756,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # Reduce the data collected over gradient accumulation steps.
         loss = torch.sum(torch.stack(accumulated_losses))
 
-        # log metrics
+        # flush metrics from the previous logging step; metrics are always
+        # delayed by one step so that we can do async D2H
+        self.metrics_processor.flush()
+
         if not self.metrics_processor.should_log(self.step):
             return
 
@@ -774,30 +777,23 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             #                = (loss * global_valid_tokens) / local_valid_tokens
             # global_max_loss = max(local_avg_loss)
             local_avg_loss = loss * global_valid_tokens / local_valid_tokens
-            global_avg_loss, global_max_loss, global_ntokens_seen = (
-                dist_utils.dist_sum(loss, loss_mesh),
-                dist_utils.dist_max(local_avg_loss, loss_mesh),
-                dist_utils.dist_sum(
-                    torch.tensor(
-                        self.ntokens_seen, dtype=torch.int64, device=self.device
-                    ),
-                    loss_mesh,
-                ),
+            global_avg_loss = dist_utils.dist_sum_tensor(loss, loss_mesh)
+            global_max_loss = dist_utils.dist_max_tensor(local_avg_loss, loss_mesh)
+            global_ntokens_seen = dist_utils.dist_sum(
+                torch.tensor(self.ntokens_seen, dtype=torch.int64, device=self.device),
+                loss_mesh,
             )
         else:
-            global_avg_loss = global_max_loss = float(loss.detach().item())
+            global_avg_loss = loss.detach()
+            global_max_loss = global_avg_loss
             global_ntokens_seen = self.ntokens_seen
 
-        extra_metrics = {
-            "n_tokens_seen": global_ntokens_seen,
-            "lr": lr,
-        }
-        self.metrics_processor.log(
+        self.metrics_processor.log_async(
             self.step,
             global_avg_loss,
             global_max_loss,
-            float(grad_norm.item()),
-            extra_metrics=extra_metrics,
+            grad_norm,
+            extra_metrics={"n_tokens_seen": global_ntokens_seen, "lr": lr},
         )
 
     @record
@@ -852,6 +848,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         timeout=timedelta(seconds=config.comm.train_timeout_seconds),
                         parallel_dims=self.parallel_dims,
                     )
+
+        # flush any pending async metrics from the last logging step
+        self.metrics_processor.flush()
 
         if torch.distributed.get_rank() == 0:
             logger.info("Sleeping 2 seconds for other ranks to complete")


### PR DESCRIPTION
Stacked PRs:
 * __->__#2728
 * #2171


--- --- ---

Add async logging

I set this by default  but curious if there is interest  

```Py
~/.venvs/nightly/bin/torchrun --nproc-per-node=1 -m torchtitan.train \
    --module llama3 --config llama3_debugmodel \
    --training.steps 200 \
    --training.local-batch-size 64 \
    --training.seq-len 8192 \
    --metrics.log_freq 5
```
    
Running before after on my b200 gives me non trivial speedups:
<img width="498" height="84" alt="image" src="https://github.com/user-attachments/assets/3ded19d5-d0c7-432e-8edb-47bd4e4830a5" />
However in real workloads you can do other things ( log less frequently)