### PR TITLE
[Module] Config-based sharding infrastructure + Llama3

### DIFF
--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -8,14 +8,19 @@ from collections.abc import Sequence
 from typing import Any, cast
 
 import torch
+import torch.distributed as c10d
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.experimental._attention import (
     _context_parallel_shard,
     _ContextParallel,
     _enable_context_parallel_dispatcher,
     _HeadTailLoadBalancer,
     _PTRRLoadBalancer,
+)
+from torch.distributed.tensor.experimental._context_parallel._attention import (
+    flex_cp_allgather,
 )
 from torch.distributed.tensor.parallel import parallelize_module
 from torch.nn.attention.flex_attention import BlockMask
@@ -73,6 +78,80 @@ def apply_cp_to_attention_module(
         )
 
     logger.info("Applied Context Parallel to the model")
+
+
+def apply_cp_to_forward(
+    attention_modules: Sequence[nn.Module],
+    cp_mesh: DeviceMesh,
+) -> None:
+    """Wrap inner attention ``forward`` with CP logic.
+
+    Must be called **before** ``Module.parallelize()`` so the CP wrapper
+    is captured inside parallelize's ``local_map`` wrapping.
+
+    Replaces ``_ContextParallel`` hooks with direct forward wrapping.
+    The attention type is inferred via isinstance on the first module.
+
+    Args:
+        attention_modules: Sequence of inner attention modules to apply CP to.
+        cp_mesh: Device mesh for context parallel dimension.
+    """
+    from torchtitan.models.common.attention import (
+        FlexAttention,
+        ScaledDotProductAttention,
+        VarlenAttention,
+    )
+
+    first = attention_modules[0]
+    if isinstance(first, FlexAttention):
+        for mod in attention_modules:
+            original_forward = mod.forward
+
+            def _make_cp_forward(orig_fn, mesh):
+                pg_name = c10d._get_process_group_name(mesh.get_group())
+
+                def cp_forward(q, k, v, **kwargs):
+                    k = k.contiguous()
+                    v = v.contiguous()
+                    global_k, global_v = flex_cp_allgather(k, v, 2, pg_name)
+                    return orig_fn(q, global_k, global_v, **kwargs)
+
+                return cp_forward
+
+            mod.forward = _make_cp_forward(original_forward, cp_mesh)
+
+    elif isinstance(first, ScaledDotProductAttention):
+        _enable_context_parallel_dispatcher()
+
+        for mod in attention_modules:
+            original_forward = mod.forward
+
+            def _make_cp_forward(orig_fn, mesh):
+                placement = [Shard(2)]
+
+                def cp_forward(q, k, v, **kwargs):
+                    if not isinstance(q, DTensor):
+                        q = DTensor.from_local(q, mesh, placement, run_check=False)
+                    if not isinstance(k, DTensor):
+                        k = DTensor.from_local(k, mesh, placement, run_check=False)
+                    if not isinstance(v, DTensor):
+                        v = DTensor.from_local(v, mesh, placement, run_check=False)
+                    output = orig_fn(q, k, v, **kwargs)
+                    return output.to_local() if isinstance(output, DTensor) else output
+
+                return cp_forward
+
+            mod.forward = _make_cp_forward(original_forward, cp_mesh)
+
+    elif isinstance(first, VarlenAttention):
+        raise NotImplementedError("Variable-length attention CP is not yet supported")
+    else:
+        raise NotImplementedError(
+            f"Context Parallel forward wrapping is not supported for "
+            f"{type(first).__name__}"
+        )
+
+    logger.info("Applied Context Parallel (forward wrapping) to the model")
 
 
 def prepare_context_parallel_input(

--- a/torchtitan/distributed/sharding.py
+++ b/torchtitan/distributed/sharding.py
@@ -1,0 +1,176 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Functions to fill ``ShardingSpec`` on model configs based on parallelism settings.
+
+Called after ``expand_layer_configs()`` and ``update_from_config()``,
+before ``build()``.  Each model has its own ``set_*_sharding_spec``
+function that knows the model's structure.
+"""
+
+from torch.distributed.tensor import Replicate, Shard
+
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.models.common.attention import FlexAttention, VarlenAttention
+from torchtitan.protocols.sharding import LocalMapSpec, MeshDimName, ShardingSpec
+
+TP = MeshDimName.TP
+
+
+# ---------------------------------------------------------------------------
+# Llama3
+# ---------------------------------------------------------------------------
+
+
+def set_llama3_sharding_spec(
+    config,
+    parallel_dims: ParallelDims,
+    *,
+    loss_parallel: bool,
+) -> None:
+    """Fill ``sharding_spec`` on all Llama3 sub-configs.
+
+    No-op when TP is not enabled.
+    """
+    if not parallel_dims.tp_enabled:
+        return
+
+    _set_decoder_sharding_spec(config, loss_parallel)
+    for layer_cfg in config.layers:
+        _set_llama3_layer_sharding(layer_cfg)
+
+
+# ---------------------------------------------------------------------------
+# Shared decoder helpers (tok_embeddings, norm, output)
+# ---------------------------------------------------------------------------
+
+
+def _set_decoder_sharding_spec(config, loss_parallel: bool) -> None:
+    """Set sharding on tok_embeddings, norm, output — shared by all decoders."""
+    # tok_embeddings: RowwiseParallel — weight Shard(1), input Replicate, output Shard(1)
+    config.tok_embeddings.sharding_spec = ShardingSpec(
+        state_shardings={"weight": {TP: Shard(1)}},
+        input_layouts={"input": {TP: Replicate()}},
+        in_shardings={"input": {TP: Replicate()}},
+        out_shardings={TP: Shard(1)},
+    )
+    # norm: SequenceParallel
+    config.norm.sharding_spec = _sequence_parallel_spec()
+    # output: ColwiseParallel — all-gather input before matmul
+    config.output.sharding_spec = ShardingSpec(
+        state_shardings={"weight": {TP: Shard(0)}},
+        input_layouts={"input": {TP: Shard(1)}},
+        in_shardings={"input": {TP: Replicate()}},
+        out_shardings={TP: Shard(-1)} if loss_parallel else {TP: Replicate()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-layer sharding
+# ---------------------------------------------------------------------------
+
+
+def _set_llama3_layer_sharding(layer_cfg) -> None:
+    """Set sharding on one Llama3 transformer layer.
+
+    Following PR 2149's full-DTensor approach:
+    - All modules use use_local_output=False (DTensors flow everywhere)
+    - ColwiseParallel outputs DTensor Shard(-1)
+    - RowwiseParallel outputs DTensor Shard(1) (sequence parallel)
+    - SequenceParallel norms keep DTensor
+    - rope_cache is wrapped as DTensor Replicate via in_shardings
+    """
+    # Norms: SequenceParallel
+    layer_cfg.attention_norm.sharding_spec = _sequence_parallel_spec()
+    layer_cfg.ffn_norm.sharding_spec = _sequence_parallel_spec()
+
+    # Attention: input x is Shard(1) from sequence-parallel norm,
+    # needs all-gather to Replicate. rope_cache (freqs_cis) is a plain
+    # tensor that must be wrapped as DTensor Replicate.
+    layer_cfg.attention.sharding_spec = ShardingSpec(
+        input_layouts={
+            "x": {TP: Shard(1)},
+            "rope_cache": {TP: Replicate()},
+        },
+        in_shardings={
+            "x": {TP: Replicate()},
+            "rope_cache": {TP: Replicate()},
+        },
+    )
+    # wq/wk/wv: ColwiseParallel (DTensor output, no to_local)
+    for w in (
+        layer_cfg.attention.wq,
+        layer_cfg.attention.wk,
+        layer_cfg.attention.wv,
+    ):
+        w.sharding_spec = _colwise_spec()
+    # wo: RowwiseParallel with reduce-scatter to Shard(1)
+    layer_cfg.attention.wo.sharding_spec = _rowwise_spec(out_shardings={TP: Shard(1)})
+
+    # Inner attention: local_map for backends that don't support DTensor.
+    # SDPA supports DTensor natively; FlexAttention and Varlen do not.
+    inner_attn_cfg = layer_cfg.attention.inner_attention
+    if isinstance(inner_attn_cfg, (FlexAttention.Config, VarlenAttention.Config)):
+        qkv_placements = (Shard(1),)
+        layer_cfg.attention.inner_attention_local_map = LocalMapSpec(
+            in_placements=(qkv_placements, qkv_placements, qkv_placements),
+            out_placements=(qkv_placements,),
+            in_grad_placements=(
+                qkv_placements,
+                qkv_placements,
+                qkv_placements,
+            ),
+        )
+
+    # FFN: input x is Shard(1) from sequence-parallel norm,
+    # needs all-gather to Replicate.
+    assert layer_cfg.feed_forward is not None
+    layer_cfg.feed_forward.sharding_spec = ShardingSpec(
+        input_layouts={"x": {TP: Shard(1)}},
+        in_shardings={"x": {TP: Replicate()}},
+    )
+    # w1, w3: ColwiseParallel (DTensor output)
+    layer_cfg.feed_forward.w1.sharding_spec = _colwise_spec()
+    layer_cfg.feed_forward.w3.sharding_spec = _colwise_spec()
+    # w2: RowwiseParallel with reduce-scatter to Shard(1)
+    layer_cfg.feed_forward.w2.sharding_spec = _rowwise_spec(
+        out_shardings={TP: Shard(1)}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reusable spec factories
+# ---------------------------------------------------------------------------
+
+
+def _colwise_spec() -> ShardingSpec:
+    """ColwiseParallel: weight Shard(0), output Shard(-1)."""
+    return ShardingSpec(
+        state_shardings={"weight": {TP: Shard(0)}, "bias": {TP: Shard(0)}},
+        out_shardings={TP: Shard(-1)},
+    )
+
+
+def _rowwise_spec(
+    out_shardings: dict | None = None,
+) -> ShardingSpec:
+    """RowwiseParallel: weight Shard(1), output as specified."""
+    if out_shardings is None:
+        out_shardings = {TP: Replicate()}
+    return ShardingSpec(
+        state_shardings={"weight": {TP: Shard(1)}},
+        out_shardings=out_shardings,
+    )
+
+
+def _sequence_parallel_spec() -> ShardingSpec:
+    """SequenceParallel: weight Replicate, Shard(1) in, Shard(1) out."""
+    return ShardingSpec(
+        state_shardings={"weight": {TP: Replicate()}},
+        input_layouts={"input": {TP: Shard(1)}},
+        in_shardings={"input": {TP: Shard(1)}},
+        out_shardings={TP: Shard(1)},
+    )

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -12,7 +12,7 @@ os.environ.setdefault("DISABLE_LLVM_OPT", "1")
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple
+from typing import Any, ClassVar, NamedTuple
 
 import torch
 import torch.nn.functional as F
@@ -564,6 +564,10 @@ class GQAttention(BaseAttention):
         inner_attention: LocalMapInnerAttention.Config
         mask_type: str = "causal"
         rope_backend: str = "complex"  # "complex" or "cos_sin"
+        # Set by set_sharding_spec() for inner attention local_map.
+        # None when TP is off or when the backend supports DTensor (SDPA).
+        # Uses Any type to avoid circular import with sharding.py.
+        inner_attention_local_map: Any | None = None  # LocalMapSpec | None
 
         def __post_init__(self):
             BaseAttention.Config.__post_init__(self)
@@ -601,6 +605,14 @@ class GQAttention(BaseAttention):
         self.wo = config.wo.build()
 
         self.inner_attention = config.inner_attention.build()
+
+        # Propagate local_map spec to inner attention for parallelize()
+        if config.inner_attention_local_map is not None:
+            from torchtitan.protocols.sharding import ShardingSpec
+
+            self.inner_attention._sharding_spec = ShardingSpec(
+                local_map=config.inner_attention_local_map
+            )
 
     def forward(
         self,

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 
 from torchtitan.components.loss import build_cross_entropy_loss
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.distributed.sharding import set_llama3_sharding_spec
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
     Embedding,
@@ -405,4 +406,5 @@ def model_registry(flavor: str) -> ModelSpec:
         build_loss_fn=build_cross_entropy_loss,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
+        set_sharding_spec_fn=set_llama3_sharding_spec,
     )

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -13,16 +13,7 @@ from torch.distributed._composable.fsdp import FSDPModule
 from torch.distributed._composable.replicate_with_fsdp import replicate
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
-from torch.distributed.tensor import Replicate, Shard
-from torch.distributed.tensor.parallel import (
-    ColwiseParallel,
-    parallelize_module,
-    PrepareModuleInput,
-    RowwiseParallel,
-    SequenceParallel,
-)
 
-from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
@@ -33,9 +24,9 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.compile import apply_compile_dense
-from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
+from torchtitan.distributed.context_parallel import apply_cp_to_forward
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
-from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.models.llama3.model import Llama3Model
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
@@ -59,9 +50,6 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
-    # TODO: TP currently cannot handle uneven seq_len because we set
-    #       `use_local_output=True` to use plain Tensors for legacy reasons.
-    #       Need to revisit this.
     assert (
         training.seq_len % parallel_dims.seq_len_divisor == 0
     ), f"""
@@ -69,38 +57,20 @@ def parallelize_llama(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
-    if parallel_dims.tp_enabled:
-        float8_config = find_float8_linear_config(model_converters.converters)
-        enable_float8_linear = float8_config is not None
-        float8_is_rowwise = float8_config is not None and float8_config.recipe_name in (
-            "rowwise",
-            "rowwise_with_gw_hp",
-        )
-
-        # For now, float8 all-gather with TP is only supported for tensorwise
-        # float8 scaling recipes. For rowwise recipes, we use regular TP and
-        # all-gather happens in high precision.
-        enable_float8_tensorwise_tp = enable_float8_linear and not float8_is_rowwise
-
-        enable_sp = parallelism.enable_sequence_parallel
-
-        tp_mesh = parallel_dims.get_mesh("tp")
-        apply_tp(
-            model,
-            tp_mesh,
-            enable_loss_parallel=not parallelism.disable_loss_parallel,
-            enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
-            enable_cp=parallel_dims.cp_enabled,
-            enable_sp=enable_sp,
-        )
-        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
-
+    # CP: wrap inner attention forward BEFORE parallelize() so CP logic
+    # runs inside the local_map boundary on local tensors.
     if parallel_dims.cp_enabled:
-        apply_cp_to_attention_module(
+        apply_cp_to_forward(
             # pyrefly: ignore [missing-attribute, not-callable]
             [block.attention.inner_attention for block in model.layers.values()],
             parallel_dims.get_mesh("cp"),
         )
+
+    # TP: config-driven, auto-recursive via Module.parallelize()
+    if parallel_dims.tp_enabled:
+        tp_mesh = parallel_dims.get_mesh("tp")
+        model.parallelize(tp_mesh)
+        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
 
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
@@ -150,108 +120,6 @@ def parallelize_llama(
         )
 
     return model
-
-
-def apply_tp(
-    model: nn.Module,
-    tp_mesh: DeviceMesh,
-    enable_loss_parallel: bool,
-    enable_float8_tensorwise_tp: bool,
-    enable_cp: bool = False,
-    enable_sp: bool = True,
-):
-    """Apply tensor parallelism."""
-    # 1. Parallelize the embedding and shard its outputs (which are the first
-    # transformer block's inputs)
-    # 2. Parallelize the root norm layer over the sequence dim
-    # 3. Parallelize the final linear output layer
-    sp_layout = Shard(1) if enable_sp else Replicate()
-    embed_plan = RowwiseParallel(
-        input_layouts=Replicate(),
-        output_layouts=sp_layout,
-        use_local_output=enable_sp,
-    )
-
-    parallelize_module(
-        model,
-        tp_mesh,
-        {
-            "tok_embeddings": embed_plan,
-            "norm": SequenceParallel() if enable_sp else NoParallel(),
-            "output": ColwiseParallel(
-                input_layouts=sp_layout,
-                output_layouts=Shard(-1) if enable_loss_parallel else Replicate(),
-                use_local_output=not enable_loss_parallel,
-            ),
-        },
-    )
-
-    # Parallel styles used for transformer block linear weights and their
-    # inputs may be different for float8 linears with tensorwise scaling.
-    if enable_float8_tensorwise_tp:
-        # TODO(vkuzo): add the items below to __init__.py of torchao.float8 and import from there
-        from torchao.float8.float8_tensor_parallel import (
-            Float8ColwiseParallel,
-            Float8RowwiseParallel,
-            PrepareFloat8ModuleInput,
-        )
-
-        rowwise_parallel, colwise_parallel, prepare_module_input = (
-            Float8RowwiseParallel,
-            Float8ColwiseParallel,
-            PrepareFloat8ModuleInput,
-        )
-    else:
-        rowwise_parallel, colwise_parallel, prepare_module_input = (
-            RowwiseParallel,
-            ColwiseParallel,
-            PrepareModuleInput,
-        )
-
-    # Apply tensor + sequence parallelism to every transformer block
-    # NOTE: At the cost of model code change, we can accelerate Sequence Parallel
-    #       by folding (and unfolding) the batch dimension and the sequence dimension.
-    #       Examples can be found at https://github.com/pytorch/torchtitan/pull/437
-    norm_plan = SequenceParallel() if enable_sp else NoParallel()
-    rowwise_output_plan = rowwise_parallel(
-        output_layouts=sp_layout, use_local_output=enable_sp
-    )
-
-    # pyrefly: ignore [not-callable]
-    for transformer_block in model.layers.values():
-        # pyrefly: ignore [no-matching-overload]
-        layer_plan = {
-            "attention_norm": norm_plan,
-            "attention": prepare_module_input(
-                input_layouts=(sp_layout, None, None, None),
-                desired_input_layouts=(Replicate(), None, None, None),
-            ),
-            "attention.wq": colwise_parallel(),
-            "attention.wk": colwise_parallel(),
-            "attention.wv": colwise_parallel(),
-            "attention.wo": rowwise_output_plan,
-            "ffn_norm": norm_plan,
-            "feed_forward": prepare_module_input(
-                input_layouts=(sp_layout,),
-                desired_input_layouts=(Replicate(),),
-            ),
-            "feed_forward.w1": colwise_parallel(),
-            "feed_forward.w2": rowwise_output_plan,
-            "feed_forward.w3": colwise_parallel(),
-        }
-
-        parallelize_module(
-            # pyrefly: ignore [bad-argument-type]
-            module=transformer_block,
-            device_mesh=tp_mesh,
-            # pyrefly: ignore [bad-argument-type]
-            parallelize_plan=layer_plan,
-        )
-
-    logger.info(
-        f"Applied {'Float8 tensorwise ' if enable_float8_tensorwise_tp else ''}"
-        "Tensor Parallelism to the model"
-    )
 
 
 def disable_fsdp_gradient_division(model: nn.Module) -> None:

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 from copy import deepcopy
 from functools import partial
 

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -44,8 +44,9 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+    set_sharding_spec_fn: Callable | None = None
 
 
 @dataclass
 class FaultTolerantModelSpec(ModelSpec):
-    fragment_fn: Callable | None
+    fragment_fn: Callable | None = None

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -4,14 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import distribute_tensor, DTensor
 
 from torchtitan.config import Configurable, Function
+from torchtitan.protocols.sharding import (
+    resolve_placements,
+    ShardingSpec,
+    Unconstrained,
+)
 
 
 # Cache: maps nn.Module subclass -> created Module wrapper class.
@@ -32,10 +39,12 @@ class Module(nn.Module, Configurable):
     """
 
     _param_init: dict[str, Callable] | None = None
+    _sharding_spec: ShardingSpec | None = None
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
         param_init: dict | Function.Config | None = None
+        sharding_spec: ShardingSpec | None = None
 
         def build(self, **kwargs):
             # slots=True prevents super().build() from working; call explicitly.
@@ -44,6 +53,8 @@ class Module(nn.Module, Configurable):
             instance = Configurable.Config.build(self, **kwargs)
             if self.param_init is not None:
                 instance._param_init = self.param_init
+            if self.sharding_spec is not None:
+                instance._sharding_spec = self.sharding_spec
             return instance
 
     def init_states(
@@ -114,6 +125,75 @@ class Module(nn.Module, Configurable):
         """
         pass
 
+    def parallelize(self, mesh: "torch.distributed.DeviceMesh") -> None:
+        """Parallelize this module and all Module children recursively.
+
+        For each module with a ``sharding_spec``:
+
+        1. ``distribute_tensor`` on params per ``state_shardings``.
+        2. Wrap ``self.forward`` with redistribution (+ ``local_map`` if needed).
+
+        The wrapping order is: ``shard_inputs → [local_map →] fn → shard_outputs``.
+        CP (applied before ``parallelize``) is captured inside ``local_map``.
+        FSDP hooks on ``__call__`` fire around the wrapped ``forward``.
+        """
+        # Recurse children first (bottom-up, like sixlib)
+        queue = list(self.children())
+        while queue:
+            child = queue.pop()
+            if isinstance(child, Module):
+                child.parallelize(mesh)
+            else:
+                # Look through non-Module wrappers (CheckpointWrapper, compile)
+                queue.extend(child.children())
+
+        spec = self._sharding_spec
+        if spec is None:
+            return
+
+        assert mesh.mesh_dim_names is not None, "DeviceMesh must have named dims"
+        mesh_dim_names = mesh.mesh_dim_names
+
+        # 1. Distribute parameters
+        for name, param in self.named_parameters(recurse=False):
+            if name in spec.state_shardings:
+                placements = resolve_placements(
+                    spec.state_shardings[name], mesh_dim_names
+                )
+                self.register_parameter(
+                    name,
+                    nn.Parameter(distribute_tensor(param, mesh, list(placements))),
+                )
+
+        # 2. Wrap forward with redistribution (+ local_map if needed)
+        fn = self.forward  # capture current forward (may already be CP-wrapped)
+
+        if spec.local_map is not None:
+            from torch.distributed.tensor.experimental import local_map
+
+            fn = local_map(
+                fn,
+                in_placements=spec.local_map.in_placements,
+                out_placements=spec.local_map.out_placements,
+                in_grad_placements=spec.local_map.in_grad_placements,
+                device_mesh=mesh,
+            )
+
+        # Always wrap with redistribution
+        captured_fn = fn
+        captured_spec = spec
+        captured_mesh = mesh
+        captured_mod = self
+
+        def with_redistribution(*args, **kwargs):
+            args, kwargs = _shard_inputs(
+                captured_mod, captured_mesh, captured_spec, args, kwargs
+            )
+            outputs = captured_fn(*args, **kwargs)
+            return _shard_outputs(captured_mesh, captured_spec, outputs)
+
+        self.forward = with_redistribution  # pyrefly: ignore [missing-attribute]
+
     @classmethod
     def from_nn_module(cls, nn_module_cls: type[nn.Module]) -> type["Module"]:
         """Create a ``Module``-protocol-compatible version of *nn_module_cls*.
@@ -170,3 +250,82 @@ class Sequential(nn.Sequential, Module):
     """Module-protocol-compatible version of ``nn.Sequential``."""
 
     pass
+
+
+# ---------------------------------------------------------------------------
+# Sharding helpers for Module.parallelize()
+# ---------------------------------------------------------------------------
+
+
+def _shard_inputs(
+    mod: Module,
+    mesh: "torch.distributed.DeviceMesh",
+    spec: ShardingSpec,
+    args: tuple,
+    kwargs: dict,
+) -> tuple[tuple, dict]:
+    """Redistribute positional inputs to desired placements.
+
+    Two-step process per arg:
+    1. If plain tensor, wrap as DTensor using ``input_layouts`` (annotation).
+    2. If DTensor placements != ``in_shardings``, redistribute.
+    """
+    if spec.in_shardings is None and spec.input_layouts is None:
+        return args, kwargs
+
+    # Use the class forward signature (not the wrapped one) for arg names.
+    sig = inspect.signature(type(mod).forward)  # pyrefly: ignore [missing-attribute]
+    param_names = [
+        p.name
+        for p in sig.parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ][
+        1:
+    ]  # skip 'self'
+
+    assert mesh.mesh_dim_names is not None
+    mesh_dim_names = mesh.mesh_dim_names
+    in_shardings = spec.in_shardings or {}
+    input_layouts = spec.input_layouts or {}
+
+    new_args = list(args)
+    for i, arg in enumerate(new_args):
+        name = param_names[i] if i < len(param_names) else None
+        if name is None:
+            continue
+        if not isinstance(arg, torch.Tensor):
+            continue
+
+        # Step 1: Annotate plain tensor as DTensor using input_layouts
+        if not isinstance(arg, DTensor) and name in input_layouts:
+            layout = resolve_placements(input_layouts[name], mesh_dim_names)
+            arg = DTensor.from_local(arg, mesh, layout, run_check=False)
+
+        # Step 2: Redistribute to desired placement if needed
+        if name in in_shardings and isinstance(arg, DTensor):
+            desired = resolve_placements(in_shardings[name], mesh_dim_names)
+            if any(isinstance(p, Unconstrained) for p in desired):
+                continue
+            if arg.placements != desired:
+                arg = arg.redistribute(placements=desired, async_op=True)
+
+        new_args[i] = arg
+        new_args[i] = arg
+    return tuple(new_args), kwargs
+
+
+def _shard_outputs(
+    mesh: "torch.distributed.DeviceMesh",
+    spec: ShardingSpec,
+    outputs: Any,
+) -> Any:
+    """Redistribute output to desired placement."""
+    if spec.out_shardings is None:
+        return outputs
+    assert mesh.mesh_dim_names is not None
+    desired = resolve_placements(spec.out_shardings, mesh.mesh_dim_names)
+    if any(isinstance(p, Unconstrained) for p in desired):
+        return outputs
+    if isinstance(outputs, DTensor) and outputs.placements != desired:
+        outputs = outputs.redistribute(placements=desired, async_op=True)
+    return outputs

--- a/torchtitan/protocols/sharding.py
+++ b/torchtitan/protocols/sharding.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Sharding types for config-based parallelization.
+
+``ShardingSpec`` is set on ``Module.Config`` by ``set_sharding_spec()``
+and read by ``Module.parallelize(mesh)``.  All placements use
+``NamedPlacement`` (dict keyed by ``MeshDimName``) so they are
+self-documenting and support multi-dim meshes.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from torch.distributed.tensor import Placement
+
+
+class StrEnum(str, Enum):
+    """str + Enum for Python < 3.11 compatibility."""
+
+    pass
+
+
+class MeshDimName(StrEnum):
+    """Mesh dimension names for parallelism."""
+
+    DP = "dp"
+    DP_REPLICATE = "dp_replicate"
+    FSDP = "fsdp"
+    TP = "tp"
+    CP = "cp"
+    PP = "pp"
+    EP = "ep"
+    ETP = "etp"
+    EFSDP = "efsdp"
+
+
+# Placement per mesh dim, keyed by MeshDimName.
+# Example: {MeshDimName.TP: Shard(0), MeshDimName.DP: Replicate()}
+# Unspecified mesh dims default to Replicate() at resolve time.
+NamedPlacement = dict[MeshDimName, Placement]
+
+
+class Unconstrained(Placement):
+    """Preserve existing placement — no redistribution."""
+
+    def __init__(self) -> None:
+        # Placement.__init__ requires no args for custom subclasses
+        super().__init__()
+
+
+@dataclass(kw_only=True, slots=True)
+class LocalMapSpec:
+    """Spec for modules computing on local tensors (inner attention).
+
+    Wraps forward with ``local_map()``: DTensor → local before forward,
+    local → DTensor after forward.  Required for kernels that don't
+    support DTensor inputs (FlexAttention, VarlenAttention).
+
+    Attributes:
+        in_placements: Per-input placements (positional: q, k, v).
+        out_placements: Per-output placements.
+        in_grad_placements: Per-input gradient placements.
+    """
+
+    in_placements: tuple[tuple[Placement, ...], ...]
+    out_placements: tuple[tuple[Placement, ...], ...]
+    in_grad_placements: tuple[tuple[Placement, ...], ...]
+
+    def to_dict(self) -> dict:
+        """Serialize for JSON logging."""
+        return {"repr": repr(self)}
+
+
+@dataclass(kw_only=True, slots=True)
+class ShardingSpec:
+    """Declarative sharding for a Module's states and activations.
+
+    All placements use ``NamedPlacement`` (``dict[MeshDimName, Placement]``)
+    keyed by mesh dim names.  At ``parallelize()`` time, NamedPlacements
+    are resolved to ``tuple[Placement, ...]`` in mesh dim order.
+
+    Completely dtype-agnostic — quantization (Float8/MXFP8) is orthogonal.
+
+    Attributes:
+        state_shardings: Parameter/buffer placements for ``distribute_tensor``.
+            Outer dict keys are param names.
+            e.g. ``{"weight": {TP: Shard(0)}}`` for colwise.
+        input_layouts: How to annotate plain tensor inputs as DTensors,
+            keyed by ``forward()`` arg name. Used when inputs arrive as
+            plain tensors (e.g., from dataloader or FSDP-only path).
+            e.g. ``{"x": {TP: Shard(1)}}`` means the plain tensor is a
+            local shard on TP dim. ``None`` means no annotation needed.
+            Will be unnecessary once full DTensor is adopted.
+        in_shardings: Desired input placements after redistribution,
+            keyed by ``forward()`` arg name.
+            e.g. ``{"x": {TP: Replicate()}}`` for all-gather.
+            ``None`` means no input redistribution.
+        out_shardings: Desired output placement.
+            e.g. ``{TP: Shard(1)}`` for reduce-scatter to sequence-parallel.
+            ``None`` means no output redistribution.
+        local_map: If set, wraps forward with ``local_map()`` for
+            DTensor → local conversion before forward.
+    """
+
+    state_shardings: dict[str, NamedPlacement] = field(default_factory=dict)
+    input_layouts: dict[str, NamedPlacement] | None = None
+    in_shardings: dict[str, NamedPlacement] | None = None
+    out_shardings: NamedPlacement | None = None
+    local_map: LocalMapSpec | None = None
+
+    def to_dict(self) -> dict:
+        """Serialize for JSON logging. Placements become repr strings."""
+        return {"repr": repr(self)}
+
+
+def resolve_placements(
+    named: NamedPlacement,
+    mesh_dim_names: tuple[str, ...],
+) -> tuple[Placement, ...]:
+    """Convert NamedPlacement to ``tuple[Placement, ...]`` in mesh dim order.
+
+    Unspecified mesh dims default to ``Replicate()``.
+    """
+    from torch.distributed.tensor import Replicate
+
+    # MeshDimName is a str subclass so str lookup works at runtime.
+    return tuple(
+        named.get(MeshDimName(dim_name), Replicate()) for dim_name in mesh_dim_names
+    )

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -250,6 +250,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
         self.model_config = model_config
 
+        # Fill sharding specs based on parallelism settings (before build)
+        if model_spec.set_sharding_spec_fn is not None:
+            model_spec.set_sharding_spec_fn(
+                model_config,
+                parallel_dims,
+                loss_parallel=not config.parallelism.disable_loss_parallel,
+            )
+
         logger.info(
             f"Building {model_spec.name} {model_spec.flavor} "
             f"with {json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2800
* #2785

Replace imperative parallelize_module() TP plans with declarative
ShardingSpec on Module.Config for Llama3. DTensors flow everywhere.

Key changes:
- ShardingSpec with NamedPlacement (dict[MeshDimName, Placement])
- Module.parallelize(mesh) auto-recurses and wraps forward with
  shard_inputs/shard_outputs + optional local_map
- set_llama3_sharding_spec() fills specs on expanded config
- apply_cp_to_forward() replaces _ContextParallel hooks with direct
  forward wrapping (must be called before parallelize)
- LocalMapSpec on inner attention for FlexAttention/Varlen (no DTensor support)
- Float8/MXFP8 converters unchanged (sharding is dtype-agnostic)
- PP expected to break (separate effort)