### PR TITLE
[graph_trainer] Preserve AC sub-fields when overriding mode to selective

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field, fields, replace
 from typing import Literal
 
 from torchtitan.config import ActivationCheckpointConfig
@@ -78,8 +78,10 @@ def to_graph_trainer_config(
 
     # graph_trainer uses graph-based SAC instead of eager AC. Override any
     # non-"none" AC mode to "selective" so callers don't need per-config fixups.
+    # Use replace() to preserve user-configured sub-fields (preserve_rng_state,
+    # early_stop, determinism_check, etc.).
     ac = d.get("activation_checkpoint")
     if ac is not None and ac.mode != "none":
-        d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
+        d["activation_checkpoint"] = replace(ac, mode="selective")
 
     return GraphTrainer.Config(**d)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* #2813
* #2812
* #2811
* __->__ #2810
* #2809
* #2808
* #2806
* #2805
* #2799
* #2797

to_graph_trainer_config() was creating a fresh
ActivationCheckpointConfig(mode="selective"), which silently discarded
any user-configured sub-fields like preserve_rng_state, early_stop,
determinism_check, debug, memory_budget, and
per_op_sac_force_recompute_mm_shapes_by_fqns.

Use dataclasses.replace() instead to only change the mode field while
preserving all other user settings.