### PR TITLE
[graph_trainer] Revert precompile integration

### DIFF
--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -10,15 +10,9 @@ Unified JIT/AOT compilation dispatcher for graph_trainer training.
 Supports two compilation modes via --compile.mode:
 - JIT: standard torch.compile() with custom backend
 - AOT: explicit joint graph export + custom graph passes
-
-Additionally supports pre-compile via --compile.precompile:
-- On first run: compiles with serializable=True, saves the artifact, continues training
-- On subsequent runs: detects existing artifact, loads it, skips compilation
 """
 
-import dataclasses
 import functools
-import pickle
 
 import torch
 import torch.nn as nn
@@ -42,30 +36,7 @@ from torchtitan.experiments.graph_trainer.graph_utils import (
 from torchtitan.experiments.graph_trainer.jit_backend import (
     get_compile_backend_with_passes,
 )
-from torchtitan.experiments.graph_trainer.storage import (
-    DiskStorageAdapter,
-    StorageAdapter,
-)
 from torchtitan.tools.logging import logger
-
-# Compiler passes whose output supports serialization for precompile.
-# full_inductor_compilation produces OutputCode via compile_fx_inner;
-# regional_inductor produces RegionalOutputCode (an OutputCode subclass).
-_SERIALIZABLE_PASSES: frozenset[str] = frozenset(
-    ("full_inductor_compilation", "regional_inductor")
-)
-
-
-def _get_precompile_storage_and_key(
-    compile_config: GraphTrainerCompileConfig,
-) -> tuple[StorageAdapter, str]:
-    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
-    rank = torch.distributed.get_rank()
-    # Per-rank artifact keys will go away once the Compile on one Rank
-    # (CooR) project lands — at that point we will precompile once and
-    # reuse that artifact across all ranks.
-    artifact_key = f"default_rank{rank}"
-    return storage, artifact_key
 
 
 def _apply_jit_compile(
@@ -89,39 +60,6 @@ def _apply_jit_compile(
     return model
 
 
-def _make_precompile_callback(
-    model: nn.Module,
-    compile_config: GraphTrainerCompileConfig,
-    parallel_dims: ParallelDims,
-    storage: StorageAdapter | None = None,
-    artifact_key: str | None = None,
-):
-    """Build the on_compile callback that saves the compiled artifact to disk."""
-    from .precompile import compute_config_fingerprint, precompile_save
-
-    if storage is None or artifact_key is None:
-        storage, artifact_key = _get_precompile_storage_and_key(compile_config)
-    config_fingerprint = compute_config_fingerprint(
-        model, compile_config, parallel_dims
-    )
-
-    def on_compile(compiled_fn, out_spec):
-        precompile_save(
-            model,
-            compiled_fn,
-            storage,
-            artifact_key,
-            out_spec=out_spec,
-            metadata={
-                "world_size": torch.distributed.get_world_size(),
-                "rank": torch.distributed.get_rank(),
-            },
-            config_fingerprint=config_fingerprint,
-        )
-
-    return on_compile
-
-
 def _apply_aot_compile(
     model: nn.Module,
     parallel_dims: ParallelDims,
@@ -132,38 +70,6 @@ def _apply_aot_compile(
 ) -> CompiledModule:
     """Apply AOT compilation (joint graph export + pass pipeline)."""
     register_blockmask_pytree_node()
-
-    # When precompile is enabled, compute storage/key once and reuse them
-    # for both the load attempt and the save callback to avoid duplicate
-    # DiskStorageAdapter construction and fingerprint computation.
-    storage: StorageAdapter | None = None
-    artifact_key: str | None = None
-    if compile_config.precompile:
-        storage, artifact_key = _get_precompile_storage_and_key(compile_config)
-
-        if storage.exists(artifact_key):
-            from .precompile import compute_config_fingerprint
-
-            config_fingerprint = compute_config_fingerprint(
-                model, compile_config, parallel_dims
-            )
-            try:
-                return _apply_aot_compile_load(
-                    model, parallel_dims, storage, artifact_key, config_fingerprint
-                )
-            except (ValueError, pickle.UnpicklingError, RuntimeError) as e:
-                # ValueError: fingerprint/param/buffer mismatches from our
-                # validation. pickle.UnpicklingError: corrupted or
-                # incompatible serialized data. RuntimeError: intentionally
-                # broad to catch remaining deserialization failures (e.g.
-                # shape mismatches in torch.load) that surface as
-                # RuntimeError. We log the exception type so unrelated
-                # errors (CUDA OOM, NCCL) are distinguishable in logs.
-                logger.warning(
-                    f"Stale precompile artifact detected ({type(e).__name__}), "
-                    f"recompiling: {e}"
-                )
-                storage.delete(artifact_key)
 
     # Get joint custom passes from config
     joint_custom_passes = get_joint_custom_passes_from_config(
@@ -182,19 +88,6 @@ def _apply_aot_compile(
         compiler_passes, dump_folder=dump_folder
     )
 
-    serializable = compile_config.precompile
-    on_compile = (
-        _make_precompile_callback(
-            model,
-            compile_config,
-            parallel_dims,
-            storage=storage,
-            artifact_key=artifact_key,
-        )
-        if serializable
-        else None
-    )
-
     # Create custom joint_graph_builder with compilers
     model_joint_graph_builder = functools.partial(
         joint_graph_builder,
@@ -203,53 +96,13 @@ def _apply_aot_compile(
         joint_custom_passes=joint_custom_passes,
         dump_folder=dump_folder,
         compile_config=compile_config,
-        serializable=serializable,
-        on_compile=on_compile,
     )
 
     model = CompiledModule(
         model, parallel_dims, model_joint_graph_builder, parallelize_inputs
     )
-    msg = "Applied AOT compilation (joint graph export) to the model"
-    if serializable:
-        msg += " with serializable=True (precompile save)"
-    logger.info(msg)
+    logger.info("Applied AOT compilation (joint graph export) to the model")
     return model
-
-
-def _apply_aot_compile_load(
-    model: nn.Module,
-    parallel_dims: ParallelDims,
-    storage: StorageAdapter,
-    artifact_key: str,
-    config_fingerprint: str,
-) -> CompiledModule:
-    """Load a precompiled artifact and wrap the model with it."""
-    from .precompile import precompile_load
-
-    # BlockMask must be registered as a pytree node before unpickling
-    # the artifact, which may contain BlockMask objects in its specs.
-    register_blockmask_pytree_node()
-
-    precompiled_fn = precompile_load(
-        model, storage, artifact_key, expected_fingerprint=config_fingerprint
-    )
-
-    def _unused_graph_builder(*args, **kwargs):
-        raise RuntimeError(
-            "joint_graph_builder should not be called when "
-            "using a precompiled artifact"
-        )
-
-    compiled_model = CompiledModule(
-        model,
-        parallel_dims,
-        joint_graph_builder=_unused_graph_builder,
-        parallelize_inputs=parallelize_inputs,
-        precompiled_fn=precompiled_fn,
-    )
-    logger.info("Applied precompiled artifact (precompile load) to the model")
-    return compiled_model
 
 
 def apply_compile(
@@ -284,21 +137,6 @@ def apply_compile(
     fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
     )
-
-    if compile_config.precompile and mode != "aot":
-        logger.warning(
-            "--compile.precompile is only supported with --compile.mode=aot, "
-            f"but mode is '{mode}'. Ignoring precompile."
-        )
-        compile_config = dataclasses.replace(compile_config, precompile=False)
-
-    if compile_config.precompile and not (
-        _SERIALIZABLE_PASSES & set(compile_config.passes)
-    ):
-        raise ValueError(
-            "--compile.precompile requires at least one serializable pass "
-            f"({', '.join(sorted(_SERIALIZABLE_PASSES))}) in --compile.passes."
-        )
 
     if mode == "jit":
         if "model" not in compile_config.components:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -37,21 +37,6 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Joint graph pass names to apply on the joint forward-backward
     graph before partitioning. Only used in AOT mode."""
 
