### PR TITLE
[graph_trainer] Add cudagraph support for Inductor-compiled and non-compiled graphs

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -128,6 +128,10 @@ class CUDAGraphWrapper:
         _cg_manager.register_wrapper(self)
 
         self._runnable = runnable
+        # Boxed-call functions (e.g. CompiledFxGraph from Inductor)
+        # take a single list argument instead of individual *args.
+        # We adapt our calling convention accordingly.
+        self._boxed_call_inner = getattr(runnable, "_boxed_call", False)
         self._static_input_indices = OrderedSet(
             static_input_indices if static_input_indices is not None else []
         )
@@ -157,15 +161,21 @@ class CUDAGraphWrapper:
             self._args[i].copy_(args[i])
 
     def _check_input_types(self, inputs) -> None:
-        for inp in inputs:
-            assert isinstance(inp, (torch.Tensor, int, torch._C.Generator)), (
-                "args must be tensor, integer (for dynamic shapes), "
-                "or Generator (for random number generator), "
-                f"but found {type(inp)}"
-            )
+        for i, inp in enumerate(inputs):
+            if isinstance(inp, (torch.Tensor, int, torch._C.Generator)):
+                continue
+            # Opaque inputs (e.g. DeviceMesh from SimpleFSDP/DTensor) are
+            # valid graph inputs. They are inherently static — their values
+            # don't change between iterations — so we treat them as static
+            # even if AOT Autograd didn't mark them. This ensures they are
+            # never included in _input_indices_to_copy (which already
+            # filters for torch.Tensor).
+            self._static_input_indices.add(i)
 
     def _check_static_inputs_address(self) -> None:
         for i in self._static_input_indices:
+            if not isinstance(self._args[i], torch.Tensor):
+                continue
             actual = self._args[i].data_ptr()
             expected = self._input_addresses[i]
             assert expected == actual, (
@@ -173,7 +183,19 @@ class CUDAGraphWrapper:
                 f"{expected} != {actual}"
             )
 
+    def _call_runnable(self, flat_args):
+        if self._boxed_call_inner:
+            return self._runnable(list(flat_args))
+        return self._runnable(*flat_args)
+
     def __call__(self, *args):
+        # Normalize boxed vs unboxed calling convention: internally we
+        # always work with a flat tuple of individual inputs.
+        if self._boxed_call_inner and len(args) == 1 and isinstance(args[0], (list, tuple)):
+            flat_args = tuple(args[0])
+        else:
+            flat_args = args
+
         if not self._has_warmup:
             self._has_warmup = True
             device = torch.cuda.current_device()
@@ -183,14 +205,15 @@ class CUDAGraphWrapper:
             with _use_cuda_memory_pool_manager(
                 device, _cg_manager.graph_pool, _cg_manager.stream
             ):
-                out = self._runnable(*args)
+                out = self._call_runnable(flat_args)
             return out
 
         if self._cudagraph is None:
-            self._check_input_types(args)
-            self._args = args
+            self._check_input_types(flat_args)
+            self._args = flat_args
             self._input_addresses = [
-                x.data_ptr() if isinstance(x, torch.Tensor) else None for x in args
+                x.data_ptr() if isinstance(x, torch.Tensor) else None
+                for x in flat_args
             ]
 
             self._cudagraph = torch.cuda.CUDAGraph()
@@ -201,12 +224,12 @@ class CUDAGraphWrapper:
                 stream=_cg_manager.stream,
             ):
                 # `output` is managed by pytorch's cudagraph pool
-                self._output = self._runnable(*args)
+                self._output = self._call_runnable(flat_args)
 
         if self._should_check_address:
             self._check_static_inputs_address()
 
