### PR TITLE
[Bugfix] Move recompile limit for now

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -80,13 +80,6 @@ class PolicyTrainer(Actor, Configurable):
         requested = TORCH_DTYPE_MAP[transfer_dtype] if transfer_dtype else None
         self._transfer_dtype = requested if requested != training_dtype else None
 
-        # The policy and ref models share code objects, so dynamo's
-        # per-code-object cache must hold entries for both grad modes
-        # (grad for policy, no_grad for ref). The default limit of 8
-        # is not enough; 16 accommodates both without recompile storms.
-        # TODO: @Lucaskabela fix recompiles in general as these increase startup
-        torch._dynamo.config.cache_size_limit = 16
-
         # Device setup
         device_module, device_type = utils.device_module, utils.device_type
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
@@ -273,6 +266,11 @@ class PolicyTrainer(Actor, Configurable):
         Returns:
             Training metrics
         """
+        # The default limit of 8
+        # is not enough; 16 accommodates without recompile storms.
+        # TODO: @Lucaskabela fix recompiles in general as these increase startup
+        torch._dynamo.config.recompile_limit = 16
+
         logger.debug(
             f"{os.getpid()=} PolicyTrainer starting step {self.policy_version} "
         )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -266,8 +266,10 @@ class PolicyTrainer(Actor, Configurable):
         Returns:
             Training metrics
         """
-        # The default limit of 8
-        # is not enough; 16 accommodates without recompile storms.
+        # The policy and ref models share code objects, so dynamo's
+        # per-code-object cache must hold entries for both grad modes
+        # (grad for policy, no_grad for ref). The default limit of
+        # is not enough; 16 accommodates both without recompile storms.
         # TODO: @Lucaskabela fix recompiles in general as these increase startup
         torch._dynamo.config.recompile_limit = 16
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -8,7 +8,7 @@ import os
 
 # TODO: Re-enable once we have closed
 # https://github.com/pytorch/torchtitan/issues/2722
-os.environ.setdefault("DISABLE_LLVM_OPT", "1")
+os.environ.setdefault("DISABLE_LLVM_OPT", "disable-slp-vectorization")
 
 from collections.abc import Callable
 from dataclasses import dataclass, field

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -8,7 +8,7 @@ import os
 
 # TODO: Re-enable once we have closed
 # https://github.com/pytorch/torchtitan/issues/2722
-os.environ.setdefault("DISABLE_LLVM_OPT", "disable-slp-vectorization")
+os.environ.setdefault("DISABLE_LLVM_OPT", "1")
 
 from collections.abc import Callable
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary

Lower the `recompile_limit`/`cache_size` change to inside the trainer step as it was not getting picked up at top level resulting in some crash

## Test plan
```
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```