### PR TITLE
[graph_trainer] Add nightly self-improvement scout and first report

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/nightly.md
+++ b/torchtitan/experiments/graph_trainer/.claude/nightly.md
@@ -1,0 +1,294 @@
+# GraphTrainer Nightly Self-Improvement Scout
+
+This prompt is designed to be run nightly by Claude Code. Its purpose is NOT to
+check if things are broken (CI does that). Its purpose is to discover
+**opportunities and risks we haven't acted on yet**.
+
+Run with:
+```bash
+claude -p "$(cat torchtitan/experiments/graph_trainer/.claude/nightly.md)"
+```
+
+---
+
+## 0. Prerequisites
+
+Ensure you are on the torchtitan `main` branch:
+
+```bash
+git checkout main
+```
+
+### 0a. Read Prior Reports
+
+Read all reports from the past 7 days:
+
+```bash
+# List reports from the past 7 days
+find torchtitan/experiments/graph_trainer/reports/ -name "*.md" -mtime -7 | sort
+```
+
+Read each report found. Build a mental summary of:
+
+1. **Open action items** — items flagged in prior reports that have NOT been
+   resolved in the codebase yet (i.e., the underlying code issue still exists).
+   These will be re-investigated in subsequent sections rather than discovered
+   from scratch.
+2. **Previously "all clear" areas** — areas that were stable in prior reports.
+   Give these a lighter check (just verify nothing changed).
+3. **Recurring FYI items** — context items that appeared in multiple reports.
+   Don't re-report these unless the situation has materially changed.
+
+Record the date of the most recent prior report. This becomes the baseline for
+`git log` ranges in Section 1 (use `--since="<last_report_date>"` instead of
+a hardcoded window).
+
+If no prior reports exist, proceed as if this is the first run.
+
+### 0b. Check Prior Self-Improvement Commits
+
+Check what the nightly scout has already attempted to fix:
+
+```bash
+# List local self-improve branches
+git branch --list "graph_trainer/self_improve/*" --sort=-committerdate
+
+# Check commits on each branch from the past 7 days
+for branch in $(git branch --list "graph_trainer/self_improve/*" --sort=-committerdate); do
+    echo "=== $branch ==="
+    git log --oneline --since="7 days ago" "$branch" --grep="self_improve"
+done
+
+# Also check main
+git log --oneline --since="7 days ago" main --grep="self_improve"
+```
+
+Items that were already committed by a prior run should not be re-attempted
+unless the commit was reverted or the fix was incomplete.
+
+---
+
+## 1. Core Torchtitan Delta Review
+
+Check what changed in core torchtitan since the **last report date** (from
+Step 0a) that graph_trainer should know about. Not "did it break us" but "did
+we miss an opportunity or fall behind?" If no prior report exists, use
+`--since="1 day ago"`.
+
+```
+git log --since="<last_report_date>" --oneline -- \
+    torchtitan/trainer.py \
+    torchtitan/config/ \
+    torchtitan/distributed/ \
+    torchtitan/models/common/ \
+    torchtitan/models/llama3/ \
+    torchtitan/models/deepseek_v3/ \
+    torchtitan/protocols/ \
+    torchtitan/components/ \
+    torchtitan/experiments/__init__.py
+```
+
+For each commit found, answer:
+- Does this add a new API that graph_trainer could use instead of its own
+  implementation? (e.g., a new utility in `torchtitan/distributed/` that
+  replaces something graph_trainer hand-rolls)
+- Does this change a signature or field that graph_trainer depends on?
+  Key fragile surfaces:
+  - `Trainer.Config` fields (dict-spread copy in `configs.py:to_graph_trainer_config`)
+  - `Trainer.post_dataloading_process()` return tuple
+  - `CompileConfig` fields (extended by `GraphTrainerCompileConfig`)
+  - `FlexAttention.forward`, `MoE.forward` signatures (monkey-patched)
+  - `ParallelDims` properties and `build_mesh()`
+- Does this add a new model variant that graph_trainer should consider supporting?
+- Does this unify code across models in a way that makes graph_trainer's
+  per-model wrappers redundant?
+
+Output a brief summary with action items (or "nothing actionable").
+
+## 2. TODO Unblock Detection
+
+Graph_trainer has known TODOs blocked on upstream work. **Discover them
+dynamically** — do NOT rely on a static list.
+
+### 2a. Collect all TODOs
+
+```bash
+grep -rn "TODO\|FIXME\|HACK\|XXX" torchtitan/experiments/graph_trainer/ --include="*.py"
+```
+
+For each TODO found, read the surrounding context (a few lines above and below)
+to understand what it's blocked on.
+
+### 2b. Cross-reference with prior reports
+
+If a prior report (from Step 0a) already flagged a TODO as "still blocked" and
+no upstream activity has occurred since then, do a quick re-check but don't
+deep-dive. Just note "still blocked, no upstream change since YYYY-MM-DD."
+
+For TODOs NOT mentioned in prior reports (i.e., newly added), investigate fully.
+
+### 2c. Check upstream progress (local only)
+
+For each blocked TODO, check if the installed torch package now has the
+relevant fix or API:
+- If a TODO mentions a specific API or feature, grep the installed torch
+  package for it.
+- If a TODO names an owner, note that — just flag them as "owned by X."
+
+## 3. Test & CI Coverage Gap Analysis
+
+Look for things we should be testing but aren't, and things we test locally
+but CI doesn't pick up.
+
+**Prior report context:** If a coverage gap was already flagged in a prior
+report and the test file hasn't changed since, don't re-investigate — just
+carry it forward with "still open since YYYY-MM-DD." Focus fresh analysis on
+newly added code paths and passes since the last report.
+
+### Tests missing from CI
+
+Graph_trainer has two GitHub Actions workflows:
+- `.github/workflows/integration_test_8gpu_graph_trainer.yaml` (A10 GPUs)
+- `.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml` (H100 GPUs)
+
+Compare every `test_*.py` file under
+`torchtitan/experiments/graph_trainer/tests/` against the pytest/torchrun
+invocations in both workflow YAML files. Any test file that exists locally
+but is not invoked by either workflow is a CI gap. Report each missing test
+with a suggested one-liner to add to the appropriate workflow.
+
+### Test coverage gaps
+
+- Are there parallelism combinations that core torchtitan tests but
+  graph_trainer's integration_tests.py doesn't? Compare:
+  - `tests/integration_tests/features.py` and `tests/integration_tests/h100.py`
+    vs `torchtitan/experiments/graph_trainer/tests/integration_tests.py`
+- Are there new graph passes in
+  `torchtitan/experiments/graph_trainer/passes.py` without corresponding
+  tests in `torchtitan/experiments/graph_trainer/tests/test_passes.py`?
+- Are there new code paths added to graph_trainer files that have no test
+  exercising them? Check recent commits for untested additions.
+- Are there model configs registered in graph_trainer's `config_registry.py`
+  files that no test or integration test uses?
+
+Output: a list of specific coverage gaps with suggested test descriptions.
+
+## 4. Code Freshness & Technical Debt
+
+Detect places where graph_trainer has drifted from how core torchtitan
+now does things.
+
+**Prior report context:** For items flagged as "all clear" or "signature-stable"
+in prior reports, only re-check if the relevant upstream files have changed
+since the last report date. For debt items already reported, verify whether
+they've been addressed; if not, carry forward.
+
+- **Stale monkey-patches**: Graph_trainer patches `FlexAttention.forward`,
+  `MoE.forward`, `ExpertParallel._token_dispatch/_token_combine`. Check if
+  the upstream signatures have changed, making our patches do unnecessary
+  work or miss new parameters.
+- **Private API usage**: `simple_fsdp.py` uses `DTensorSpec`,
+  `redistribute_local_tensor`, `_StridedShard`. Check if public alternatives
+  have appeared in recent PyTorch releases.
+- **Duplicated logic**: Check if graph_trainer reimplements anything that
+  core torchtitan now provides as a shared utility. Common areas:
+  - Activation checkpointing policy (`passes.py` vs `torchtitan/distributed/activation_checkpoint.py`)
+  - FSDP wrapping logic (`simple_fsdp.py` vs `torchtitan/distributed/fsdp.py`)
+  - Model parallelization patterns (graph_trainer's `parallelize.py` vs core's)
+- **Config drift**: Run `to_graph_trainer_config()` mentally — are there new
+  fields in `Trainer.Config` that aren't being copied over or that need
+  graph_trainer-specific handling?
+
+Output: specific debt items with severity (blocking / should-fix / nice-to-have).
+
+## 5. Documentation Freshness
+
+Check if graph_trainer's docs match reality.
+
+- Does `.claude/CLAUDE.md` reference correct file paths, test commands, and
+  CLI flags? Run a spot-check: do the test files mentioned still exist? Do
+  the benchmark commands still parse correctly?
+- Does `README.md` match the current feature set and supported models?
+- Are the run commands stored in Claude's memory file still correct?
+- Are there new features or passes that aren't documented anywhere?
+
+Output: specific inaccuracies found, or "docs are current."
+
+---
+
+## 6. Write Report
+
+Write the report to `torchtitan/experiments/graph_trainer/reports/YYYY-MM-DD.md`
+(create the `reports/` directory if it doesn't exist). Use the following template:
+
+```markdown
+# Nightly Scout Report — YYYY-MM-DD
+
+## Action Items (new findings)
+- [ ] [P0/P1/P2] Description — why, what file/area
+
+## Carried Forward (from prior reports, re-investigated)
+- [ ] [Pn] Description — first reported YYYY-MM-DD, status update
+
+## Opportunities (things to consider)
+- Description — potential benefit
+
+## FYI (awareness, no action needed)
+- Description
+
+## Docs
+- Inaccuracies found, or "docs are current"
+
+## All Clear
+- Areas with nothing to report
+```
+
+Keep it short. If a section has nothing, say "nothing to report" and move on.
+Don't repeat what CI already tells us. Focus on what a human developer wouldn't
+notice without actively looking.
+
+**Deduplication rules for the report:**
+- An item is "new" if it was NOT in any prior report from Step 0a.
+- An item is "carried forward" if it appeared in a prior report and the
+  underlying issue still exists. Include a brief status update (e.g.,
+  "no upstream change", "partial fix landed", "situation worsened").
+- An FYI item that appeared in 3+ consecutive reports with no change should
+  be dropped from the report entirely — it's noise at that point.
+
+---
+
+## 7. Implement Action Items
+
+After writing the report, implement every action item from the report.
+
+### 7a. Create a feature branch
+
+Before making any code changes, create a dedicated branch off `main`:
+
+```bash
+git checkout -b graph_trainer/self_improve/YYYY-MM-DD
+```
+
+All commits in this section go on this branch. Do NOT commit to `main` directly.
+
+### 7b. Implementation rules
+
+- **One commit per action item.** Do not bundle multiple items into one commit.
+- **Priority order.** Work through P0 items first, then P1, then P2.
+- **Commit messages.** Each commit must have a clear, reviewable message:
+  - Prefix with `[graph_trainer][self_improve]`
+  - Explain *why* the change is needed, not just *what* changed
+  - Reference the nightly report priority (e.g., "P0 fix" or "P1 coverage gap")
+- **Scope discipline.** Each commit should touch only what is necessary for that
+  action item. Do not sneak in unrelated cleanups or refactors.
+- **Loop until done.** When you finish one item, move on to the next. Do not
+  stop until all action items are committed.
+- **Don't re-attempt carried-forward items.** If a "Carried Forward" item was
+  already committed by a prior nightly run (detected in Step 0b) and that
+  commit hasn't been reverted, skip it. Only re-attempt if the prior fix was
+  incomplete or reverted.
+- **New items only.** Focus implementation effort on items in the "Action Items
+  (new findings)" section. Carried-forward items should only be implemented if
+  the situation has materially changed (e.g., an upstream blocker was removed).
+
+The resulting commits are ready for morning review on the feature branch.

--- a/torchtitan/experiments/graph_trainer/reports/2026-04-02.md
+++ b/torchtitan/experiments/graph_trainer/reports/2026-04-02.md
@@ -1,0 +1,106 @@
+# Nightly Scout Report — 2026-04-02
+
+## Action Items (things to do)
+
+- [ ] **[P0] Llama3 `apply_tp` call missing `enable_cp` and `enable_sp` params** —
+  `graph_trainer/llama3/parallelize.py:99-104` calls `apply_tp()` without passing
+  `enable_cp=parallel_dims.cp_enabled` or `enable_sp=enable_sp`. Core's
+  `parallelize_llama` passes both explicitly. This means CP silently malfunctions
+  with graph_trainer's llama3 path. Additionally, `apply_cp_to_attention_module` is
+  never called. README.md claims "Context Parallelism ✅" but the llama3 path
+  doesn't wire it up. Integration tests do test FSDP+TP+CP for llama3 JIT mode —
+  investigate whether those tests are actually validating CP correctness or just
+  not crashing.
+
+- [ ] **[P0] `fsdp_reshard_after_fwd_pass` has zero test coverage** — This joint
+  pass is registered in `AVAILABLE_JOINT_PASSES` but has no unit test and no
+  integration test. Core torchtitan tests
+  `--parallelism.fsdp_reshard_after_forward always` but graph_trainer never
+  exercises this path.
+
+- [ ] **[P1] `to_graph_trainer_config()` silently discards AC sub-fields** —
+  `configs.py:82-83` creates a fresh `ActivationCheckpointConfig(mode="selective")`,
+  losing user-configured `preserve_rng_state`, `early_stop`, `determinism_check`,
+  `debug`, `memory_budget`, and `per_op_sac_force_recompute_mm_shapes_by_fqns`.
+  Fix: use `dataclasses.replace(ac, mode="selective")` instead.
+
+- [ ] **[P1] SAC pass diverged from core** — `passes.py` `apply_sac_pass` lacks
+  two features core's `_apply_op_sac` has: (1) `per_op_sac_force_recompute_mm_shapes_by_fqns`
+  support, (2) CUDA-to-CPU `_to_copy` as MUST_SAVE. This means graph_trainer may
+  wastefully recompute device transfers.
+
+- [ ] **[P1] `precompile` has no end-to-end integration test** — Unit tests exist
+  for components (`DiskStorageAdapter`, `PrecompiledArtifact`, fingerprinting) but
+  no test exercises the full compile-save-reload-train loop.
+
+- [ ] **[P2] DeepSeek-v3 missing pass parity with Llama3** — DeepSeek-v3 has no
+  AOT integration tests for `auto_bucketing`, `cudagraph`, `regional_inductor`, or
+  `full_inductor_compilation`. All are tested for Llama3.
+
+- [ ] **[P2] Gradient accumulation untested** — Core tests custom `global_batch_size`
+  for gradient accumulation. Graph_trainer never tests this.
+
+- [ ] **[P2] README.md doesn't mention `aot_fx_trace` mode** — The "two compilation
+  modes" section lists AOT and JIT but omits `aot_fx_trace`, which is a distinct
+  third mode with its own code path (`FwdBwdStepModule` + `make_fx` tracing).
+
+## Opportunities (things to consider)
+
+- **Qwen3 support** — Qwen3 (dense + MoE variants) landed in core. It uses the
+  same building blocks as llama3/deepseek_v3 (`GQAttention`, `MoE`, `Decoder`).
+  Adding support would be low effort (thin model subclass + parallelize file
+  borrowed from llama3) and validates graph_trainer's generality.
+
+- **`Decouple SP with TP` (commit aa68af18)** — Core recently decoupled sequence
+  parallelism from tensor parallelism. Graph_trainer's parallelize files may
+  benefit from this decoupling, especially given the `use_local_output=True` TODO.
+
+- **`per_op_sac_force_recompute_mm_shapes_by_fqns`** — Core SAC now supports
+  forcing recompute for specific mm shapes by FQN (e.g., `moe.router.gate`). If
+  graph_trainer's SAC pass adopted this, users could fine-tune SAC for MoE models.
+
+- **`Float8TrainingOpConfig` migration (commit 72229411)** — Core switched from
+  `FP8GroupedMMConfig` to `Float8TrainingOpConfig`. Verify graph_trainer's float8
+  paths use the new API.
+
+## FYI (awareness, no action needed)
+
+- **All 11 upstream-dependent TODOs remain blocked.** Partial progress on TODO #8
+  (TP uneven seq_len): `LocalMapInnerAttention` in core demonstrates the
+  architectural direction for `use_local_output=False`, but TP plans haven't
+  switched yet.
+
+- **`simple_fsdp.py` uses 5+ private DTensor APIs** (`DTensorSpec`,
+  `redistribute_local_tensor`, `_StridedShard`, `_spec`, `_local_tensor`). No
+  public alternatives exist yet. The bitwise deterministic test implicitly guards
+  against breakage here.
+
+- **MoE padding removal (commit fe80b63c)** — Core removed unnecessary padding in
+  MoE. This changes traced graph shapes for DeepSeek-v3. If graph_trainer's
+  precompile artifacts were cached, they'd need regeneration (fingerprint mismatch
+  should catch this).
+
+- **All monkey-patches are signature-stable** — `FlexAttention.forward`,
+  `MoE.forward`, `ExpertParallel._token_dispatch/_token_combine` signatures are
+  unchanged upstream. `annotate_fn` wrapping is signature-agnostic.
+
+- **`gh` CLI not available** — PR/issue tracking section could not run. Consider
+  configuring `gh auth` for future nightly runs.
+
+## Docs
+
+- **CLAUDE.md** — All referenced file paths and test commands are correct. All 7
+  test/benchmark files exist.
+- **Memory file** — Run commands are current (verified 2026-04-02).
+- **README.md** — Two inaccuracies: (1) Missing `aot_fx_trace` as a third
+  compilation mode. (2) CP marked as ✅ but llama3 path doesn't fully wire it up.
+
+## All Clear
+
+- `Trainer.Config` fields — stable, dict-spread copy works correctly
+- `CompileConfig` — no new fields, no naming collision risk
+- `post_dataloading_process()` — 4-tuple return signature unchanged
+- `ParallelDims` — no field or property changes
+- Import paths — all valid, no deprecated references
+- Core config flow — new fields (`validator`, `comm.mode`, `debug.detect_anomaly`)
+  flow through automatically


