### PR TITLE
[graph_trainer] Replace trace_module/run_traced_module with aot_function API

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import itertools
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -16,6 +15,7 @@ import torch.utils._pytree as pytree
 from torch._functorch._aot_autograd.logging_utils import (
     setup_stacktrace_preservation_hooks,
 )
+from torch._guards import TracingContext, tracing
 from torch._subclasses import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.traceback import preserve_node_meta
@@ -54,17 +54,6 @@ class SubclassMeta:
 class SubclassLayout:
     num_tensors: int
     meta: SubclassMeta | None
-
-
-@dataclass
-class TracedResult:
-    """Holds the traced graph and metadata needed to run it."""
-
-    gm: torch.fx.GraphModule
-    params_len: int
-    params_spec: pytree.TreeSpec
-    input_subclass_layouts: list[SubclassLayout]
-    output_subclass_layouts: list[SubclassLayout]
 
 
 def _unwrap_subclass(t: torch.Tensor) -> tuple[list[torch.Tensor], SubclassMeta | None]:
@@ -107,19 +96,46 @@ def _wrap_to_subclass(
     )
 
 
-def _wrap_to_subclasses(
-    flat_tensors: tuple[torch.Tensor, ...] | list[torch.Tensor],
-    layouts: list[SubclassLayout],
-) -> list[torch.Tensor]:
+def _unwrap_subclasses(
+    args: list,
+) -> tuple[list, dict[int, SubclassLayout]]:
+    """Unwrap tensor subclasses into plain tensors.
+
+    Returns the flattened plain tensors and a dict mapping original arg index
+    to its SubclassLayout.  Plain tensors have no entry.
+    """
+    flat: list = []
+    layouts: dict[int, SubclassLayout] = {}
+    for i, arg in enumerate(args):
+        if isinstance(arg, torch.Tensor) and is_traceable_wrapper_subclass(arg):
+            inner_tensors, meta = _unwrap_subclass(arg)
+            layouts[i] = SubclassLayout(len(inner_tensors), meta)
+            flat.extend(inner_tensors)
+        else:
+            flat.append(arg)
+    return flat, layouts
+
+
+def _wrap_subclasses(
+    flat_tensors: tuple | list,
+    num_args: int,
+    layouts: dict[int, SubclassLayout],
+) -> list:
+    """Rewrap plain tensors back into their original subclass types.
+
+    Positions not in ``layouts`` are plain tensors (taken one-to-one).
+    """
     wrapped = []
     idx = 0
-    for layout in layouts:
-        tensors = flat_tensors[idx : idx + layout.num_tensors]
-        idx += layout.num_tensors
-        if layout.meta is None:
-            wrapped.append(tensors[0])
-        else:
+    for i in range(num_args):
+        if i in layouts:
+            layout = layouts[i]
+            tensors = flat_tensors[idx : idx + layout.num_tensors]
+            idx += layout.num_tensors
             wrapped.append(_wrap_to_subclass(list(tensors), layout.meta))
+        else:
+            wrapped.append(flat_tensors[idx])
+            idx += 1
     return wrapped
 
 
@@ -194,10 +210,6 @@ def _patch_engine_run_backward() -> Generator[None, None, None]:
     nodes back to their forward counterparts (needed by
     ``_copy_fwd_metadata_to_bw_nodes``).
 
