### PR TITLE
[graph_trainer] Add CLAUDE.md development guide

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -42,12 +42,10 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmo
 ### Tests
 
 ```bash
-# Unit tests (CPU)
+# Unit tests (GPU)
 pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x
 pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -x
 pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -x
-
-# Numerics tests (GPU)
 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -x
 
 # Integration tests (8 GPUs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2802
* #2799
* __->__ #2797

Add a dedicated CLAUDE.md for the graph_trainer experiment covering:
- Graph pass signature convention (gm, example_inputs, *, kwargs) -> gm
- Core modification policy (extend via subclassing, not branching)
- Local development commands for Llama3 and DeepSeek-v3 aot_fx_trace
- Unit, numerics, and integration test commands
- Reference to root CLAUDE.md for shared conventions