### PR TITLE
fix: ensure non-zero exit code on unhandled exceptions

### DIFF
--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -65,4 +65,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Training failed with error: {e}", exc_info=True)
+        sys.exit(1)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import sys
 
 import torch
 


### PR DESCRIPTION
Fixes issue where training failures (e.g., ValueError from external libraries) would exit with code 0 in CI, masking errors. Now wraps main() in try/except that explicitly calls sys.exit(1) on any uncaught exception