### PR TITLE
[RL] Fix recompiles (From 10+ to only 1)

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -89,13 +89,6 @@ class PolicyTrainer(Actor, Configurable):
         requested = TORCH_DTYPE_MAP[transfer_dtype] if transfer_dtype else None
         self._transfer_dtype = requested if requested != training_dtype else None
 
-        # The policy and ref models share code objects, so dynamo's
-        # per-code-object cache must hold entries for both grad modes
-        # (grad for policy, no_grad for ref). The default limit of 8
-        # is not enough; 16 accommodates both without recompile storms.
-        # TODO: @Lucaskabela fix recompiles in general as these increase startup
-        torch._dynamo.config.cache_size_limit = 16
-
         # Device setup
         device_module, device_type = utils.device_module, utils.device_type
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
@@ -134,7 +127,11 @@ class PolicyTrainer(Actor, Configurable):
         # TODO: @joecummings remove ref entirely, this is hacky and we don't need it
         if getattr(config.loss, "kl_coef", 0) > 0:
             ref_model = self._build_model(
-                model_spec, config, device_type, hf_assets_path
+                model_spec,
+                config,
+                device_type,
+                hf_assets_path,
+                isolate_code_objects=True,
             )
             ref_model.eval()
             ref_model.requires_grad_(False)
@@ -207,6 +204,7 @@ class PolicyTrainer(Actor, Configurable):
         config: Config,
         device_type: str,
         hf_assets_path: str,
+        isolate_code_objects: bool = False,
     ):
         """Build, parallelize, and initialize a model from checkpoint.
         Will be used to build trainer's policy model and reference model.
@@ -232,12 +230,48 @@ class PolicyTrainer(Actor, Configurable):
             with utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]):
                 model = model_spec.model.build()
 
+        if isolate_code_objects:
+            # Give each TransformerBlock a distinct closure so dynamo's
+            # per-code-object cache partitions by ID_MATCH on the closure
+            # cell, keeping this model's compilations independent from other
+            # models of the same class (e.g. policy vs ref — different
+            # grad_mode would otherwise recompile into a shared cache).
+            # Must run BEFORE parallelize_fn: apply_compile (inside
+            # parallelize_fn) wraps block._call_impl, which dispatches to
+            # whatever block.forward is at that moment. Isolation afterwards
+            # would be invisible to the compile wrapper.
+            for block in model.layers.values():  # pyrefly: ignore [not-callable]
+                orig_forward = block.forward.__func__
+
+                def _make_isolated(fn):
+                    def forward(self, *args, **kwargs):
+                        return fn(self, *args, **kwargs)
+
+                    return forward
+
+                wrapped = _make_isolated(orig_forward)
+                # Sentinel so we can assert post-parallelize_fn that isolation
+                # was not silently undone (e.g. by a future TP/compile helper
+                # replacing block.forward).
+                wrapped.__isolated_for__ = id(block)
+                block.forward = wrapped.__get__(block)
+
         model = model_spec.parallelize_fn(
             model,
             parallel_dims=self.parallel_dims,
             parallelism=config.parallelism,
             compile_config=config.compile,
         )
+
+        if isolate_code_objects:
+            for block in model.layers.values():  # pyrefly: ignore [not-callable]
+                marker = getattr(block.forward.__func__, "__isolated_for__", None)
+                if marker != id(block):
+                    raise RuntimeError(
+                        "isolate_code_objects was undone by parallelize_fn — "
+                        "the ref model will share a dynamo cache with the "
+                        "policy and recompile under grad_mode changes."
+                    )
 
         model.to_empty(device=device_type)
         with torch.no_grad():
@@ -282,19 +316,19 @@ class PolicyTrainer(Actor, Configurable):
         Returns:
             dict: Training metrics (loss, policy version, etc.).
         """
-        # The policy and ref models share code objects, so dynamo's
-        # per-code-object cache must hold entries for both grad modes
-        # (grad for policy, no_grad for ref). The default limit of
-        # is not enough; 16 accommodates both without recompile storms.
-        # TODO: @Lucaskabela fix recompiles in general as these increase startup
-        torch._dynamo.config.recompile_limit = 16
-
         logger.debug(
             f"{os.getpid()=} PolicyTrainer starting step {self.policy_version} "
         )