-    This context manager patches ``_engine_run_backward`` to call
-    ``setup_stacktrace_preservation_hooks`` before the autograd engine runs,
-    restoring ``seq_nr`` propagation during tracing.
-
     We must patch the name in both modules since ``torch.autograd.__init__``
     imports it via ``from .graph import``.
     """
@@ -252,94 +264,221 @@ def _copy_fwd_metadata_to_bw_nodes(fx_g: torch.fx.GraphModule) -> None:
                 node.meta["nn_module_stack"] = nn_module_stack.copy()
 
 
-def trace_module(
-    mod: nn.Module,
+class TracedResult:
+    """Holds the traced graph and metadata needed to execute it.
+
+    Returned by :func:`aot_function`.  Call the instance directly to execute
+    the traced graph with fresh parameters read from the live module::
+
+        traced = aot_function(train_step, (model, tokens, labels))
+        result = traced(model, tokens, labels)
+    """
+
+    def __init__(
+        self,
+        gm: torch.fx.GraphModule,
+        module_index: int,
+        param_fqns: list[str],
+        num_params: int,
+        num_flat_inputs: int,
+        input_subclass_layouts: dict[int, SubclassLayout],
+        num_flat_outputs: int,
+        output_subclass_layouts: dict[int, SubclassLayout],
+        output_spec: pytree.TreeSpec,
+    ) -> None:
+        """
+        Args:
+            gm: The traced FX graph (a pure function of flat tensors).
+            module_index: Position of the ``nn.Module`` in the original ``args``.
+            param_fqns: Fully qualified names of the module's parameters and
+                buffers, recorded at trace time for validation.
+            num_params: Number of parameters + buffers (flat count).
+            num_flat_inputs: Number of original args (before subclass unwrapping).
+            input_subclass_layouts: Maps arg positions that are tensor subclasses
+                to their unwrap/rewrap metadata.  Plain tensors have no entry.
+            num_flat_outputs: Number of original outputs (before subclass unwrapping).
+            output_subclass_layouts: Maps output positions that are tensor subclasses
+                to their rewrap metadata.  Plain tensors have no entry.
+            output_spec: Pytree spec of the original function's return value,
+                used to reconstruct the output structure.
+        """
+        self.gm = gm
+        self.module_index = module_index
+        self.param_fqns = param_fqns
+        self.num_params = num_params
+        self.num_flat_inputs = num_flat_inputs
+        self.input_subclass_layouts = input_subclass_layouts
+        self.num_flat_outputs = num_flat_outputs
+        self.output_subclass_layouts = output_subclass_layouts
+        self.output_spec = output_spec
+        self._validated = False
+
+    def __call__(self, *args: Any) -> Any:
+        """Execute the traced graph, reading fresh params from the module in ``args``.
+
+        Runs under ``torch.no_grad()`` because the graph already contains
+        explicit backward ops (from ``torch.autograd.grad`` traced by make_fx).
+        Without this, PyTorch would build a redundant autograd graph on top,
+        keeping all forward intermediates alive via ``grad_fn`` references.
+        """
+        mod = args[self.module_index]
+        params_dict = {
+            **dict(mod.named_parameters(remove_duplicate=False)),
+            **dict(mod.named_buffers(remove_duplicate=False)),
+        }
+        if not self._validated:
+            fqns = list(params_dict.keys())
+            if fqns != self.param_fqns:
+                raise ValueError(
+                    f"Module at arg position {self.module_index} has different "
+                    f"parameter/buffer names than during tracing.\n"
+                    f"  Traced: {self.param_fqns}\n"
+                    f"  Got:    {fqns}"
+                )
+            self._validated = True
+        params_flat = list(params_dict.values())
+
+        user_args = [a for i, a in enumerate(args) if i != self.module_index]
+        user_args_flat, _ = pytree.tree_flatten(user_args)
+
+        all_args = params_flat + list(user_args_flat)
+        flat_inputs, _ = _unwrap_subclasses(all_args)
+
+        with torch.no_grad():
+            flat_outputs = self.gm(*flat_inputs)
+        wrapped = _wrap_subclasses(
+            flat_outputs, self.num_flat_outputs, self.output_subclass_layouts
+        )
+        return pytree.tree_unflatten(wrapped, self.output_spec)
+
+
+def aot_function(
+    fn: nn.Module | Callable,
     args: tuple,
 ) -> TracedResult:
-    """Trace ``mod(*args)`` into a flat FX graph, unwrapping tensor subclasses.
+    """Trace ``fn(*args)`` into a flat FX graph, unwrapping tensor subclasses.
 
-    Parameters and buffers are lifted as extra graph inputs so the returned
-    graph is a pure function.  Tensor subclasses (e.g. DTensor) are recursively
-    unwrapped into plain tensors for tracing, and the layouts needed to rewrap
-    them are recorded in the returned :class:`TracedResult`.
+    Exactly one ``nn.Module`` must be present in ``args``.  Its parameters and
+    buffers are lifted as extra graph inputs so the returned graph is a pure
+    function.  Tensor subclasses (e.g. DTensor) are recursively unwrapped into
+    plain tensors for tracing, and the layouts needed to rewrap them are
+    recorded in the returned :class:`TracedResult`.
+
+    ``fn`` may be an ``nn.Module`` — in which case it is treated as though the
+    caller wrote ``aot_function(lambda m, *a: m(*a), (fn,) + args)``, i.e. the
+    module is prepended to ``args`` and its parameters are lifted automatically.
+
+    The returned :class:`TracedResult` is directly callable — pass the same
+    positional arguments (with the live module) to execute the graph::
+
+        traced = aot_function(train_step, (model, tokens, labels))
+        result = traced(model, tokens, labels)
 
     Args:
-        mod: The module to trace.
-        args: The user arguments to trace with.
+        fn: The callable (or ``nn.Module``) to trace.
+        args: The positional arguments to trace with.  Must contain exactly one
+            ``nn.Module`` whose parameters will be lifted.
     """
