### PR TITLE
[graph_trainer] Fix missing CP wiring in llama3 and deepseek_v3 parallelize

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -16,7 +16,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-
+from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
@@ -136,6 +136,12 @@ def parallelize_deepseekv3(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             pad_multiple=pad_multiple,
+        )
+
+    if parallel_dims.cp_enabled:
+        apply_cp_to_attention_module(
+            [block.attention.inner_attention for block in model.layers.values()],
+            parallel_dims.get_mesh("cp"),
         )
 
     if ac_config.mode != "none":

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -15,6 +15,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
@@ -101,8 +102,16 @@ def parallelize_llama(
             tp_mesh,
             enable_loss_parallel=not parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+            enable_cp=parallel_dims.cp_enabled,
+            enable_sp=parallelism.enable_sequence_parallel,
         )
         maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+
+    if parallel_dims.cp_enabled:
+        apply_cp_to_attention_module(
+            [block.attention.inner_attention for block in model.layers.values()],
+            parallel_dims.get_mesh("cp"),
+        )
 
     if ac_config.mode != "none":
         apply_graph_ac(compile_config, ac_config)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* #2813
* #2812
* #2811
* #2810
* #2809
* __->__ #2808
* #2806
* #2805
* #2799
* #2797

Llama3's parallelize_llama was calling apply_tp() without passing
enable_cp and enable_sp, causing context parallelism to silently
malfunction — TP plans wouldn't account for CP sharding, and positions
wouldn't be handled correctly.

Both llama3 and deepseek_v3 were missing the apply_cp_to_attention_module()
call that configures attention modules for CP ring attention communication.
Without this, inputs are sharded by CP (via Trainer.post_dataloading_process)
but attention modules compute only on the local shard without seeing the
full context.

Changes:
- llama3/parallelize.py: Pass enable_cp and enable_sp to apply_tp(),
  add apply_cp_to_attention_module() call
- deepseek_v3/parallelize.py: Add apply_cp_to_attention_module() call
  (enable_cp/enable_sp were already passed correctly)