### PR TITLE
[CP] Fix positions handling with CP + block_causal + flexattention

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -187,14 +187,23 @@ class Validator(BaseValidator):
 
         # TODO: deduplicate with Trainer.post_dataloading_process which has
         # the same logic; extract a shared function to prevent further drift.
-        # For causal attention the whole packed sequence is one document,
-        # so sequential RoPE positions (positions=None) are correct.
+        # Resolve positions once: per-document positions for block_causal,
+        # sequential positions when CP needs them for shard indexing,
+        # or None (model uses sequential RoPE slice by default).
         model_config = getattr(model_parts[0], "config", None)
         layer = getattr(model_config, "layer", None)
         attn_config = getattr(layer, "attention", None) if layer else None
         attn_mask_type = getattr(attn_config, "mask_type", "causal")
-        if attn_mask_type != "block_causal":
-            extra_inputs.pop("positions", None)
+
+        positions = extra_inputs.pop("positions", None)
+        if attn_mask_type == "block_causal":
+            # Per-document positions from the dataloader
+            extra_kwargs["positions"] = positions
+        elif self.parallel_dims.cp_enabled:
+            # Sequential positions needed for correct RoPE after CP sharding
+            extra_kwargs["positions"] = torch.arange(
+                0, inputs.shape[1], dtype=torch.int32, device=inputs.device
+            ).expand(inputs.shape)
 
         try:
             # pyrefly: ignore [not-callable]

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import torch
 from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
+from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
 logger = logging.getLogger(__name__)
@@ -157,12 +158,17 @@ class CUDAGraphWrapper:
             self._args[i].copy_(args[i])
 
     def _check_input_types(self, inputs) -> None:
-        for inp in inputs:
-            assert isinstance(inp, (torch.Tensor, int, torch._C.Generator)), (
-                "args must be tensor, integer (for dynamic shapes), "
-                "or Generator (for random number generator), "
-                f"but found {type(inp)}"
-            )
+        for i, inp in enumerate(inputs):
+            if not (
+                isinstance(inp, (torch.Tensor, int, torch._C.Generator))
+                or is_opaque_value(inp)
+            ):
+                raise ValueError(
+                    "args must be tensor, integer (for dynamic shapes), "
+                    "Generator (for random number generator), "
+                    "or opaque object, "
+                    f"but found {type(inp)} with value {inp!r} at index {i}"
+                )
 
     def _check_static_inputs_address(self) -> None:
         for i in self._static_input_indices:

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -855,5 +855,93 @@ class TestTraceFSDP(FSDPTest):
         )
 
 
+class TestAutogradGradVsBackwardFSDP(FSDPTest):
+    """Verify autograd.grad() and loss.backward() have identical peak memory with FSDP."""
+
+    @property
+    def world_size(self):
+        return min(torch.cuda.device_count(), 4)
+
+    def test_peak_memory_identical_fsdp(self):
+        from torchtitan.distributed import ParallelDims
+        from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+        from torchtitan.models.llama3 import llama3_configs, Llama3Model
+
+        config = llama3_configs["debugmodel"]
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        prev_deterministic = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+
+        try:
+            parallel_dims = ParallelDims(
+                dp_shard=-1,
+                dp_replicate=1,
+                cp=1,
+                tp=1,
+                pp=1,
+                ep=1,
+                etp=1,
+                world_size=self.world_size,
+            )
+            fsdp_mesh = parallel_dims.get_mesh("fsdp")
+
+            model_backward = create_model(Llama3Model, config, "cuda", torch.bfloat16)
+            model_grad = create_model(Llama3Model, config, "cuda", torch.bfloat16)
+            model_grad.load_state_dict(model_backward.state_dict())
+            model_backward = data_parallel(
+                model_backward, device_mesh=fsdp_mesh, mode="fully_shard"
+            )
+            model_grad = data_parallel(
+                model_grad, device_mesh=fsdp_mesh, mode="fully_shard"
+            )
+
+            tokens = torch.randint(0, config.vocab_size, (2, 128), device="cuda")
+            labels = torch.randint(0, config.vocab_size, (2, 128), device="cuda")
+
+            def run_backward(model):
+                logits = model(tokens)
+                loss = get_loss(logits, labels)
+                loss.backward()
+
+            def run_grad(model):
+                logits = model(tokens)
+                loss = get_loss(logits, labels)
+                params = [p for p in model.parameters() if p.requires_grad]
+                grads = torch.autograd.grad(loss, params)
+                for p, g in zip(params, grads):
+                    p.grad = g
+
+            # Warmup
+            run_backward(model_backward)
+            model_backward.zero_grad()
+            run_grad(model_grad)
+            model_grad.zero_grad()
+            torch.cuda.empty_cache()
+
+            # Measure backward()
+            torch.cuda.reset_peak_memory_stats()
+            run_backward(model_backward)
+            peak_backward = torch.cuda.max_memory_allocated()
+            model_backward.zero_grad()
+            torch.cuda.empty_cache()
+
+            # Measure autograd.grad()
+            torch.cuda.reset_peak_memory_stats()
+            run_grad(model_grad)
+            peak_grad = torch.cuda.max_memory_allocated()
+            model_grad.zero_grad()
+            torch.cuda.empty_cache()
+
+            self.assertEqual(
+                peak_backward,
+                peak_grad,
+                f"Peak memory differs: backward()={peak_backward / 1e9:.2f} GB "
+                f"vs autograd.grad()={peak_grad / 1e9:.2f} GB",
+            )
+        finally:
+            torch.use_deterministic_algorithms(prev_deterministic)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2780

**Issue:**

When CP is enabled with block_causal + FlexAttention, the dataloader provides per-document positions in `extra_inputs` AND `prepare_context_parallel_input()` creates its own sequential positions in
extra_kwargs. Both dicts are unpacked in the model call, causing "got multiple values for keyword argument 'positions'". Additionally, the sequential positions overwrote the dataloader's per-document positions, which are needed for correct RoPE with packed sequences.

**Fix:**

Consolidate all positions resolution in `post_dataloading_process` and make `prepare_context_parallel_input` a pure sharding function.

- `post_dataloading_process` now always pops `positions` from `extra_inputs`
and places them in `extra_kwargs` when needed: dataloader per-document `positions` for block_causal, sequential arange `positions` for CP with causal attention, or nothing (model defaults to sequential RoPE slice).
- `prepare_context_parallel_input` no longer creates `positions` — it just shards whatever the caller provides in `extra_kwargs["positions"]`.
- `Positions` always go into `extra_kwargs` (forwarded to all PP stages) rather than extra_inputs (first stage only), which is correct since every stage needs them for RoPE.

**Verification:**
 - CP2+TP2+FlexAttention
 - FlexAttention-only
 - SDPA+CP2+TP2
 - SDPA-only