### PR TITLE
[graph_trainer] Add bitwise deterministic guardrail test

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -8,3 +8,5 @@ tokenizers >= 0.15.0
 safetensors
 einops
 pillow
+numpy < 2
+pytest

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -47,6 +47,9 @@ pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x
 pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -x
 pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -x
 
+# Bitwise deterministic guardrail (GPU, single-GPU) — ALL changes must pass this first
+pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x
+
 # Numerics tests (GPU)
 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -x
 
@@ -54,3 +57,14 @@ pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -x
 python torchtitan/experiments/graph_trainer/tests/integration_tests.py <output_dir> \
     --test_suite graph_trainer_default --ngpu 8
 ```
+
+### Bitwise Deterministic Guardrail
+
+Before submitting any change, run the bitwise deterministic test first:
+```bash
+pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x
+```
+This verifies that the aot_fx_trace path produces bitwise identical losses
+and gradients across runs, and matches eager numerics exactly. Any change
+that breaks this test must be investigated and fixed before proceeding with
+other tests.

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Bitwise deterministic tests for graph_trainer's aot_fx_trace path.
+
+Tests that running the same model and inputs twice produces bitwise identical
+losses and gradients, and that aot_fx_trace matches eager numerics exactly.
+
+Requires a CUDA GPU. Run with:
+    pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x
+"""
+
+import copy
+import unittest
+
+import torch
+import torch.nn as nn
+from expecttest import assert_expected_inline
+from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.experiments.graph_trainer.llama3 import model_registry
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_module,
+    trace_module,
+)
+from torchtitan.experiments.graph_trainer.trainer import FwdBwdStepModule
+from torchtitan.tools.utils import hash_gradient, hash_model
+
+SEED = 42
+NUM_STEPS = 5
+BATCH_SIZE = 4
+SEQ_LEN = 128
+VOCAB_SIZE = 2048  # must match llama3 debugmodel config
+
+
+def _set_deterministic(seed: int = SEED) -> None:
+    """Set all random seeds and enable deterministic mode."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def _build_model() -> nn.Module:
+    """Build a Llama3 debug model for testing."""
+    model_spec = model_registry("debugmodel")
+    with torch.device("meta"):
+        model = model_spec.model.build()
+    model.to_empty(device="cuda")
+    with torch.no_grad():
+        model.init_states(buffer_device=None)
+    model.train()
+    return model
+
+
+def _build_inputs() -> tuple[torch.Tensor, torch.Tensor]:
+    """Build deterministic token inputs and labels."""
+    tokens = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN), device="cuda")
+    labels = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN), device="cuda")
+    return tokens, labels
+
+
+def _run_eager_steps(
+    model: nn.Module,
+    inputs: torch.Tensor,
+    labels: torch.Tensor,
+    num_steps: int = NUM_STEPS,
+) -> tuple[torch.Tensor, str, str]:
+    """Run eager forward-backward-optimizer steps.
+
+    Returns:
+        Tuple of (final_loss, final_model_hash, final_gradient_hash).
+    """
+    global_valid_tokens = torch.tensor(
+        BATCH_SIZE * SEQ_LEN, dtype=torch.float, device="cuda"
+    )
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+
+    for _ in range(num_steps):
+        optimizer.zero_grad()
+        pred = model(inputs)
+        loss = cross_entropy_loss(pred, labels) / global_valid_tokens
+        loss.backward()
+        optimizer.step()
+
+    return loss.detach().clone(), hash_model(model), hash_gradient(model)
+
+
+def _run_aot_fx_trace_steps(
+    model: nn.Module,
+    inputs: torch.Tensor,
+    labels: torch.Tensor,
+    num_steps: int = NUM_STEPS,
+) -> tuple[torch.Tensor, str, str]:
+    """Run aot_fx_trace forward-backward-optimizer steps using graph_trainer's make_fx tracer.
+
+    Returns:
+        Tuple of (final_loss, final_model_hash, final_gradient_hash).
+    """
+    global_valid_tokens = torch.tensor(
+        BATCH_SIZE * SEQ_LEN, dtype=torch.float, device="cuda"
+    )
+    fwd_bwd = FwdBwdStepModule(model, cross_entropy_loss)
+
+    # Trace the full fwd+loss+bwd graph
+    traced = trace_module(
+        fwd_bwd,
+        (inputs, labels, global_valid_tokens, {}, {}),
+    )
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+    params = [p for p in model.parameters() if p.requires_grad]
+
+    for _ in range(num_steps):
+        optimizer.zero_grad()
+        params_and_buffers = {
+            **dict(fwd_bwd.named_parameters(remove_duplicate=False)),
+            **dict(fwd_bwd.named_buffers(remove_duplicate=False)),
+        }
+        outputs = run_traced_module(
+            traced,
+            params_and_buffers,
+            (inputs, labels, global_valid_tokens, {}, {}),
+        )
+        loss = outputs[0]
+        grads = outputs[1:]
+
+        for param, grad in zip(params, grads):
+            param.grad = grad
+        optimizer.step()
+
+    return loss.detach().clone(), hash_model(model), hash_gradient(model)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestBitwiseDeterministic(unittest.TestCase):
+    """Test bitwise determinism for graph_trainer's aot_fx_trace path.
+
+    Each test builds a Llama3 debug model, runs forward-backward-optimizer
+    steps under deterministic settings, and asserts bitwise equality of
+    losses, model hashes, and gradient hashes.
+    """
+
+    def setUp(self):
+        _set_deterministic()
+        self.model1 = _build_model()
+        self.model2 = copy.deepcopy(self.model1)
+        self.inputs1, self.labels1 = _build_inputs()
+        self.inputs2 = self.inputs1.clone()
+        self.labels2 = self.labels1.clone()
+
+    def _assert_runs_match(
+        self,
+        run_a: tuple[torch.Tensor, str, str],
+        run_b: tuple[torch.Tensor, str, str],
+        msg_prefix: str = "",
+    ) -> None:
+        loss_a, model_hash_a, grad_hash_a = run_a
+        loss_b, model_hash_b, grad_hash_b = run_b
+
+        self.assertTrue(
+            torch.equal(loss_a, loss_b),
+            f"{msg_prefix}loss mismatch: {loss_a.item()} vs {loss_b.item()}",
+        )
+        self.assertEqual(model_hash_a, model_hash_b, f"{msg_prefix}model hash mismatch")
+        self.assertEqual(
+            grad_hash_a, grad_hash_b, f"{msg_prefix}gradient hash mismatch"
+        )
+
+    def test_eager_self_deterministic(self):
+        """Eager mode: results match hardcoded expected values.
+
+        Run `EXPECTTEST_ACCEPT=1 pytest <this_file> ` to update the inline expected values.
+        """
+        loss, model_hash, grad_hash = _run_eager_steps(
+            self.model1, self.inputs1, self.labels1
+        )
+        assert_expected_inline(str(loss.item()), """7.961757659912109""")
+        assert_expected_inline(
+            model_hash,
+            """15134607def7232e128240d553c8ee7021a7edbc2ed44d86e927ba61e490b865""",
+        )
+        assert_expected_inline(
+            grad_hash,
+            """66bbbbc98b4c1635e42a133ac1fbd499a2b8633ca879f4121cf206708c21dbdf""",
+        )
+
+    def test_aot_fx_trace_vs_eager(self):
+        """aot_fx_trace and eager produce bitwise identical losses and grads."""
+        run_eager = _run_eager_steps(self.model1, self.inputs1, self.labels1)
+        run_traced = _run_aot_fx_trace_steps(self.model2, self.inputs2, self.labels2)
+
+        self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -168,6 +168,115 @@ def get_peak_flops(device_name: str) -> float:
         return 312e12
 
 
+def _hash_model_impl(
+    model: torch.nn.Module,
+    algo: str,
+    per_tensor: bool,
+    include_weights: bool,
+    include_gradients: bool,
+) -> str:
+    """Internal implementation for hashing model parameters, buffers, and/or gradients."""
+    import hashlib
+
+    from torch.distributed.tensor import DTensor
+
+    # Only compute hash on rank 0 in distributed settings.
+    if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+        return ""
+
+    h = hashlib.new(algo)
+    hashes: dict[str, str] = {}
+
+    def hash_named_tensor(name: str, obj) -> None:
+        if isinstance(obj, torch.Tensor):
+            if isinstance(obj, DTensor):
+                t = obj.to_local().cpu().contiguous()
+            else:
+                t = obj.cpu().contiguous()
+            if per_tensor:
+                tensor_hash = hashlib.new(algo)
+                tensor_hash.update(t.numpy().tobytes())
+                hashes[name] = tensor_hash.hexdigest()
+            else:
+                h.update(name.encode("utf-8"))
+                h.update(bytes(t.numpy().tobytes()))
+
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if include_weights:
+                hash_named_tensor(name, param)
+            if include_gradients and param.grad is not None:
+                hash_named_tensor(f"{name}.grad", param.grad)
+        if include_weights:
+            for name, buffer in model.named_buffers():
+                hash_named_tensor(name, buffer)
+
+    if per_tensor:
+        return str(hashes)
+    return h.hexdigest()
+
+
+def hash_model(
+    model: torch.nn.Module,
+    algo: str = "sha256",
+    per_tensor: bool = False,
+) -> str:
+    """Computes a hash of model parameters and buffers.
+
+    Useful for verifying deterministic training by comparing model states
+    across runs. Handles DTensor by calling to_local() before hashing.
+    For distributed training, only rank 0 performs the hashing.
+
+    Args:
+        model: The model to hash.
+        algo: The hash algorithm to use (default: "sha256").
+        per_tensor: If True, returns a stringified dictionary mapping each tensor
+            name to its hex hash. If False, returns a single hash of all tensors.
+
+    Returns:
+        A hex string hash, or a stringified per-tensor hash dictionary.
+        Empty string for non-rank0 processes in distributed settings.
+    """
+    return _hash_model_impl(
+        model,
+        algo=algo,
+        per_tensor=per_tensor,
+        include_weights=True,
+        include_gradients=False,
+    )
+
+
+def hash_gradient(
+    model: torch.nn.Module,
+    algo: str = "sha256",
+    per_tensor: bool = False,
+) -> str:
+    """Computes a hash of model parameter gradients.
+
+    Useful for verifying deterministic training by comparing gradient states
+    across runs. Handles DTensor by calling to_local() before hashing.
+    For distributed training, only rank 0 performs the hashing.
+    Parameters without gradients are skipped.
+
+    Args:
+        model: The model to hash gradients for.
+        algo: The hash algorithm to use (default: "sha256").
+        per_tensor: If True, returns a stringified dictionary mapping each gradient
+            name to its hex hash. If False, returns a single hash of all gradients.
+
+    Returns:
+        A hex string hash, or a stringified per-tensor hash dictionary.
+        Empty string for non-rank0 processes in distributed settings.
+    """
+    return _hash_model_impl(
+        model,
+        algo=algo,
+        per_tensor=per_tensor,
+        include_weights=False,
+        include_gradients=True,
+    )
+
+
 @dataclass(frozen=True)
 class Color:
     black = "\033[30m"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2798
* #2797

Add test_bitwise_deterministic.py that verifies the aot_fx_trace path
produces bitwise identical losses, model weights, and gradients across
repeated runs, and matches eager numerics exactly. Uses hash_model and
hash_gradient utilities for efficient whole-model comparison.

This serves as a guardrail — all graph_trainer changes must pass this
test before proceeding with other tests.

Also adds hash_model/hash_gradient to torchtitan/tools/utils.py and
documents the guardrail in graph_trainer's CLAUDE.md.

TODO:
1. Add DeepSeek-v3 model coverage
2. Use distributed setup for multi-GPU testing