### PR TITLE
[graph_trainer] Add precompile end-to-end integration test

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -298,6 +298,38 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                # First run: compile + save artifact
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--compile.joint_passes inductor_decomposition",
+                    "--compile.passes auto_bucketing,full_inductor_compilation",
+                    "--compile.precompile",
+                    "--compile.precompile_artifact_dir /tmp/graph_trainer_precompile_test",
+                ],
+                # Second run: load artifact, skip compilation
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--compile.joint_passes inductor_decomposition",
+                    "--compile.passes auto_bucketing,full_inductor_compilation",
+                    "--compile.precompile",
+                    "--compile.precompile_artifact_dir /tmp/graph_trainer_precompile_test",
+                    "--training.steps 20",
+                ],
+            ],
+            "AOT llama3 precompile save+load",
+            "aot_llama3_precompile",
+            ngpu=8,
+        ),
         # === aot_fx_trace mode tests ===
         OverrideDefinitions(
             [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* #2813
* __->__ #2812
* #2811
* #2810
* #2809
* #2808
* #2806
* #2805
* #2799
* #2797

Precompile has unit tests for its components (DiskStorageAdapter,
PrecompiledArtifact, fingerprinting) but no integration test exercised
the full compile-save-reload-train loop.

Add a two-step AOT Llama3 test:
1. First run compiles with inductor_decomposition + full_inductor_compilation
   and saves the precompile artifact to disk
2. Second run detects the existing artifact and loads it, skipping
   compilation entirely, then trains from step 10 to 20

This validates the full precompile lifecycle including artifact
serialization, fingerprint matching, and correct training resumption.