-    precompile: bool = False
-    """
-    Enable serializable compilation. On first run, compiles with
-    serializable=True and saves the artifact. On subsequent runs, detects
-    the existing artifact and loads it, skipping compilation entirely.
-    """
-
-    precompile_artifact_dir: str = "/tmp/precompile_artifacts"
-    """
-    Directory where precompile artifacts are stored. The default /tmp
-    is ephemeral on most cluster environments. For multi-node setups
-    or persistence across job restarts, set this to a shared filesystem
-    path (e.g. under the job output directory).
-    """
-
 
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerConfig(Trainer.Config):

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -111,8 +111,6 @@ def joint_graph_builder(
     joint_custom_passes: list[Callable] | None = None,
     dump_folder: str | None = None,
     compile_config: CompileConfig | None = None,
-    serializable: bool = False,
-    on_compile: Callable | None = None,
 ):
     """
     Build a joint forward-backward graph for the model with optional custom compilers.
@@ -125,10 +123,7 @@ def joint_graph_builder(
         bw_compiler: Optional custom backward compiler function
         joint_custom_passes: list of custom passes to run on the joint graph
         dump_folder: Optional folder to dump the graph to
-        compile_config: Compile configuration
-        serializable: If True, compile with serialization support
-        on_compile: Optional callback invoked after compilation with
-            (compiled_fn, out_spec)
+        job_config: Job configuration
     """
     assert isinstance(model_args, tuple)
 
