### PR TITLE
[graph_trainer] Add integration test for fsdp_reshard_after_fwd joint pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -185,6 +185,21 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
                     "--compile.mode aot",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.fsdp_reshard_after_forward always",
+                ],
+            ],
+            "AOT llama3 FSDP+TP fsdp_reshard_after_fwd",
+            "aot_llama3_fsdp_tp_reshard_after_fwd",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
                     "--compile.passes auto_bucketing",
                 ],
             ],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* #2813
* #2812
* #2811
* #2810
* __->__ #2809
* #2808
* #2806
* #2805
* #2799
* #2797

The fsdp_reshard_after_fwd_pass is always applied as the last joint pass
in the AOT compilation pipeline, but no integration test exercised the
--parallelism.fsdp_reshard_after_forward=always path, which annotates
SimpleFSDP all-gather nodes as MUST_RECOMPUTE to free memory after
forward and re-gather in backward.

Add an AOT Llama3 FSDP+TP test with fsdp_reshard_after_forward=always.