### PR TITLE
[graph_trainer] Add opaque obj to CUDAGraph input check

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import torch
 from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
+from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
 logger = logging.getLogger(__name__)
@@ -157,12 +158,17 @@ class CUDAGraphWrapper:
             self._args[i].copy_(args[i])
 
     def _check_input_types(self, inputs) -> None:
-        for inp in inputs:
-            assert isinstance(inp, (torch.Tensor, int, torch._C.Generator)), (
-                "args must be tensor, integer (for dynamic shapes), "
-                "or Generator (for random number generator), "
-                f"but found {type(inp)}"
-            )
+        for i, inp in enumerate(inputs):
+            if not (
+                isinstance(inp, (torch.Tensor, int, torch._C.Generator))
+                or is_opaque_value(inp)
+            ):
+                raise ValueError(
+                    "args must be tensor, integer (for dynamic shapes), "
+                    "Generator (for random number generator), "
+                    "or opaque object, "
+                    f"but found {type(inp)} with value {inp!r} at index {i}"
+                )
 
     def _check_static_inputs_address(self) -> None:
         for i in self._static_input_indices:


### PR DESCRIPTION
Allow CUDA graph wrapper to accept opaque objects as valid inputs, in addition to tensors, integers, and generators.

This fixes the graph trainer CI failure

```
NGPU=8 ./run_train.sh --module graph_trainer.llama3 --config graph_trainer_llama3_debugmodel --compile.mode aot --parallelism.data_parallel_shard_degree 4 --parallelism.tensor_parallel_degree 2 --compile.passes cudagraph
```