### PR TITLE
[graph_trainer] aot_nested_region: add kwargs support

### DIFF
--- a/torchtitan/experiments/graph_trainer/nested_region.py
+++ b/torchtitan/experiments/graph_trainer/nested_region.py
@@ -21,7 +21,9 @@ automatically flattened as explicit positional operands so invoke_subgraph can
 deduplicate across calls with identical structure (e.g. repeated transformer
 blocks sharing one traced subgraph).
 
-For free functions, all inputs must already be positional tensor arguments.
+Tensor arguments (positional and keyword) become invoke_subgraph operands.
+Non-tensor arguments (None, int, etc.) are specialized as constants inside the
+subgraph, mirroring Dynamo's "automatic" input mode for invoke_subgraph.
 """
 
 from typing import Any, Callable
@@ -186,7 +188,9 @@ def aot_nested_region(
     For nn.Module instances and method decorators, parameters and buffers are
     automatically flattened as leading operands for deduplication across layers.
 
-    For free functions, all inputs must already be positional tensor arguments.
+    Tensor arguments (positional and keyword) become invoke_subgraph operands.
+    Non-tensor arguments (None, int, etc.) are specialized as constants inside the
+    subgraph, mirroring Dynamo's "automatic" input mode for invoke_subgraph.
 
     Usage on an nn.Module instance::
 
@@ -201,7 +205,7 @@ def aot_nested_region(
 
     Usage as a decorator on a free function::
 
-        @aot_nested_region(hash_fn=lambda *args: "block")
+        @aot_nested_region(hash_fn=lambda *args, **kwargs: "block")
         def block_fwd(x, w1, b1, w2, b2):
             ...
 
@@ -231,15 +235,6 @@ def aot_nested_region(
         orig_fn = target
 
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # For free functions (not method decorators), reject kwargs eagerly.
-            # Method decorator calls have args[0] as the nn.Module instance.
-            is_method_call = args and isinstance(args[0], nn.Module)
-            if kwargs and not is_method_call:
-                raise ValueError(
-                    "aot_nested_region does not support keyword arguments for free "
-                    f"functions. Got kwargs: {set(kwargs.keys())}."
-                )
-
             if get_proxy_mode() is None:
                 return orig_fn(*args, **kwargs)
 
@@ -257,16 +252,22 @@ def aot_nested_region(
                 bound_method = orig_fn.__get__(module, type(module))
                 return _invoke_as_module(module, bound_method, cache_key, args[1:], kwargs)
 
-            # Free function path: only positional tensor args become operands.
-            tensor_arg_indices = [i for i, a in enumerate(args) if isinstance(a, torch.Tensor)]
-            tensor_args = tuple(args[i] for i in tensor_arg_indices)
-            all_operands = tensor_args
+            # Free function path: only tensor args/kwargs become operands.
+            tensor_arg_indices, tensor_kwarg_keys, tensor_args, tensor_kwargs = (
+                _extract_tensor_operands(args, kwargs)
+            )
+            all_operands = (*tensor_args, *tensor_kwargs)
 
             def subgraph_fn(*operands: Any) -> tuple:
-                full_args = list(args)
-                for idx, val in zip(tensor_arg_indices, operands):
-                    full_args[idx] = val
-                out = orig_fn(*full_args)
+                n_tensor_args = len(tensor_arg_indices)
+                tensor_fwd_args = operands[:n_tensor_args]
+                tensor_fwd_kwargs = operands[n_tensor_args:]
+                full_args, full_kwargs = _reconstruct_args_kwargs(
+                    args, kwargs,
+                    tensor_arg_indices, tensor_kwarg_keys,
+                    tensor_fwd_args, tensor_fwd_kwargs,
+                )
+                out = orig_fn(*full_args, **full_kwargs)
                 if isinstance(out, torch.Tensor):
                     return (out,)
                 return tuple(out) if isinstance(out, (list, tuple)) else (out,)

--- a/torchtitan/experiments/graph_trainer/tests/test_nested_region.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_nested_region.py
@@ -34,7 +34,7 @@ def create_model(config_cls, model_config, device="cuda", dtype=torch.float32):
     return model
 
 
-CONST_HASH = lambda *args: "block"
+CONST_HASH = lambda *args, **kwargs: "block"
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
@@ -457,13 +457,83 @@ class TestNestedRegion(unittest.TestCase):
             class Block(nn.Module):
                 pass
 
-    def test_error_on_kwargs(self):
-        @aot_nested_region(hash_fn=CONST_HASH)
-        def fn(x):
-            return x
+    def test_module_kwargs(self):
+        """Tensor kwargs become operands; non-tensor kwargs are constants."""
 
-        with self.assertRaisesRegex(ValueError, "keyword arguments"):
-            fn(x=torch.randn(4))
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc = nn.Linear(dim, dim)
+
+            def forward(self, x, *, mask=None, scale: int = 1):
+                out = self.fc(x)
+                if mask is not None:
+                    out = out * mask
+                return out * scale
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleDict(
+                    {str(i): Block(dim) for i in range(n_layers)}
+                )
+
+            def forward(self, x, mask):
+                for layer in self.layers.values():
+                    x = layer(x, mask=mask, scale=2)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        for layer in model.layers.values():
+            aot_nested_region(layer, hash_fn=CONST_HASH)
+
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+        mask = torch.ones(2, 4, dim, device=self.DEVICE)
+        out_eager = model(x, mask)
+        traced_result = trace_module(model, (x, mask))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x, mask))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
+
+    def test_free_function_kwargs(self):
+        """@aot_nested_region on a free function with tensor and non-tensor kwargs."""
+        import torch.nn.functional as F
+
+        @aot_nested_region(hash_fn=CONST_HASH)
+        def block_fwd(w1, b1, w2, b2, *, x, scale: int = 1):
+            h = F.relu(F.linear(x, w1, b1))
+            return F.linear(h, w2, b2) * scale
+
+        class Model(nn.Module):
+            def __init__(self, dim, n_layers):
+                super().__init__()
+                self.layers = nn.ModuleList(
+                    [nn.Sequential(nn.Linear(dim, dim * 2), nn.Linear(dim * 2, dim))
+                     for _ in range(n_layers)]
+                )
+
+            def forward(self, x):
+                for blk in self.layers:
+                    fc1, fc2 = blk[0], blk[1]
+                    x = block_fwd(fc1.weight, fc1.bias, fc2.weight, fc2.bias, x=x, scale=2)
+                return x
+
+        dim, n_layers = 16, 3
+        model = Model(dim, n_layers).to(device=self.DEVICE)
+        x = torch.randn(2, 4, dim, device=self.DEVICE)
+
+        out_eager = model(x)
+        traced_result = trace_module(model, (x,))
+
+        self._assert_invoke_subgraph_count(traced_result, n_layers)
+
+        params_and_buffers = _get_params_and_buffers(model)
+        out_traced = run_traced_module(traced_result, params_and_buffers, (x,))
+        self.assertTrue(torch.equal(out_eager, out_traced[0]))
 
     def test_unique_hash_no_dedup(self):
         """Each unique hash key traces a separate subgraph — no deduplication.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2746
* #2745

Tensor kwargs become invoke_subgraph operands alongside tensor args.
Non-tensor kwargs (None, int, etc.) are specialized as constants inside the
subgraph, consistent with how positional non-tensors are handled.