### PR TITLE
[graph_trainer] Add fsdp2_sac activation checkpointing mode

### DIFF
--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -231,7 +231,7 @@ class ParallelismConfig:
 @dataclass(kw_only=True, slots=True)
 class ActivationCheckpointConfig:
     mode: Literal["selective", "full", "memory_budget", "none"] = "selective"
-    """Type of activation checkpointing to use"""
+    """Type of activation checkpointing to use."""
 
     per_op_sac_force_recompute_mm_shapes_by_fqns: list[str] = field(
         default_factory=lambda: ["moe.router.gate"]

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -232,3 +232,33 @@ def apply_simple_fsdp(
         "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
     )
     return model
+
+
+def apply_graph_ac(
+    compile_config: CompileConfig,
+    ac_config: "ActivationCheckpointConfig",
+) -> None:
+    """Add the appropriate SAC joint pass based on ac_config.mode.
+
+    Must be called only when ac_config.mode != "none".
+    Supported modes: "selective" (graph-level PREFER annotations) and
+    "fsdp2_sac" (MUST annotations matching FSDP2 eager policy).
+    """
+    mode_to_pass = {
+        "selective": "apply_sac",
+        "fsdp2_sac": "fsdp2_sac",
+    }
+    pass_name = mode_to_pass.get(ac_config.mode)
+    if pass_name is None:
+        raise ValueError(
+            f"graph_trainer only supports activation_checkpoint.mode "
+            f"'selective', 'fsdp2_sac', or 'none', got {ac_config.mode!r}."
+        )
+
+    joint_pass_names = getattr(compile_config, "joint_passes", [])
+    if pass_name not in joint_pass_names:
+        compile_config.joint_passes = list(joint_pass_names) + [pass_name]
+        logger.info(
+            f"activation_checkpoint.mode is {ac_config.mode!r}, "
+            f"added {pass_name} to compile.joint_passes"
+        )

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -16,6 +16,21 @@ from torchtitan.trainer import Trainer
 
 
 @dataclass(kw_only=True, slots=True)
+class GraphTrainerActivationCheckpointConfig(ActivationCheckpointConfig):
+    mode: Literal[
+        "selective", "full", "memory_budget", "fsdp2_sac", "none"
+    ] = "selective"
+    """Extends base AC config with graph-trainer-specific modes.
+
+    "fsdp2_sac": closely matches FSDP2's eager per-op selective AC policy --
+    same save ops, per-AC-region mm counters, and MUST_SAVE / MUST_RECOMPUTE
+    annotations. Use for direct memory comparison between graph_trainer and
+    FSDP2 eager trainer. Note: does not yet support
+    per_op_sac_force_recompute_mm_shapes_by_fqns.
+    """
+
+
+@dataclass(kw_only=True, slots=True)
 class GraphTrainerCompileConfig(CompileConfig):
     mode: Literal["jit", "aot", "aot_fx_trace"] | None = "aot_fx_trace"
     """
@@ -112,11 +127,14 @@ def to_graph_trainer_config(
     )
     d.pop("compile")
 
-    # graph_trainer uses graph-based SAC instead of eager AC. Override any
-    # non-"none" AC mode to "selective" so callers don't need per-config fixups.
-    ac = d.get("activation_checkpoint")
-    if ac is not None and ac.mode != "none":
-        d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
+    # Convert base AC config to graph-trainer AC config. Override any
+    # unsupported AC mode to "selective" so callers don't need per-config fixups.
+    ac = d.pop("activation_checkpoint", None)
+    if ac is not None:
+        ac_fields = {f.name: getattr(ac, f.name) for f in fields(ac)}
+        if ac_fields["mode"] not in ("none", "selective", "fsdp2_sac"):
+            ac_fields["mode"] = "selective"
+        d["activation_checkpoint"] = GraphTrainerActivationCheckpointConfig(**ac_fields)
 
     # TODO: graph_trainer doesn't yet support ChunkedCELoss
     if isinstance(d.get("loss"), ChunkedCELoss.Config):

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -703,6 +703,48 @@ def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
     return policy_fn
 
 
+def _propagate_recompute_tag(node: torch.fx.Node) -> bool:
+    """Propagate recompute/ac_graph_id from parent for getitem and wait_tensor.
+
+    getitem: When a node returns a tuple/list (e.g., rmsnorm, sdpa), it is
+    followed by getitem nodes that extract individual elements. They inherit
+    the parent's recompute tag, otherwise they will be exposed as graph outputs
+    and saved for backwards unnecessarily.
+
+    wait_tensor: Semantically tied to its parent async collective (e.g.,
+    reduce_scatter_tensor, all_gather_into_tensor) and must share the same
+    save/recompute decision.
+
+    Returns True if the node was handled (caller should ``continue``).
+    """
+    if node.target not in (
+        operator.getitem,
+        torch.ops._c10d_functional.wait_tensor.default,
+    ):
+        return False
+    parent = node.args[0]
+    if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
+        node.meta["recompute"] = parent.meta["recompute"]
+        node.meta["ac_graph_id"] = parent.meta.get("ac_graph_id", 0)
+    return True
+
+
+def _log_ac_region_stats(
+    pass_name: str,
+    ac_region_stats: dict[int, dict[str, int]],
+    save_label: str,
+    recompute_label: str,
+) -> None:
+    """Log per-AC-region annotation statistics."""
+    for ac_region_id in sorted(ac_region_stats):
+        stats = ac_region_stats[ac_region_id]
+        logger.info(
+            f"  AC region {ac_region_id}: "
+            f"{stats['save']} {save_label}, "
+            f"{stats['recompute']} {recompute_label}"
+        )
+
+
 def apply_sac_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
@@ -742,21 +784,10 @@ def apply_sac_pass(
         if node.op != "call_function":
             continue
 
-        # Skip backward nodes — they must not carry recompute tags,
-        # otherwise the remat pass would try to duplicate backward ops.
         if _is_backward_node(node):
             continue
 
-        if node.target in (
-            operator.getitem,
-            torch.ops._c10d_functional.wait_tensor.default,
-        ):
-            # Propagate from parent: getitem extracts tuple elements,
-            # wait_tensor is tied to its async collective — both must
-            # share the parent's save/recompute decision.
-            parent = node.args[0]
-            if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
-                node.meta["recompute"] = parent.meta["recompute"]
+        if _propagate_recompute_tag(node):
             continue
 
         layer_id = _get_layer_id(node)
@@ -808,6 +839,106 @@ def apply_sac_pass(
             f"{stats['save']} MUST_SAVE, "
             f"{stats['recompute']} PREFER_RECOMPUTE"
         )
+
+    gm.recompile()
+    return gm
+
+
+def fsdp2_sac_pass(
+    gm: torch.fx.GraphModule,
+) -> torch.fx.GraphModule:
+    """Apply selective AC closely matching FSDP2's eager per-op policy.
+
+    Unlike ``apply_sac_pass`` which uses ``PREFER_RECOMPUTE`` with a single
+    global mm counter, this pass uses ``MUST_SAVE`` / ``MUST_RECOMPUTE`` with
+    per-AC-region mm counters and the same op list as FSDP2 eager
+    (``_get_save_ops``).  Only nodes inside AC regions are annotated —
+    nodes outside (embedding, output, loss) are left for the partitioner.
+
+    Key differences from ``apply_sac_pass``:
+      - **MUST policies** instead of PREFER — removes partitioner flexibility to
+        ensure deterministic save/recompute decisions matching FSDP2.
+      - **Per-AC-region mm counters** — each transformer block resets its own
+        mm counter, matching FSDP2's per-module ``checkpoint_wrapper``.
+      - **mm_ops includes aten.linear** — some backends keep linear as a leaf op.
+      - **CUDA→CPU _to_copy always saved** — for MoE D2H sync metadata.
+
+    Note: ``per_op_sac_force_recompute_mm_shapes_by_fqns`` is not yet supported
+    in this graph pass. For MoE models that rely on force-recomputing specific
+    mm shapes (e.g. router gate), use ``apply_sac_pass`` (mode ``selective``)
+    until this is added.
+
+    Use ``--activation_checkpoint.mode fsdp2_sac`` to enable.
+    """
+    save_ops = _get_save_ops()
+    mm_ops = {torch.ops.aten.mm.default, torch.ops.aten.linear.default}
+
+    ac_region_stats: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"save": 0, "recompute": 0}
+    )
+    # Per-AC-region mm counters, matching FSDP2's per-module counter reset
+    mm_counts: dict[int, int] = defaultdict(int)
+    has_ac_regions = False
+
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+
+        if _propagate_recompute_tag(node):
+            continue
+
+        custom_meta = node.meta.get("custom", {})
+        # Only annotate nodes inside AC regions (transformer blocks).
+        if _AC_REGION_ID not in custom_meta:
+            continue
+        has_ac_regions = True
+        ac_region_id = custom_meta[_AC_REGION_ID]
+        node.meta["ac_graph_id"] = ac_region_id
+
+        # CUDA→CPU _to_copy: always save (matches FSDP2 eager policy for
+        # MoE D2H sync metadata).
+        if node.target == torch.ops.aten._to_copy.default:
+            src_val = node.args[0].meta.get("val") if node.args else None
+            if (
+                src_val is not None
+                and hasattr(src_val, "device")
+                and src_val.device.type == "cuda"
+                and "device" in node.kwargs
+                and torch.device(node.kwargs["device"]).type == "cpu"
+            ):
+                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+                ac_region_stats[ac_region_id]["save"] += 1
+                continue
+
+        if node.target in mm_ops:
+            mm_counts[ac_region_id] += 1
+            if mm_counts[ac_region_id] % 2 == 0:
+                policy = CheckpointPolicy.MUST_RECOMPUTE
+            else:
+                policy = CheckpointPolicy.MUST_SAVE
+        elif node.target in save_ops:
+            policy = CheckpointPolicy.MUST_SAVE
+        else:
+            policy = CheckpointPolicy.MUST_RECOMPUTE
+
+        node.meta["recompute"] = policy
+        if policy == CheckpointPolicy.MUST_SAVE:
+            ac_region_stats[ac_region_id]["save"] += 1
+        else:
+            ac_region_stats[ac_region_id]["recompute"] += 1
+
+    if not has_ac_regions:
+        logger.warning(
+            "fsdp2_sac_pass: no nodes with AC region annotations found. "
+            "Ensure annotate_ac_regions() was called on the model before tracing."
+        )
+
+    gm.recompile()
+    logger.info(
+        "Applied fsdp2_sac: selective AC with MUST_SAVE/MUST_RECOMPUTE "
+        "matching FSDP2 eager policy."
+    )
+    _log_ac_region_stats("fsdp2_sac", ac_region_stats, "MUST_SAVE", "MUST_RECOMPUTE")
     return gm
 
 
@@ -1071,4 +1202,5 @@ AVAILABLE_COMPILER_PASSES = {
 AVAILABLE_JOINT_PASSES = {
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
     "apply_sac": apply_sac_pass,
+    "fsdp2_sac": fsdp2_sac_pass,
 }

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -34,6 +34,7 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
 from torchtitan.experiments.graph_trainer.passes import (
     _make_default_memory_policy,
     apply_sac_pass,
+    fsdp2_sac_pass,
     insert_kernel_annotations_pass,
     overlap_fsdp_ag_rs_pass,
     remove_detach_pass,
@@ -1399,6 +1400,84 @@ class TestAsyncTensorParallelPass(FSDPTest):
 
         fused = torch.ops.symm_mem.fused_matmul_reduce_scatter.default
         self.assertTrue(any(n.target == fused for n in gm.graph.nodes))
+
+
+class TestFSDP2SACPass(TestCase):
+    """Unit tests for the fsdp2_sac_pass joint graph pass."""
+
+    def _build_gm(self, op_targets, ac_region_ids=None):
+        """Build a GraphModule with call_function nodes, optionally annotated
+        with AC region IDs.
+
+        ac_region_ids: list parallel to op_targets. None entries leave the node
+        unannotated; int entries set _AC_REGION_ID in custom metadata.
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        last = x
+        for i, target in enumerate(op_targets):
+            if target is operator.getitem:
+                last = graph.call_function(target, args=(last, 0))
+            else:
+                last = graph.call_function(target, args=(last, y))
+        graph.output(last)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        if ac_region_ids is not None:
+            call_fn_nodes = [n for n in gm.graph.nodes if n.op == "call_function"]
+            for node, rid in zip(call_fn_nodes, ac_region_ids, strict=True):
+                if rid is not None:
+                    node.meta["custom"] = {_AC_REGION_ID: rid}
+
+        return gm
+
+    def test_only_ac_region_nodes_annotated(self):
+        """Nodes outside AC regions are skipped; nodes inside get MUST_* policies."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.mm.default,
+                torch.ops.aten.relu.default,
+            ],
+            ac_region_ids=[None, 0, 0],
+        )
+        fsdp2_sac_pass(gm)
+        nodes = [n for n in gm.graph.nodes if n.op == "call_function"]
+        # Outside AC region — no annotation
+        self.assertNotIn("recompute", nodes[0].meta)
+        # Inside AC region — MUST_* policies only
+        for node in nodes[1:]:
+            self.assertIn(
+                node.meta["recompute"],
+                {
+                    CheckpointPolicy.MUST_SAVE,
+                    CheckpointPolicy.MUST_RECOMPUTE,
+                },
+            )
+
+    def test_per_region_mm_counters(self):
+        """Each AC region has an independent mm counter (odd=save, even=recompute),
+        and aten.linear participates in the counter alongside aten.mm."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.mm.default,  # region 0, mm #1 -> MUST_SAVE
+                torch.ops.aten.linear.default,  # region 1, mm #1 -> MUST_SAVE
+                torch.ops.aten.mm.default,  # region 0, mm #2 -> MUST_RECOMPUTE
+                torch.ops.aten.linear.default,  # region 1, mm #2 -> MUST_RECOMPUTE
+            ],
+            ac_region_ids=[0, 1, 0, 1],
+        )
+        fsdp2_sac_pass(gm)
+        nodes = [n for n in gm.graph.nodes if n.op == "call_function"]
+        expected = [
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.MUST_RECOMPUTE,
+            CheckpointPolicy.MUST_RECOMPUTE,
+        ]
+        for node, policy in zip(nodes, expected, strict=True):
+            self.assertEqual(node.meta["recompute"], policy, f"node {node.name}")
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -15,7 +15,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
     maybe_register_blockmask_pytree_node,
 )