-    named_parameters = dict(mod.named_parameters(remove_duplicate=False))
-    named_buffers = dict(mod.named_buffers(remove_duplicate=False))
+    # When fn is an nn.Module, treat it as the first arg so its params get
+    # lifted like any other module arg.
+    if isinstance(fn, nn.Module):
+        args = (fn,) + args
+        fn = type(fn).__call__
 
-    params_and_buffers = {**named_parameters, **named_buffers}
-    params_and_buffers_flat, params_spec = pytree.tree_flatten(params_and_buffers)
-    params_len = len(params_and_buffers_flat)
+    # Find the single nn.Module in args — must be at position 0.
+    module_indices = [i for i, a in enumerate(args) if isinstance(a, nn.Module)]
+    if len(module_indices) != 1:
+        raise ValueError(
+            f"aot_function expects exactly one nn.Module in args, "
+            f"got {len(module_indices)} at positions {module_indices}."
+        )
+    if module_indices[0] != 0:
+        raise ValueError(
+            f"The nn.Module must be the first argument (position 0), "
+            f"got it at position {module_indices[0]}."
+        )
+    module_index = 0
+    mod = args[module_index]
 
-    def functional_call(*all_args):
-        flat_params = all_args[:params_len]
-        user_args = all_args[params_len:]
-        params = pytree.tree_unflatten(list(flat_params), params_spec)
-        with stateless._reparametrize_module(mod, params):
-            return mod.forward(*user_args)
+    # Extract params/buffers from the module.
+    params_dict = {
+        **dict(mod.named_parameters(remove_duplicate=False)),
+        **dict(mod.named_buffers(remove_duplicate=False)),
+    }
+    param_fqns = list(params_dict.keys())
+    params_flat = list(params_dict.values())
+    num_params = len(params_flat)
 
-    user_args_flat, user_args_spec = pytree.tree_flatten(args)
-    full_args = tuple(params_and_buffers_flat) + tuple(user_args_flat)
+    # User args: everything except the module.
+    user_args = [a for i, a in enumerate(args) if i != module_index]
+    user_args_flat, user_args_spec = pytree.tree_flatten(user_args)
 
-    unwrapped_args = []
-    input_layouts: list[SubclassLayout] = []
+    # Validate leaves: tensors and make_fx-safe primitives are allowed.
+    _ALLOWED_LEAF_TYPES = (torch.Tensor, int, float, bool, str, type(None))
+    for leaf in user_args_flat:
+        if not isinstance(leaf, _ALLOWED_LEAF_TYPES):
+            raise ValueError(
+                f"aot_function requires all pytree leaves in args to be tensors "
+                f"or primitives (int/float/bool/str), got {type(leaf).__name__}. "
+                f"Non-primitive values should either be registered as pytree "
+                f"nodes (register_pytree_node) or constants "
+                f"(pytree.register_constant), or captured in fn's closure."
+            )
 
-    for arg in full_args:
-        if isinstance(arg, torch.Tensor) and is_traceable_wrapper_subclass(arg):
-            inner_tensors, meta = _unwrap_subclass(arg)
-            unwrapped_args.extend(inner_tensors)
-            input_layouts.append(SubclassLayout(len(inner_tensors), meta))
-        else:
-            unwrapped_args.append(arg)
-            input_layouts.append(SubclassLayout(1, None))
+    # Combined flat input: [*params, *user_args] with subclasses unwrapped.
+    full_args = params_flat + list(user_args_flat)
+    num_full_args = len(full_args)
+    unwrapped_args, input_layouts = _unwrap_subclasses(full_args)
 
     fake_mode = FakeTensorMode(
         allow_non_fake_inputs=True,
         shape_env=torch.fx.experimental.symbolic_shapes.ShapeEnv(),
     )
