### PR TITLE
Enable per-layer compile with or without MoE

### DIFF
--- a/tests/unit_tests/test_compile_moe.py
+++ b/tests/unit_tests/test_compile_moe.py
@@ -9,7 +9,7 @@ import unittest
 import torch
 
 from torchtitan.config import CompileConfig
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
@@ -42,41 +42,32 @@ class TinyModel(Module):
 
 
 class TestApplyCompile(unittest.TestCase):
-    def test_patched_once(self):
-        """
-        Calls apply_compile multiple times, as in the case with PP.
-        But patches should only happen once
-        """
-        unused_model1 = TinyModel(num_layers=2, dim=128)
-        unused_model2 = TinyModel(num_layers=2, dim=128)
-        compile_config = CompileConfig(backend="eager")
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_grouped_mm_compiles_and_runs(self):
+        model = TinyModel(num_layers=2, dim=128).cuda()
+        compile_config = CompileConfig(backend="inductor")
 
-        apply_compile_sparse(unused_model1, compile_config, ep_enabled=True)
-        apply_compile_sparse(unused_model2, compile_config, ep_enabled=True)
+        apply_compile(model, compile_config)
 
         from torchtitan.models.common import moe as moe_module
 
-        # Generate sample inputs for _run_experts_grouped_mm
         num_experts = 8
         dim = 128
         hidden_dim = 256
-        w1 = torch.randn(num_experts, hidden_dim, dim)
-        w2 = torch.randn(num_experts, dim, hidden_dim)
-        w3 = torch.randn(num_experts, hidden_dim, dim)
+        w1 = torch.randn(num_experts, hidden_dim, dim, device="cuda")
+        w2 = torch.randn(num_experts, dim, hidden_dim, device="cuda")
+        w3 = torch.randn(num_experts, hidden_dim, dim, device="cuda")
         num_tokens_per_expert = torch.tensor(
-            [10, 8, 12, 9, 11, 7, 10, 13], dtype=torch.int32
+            [10, 8, 12, 9, 11, 7, 10, 13], dtype=torch.int32, device="cuda"
         )
         total_tokens = num_tokens_per_expert.sum().item()
-        x = torch.randn(total_tokens, dim)
+        x = torch.randn(total_tokens, dim, device="cuda")
 
-        # Call the function, should not error
         output = moe_module._run_experts_grouped_mm(
             w1, w2, w3, x, num_tokens_per_expert
         )
 
-        print(f"Input shape: {x.shape}")
-        print(f"Output shape: {output.shape}")
-        print(f"Num tokens per expert: {num_tokens_per_expert}")
+        self.assertEqual(output.shape, x.shape)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -7,12 +7,8 @@
 import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    CheckpointWrapper,
-)
 
 from torchtitan.config import CompileConfig
-from torchtitan.models.common import moe as moe_module
 from torchtitan.tools.logging import logger
 
 
@@ -24,43 +20,13 @@ FakeTensorMode.__init__ = torch.compiler.disable(  # type: ignore[method-assign]
 )
 
 
-def apply_compile_dense(model: nn.Module, compile_config: CompileConfig) -> None:
+def apply_compile(model: nn.Module, compile_config: CompileConfig) -> None:
     """
     Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
     repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for dense (non-MoE) models. It compiles each TransformerBlock as a whole.
     """
-    # Skip replaying forward side effects (e.g. RoPE cache updates) during
-    # the AC recompute in backward. Eager AC replays the forward python
-    # side-effects in backward, but torch.compile has no easy way to reapply
-    # python mutations in the backward. Setting this flag accepts this eager
-    # and compile divergence by skipping reapplication of side effects.
-    torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = (
-        True  # pyrefly: ignore [bad-assignment]
-    )
-
-    # pyrefly: ignore [missing-attribute]
-    for layer_id, transformer_block in model.layers.named_children():
-        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    logger.info("Compiling each TransformerBlock with torch.compile")
-
-
-def apply_compile_sparse(
-    model: nn.Module, compile_config: CompileConfig, ep_enabled: bool
-) -> None:
-    """
-    Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
-    repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for MoE (sparse) models. It compiles sub-modules individually to avoid
-    graph breaks from FSDP(GroupedExperts).
-    """
-    # Needed for torch.compile to avoid graph breaking on dynamic shapes in
-    # token-choice MoE, but it is experimental.
+    # Needed for torch.compile to handle data-dependent dynamic shapes in
+    # token-choice MoE dispatch. Harmless for dense models.
     torch._dynamo.config.capture_scalar_outputs = True
     # Skip replaying forward side effects (e.g. RoPE cache updates) during
     # the AC recompute in backward. Eager AC replays the forward python