### PR DESCRIPTION
Add a nightly prompt (.claude/nightly.md) designed to be run by Claude Code to discover self-improvement opportunities — not breakage detection (CI handles that), but things like upstream API drift, test coverage gaps, unblocked TODOs, and code freshness issues.

The scout covers 5 areas (all local, no network access required):
1. Core torchtitan delta review (opportunity/risk from upstream changes)
2. TODO unblock detection (dynamic discovery, local torch inspection)
3. Test & CI coverage gap analysis (file comparison vs workflow YAMLs)
4. Code freshness & technical debt (monkey-patches, private APIs, config drift)
5. Documentation freshness

Removed from earlier version: performance opportunity discovery (produced no actionable output), open work tracking (requires GitHub API), CI status checks (requires GitHub API), git push (requires network access).

Reports are written to graph_trainer/reports/YYYY-MM-DD.md. After the report, action items are implemented as one-commit-per-item on a graph_trainer/self_improve/YYYY-MM-DD branch.

The first report (2026-04-02) surfaces two P0 findings:
- Llama3 parallelize.py missing enable_cp/enable_sp in apply_tp() call, meaning context parallelism silently malfunctions despite README claiming CP support
- fsdp_reshard_after_fwd_pass has zero test coverage (no unit or integration test)

ghstack-source-id: 7c03f4a1bf1d69f00ed296ac4357a60443142213
Pull Request resolved: https://github.com/pytorch/torchtitan/pull/2806