### PR TITLE
[graph_trainer] Add DeepSeek-v3 AOT pass parity integration tests

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -475,6 +475,59 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_deepseekv3_inductor_decomposition",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                    "--compile.passes auto_bucketing",
+                ],
+            ],
+            "AOT deepseek_v3 FSDP+TP+EP autobucketing",
+            "aot_deepseekv3_fsdp_tp_ep_autobucketing",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                    "--compile.passes cudagraph",
+                ],
+            ],
+            "AOT deepseek_v3 FSDP+TP+EP+cudagraph",
+            "aot_deepseekv3_fsdp_tp_ep_cudagraph",
+            ngpu=8,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                    "--parallelism.expert_tensor_parallel_degree 1",
+                    "--compile.joint_passes inductor_decomposition",
+                    "--compile.passes auto_bucketing,full_inductor_compilation",
+                ],
+            ],
+            "AOT deepseek_v3 auto_bucketing+full_inductor_compilation",
+            "aot_deepseekv3_auto_bucketing_full_inductor_compilation",
+            ngpu=8,
+        ),
         # === aot_fx_trace mode tests ===
         OverrideDefinitions(
             [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* #2814
* __->__ #2813
* #2812
* #2811
* #2810
* #2809
* #2808
* #2806
* #2805
* #2799
* #2797

DeepSeek-v3 was missing AOT integration tests for auto_bucketing,
cudagraph, and full_inductor_compilation — all of which were tested
for Llama3 but not for DeepSeek-v3 with its MoE/EP architecture.

Add three new AOT tests for DeepSeek-v3 FSDP+TP+EP:
- auto_bucketing
- cudagraph
- auto_bucketing + full_inductor_compilation (with inductor_decomposition)