### PR TITLE
Rebuild validation dataset at each validation round

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -92,8 +92,6 @@ class Validator(BaseValidator):
                 self.steps > 0 or self.steps == -1
             ), "validation steps must be positive or -1"
 
-    validation_dataloader: BaseDataLoader
-
     # TODO: improve the constructor signature
     def __init__(
         self,
@@ -121,14 +119,11 @@ class Validator(BaseValidator):
         self.parallel_dims = parallel_dims
         self.loss_fn = loss_fn
         # pyrefly: ignore [unexpected-keyword]
-        dl_config = replace(config.dataloader, infinite=config.steps != -1)
-        self.validation_dataloader = dl_config.build(
-            dp_world_size=dp_world_size,
-            dp_rank=dp_rank,
-            tokenizer=tokenizer,
-            seq_len=seq_len,
-            local_batch_size=local_batch_size,
-        )
+        self.dl_config = replace(config.dataloader, infinite=config.steps != -1)
+        self.dp_world_size = dp_world_size
+        self.dp_rank = dp_rank
+        self.seq_len = seq_len
+        self.local_batch_size = local_batch_size
         self.validation_context = validation_context
         self.maybe_enable_amp = maybe_enable_amp
         self.metrics_processor = metrics_processor
@@ -245,7 +240,15 @@ class Validator(BaseValidator):
         device_type = utils.device_type
         num_steps = 0
 
-        for input_dict, labels in self.validation_dataloader:
+        validation_dataloader = self.dl_config.build(
+            dp_world_size=self.dp_world_size,
+            dp_rank=self.dp_rank,
+            tokenizer=self.tokenizer,
+            seq_len=self.seq_len,
+            local_batch_size=self.local_batch_size,
+        )
+
+        for input_dict, labels in validation_dataloader:
             # pyrefly: ignore [missing-attribute, unsupported-operation]
             if self.config.steps != -1 and num_steps >= self.config.steps:
                 break

--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -69,8 +69,6 @@ class FluxValidator(Validator):
         sampling: SamplingConfig = field(default_factory=SamplingConfig)
         """Sampling configuration for validation image generation"""
 
-    validation_dataloader: BaseDataLoader
-
     def __init__(
         self,
         config: Config,
@@ -100,17 +98,14 @@ class FluxValidator(Validator):
         assert isinstance(config.dataloader, FluxDataLoader.Config)
         assert isinstance(tokenizer, FluxTokenizerContainer)
 
-        dl_config = replace(
+        self.dl_config = replace(
             config.dataloader,
             infinite=config.steps != -1,
             generate_timesteps=not config.all_timesteps,
         )
-        self.validation_dataloader = dl_config.build(
-            dp_world_size=dp_world_size,
-            dp_rank=dp_rank,
-            local_batch_size=local_batch_size,
-            tokenizer=tokenizer,
-        )
+        self.dp_world_size = dp_world_size
+        self.dp_rank = dp_rank
+        self.local_batch_size = local_batch_size
         self.validation_context = validation_context
         self.maybe_enable_amp = maybe_enable_amp
         # pyrefly: ignore [bad-assignment]
@@ -159,7 +154,14 @@ class FluxValidator(Validator):
         device_type = dist_utils.device_type
         num_steps = 0
 
-        for input_dict, labels in self.validation_dataloader:
+        validation_dataloader = self.dl_config.build(
+            dp_world_size=self.dp_world_size,
+            dp_rank=self.dp_rank,
+            local_batch_size=self.local_batch_size,
+            tokenizer=self.tokenizer,
+        )
+
+        for input_dict, labels in validation_dataloader:
             if self.config.steps != -1 and num_steps >= self.config.steps:
                 break
 


### PR DESCRIPTION
Rebuild validation dataset at each validation round as discussed in https://github.com/pytorch/torchtitan/pull/2637 and related to https://github.com/pytorch/torchtitan/issues/2636.

This produces a more informative validation loss and prevents the zig‑zag behavior observed in the current implementation due to different batches evaluated at each validation round. The plot below compares the current implementation (`prev-validation`) with the proposed new validation setup (`new-validation`).
The test has been run with the [`run_train.sh`](https://github.com/pytorch/torchtitan/blob/main/run_train.sh) script configuration, adding
```bash
--training.steps 100  --validator.enable --validator.freq 5 --validator.dataloader.dataset c4_test
```
<img width="975" height="610" alt="validation_comaprison" src="https://github.com/user-attachments/assets/685eaa2a-ded2-4b43-8269-5edcbd4b9d16" />