-from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.configs import (
+    GraphTrainerActivationCheckpointConfig,
+    GraphTrainerCompileConfig,
+)
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     run_traced_train_step,
@@ -64,6 +67,9 @@ class GraphTrainer(Trainer):
     class Config(Trainer.Config):
         compile: GraphTrainerCompileConfig = field(
             default_factory=GraphTrainerCompileConfig
+        )
+        activation_checkpoint: GraphTrainerActivationCheckpointConfig = field(
+            default_factory=GraphTrainerActivationCheckpointConfig
         )
 
     def __init__(self, config):


### PR DESCRIPTION
The problem:
Using SimpleFSDP/graph_trainer AC modes do not give equivalent AC strategy vs FSDP2 (baseline).


Solution
Add a new `fsdp2_sac` AC mode to graph_trainer that closely matches FSDP2's eager per-op selective activation checkpointing policy.
This allows to have clean comparison of performance.


Key differences from the existing `selective` (apply_sac) graph pass:
- MUST_SAVE / MUST_RECOMPUTE instead of PREFER — removes partitioner flexibility to ensure deterministic save/recompute decisions.
- Per-AC-region mm counters — each transformer block resets its own counter, matching FSDP2's per-module checkpoint_wrapper behavior.
- mm_ops includes aten.linear — some backends keep linear as a leaf op.
- CUDA→CPU _to_copy always saved — for MoE D2H sync metadata.
- Only annotates nodes inside AC regions — embedding, output, and loss nodes are left for the partitioner to decide.