### PR TITLE
[graph_trainer] Add prerequisite step to nightly scout: checkout main

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/nightly.md
+++ b/torchtitan/experiments/graph_trainer/.claude/nightly.md
@@ -11,6 +11,21 @@ claude -p "$(cat torchtitan/experiments/graph_trainer/.claude/nightly.md)"
 
 ---
 
+## 0. Prerequisites
+
+Before running any checks, ensure you are on the torchtitan `main` branch
+with the latest upstream changes:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+If not on `main`, the delta review and freshness checks will produce
+misleading results based on stale or branch-specific state.
+
+---
+
 ## 1. Core Torchtitan Delta Review
 
 Check what changed in core torchtitan since yesterday that graph_trainer should


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2807
* #2806
* #2805
* #2799
* #2797

The nightly scout must run against the main branch to produce accurate
delta reviews and freshness checks, not a stale feature branch.