### PR TITLE
Fix off-by-one masking for chat data

### DIFF
--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -110,7 +110,13 @@ class TestChatDatasetShiftedTokens(unittest.TestCase):
             messages[:1], add_generation_prompt=True
         )
         prompt_tokens = tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
-        response_start = len(prompt_tokens)  # labels [0, prompt_len) are masked
+        response_start = len(prompt_tokens) - 1
+        self.assertGreaterEqual(response_start, 0)
+        self.assertNotEqual(
+            label_ids[response_start].item(),
+            IGNORE_INDEX,
+            "First assistant token should not be masked",
+        )
         self.assertEqual(
             label_ids[response_start:seq_len_actual].tolist(),
             expected_label[response_start:],

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -361,8 +361,9 @@ class ChatDataset(IterableDataset, Stateful):
         prompt_tokens = self._tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
         prompt_len = len(prompt_tokens)
 
-        # Mask prompt tokens in labels [0, prompt_len).
-        mask_end = min(prompt_len, len(label_ids))
+        # Labels are shifted by one token, so the first assistant token is
+        # predicted at index prompt_len - 1 and must remain unmasked.
+        mask_end = min(max(prompt_len - 1, 0), len(label_ids))
         label_ids[:mask_end] = [IGNORE_INDEX] * mask_end
 
         return input_ids, label_ids


### PR DESCRIPTION
Seems like there's an off-by-one issue in the SFT masking:

- `input_ids = full_tokens[:-1]` (all tokens except the last)
- `label_ids = full_tokens[1:]` (all tokens except the first)

The prompt tokens are `full_tokens[0:prompt_len]`. The first assistant token is `full_tokens[prompt_len]`.

In the label array, `label_ids[i] = full_tokens[i+1]`. The first position where the label is an assistant token is `i = prompt_len - 1`, because `label_ids[prompt_len - 1] = full_tokens[prompt_len] = first assistant token`.

So we want to mask `label_ids[0:prompt_len-1]`. The position prompt_len - 1 should NOT be masked because that's where the model predicts the first assistant.

pre-commit issues I saw do not stem from my change.

@joecummings 