### PR TITLE
[graph_trainer] Save CUDA-to-CPU copies in SAC pass to match core behavior

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -214,6 +214,20 @@ def apply_sac_pass(
         ac_region_id = custom_meta.get(_AC_REGION_ID, 0)
         node.meta["ac_graph_id"] = ac_region_id
 
+        # Always save CUDA->CPU copies to avoid recomputing device transfers
+        # (e.g., MoE D2H sync for all-to-all metadata).
+        if (
+            node.target is torch.ops.aten._to_copy.default
+            and isinstance(node.args[0], torch.fx.Node)
+            and "val" in node.args[0].meta
+            and "cuda" in str(node.args[0].meta["val"].device)
+            and str(node.kwargs.get("device", "")) == "cpu"
+        ):
+            policy = CheckpointPolicy.MUST_SAVE
+            node.meta["recompute"] = policy
+            ac_region_stats[ac_region_id]["save"] += 1
+            continue
+
         if node.target is torch.ops.aten.mm.default:
             mm_count += 1
             # Save every odd mm, recompute every even mm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* #2813
* #2812
* __->__ #2811
* #2810
* #2809
* #2808
* #2806
* #2805
* #2799
* #2797

Core's _apply_op_sac always marks aten._to_copy CUDA->CPU transfers as
MUST_SAVE to avoid wastefully recomputing device transfers during
backward (e.g., MoE D2H sync for all-to-all metadata).

Graph_trainer's apply_sac_pass was missing this check, causing these
transfers to fall through to PREFER_RECOMPUTE. Add the same logic at
the FX graph level by inspecting the source node's fake tensor device
and the target device kwarg.