### PR TITLE
[graph_trainer] Fix precompile unittest

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -210,17 +210,14 @@ class TestPrecompileSaveLoad(unittest.TestCase):
                     model,
                     compiled_fn,
                     storage,
-                    "test_key",
                     out_spec=None,
                     config_fingerprint="abc123",
                 )
 
-            self.assertTrue(storage.exists("test_key"))
+            self.assertTrue(storage.exists("default"))
 
             # Load should succeed with matching model
-            wrapper = precompile_load(
-                model, storage, "test_key", expected_fingerprint="abc123"
-            )
+            wrapper = precompile_load(model, storage, expected_fingerprint="abc123")
             self.assertTrue(callable(wrapper))
 
     def test_load_param_mismatch(self):
@@ -237,13 +234,13 @@ class TestPrecompileSaveLoad(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
-            storage.save("key", pickle.dumps(artifact))
+            storage.save("default", pickle.dumps(artifact))
 
             # Model with different params should fail
             model = torch.nn.Linear(8, 8)
             model.extra = torch.nn.Parameter(torch.zeros(1))
             with self.assertRaisesRegex(ValueError, "Parameter mismatch"):
-                precompile_load(model, storage, "key", expected_fingerprint="")
+                precompile_load(model, storage, expected_fingerprint="")
 
     def test_load_buffer_mismatch(self):
         from torchtitan.experiments.graph_trainer.precompile import (
@@ -259,12 +256,12 @@ class TestPrecompileSaveLoad(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
-            storage.save("key", pickle.dumps(artifact))
+            storage.save("default", pickle.dumps(artifact))
 
             # nn.Linear has no buffers, so buffers_spec won't match
             model = torch.nn.Linear(4, 4)
             with self.assertRaisesRegex(ValueError, "Buffer mismatch"):
-                precompile_load(model, storage, "key", expected_fingerprint="")
+                precompile_load(model, storage, expected_fingerprint="")
 
     def test_load_fingerprint_mismatch(self):
         from torchtitan.experiments.graph_trainer.precompile import (
@@ -282,12 +279,10 @@ class TestPrecompileSaveLoad(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
-            storage.save("key", pickle.dumps(artifact))
+            storage.save("default", pickle.dumps(artifact))
 
             with self.assertRaisesRegex(ValueError, "fingerprint mismatch"):
-                precompile_load(
-                    model, storage, "key", expected_fingerprint="new_fingerprint"
-                )
+                precompile_load(model, storage, expected_fingerprint="new_fingerprint")
 
     def test_load_with_out_spec_unflattens(self):
         from torch._dynamo.aot_compile_types import (
@@ -312,7 +307,7 @@ class TestPrecompileSaveLoad(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
-            storage.save("key", pickle.dumps(artifact))
+            storage.save("default", pickle.dumps(artifact))
 
             # Mock deserialize to return a fn that returns flat outputs
             def fake_compiled_fn(*args, **kwargs):
@@ -323,9 +318,7 @@ class TestPrecompileSaveLoad(unittest.TestCase):
                 "deserialize_compile_artifacts",
                 return_value=fake_compiled_fn,
             ):
-                wrapper = precompile_load(
-                    model, storage, "key", expected_fingerprint=""
-                )
+                wrapper = precompile_load(model, storage, expected_fingerprint="")
                 result = wrapper((), {})
 
             self.assertIsInstance(result, dict)
@@ -350,10 +343,10 @@ class TestPrecompileSaveLoad(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
-            storage.save("key", pickle.dumps(artifact))
+            storage.save("default", pickle.dumps(artifact))
 
             with self.assertLogs(level="WARNING") as cm:
-                precompile_load(model, storage, "key", expected_fingerprint="some_fp")
+                precompile_load(model, storage, expected_fingerprint="some_fp")
             self.assertTrue(any("legacy artifact" in msg for msg in cm.output))
 
 
@@ -375,7 +368,6 @@ class TestPrecompileSaveValidation(unittest.TestCase):
                     model,
                     not_serializable,
                     storage,
-                    "test_key",
                     out_spec=None,
                 )
 


### PR DESCRIPTION
Update `test_precompile.py` to align with the API changes from #2713 (CooR precompile support), which removed the explicit key parameter from `precompile_save` and `precompile_load`

``` 
pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py 
```