### PR TITLE
[DeepEP] hide buffer init from sac

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 
 import torch
 from torch.distributed import ProcessGroup
+from torch.utils._python_dispatch import _disable_current_modes
 
 try:
     from deep_ep import Buffer  # pyrefly: ignore[missing-import]
@@ -422,18 +423,23 @@ def dispatch_tokens(
     if top_scores.dtype != torch.float32:
         top_scores = top_scores.float()
 
-    buffer = get_buffer(group, get_hidden_bytes(hidden_states))
+    # Hide buffer setup from SAC's __torch_dispatch__ via _disable_current_modes().
+    # Buffer.__init__ calls all_gather_object() which triggers aten._to_copy
+    # (CUDA→CPU), a MUST_SAVE op in our SAC policy. These are infrastructure
+    # ops, not model compute, and must not enter SAC's FIFO cache.
+    with _disable_current_modes():
+        buffer = get_buffer(group, get_hidden_bytes(hidden_states))
 
-    # Calculate dispatch layout before actual dispatch
-    (
-        num_tokens_per_rank,
-        num_tokens_per_rdma_rank,
-        num_tokens_per_expert_dispatch,
-        is_token_in_rank,
-        _,
-    ) = buffer.get_dispatch_layout(
-        topk_idx=selected_experts_indices, num_experts=num_experts
-    )
+        # Calculate dispatch layout before actual dispatch
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert_dispatch,
+            is_token_in_rank,
+            _,
+        ) = buffer.get_dispatch_layout(
+            topk_idx=selected_experts_indices, num_experts=num_experts
+        )
 
     # Dispatch tokens to experts
     (

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -28,6 +28,7 @@ from torch._library.opaque_object import (
     register_opaque_type,
 )
 from torch.distributed import ProcessGroup
+from torch.utils._python_dispatch import _disable_current_modes
 
 _buffer: Any = None  # Global buffer instance
 
@@ -365,7 +366,8 @@ def get_buffer(
         raise AssertionError("HybridEP FP8 dispatch not yet supported")
 
     try:
-        from deep_ep import HybridEPBuffer  # pyrefly: ignore [missing-import]
+        # pyrefly: ignore [missing-import, missing-module-attribute]
+        from deep_ep import HybridEPBuffer
     except ImportError as e:
         raise ImportError(
             "HybridEP requires deep_ep library. "
@@ -433,12 +435,17 @@ def dispatch_tokens(
     selected_experts_indices = selected_experts_indices.contiguous()
     top_scores = top_scores.contiguous()
 
-    get_buffer(
-        group=group,
-        hidden_dim=hidden_states.shape[1],
-        num_tokens=hidden_states.shape[0],
-        num_local_experts=num_local_experts,
-    )
+    # Hide buffer setup from SAC's __torch_dispatch__ via _disable_current_modes().
+    # Buffer.__init__ calls all_gather_object() which triggers aten._to_copy
+    # (CUDA→CPU), a MUST_SAVE op in our SAC policy. These are infrastructure
+    # ops, not model compute, and must not enter SAC's FIFO cache.
+    with _disable_current_modes():
+        get_buffer(
+            group=group,
+            hidden_dim=hidden_states.shape[1],
+            num_tokens=hidden_states.shape[0],
+            num_local_experts=num_local_experts,
+        )
 
     (
         hidden,


### PR DESCRIPTION
DeepEP `Buffer.__init__ ` calls `all_gather_object()`, which internally does `aten._to_copy` (CUDA→CPU). Our SAC policy marks `aten._to_copy` as `MUST_SAVE`, so these infrastructure ops enter the FIFO cache and later ops consume wrong saved tensors during recompute, causing shape mismatch errors. This pr wraps `get_buffer()` and `get_dispatch_layout()` in `_disable_current_modes()` in both `deepep.py` and `hybridep.py`'s `dispatch_tokens()`, hiding these ops from SAC's `__torch_dispatch__`. This should fix https://github.com/pytorch/torchtitan/issues/2505. 