-
-    def to_fake(t):
-        if isinstance(t, torch.Tensor):
-            return fake_mode.from_tensor(t, static_shapes=True)
-        return t
-
-    fake_args = tuple(to_fake(a) for a in unwrapped_args)
-
-    output_layouts: list[SubclassLayout] = []
-
-    def fn_with_subclass_handling(*plain_args):
-        nonlocal output_layouts
-        output_layouts = []
-
-        wrapped_args = _wrap_to_subclasses(plain_args, input_layouts)
-
-        params_args = wrapped_args[:params_len]
-        user_args_wrapped = wrapped_args[params_len:]
-        user_args_restored = pytree.tree_unflatten(
-            list(user_args_wrapped), user_args_spec
+    fake_args = tuple(
+        (
+            fake_mode.from_tensor(a, static_shapes=True)
+            if isinstance(a, torch.Tensor)
+            else a
         )
+        for a in unwrapped_args
+    )
 
-        with _patch_engine_run_backward():
-            outputs = functional_call(*params_args, *user_args_restored)
+    output_layouts: dict[int, SubclassLayout] = {}
+    num_flat_outputs: int = 0
+    output_spec: pytree.TreeSpec | None = None
 
-        flat_outputs, _ = pytree.tree_flatten(outputs)
-        unwrapped_outputs = []
-        for out in flat_outputs:
-            if isinstance(out, torch.Tensor) and is_traceable_wrapper_subclass(out):
-                inner, meta = _unwrap_subclass(out)
-                unwrapped_outputs.extend(inner)
-                output_layouts.append(SubclassLayout(len(inner), meta))
-            else:
-                unwrapped_outputs.append(out)
-                output_layouts.append(SubclassLayout(1, None))
+    def fn_with_subclass_handling(*plain_args: Any) -> list:
+        nonlocal output_layouts, output_spec, num_flat_outputs
+        output_layouts = {}
 
-        return unwrapped_outputs
+        wrapped = _wrap_subclasses(plain_args, num_full_args, input_layouts)
+        params_wrapped = wrapped[:num_params]
+        user_flat = wrapped[num_params:]
 
+        params_for_mod = dict(zip(param_fqns, params_wrapped, strict=True))
+        user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
+
+        # Reconstruct the original args: module position keeps the live module,
+        # other positions get the traced user tensors.
+        rebuilt: list = list(args)
+        user_idx = 0
+        for i in range(len(args)):
+            if i != module_index:
+                rebuilt[i] = user_list[user_idx]
+                user_idx += 1
+
+        with stateless._reparametrize_module(mod, params_for_mod):
+            with _patch_engine_run_backward():
+                result = fn(*rebuilt)
+
+        flat_outs, output_spec = pytree.tree_flatten(result)
+        num_flat_outputs = len(flat_outs)
+        unwrapped_outs, output_layouts = _unwrap_subclasses(flat_outs)
+        return unwrapped_outs
+
+    ctx = TracingContext(fake_mode)
     # preserve_node_meta propagates fx.traceback.annotate metadata to traced nodes
-    with fake_mode, preserve_node_meta(), _skip_nested_compile():
+    with fake_mode, tracing(ctx), preserve_node_meta(), _skip_nested_compile():
         traced = make_fx(
             fn_with_subclass_handling,
             record_stack_traces=True,
@@ -349,39 +488,17 @@ def trace_module(
     # Copy forward annotations to backward nodes.
     # Must run before DCE so that forward nodes used for matching aren't removed.
     _copy_fwd_metadata_to_bw_nodes(traced)
-
     _remove_cpu_shadow_chains(traced)
 
+    assert output_spec is not None
     return TracedResult(
         gm=traced,
-        params_len=params_len,
-        params_spec=params_spec,
+        module_index=module_index,
+        param_fqns=param_fqns,
+        num_params=num_params,
+        num_flat_inputs=num_full_args,
         input_subclass_layouts=input_layouts,
+        num_flat_outputs=num_flat_outputs,
         output_subclass_layouts=output_layouts,
+        output_spec=output_spec,
     )
-
-
-def run_traced_module(
-    traced_result: TracedResult,
-    params_and_buffers: dict[str, torch.Tensor],
-    args: tuple,
-) -> list[torch.Tensor]:
-    """Execute a traced graph and rewrap outputs into their original subclass types.
-
-    Accepts a ``params_and_buffers`` dict (from ``named_parameters`` /
-    ``named_buffers``) instead of the module itself, so callers control exactly
-    which parameter snapshot is used.
-    """
-    params_flat, _ = pytree.tree_flatten(params_and_buffers)
-    user_args_flat, _ = pytree.tree_flatten(args)
-
-    all_args = []
-    for a in itertools.chain(params_flat, user_args_flat):
-        if isinstance(a, torch.Tensor) and is_traceable_wrapper_subclass(a):
-            inner, _ = _unwrap_subclass(a)
-            all_args.extend(inner)
-        else:
-            all_args.append(a)
-
-    flat_outputs = traced_result.gm(*all_args)
-    return _wrap_to_subclasses(flat_outputs, traced_result.output_subclass_layouts)

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -12,15 +12,21 @@ import torch
 import torch.nn as nn
 from torch.testing._internal.common_fsdp import FSDPTest
 
+from torchtitan.experiments.graph_trainer.common_utils import (
+    register_blockmask_pytree_node,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     _patch_engine_run_backward,
-    run_traced_module,
-    trace_module,
+    aot_function,
 )
 from torchtitan.models.common.attention import (
     annotate_flex_attention_for_regional_inductor,
 )
+
+# BlockMask must be registered as a pytree node so its tensor children
+# are properly traced as graph inputs instead of opaque leaves.
+register_blockmask_pytree_node()
 
 
 def get_loss(logits, labels):
@@ -31,28 +37,18 @@ def get_loss(logits, labels):
     )
 
 
-class TrainStepModule(nn.Module):
-    def __init__(self, model, loss_fn):
-        super().__init__()
-        self.model = model
-        self.loss_fn = loss_fn
+def make_train_step(loss_fn):
+    """Return a plain function for aot_function tracing.  loss_fn is captured in closure."""
 
-    def forward(self, *args):
+    def train_step(model, *args):
         *fwd_args, labels = args
-        logits = self.model(*fwd_args)
-        loss = self.loss_fn(logits, labels)
-        # Must look up params in forward (not __init__) so that
-        # _reparametrize_module's swapped parameters are captured during tracing.
-        params = list(self.model.parameters())
+        logits = model(*fwd_args)
+        loss = loss_fn(logits, labels)
+        params = list(model.parameters())
         grads = torch.autograd.grad(loss, params)
         return [loss] + list(grads)
 
-
-def _get_params_and_buffers(mod):
-    return {
-        **dict(mod.named_parameters(remove_duplicate=False)),
-        **dict(mod.named_buffers(remove_duplicate=False)),
-    }
+    return train_step
 
 
 def create_model(config_cls, model_config, device="cuda", dtype=torch.float32):
@@ -123,28 +119,25 @@ class TestTraceModule(unittest.TestCase):
 
     def test_mlp_forward(self):
         model, tokens, labels, loss_fn = self._make_mlp()
-        traced_result = trace_module(model, (tokens,))
+        traced = aot_function(model, (tokens,))
         out_eager = model(tokens)
-        params_and_buffers = _get_params_and_buffers(model)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens,))
-        self.assertTrue(torch.equal(out_eager, wrapped[0]))
+        wrapped = traced(model, tokens)
+        self.assertTrue(torch.equal(out_eager, wrapped))
 
     def test_mlp_train_step(self):
         model_ref, tokens, labels, loss_fn = self._make_mlp()
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step = TrainStepModule(model_ref, loss_fn)
-        traced_result = trace_module(train_step, (tokens, labels))
+        train_step = make_train_step(loss_fn)
+        traced = aot_function(train_step, (model_ref, tokens, labels))
 
         logits_ref = model_ref(tokens)
         loss_ref = loss_fn(logits_ref, labels)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        train_step_copy = TrainStepModule(model_test, loss_fn)
