### PR TITLE
[RL] Add support for Compiled loss

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -98,7 +98,7 @@ class PolicyTrainer(Actor, Configurable):
         init_logger()
 
         self.config = config
-        self.loss_fn = config.loss.build()
+        self.loss_fn = config.loss.build(compile_config=config.compile)
 
         # Only cast if generator dtype differs from training dtype, otherwise
         # staging buffers would be allocated for a no-op cast.
@@ -315,7 +315,7 @@ class PolicyTrainer(Actor, Configurable):
             all_policy_logprobs, seq_lens, prompt_lens, response_lens
         )
 
-        loss, loss_metrics = self.loss_fn(
+        loss, loss_metric_tensors = self.loss_fn(
             policy_logprobs=policy_logprobs,
             advantages=advantages,
         )
@@ -336,6 +336,10 @@ class PolicyTrainer(Actor, Configurable):
         # Backward pass
         self.optimizers.zero_grad()
         loss.backward()
+
+        # Call .item() after backward to match the idiomatic "queue GPU
+        # work first, then sync" pattern.
+        loss_metrics = {k: v.item() for k, v in loss_metric_tensors.items()}
 
         return {
             "loss": loss.item(),

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -54,6 +54,32 @@ def _dtensor_safe_weak_ref_tensor(tensor):
 _torch_utils.weak_ref_tensor = _dtensor_safe_weak_ref_tensor
 
 
+# NOTE: Monkeypatch DTensor placement types' __repr__ to use fully
+# qualified names. vLLM's compilation/codegen.py falls back to repr()
+# when stringifying non-primitive graph args, producing bare names like
+# "Shard(dim=2)". The generated execution_fn is exec'd in a namespace
+# that only does "import torch", so these bare references raise
+# NameError. qwen3's TP parallelize plan emits redistribute(placements=
+# (Shard(1),...)) which hits this path. Returning a qualified name like
+# "torch.distributed.tensor.placement_types.Shard(dim=2)" resolves
+# cleanly against the torch-only globals.
+from torch.distributed.tensor.placement_types import (  # noqa: E402
+    Partial as _Partial,
+    Replicate as _Replicate,
+    Shard as _Shard,
+)
+
+_Shard.__repr__ = (
+    lambda self: f"torch.distributed.tensor.placement_types.Shard(dim={self.dim})"
+)
+_Replicate.__repr__ = (
+    lambda self: "torch.distributed.tensor.placement_types.Replicate()"
+)
+_Partial.__repr__ = (
+    lambda self: f"torch.distributed.tensor.placement_types.Partial({self.reduce_op!r})"
+)
+
+
 def create_torchtitan_config_from_vllm_config(
     vllm_config: VllmConfig,
 ) -> tuple[ParallelDims, ParallelismConfig]:

--- a/torchtitan/experiments/rl/simple_grpo_sum_digits.py
+++ b/torchtitan/experiments/rl/simple_grpo_sum_digits.py
@@ -36,7 +36,7 @@ import torchstore as ts
 from monarch.actor import this_host
 from monarch.spmd import setup_torch_elastic_env_async
 
-from torchtitan.config import Configurable, ParallelismConfig
+from torchtitan.config import CompileConfig, Configurable, ParallelismConfig
 from torchtitan.config.manager import ConfigManager
 from torchtitan.experiments.rl.actors.generator import VLLMGenerator
 from torchtitan.experiments.rl.actors.grader import Grader
@@ -46,6 +46,34 @@ from torchtitan.experiments.rl.types import Episode, TrainBatch
 from torchtitan.protocols.model_spec import ModelSpec
 
 logger = logging.getLogger(__name__)
+
+
+def _grpo_surrogate(
+    mean_log_ratio: torch.Tensor,
+    advantages: torch.Tensor,
+    clip_eps: float,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compile-friendly PPO-clipped surrogate over per-sample mean log ratios.
+
+    Takes the already-reduced ``mean_log_ratio`` [batch] tensor (one scalar
+    per sample) — the per-sample ``.mean()`` over variable-length sequences
+    is done in Python before calling this, since padding to a rectangular
+    tensor adds more overhead than it saves. Metrics are returned as
+    on-device tensors so the caller can ``.item()`` them after
+    ``loss.backward()``.
+    """
+    ratio = torch.exp(mean_log_ratio)
+    unclipped_loss = ratio * advantages
+    clipped_ratio = torch.clamp(ratio, 1 - clip_eps, 1 + clip_eps)
+    clipped_loss = clipped_ratio * advantages
+    pg_loss = -torch.min(unclipped_loss, clipped_loss).mean()
+
+    metrics = {
+        "pg_loss": pg_loss,
+        "ratio_mean": ratio.mean(),
+        "ratio_clipped_frac": (torch.abs(ratio - clipped_ratio) > 1e-6).float().mean(),
+    }
+    return pg_loss, metrics
 
 
 class GRPOLoss(Configurable):
@@ -60,35 +88,39 @@ class GRPOLoss(Configurable):
         clip_eps: float = 0.2
         """PPO clipping epsilon for the probability ratio."""
 
-    def __init__(self, config: Config):
+    def __init__(
+        self,
+        config: Config,
+        *,
+        compile_config: CompileConfig | None = None,
+    ):
         self.clip_eps = config.clip_eps
+
+        loss_fn = _grpo_surrogate
+        if (
+            compile_config is not None
+            and compile_config.enable
+            and "loss" in compile_config.components
+        ):
+            logger.info("Compiling GRPO loss surrogate with torch.compile")
+            loss_fn = torch.compile(loss_fn, backend=compile_config.backend)
+        self._loss_fn = loss_fn
 
     def __call__(
         self,
         policy_logprobs: list[torch.Tensor],
         advantages: torch.Tensor,
-    ) -> tuple[torch.Tensor, dict[str, float]]:
-        per_sample_mean_lps = []
-        for policy_lps in policy_logprobs:
-            per_sample_mean_lps.append(policy_lps.mean())
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Returns ``(pg_loss, metrics)`` with metrics as on-device tensors.
 
-        mean_log_ratio = torch.stack(per_sample_mean_lps)
-        ratio = torch.exp(mean_log_ratio)
-
-        unclipped_loss = ratio * advantages
-        clipped_ratio = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps)
-        clipped_loss = clipped_ratio * advantages
-        pg_loss = -torch.min(unclipped_loss, clipped_loss).mean()
-
-        metrics = {
-            "pg_loss": pg_loss.item(),
-            "ratio_mean": ratio.mean().item(),
-            "ratio_clipped_frac": (torch.abs(ratio - clipped_ratio) > 1e-6)
-            .float()
-            .mean()
-            .item(),
-        }
-        return pg_loss, metrics
+        Caller is expected to ``.item()`` the metric values after
+        ``loss.backward()``.
+        """
+        # Per-sample mean over variable-length sequences — kept in Python
+        # because padding to a rectangular tensor costs more than it saves
+        # at typical RL batch sizes (5-16 samples).
+        mean_log_ratio = torch.stack([lps.mean() for lps in policy_logprobs])
+        return self._loss_fn(mean_log_ratio, advantages, self.clip_eps)
 
 
 class Provisioner:


### PR DESCRIPTION
## Summary

Enable compiled loss matching general torchtitan trainer

### Testplan
```bash
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```

### Results:
```
[actor=<root>] RL Training complete
[actor=<root>] Evaluating post-training performance...
[actor=<root>] Eval: Accuracy=60% (12/20) Format=95% (19/20)
[actor=<root>] ================================================================================
[actor=<root>] Pre-training:  Accuracy=40% (8/20) Format=50% (10/20)
[actor=<root>] Post-training: Accuracy=60% (12/20) Format=95% (19/20)
[actor=<root>] ================================================================================
```

Per step timing data:
| Metric | Inductor (compiled loss) | No compile |
  |--------|--------------------------|------------|
  | Step 1 | 8.9s | 9.0s |
  | Step 2 | 8.0s | 8.0s |
  | Step 3 | 8.4s | 8.8s |
  | Step 4 | 8.2s | 8.1s |
  | Step 5 | 8.3s | 7.9s |
  | Step 6 | 9.0s | 9.5s |
  | Step 7 | 8.6s | 8.5s |
  | Step 8 | 8.2s | 7.7s |
  | Step 9 | 9.1s | 8.9s |
  | **P50** | **8.4s** | **8.5s** |
  | **Total (1-9)** | **76.7s** | **76.4s** |

So no real change yet; however with batching forward (coming soon from @joecummings we could expect to see much larger improvements