### PR TITLE
repro `Unsupported inductor graph input type: <class 'sympy.core.relational.Equality'>.` for per-layer compile

### DIFF
--- a/tests/unit_tests/test_compile_moe.py
+++ b/tests/unit_tests/test_compile_moe.py
@@ -9,7 +9,7 @@ import unittest
 import torch
 
 from torchtitan.config import CompileConfig
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
@@ -47,12 +47,13 @@ class TestApplyCompile(unittest.TestCase):
         Calls apply_compile multiple times, as in the case with PP.
         But patches should only happen once
         """
-        unused_model1 = TinyModel(num_layers=2, dim=128)
-        unused_model2 = TinyModel(num_layers=2, dim=128)
         compile_config = CompileConfig(backend="eager")
 
-        apply_compile_sparse(unused_model1, compile_config, ep_enabled=True)
-        apply_compile_sparse(unused_model2, compile_config, ep_enabled=True)
+        model1 = TinyModel(num_layers=2, dim=128)
+        model2 = TinyModel(num_layers=2, dim=128)
+
+        apply_compile(model1, compile_config)
+        apply_compile(model2, compile_config)
 
         from torchtitan.models.common import moe as moe_module
 
@@ -74,9 +75,7 @@ class TestApplyCompile(unittest.TestCase):
             w1, w2, w3, x, num_tokens_per_expert
         )
 
-        print(f"Input shape: {x.shape}")
-        print(f"Output shape: {output.shape}")
-        print(f"Num tokens per expert: {num_tokens_per_expert}")
+        self.assertEqual(output.shape, x.shape)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -7,12 +7,8 @@
 import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    CheckpointWrapper,
-)
 
 from torchtitan.config import CompileConfig
-from torchtitan.models.common import moe as moe_module
 from torchtitan.tools.logging import logger
 
 
@@ -24,43 +20,13 @@ FakeTensorMode.__init__ = torch.compiler.disable(  # type: ignore[method-assign]
 )
 
 
-def apply_compile_dense(model: nn.Module, compile_config: CompileConfig) -> None:
+def apply_compile(model: nn.Module, compile_config: CompileConfig) -> None:
     """
     Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
     repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for dense (non-MoE) models. It compiles each TransformerBlock as a whole.
     """
-    # Skip replaying forward side effects (e.g. RoPE cache updates) during
-    # the AC recompute in backward. Eager AC replays the forward python
-    # side-effects in backward, but torch.compile has no easy way to reapply
-    # python mutations in the backward. Setting this flag accepts this eager
-    # and compile divergence by skipping reapplication of side effects.
-    torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = (
-        True  # pyrefly: ignore [bad-assignment]
-    )
-
-    # pyrefly: ignore [missing-attribute]
-    for layer_id, transformer_block in model.layers.named_children():
-        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    logger.info("Compiling each TransformerBlock with torch.compile")
-
-
-def apply_compile_sparse(
-    model: nn.Module, compile_config: CompileConfig, ep_enabled: bool
-) -> None:
-    """
-    Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
-    repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for MoE (sparse) models. It compiles sub-modules individually to avoid
-    graph breaks from FSDP(GroupedExperts).
-    """
-    # Needed for torch.compile to avoid graph breaking on dynamic shapes in
-    # token-choice MoE, but it is experimental.
+    # Needed for torch.compile to handle data-dependent dynamic shapes in
+    # token-choice MoE dispatch. Harmless for dense models.
     torch._dynamo.config.capture_scalar_outputs = True
     # Skip replaying forward side effects (e.g. RoPE cache updates) during
     # the AC recompute in backward. Eager AC replays the forward python
@@ -73,77 +39,6 @@ def apply_compile_sparse(
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
-        if transformer_block.moe_enabled:
-            # If it is a MoE layer, FSDP(GroupedExperts) will cause a graph break
-            # So we must weave compile wrappers around those FSDP hooks to
-            # prevent AC from falling back the whole graph to eager.
-            # TODO: Fix Compile(AC(graph break))
-
-            if isinstance(transformer_block, CheckpointWrapper):
-                # TODO: Make CheckpointWrapper a transparent wrapper
-                # unwrap so that .named_children() works
-                block = transformer_block._checkpoint_wrapped_module
-            else:
-                block = transformer_block
-
-            for attr_name, submod in block.named_children():
-                assert getattr(block, attr_name) == getattr(
-                    transformer_block, attr_name
-                )
-
-                if isinstance(submod, moe_module.MoE):
-                    # avoid graph breaking on the GroupedExperts' FSDP hooks
-                    # by wrapping each submod's forward instead of their __call__
-                    moe = submod
-                    for attr_name, submod in moe.named_children():
-                        if attr_name == "experts":
-                            # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
-                            # https://github.com/pytorch/torchtitan/issues/1940
-                            continue
-                        submod.compile(backend=compile_config.backend, fullgraph=True)
-                else:
-                    submod.compile(backend=compile_config.backend, fullgraph=True)
-        else:
-            # If it's not a MoE layer, there is no FSDP(GroupedExperts)
-            # So we can compile the whole block
-            transformer_block.compile(
-                backend=compile_config.backend,
-                fullgraph=True,
-            )
-
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    # Patch some globals only once (apply_compile_sparse is called multiple times for PP setup)
-    already_patched = (
-        "_run_experts_grouped_mm_dynamic"
-        in moe_module._run_experts_grouped_mm.__qualname__
-    )
-    if not already_patched:
-        moe_module._run_experts_grouped_mm = torch.compile(
-            moe_module._run_experts_grouped_mm,
-            backend=compile_config.backend,
-            fullgraph=True,
-        )
-
-        if ep_enabled:
-            compiled_fn = moe_module._run_experts_grouped_mm
-
-            # keep function logic in sync with `already_patched` above
-            def _run_experts_grouped_mm_dynamic(
-                w1: torch.Tensor,
-                w2: torch.Tensor,
-                w3: torch.Tensor,
-                x: torch.Tensor,
-                num_tokens_per_expert: torch.Tensor,
-            ) -> torch.Tensor:
-                # dynamic number of tokens in expert parallel
-                torch._dynamo.mark_dynamic(x, 0)
-                return compiled_fn(w1, w2, w3, x, num_tokens_per_expert)
-
-            moe_module._run_experts_grouped_mm = _run_experts_grouped_mm_dynamic
-
-    # NOTE: We don't compile for loop code path due to an issue with unbacked symints:
-    # https://github.com/pytorch/pytorch/issues/166460
+        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
 
     logger.info("Compiling each TransformerBlock with torch.compile")

--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -37,10 +37,10 @@ def _generate_permute_indices(
     Output layout: (e0,r0), (e0,r1), ..., (e1,r0), (e1,r1), ...  (expert-major)
     """
     device = tokens_per_expert_group.device
