### PR TITLE
[graph_trainer] Add aot_nested_region for invoke_subgraph deduplication

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -16,8 +16,11 @@ import torch.utils._pytree as pytree
 from torch._functorch._aot_autograd.logging_utils import (
     setup_stacktrace_preservation_hooks,
 )
+from torch._guards import TracingContext, tracing
+from torch._higher_order_ops.invoke_subgraph import InvokeSubgraphAutogradOp
+from torch._higher_order_ops.utils import reenter_make_fx
 from torch._subclasses import FakeTensorMode
-from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.proxy_tensor import get_proxy_mode, make_fx
 from torch.fx.traceback import preserve_node_meta
 from torch.nn.utils import stateless
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -177,6 +180,178 @@ def _remove_cpu_shadow_chains(gm: torch.fx.GraphModule) -> None:
 
     gm.graph.lint()
     gm.recompile()
+
+
+def _trace_bw_graph_for_make_fx(
+    subgraph_fn: Callable,
+    num_primals: int,
+    num_tangents: int,
+    primals_and_tangents: tuple,
+) -> torch.fx.GraphModule:
+    """Trace the backward graph for an invoke_subgraph subgraph inside make_fx.
+
+    Differentiates through the original Python callable (subgraph_fn) rather
+    than a pre-traced GraphModule. The backward re-runs the forward from
+    scratch (activation-checkpointing style) so no partitioner is needed.
+
+    reenter_make_fx converts primals_and_tangents into fresh leaf fake tensors,
+    preserving requires_grad=True for params and activations alike (requires_grad
+    is True for both leaf params and non-leaf activation tensors output by prior
+    invoke_subgraph calls). No .detach() or .requires_grad_() is needed: we never
+    touch requires_grad on the original primals, and the fresh leaf fake tensors
+    inside bwd_fn have the correct requires_grad for torch.autograd.grad.
+
+    Output signature: (*primals, *tangents) → (*grads_for_all_primals, *fw_outs)
+    so InvokeSubgraphAutogradOp.backward can extract grads via [:num_primals].
+    """
+
+    def bwd_fn(*args: torch.Tensor) -> tuple:
+        primals = list(args[:num_primals])
+        tangents = list(args[num_primals : num_primals + num_tangents])
+
+        with torch.enable_grad():
+            # Differentiate through the original Python callable, not the
+            # pre-traced gm. This ensures correct autograd semantics; the
+            # forward is recomputed here (activation-checkpointing style).
+            fw_outs = subgraph_fn(*primals)
+
+        if isinstance(fw_outs, torch.Tensor):
+            fw_outs = (fw_outs,)
+        fw_outs = tuple(fw_outs)
+
+        differentiable_outs = [
+            o for o in fw_outs if isinstance(o, torch.Tensor) and o.requires_grad
+        ]
+        differentiable_ins = [
+            p for p in primals if isinstance(p, torch.Tensor) and p.requires_grad
+        ]
+
+        raw_grads = torch.autograd.grad(
+            differentiable_outs, differentiable_ins, tangents, allow_unused=True
+        )
+
+        # Map back to all primals, zeros for non-differentiable.
+        grad_iter = iter(raw_grads)
+        all_grads: list[torch.Tensor] = []
+        for p in primals:
+            if isinstance(p, torch.Tensor) and p.requires_grad:
+                g = next(grad_iter)
+                all_grads.append(g if g is not None else torch.zeros_like(p))
+            else:
+                all_grads.append(torch.zeros_like(p) if isinstance(p, torch.Tensor) else p)
+
+        # Signature: (*grads_for_all_primals, *fw_outs)
+        return tuple(all_grads) + fw_outs
+
+    return reenter_make_fx(bwd_fn)(*primals_and_tangents)
+
+
+@contextmanager
+def _patch_invoke_subgraph_backward() -> Generator[None, None, None]:
+    """Patch InvokeSubgraphAutogradOp.backward to handle make_fx tracing context.
+
+    In the normal torch.compile path, InvokeSubgraphAutogradOp.backward is
+    called by AOTAutograd's joint tracer with fake tensors. It lazily traces a
+    bw_graph via trace_joint_graph_as_bwd (which uses create_joint, an
+    AOTAutograd utility) and emits an invoke_subgraph(bw_graph, ...) HOP node.
+
+    When loss.backward() is called inside make_fx instead, two things break:
+
+    1. trace_joint_graph_as_bwd / create_joint is AOTAutograd machinery that is
+       not appropriate for the make_fx tracing path. A concrete symptom: it reads
+       output_node.meta["val"].requires_grad to filter tangents, but snapshot_fake
+       always strips requires_grad → all outputs appear non-differentiable →
+       filtered_grad_outs=[] → AssertionError inside create_joint.
+
+    2. The C++ autograd engine runs InvokeSubgraphAutogradOp.backward on a worker
+       thread. threading.local() does not propagate across threads, so
+       get_invoke_subgraph_cache() returns None on the worker thread even though
+       a TracingContext is active on the main thread.
+
+    This patch fixes both: it captures the TracingContext on the main thread and
+    re-establishes it on the worker thread, and replaces trace_joint_graph_as_bwd
+    with _trace_bw_graph_for_make_fx, which runs subgraph_fn (the original Python
+    callable) directly to build a real autograd graph and uses torch.autograd.grad
+    — no AOTAutograd machinery needed.
+
+    TODO(upstream): This patch should be contributed upstream to PyTorch once the
+    make_fx-based tracer moves out of torchtitan/experiments. At that point,
+    InvokeSubgraphAutogradOp.backward should natively handle the make_fx tracing
+    context instead of requiring this monkey-patch.
+    """
+    from torch._guards import TracingContext, tracing
+    from torch._higher_order_ops.invoke_subgraph import (
+        get_invoke_subgraph_cache,
+        invoke_subgraph,
+        saved_values,
+    )
+
+    # Capture the TracingContext from the main thread now. The autograd engine
+    # runs InvokeSubgraphAutogradOp.backward on a worker thread, where
+    # threading.local() does not propagate — so get_invoke_subgraph_cache()
+    # would return None if we didn't re-establish the context inside the patch.
+    captured_tracing_ctx = TracingContext.try_get()
+
+    _orig_backward = InvokeSubgraphAutogradOp.backward
+
+    @staticmethod  # type: ignore[misc]
+    def _patched_backward(ctx, *grad_outs):  # type: ignore[no-untyped-def]
+        if get_proxy_mode() is None:
+            # Not in make_fx — use the original path unchanged.
+            return _orig_backward(ctx, *grad_outs)
+
+        # Re-establish the TracingContext for this worker thread so that
+        # get_invoke_subgraph_cache() can find the cache.
+        with tracing(captured_tracing_ctx):
+            return _patched_backward_impl(ctx, *grad_outs)
+
+    @staticmethod  # type: ignore[misc]
+    def _patched_backward_impl(ctx, *grad_outs):  # type: ignore[no-untyped-def]
+        # ── make_fx path ──────────────────────────────────────────────────────
+        subgraph = ctx._subgraph
+        identifier = ctx._identifier
+        primals = saved_values(ctx)
+
+        # We do not use output_metadata.indexes_with_no_grad here.
+        # _trace_bw_graph_for_make_fx runs subgraph_fn directly and inspects
+        # o.requires_grad on the real (fake) tensors to determine differentiability,
+        # so static graph metadata is not needed. The C++ autograd engine already
+        # passes None for outputs that don't require grad, so filtering by
+        # o is not None is sufficient.
+        tangents = tuple(o for o in grad_outs if o is not None)
+        primals_and_tangents = primals + tangents
+
+        # Use the original Python callable stored on the gm so we differentiate
+        # through the source function rather than the pre-traced graph.
+        # Falls back to the gm itself for subgraphs not created by aot_nested_region
+        # (e.g. mark_compile_region), preserving the old behavior.
+        subgraph_fn = getattr(subgraph, "_orig_subgraph_fn", subgraph)
+
+        bw_graph = _trace_bw_graph_for_make_fx(
+            subgraph_fn, len(primals), len(tangents), primals_and_tangents
+        )
+
+        invoke_subgraph_cache = get_invoke_subgraph_cache()
+        assert invoke_subgraph_cache is not None, (
+            "_patched_backward: expected TracingContext to be active on this thread "
+            "(captured_tracing_ctx should have been re-established via tracing())"
+        )
+        existing, suffix = invoke_subgraph_cache.get_lazy_bwd_entry(identifier, ())
+        if existing is None:
+            suffix = invoke_subgraph_cache.add_lazy_bwd_entry(identifier, (), bw_graph)
+
+        # bw_graph output: (*grads_for_all_primals, *fw_outs)
+        # We want only the gradient tensors (first len(primals) outputs).
+        grads = invoke_subgraph(
+            bw_graph, f"bw_{identifier}_{suffix}", *primals_and_tangents
+        )[: len(primals)]
+        return None, None, None, *grads
+
+    InvokeSubgraphAutogradOp.backward = _patched_backward
+    try:
+        yield
+    finally:
+        InvokeSubgraphAutogradOp.backward = _orig_backward
 
 
 @contextmanager