-
         local_batch = train_data[self.dp_rank]
         device = self.device
+        # TP collectives cause one expected recompile per code object: layer 0
+        # receives a plain DTensor from embeddings, but layers 1+ receive a
+        # DTensor with AsyncCollectiveTensor from the prior layer's collective.
+        # After step 0 both variants are cached; lock down to catch regressions.
+        # NOTE: torch._dynamo.config is process-global; this is safe because
+        # the trainer and generator run in separate monarch actor processes.
+        if self.policy_version > 0:
+            torch._dynamo.config.recompile_limit = 1
 
         token_ids = local_batch.token_ids.to(device)
         seq_lens = local_batch.seq_lens

--- a/torchtitan/experiments/rl/actors/utils.py
+++ b/torchtitan/experiments/rl/actors/utils.py
@@ -19,11 +19,15 @@ def create_varlen_metadata(seq_lens: list[int], device: torch.device) -> VarlenM
     Example:
         seq_lens = [3, 5, 2]
         -> cu_seqs = [0, 3, 8, 10], max_len = 5
+
+    ``max_q``/``max_k`` are wrapped as 0-dim tensors (rather than Python ints)
+    so that dynamo does not specialize on the exact value, which would force a
+    recompile every time the longest rollout length changes in RL.
     """
     cu_seqs = torch.tensor(
         [0] + list(itertools.accumulate(seq_lens)), dtype=torch.int32, device=device
     )
-    max_len = max(seq_lens)
+    max_len = torch.tensor(max(seq_lens), dtype=torch.int32, device=device)
     return VarlenMetadata(
         cu_seq_q=cu_seqs, cu_seq_k=cu_seqs, max_q=max_len, max_k=max_len
     )

--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -11,6 +11,7 @@
 
 import logging
 
+import torch
 import torch.nn as nn
 
 from torch.distributed.device_mesh import DeviceMesh
@@ -30,6 +31,39 @@ from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.tensor_parallel import NoParallel
 
 logger = logging.getLogger(__name__)
+
+
+def _make_dynamic_seq_len_forward(model: nn.Module) -> None:
+    """Override ``model.forward`` to mark the seq_len dimension (dim 1) as
+    dynamic on the hidden states and positions before each compiled layer call.
+
+    ``mark_dynamic`` is ``forbid_in_graph``, so it must run in eager code.
+    The Decoder forward loop is eager (only individual blocks are compiled),
+    so inserting the calls here keeps them outside the compiled region.
+
+    NOTE: the body mirrors ``Decoder.forward`` in
+    ``torchtitan/models/common/decoder.py`` — keep in sync if the decoder
+    loop signature or structure changes.
+    """
+
+    def forward(
+        tokens: torch.Tensor,
+        attention_masks=None,
+        positions: torch.Tensor | None = None,
+    ):
+        h = model.tok_embeddings(tokens) if model.tok_embeddings is not None else tokens
+
+        for layer in model.layers.values():
+            torch._dynamo.mark_dynamic(h, 1)
+            if positions is not None:
+                torch._dynamo.mark_dynamic(positions, 1)
+            h = layer(h, model.freqs_cis, attention_masks, positions)
+
+        h = model.norm(h) if model.norm is not None else h
+        output = model.output(h) if model.output is not None else h
+        return output
+
+    model.forward = forward
 
 
 def parallelize_qwen3(
@@ -72,7 +106,39 @@ def parallelize_qwen3(
         and compile_config.enable
         and "model" in compile_config.components
     ):
+        if parallel_dims.tp_enabled:
+            # Eagerly init local_map on inner_attention so dynamo never sees
+            # the _local_map_fn=None lazy-init branch (avoids a recompile).
+            # Derive qkv placements from the parallelized wq weight:
+            # ColwiseParallel shards the output-features dim (weight dim 0).
+            # After attention reshape [bs, seq, n_heads, head_dim], the sharded
+            # output features map to the n_heads dim (index 2).
+            first_block = next(
+                iter(model.layers.values())
+            )  # pyrefly: ignore [not-callable]
+            qkv_placements = tuple(
+                Shard(2) if isinstance(p, Shard) else p
+                for p in first_block.attention.wq.weight.placements
+            )
+            # Assert uniform TP plan across blocks; qkv_placements is derived
+            # once from block 0 and reused for all blocks, so divergence would
+            # silently produce wrong placements.
+            for i, block in enumerate(
+                model.layers.values()
+            ):  # pyrefly: ignore [not-callable]
+                block_placements = block.attention.wq.weight.placements
+                if block_placements != first_block.attention.wq.weight.placements:
+                    raise ValueError(
+                        f"parallelize_qwen3 requires uniform TP placements across "
+                        f"blocks, but block {i} has wq.weight.placements="
+                        f"{block_placements!r} vs block 0's "
+                        f"{first_block.attention.wq.weight.placements!r}"
+                    )
+                block.attention.inner_attention.init_local_map(qkv_placements, tp_mesh)
         apply_compile(model, compile_config)
+        # Override forward to mark seq_len dim as dynamic before each
+        # compiled layer call, avoiding per-episode recompiles.
+        _make_dynamic_seq_len_forward(model)
 
     return model
 

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -204,8 +204,9 @@ def _build_padded_varlen_metadata(batch_size, max_len, device):
     cu_seqs = torch.arange(
         0, (batch_size + 1) * max_len, max_len, dtype=torch.int32, device=device
     )
+    max_len_t = torch.tensor(max_len, dtype=torch.int32, device=device)
     return VarlenMetadata(
-        cu_seq_q=cu_seqs, cu_seq_k=cu_seqs, max_q=max_len, max_k=max_len
+        cu_seq_q=cu_seqs, cu_seq_k=cu_seqs, max_q=max_len_t, max_k=max_len_t
     )
 
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -10,6 +10,7 @@ from typing import ClassVar, NamedTuple
 
 import torch
 import torch.nn.functional as F
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor, Shard
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention import (
@@ -60,12 +61,17 @@ class VarlenMetadata(NamedTuple):
     """
     Cumulative sequence positions for queries and keys/values.
 
