### PR TITLE
Add a test guarding autograd.grad rewrite doesn't cause memory increase 

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -819,5 +819,93 @@ class TestTraceFSDP(FSDPTest):
         )
 
 
+class TestAutogradGradVsBackwardFSDP(FSDPTest):
+    """Verify autograd.grad() and loss.backward() have identical peak memory with FSDP."""
+
+    @property
+    def world_size(self):
+        return min(torch.cuda.device_count(), 4)
+
+    def test_peak_memory_identical_fsdp(self):
+        from torchtitan.distributed import ParallelDims
+        from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+        from torchtitan.models.llama3 import llama3_configs, Llama3Model
+
+        config = llama3_configs["debugmodel"]
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        prev_deterministic = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+
+        try:
+            parallel_dims = ParallelDims(
+                dp_shard=-1,
+                dp_replicate=1,
+                cp=1,
+                tp=1,
+                pp=1,
+                ep=1,
+                etp=1,
+                world_size=self.world_size,
+            )
+            fsdp_mesh = parallel_dims.get_mesh("fsdp")
+
+            model_backward = create_model(Llama3Model, config, "cuda", torch.bfloat16)
+            model_grad = create_model(Llama3Model, config, "cuda", torch.bfloat16)
+            model_grad.load_state_dict(model_backward.state_dict())
+            model_backward = data_parallel(
+                model_backward, device_mesh=fsdp_mesh, mode="fully_shard"
+            )
+            model_grad = data_parallel(
+                model_grad, device_mesh=fsdp_mesh, mode="fully_shard"
+            )
+
+            tokens = torch.randint(0, config.vocab_size, (2, 128), device="cuda")
+            labels = torch.randint(0, config.vocab_size, (2, 128), device="cuda")
+
+            def run_backward(model):
+                logits = model(tokens)
+                loss = get_loss(logits, labels)
+                loss.backward()
+
+            def run_grad(model):
+                logits = model(tokens)
+                loss = get_loss(logits, labels)
+                params = [p for p in model.parameters() if p.requires_grad]
+                grads = torch.autograd.grad(loss, params)
+                for p, g in zip(params, grads):
+                    p.grad = g
+
+            # Warmup
+            run_backward(model_backward)
+            model_backward.zero_grad()
+            run_grad(model_grad)
+            model_grad.zero_grad()
+            torch.cuda.empty_cache()
+
+            # Measure backward()
+            torch.cuda.reset_peak_memory_stats()
+            run_backward(model_backward)
+            peak_backward = torch.cuda.max_memory_allocated()
+            model_backward.zero_grad()
+            torch.cuda.empty_cache()
+
+            # Measure autograd.grad()
+            torch.cuda.reset_peak_memory_stats()
+            run_grad(model_grad)
+            peak_grad = torch.cuda.max_memory_allocated()
+            model_grad.zero_grad()
+            torch.cuda.empty_cache()
+
+            self.assertEqual(
+                peak_backward,
+                peak_grad,
+                f"Peak memory differs: backward()={peak_backward / 1e9:.2f} GB "
+                f"vs autograd.grad()={peak_grad / 1e9:.2f} GB",
+            )
+        finally:
+            torch.use_deterministic_algorithms(prev_deterministic)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In non-strict trace, it will be hard to support tensor.backward(). The alternative is to use autograd.grad. This tests guards that we don't regress memory footprint when we switch. I also did Llama3B model and confirmed there was no memory regression. 