### PR TITLE
[Perf] Adds missing moe.compile in apply_compile_sparse

### DIFF
--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -101,6 +101,7 @@ def apply_compile_sparse(
                             # https://github.com/pytorch/torchtitan/issues/1940
                             continue
                         submod.compile(backend=compile_config.backend, fullgraph=True)
+                    moe.compile(backend=compile_config.backend, fullgraph=False)
                 else:
                     submod.compile(backend=compile_config.backend, fullgraph=True)
         else:

--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -99,6 +99,7 @@ def apply_compile_sparse(
                         if attr_name == "experts":
                             # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
                             # https://github.com/pytorch/torchtitan/issues/1940
+                            torch.compiler.disable(submod)
                             continue
                         submod.compile(backend=compile_config.backend, fullgraph=True)
                     moe.compile(backend=compile_config.backend, fullgraph=False)


### PR DESCRIPTION
Related #2775  #2225 

This PR addresses the slow bmm dispatch when compile is turned on at least, by compiling MoE.forward, which wasn't compiled before even when compilation was enabled.

Perf results with Qwen3-30B-A3B on 8xH100:
| main | this pr |
| --- | --- |
| 22.7% MFU | 27.6% MFU |

Log files:
[qwen3_30b_a3b_mfu.txt](https://github.com/user-attachments/files/26418928/qwen3_30b_a3b_mfu.txt)