@@ -73,77 +39,6 @@ def apply_compile_sparse(
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
-        if transformer_block.moe_enabled:
-            # If it is a MoE layer, FSDP(GroupedExperts) will cause a graph break
-            # So we must weave compile wrappers around those FSDP hooks to
-            # prevent AC from falling back the whole graph to eager.
-            # TODO: Fix Compile(AC(graph break))
-
-            if isinstance(transformer_block, CheckpointWrapper):
-                # TODO: Make CheckpointWrapper a transparent wrapper
-                # unwrap so that .named_children() works
-                block = transformer_block._checkpoint_wrapped_module
-            else:
-                block = transformer_block
-
-            for attr_name, submod in block.named_children():
-                assert getattr(block, attr_name) == getattr(
-                    transformer_block, attr_name
-                )
-
-                if isinstance(submod, moe_module.MoE):
-                    # avoid graph breaking on the GroupedExperts' FSDP hooks
-                    # by wrapping each submod's forward instead of their __call__
-                    moe = submod
-                    for attr_name, submod in moe.named_children():
-                        if attr_name == "experts":
-                            # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
-                            # https://github.com/pytorch/torchtitan/issues/1940
-                            continue
-                        submod.compile(backend=compile_config.backend, fullgraph=True)
-                else:
-                    submod.compile(backend=compile_config.backend, fullgraph=True)
-        else:
-            # If it's not a MoE layer, there is no FSDP(GroupedExperts)
-            # So we can compile the whole block
-            transformer_block.compile(
-                backend=compile_config.backend,
-                fullgraph=True,
-            )
-
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    # Patch some globals only once (apply_compile_sparse is called multiple times for PP setup)
-    already_patched = (
-        "_run_experts_grouped_mm_dynamic"
-        in moe_module._run_experts_grouped_mm.__qualname__
-    )
-    if not already_patched:
-        moe_module._run_experts_grouped_mm = torch.compile(
-            moe_module._run_experts_grouped_mm,
-            backend=compile_config.backend,
-            fullgraph=True,
-        )
-
-        if ep_enabled:
-            compiled_fn = moe_module._run_experts_grouped_mm
-
-            # keep function logic in sync with `already_patched` above
-            def _run_experts_grouped_mm_dynamic(
-                w1: torch.Tensor,
-                w2: torch.Tensor,
-                w3: torch.Tensor,
-                x: torch.Tensor,
-                num_tokens_per_expert: torch.Tensor,
-            ) -> torch.Tensor:
-                # dynamic number of tokens in expert parallel
-                torch._dynamo.mark_dynamic(x, 0)
-                return compiled_fn(w1, w2, w3, x, num_tokens_per_expert)
-
-            moe_module._run_experts_grouped_mm = _run_experts_grouped_mm_dynamic
-
-    # NOTE: We don't compile for loop code path due to an issue with unbacked symints:
-    # https://github.com/pytorch/pytorch/issues/166460
+        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
 
     logger.info("Compiling each TransformerBlock with torch.compile")

--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -160,10 +160,14 @@ class ExpertParallel(BaseExpertParallel):
             num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
                 num_tokens_per_expert_group
             )
+            # non_blocking=True is safe in eager, but under torch.compile the
+            # async D2H transfer can race with the subsequent .tolist()/.item()
+            # calls, producing stale values and failing unbacked-symint guards.
+            non_blocking = not torch.compiler.is_compiling()
             input_splits = (
                 num_tokens_per_expert.view(ep_degree, -1)
                 .sum(dim=1)
-                .to(torch.device("cpu"), non_blocking=True)
+                .to(torch.device("cpu"), non_blocking=non_blocking)
             )
             # NOTE: this would incur a device-to-host sync
             output_splits = (
@@ -498,10 +502,14 @@ class TorchAOExpertParallel(ExpertParallel):
             num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
                 num_tokens_per_expert_group
             )
