### PR TITLE
Integration tests always run all tests instead of exiting on the first failure

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -73,7 +73,6 @@ jobs:
         pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"
 
         # Run precompile unit tests
-        # TODO: Currently failing, re-enable once fixed.
-        # pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
 
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -65,4 +65,5 @@ jobs:
 
         # Run the DeepSeek numerics tests
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "dsv3"
+
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -25,7 +25,7 @@ _TEST_SUITES_FUNCTION = {
 
 
 def _run_cmd(cmd):
-    return subprocess.run([cmd], text=True, shell=True)
+    return subprocess.run([cmd], text=True, shell=True, capture_output=True)
 
 
 def run_single_test(
@@ -68,10 +68,13 @@ def run_single_test(
             )
 
         result = _run_cmd(cmd)
-        logger.info(result.stdout)
+        if result.stdout:
+            logger.info(result.stdout)
         if result.returncode != 0:
-            raise Exception(
-                f"Integration test failed, flavor : {test_flavor.test_descr}, command : {cmd}"
+            raise RuntimeError(
+                f"\nFailed test flavor: {test_flavor.test_descr}.\n"
+                f"Command: {cmd}\n"
+                f"stderr: {result.stderr}\n"
             )
 
 
@@ -83,6 +86,7 @@ def run_tests(args, test_list: list[OverrideDefinitions], module=None, config=No
         exclude_set = {name.strip() for name in args.exclude.split(",")}
 
     ran_any_test = False
+    failed_tests: list[tuple[str, str]] = []
     for test_flavor in test_list:
         # Filter by test_name if specified
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
@@ -105,8 +109,20 @@ def run_tests(args, test_list: list[OverrideDefinitions], module=None, config=No
                 f" because --ngpu arg is {args.ngpu}"
             )
         else:
-            run_single_test(test_flavor, args.output_dir, module, config)
+            try:
+                run_single_test(test_flavor, args.output_dir, module, config)
+            except Exception as e:
+                logger.error(str(e))
+                failed_tests.append((test_flavor.test_name, str(e)))
             ran_any_test = True
+
+    if failed_tests:
+        failure_summary = "\n".join(
+            f"  {name}: {error}" for name, error in failed_tests
+        )
+        raise RuntimeError(
+            f"{len(failed_tests)} integration test(s) failed:\n{failure_summary}"
+        )
 
     if not ran_any_test:
         available_tests = [t.test_name for t in test_list if not t.disabled]


### PR DESCRIPTION
  - Integration tests now always run all tests to completion instead of exiting on the first failure
  - Failed tests are logged immediately and a summary of all failures with error messages is reported at the end
  - The process still exits with a non-zero code when any test fails
