### PR TITLE
ft: add support for MCCL and docs updates

### DIFF
--- a/torchtitan/experiments/ft/manager.py
+++ b/torchtitan/experiments/ft/manager.py
@@ -15,7 +15,6 @@ from typing import cast, TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
-
 import torch.nn as nn
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule
 from torch.distributed.distributed_c10d import ReduceOp
@@ -93,6 +92,18 @@ class FTManager(Configurable):
             pg = ft.ProcessGroupGloo(timeout=process_group_timeout)
         elif config.process_group == "nccl":
             pg = ft.ProcessGroupNCCL(timeout=process_group_timeout)
+        elif config.process_group == "mccl":
+            import torchcomms
+            from torchft.torchcomms import ProcessGroupTorchComms
+
+            comm = torchcomms.new_comm(
+                "mccl",
+                device=torch.device("cuda"),
+                name="mccl_ft",
+                timeout=process_group_timeout,
+                enable_reconfigure=True,
+            )
+            pg = ProcessGroupTorchComms(comm, timeout=process_group_timeout)
         else:
             raise ValueError(f"Unsupported process group: {config.process_group}")
 

--- a/torchtitan/experiments/ft/torchft.md
+++ b/torchtitan/experiments/ft/torchft.md
@@ -36,12 +36,12 @@ RUST_BACKTRACE=1 torchft_lighthouse --min_replicas 1 --quorum_tick_ms 100 --join
 2. Launch the first TorchTitan instance:
 
 ```bash
-NGPU=4 CUDA_VISIBLE_DEVICES=0,1,2,3 TRAIN_FILE=torchtitan.experiments.ft.train MODEL=llama3 CONFIG=llama3_8B ./run_train.sh --fault_tolerance.enable --fault_tolerance.replica_id=0 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=4
+NGPU=4 CUDA_VISIBLE_DEVICES=0,1,2,3 MODULE=ft.llama3 NGPU=4 TRAIN_FILE=torchtitan.experiments.ft.train CONFIG=llama3_ft_debugmodel ./run_train.sh --fault_tolerance.enable --fault_tolerance.replica_id=0 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=4
 ```
 3. Launch the second TorchTitan instance:
 
 ```bash
-NGPU=4 CUDA_VISIBLE_DEVICES=4,5,6,7 TRAIN_FILE=torchtitan.experiments.ft.train MODEL=llama3 CONFIG=llama3_8B ./run_train.sh --fault_tolerance.enable --fault_tolerance.replica_id=1 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=4
+NGPU=4 CUDA_VISIBLE_DEVICES=4,5,6,7 MODULE=ft.llama3 NGPU=4 TRAIN_FILE=torchtitan.experiments.ft.train CONFIG=llama3_ft_debugmodel ./run_train.sh --fault_tolerance.enable --fault_tolerance.replica_id=0 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=4
 ```
 
 ### Explanation


### PR DESCRIPTION
This adds integration for mccl and fixes some doc issues due to staleness.

Test plan:

```
CUDA_VISIBLE_DEVICES=0,1 MODULE=ft.llama3 NGPU=2 TRAIN_FILE=torchtitan.experiments.ft.train CONFIG=llama3_ft_debugmodel ./run_train.sh --fault_tole
rance.enable --fault_tolerance.replica_id=0 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=2 --fault_tolerance.process_group=mccl
CUDA_VISIBLE_DEVICES=2,3 MODULE=ft.llama3 NGPU=2 TRAIN_FILE=torchtitan.experiments.ft.train CONFIG=llama3_ft_debugmodel ./run_train.sh --fault_tole
rance.enable --fault_tolerance.replica_id=0 --fault_tolerance.group_size=2 --parallelism.data_parallel_shard_degree=2 --fault_tolerance.process_group=mccl
```