-        params_and_buffers = _get_params_and_buffers(train_step_copy)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens, labels))
+        wrapped = traced(model_test, tokens, labels)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -157,9 +150,8 @@ class TestTraceModule(unittest.TestCase):
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step_ref = TrainStepModule(model_ref, loss_fn)
-        train_step_copy = TrainStepModule(model_test, loss_fn)
-        traced_result = trace_module(train_step_ref, (tokens, labels))
+        train_step = make_train_step(loss_fn)
+        traced = aot_function(train_step, (model_ref, tokens, labels))
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=self.LR)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=self.LR)
@@ -172,10 +164,7 @@ class TestTraceModule(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (tokens, labels)
-            )
+            wrapped = traced(model_test, tokens, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -188,6 +177,36 @@ class TestTraceModule(unittest.TestCase):
             )
             for gr, gt in zip(grads_ref, grads_tr, strict=True):
                 self.assertTrue(torch.equal(gr, gt), f"Step {step}: grad mismatch")
+
+    def test_mismatched_module_raises(self):
+        """Executing with a module that has different params than at trace time raises."""
+        model, tokens, labels, loss_fn = self._make_mlp()
+
+        def forward(model, tokens):
+            return model(tokens)
+
+        traced = aot_function(forward, (model, tokens))
+
+        # A model with a different architecture (extra layer → different FQNs).
+        different_model = nn.Sequential(
+            nn.Embedding(256, 64),
+            nn.Linear(64, 256),
+        ).to(device=self.DEVICE, dtype=self.DTYPE)
+
+        with self.assertRaises(ValueError, msg="different parameter/buffer names"):
+            traced(different_model, tokens)
+
+    def test_non_tensor_leaf_raises(self):
+        """Passing a callable leaf in args raises (should be in closure instead)."""
+
+        def fn(model, x, loss_fn):
+            return loss_fn(model(x))
+
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+
+        with self.assertRaises(ValueError, msg="all pytree leaves"):
+            aot_function(fn, (model, tokens, lambda x: x.sum()))
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
@@ -238,15 +257,14 @@ class TestTraceDTensor(unittest.TestCase):
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
 
-        traced_result = trace_module(model, (tokens_dt,))
+        traced = aot_function(model, (tokens_dt,))
         has_subclass = any(
-            layout.meta is not None for layout in traced_result.input_subclass_layouts
+            layout.meta is not None for layout in traced.input_subclass_layouts
         )
         self.assertTrue(has_subclass)
 
         out_eager = model(tokens_dt)
