### PR TITLE
[MoE Rewrite 1/n] Use local map for torch.histc and torch.gather, and use DTensor for router 

### DIFF
--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -249,7 +249,7 @@ def register_moe_load_balancing_hook(
                 if transformer_block.moe_enabled:
                     # Assumption: load_balance_coeff is set universally on all moe blocks.
                     # pyrefly: ignore [missing-attribute]
-                    return bool(transformer_block.moe.load_balance_coeff)
+                    return bool(transformer_block.moe.router.load_balance_coeff)
         return False
 
     # for MoE auxiliary-loss-free load balancing
@@ -271,7 +271,7 @@ def register_moe_load_balancing_hook(
                 if not transformer_block.moe_enabled:
                     continue
                 # pyrefly: ignore [missing-attribute]
-                if transformer_block.moe.load_balance_coeff is None:
+                if transformer_block.moe.router.load_balance_coeff is None:
                     return
                 # pyrefly: ignore [missing-attribute]
                 tokens_per_expert = transformer_block.moe.tokens_per_expert
@@ -318,12 +318,19 @@ def register_moe_load_balancing_hook(
                     # update the expert bias
                     # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
                     # pyrefly: ignore [missing-attribute]
-                    expert_bias_delta = moe.load_balance_coeff * torch.sign(
+                    expert_bias_delta = moe.router.load_balance_coeff * torch.sign(
                         tokens_per_expert.mean() - tokens_per_expert
                     )
                     expert_bias_delta = expert_bias_delta - expert_bias_delta.mean()
+                    # expert_bias may be a DTensor (Replicate on TP mesh) after
+                    # parallelization. Use _local_tensor for the in-place
+                    # update, which is safe because expert_bias is Replicate
+                    # and expert_bias_delta is identical across all ranks.
                     # pyrefly: ignore [missing-attribute]
-                    moe.expert_bias.add_(expert_bias_delta)
+                    expert_bias = moe.router.expert_bias
+                    if isinstance(expert_bias, torch.distributed.tensor.DTensor):
+                        expert_bias = expert_bias._local_tensor
+                    expert_bias.add_(expert_bias_delta)
                     # pyrefly: ignore [missing-attribute]
                     moe.tokens_per_expert.zero_()
 

--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -74,19 +74,37 @@ class NoParallel(ParallelStyle):
         return (input_tensor, *inputs[1:])
 
     @staticmethod
+    def _prepare_single_output(
+        output: DTensor,
+        output_layout: Placement,
+        local_output_grad_placements: Sequence[Placement] | None,
+    ) -> torch.Tensor | DTensor:
+        if output.placements != (output_layout,):
+            output = output.redistribute(placements=(output_layout,), async_op=True)
+        if local_output_grad_placements is not None:
+            return output.to_local(grad_placements=local_output_grad_placements)
+        return output
+
+    @staticmethod
     def _prepare_output_fn(
         output_layout: Placement,
         local_output_grad_placements: Sequence[Placement] | None,
         mod: nn.Module,
-        outputs: DTensor,
+        outputs: DTensor | tuple,
         device_mesh: DeviceMesh,
-    ) -> torch.Tensor | DTensor:
-        if outputs.placements != (output_layout,):
-            outputs = outputs.redistribute(placements=(output_layout,), async_op=True)
-        if local_output_grad_placements is not None:
-            return outputs.to_local(grad_placements=local_output_grad_placements)
-        else:
-            return outputs
+    ) -> torch.Tensor | DTensor | tuple:
+        if isinstance(outputs, tuple):
+            return tuple(
+                NoParallel._prepare_single_output(
+                    o, output_layout, local_output_grad_placements
+                )
+                if isinstance(o, DTensor)
+                else o
+                for o in outputs
+            )
+        return NoParallel._prepare_single_output(
+            outputs, output_layout, local_output_grad_placements
+        )
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         return distribute_module(

--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -174,7 +174,7 @@ def moe_forward(self, x: torch.Tensor) -> torch.Tensor:
     out, num_tokens_per_expert = _moe_forward(
         x,
         self.router.gate.weight,
-        self.expert_bias,
+        self.router.expert_bias,
         self.experts.w1,
         self.experts.w3,
         self.experts.w2,
@@ -441,8 +441,8 @@ def _preserve_moe_attributes(original_model, parallel_model):
     # This is fine to do since these attributes are read only
     for orig_moe, par_moe in zip(original_moe_modules, parallel_moe_modules):
         if hasattr(orig_moe, "moe_enabled"):
-            par_moe.load_balance_coeff = orig_moe.load_balance_coeff
+            par_moe.router.load_balance_coeff = orig_moe.router.load_balance_coeff
 
         # Copy load_balance_coeff
         if hasattr(orig_moe, "load_balance_coeff"):
-            par_moe.load_balance_coeff = orig_moe.load_balance_coeff
+            par_moe.router.load_balance_coeff = orig_moe.router.load_balance_coeff

--- a/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
@@ -188,8 +188,8 @@ def _preserve_moe_attributes(original_model, parallel_model):
     # This is fine to do since these attributes are read only
     for orig_moe, par_moe in zip(original_moe_modules, parallel_moe_modules):
         if hasattr(orig_moe, "moe_enabled"):
-            par_moe.load_balance_coeff = orig_moe.load_balance_coeff
+            par_moe.router.load_balance_coeff = orig_moe.router.load_balance_coeff
 
         # Copy load_balance_coeff
         if hasattr(orig_moe, "load_balance_coeff"):
-            par_moe.load_balance_coeff = orig_moe.load_balance_coeff
+            par_moe.router.load_balance_coeff = orig_moe.router.load_balance_coeff

--- a/torchtitan/models/common/moe/moe.py
+++ b/torchtitan/models/common/moe/moe.py
@@ -317,6 +317,38 @@ class TokenChoiceTopKRouter(Module):
                 - num_tokens_per_expert (torch.Tensor):
                     Number of tokens assigned to each expert with shape ``(num_experts,)``.
         """
+        # === DEBUG: Check gate weight consistency across ranks ===
+        import torch.distributed as dist
+
+        if dist.is_initialized() and dist.get_world_size() > 1:
+            rank = dist.get_rank()
+            gate_weight = self.gate.weight
+            if isinstance(gate_weight, DTensor):
+                gate_weight_local = gate_weight.to_local()
+            else:
+                gate_weight_local = gate_weight
+            # allgather gate weights from all ranks
+            gathered = [
+                torch.zeros_like(gate_weight_local)
+                for _ in range(dist.get_world_size())
+            ]
+            dist.all_gather(gathered, gate_weight_local.contiguous())
+            # check if all ranks have the same gate weight
+            for other_rank, other_weight in enumerate(gathered):
+                if other_rank != rank:
+                    if not torch.equal(gate_weight_local, other_weight):
+                        max_diff = (gate_weight_local - other_weight).abs().max().item()
+                        print(
+                            f"[DEBUG] GATE WEIGHT DIVERGED! rank {rank} vs rank {other_rank}, "
+                            f"max_diff={max_diff:.6e}, "
+                            f"rank_{rank}_norm={gate_weight_local.norm().item():.6f}, "
+                            f"rank_{other_rank}_norm={other_weight.norm().item():.6f}"
+                        )
+                    else:
+                        print(
+                            f"[DEBUG] GATE WEIGHT MATCH: rank {rank} == rank {other_rank}"
+                        )
+        # === END DEBUG ===
         # scores shape (bs*slen, num_experts)
         # Compute gate in float32 to help stability of expert load balancing.
         with torch.autocast(device_type=x.device.type, dtype=torch.float32):
@@ -378,7 +410,9 @@ class TokenChoiceTopKRouter(Module):
         # per expert. scatter is wrapped with local_map for DTensor support,
         # while sum has native DTensor support.
         if isinstance(selected_experts_indices, DTensor):
-            assert isinstance(scores, DTensor), "scores and selected_experts_indices should both be DTensors"
+            assert isinstance(
+                scores, DTensor
+            ), "scores and selected_experts_indices should both be DTensors"
             _local_generate_routing_map = local_map(
                 _generate_routing_map,
                 out_placements=(list(selected_experts_indices.placements),),
@@ -391,9 +425,7 @@ class TokenChoiceTopKRouter(Module):
         else:
             _local_generate_routing_map = _generate_routing_map
 
-        routing_map = _local_generate_routing_map(
-            scores, selected_experts_indices
-        )
+        routing_map = _local_generate_routing_map(scores, selected_experts_indices)
         num_tokens_per_expert = routing_map.sum(dim=0)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert
@@ -491,7 +523,9 @@ class MoE(Module):
             dim=dim, hidden_dim=hidden_dim, num_experts=num_experts
         )
         self.router = config.router.build(
-            dim=dim, num_experts=num_experts, load_balance_coeff=config.load_balance_coeff
+            dim=dim,
+            num_experts=num_experts,
+            load_balance_coeff=config.load_balance_coeff,
         )
         self.reorderer = TokenReorderer(
             num_experts=num_experts, top_k=config.router.top_k

--- a/torchtitan/models/common/moe/moe.py
+++ b/torchtitan/models/common/moe/moe.py
@@ -11,12 +11,58 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torch.distributed.tensor import DTensor, Partial
+from torch.distributed.tensor.experimental import local_map
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
 
 from .utils import indices_padding_wrapper
+
+
+def _gather_topk_scores(
+    scores: torch.Tensor,
+    selected_experts_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Gather top-k scores from the full score tensor using expert indices.
+
+    Args:
+        scores: Full routing scores, shape (num_tokens, num_experts).
+        selected_experts_indices: Expert indices, shape (num_tokens, top_k).
+
+    Returns:
+        Top-k scores, shape (num_tokens, top_k).
+    """
+    return torch.gather(scores, -1, selected_experts_indices)
+
+
+def _generate_routing_map(
+    selected_experts_indices: torch.Tensor,
+    num_experts: int,
+) -> torch.Tensor:
+    """Build a boolean routing map from expert indices.
+
+    Args:
+        selected_experts_indices: Expert indices for each token,
+            shape (num_tokens, top_k).
+        num_experts: Total number of experts.
+
+    Returns:
+        routing_map: Boolean tensor of shape (num_tokens, num_experts),
+            where routing_map[i, j] is True if token i is routed to expert j.
+    """
+    num_tokens = selected_experts_indices.shape[0]
+    routing_map = torch.scatter(
+        torch.zeros(
+            (num_tokens, num_experts),
+            dtype=torch.bool,
+            device=selected_experts_indices.device,
+        ),
+        -1,
+        selected_experts_indices,
+        True,
+    )
+    return routing_map
 
 
 # NOTE: keeping this for-loop implementation for comparison
@@ -278,7 +324,22 @@ class TokenChoiceTopKRouter(Module):
         # top scores shape (bs*slen, top_k)
         # NOTE: The expert_bias is only used for routing. The gating value
         #       top_scores is still derived from the original scores.
-        top_scores = scores.gather(dim=1, index=selected_experts_indices)
+        # gather is wrapped with local_map for DTensor support.
+        if isinstance(selected_experts_indices, DTensor):
+            assert isinstance(scores, DTensor), "scores and selected_experts_indices should both be DTensors"
+            _local_gather_topk_scores = local_map(
+                _gather_topk_scores,
+                out_placements=(list(scores.placements),),
+                in_placements=(
+                    list(scores.placements),
+                    list(selected_experts_indices.placements),
+                ),
+                device_mesh=scores.device_mesh,
+            )
+        else:
+            _local_gather_topk_scores = _gather_topk_scores
+
+        top_scores = _local_gather_topk_scores(scores, selected_experts_indices)
 
         # debug override: balanced round-robin routing
         if self._debug_force_load_balance:
@@ -292,13 +353,23 @@ class TokenChoiceTopKRouter(Module):
             top_scores = top_scores / denominator
         top_scores = top_scores * self.route_scale
 
-        # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
-        num_tokens_per_expert = torch.histc(
-            selected_experts_indices.view(-1),
-            bins=self.num_experts,
-            min=0,
-            max=self.num_experts,
+        # Build a boolean routing map via scatter, then sum to count tokens
+        # per expert. scatter is wrapped with local_map for DTensor support,
+        # while sum has native DTensor support.
+        if isinstance(selected_experts_indices, DTensor):
+            _local_generate_routing_map = local_map(
+                _generate_routing_map,
+                out_placements=(list(selected_experts_indices.placements),),
+                in_placements=(list(selected_experts_indices.placements),),
+                device_mesh=selected_experts_indices.device_mesh,
+            )
+        else:
+            _local_generate_routing_map = _generate_routing_map
+
+        routing_map = _local_generate_routing_map(
+            selected_experts_indices, self.num_experts
         )
+        num_tokens_per_expert = routing_map.sum(dim=0)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert
 
@@ -340,13 +411,10 @@ class TokenReorderer(Module):
                 - token_indices_experts_sorted: Token indices reordered to match expert ordering
                 - num_tokens_per_expert: Number of tokens assigned to each expert
         """
-        # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
-        num_tokens_per_expert = torch.histc(
-            selected_experts_indices.view(-1),
-            bins=self.num_experts,
-            min=0,
-            max=self.num_experts,
+        routing_map = _generate_routing_map(
+            selected_experts_indices, self.num_experts
         )
+        num_tokens_per_expert = routing_map.sum(dim=0)
 
         # Reorder the token indices to match the order of the experts
         # token_indices_experts_sorted shape (bs*slen*top_k,)

--- a/torchtitan/models/common/moe/moe.py
+++ b/torchtitan/models/common/moe/moe.py
@@ -37,21 +37,26 @@ def _gather_topk_scores(
 
 
 def _generate_routing_map(
+    scores: torch.Tensor,
     selected_experts_indices: torch.Tensor,
-    num_experts: int,
 ) -> torch.Tensor:
     """Build a boolean routing map from expert indices.
 
+    Takes scores as a tensor arg (instead of num_experts as an int) so
+    that ``local_map`` can specify DTensor placements for both inputs.
+
     Args:
+        scores: Router scores, shape (num_tokens, num_experts).
+            Only used to derive num_experts from the last dimension.
         selected_experts_indices: Expert indices for each token,
             shape (num_tokens, top_k).
-        num_experts: Total number of experts.
 
     Returns:
         routing_map: Boolean tensor of shape (num_tokens, num_experts),
             where routing_map[i, j] is True if token i is routed to expert j.
     """
     num_tokens = selected_experts_indices.shape[0]
+    num_experts = scores.shape[-1]
     routing_map = torch.scatter(
         torch.zeros(
             (num_tokens, num_experts),
@@ -199,6 +204,7 @@ class TokenChoiceTopKRouter(Module):
     class Config(Module.Config):
         dim: int = field(init=False)
         num_experts: int = field(init=False)
+        load_balance_coeff: float | None = field(init=False)
         num_expert_groups: int | None = None  # must be a divisor of num_experts
         num_limited_groups: int | None = None
         top_k: int = 1
@@ -221,6 +227,20 @@ class TokenChoiceTopKRouter(Module):
         self.route_norm = config.route_norm
         self.route_scale = config.route_scale
         self._debug_force_load_balance = config._debug_force_load_balance
+
+        # Auxiliary-loss-free load balancing (https://arxiv.org/abs/2408.15664)
+        # expert_bias lives on the router so that distribute_module in the
+        # parallelize plan automatically distributes it as a DTensor buffer,
+        # avoiding mixed Tensor/DTensor arithmetic with gate scores.
+        # expert_bias is updated outside the model in an optimizer step pre hook.
+        self.load_balance_coeff = config.load_balance_coeff
+        if self.load_balance_coeff is not None:
+            assert self.load_balance_coeff > 0.0
+            self.register_buffer(
+                "expert_bias",
+                torch.zeros(config.num_experts, dtype=torch.float32),
+                persistent=True,
+            )
 
     def _debug_force_load_balance_routing(
         self, scores: torch.Tensor
@@ -282,13 +302,11 @@ class TokenChoiceTopKRouter(Module):
         return scores_for_choice
 
     def forward(
-        self, x: torch.Tensor, expert_bias: torch.Tensor | None = None
+        self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Args:
             x (torch.Tensor): Input tensor with shape ``(bs*slen, dim)``.
-            expert_bias (torch.Tensor | None, optional): Optional bias tensor for experts with shape ``(num_experts,)``.
-                Used for load balancing. Defaults to None.
 
         Returns:
             tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -313,6 +331,7 @@ class TokenChoiceTopKRouter(Module):
         else:
             raise NotImplementedError(f"Unknown score function {self.score_func}")
 
+        expert_bias = getattr(self, "expert_bias", None)
         scores_for_choice = scores if expert_bias is None else scores + expert_bias
         # Apply node-limited routing if configured
         if self.num_expert_groups is not None:
@@ -326,7 +345,9 @@ class TokenChoiceTopKRouter(Module):
         #       top_scores is still derived from the original scores.
         # gather is wrapped with local_map for DTensor support.
         if isinstance(selected_experts_indices, DTensor):
-            assert isinstance(scores, DTensor), "scores and selected_experts_indices should both be DTensors"
+            assert isinstance(
+                scores, DTensor
+            ), "scores and selected_experts_indices should both be DTensors"
             _local_gather_topk_scores = local_map(
                 _gather_topk_scores,
                 out_placements=(list(scores.placements),),
@@ -357,17 +378,21 @@ class TokenChoiceTopKRouter(Module):
         # per expert. scatter is wrapped with local_map for DTensor support,
         # while sum has native DTensor support.
         if isinstance(selected_experts_indices, DTensor):
+            assert isinstance(scores, DTensor), "scores and selected_experts_indices should both be DTensors"
             _local_generate_routing_map = local_map(
                 _generate_routing_map,
                 out_placements=(list(selected_experts_indices.placements),),
-                in_placements=(list(selected_experts_indices.placements),),
+                in_placements=(
+                    list(scores.placements),
+                    list(selected_experts_indices.placements),
+                ),
                 device_mesh=selected_experts_indices.device_mesh,
             )
         else:
             _local_generate_routing_map = _generate_routing_map
 
         routing_map = _local_generate_routing_map(
-            selected_experts_indices, self.num_experts
+            scores, selected_experts_indices
         )
         num_tokens_per_expert = routing_map.sum(dim=0)
 
@@ -377,6 +402,10 @@ class TokenChoiceTopKRouter(Module):
         init_std = kwargs.get("init_std")
         assert init_std is not None
         self.gate.init_weights(init_std=init_std)
+
+        expert_bias = getattr(self, "expert_bias", None)
+        if expert_bias is not None:
+            expert_bias.zero_()
 
 
 # NOTE: the reason we make this a stateless module is to support
@@ -411,8 +440,16 @@ class TokenReorderer(Module):
                 - token_indices_experts_sorted: Token indices reordered to match expert ordering
                 - num_tokens_per_expert: Number of tokens assigned to each expert
         """
-        routing_map = _generate_routing_map(
-            selected_experts_indices, self.num_experts
+        num_tokens = selected_experts_indices.shape[0]
+        routing_map = torch.scatter(
+            torch.zeros(
+                (num_tokens, self.num_experts),
+                dtype=torch.bool,
+                device=selected_experts_indices.device,
+            ),
+            -1,
+            selected_experts_indices,
+            True,
         )
         num_tokens_per_expert = routing_map.sum(dim=0)
 
@@ -453,7 +490,9 @@ class MoE(Module):
         self.experts = config.experts.build(
             dim=dim, hidden_dim=hidden_dim, num_experts=num_experts
         )
-        self.router = config.router.build(dim=dim, num_experts=num_experts)
+        self.router = config.router.build(
+            dim=dim, num_experts=num_experts, load_balance_coeff=config.load_balance_coeff
+        )
         self.reorderer = TokenReorderer(
             num_experts=num_experts, top_k=config.router.top_k
         )
@@ -466,21 +505,8 @@ class MoE(Module):
         )
         self.score_before_experts = config.score_before_experts
 
-        # define fields for auxiliary-loss-free load balancing (https://arxiv.org/abs/2408.15664)
-        # NOTE: tokens_per_expert is accumulated in the model forward pass.
-        #       expert_bias is updated outside the model in an optimizer step pre hook
-        #       to work with gradient accumulation.
-        self.load_balance_coeff = config.load_balance_coeff
-        if self.load_balance_coeff is not None:
-            assert self.load_balance_coeff > 0.0
-            self.register_buffer(
-                "expert_bias",
-                torch.zeros(num_experts, dtype=torch.float32),
-                persistent=True,
-            )
-        else:
-            self.expert_bias = None
-        # tokens_per_expert will be used to track expert usage and to update the expert bias for load balancing
+        # tokens_per_expert is accumulated in the model forward pass and used
+        # to update the expert bias for load balancing.
         self.register_buffer(
             "tokens_per_expert",
             torch.zeros(num_experts, dtype=torch.float32),
@@ -495,7 +521,21 @@ class MoE(Module):
         Returns:
             out (torch.Tensor): Output tensor with shape ``(bs, slen, dim)``.
         """
-        # Convert DTensor to local tensor for MoE-internal computation.
+        bs, slen, dim = x.shape
+        x = x.view(-1, dim)
+
+        # Router runs in full DTensor (Replicate on TP mesh).
+        # top_scores and selected_experts_indices shape (bs*slen, top_k)
+        # num_tokens_per_expert shape (num_experts,)
+        (
+            top_scores,
+            selected_experts_indices,
+            num_tokens_per_expert,
+        ) = self.router(x)
+
+        # Convert DTensor to local tensor after the router for the
+        # reorderer, experts, and combine steps which use ops without
+        # DTensor support (argsort, index assignment, etc.).
         # grad_placements=(Partial(),) ensures x.grad is Partial on the tp_mesh
         # in backward, so gradient reduction (reduce-scatter from Partial to
         # Shard(1)) happens once at the MoE boundary rather than being
@@ -508,7 +548,7 @@ class MoE(Module):
         #   (via ReordererSequenceParallel), so grad(x) is non-zero only at
         #   each rank's token positions(Partial).
         #
-        # This holds for all MoE components (router.gate, routed experts, shared
+        # This holds for all MoE components (routed experts, shared
         # experts) and regardless of score_before_experts.
         if isinstance(x, DTensor):
             assert (
@@ -518,16 +558,9 @@ class MoE(Module):
                 "tp",
             ), f"Expected TP mesh, got mesh_dim_names={x.device_mesh.mesh_dim_names}"
             x = x.to_local(grad_placements=(Partial(),))
-        bs, slen, dim = x.shape
-        x = x.view(-1, dim)
-
-        # top_scores and selected_experts_indices shape (bs*slen, top_k)
-        # num_tokens_per_expert shape (num_experts,)
-        (
-            top_scores,
-            selected_experts_indices,
-            num_tokens_per_expert,
-        ) = self.router(x, self.expert_bias)
+            top_scores = top_scores.to_local(grad_placements=(Partial(),))
+            selected_experts_indices = selected_experts_indices.to_local()
+            num_tokens_per_expert = num_tokens_per_expert.to_local()
 
         # tokens_per_expert will be used to update the expert bias for load balancing.
         # and also to count the expert usage
@@ -609,7 +642,3 @@ class MoE(Module):
             self.tokens_per_expert = torch.zeros(
                 self.experts.num_experts, dtype=torch.float32
             )
-            if self.load_balance_coeff is not None:
-                self.expert_bias = torch.zeros(
-                    self.experts.num_experts, dtype=torch.float32
-                )

--- a/torchtitan/models/common/moe/moe_deepep.py
+++ b/torchtitan/models/common/moe/moe_deepep.py
@@ -78,11 +78,9 @@ class DeepEPMoE(MoE):
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
 
-        top_scores, selected_experts_indices, num_tokens_per_expert = self.router(
-            x, self.expert_bias
-        )
+        top_scores, selected_experts_indices, num_tokens_per_expert = self.router(x)
 
-        if self.load_balance_coeff is not None:
+        if self.router.load_balance_coeff is not None:
             with torch.no_grad():
                 self.tokens_per_expert.add_(num_tokens_per_expert)
 

--- a/torchtitan/models/deepseek_v3/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/state_dict_adapter.py
@@ -51,7 +51,7 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
             "model.layers.{}.mlp.shared_experts.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "model.layers.{}.mlp.shared_experts.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",
             "model.layers.{}.mlp.shared_experts.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
-            "model.layers.{}.mlp.gate.e_score_correction_bias": "layers.{}.moe.expert_bias",
+            "model.layers.{}.mlp.gate.e_score_correction_bias": "layers.{}.moe.router.expert_bias",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "output.weight",
         }

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -552,10 +552,10 @@ def apply_moe_ep_tp(
                     output_layouts=(Partial(),),
                     desired_output_layouts=(Shard(1),),
                 ),
-                # replicate computation for the router
-                "moe.router.gate": NoParallel(
-                    local_output_grad_placements=(Partial(),),
-                ),
+                # Replicate router params (gate weight) and buffers (expert_bias)
+                # as DTensors so the router runs in DTensor.
+                # to_local happens after the router in MoE.forward.
+                "moe.router": NoParallel(),
             }
             if ep_mesh is not None and etp_mesh is None:
                 # If TP is borrowed for EP, then split the tokens across TP ranks so that

--- a/torchtitan/models/llama4/state_dict_adapter.py
+++ b/torchtitan/models/llama4/state_dict_adapter.py
@@ -35,7 +35,7 @@ class Llama4StateDictAdapter(StateDictAdapter):
             "language_model.model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "language_model.model.layers.{}.feed_forward.router.weight": "layers.{}.moe.router.gate.weight",
             "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2",
-            None: "layers.{}.moe.expert_bias",
+            None: "layers.{}.moe.router.expert_bias",
             "language_model.model.layers.{}.feed_forward.shared_expert.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "language_model.model.layers.{}.feed_forward.shared_expert.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
             "language_model.model.layers.{}.feed_forward.shared_expert.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2770

**Summary**                                                           
                                                                                                
  - Refactored MoE router to run natively in DTensor (Replicate on TP mesh) instead of          
  converting to local tensors before routing. Distribute_module automatically handle parameter and buffer distribution.                                                                      
  - Replaced torch.histc (no DTensor support) with torch.scatter + sum to compute
  num_tokens_per_expert, and wrapped torch.gather and torch.scatter with local_map as DTensor  
  prop doesn't work for these two ops.
  - Updated NoParallel to handle tuple outputs (the router returns a 3-tuple of scores, indices,
   and token counts). 
  - Moved expert_bias and load_balance_coeff from MoE to TokenChoiceTopKRouter, so
  distribute_module in the parallelize plan distributes expert_bias as a DTensor buffer         
  alongside the gate weight. The to_local conversion now happens after the router in
  MoE.forward.                                                                                      
  - Updated the optimizer load-balancing hook to access expert_bias via moe.router.expert_bias
  and handle DTensor in-place updates using _local_tensor.                                      
  - Updated state dict adapters (Llama4, DeepSeek V3) and all parallelize callsites (including
  experiments) to reflect the new expert_bias path.    

**Test:**
```
NCCL_NVLS_ENABLE=0  NGPU=4 ./run_train.sh --module llama4 --config llama4_debugmodel     --parallelism.pipeline_parallel_degree 1     --parallelism.data_parallel_shard_degree 2     --parallelism.tensor_parallel_degree 2    --parallelism.expert_parallel_degree 2     --parallelism.expert_tensor_parallel_degree 2
```
**Run loss compare:**
```
NCCL_NVLS_ENABLE=0 python scripts/loss_compare.py . main --baseline-module='llama4' --baseline-config='llama4_debugmodel' --baseline-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2 --parallelism.expert_tensor_parallel_degree 2" --baseline-ngpus=4 --test-module='llama4' --test-config='llama4_debugmodel' --test-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2 --parallelism.expert_tensor_parallel_degree 2" --test-ngpus=4 --assert-equal --no-seed-checkpoint
```