@@ -168,14 +163,8 @@ def joint_graph_builder(
 
     with tracing(tracing_context):
         fn = aot_compile_joint_with_descriptors(
-            joint_with_descriptors,
-            fw_compiler=fw_compiler,
-            bw_compiler=bw_compiler,
-            serializable=serializable,
+            joint_with_descriptors, fw_compiler=fw_compiler, bw_compiler=bw_compiler
         )
-
-    if on_compile is not None:
-        on_compile(fn, joint_with_descriptors.out_spec)
 
     def wrapper_fn(args, kwargs):
         inputs = [
@@ -195,7 +184,6 @@ class CompiledModule(Module):
         parallel_dims: ParallelDims,
         joint_graph_builder: Callable,
         parallelize_inputs: Callable,
-        precompiled_fn: Callable | None = None,
         **overrides,
     ) -> None:
         super().__init__()
@@ -204,7 +192,6 @@ class CompiledModule(Module):
 
         self.joint_graph_builder = joint_graph_builder
         self.joint_graph_module = None
-        self.precompiled_fn = precompiled_fn
 
         self.parallelize_inputs = parallelize_inputs
 
@@ -259,12 +246,9 @@ class CompiledModule(Module):
         dt_args, dt_kwargs = self.parallelize_inputs(self.parallel_dims, args, kwargs)
 
         if self.joint_graph_module is None:
-            if self.precompiled_fn is not None:
-                self.joint_graph_module = self.precompiled_fn
-            else:
-                self.joint_graph_module = self.joint_graph_builder(
-                    self.inner, dt_args, dt_kwargs
-                )
+            self.joint_graph_module = self.joint_graph_builder(
+                self.inner, dt_args, dt_kwargs
+            )
 
         # calling the line below returns control to torchtitan's runner
         # letting it call the backward, and optimizer.
@@ -476,23 +460,6 @@ def get_compiler_passes_from_config(
                 functools.partial(
                     AVAILABLE_COMPILER_PASSES[pass_name],
                     fsdp_manual_buckets=get_transformer_block_buckets(model),
-                )
-            )
-        elif pass_name == "regional_inductor" and getattr(
-            compile_config, "precompile", False
-        ):
-            # regional_inductor needs an explicit serializable=True at
-            # the pass level so it produces serializable RegionalOutputCode.
-            # full_inductor_compilation does NOT need a pass-level flag:
-            # compile_fx_inner already returns a CompiledFxGraph that is
-            # natively serializable, so aot_compile_joint_with_descriptors
-            # (called with serializable=True in joint_graph_builder) can
-            # bundle it into a BundledAOTAutogradSerializableCallable
-            # without any pass-level cooperation.
-            compiler_passes.append(
-                functools.partial(
-                    AVAILABLE_COMPILER_PASSES[pass_name],
-                    serializable=True,
                 )
             )
         else:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -66,48 +66,12 @@ def transformer_block_bucketing_reordering_pass(
     return gm
 
 
-def _ops_filter_with_distributed(name: str) -> bool:
-    """Ops filter that allows distributed collective ops for serialization.
-
-    The default GraphPickler ops filter only allows aten and fbgemm ops.
-    SimpleFSDP uses _c10d_functional collectives that must also be
-    allowed for the graph to serialize correctly.
-    """
-    return name.startswith(
-        (
-            "torch.ops.aten",
-            "torch.ops.fbgemm",
-            "torch.ops._c10d_functional",
-        )
-    )
-
-
 def regional_inductor_pass(
-    gm: torch.fx.GraphModule, example_inputs, *, serializable: bool = False
+    gm: torch.fx.GraphModule, example_inputs
 ) -> torch.fx.GraphModule:
     """
     Apply regional inductor compilation based on user annotation.
-
-    When serializable=True (precompile mode), sets force_autograd_cache
-    so that regional_inductor wraps its output in RegionalOutputCode,
-    and overrides the ops filter to allow distributed collective ops.
     """
-    if serializable:
-        with torch._functorch.config.patch("force_autograd_cache", True):
-            result = regional_inductor(gm, example_inputs)
-        from torch._inductor.output_code import RegionalOutputCode
-
-        # Override the ops filter after compilation so that
-        # serialization (which happens later) allows distributed
-        # collective ops like _c10d_functional through GraphPickler.
-        if isinstance(result, RegionalOutputCode):
-            result._ops_filter = _ops_filter_with_distributed
-        else:
-            logger.warning(
-                "regional_inductor with serializable=True did not produce "
-                "RegionalOutputCode; distributed ops may not serialize correctly."
-            )
-        return result
     return regional_inductor(gm, example_inputs)
 
 

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import sys
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -127,9 +126,6 @@ def _distribute_dtensor(
     )
 
 
-_wrap_class_counter = 0  # Not thread-safe; assumes single-threaded model init
-
-
 def _register_parametrization(
     module: nn.Module, param_names: list[str], parametrization: nn.Module
 ) -> None:
@@ -140,8 +136,6 @@ def _register_parametrization(
     TODO: In checkpoint saving/loading, avoid parametrization calls when calling
     get_model_state_dict func in torchtitan's torchtitan/components/checkpoint.py.
     """
-    global _wrap_class_counter
-    _wrap_class_counter += 1
     param_name_to_property = {
         param_name: property(
             lambda self, pn=param_name: parametrization(self._parameters[pn])
@@ -149,14 +143,11 @@ def _register_parametrization(
         for param_name in param_names
     }
     module_cls = type(
-        f"SimpleFSDP{module.__class__.__name__}_{_wrap_class_counter}",
+        f"SimpleFSDP{module.__class__.__name__}",
         (module.__class__,),
         param_name_to_property,
     )
     module.__class__ = module_cls
-    # Expose the dynamically created class as a real, importable symbol
-    # so that pickle/GraphPickler can resolve it during serialization.
-    sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
 
 
 class ReplicateComputation(Module):


### PR DESCRIPTION
Manually revert #2671 

#2669 and #2670 appear to be purely additional components and include unit tests.

The integration in #2671 is very invasive, it should come with model integration tests (something like #2672) and undergo more thorough reviews.