-        params_and_buffers = _get_params_and_buffers(model)
-        wrapped = run_traced_module(traced_result, params_and_buffers, (tokens_dt,))
+        wrapped = traced(model, tokens_dt)
         self.assertTrue(torch.equal(out_eager.full_tensor(), wrapped[0].full_tensor()))
 
     def test_dtensor_train_step(self):
@@ -267,19 +285,15 @@ class TestTraceDTensor(unittest.TestCase):
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
         labels_dt = DTensor.from_local(labels, mesh, [Replicate()])
 
-        train_step = TrainStepModule(model_ref, get_loss)
-        traced_result = trace_module(train_step, (tokens_dt, labels_dt))
+        train_step = make_train_step(get_loss)
+        traced = aot_function(train_step, (model_ref, tokens_dt, labels_dt))
 
         logits_ref = model_ref(tokens_dt)
         loss_ref = get_loss(logits_ref, labels_dt)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        train_step_copy = TrainStepModule(model_test, get_loss)
-        params_and_buffers = _get_params_and_buffers(train_step_copy)
-        wrapped = run_traced_module(
-            traced_result, params_and_buffers, (tokens_dt, labels_dt)
-        )
+        wrapped = traced(model_test, tokens_dt, labels_dt)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -301,15 +315,15 @@ class TestMetadataPropagation(unittest.TestCase):
     def test_backward_nodes_have_seq_nr(self):
         """Verify that backward FX nodes get seq_nr metadata via the patched engine."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        train_step = TrainStepModule(model, get_loss)
+        train_step = make_train_step(get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced_result = trace_module(train_step, (tokens, labels))
+        traced = aot_function(train_step, (model, tokens, labels))
 
         # Collect seq_nr values from all call_function nodes
         seq_nrs = []
-        for node in traced_result.gm.graph.nodes:
+        for node in traced.gm.graph.nodes:
             if node.op == "call_function" and "seq_nr" in node.meta:
                 seq_nrs.append(node.meta["seq_nr"])
 
@@ -329,17 +343,13 @@ class TestMetadataPropagation(unittest.TestCase):
         """Verify _copy_fwd_metadata_to_bw_nodes copies custom metadata to bwd nodes."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
 
-        # Use annotate to set custom metadata on forward nodes, then trace
-        # with backward to verify it propagates
-        train_step = TrainStepModule(model, get_loss)
+        train_step = make_train_step(get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced_result = trace_module(train_step, (tokens, labels))
-        gm = traced_result.gm
+        traced = aot_function(train_step, (model, tokens, labels))
+        gm = traced.gm
 
-        # Manually set custom metadata on the first fwd node for each seq_nr
-        # to test that _copy_fwd_metadata_to_bw_nodes works
         seq_nr_first: dict[int, torch.fx.Node] = {}
         for node in gm.graph.nodes:
             if node.op == "call_function" and "seq_nr" in node.meta:
@@ -348,16 +358,13 @@ class TestMetadataPropagation(unittest.TestCase):
                     seq_nr_first[seq_nr] = node
                     node.meta["custom"] = {"test_key": "test_value"}
 
-        # Run the copy pass again
         _copy_fwd_metadata_to_bw_nodes(gm)
 
-        # Check that bwd nodes with shared seq_nr got the custom metadata
         for node in gm.graph.nodes:
             if node.op != "call_function" or "seq_nr" not in node.meta:
                 continue
             seq_nr = node.meta["seq_nr"]
             if node is not seq_nr_first.get(seq_nr):
-                # This is a backward node
                 custom = node.meta.get("custom")
                 self.assertIsNotNone(
                     custom,
@@ -373,11 +380,9 @@ class TestMetadataPropagation(unittest.TestCase):
         orig_fn = torch.autograd.graph._engine_run_backward
 
         with _patch_engine_run_backward():
-            # Inside the context, it should be patched
             self.assertIsNot(torch.autograd.graph._engine_run_backward, orig_fn)
             self.assertIsNot(torch.autograd._engine_run_backward, orig_fn)
 
-        # After the context, it should be restored
         self.assertIs(torch.autograd.graph._engine_run_backward, orig_fn)
         self.assertIs(torch.autograd._engine_run_backward, orig_fn)
 
@@ -409,20 +414,25 @@ class TestTraceModels(unittest.TestCase):
         num_steps=5,
         lr=1e-3,
     ):
-        train_step_ref = TrainStepModule(model_ref, get_loss)
+        train_step = make_train_step(get_loss)
 
-        with annotate_flex_attention_for_regional_inductor() if use_regional_inductor else contextlib.nullcontext():
-            traced_result = trace_module(train_step_ref, (*fwd_args, labels))
+        maybe_regional_inductor = (
+            annotate_flex_attention_for_regional_inductor()
+            if use_regional_inductor
+            else contextlib.nullcontext()
+        )
+        with maybe_regional_inductor:
+            traced = aot_function(train_step, (model_ref, *fwd_args, labels))
 
         if check_collective_ops:
             ag = sum(
                 1
-                for n in traced_result.gm.graph.nodes
+                for n in traced.gm.graph.nodes
                 if "all_gather_into_tensor" in str(n.target)
             )
             rs = sum(
                 1
-                for n in traced_result.gm.graph.nodes
+                for n in traced.gm.graph.nodes
                 if "reduce_scatter_tensor" in str(n.target)
             )
             self.assertTrue(
@@ -431,7 +441,7 @@ class TestTraceModels(unittest.TestCase):
             )
 
         if use_regional_inductor:
-            _apply_regional_inductor(traced_result)
+            _apply_regional_inductor(traced)
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=lr)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=lr)
@@ -444,11 +454,7 @@ class TestTraceModels(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            train_step_copy = TrainStepModule(model_test, get_loss)
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (*fwd_args, labels)
-            )
+            wrapped = traced(model_test, *fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -618,11 +624,11 @@ class TestTraceModels(unittest.TestCase):
             "sliding_window_mask": sliding_window_mask,
         }
         with annotate_flex_attention_for_regional_inductor():
