### PR TITLE
[graph_trainer] Replace trace_module/run_traced_module with aot_function API

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import itertools
-from collections.abc import Generator
+import contextlib
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -16,6 +16,7 @@ import torch.utils._pytree as pytree
 from torch._functorch._aot_autograd.logging_utils import (
     setup_stacktrace_preservation_hooks,
 )
+from torch._guards import TracingContext, tracing
 from torch._subclasses import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.traceback import preserve_node_meta
@@ -57,14 +58,12 @@ class SubclassLayout:
 
 
 @dataclass
-class TracedResult:
-    """Holds the traced graph and metadata needed to run it."""
+class _ModuleParamsMeta:
+    """Per-module parameter metadata captured during tracing."""
 
-    gm: torch.fx.GraphModule
-    params_len: int
-    params_spec: pytree.TreeSpec
-    input_subclass_layouts: list[SubclassLayout]
-    output_subclass_layouts: list[SubclassLayout]
+    fqns: list[str]
+    spec: pytree.TreeSpec
+    length: int
 
 
 def _unwrap_subclass(t: torch.Tensor) -> tuple[list[torch.Tensor], SubclassMeta | None]:
@@ -252,41 +251,138 @@ def _copy_fwd_metadata_to_bw_nodes(fx_g: torch.fx.GraphModule) -> None:
                 node.meta["nn_module_stack"] = nn_module_stack.copy()
 
 