@@ -339,7 +514,11 @@ def trace_module(
         return unwrapped_outputs
 
     # preserve_node_meta propagates fx.traceback.annotate metadata to traced nodes
-    with fake_mode, preserve_node_meta(), _skip_nested_compile():
+    # Install TracingContext so that invoke_subgraph's ProxyTorchDispatchMode impl
+    # can cache traced subgraphs (its cache lives in TracingContext.hop_dispatch_set_cache).
+    # Without this, invoke_subgraph re-traces the subgraph on every call.
+    tracing_ctx = TracingContext(fake_mode=fake_mode)
+    with fake_mode, preserve_node_meta(), _skip_nested_compile(), tracing(tracing_ctx), _patch_invoke_subgraph_backward():
         traced = make_fx(
             fn_with_subclass_handling,
             record_stack_traces=True,

--- a/torchtitan/experiments/graph_trainer/nested_region.py
+++ b/torchtitan/experiments/graph_trainer/nested_region.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""aot_nested_region: trace a subgraph once and reuse it via invoke_subgraph.
+
+Patches a free function, an nn.Module instance, or a method so that during
+make_fx tracing:
+
+1. First call: traces the subgraph via reenter_make_fx, caches it, and calls
+   invoke_subgraph which emits the HOP node into the outer graph.
+2. Subsequent calls with the same hash_fn key: cache hit — calls invoke_subgraph
+   with the cached GraphModule (the HOP's ProxyTorchDispatchMode impl reuses
+   the cached subgraph via TracingContext.hop_dispatch_set_cache).
+3. Outside of tracing: transparent passthrough to the original callable.
+
+For nn.Module instances and method decorators, parameters and buffers are
+automatically flattened as explicit positional operands so invoke_subgraph can
+deduplicate across calls with identical structure (e.g. repeated transformer
+blocks sharing one traced subgraph).
+
+For free functions, all inputs must already be positional tensor arguments.
+"""
+
+from typing import Any, Callable
+
+import torch
+import torch.nn as nn
+from torch._higher_order_ops.invoke_subgraph import (
+    get_invoke_subgraph_cache,
+    invoke_subgraph,
+)
+from torch._higher_order_ops.utils import reenter_make_fx
+from torch.fx.experimental.proxy_tensor import get_proxy_mode
+from torch.nn.utils import stateless
+
+
+def _ensure_subgraph_cached(
+    cache_key: str,
+    subgraph_fn: Callable,
+    all_operands: tuple,
+) -> torch.fx.GraphModule:
+    """Trace and cache the subgraph if not already cached."""
+    cache = get_invoke_subgraph_cache()
+    if cache is not None:
+        cached = cache.get_proxy_dispatch_entry(cache_key)
+        if cached is not None:
+            return cached
+
+    gm = reenter_make_fx(subgraph_fn)(*all_operands)
+
+    # Store the original callable on the gm so _trace_bw_graph_for_make_fx
+    # can differentiate through the Python function rather than the traced gm,
+    # ensuring correct autograd semantics in the backward.
+    gm._orig_subgraph_fn = subgraph_fn
+
+    if cache is not None:
+        cache.add_proxy_dispatch_entry(cache_key, gm)
+
+    return gm
+
+
+def _extract_tensor_operands(
+    args: tuple, kwargs: dict
+) -> tuple[list[int], list[str], tuple, tuple]:
+    """Split args/kwargs into tensor operands and non-tensor constants.
+
+    Returns:
+        tensor_arg_indices: positions in args that are tensors
+        tensor_kwarg_keys: keys in kwargs whose values are tensors
+        tensor_args: tensor values from args (in index order)
+        tensor_kwargs: tensor values from kwargs (in key order)
+    """
+    tensor_arg_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
+    tensor_kwarg_keys = [k for k, v in kwargs.items() if isinstance(v, torch.Tensor)]
+    tensor_args = tuple(args[i] for i in tensor_arg_indices)
+    tensor_kwargs = tuple(kwargs[k] for k in tensor_kwarg_keys)
+    return tensor_arg_indices, tensor_kwarg_keys, tensor_args, tensor_kwargs
+
+
+def _reconstruct_args_kwargs(
+    args: tuple,
+    kwargs: dict,
+    tensor_arg_indices: list[int],
+    tensor_kwarg_keys: list[str],
+    tensor_fwd_args: tuple,
+    tensor_fwd_kwargs: tuple,
+) -> tuple[list, dict]:
+    """Reconstruct full args/kwargs by slotting traced tensor operands back in."""
+    full_args = list(args)
+    for idx, val in zip(tensor_arg_indices, tensor_fwd_args):
+        full_args[idx] = val
+    full_kwargs = dict(kwargs)
+    for k, val in zip(tensor_kwarg_keys, tensor_fwd_kwargs):
+        full_kwargs[k] = val
+    return full_args, full_kwargs
+
+
+def _invoke_as_module(
+    module: nn.Module,
+    orig_forward: Callable,
+    cache_key: str,
+    args: tuple,
+    kwargs: dict,
+) -> Any:
+    """Dispatch an nn.Module forward call through invoke_subgraph.
+
+    Flattens parameters and buffers as the leading operands so invoke_subgraph
+    can deduplicate across layers with the same architecture.
+
+    orig_forward must be the bound method (no self in args/kwargs).
+    """
+    param_names = [n for n, _ in module.named_parameters()]
+    buffer_names = [n for n, _ in module.named_buffers()]
+    n_params = len(param_names)
+    n_buffers = len(buffer_names)
+
+    # Flatten parameters and buffers as explicit operands so invoke_subgraph
+    # can deduplicate across layers with the same architecture.
+    param_vals = [p for _, p in module.named_parameters()]
+    buffer_vals = [b for _, b in module.named_buffers()]
+
+    # Only tensor args/kwargs become invoke_subgraph operands — non-tensors
+    # (None, int, etc.) are specialized as constants inside the subgraph, same
+    # as Dynamo's "automatic" input mode for invoke_subgraph.
+    tensor_arg_indices, tensor_kwarg_keys, tensor_args, tensor_kwargs = (
+        _extract_tensor_operands(args, kwargs)
+    )
+    all_operands = (*param_vals, *buffer_vals, *tensor_args, *tensor_kwargs)
+
+    def subgraph_fn(*operands: Any) -> tuple:
+        params = dict(zip(param_names, operands[:n_params]))
+        buffers = dict(zip(buffer_names, operands[n_params : n_params + n_buffers]))
+        n_tensor_args = len(tensor_arg_indices)
+        tensor_fwd_args = operands[n_params + n_buffers : n_params + n_buffers + n_tensor_args]
+        tensor_fwd_kwargs = operands[n_params + n_buffers + n_tensor_args :]
+        # Reconstruct full args/kwargs: non-tensors stay from the outer closure,
+        # tensor positions are filled from the traced operands.
+        full_args, full_kwargs = _reconstruct_args_kwargs(
+            args, kwargs,
+            tensor_arg_indices, tensor_kwarg_keys,
+            tensor_fwd_args, tensor_fwd_kwargs,
+        )
+        with stateless._reparametrize_module(module, {**params, **buffers}):
+            out = orig_forward(*full_args, **full_kwargs)
+        if isinstance(out, torch.Tensor):
+            return (out,)
+        return tuple(out) if isinstance(out, (list, tuple)) else (out,)
+
+    gm = _ensure_subgraph_cached(cache_key, subgraph_fn, all_operands)
+    result = invoke_subgraph(gm, cache_key, *all_operands)
+    if isinstance(result, (tuple, list)) and len(result) == 1:
+        return result[0]
+    return result
+
+
+def _make_module_wrapper(
+    module: nn.Module,
+    orig_forward: Callable,
+    hash_fn: Callable[..., str],
+) -> Callable:
+    """Return a patched forward that auto-flattens params/buffers as operands."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if get_proxy_mode() is None:
+            return orig_forward(*args, **kwargs)
+        cache_key = hash_fn(*args, **kwargs)
+        if not isinstance(cache_key, str):
+            raise ValueError(
+                f"hash_fn must return a str, got {type(cache_key).__name__}"
+            )
+        return _invoke_as_module(module, orig_forward, cache_key, args, kwargs)
+
+    return wrapper
+
+
+def aot_nested_region(
+    fn=None,
+    *,
+    hash_fn: Callable[..., str],
+):
+    """Patch a free function, nn.Module instance, or method to emit invoke_subgraph during make_fx tracing.
+
+    For nn.Module instances and method decorators, parameters and buffers are
+    automatically flattened as leading operands for deduplication across layers.
+
+    For free functions, all inputs must already be positional tensor arguments.
+
+    Usage on an nn.Module instance::
+
+        aot_nested_region(layer, hash_fn=lambda *args, **kwargs: "block")
+
+    Usage as a decorator on a method (params/buffers auto-flattened)::
+
+        class Block(nn.Module):
+            @aot_nested_region(hash_fn=lambda *args, **kwargs: "block")
+            def forward(self, x):
+                ...
+
+    Usage as a decorator on a free function::
+
+        @aot_nested_region(hash_fn=lambda *args: "block")
+        def block_fwd(x, w1, b1, w2, b2):
+            ...
+
+    Args:
+        fn: The callable or nn.Module instance to patch. If None, returns a decorator.
+        hash_fn: Returns a str cache key from the forward call arguments (not including
+            the module itself). Calls with the same key share a single traced subgraph.
+    """
+
+    def patch(target):
+        if isinstance(target, type):
+            raise ValueError(
+                f"aot_nested_region does not support classes, got {target.__name__}. "
+                "Pass an nn.Module instance or a free function instead."
+            )
+
+        if isinstance(target, nn.Module):
+            orig_forward = target.forward
+            target.forward = _make_module_wrapper(target, orig_forward, hash_fn)
+            return target
+
+        if not callable(target):
+            raise ValueError(
+                f"aot_nested_region expects a callable, got {type(target).__name__}."
+            )
+
+        orig_fn = target
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # For free functions (not method decorators), reject kwargs eagerly.
+            # Method decorator calls have args[0] as the nn.Module instance.
+            is_method_call = args and isinstance(args[0], nn.Module)
+            if kwargs and not is_method_call:
+                raise ValueError(
+                    "aot_nested_region does not support keyword arguments for free "
+                    f"functions. Got kwargs: {set(kwargs.keys())}."
+                )
+
+            if get_proxy_mode() is None:
+                return orig_fn(*args, **kwargs)
+
+            cache_key = hash_fn(*args, **kwargs)
+            if not isinstance(cache_key, str):
+                raise ValueError(
+                    f"hash_fn must return a str, got {type(cache_key).__name__}"
+                )
+
+            # Method decorator: first arg is an nn.Module instance (self).
+            # Dispatch through _invoke_as_module so params/buffers are flattened
+            # as operands, identical to the nn.Module instance patching path.
+            if args and isinstance(args[0], nn.Module):
+                module = args[0]
+                bound_method = orig_fn.__get__(module, type(module))
+                return _invoke_as_module(module, bound_method, cache_key, args[1:], kwargs)
+
+            # Free function path: only positional tensor args become operands.
+            tensor_arg_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
+            tensor_args = tuple(args[i] for i in tensor_arg_indices)
+            all_operands = tensor_args
+
+            def subgraph_fn(*operands: Any) -> tuple:
+                full_args = list(args)
+                for idx, val in zip(tensor_arg_indices, operands):
+                    full_args[idx] = val
+                out = orig_fn(*full_args)
+                if isinstance(out, torch.Tensor):
+                    return (out,)
+                return tuple(out) if isinstance(out, (list, tuple)) else (out,)
+
+            gm = _ensure_subgraph_cached(cache_key, subgraph_fn, all_operands)
+            result = invoke_subgraph(gm, cache_key, *all_operands)
+            if isinstance(result, (tuple, list)) and len(result) == 1:
+                return result[0]
+            return result
+
+        return wrapper
+
+    if fn is None:
+        return patch
+    return patch(fn)

--- a/torchtitan/experiments/graph_trainer/tests/test_nested_region.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_nested_region.py
@@ -1,0 +1,584 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Bitwise correctness tests for aot_nested_region."""
+
+import unittest
+
+import torch
+import torch.nn as nn
+from torch._higher_order_ops.invoke_subgraph import invoke_subgraph
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_module,
+    trace_module,
+)
+from torchtitan.experiments.graph_trainer.nested_region import aot_nested_region
+
+
+def _get_params_and_buffers(mod):
+    return {
+        **dict(mod.named_parameters(remove_duplicate=False)),
+        **dict(mod.named_buffers(remove_duplicate=False)),
+    }
+
+
+def create_model(config_cls, model_config, device="cuda", dtype=torch.float32):
+    model = config_cls(model_config)
+    model.to(device=device, dtype=dtype)
+    with torch.no_grad():
+        model.init_weights(buffer_device=torch.device(device))
+    return model
+
+
+CONST_HASH = lambda *args: "block"
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestNestedRegion(unittest.TestCase):
+    DEVICE = "cuda"
+    DTYPE = torch.float32
+    BATCH_SIZE = 2
+    SEQ_LEN = 128
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.use_deterministic_algorithms(True)
+
+    def tearDown(self):
+        torch.use_deterministic_algorithms(False)
+
+    def _assert_invoke_subgraph_count(self, traced_result, expected):
+        invoke_count = sum(
+            1
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and "invoke_subgraph" in str(n.target)
+        )
+        self.assertEqual(invoke_count, expected)
+
+    def _run_forward_bitwise_test(self, model_ref, model_test, fwd_args):
+        """Compare eager forward vs traced-with-nested-region forward."""
+        traced_result = trace_module(model_test, fwd_args)
+
+        num_layers = len(list(model_ref.layers.children()))
+        self._assert_invoke_subgraph_count(traced_result, num_layers)
+
+        out_eager = model_ref(*fwd_args)
+        params_and_buffers = _get_params_and_buffers(model_test)
+        out_traced = run_traced_module(traced_result, params_and_buffers, fwd_args)
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def _make_model_pair(self, config_cls, config):
+        model_ref = create_model(config_cls, config, self.DEVICE, self.DTYPE)
+        model_test = create_model(config_cls, config, self.DEVICE, self.DTYPE)
+        model_test.load_state_dict(model_ref.state_dict())
+        tokens = torch.randint(
+            0, config.vocab_size, (self.BATCH_SIZE, self.SEQ_LEN), device=self.DEVICE
+        )
+        return model_ref, model_test, tokens
+
+    def test_module_instance(self):
+        # Verify graph structure (4-layer MLP, dim=64):
+        #
+        # outer graph: only invoke_subgraph nodes, no inlined aten ops
+        #   %invoke_subgraph   = invoke_subgraph(subgraph, block, w1, b1, w2, b2, x)
+        #   %invoke_subgraph_1 = invoke_subgraph(subgraph, block, w3, b3, w4, b4, x1)
+        #   ...
+        #
+        # subgraph (repeated_subgraph0):
+        #   placeholders: fc1.weight, fc1.bias, fc2.weight, fc2.bias, x
+        #   aten ops: t, addmm, relu, t, addmm, add
+        #   return (add,)
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc1 = nn.Linear(dim, dim * 2)
+                self.fc2 = nn.Linear(dim * 2, dim)
+
+            def forward(self, x):
+                return x + self.fc2(torch.relu(self.fc1(x)))
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        dim, n_layers = 64, 4
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+
+        x = torch.randn(2, 8, dim, device=self.DEVICE)
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+        gm = traced_result.gm
+
+        # Outer graph: only invoke_subgraph calls, no inlined aten ops
+        invoke_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is invoke_subgraph
+        ]
+        self.assertEqual(len(invoke_nodes), n_layers)
+
+        aten_ops_in_outer = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and "aten" in str(n.target)
+            and "empty_strided" not in str(n.target)
+        ]
+        self.assertEqual(aten_ops_in_outer, [])
+
+        # All invoke_subgraph nodes reference the same subgraph
+        subgraph_targets = {n.args[0].target for n in invoke_nodes}
+        self.assertEqual(len(subgraph_targets), 1)
+
+        # invoke_subgraph calls are chained: output of N feeds input of N+1
+        for i in range(1, len(invoke_nodes)):
+            prev_out = invoke_nodes[i].args[-1]
+            self.assertIn("getitem", prev_out.name)
+
+        # Bitwise correctness
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_module_instance_with_nontensor_args(self):
+        """Non-tensor forward args (None, int) are captured via closure, not passed
+        as invoke_subgraph operands."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, x, mask=None, scale: int = 1):
+                out = self.fc(x)
+                if mask is not None:
+                    out = out * mask
+                return out * scale
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    # None and int are non-tensor args
+                    x = layer(x, None, 1)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_module_instance_with_nontensor_args_interleaved(self):
+        """Tensor arg in the middle: forward(mask, x, scale) exercises that
+        tensor_arg_indices correctly identifies non-first tensor positions."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, mask, x, scale: int = 1):
+                out = self.fc(x)
+                if mask is not None:
+                    out = out * mask
+                return out * scale
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(None, x, 2)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_free_function_decorator(self):
+        """@aot_nested_region on a free function with explicit param args."""
+        import torch.nn.functional as F
+
+        @aot_nested_region(hash_fn=CONST_HASH)
+        def block_fwd(x, w1, b1, w2, b2):
+            h = F.relu(F.linear(x, w1, b1))
+            return x + F.linear(h, w2, b2)
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleList(
+                    [nn.Sequential(nn.Linear(dim, dim * 2), nn.Linear(dim * 2, dim))
+                     for _ in range(n_layers)]
+                )
+
+            def forward(self, x):
+                for blk in self.layers:
+                    fc1, fc2 = blk[0], blk[1]
+                    x = block_fwd(x, fc1.weight, fc1.bias, fc2.weight, fc2.bias)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_llama3_forward(self):
+        from torchtitan.models.llama3 import llama3_configs, Llama3Model
+
+        model_ref, model_test, tokens = self._make_model_pair(
+            Llama3Model, llama3_configs["debugmodel"]
+        )
+        for layer in model_test.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+        self._run_forward_bitwise_test(model_ref, model_test, (tokens,))
+
+    def test_qwen3_forward(self):
+        from torchtitan.models.qwen3 import qwen3_configs
+        from torchtitan.models.qwen3.model import Qwen3Model
+
+        model_ref, model_test, tokens = self._make_model_pair(
+            Qwen3Model, qwen3_configs["debugmodel"]
+        )
+        for layer in model_test.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+        self._run_forward_bitwise_test(model_ref, model_test, (tokens,))
+
+    def test_forward_hooks_preserved(self):
+        """Forward hooks fire in the outer graph, not inside invoke_subgraph."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.fc(x)
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        dim, n_layers = 64, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+
+        # Register a forward hook that multiplies output by 2
+        for layer in model.layers.values():
+            layer.register_forward_hook(lambda mod, inp, out: out * 2)
+
+        x = torch.randn(2, 8, dim, device=self.DEVICE)
+
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        # The hook's mul op should be in the outer graph, not inside invoke_subgraph
+        mul_count = sum(
+            1
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and "mul" in str(n.target)
+        )
+        self.assertEqual(mul_count, n_layers, "hook mul ops should be in outer graph")
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_method_decorator(self):
+        """@aot_nested_region on forward() auto-flattens params/buffers like the
+        module instance patching path."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc1 = nn.Linear(dim, dim * 2)
+                self.fc2 = nn.Linear(dim * 2, dim)
+
+            @aot_nested_region(hash_fn=CONST_HASH)
+            def forward(self, x):
+                return x + self.fc2(torch.relu(self.fc1(x)))
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        dim, n_layers = 64, 4
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        x = torch.randn(2, 8, dim, device=self.DEVICE)
+
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        # All invoke_subgraph nodes reference the same subgraph
+        invoke_nodes = [
+            n
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and n.target is invoke_subgraph
+        ]
+        subgraph_targets = {n.args[0].target for n in invoke_nodes}
+        self.assertEqual(len(subgraph_targets), 1)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_method_decorator_train_step(self):
+        """@aot_nested_region on forward() produces correct fwd+bwd invoke_subgraph
+        HOPs in a full train step trace."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            @aot_nested_region(hash_fn=CONST_HASH)
+            def forward(self, x):
+                return torch.relu(self.fc(x))
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        class TrainStep(nn.Module):
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, x):
+                out = self.model(x)
+                loss = out.sum()
+                loss.backward()
+                return loss.detach()
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        train_step = TrainStep(model)
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        traced_result = trace_module(train_step, (x,))
+
+        invoke_nodes = [
+            n
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and "invoke_subgraph" in str(n.target)
+        ]
+        # Forward: n_layers HOPs; backward: n_layers HOPs
+        self.assertEqual(len(invoke_nodes), n_layers * 2)
+
+        identifiers = {n.args[1] for n in invoke_nodes}
+        self.assertEqual(len(identifiers), 2)
+        self.assertEqual(len({id_ for id_ in identifiers if id_.startswith("fw_")}), 1)
+        self.assertEqual(len({id_ for id_ in identifiers if id_.startswith("bw_")}), 1)
+
+    def test_error_on_class(self):
+        with self.assertRaisesRegex(ValueError, "does not support classes"):
+            @aot_nested_region(hash_fn=CONST_HASH)
+            class Block(nn.Module):
+                pass
+
+    def test_error_on_kwargs(self):
+        @aot_nested_region(hash_fn=CONST_HASH)
+        def fn(x):
+            return x
+
+        with self.assertRaisesRegex(ValueError, "keyword arguments"):
+            fn(x=torch.randn(4))
+
+    def test_unique_hash_no_dedup(self):
+        """Each unique hash key traces a separate subgraph — no deduplication.
+        With hash_fn returning the layer index, n_layers invoke_subgraph nodes
+        must reference n_layers distinct subgraphs (one per unique key)."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.fc(x)
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for i, layer in enumerate(model.layers.values()):
+            aot_nested_region(layer, hash_fn=lambda *args, _i=i: f"block_{_i}")
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        # One invoke_subgraph per layer, each with a distinct subgraph target
+        invoke_nodes = [
+            n
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and "invoke_subgraph" in str(n.target)
+        ]
+        self.assertEqual(len(invoke_nodes), n_layers)
+        subgraph_targets = {n.args[0].target for n in invoke_nodes}
+        self.assertEqual(len(subgraph_targets), n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_full_train_step(self):
+        """Trace a full forward+backward train step and verify both forward and
+        backward invoke_subgraph HOPs appear in the outer graph."""
+
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return torch.relu(self.fc(x))
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x):
+                for layer in self.layers.values():
+                    x = layer(x)
+                return x
+
+        class TrainStep(nn.Module):
+            """Wraps model so that trace_module captures fwd+bwd in one graph."""
+
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, x):
+                out = self.model(x)
+                loss = out.sum()
+                loss.backward()
+                return loss.detach()
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+        train_step = TrainStep(model)
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        traced_result = trace_module(train_step, (x,))
+
+        invoke_nodes = [
+            n
+            for n in traced_result.gm.graph.nodes
+            if n.op == "call_function" and "invoke_subgraph" in str(n.target)
+        ]
+        # Forward: n_layers HOPs; backward: n_layers HOPs
+        self.assertEqual(len(invoke_nodes), n_layers * 2)
+
+        # Forward HOPs use one identifier, backward HOPs use another
+        identifiers = {n.args[1] for n in invoke_nodes}
+        self.assertEqual(len(identifiers), 2)
+        fwd_ids = {id_ for id_ in identifiers if id_.startswith("fw_")}
+        bwd_ids = {id_ for id_ in identifiers if id_.startswith("bw_")}
+        self.assertEqual(len(fwd_ids), 1)
+        self.assertEqual(len(bwd_ids), 1)
+
+    # NOTE: MoE models (qwen3_moe, deepseek_v3) are not tested here because:
+    # - MoE layers have in-place mutations that invoke_subgraph doesn't support
+    # - DeepSeek V3 has heterogeneous layers (dense vs MoE) with different param counts
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2746
* __->__ #2745

Adds aot_nested_region, a utility that patches a free function, nn.Module
instance, or method so that during make_fx tracing, repeated calls with the
same hash_fn key share a single traced subgraph via invoke_subgraph HOP,
enabling deduplication across identical layers (e.g. transformer blocks).

Key design points:
- Module instances and method decorators auto-flatten params/buffers as leading
  invoke_subgraph operands. Tensor args become operands; non-tensors (None, int)
  are specialized as constants inside the subgraph.
- _invoke_as_module is the shared dispatch core for both module instance patching
  and the method decorator path.
- Free functions pass all positional tensor args as operands. Kwargs are not yet
  supported for free functions.

Backward tracing patch (_patch_invoke_subgraph_backward):
- The C++ autograd engine runs InvokeSubgraphAutogradOp.backward on a worker
  thread where threading.local() does not propagate. Captures TracingContext on
  the main thread and re-establishes it on the worker thread so
  get_invoke_subgraph_cache() finds the cache.
- Replaces trace_joint_graph_as_bwd (AOTAutograd machinery) with
  _trace_bw_graph_for_make_fx, which runs subgraph_fn directly and uses
  torch.autograd.grad — no static output metadata needed.