-    total = tokens_per_expert_group.sum()
 
     # [R, E] matrix of token counts per (rank, expert)
     t_mat = tokens_per_expert_group.view(num_ranks, experts_per_rank)
+    num_tokens_per_expert = t_mat.sum(0)
 
     # Where each (r, e) segment starts in the input (rank-major order)
     input_starts = (tokens_per_expert_group.cumsum(0) - tokens_per_expert_group).view(
@@ -57,13 +57,16 @@ def _generate_permute_indices(
         segment_lens
     )
     output_starts = segment_lens.cumsum(0) - segment_lens
+    # seg_ids.shape[0] == segment_lens.sum(), but reuses the unbacked symint
+    # already created by repeat_interleave. Computing the sum separately would
+    # introduce a second symint for the same value, producing an Eq(u1, u2)
+    # constraint that inductor cannot lower.
     permuted_indices = (
         input_starts[seg_ids]
-        + torch.arange(total, device=device)  # pyrefly: ignore [no-matching-overload]
+        + torch.arange(seg_ids.shape[0], device=device)
         - output_starts[seg_ids]
     )
 
-    num_tokens_per_expert = t_mat.sum(0)
     return permuted_indices, num_tokens_per_expert
 
 

--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor.parallel import (
 from torchtitan.config import ParallelismConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.tensor_parallel import NoParallel
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ def parallelize_qwen3(
         and compile_config.enable
         and "model" in compile_config.components
     ):
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     return model
 

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -27,7 +27,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.llama3.parallelize import (
@@ -96,7 +96,7 @@ def parallelize_hf_transformers(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     if parallel_dims.fsdp_enabled:
         # apply FSDP or HSDP, potentially with Context Parallel

--- a/torchtitan/experiments/vlm/infra/parallelize.py
+++ b/torchtitan/experiments/vlm/infra/parallelize.py
@@ -20,7 +20,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.models.llama3.parallelize import (
     apply_replicate,
@@ -78,8 +78,8 @@ def parallelize_vlm(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if compile_config.enable:
-        apply_compile_dense(model, compile_config)
-        apply_compile_dense(model.encoder, compile_config)
+        apply_compile(model, compile_config)
+        apply_compile(model.encoder, compile_config)
 
     if parallel_dims.fsdp_enabled:
         # apply FSDP or HSDP, potentially with Context Parallel

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -29,10 +29,17 @@ def _run_experts_for_loop(
     # NOTE: this would incur a synchronization between device and host
     num_tokens_per_expert_list = num_tokens_per_expert.tolist()
 
+    total_tokens = sum(num_tokens_per_expert_list)
+    # Use two inequality checks to assert total_tokens == x.shape[0].
+    # torch._check(==) produces a sympy.Equality which inductor can't handle,
+    # but <= and >= together imply equality via sympy.Expr inequalities.
+    torch._check(x.shape[0] >= total_tokens)
+    torch._check(x.shape[0] <= total_tokens)
+
     # a tuple of tensors indexed by experts
     # each with shape (tokens_per_expert(varying), dim)
     x_splits = torch.split(
-        x[: sum(num_tokens_per_expert_list)],
+        x,
         split_size_or_sections=num_tokens_per_expert_list,
         dim=0,
     )

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -29,13 +29,6 @@ def _run_experts_for_loop(
     # NOTE: this would incur a synchronization between device and host
     num_tokens_per_expert_list = num_tokens_per_expert.tolist()
 
-    total_tokens = sum(num_tokens_per_expert_list)
-    # Use two inequality checks to assert total_tokens == x.shape[0].
-    # torch._check(==) produces a sympy.Equality which inductor can't handle,
-    # but <= and >= together imply equality via sympy.Expr inequalities.
-    torch._check(x.shape[0] >= total_tokens)
-    torch._check(x.shape[0] <= total_tokens)
-
     # a tuple of tensors indexed by experts
     # each with shape (tokens_per_expert(varying), dim)
     x_splits = torch.split(

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -25,7 +25,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
@@ -135,7 +135,7 @@ def parallelize_deepseekv3(
         )
 
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh: DeviceMesh | None = None
     if parallel_dims.fsdp_enabled or parallel_dims.ep_enabled:

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -28,7 +28,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     ExpertParallel,
@@ -125,7 +125,7 @@ def parallelize_gptoss(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh: DeviceMesh | None = None
     if parallel_dims.fsdp_enabled or parallel_dims.ep_enabled:

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -32,7 +32,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
@@ -116,7 +116,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     if parallel_dims.fsdp_enabled:
         # dp_mesh is the mesh for FSDP/HSDP

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -34,7 +34,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     DeepEPExpertParallel,
@@ -163,7 +163,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     if parallel_dims.fsdp_enabled or parallel_dims.ep_enabled:
         # dp_mesh is the mesh for FSDP/HSDP

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -31,7 +31,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import NoParallel
 from torchtitan.models.llama3.parallelize import apply_replicate
@@ -122,7 +122,7 @@ def parallelize_qwen3(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     if parallel_dims.fsdp_enabled:
         # apply FSDP or HSDP, potentially with Context Parallel


### PR DESCRIPTION
repro: `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh --compile.enable --compile.components model,loss --parallelism.expert_parallel_degree 4`

inductor error on `AssertionError: Unsupported inductor graph input type: <class
  'sympy.core.relational.Equality'>`

```
    File "/data/users/weif/code-review/pytorch/torch/_functorch/_aot_autograd/schemas.py", line 1416, in
  __call__
        output_code = self.compiler_fn(gm, example_inputs)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_dynamo/backends/common.py", line 83, in
  _wrapped_bw_compiler
        disable(
      File "/data/users/weif/code-review/pytorch/torch/_dynamo/eval_frame.py", line 1272, in _fn
        return fn(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_utils_internal.py", line 96, in wrapper_function
        return function(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 2857, in bw_compiler
        return compile_fx_backward(
               ^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 2532, in
  compile_fx_backward
        return inner_compile(
               ^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 826, in compile_fx_inner
        return wrap_compiler_debug(_compile_fx_inner, compiler_name="inductor")(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_dynamo/repro/after_aot.py", line 309, in debug_wrapper
        inner_compiled_fn = compiler_fn(gm, example_inputs)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 1026, in _compile_fx_inner
        raise InductorError(e, currentframe()).with_traceback(
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 1022, in _compile_fx_inner
        mb_compiled_graph = fx_codegen_and_compile(
                            ^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 1802, in
  fx_codegen_and_compile
        return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/compile_fx.py", line 1489, in
  codegen_and_compile
        graph.run(*example_inputs)
      File "/data/users/weif/code-review/pytorch/torch/_inductor/graph.py", line 1050, in run
        return super().run(*args)
               ^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/fx/interpreter.py", line 200, in run
        self.env[node] = self.run_node(node)
                         ^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/graph.py", line 1895, in run_node
        result = super().run_node(n)
                 ^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/fx/interpreter.py", line 297, in run_node
        return getattr(self, n.op)(n.target, args, kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/data/users/weif/code-review/pytorch/torch/_inductor/graph.py", line 1621, in output
        assert isinstance(value, TensorBox), (
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    torch._inductor.exc.InductorError: AssertionError: Unsupported inductor graph input type: <class
  'sympy.core.relational.Equality'>
```

claude annotated error
```
Root Cause (rank 4):
    trainer.py:850  → train_step
    trainer.py:760  → forward_backward_step
    trainer.py:718  → loss.backward()
    autograd/graph.py:882  → _engine_run_backward
    autograd/function.py:317  → CompiledFunction.apply
    runtime_wrappers.py:2871  → backward impl_fn()
    runtime_wrappers.py:2911  → backward_compiler.get_or_compile (lazy bw compile)
    runtime_wrappers.py:2669  → aot_config.bw_compiler
    compile_fx.py:2857  → compile_fx_backward
    compile_fx.py:1026  → _compile_fx_inner
    compile_fx.py:1802  → fx_codegen_and_compile → codegen_and_compile
    compile_fx.py:1489  → graph.run(*example_inputs)
    graph.py:1050   → super().run(*args)
    fx/interpreter.py:200  → run_node
    graph.py:1895   → super().run_node(n)
    graph.py:1621   → assert isinstance(value, TensorBox)

    InductorError: Unsupported inductor graph input type: <class 'sympy.core.relational.Equality'>
```