+    ``max_q``/``max_k`` are 0-dim int32 tensors (not Python ints) so that dynamo
+    does not specialize on their exact value. Inside the compiled region they
+    are converted to unbacked SymInts via ``.item()`` before being passed to
+    the varlen attention op, avoiding per-seq-length recompiles in RL-style
+    workloads where the longest sequence varies each step.
     """
 
     cu_seq_q: torch.Tensor
     cu_seq_k: torch.Tensor
-    max_q: int
-    max_k: int
+    max_q: torch.Tensor
+    max_k: torch.Tensor
 
 
 AttentionMasksType = dict[str, BlockMask] | BlockMask | VarlenMetadata
@@ -90,6 +96,36 @@ class LocalMapInnerAttention(Module):
     def __init__(self, config: Config) -> None:
         super().__init__()
         self._local_map_fn: Callable | None = None
+
+    def init_local_map(
+        self,
+        placements: tuple,
+        device_mesh: DeviceMesh,
+        return_lse: bool = False,
+    ) -> None:
+        """Eagerly initialize ``_local_map_fn`` so that ``__call__`` never
+        takes the lazy-init branch.  Call this after TP is applied and before
+        ``torch.compile`` so dynamo never sees ``_local_map_fn is None``,
+        eliminating the resulting recompile.
+
+        All entries in *placements* must be ``Shard``; this mirrors the
+        assertion in ``__call__``.  Callers that use ``return_lse=True``
+        (e.g. GPT-OSS attention sinks) must pass it here so that
+        ``out_placements`` has the correct arity.
+        """
+        for p in placements:
+            if not isinstance(p, Shard):
+                raise ValueError(
+                    f"init_local_map requires all Shard placements, got {placements}"
+                )
+        out_placements = (placements, placements) if return_lse else (placements,)
+        self._local_map_fn = local_map(
+            super().__call__,
+            in_placements=(placements, placements, placements),
+            out_placements=out_placements,
+            in_grad_placements=(placements, placements, placements),
+            device_mesh=device_mesh,
+        )
 
     def __call__(
         self,
@@ -124,18 +160,24 @@ class LocalMapInnerAttention(Module):
                 f"All Shard placements must shard on the same dim, "
                 f"but got dims {shard_dims}"
             )
-            # return_lse=True (e.g. gpt_oss attention sinks) produces
-            # 2 outputs instead of 1, requiring different out_placements.
-            return_lse = kwargs.get("return_lse", False)
-            out_placements = (
-                (q.placements, q.placements) if return_lse else (q.placements,)
-            )
             if self._local_map_fn is None:
+                # Fallback lazy init for callers that didn't call
+                # init_local_map (e.g. non-compiled paths).
+                # return_lse=True (e.g. gpt_oss attention sinks) produces
+                # 2 outputs instead of 1, requiring different out_placements.
+                return_lse = kwargs.get("return_lse", False)
+                out_placements = (
+                    (q.placements, q.placements) if return_lse else (q.placements,)
+                )
                 self._local_map_fn = local_map(
                     super().__call__,
                     in_placements=(q.placements, k.placements, v.placements),
                     out_placements=out_placements,
-                    in_grad_placements=(q.placements, k.placements, v.placements),
+                    in_grad_placements=(
+                        q.placements,
+                        k.placements,
+                        v.placements,
+                    ),
                     device_mesh=q.device_mesh,
                 )
             # pyrefly: ignore [bad-argument-count]
@@ -184,8 +226,12 @@ class VarlenAttention(LocalMapInnerAttention):
 
         cu_seq_q = attention_masks.cu_seq_q
         cu_seq_k = attention_masks.cu_seq_k
-        max_q = attention_masks.max_q
-        max_k = attention_masks.max_k
+        # ``.item()`` on a 0-dim tensor under ``capture_scalar_outputs=True``
+        # yields an unbacked SymInt inside torch.compile, so dynamo does not
+        # install an equality guard on the value. The underlying custom op
+        # ``torch.ops.torch_attn._varlen_attn`` accepts SymInt for these args.
+        max_q = attention_masks.max_q.item()
+        max_k = attention_masks.max_k.item()
 
         batch_size, seq_len, _, head_dim = xq.shape
 
@@ -502,7 +548,6 @@ def create_varlen_metadata_for_document(
     device = input_batch.device
     cu_seqlens_list, all_seq_lengths = [], []
     offset = 0
-    max_seqlen = 0
 
     for b in range(batch_size):
         tokens = input_batch[b]
@@ -528,12 +573,14 @@ def create_varlen_metadata_for_document(
         cu_seqlens_list + [torch.tensor([offset], dtype=torch.int32, device=device)]
     )
 
-    max_seqlen: int = 0
     if len(all_seq_lengths) > 0:
         all_seq_lengths = torch.cat(all_seq_lengths)
-        # device to host sync but only done once per model forward
-        # pyrefly: ignore[bad-assignment]
-        max_seqlen = all_seq_lengths.max().item()
+        # Keep as a 0-dim tensor (no ``.item()`` sync): ``VarlenAttention``
+        # unwraps via ``.item()`` inside the compiled region, which produces
+        # an unbacked SymInt rather than a value-specialized int.
+        max_seqlen = all_seq_lengths.max()
+    else:
+        max_seqlen = torch.zeros((), dtype=torch.int32, device=device)
 
     return VarlenMetadata(
         cu_seq_q=packed_cu_seqlens,


### PR DESCRIPTION
## Summary


We make the following changes:

*torchtitan/models/common/attention.py*

 - VarlenMetadata: max_q/max_k changed from int → 0-dim torch.Tensor. Prevents dynamo from specializing on the exact value so per-rollout seq-length changes don't recompile.
  - VarlenAttention.forward: .item() the tensors to yield unbacked SymInts (works because capture_scalar_outputs=True is set in apply_compile).
  - create_varlen_metadata_for_document: stops calling .item() on the d2h-synced max; returns a 0-dim tensor.
  - LocalMapInnerAttention.init_local_map: new method to eagerly initialize _local_map_fn so dynamo never sees the None → callable transition.

*torchtitan/experiments/rl/models/parallelize.py*

  - _make_dynamic_seq_len_forward: overrides model.forward to mark_dynamic(h, 1) and mark_dynamic(positions, 1) before each compiled block call. Keeps the mark outside the compiled region (required since mark_dynamic is                
  forbid_in_graph).
  - parallelize_qwen3: after TP is applied but before apply_compile, calls init_local_map on each block's inner attention with placements derived from the parallelized wq weight.

*torchtitan/experiments/rl/actors/trainer.py*

  - Removed the old cache_size_limit = 16 and recompile_limit = 16 bandaids.
  - _build_model gains an isolate_code_objects flag; ref model gets its own per-block forward code objects so its cache doesn't fight the policy's under recompile_limit=1.
  - After step 0, locks recompile_limit = 1 as a regression guard (one expected recompile: the AsyncCollectiveTensor vs plain-tensor split between layer 0 and layers 1+).
                                                                                                                                                                                                                                           *torchtitan/experiments/rl/actors/utils.py*

  - create_varlen_metadata: wraps max(seq_lens) as a 0-dim int32 tensor on device (matches new VarlenMetadata contract).                                                                                                                   
   
*torchtitan/experiments/rl/tests/test_bitwise_parity.py*

  - _build_padded_varlen_metadata: same wrapping for the test helper.                                                                                                                                                                      
   
## Net effect                                                                                                                                                                                                                               

From 9+ recompiles (grad-mode splits + AsyncCollectiveTensor + lazy _local_map_fn + seq-len shape + varying max_k) down to 1 expected recompile (the AsyncCollectiveTensor between layer-0 and layer-1+), locked down after step 0. 

## Testplan

```bash
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --hf_assets_path=torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B
```

Results in 
```
[__recompiles]     - 1/0: ___check_type_id(x._local_tensor, 140561999080752), type=<class 'torch.distributed._functional_collectives.AsyncCollectiveTensor'>  # return inner()  # nn/modules/module.py:1881 in _call_impl (HINT: type AsyncCollectiveTensor)
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     - User stack trace:
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -   File "/home/lucaskabela/torchtitan/torchtitan/models/qwen3/model.py", line 65, in forward
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -     self.attention_norm(x), freqs_cis, attention_masks, positions
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -   File "/home/lucaskabela/pytorch/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -     return self._call_impl(*args, **kwargs)
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -   File "/home/lucaskabela/pytorch/torch/nn/modules/module.py", line 1881, in _call_impl
[rank0]:V0403 13:52:56.045000 788326 /home/lucaskabela/pytorch/torch/_dynamo/guards.py:5142] [1/1] [__recompiles]     -     return inner()
...
[actor=<root>] Step  9 | Loss: +0.9693 | Reward: +0.350 | Correct: 27/40 | Avg tokens: 100 | Logprob diff: mean=-1.0396e-01, max=1.0704e+01 | Time: 16.3s
[actor=<root>] RL Training complete
[actor=<root>] Evaluating post-training performance...
[actor=<root>] Eval: Accuracy=65% (13/20) Format=90% (18/20)
[actor=<root>] ================================================================================
[actor=<root>] Pre-training:  Accuracy=40% (8/20) Format=50% (10/20)
[actor=<root>] Post-training: Accuracy=65% (13/20) Format=90% (18/20)
[actor=<root>] ================================================================================
```

TIMING RESULTS:

| | Baseline | This PR | Delta |
  |---|---|---|---|
  | **Step 0 (warmup)** | 35.3s | 28.7s | **-6.6s (-19%)** |                                                                                                                                   
  | — ref | 11.8s | 8.3s | -3.5s |
  | — policy | 17.7s | 14.7s | -3.0s |                                                                                                                                                         
  | — backward | 2.7s | 2.6s | -0.1s |                            
  | **Avg step 1–9** | 9.3s | 9.2s | ~same |                                                                                                                                                   
  | **E2E** | 119.1s | 112.0s | **-7.1s (-6%)** |                 
                                                    