+            # non_blocking=True is safe in eager, but under torch.compile the
+            # async D2H transfer can race with the subsequent .tolist()/.item()
+            # calls, producing stale values and failing unbacked-symint guards.
+            non_blocking = not torch.compiler.is_compiling()
             input_splits = (
                 num_tokens_per_expert.view(ep_degree, -1)
                 .sum(dim=1)
-                .to(torch.device("cpu"), non_blocking=True)
+                .to(torch.device("cpu"), non_blocking=non_blocking)
             )
             # NOTE: this would incur a device-to-host sync
             output_splits = (

--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor.parallel import (
 from torchtitan.config import ParallelismConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.tensor_parallel import NoParallel
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ def parallelize_qwen3(
         and compile_config.enable
         and "model" in compile_config.components
     ):
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     return model
 

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -27,7 +27,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.llama3.parallelize import disable_fsdp_gradient_division
@@ -93,7 +93,7 @@ def parallelize_hf_transformers(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     dp_mesh_dim_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/experiments/vlm/infra/parallelize.py
+++ b/torchtitan/experiments/vlm/infra/parallelize.py
@@ -20,7 +20,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.models.llama3.parallelize import disable_fsdp_gradient_division
 from torchtitan.protocols.model_converter import ModelConvertersContainer
@@ -75,8 +75,8 @@ def parallelize_vlm(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if compile_config.enable:
-        apply_compile_dense(model, compile_config)
-        apply_compile_dense(model.encoder, compile_config)
+        apply_compile(model, compile_config)
+        apply_compile(model.encoder, compile_config)
 
     names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
     apply_fsdp(

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -33,8 +33,10 @@ def _run_experts_for_loop(
 
     # a tuple of tensors indexed by experts
     # each with shape (tokens_per_expert(varying), dim)
+    # NOTE: x is not sliced because padding was removed in #2774, so
+    # sum(num_tokens_per_expert) == x.shape[0] always holds.
     x_splits = torch.split(
-        x[: sum(num_tokens_per_expert_list)],
+        x,
         split_size_or_sections=num_tokens_per_expert_list,
         dim=0,
     )

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -25,7 +25,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
@@ -134,7 +134,7 @@ def parallelize_deepseekv3(
         )
 
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -28,7 +28,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     ExpertParallel,
@@ -125,7 +125,7 @@ def parallelize_gptoss(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -30,7 +30,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.fsdp import (
     disable_fsdp_gradient_division,
@@ -117,7 +117,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
     dp_mesh = parallel_dims.get_mesh(names)

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -30,7 +30,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     DeepEPExpertParallel,
@@ -160,7 +160,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -31,7 +31,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import NoParallel
 from torchtitan.models.llama4.parallelize import apply_fsdp, apply_moe_ep_tp
@@ -121,7 +121,7 @@ def parallelize_qwen3(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/qwen3_vl/parallelize.py
+++ b/torchtitan/models/qwen3_vl/parallelize.py
@@ -36,7 +36,7 @@ from torchtitan.config import (
 
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense, apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import NoParallel
 from torchtitan.models.llama4.parallelize import apply_fsdp, apply_moe_ep_tp
@@ -311,11 +311,11 @@ def parallelize_qwen3_vl(
 
     # Apply torch.compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
     if compile_config.enable:
         if model.vision_encoder is not None:
             # pyrefly: ignore [bad-argument-type]
-            apply_compile_dense(model.vision_encoder, compile_config)
+            apply_compile(model.vision_encoder, compile_config)
 
     # Apply FSDP / HSDP unconditionally (fully_shard handles dp_shard=1)
     dp_mesh_names = (


### PR DESCRIPTION
per-layer compile becomes possible after applying fully_shard at layer-level (no more moe level): https://github.com/pytorch/torchtitan/pull/2281 

`apply_compile`: consolidate apply_compile_dense and apply_compile_sparse into one.                             
  The only difference was capture_scalar_outputs which is harmless for dense models.                            
  Also removed the _run_experts_grouped_mm separate compile boundary and EP wrapper.                            

FSDP2 + EP: `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh --compile.enable --compile.components model,loss --parallelism.expert_parallel_degree 4`

FSDP2 + EP + TP: `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh --compile.enable --compile.components model,loss --parallelism.expert_parallel_degree 4 --parallelism.tensor_parallel_degree 2`

FSDP2 + EP + TP&ETP: `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh --compile.enable --compile.components model,loss --parallelism.expert_parallel_degree 4 --parallelism.tensor_parallel_degree 2 --parallelism.expert_tensor_parallel_degree 2`

qwen3-vl: `NGPU=8 MODULE=qwen3_vl CONFIG=qwen3_vl_debugmodel_moe ./run_train.sh --compile.enable --compile.components  model,loss --parallelism.expert_parallel_degree 4 --training.steps 20`

H100 works
<img width="610" height="173" alt="Screenshot 2026-04-02 at 16 28 08" src="https://github.com/user-attachments/assets/d60d3c40-5c64-4399-b7ea-b2914f5c5b82" />

<img width="1226" height="356" alt="Screenshot 2026-04-03 at 00 32 26" src="https://github.com/user-attachments/assets/55313369-6c48-481c-8889-1dac145b473f" />

A100 also works
<img width="885" height="225" alt="Screenshot 2026-04-03 at 00 26 14" src="https://github.com/user-attachments/assets/0908fcd7-7eab-4adb-ac60-e9d4ffa200b9" />

