### PR TITLE
[graph_trainer] Start deprecating jit and aot compile modes in graph_trainer

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -10,9 +10,10 @@ This experiment demonstrates graph-based distributed training in torchtitan thro
 - Graph optimization via FX graph passes
 
 The goal is to give users more explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training. Three compilation modes are currently supported:
+- **AOT FX trace mode** (`--compile.mode aot_fx_trace`): Non-strict tracing of the full forward + loss + backward via `make_fx`, producing a single end-to-end graph without AOTAutograd partitioning.
 - **AOT mode** (`--compile.mode aot`): Explicit joint graph export with a custom graph pass pipeline.
 - **JIT mode** (`--compile.mode jit`): Standard `torch.compile()` with graph passes registered to custom backends.
-- **AOT FX trace mode** (`--compile.mode aot_fx_trace`): Non-strict tracing of the full forward + loss + backward via `make_fx`, producing a single end-to-end graph without AOTAutograd partitioning.
+> **Deprecation notice:** The `aot` and `jit` compile modes are deprecated and will be removed in the future. Please migrate to `aot_fx_trace`.
 
 ### Prerequisites
 
@@ -49,22 +50,20 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./r
 
 ### Compiler Optimizations
 
-By default, the graph is captured with the AOT mode (switch to JIT mode via `--compile.mode jit` or AOT FX trace mode via `--compile.mode aot_fx_trace`) and compiled with the `aot_eager` backend.
-
-Graph passes can be applied to further optimize the graph by using the `--compile.joint_passes` and `--compile.passes` flags.
+> **Note:** Graph pass support for `aot_fx_trace` mode is a work in progress. The `--compile.passes` and `--compile.joint_passes` flags currently only apply to the deprecated `aot` and `jit` modes.
 
 ```bash
 # Auto bucketing for comm/compute overlap
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.passes auto_bucketing
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes auto_bucketing
 
 # Transformer-block bucketing for comm/compute overlap
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.passes transformer_block_bucketing
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes transformer_block_bucketing
 
 # CUDAGraph
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.passes cudagraph
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes cudagraph
 
 # Full Inductor compilation (AOT)
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.joint_passes inductor_decomposition --compile.passes full_inductor_compilation
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.joint_passes inductor_decomposition --compile.passes full_inductor_compilation
 
 # Full Inductor compilation (JIT)
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode jit --compile.backend inductor

--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -19,6 +19,7 @@ Additionally supports pre-compile via --compile.precompile_artifact_dir:
 
 import dataclasses
 import functools
+import warnings
 
 import torch
 import torch.nn as nn
@@ -238,6 +239,14 @@ def apply_compile(
     if mode is None:
         logger.info("No compile mode set, skipping compilation")
         return model
+
+    if mode in ("aot", "jit"):
+        warnings.warn(
+            f"compile.mode='{mode}' is deprecated and will be removed in the "
+            "future. Please use --compile.mode='aot_fx_trace' instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     torch._inductor.config.reorder_for_peak_memory = False
     torch._dynamo.config.capture_scalar_outputs = True

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -16,12 +16,12 @@ from torchtitan.trainer import Trainer
 
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerCompileConfig(CompileConfig):
-    mode: Literal["jit", "aot", "aot_fx_trace"] | None = "aot"
+    mode: Literal["jit", "aot", "aot_fx_trace"] | None = "aot_fx_trace"
     """
     Compilation mode. Options:
-        jit: standard torch.compile() with custom backend
-        aot: explicit joint graph export + custom graph passes
         aot_fx_trace: non-strict tracing of fwd+loss+bwd via make_fx
+        jit: standard torch.compile() with custom backend (deprecated)
+        aot: explicit joint graph export + custom graph passes (deprecated)
     """
 
     backend: str = "aot_eager"

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -20,6 +20,7 @@ Usage (aot mode):
     python -m torchtitan.experiments.graph_trainer.precompile_main \
         --module graph_trainer.llama3 \
         --config graph_trainer_llama3_debugmodel \
+        --compile.mode aot \
         --compile.passes full_inductor_compilation \
         --compile.joint_passes inductor_decomposition \
         --compile.precompile_artifact_dir /tmp/precompile_artifacts


### PR DESCRIPTION
Summary:
Going forward, we want to make the minimal `make_fx` tracer the default and only graph capture path in the graph trainer to minimize the attack surface for graph capture. So we will deprecate the existing `aot` and `jit` modes that rely on Dynamo and AOT Autograd. 

In this PR:
- Start deprecating the `aot` and `jit` compile modes in the graph_trainer experiment, making `aot_fx_trace` the new default. Users can still use the old modes by explicitly passing `--compile.mode aot` or `--compile.mode jit`, which will emit a FutureWarning. 
- Update README to document `aot_fx_trace` as the primary mode and add deprecation notice for the old modes 