```
[rank0]:[titan] 2026-04-03 13:00:48,170 - root - INFO - step: 96  loss:  2.81863  grad_norm:  0.2686  memory:  1.00GiB(1.06%)  tps: 152,515  tflops: 10.92  mfu: 1.10%
[rank0]:[titan] 2026-04-03 13:00:48,172 - root - INFO - Staging ft checkpoint took 0.00266792401089333 secs.
[rank0]:[titan] 2026-04-03 13:00:48,267 - root - INFO - step: 97  loss:  2.89489  grad_norm:  0.3341  memory:  1.00GiB(1.06%)  tps: 169,542  tflops: 12.14  mfu: 1.23%
[rank0]:[titan] 2026-04-03 13:00:48,269 - root - INFO - Staging ft checkpoint took 0.0018724950205069035 secs.
[rank0]:[titan] 2026-04-03 13:00:48,383 - root - INFO - step: 98  loss:  2.81167  grad_norm:  0.2529  memory:  1.00GiB(1.06%)  tps: 140,775  tflops: 10.08  mfu: 1.02%
[rank0]:[titan] 2026-04-03 13:00:48,385 - root - INFO - Staging ft checkpoint took 0.0015910789952613413 secs.
[rank0]:[titan] 2026-04-03 13:00:48,484 - root - INFO - step: 99  loss:  2.86018  grad_norm:  0.1774  memory:  1.00GiB(1.06%)  tps: 162,943  tflops: 11.66  mfu: 1.18%
[rank0]:[titan] 2026-04-03 13:00:48,486 - root - INFO - Staging ft checkpoint took 0.0013235869992058724 secs.
[rank0]:[titan] 2026-04-03 13:00:48,513 - root - INFO - [GC] Performing periodic GC collection took 0.03 seconds
[rank0]:2026-04-03T13:00:48.604 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] Start quorum for group_rank 0
[rank0]:2026-04-03T13:00:48.607 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] Start quorum for group_rank 1
[rank0]:2026-04-03T13:00:48.607 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] All workers joined - starting quorum
[rank0]:[titan] 2026-04-03 13:00:48,716 - torchft.local_sgd - INFO - Preparing fragment=1 step=5
[rank0]:[titan] 2026-04-03 13:00:48,725 - torchft.local_sgd - INFO - Syncing fragment=1 step=5 manager_step=19
[rank0]:[titan] 2026-04-03 13:00:48,741 - torchft.manager - INFO - [torchtitan_ft_0:f1f87aa2-dc59-4f23-9b73-2aa45fa12b5e/0 - step 19] should_commit=True enough_replicas=True, errored=None
[rank0]:[titan] 2026-04-03 13:00:48,741 - torchft_commits - INFO - 
[rank0]:[titan] 2026-04-03 13:00:48,751 - root - INFO - step: 100  loss:  2.78191  grad_norm:  0.2701  memory:  1.00GiB(1.06%)  tps: 61,498  tflops: 4.40  mfu: 0.45%
[rank0]:[titan] 2026-04-03 13:00:48,753 - root - INFO - Staging ft checkpoint took 0.001979056018171832 secs.
[rank0]:2026-04-03T13:00:48.715 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] got lighthouse quorum LighthouseQuorumResponse { quorum: Some(Quorum { quorum_id: 4, participants: [QuorumMember { replica_id: "torchtitan_ft_0:01059e66-e76a-4086-ab75-50fe85a7dbb1", address: "http://devvm5553.cco0.facebook.com:43271", store_address: "devvm5553.cco0.facebook.com:35939", step: 19, world_size: 2, shrink_only: false, commit_failures: 0, data: "" }, QuorumMember { replica_id: "torchtitan_ft_0:f1f87aa2-dc59-4f23-9b73-2aa45fa12b5e", address: "http://devvm5553.cco0.facebook.com:47877", store_address: "devvm5553.cco0.facebook.com:38189", step: 19, world_size: 2, shrink_only: false, commit_failures: 0, data: "" }], created: Some(Timestamp { seconds: 1775246448, nanos: 715352445 }) }) }
[rank0]:2026-04-03T13:00:48.715 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] Finished quorum for group_rank 1
[rank0]:2026-04-03T13:00:48.715 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] Finished quorum for group_rank 0
[rank0]:W0403 13:00:48.719015 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.719369 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.719605 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.719830 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.720076 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.720317 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.720548 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.720769 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.720986 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.721239 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.721460 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.721678 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.721892 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.722118 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.722354 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.722557 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.722765 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.722979 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.723237 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.723450 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.723675 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.723895 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.724122 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.724350 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.724565 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.724778 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.724996 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.725230 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:W0403 13:00:48.725441 727535 AllReduce.cc:24] ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline
[rank0]:2026-04-03T13:00:48.740 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] should_commit request from 0 should_commit=true
[rank0]:2026-04-03T13:00:48.741 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] should_commit request from 1 should_commit=true
[rank0]:2026-04-03T13:00:48.741 [INFO] [torchft::manager] - [Replica torchtitan_ft_0] should_commit completed should_commit=true
[rank0]:[titan] 2026-04-03 13:00:49,404 - root - INFO - Dumping profiler traces at step 100
[rank0]:[titan] 2026-04-03 13:00:49,668 - root - INFO - Finished dumping profiler traces in 0.26 seconds
[rank0]:[titan] 2026-04-03 13:00:49,878 - root - INFO - Dumping profiler traces at step 100
[rank0]:[titan] 2026-04-03 13:00:49,881 - root - INFO - Finished dumping profiler traces in 0.00 seconds
[rank0]:[titan] 2026-04-03 13:00:49,881 - root - INFO - Sleeping 2 seconds for other ranks to complete
[rank0]:[titan] 2026-04-03 13:00:51,883 - root - INFO - Training completed
[rank0]:[titan] 2026-04-03 13:00:51,945 - root - INFO - Process group destroyed
[rank0]:I0403 13:00:52.654705 728337 AsyncSocket.cc:159] AsyncServerSocket is shutting down on [2401:db00:22c:1522:face:0:243:0]:45569, fd=116
[rank0]:I0403 13:00:52.654870 727535 IpcRegCache.cc:425] CTRAN-REGCACHE: AsyncSocket server stopped
```