### PR TITLE
[rl] Guard manual allreduce to skip when FSDP is active

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -336,7 +336,8 @@ class PolicyTrainer(Actor, Configurable):
 
         # All-reduce gradients across DP ranks so all ranks have consistent
         # weight updates despite processing different data shards.
-        if self.dp_enabled:
+        # Skip when FSDP is active — it handles gradient sync automatically.
+        if self.dp_enabled and self.parallel_dims.dp_shard == 1:
             for param in self.model.parameters():
                 if param.grad is not None:
                     dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)


### PR DESCRIPTION
Summary:
When FSDP (`dp_shard > 1`) is active, model parameters and gradients are
DTensors on the FSDP mesh. Calling `dist.all_reduce` on DTensor gradients
fails with `found no DeviceMesh from dtensor args`. FSDP handles gradient
sync automatically via reduce-scatter, so manual allreduce is only needed
for DDP-replicate mode (`dp_shard == 1`).

This adds a `dp_shard == 1` guard to the existing `dp_enabled` check so
that manual gradient allreduce is only performed for DDP-style replication,
not for FSDP sharding.

Test Plan:
* Ran Qwen3-1.7B with TP=2, FSDP=4 (--trainer.parallelism.tensor-parallel-degree 2 --trainer.parallelism.data-parallel-shard-degree 4) — previously crashed with RuntimeError: found no DeviceMesh from dtensor args for c10d::allreduce_, now trains successfully
* Ran Qwen3-1.7B with TP=8 (no DP) — no regression, trains as before

Differential Revision: D99074796