-            traced_result = trace_module(model, (tokens, attn_masks))
+            traced = aot_function(model, (tokens, attn_masks))
 
         flex_nodes = [
             n
-            for n in traced_result.gm.graph.nodes
+            for n in traced.gm.graph.nodes
             if "flex_attention" in str(n.target) and "backward" not in str(n.target)
         ]
         self.assertGreater(len(flex_nodes), 0, "No FlexAttentionHOP nodes found")
@@ -704,20 +710,23 @@ class TestTraceFSDP(FSDPTest):
         else:
             fwd_args = (tokens,)
 
-        train_step_ref = TrainStepModule(model_ref, get_loss)
+        train_step = make_train_step(get_loss)
 
-        with annotate_flex_attention_for_regional_inductor() if use_regional_inductor else contextlib.nullcontext():
-            traced_result = trace_module(train_step_ref, (*fwd_args, labels))
+        maybe_regional_inductor = (
+            annotate_flex_attention_for_regional_inductor()
+            if use_regional_inductor
+            else contextlib.nullcontext()
+        )
+        with maybe_regional_inductor:
+            traced = aot_function(train_step, (model_ref, *fwd_args, labels))
 
         ag = sum(
             1
-            for n in traced_result.gm.graph.nodes
+            for n in traced.gm.graph.nodes
             if "all_gather_into_tensor" in str(n.target)
         )
         rs = sum(
-            1
-            for n in traced_result.gm.graph.nodes
-            if "reduce_scatter_tensor" in str(n.target)
+            1 for n in traced.gm.graph.nodes if "reduce_scatter_tensor" in str(n.target)
         )
         self.assertTrue(
             ag > 0 and rs > 0,
@@ -725,7 +734,7 @@ class TestTraceFSDP(FSDPTest):
         )
 
         if use_regional_inductor:
-            _apply_regional_inductor(traced_result)
+            _apply_regional_inductor(traced)
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=1e-3)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=1e-3)
@@ -738,11 +747,7 @@ class TestTraceFSDP(FSDPTest):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            train_step_copy = TrainStepModule(model_test, get_loss)
-            params_and_buffers = _get_params_and_buffers(train_step_copy)
-            wrapped = run_traced_module(
-                traced_result, params_and_buffers, (*fwd_args, labels)
-            )
+            wrapped = traced(model_test, *fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -13,30 +13,32 @@ import torch.nn as nn
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-    run_traced_module,
-    trace_module,
+    aot_function,
     TracedResult,
 )
 from torchtitan.trainer import Trainer
 
 
-class FwdBwdStepModule(nn.Module):
-    """Wraps model + loss_fn + autograd.grad into a single traceable forward.
+def make_fwd_bwd_step(loss_fn):
+    """Return a plain function that traces the entire fwd+loss+bwd step.
 
