### PR TITLE
[graph_trainer] Fix enable_cp in apply_non_moe_tp

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -118,7 +118,8 @@ def parallelize_deepseekv3(
             parallel_dims.get_mesh("tp"),
             enable_loss_parallel=not parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=False,
-            cp_enabled=parallel_dims.cp_enabled,
+            enable_cp=parallel_dims.cp_enabled,
+            enable_sp=parallelism.enable_sequence_parallel,
         )
         maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 


### PR DESCRIPTION
The Decouple SP with TP PR changed the signature of `apply_non_moe_tp`. Need to change the callsite in graph_trainer as well.