-def trace_module(
-    mod: nn.Module,
+def _collect_module_params(
+    args: tuple, module_indices: list[int]
+) -> tuple[list[_ModuleParamsMeta], list[torch.Tensor]]:
+    """Extract flattened params/buffers for each nn.Module arg."""
+    per_module: list[_ModuleParamsMeta] = []
+    all_flat: list[torch.Tensor] = []
+    for i in module_indices:
+        mod = args[i]
+        params_dict = {
+            **dict(mod.named_parameters(remove_duplicate=False)),
+            **dict(mod.named_buffers(remove_duplicate=False)),
+        }
+        fqns = list(params_dict.keys())
+        flat, spec = pytree.tree_flatten(params_dict)
+        per_module.append(_ModuleParamsMeta(fqns=fqns, spec=spec, length=len(flat)))
+        all_flat.extend(flat)
+    return per_module, all_flat
+
+
+class TracedResult:
+    """Holds the traced graph and metadata needed to execute it.
+
+    Returned by :func:`aot_function`.  Call the instance directly to execute
+    the traced graph with fresh parameters read from the live modules::
+
+        traced = aot_function(train_step, (model, tokens, labels))
+        result = traced(model, tokens, labels)
+    """
+
+    def __init__(
+        self,
+        gm: torch.fx.GraphModule,
+        module_indices: list[int],
+        per_module_params: list[_ModuleParamsMeta],
+        input_subclass_layouts: list[SubclassLayout],
+        output_subclass_layouts: list[SubclassLayout],
+    ) -> None:
+        self.gm = gm
+        self.module_indices = module_indices
+        self.per_module_params = per_module_params
+        self.input_subclass_layouts = input_subclass_layouts
+        self.output_subclass_layouts = output_subclass_layouts
+
+    def __call__(self, *args: Any) -> list[torch.Tensor]:
+        """Execute the traced graph, reading fresh params from modules in ``args``."""
+        module_indices_set = set(self.module_indices)
+
+        # Read current params from live modules.
+        all_params_flat: list[torch.Tensor] = []
+        for i, pmp in zip(self.module_indices, self.per_module_params, strict=True):
+            mod = args[i]
+            params_dict = {
+                **dict(mod.named_parameters(remove_duplicate=False)),
+                **dict(mod.named_buffers(remove_duplicate=False)),
+            }
+            fqns = list(params_dict.keys())
+            if fqns != pmp.fqns:
+                raise ValueError(
+                    f"Module at arg position {i} has different parameter/buffer "
+                    f"names than during tracing.\n"
+                    f"  Traced: {pmp.fqns}\n"
+                    f"  Got:    {fqns}"
+                )
+            flat, _ = pytree.tree_flatten(params_dict)
+            all_params_flat.extend(flat)
+
+        user_args = [a for i, a in enumerate(args) if i not in module_indices_set]
+        user_args_flat, _ = pytree.tree_flatten(user_args)
+
+        all_args = all_params_flat + list(user_args_flat)
+        flat_inputs: list = []
+        for a in all_args:
+            if isinstance(a, torch.Tensor) and is_traceable_wrapper_subclass(a):
+                inner, _ = _unwrap_subclass(a)
+                flat_inputs.extend(inner)
+            else:
+                flat_inputs.append(a)
+
+        flat_outputs = self.gm(*flat_inputs)
+        return _wrap_to_subclasses(flat_outputs, self.output_subclass_layouts)
+
+
+def aot_function(
+    fn: Callable,
     args: tuple,
 ) -> TracedResult:
-    """Trace ``mod(*args)`` into a flat FX graph, unwrapping tensor subclasses.
+    """Trace ``fn(*args)`` into a flat FX graph, unwrapping tensor subclasses.
 
-    Parameters and buffers are lifted as extra graph inputs so the returned
-    graph is a pure function.  Tensor subclasses (e.g. DTensor) are recursively
-    unwrapped into plain tensors for tracing, and the layouts needed to rewrap
-    them are recorded in the returned :class:`TracedResult`.
+    Parameters and buffers from ``nn.Module`` instances in ``args`` are lifted
+    as extra graph inputs so the returned graph is a pure function.  Tensor
+    subclasses (e.g. DTensor) are recursively unwrapped into plain tensors for
+    tracing, and the layouts needed to rewrap them are recorded in the returned
+    :class:`TracedResult`.
+
+    The returned :class:`TracedResult` is directly callable — pass the same
+    positional arguments (with live modules) to execute the graph::
+
+        traced = aot_function(train_step, (model, tokens, labels))
+        result = traced(model, tokens, labels)
 
     Args:
-        mod: The module to trace.
-        args: The user arguments to trace with.
+        fn: The callable to trace.
+        args: The positional arguments to trace with.  ``nn.Module`` instances
+            are detected automatically and their parameters are lifted.
     """
-    named_parameters = dict(mod.named_parameters(remove_duplicate=False))
-    named_buffers = dict(mod.named_buffers(remove_duplicate=False))
+    module_indices = [i for i, a in enumerate(args) if isinstance(a, nn.Module)]
+    module_indices_set = set(module_indices)
 
-    params_and_buffers = {**named_parameters, **named_buffers}
-    params_and_buffers_flat, params_spec = pytree.tree_flatten(params_and_buffers)
-    params_len = len(params_and_buffers_flat)
+    per_module_params, all_params_flat = _collect_module_params(args, module_indices)
+    params_len = len(all_params_flat)
 
-    def functional_call(*all_args):
-        flat_params = all_args[:params_len]
-        user_args = all_args[params_len:]
-        params = pytree.tree_unflatten(list(flat_params), params_spec)
-        with stateless._reparametrize_module(mod, params):
-            return mod.forward(*user_args)
+    # User args: positional args that are not nn.Module instances.
+    user_args = [a for i, a in enumerate(args) if i not in module_indices_set]
+    user_args_flat, user_args_spec = pytree.tree_flatten(user_args)
 
-    user_args_flat, user_args_spec = pytree.tree_flatten(args)
-    full_args = tuple(params_and_buffers_flat) + tuple(user_args_flat)
+    # All leaves must be tensors.  Non-tensor values (callables, ints, strings)
+    # should be captured via closure or wrapped with pytree.register_constant
+    # so they end up in the TreeSpec, not as graph placeholders.
+    for leaf in user_args_flat:
+        if not isinstance(leaf, torch.Tensor):
+            raise ValueError(
+                f"aot_function requires all pytree leaves in args to be tensors, "
+                f"got {type(leaf).__name__}. Non-tensor values should either be "
+                f"registered as pytree nodes (register_pytree_node) or constants "
+                f"(pytree.register_constant), or captured in fn's closure."
+            )
 
-    unwrapped_args = []
+    # Combined flat input: [*params, *user_args] with subclasses unwrapped.
+    full_args = all_params_flat + list(user_args_flat)
+
+    unwrapped_args: list = []
     input_layouts: list[SubclassLayout] = []
-
     for arg in full_args:
         if isinstance(arg, torch.Tensor) and is_traceable_wrapper_subclass(arg):
             inner_tensors, meta = _unwrap_subclass(arg)
@@ -300,88 +396,80 @@ def trace_module(
         allow_non_fake_inputs=True,
         shape_env=torch.fx.experimental.symbolic_shapes.ShapeEnv(),
     )
-
-    def to_fake(t):
-        if isinstance(t, torch.Tensor):
-            return fake_mode.from_tensor(t, static_shapes=True)
-        return t
-
-    fake_args = tuple(to_fake(a) for a in unwrapped_args)
+    fake_args = tuple(
+        (
+            fake_mode.from_tensor(a, static_shapes=True)
+            if isinstance(a, torch.Tensor)
+            else a
+        )
+        for a in unwrapped_args
+    )
 
     output_layouts: list[SubclassLayout] = []
 
-    def fn_with_subclass_handling(*plain_args):
+    def fn_with_subclass_handling(*plain_args: Any) -> list:
         nonlocal output_layouts
         output_layouts = []
 
-        wrapped_args = _wrap_to_subclasses(plain_args, input_layouts)
+        wrapped = _wrap_to_subclasses(plain_args, input_layouts)
+        all_params = wrapped[:params_len]
+        user_flat = wrapped[params_len:]
 
-        params_args = wrapped_args[:params_len]
-        user_args_wrapped = wrapped_args[params_len:]
-        user_args_restored = pytree.tree_unflatten(
-            list(user_args_wrapped), user_args_spec
-        )
+        # Reconstruct per-module param dicts.
+        offset = 0
+        module_param_dicts = []
+        for pmp in per_module_params:
+            flat = all_params[offset : offset + pmp.length]
+            module_param_dicts.append(pytree.tree_unflatten(list(flat), pmp.spec))
+            offset += pmp.length
 
-        with _patch_engine_run_backward():
-            outputs = functional_call(*params_args, *user_args_restored)
+        user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
 
-        flat_outputs, _ = pytree.tree_flatten(outputs)
-        unwrapped_outputs = []
-        for out in flat_outputs:
+        # Reconstruct the original args: module positions keep the live module
+        # (already in args), non-module positions get the traced user tensors.
+        rebuilt: list = list(args)
+        user_idx = 0
+        for i in range(len(args)):
+            if i not in module_indices_set:
+                rebuilt[i] = user_list[user_idx]
+                user_idx += 1
+
+        with contextlib.ExitStack() as stack:
+            for i, pmp_dict in zip(module_indices, module_param_dicts, strict=True):
+                stack.enter_context(
+                    stateless._reparametrize_module(args[i], pmp_dict)
+                )
+
+            with _patch_engine_run_backward():
+                result = fn(*rebuilt)
+
+        flat_outs, _ = pytree.tree_flatten(result)
+        unwrapped_outs: list = []
+        for out in flat_outs:
             if isinstance(out, torch.Tensor) and is_traceable_wrapper_subclass(out):
                 inner, meta = _unwrap_subclass(out)
-                unwrapped_outputs.extend(inner)
+                unwrapped_outs.extend(inner)
                 output_layouts.append(SubclassLayout(len(inner), meta))
             else:
-                unwrapped_outputs.append(out)
+                unwrapped_outs.append(out)
                 output_layouts.append(SubclassLayout(1, None))
+        return unwrapped_outs
 
-        return unwrapped_outputs
-
-    # preserve_node_meta propagates fx.traceback.annotate metadata to traced nodes
-    with fake_mode, preserve_node_meta(), _skip_nested_compile():
+    ctx = TracingContext(fake_mode)
+    with fake_mode, tracing(ctx), preserve_node_meta(), _skip_nested_compile():
         traced = make_fx(
             fn_with_subclass_handling,
             record_stack_traces=True,
-            record_module_stack=False,  # don't need nn_module_stack for now
+            record_module_stack=False,
         )(*fake_args)
 
-    # Copy forward annotations to backward nodes.
-    # Must run before DCE so that forward nodes used for matching aren't removed.
     _copy_fwd_metadata_to_bw_nodes(traced)
-
     _remove_cpu_shadow_chains(traced)
 
     return TracedResult(
         gm=traced,
-        params_len=params_len,
-        params_spec=params_spec,
+        module_indices=module_indices,
+        per_module_params=per_module_params,
         input_subclass_layouts=input_layouts,
         output_subclass_layouts=output_layouts,
     )
-
-
-def run_traced_module(
-    traced_result: TracedResult,
-    params_and_buffers: dict[str, torch.Tensor],
-    args: tuple,
-) -> list[torch.Tensor]:
-    """Execute a traced graph and rewrap outputs into their original subclass types.
-
-    Accepts a ``params_and_buffers`` dict (from ``named_parameters`` /
-    ``named_buffers``) instead of the module itself, so callers control exactly
-    which parameter snapshot is used.
-    """
-    params_flat, _ = pytree.tree_flatten(params_and_buffers)
-    user_args_flat, _ = pytree.tree_flatten(args)
-
-    all_args = []
-    for a in itertools.chain(params_flat, user_args_flat):
-        if isinstance(a, torch.Tensor) and is_traceable_wrapper_subclass(a):
-            inner, _ = _unwrap_subclass(a)
-            all_args.extend(inner)
-        else:
-            all_args.append(a)
-
-    flat_outputs = traced_result.gm(*all_args)
-    return _wrap_to_subclasses(flat_outputs, traced_result.output_subclass_layouts)

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -12,15 +12,21 @@ import torch
 import torch.nn as nn
 from torch.testing._internal.common_fsdp import FSDPTest
 
+from torchtitan.experiments.graph_trainer.common_utils import (
+    register_blockmask_pytree_node,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     _patch_engine_run_backward,
-    run_traced_module,
-    trace_module,
+    aot_function,
 )
 from torchtitan.models.common.attention import (
     annotate_flex_attention_for_regional_inductor,
 )
+
+# BlockMask must be registered as a pytree node so its tensor children
+# are properly traced as graph inputs instead of opaque leaves.
+register_blockmask_pytree_node()
 
 
 def get_loss(logits, labels):
@@ -31,28 +37,18 @@ def get_loss(logits, labels):
     )
 
 
-class TrainStepModule(nn.Module):
-    def __init__(self, model, loss_fn):
-        super().__init__()
-        self.model = model
-        self.loss_fn = loss_fn
+def _make_train_step(loss_fn):
+    """Return a plain function for aot_function tracing.  loss_fn is captured in closure."""
 
-    def forward(self, *args):
+    def train_step(model, *args):
         *fwd_args, labels = args
-        logits = self.model(*fwd_args)
-        loss = self.loss_fn(logits, labels)
-        # Must look up params in forward (not __init__) so that
-        # _reparametrize_module's swapped parameters are captured during tracing.
-        params = list(self.model.parameters())
+        logits = model(*fwd_args)
+        loss = loss_fn(logits, labels)
+        params = list(model.parameters())
         grads = torch.autograd.grad(loss, params)
         return [loss] + list(grads)
 
-
-def _get_params_and_buffers(mod):
-    return {
-        **dict(mod.named_parameters(remove_duplicate=False)),
-        **dict(mod.named_buffers(remove_duplicate=False)),
-    }
+    return train_step
 
 
 def create_model(config_cls, model_config, device="cuda", dtype=torch.float32):
@@ -123,10 +119,13 @@ class TestTraceModule(unittest.TestCase):
 
     def test_mlp_forward(self):
         model, tokens, labels, loss_fn = self._make_mlp()
-        traced_result = trace_module(model, (tokens,))
+
+        def forward(model, tokens):
+            return model(tokens)
+
+        traced = aot_function(forward, (model, tokens))
         out_eager = model(tokens)
-        params_and_buffers = _get_params_and_buffers(model)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens,))
+        wrapped = traced(model, tokens)
         self.assertTrue(torch.equal(out_eager, wrapped[0]))
 
     def test_mlp_train_step(self):
@@ -134,17 +133,15 @@ class TestTraceModule(unittest.TestCase):
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step = TrainStepModule(model_ref, loss_fn)
-        traced_result = trace_module(train_step, (tokens, labels))
+        train_step = _make_train_step(loss_fn)
+        traced = aot_function(train_step, (model_ref, tokens, labels))
 
         logits_ref = model_ref(tokens)
         loss_ref = loss_fn(logits_ref, labels)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        train_step_copy = TrainStepModule(model_test, loss_fn)
-        params_and_buffers = _get_params_and_buffers(train_step_copy)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens, labels))
+        wrapped = traced(model_test, tokens, labels)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -157,9 +154,8 @@ class TestTraceModule(unittest.TestCase):
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step_ref = TrainStepModule(model_ref, loss_fn)
-        train_step_copy = TrainStepModule(model_test, loss_fn)
-        traced_result = trace_module(train_step_ref, (tokens, labels))
+        train_step = _make_train_step(loss_fn)
+        traced = aot_function(train_step, (model_ref, tokens, labels))
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=self.LR)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=self.LR)
@@ -172,10 +168,7 @@ class TestTraceModule(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (tokens, labels)
-            )
+            wrapped = traced(model_test, tokens, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -188,6 +181,102 @@ class TestTraceModule(unittest.TestCase):
             )
             for gr, gt in zip(grads_ref, grads_tr, strict=True):
                 self.assertTrue(torch.equal(gr, gt), f"Step {step}: grad mismatch")
+
+    def test_module_not_first_arg(self):
+        """Module in the middle of args: fn(tokens, model, labels)."""
+        model_ref, tokens, labels, loss_fn = self._make_mlp()
+        model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        model_test.load_state_dict(model_ref.state_dict())
+
+        def train_step(tokens, model, labels):
+            logits = model(tokens)
+            loss = get_loss(logits, labels)
+            params = list(model.parameters())
+            grads = torch.autograd.grad(loss, params)
+            return [loss] + list(grads)
+
+        traced = aot_function(train_step, (tokens, model_ref, labels))
+
+        logits_ref = model_ref(tokens)
+        loss_ref = get_loss(logits_ref, labels)
+        loss_ref.backward()
+        grads_ref = [p.grad.clone() for p in model_ref.parameters()]
+
+        wrapped = traced(tokens, model_test, labels)
+        loss_tr = wrapped[0]
+        grads_tr = wrapped[1:]
+
+        self.assertTrue(torch.equal(loss_ref, loss_tr))
+        for gr, gt in zip(grads_ref, grads_tr, strict=True):
+            self.assertTrue(torch.equal(gr, gt))
+
+    def test_multiple_modules(self):
+        """Two modules interleaved with tensors: fn(model_a, x, model_b)."""
+        torch.manual_seed(42)
+        dim = 64
+        model_a = nn.Linear(dim, dim).to(device=self.DEVICE, dtype=self.DTYPE)
+        model_b = nn.Linear(dim, dim).to(device=self.DEVICE, dtype=self.DTYPE)
+        model_a_copy = nn.Linear(dim, dim).to(device=self.DEVICE, dtype=self.DTYPE)
+        model_b_copy = nn.Linear(dim, dim).to(device=self.DEVICE, dtype=self.DTYPE)
+        model_a_copy.load_state_dict(model_a.state_dict())
+        model_b_copy.load_state_dict(model_b.state_dict())
+
+        x = torch.randn(4, dim, device=self.DEVICE, dtype=self.DTYPE)
+
+        def two_model_step(model_a, x, model_b):
+            out = model_b(torch.relu(model_a(x)))
+            loss = out.sum()
+            params = list(model_a.parameters()) + list(model_b.parameters())
+            grads = torch.autograd.grad(loss, params)
+            return [loss] + list(grads)
+
+        traced = aot_function(two_model_step, (model_a, x, model_b))
+
+        # Eager reference.
+        out_ref = model_b(torch.relu(model_a(x)))
+        loss_ref = out_ref.sum()
+        loss_ref.backward()
+        grads_ref = [p.grad.clone() for p in model_a.parameters()] + [
+            p.grad.clone() for p in model_b.parameters()
+        ]
+
+        wrapped = traced(model_a_copy, x, model_b_copy)
+        loss_tr = wrapped[0]
+        grads_tr = wrapped[1:]
+
+        self.assertTrue(torch.equal(loss_ref, loss_tr))
+        for gr, gt in zip(grads_ref, grads_tr, strict=True):
+            self.assertTrue(torch.equal(gr, gt))
+
+    def test_mismatched_module_raises(self):
+        """Executing with a module that has different params than at trace time raises."""
+        model, tokens, labels, loss_fn = self._make_mlp()
+
+        def forward(model, tokens):
+            return model(tokens)
+
+        traced = aot_function(forward, (model, tokens))
+
+        # A model with a different architecture (extra layer → different FQNs).
+        different_model = nn.Sequential(
+            nn.Embedding(256, 64),
+            nn.Linear(64, 256),
+        ).to(device=self.DEVICE, dtype=self.DTYPE)
+
+        with self.assertRaises(ValueError, msg="different parameter/buffer names"):
+            traced(different_model, tokens)
+
+    def test_non_tensor_leaf_raises(self):
+        """Passing a non-tensor, non-module leaf in args raises."""
+
+        def fn(model, x, scale):
+            return model(x) * scale
+
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+
+        with self.assertRaises(ValueError, msg="all pytree leaves.*tensors"):
+            aot_function(fn, (model, tokens, 2.0))
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
@@ -238,15 +327,14 @@ class TestTraceDTensor(unittest.TestCase):
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
 
-        traced_result = trace_module(model, (tokens_dt,))
+        traced = aot_function(model, (tokens_dt,))
         has_subclass = any(
-            layout.meta is not None for layout in traced_result.input_subclass_layouts
+            layout.meta is not None for layout in traced.input_subclass_layouts
         )
         self.assertTrue(has_subclass)
 
         out_eager = model(tokens_dt)
-        params_and_buffers = _get_params_and_buffers(model)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens_dt,))
+        wrapped = traced(model, tokens_dt)
         self.assertTrue(torch.equal(out_eager.full_tensor(), wrapped[0].full_tensor()))
 
     def test_dtensor_train_step(self):
@@ -267,19 +355,15 @@ class TestTraceDTensor(unittest.TestCase):
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
         labels_dt = DTensor.from_local(labels, mesh, [Replicate()])
 
-        train_step = TrainStepModule(model_ref, get_loss)
-        traced_result = trace_module(train_step, (tokens_dt, labels_dt))
+        train_step = _make_train_step(get_loss)
+        traced = aot_function(train_step, (model_ref, tokens_dt, labels_dt))
 
         logits_ref = model_ref(tokens_dt)
         loss_ref = get_loss(logits_ref, labels_dt)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        train_step_copy = TrainStepModule(model_test, get_loss)
-        params_and_buffers = _get_params_and_buffers(train_step_copy)
-        wrapped = run_traced_module(
-            traced_result, params_and_buffers, (tokens_dt, labels_dt)
-        )
+        wrapped = traced(model_test, tokens_dt, labels_dt)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -301,15 +385,15 @@ class TestMetadataPropagation(unittest.TestCase):
     def test_backward_nodes_have_seq_nr(self):
         """Verify that backward FX nodes get seq_nr metadata via the patched engine."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        train_step = TrainStepModule(model, get_loss)
+        train_step = _make_train_step(get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced_result = trace_module(train_step, (tokens, labels))
+        traced = aot_function(train_step, (model, tokens, labels))
 
         # Collect seq_nr values from all call_function nodes
         seq_nrs = []
-        for node in traced_result.gm.graph.nodes:
+        for node in traced.gm.graph.nodes:
             if node.op == "call_function" and "seq_nr" in node.meta:
                 seq_nrs.append(node.meta["seq_nr"])
 
@@ -329,17 +413,13 @@ class TestMetadataPropagation(unittest.TestCase):
         """Verify _copy_fwd_metadata_to_bw_nodes copies custom metadata to bwd nodes."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
 
-        # Use annotate to set custom metadata on forward nodes, then trace
-        # with backward to verify it propagates
-        train_step = TrainStepModule(model, get_loss)
+        train_step = _make_train_step(get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced_result = trace_module(train_step, (tokens, labels))
-        gm = traced_result.gm
+        traced = aot_function(train_step, (model, tokens, labels))
+        gm = traced.gm
 
-        # Manually set custom metadata on the first fwd node for each seq_nr
-        # to test that _copy_fwd_metadata_to_bw_nodes works
         seq_nr_first: dict[int, torch.fx.Node] = {}
         for node in gm.graph.nodes:
             if node.op == "call_function" and "seq_nr" in node.meta:
@@ -348,16 +428,13 @@ class TestMetadataPropagation(unittest.TestCase):
                     seq_nr_first[seq_nr] = node
                     node.meta["custom"] = {"test_key": "test_value"}
 
-        # Run the copy pass again
         _copy_fwd_metadata_to_bw_nodes(gm)
 
-        # Check that bwd nodes with shared seq_nr got the custom metadata
         for node in gm.graph.nodes:
             if node.op != "call_function" or "seq_nr" not in node.meta:
                 continue
             seq_nr = node.meta["seq_nr"]
             if node is not seq_nr_first.get(seq_nr):
-                # This is a backward node
                 custom = node.meta.get("custom")
                 self.assertIsNotNone(
                     custom,
@@ -373,11 +450,9 @@ class TestMetadataPropagation(unittest.TestCase):
         orig_fn = torch.autograd.graph._engine_run_backward
 
         with _patch_engine_run_backward():
-            # Inside the context, it should be patched
             self.assertIsNot(torch.autograd.graph._engine_run_backward, orig_fn)
             self.assertIsNot(torch.autograd._engine_run_backward, orig_fn)
 
-        # After the context, it should be restored
         self.assertIs(torch.autograd.graph._engine_run_backward, orig_fn)
         self.assertIs(torch.autograd._engine_run_backward, orig_fn)
 
@@ -409,20 +484,24 @@ class TestTraceModels(unittest.TestCase):
         num_steps=5,
         lr=1e-3,
     ):
-        train_step_ref = TrainStepModule(model_ref, get_loss)
+        train_step = _make_train_step(get_loss)
 
-        with annotate_flex_attention_for_regional_inductor() if use_regional_inductor else contextlib.nullcontext():
-            traced_result = trace_module(train_step_ref, (*fwd_args, labels))
+        with (
+            annotate_flex_attention_for_regional_inductor()
+            if use_regional_inductor
+            else contextlib.nullcontext()
+        ):
+            traced = aot_function(train_step, (model_ref, *fwd_args, labels))
 
         if check_collective_ops:
             ag = sum(
                 1
-                for n in traced_result.gm.graph.nodes
+                for n in traced.gm.graph.nodes
                 if "all_gather_into_tensor" in str(n.target)
             )
             rs = sum(
                 1
-                for n in traced_result.gm.graph.nodes
+                for n in traced.gm.graph.nodes
                 if "reduce_scatter_tensor" in str(n.target)
             )
             self.assertTrue(
@@ -431,7 +510,7 @@ class TestTraceModels(unittest.TestCase):
             )
 
         if use_regional_inductor:
-            _apply_regional_inductor(traced_result)
+            _apply_regional_inductor(traced)
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=lr)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=lr)
@@ -444,11 +523,7 @@ class TestTraceModels(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            train_step_copy = TrainStepModule(model_test, get_loss)
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (*fwd_args, labels)
-            )
+            wrapped = traced(model_test, *fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -618,11 +693,15 @@ class TestTraceModels(unittest.TestCase):
             "sliding_window_mask": sliding_window_mask,
         }
         with annotate_flex_attention_for_regional_inductor():
-            traced_result = trace_module(model, (tokens, attn_masks))
+
+            def forward(model, tokens, attn_masks):
+                return model(tokens, attn_masks)
+
+            traced = aot_function(forward, (model, tokens, attn_masks))
 
         flex_nodes = [
             n
-            for n in traced_result.gm.graph.nodes
+            for n in traced.gm.graph.nodes
             if "flex_attention" in str(n.target) and "backward" not in str(n.target)
         ]
         self.assertGreater(len(flex_nodes), 0, "No FlexAttentionHOP nodes found")
@@ -704,20 +783,22 @@ class TestTraceFSDP(FSDPTest):
         else:
             fwd_args = (tokens,)
 
-        train_step_ref = TrainStepModule(model_ref, get_loss)
+        train_step = _make_train_step(get_loss)
 
-        with annotate_flex_attention_for_regional_inductor() if use_regional_inductor else contextlib.nullcontext():
-            traced_result = trace_module(train_step_ref, (*fwd_args, labels))
+        with (
+            annotate_flex_attention_for_regional_inductor()
+            if use_regional_inductor
+            else contextlib.nullcontext()
+        ):
+            traced = aot_function(train_step, (model_ref, *fwd_args, labels))
 
         ag = sum(
             1
-            for n in traced_result.gm.graph.nodes
+            for n in traced.gm.graph.nodes
             if "all_gather_into_tensor" in str(n.target)
         )
         rs = sum(
-            1
-            for n in traced_result.gm.graph.nodes
-            if "reduce_scatter_tensor" in str(n.target)
+            1 for n in traced.gm.graph.nodes if "reduce_scatter_tensor" in str(n.target)
         )
         self.assertTrue(
             ag > 0 and rs > 0,
@@ -725,7 +806,7 @@ class TestTraceFSDP(FSDPTest):
         )
 
         if use_regional_inductor:
-            _apply_regional_inductor(traced_result)
+            _apply_regional_inductor(traced)
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=1e-3)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=1e-3)
@@ -738,11 +819,7 @@ class TestTraceFSDP(FSDPTest):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            train_step_copy = TrainStepModule(model_test, get_loss)
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (*fwd_args, labels)
-            )
+            wrapped = traced(model_test, *fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -13,30 +13,32 @@ import torch.nn as nn
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-    run_traced_module,
-    trace_module,
+    aot_function,
     TracedResult,
 )
 from torchtitan.trainer import Trainer
 
 
-class FwdBwdStepModule(nn.Module):
-    """Wraps model + loss_fn + autograd.grad into a single traceable forward.
+def _make_fwd_bwd_step(loss_fn):
+    """Return a plain function that traces the entire fwd+loss+bwd step.
 
-    This allows make_fx to trace through the entire fwd+loss+bwd as one graph.
+    ``loss_fn`` is captured in the closure so it is not a graph input.
+
+    TODO: investigate how loss_fn interacts with non-strict trace. Currently
+    it is captured as a closure variable, but non-strict tracing may need it
+    registered via pytree.register_constant or passed differently.
     """
 
-    def __init__(self, model, loss_fn):
-        super().__init__()
-        self.model = model
-        self.loss_fn = loss_fn
-
-    def forward(self, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs):
-        pred = self.model(inputs, **extra_inputs, **extra_kwargs)
-        loss = self.loss_fn(pred, labels) / global_valid_tokens
-        params = [p for p in self.model.parameters() if p.requires_grad]
+    def fwd_bwd_step(
+        model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
+    ):
+        pred = model(inputs, **extra_inputs, **extra_kwargs)
+        loss = loss_fn(pred, labels) / global_valid_tokens
+        params = [p for p in model.parameters() if p.requires_grad]
         grads = torch.autograd.grad(loss, params)
         return [loss] + list(grads)
+
+    return fwd_bwd_step
 
 
 class GraphTrainer(Trainer):
@@ -55,7 +57,6 @@ class GraphTrainer(Trainer):
             )
 
         # Lazy state for aot_fx_trace mode
-        self._fwd_bwd_step_module: FwdBwdStepModule | None = None
         self._traced_step: TracedResult | None = None
 
     def forward_backward_step(
@@ -101,23 +102,28 @@ class GraphTrainer(Trainer):
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:
         if self._traced_step is None:
-            self._fwd_bwd_step_module = FwdBwdStepModule(model, self.loss_fn)
-
+            fwd_bwd_fn = _make_fwd_bwd_step(self.loss_fn)
             with self.train_context(), self.maybe_enable_amp:
-                self._traced_step = trace_module(
-                    self._fwd_bwd_step_module,
-                    (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+                self._traced_step = aot_function(
+                    fwd_bwd_fn,
+                    (
+                        model,
+                        inputs,
+                        labels,
+                        global_valid_tokens,
+                        extra_inputs,
+                        extra_kwargs,
+                    ),
                 )
 
-        params_and_buffers = {
-            **dict(self._fwd_bwd_step_module.named_parameters(remove_duplicate=False)),
-            **dict(self._fwd_bwd_step_module.named_buffers(remove_duplicate=False)),
-        }
         with self.train_context(), self.maybe_enable_amp:
-            outputs = run_traced_module(
-                self._traced_step,
-                params_and_buffers,
-                (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+            outputs = self._traced_step(
+                model,
+                inputs,
+                labels,
+                global_valid_tokens,
+                extra_inputs,
+                extra_kwargs,
             )
         loss = outputs[0]
         grads = outputs[1:]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2751

Authored-by: Claude

Redesign the graph trainer's tracing API based on the aot_function design doc.

Key changes:

make_fx_tracer.py:
- Rename trace_module -> aot_function. Takes any callable (not just nn.Module)
  with nn.Module instances auto-detected in args and their params/buffers
  lifted as graph inputs.
- Delete run_traced_module. TracedResult is now directly callable — pass the
  same positional args (with live modules) to execute the graph. Fresh params
  are read from the modules automatically on each call.
- Add _ModuleParamsMeta with FQN storage. Parameter FQNs are recorded at trace
  time and validated at execute time to catch module structure mismatches.
- Add _collect_module_params helper for multi-module param extraction.
- Install TracingContext before make_fx so invoke_subgraph deduplication works.
- Validate that all pytree leaves in args are tensors. Non-tensor values
  (callables, ints, etc.) must be captured in fn's closure or registered via
  pytree.register_constant/register_pytree_node.

trainer.py:
- Replace FwdBwdStepModule (nn.Module wrapper that only existed because the
  old trace_module required nn.Module as fn) with _make_fwd_bwd_step, a plain
  function factory. The model is now passed as an arg, loss_fn is captured in
  the closure.
- Remove manual params_and_buffers dict construction — TracedResult.__call__
  reads fresh params from the live module automatically.
- Add TODO for investigating loss_fn interaction with non-strict trace.

test_trace_module.py:
- Replace TrainStepModule with _make_train_step plain function factory.
- Remove _get_params_and_buffers helper (no longer needed).
- Update all callsites: trace_module -> aot_function, run_traced_module ->
  direct TracedResult.__call__.
- Register BlockMask as pytree node at module level so flex_attention tests
  pass the non-tensor leaf validation.
- Add test_module_not_first_arg: module at position 1 in args.
- Add test_multiple_modules: two nn.Modules interleaved with a tensor.
- Add test_mismatched_module_raises: FQN validation catches wrong module.
- Add test_non_tensor_leaf_raises: non-tensor leaf in args raises ValueError.

All 7 model tests pass (llama3, llama4, qwen3, qwen3_moe, deepseek_v3,
gpt_oss, flex_attention_annotations).