-    This allows make_fx to trace through the entire fwd+loss+bwd as one graph.
+    ``loss_fn`` is captured in the closure so it is not a graph input.
+
+    TODO: investigate how loss_fn interacts with non-strict trace. Currently
+    it is captured as a closure variable, but non-strict tracing may need it
+    registered via pytree.register_constant or passed differently.
     """
 
-    def __init__(self, model, loss_fn):
-        super().__init__()
-        self.model = model
-        self.loss_fn = loss_fn
-
-    def forward(self, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs):
-        pred = self.model(inputs, **extra_inputs, **extra_kwargs)
-        loss = self.loss_fn(pred, labels) / global_valid_tokens
-        params = [p for p in self.model.parameters() if p.requires_grad]
+    def fwd_bwd_step(
+        model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
+    ):
+        pred = model(inputs, **extra_inputs, **extra_kwargs)
+        loss = loss_fn(pred, labels) / global_valid_tokens
+        params = [p for p in model.parameters() if p.requires_grad]
         grads = torch.autograd.grad(loss, params)
         return [loss] + list(grads)
+
+    return fwd_bwd_step
 
 
 class GraphTrainer(Trainer):
@@ -55,7 +57,6 @@ class GraphTrainer(Trainer):
             )
 
         # Lazy state for aot_fx_trace mode
-        self._fwd_bwd_step_module: FwdBwdStepModule | None = None
         self._traced_step: TracedResult | None = None
 
     def forward_backward_step(
@@ -101,23 +102,28 @@ class GraphTrainer(Trainer):
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:
         if self._traced_step is None:
-            self._fwd_bwd_step_module = FwdBwdStepModule(model, self.loss_fn)
-
+            fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
             with self.train_context(), self.maybe_enable_amp:
-                self._traced_step = trace_module(
-                    self._fwd_bwd_step_module,
-                    (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+                self._traced_step = aot_function(
+                    fwd_bwd_fn,
+                    (
+                        model,
+                        inputs,
+                        labels,
+                        global_valid_tokens,
+                        extra_inputs,
+                        extra_kwargs,
+                    ),
                 )
 
-        params_and_buffers = {
-            **dict(self._fwd_bwd_step_module.named_parameters(remove_duplicate=False)),
-            **dict(self._fwd_bwd_step_module.named_buffers(remove_duplicate=False)),
-        }
         with self.train_context(), self.maybe_enable_amp:
-            outputs = run_traced_module(
-                self._traced_step,
-                params_and_buffers,
-                (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
+            outputs = self._traced_step(
+                model,
+                inputs,
+                labels,
+                global_valid_tokens,
+                extra_inputs,
+                extra_kwargs,
             )
         loss = outputs[0]
         grads = outputs[1:]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2760
* __->__ #2759

Authored-by: Claude

Redesign the graph trainer's tracing API based on the aot_function design doc.

Key changes:

make_fx_tracer.py:
- Rename trace_module -> aot_function. Takes any callable (not just nn.Module)
  with exactly one nn.Module at position 0 in args, whose params/buffers are
  lifted as graph inputs. When fn is an nn.Module, it is prepended to args
  and type(fn).__call__ is used as the callable.
- Delete run_traced_module. TracedResult is now directly callable — pass the
  same positional args (with the live module) to execute the graph. Fresh
  params are read from the module automatically on each call.
- Execute traced graph under torch.no_grad() since it already contains
  explicit backward ops. Without this, a redundant autograd graph keeps all
  forward intermediates alive via grad_fn references.
- Store and restore output pytree spec so TracedResult.__call__ returns the
  same pytree structure as the original function (e.g. single tensor, list,
  tuple, dict), not a flat list.
- Store param/buffer FQNs at trace time, validate on first execution to catch
  module structure mismatches early.
- Install TracingContext before make_fx so invoke_subgraph deduplication works.
- Validate that all pytree leaves in args are tensors or primitives
  (int/float/bool/str). Callables like loss_fn must be captured in fn's
  closure, not passed as args.
- Handle tensor subclass (e.g. DTensor) unwrapping/rewrapping via dict-based
  layouts — only subclass positions get entries, plain tensors have no entry.

trainer.py:
- Replace FwdBwdStepModule (nn.Module wrapper that only existed because the
  old trace_module required nn.Module as fn) with make_fwd_bwd_step, a plain
  function factory. The model is now passed as an arg, loss_fn is captured in
  the closure.
- Remove manual params_and_buffers dict construction — TracedResult.__call__
  reads fresh params from the live module automatically.
- Add TODO for investigating loss_fn interaction with non-strict trace.

test_trace_module.py:
- Replace TrainStepModule with make_train_step plain function factory.
- Remove _get_params_and_buffers helper (no longer needed).
- Update all callsites: trace_module -> aot_function, run_traced_module ->
  direct TracedResult.__call__.
- Register BlockMask as pytree node at module level so flex_attention tests
  pass the leaf validation.
- Add test_mismatched_module_raises: FQN validation catches wrong module.
- Add test_non_tensor_leaf_raises: callable leaf in args raises ValueError.

All 7 model tests pass (llama3, llama4, qwen3, qwen3_moe, deepseek_v3,
gpt_oss, flex_attention_annotations).