-        self._copy_non_static_inputs(*args)
+        self._copy_non_static_inputs(*flat_args)
         self._cudagraph.replay()
         return self._output
 

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -324,9 +324,18 @@ def compiler(
         # cudagraph pass is always the last pass if it is applied
         cg_pass = passes[-1]
 
-        # to identify static input indices, cudagraph passes behaves differently for
-        # forward and backward pass. so we explicitly pass the info.
-        _cg_pass = functools.partial(cg_pass, is_forward=is_forward)
+        # Pre-compute static input indices while gm is still a
+        # GraphModule. Prior passes (e.g. full_inductor_compilation)
+        # may replace gm with a non-GraphModule callable, making it
+        # impossible to inspect the graph later.
+        from torchtitan.experiments.graph_trainer.cudagraph import (
+            get_static_input_indices,
+        )
+
+        static_input_indices = get_static_input_indices(gm, is_forward)
+        _cg_pass = functools.partial(
+            cg_pass, is_forward=is_forward, static_input_indices=static_input_indices
+        )
 
         # keep the function name for debug log
         passes[-1] = functools.wraps(cg_pass)(_cg_pass)
@@ -340,9 +349,10 @@ def compiler(
         logger.info(f"Applying pass: {pass_name}")
         gm = pass_fn(gm, example_inputs)
 
-    # Only try to print/dump if gm is still a GraphModule
-    # (compile_fx_inner returns a CompiledFxGraph which doesn't have print_readable)
-    if hasattr(gm, "print_readable"):
+    # Only try to print/dump if gm is still a GraphModule.
+    # Non-GraphModule results (CompiledFxGraph from inductor,
+    # CUDAGraphWrapper from cudagraph) don't have a readable graph.
+    if isinstance(gm, torch.fx.GraphModule):
         _dump_gm(dump_folder, gm, f"{name}_after_compiler")
 
         # Log the final transformed graph to tlparse.

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -113,7 +113,10 @@ def regional_inductor_pass(
 
 
 def cudagraph_pass(
-    gm: torch.fx.GraphModule, example_inputs: Sequence[Any], is_forward: bool
+    gm: torch.fx.GraphModule,
+    example_inputs: Sequence[Any],
+    is_forward: bool,
+    static_input_indices: list[int] | None = None,
 ) -> torch.fx.GraphModule:
     """
     Apply cudagraph.
@@ -123,17 +126,33 @@ def cudagraph_pass(
     - For the first run, it will warm up operators such as nccl.
     - For the second run, it will record cudagraph and replay cudagraph.
     - For the following runs, it will replay cudagraph.
+
+    Args:
+        static_input_indices: Pre-computed static input indices. When
+            provided, skips computing them from gm (necessary when a
+            prior pass like full_inductor_compilation replaced the
+            GraphModule with a non-inspectable callable).
     """
-    # Lazy import: cudagraph.py runs init_global_graph_pool() at import time,
-    # which must happen after torch.cuda.set_device(local_rank).
+    from torch._functorch._aot_autograd.utils import make_boxed_func
+
     from torchtitan.experiments.graph_trainer.cudagraph import (
         CUDAGraphWrapper,
         get_static_input_indices,
     )
 
-    static_input_indices = get_static_input_indices(gm, is_forward)
-    gm.forward = CUDAGraphWrapper(gm.forward, example_inputs, static_input_indices)
-    return gm
+    if static_input_indices is None:
+        static_input_indices = get_static_input_indices(gm, is_forward)
+
+    if isinstance(gm, torch.fx.GraphModule):
+        gm.forward = CUDAGraphWrapper(gm.forward, example_inputs, static_input_indices)
+        return make_boxed_func(gm)
+    else:
+        wrapper = CUDAGraphWrapper(gm, example_inputs, static_input_indices)
+        # Propagate _boxed_call so the AOT runtime uses the same
+        # calling convention (single list arg vs individual *args).
+        if getattr(gm, "_boxed_call", False):
+            wrapper._boxed_call = True
+        return wrapper
 
 
 def validate_flex_attn_annotation_pass(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2743
* __->__ #2762
* #2713

Make CUDAGraphWrapper compatible with both plain GraphModule callables
and Inductor's CompiledFxGraph (which uses the boxed calling convention).

Changes:
- CUDAGraphWrapper: detect _boxed_call on the inner runnable and
  normalize between boxed (single list arg) and unboxed (*args)
  calling conventions transparently.
- CUDAGraphWrapper: treat opaque non-tensor inputs (e.g. DeviceMesh
  from SimpleFSDP/DTensor) as static inputs instead of asserting.
  These are inherently constant across iterations.
- cudagraph_pass: pre-compute static_input_indices while gm is still
  a GraphModule, before prior passes (e.g. full_inductor_compilation)
  replace it with a non-inspectable callable.
- cudagraph_pass: return make_boxed_func(gm) for the GraphModule case
  so AOT Autograd uses the correct calling convention without warning.
- cudagraph_pass: handle non-GraphModule inputs (CompiledFxGraph) by
  wrapping directly and propagating _boxed_call.
- compiler(): use isinstance(gm, torch.fx.GraphModule) instead of
  hasattr(gm, "print_readable") for post-pass dump guard.

Validated on 8x H100 (MAST, DP=4 TP=2, llama3 debugmodel, 10 steps):
  - Baseline vs cudagraph: bitwise identical losses
  - Loss comparison plot: https://pxl.cl/9fs6t
  - Step-by-step table:   https://pxl.cl/9fs6B