### PR TITLE
[graph_trainer] Add gradient accumulation integration test

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -162,6 +162,23 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "jit_optional_checkpoint",
             ngpu=4,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    # Local batch size = 8, ngpu=4, so default
+                    # global batch size = 8 * 4 = 32.
+                    # To achieve 2 gradient accumulation steps,
+                    # multiply by 2: 32 * 2 = 64.
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode jit",
+                    "--training.local_batch_size 8",
+                    "--training.global_batch_size 64",
+                ],
+            ],
+            "JIT gradient accumulation",
+            "jit_gradient_accumulation",
+        ),
         # === AOT mode tests ===
         OverrideDefinitions(
             [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2815
* __->__ #2814
* #2813
* #2812
* #2811
* #2810
* #2809
* #2808
* #2806
* #2805
* #2799
* #2797

Core torchtitan tests gradient accumulation via global_batch_size but
graph_trainer never tested this code path. Gradient accumulation
interacts with graph_trainer's custom forward_backward_step and
SimpleFSDP's gradient handling, so it warrants explicit coverage.

Add a JIT mode test with local_batch_size=8 on 4 GPUs (default
global_batch_size=32) and global_batch_size=64 to trigger 2 gradient
accumulation steps per optimizer step.