### PR TITLE
[graph_trainer] Fix dsv3 inductor decomposition pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -295,9 +295,14 @@ def inductor_decomposition_pass(
         all_inputs.append(val)
 
     # The joint graph forward() takes (primals, tangents) as two list args.
-    # Split based on traced_tangents count from fw_metadata.
-    fw_metadata = joint_with_descriptors._aot_state.fw_metadata
-    num_tangents = len(fw_metadata.traced_tangents)
+    # Split based on the actual updated_flat_args from graph capture, which
+    # reflects post-subclass-unwrapping structure (e.g. DTensor flattened into
+    # local tensor + device mesh).
+    updated_flat_args = joint_with_descriptors._aot_graph_capture.updated_flat_args
+    assert isinstance(
+        updated_flat_args, tuple
+    ), f"Expected (primals, tangents) tuple, got {type(updated_flat_args)}"
+    num_tangents = len(updated_flat_args[1])
     primals_fake = all_inputs[: len(all_inputs) - num_tangents]
     tangents_fake = all_inputs[len(all_inputs) - num_tangents :]
 


### PR DESCRIPTION
**Summary**: https://github.com/pytorch/pytorch/pull/178115 changed `DTensor.__tensor_flatten__()` from returning `["_local_tensor"]` to `["_local_tensor", "device_mesh"]`. This means each `DTensor` input now flattens to 2 graph placeholders instead of 1 during `aot_dispatch_subclass`.

`inductor_decomposition_pass` used `len(fw_metadata.traced_tangents)` to split the graph's placeholders into primals and tangents. But `traced_tangents` reflects the pre-subclass-unwrapping count (DTensor objects), while the graph placeholders reflect the post-unwrapping structure (local tensors + device mesh objects). After the `__tensor_flatten__` change, each DTensor tangent expands to 2 placeholders, causing the primals/tangents split to be wrong and tree_flatten_spec to fail with IndexError.

This PR fixed the issue by using `joint_with_descriptors._aot_graph_capture.updated_flat_args[1]`, which contains the actual post-unwrapping tangent list matching the graph structure.

**Test**: Fixed the broken CI, verified by
```
MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel ./run_train.sh --parallelism.data_parallel_shard_degree 4 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4 --compile.mode aot --compile.joint_passes inductor_decomposition
```