### PR TITLE
[graph_trainer] Add apply_default_graph_passes entry point and propagate stac…

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -61,6 +61,7 @@ class TracedResult:
     """Holds the traced graph and metadata needed to run it."""
 
     gm: torch.fx.GraphModule
+    example_inputs: tuple[torch.Tensor, ...]
     params_len: int
     params_spec: pytree.TreeSpec
     input_subclass_layouts: list[SubclassLayout]
@@ -250,6 +251,9 @@ def _copy_fwd_metadata_to_bw_nodes(fx_g: torch.fx.GraphModule) -> None:
             nn_module_stack = fwd_node.meta.get("nn_module_stack")
             if nn_module_stack is not None:
                 node.meta["nn_module_stack"] = nn_module_stack.copy()
+            stack_trace = fwd_node.meta.get("stack_trace")
+            if stack_trace is not None:
+                node.meta["stack_trace"] = stack_trace
 
 
 def trace_module(
@@ -354,6 +358,7 @@ def trace_module(
 
     return TracedResult(
         gm=traced,
+        example_inputs=fake_args,
         params_len=params_len,
         params_spec=params_spec,
         input_subclass_layouts=input_layouts,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -40,6 +40,19 @@ from torchtitan.experiments.graph_trainer.reshard_after_forward import (
 from torchtitan.tools.logging import logger
 
 
+def apply_default_graph_passes(
+    gm: torch.fx.GraphModule, example_inputs: tuple
+) -> torch.fx.GraphModule:
+    """Entry point for optimizing the traced fwd+bwd graph.
+
+    Called by GraphTrainer after tracing to apply graph-level optimization
+    passes before execution. Individual passes are defined below.
+    """
+    gm = tlparse_log_graph_pass(gm, example_inputs, graph_name="make_fx_graph_traced")
+
+    return gm
+
+
 def autobucketing_reordering_pass(
     gm: torch.fx.GraphModule, example_inputs=None
 ) -> torch.fx.GraphModule:

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -366,6 +366,35 @@ class TestMetadataPropagation(unittest.TestCase):
                 )
                 self.assertEqual(custom.get("test_key"), "test_value")
 
+    def test_backward_nodes_have_stack_trace(self):
+        """Verify that backward nodes get stack_trace from their forward counterpart."""
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        train_step = TrainStepModule(model, get_loss)
+        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+        labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
+
+        traced_result = trace_module(train_step, (tokens, labels))
+
+        # Find backward nodes: nodes sharing a seq_nr with an earlier (forward) node
+        seq_nr_first: dict[int, torch.fx.Node] = {}
+        bwd_nodes_missing_stack_trace = []
+        for node in traced_result.gm.graph.nodes:
+            if node.op != "call_function" or "seq_nr" not in node.meta:
+                continue
+            seq_nr = node.meta["seq_nr"]
+            if seq_nr not in seq_nr_first:
+                seq_nr_first[seq_nr] = node
+            else:
+                # This is a backward node
+                if not node.stack_trace:
+                    bwd_nodes_missing_stack_trace.append((node.name, seq_nr))
+
+        self.assertEqual(
+            bwd_nodes_missing_stack_trace,
+            [],
+            f"Backward nodes missing stack_trace: {bwd_nodes_missing_stack_trace}",
+        )
+
     def test_patch_engine_restores_original(self):
         """Verify that _patch_engine_run_backward restores the original function."""
         import torch.autograd

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -17,6 +17,7 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     trace_module,
     TracedResult,
 )
+from torchtitan.experiments.graph_trainer.passes import apply_default_graph_passes
 from torchtitan.trainer import Trainer
 
 
@@ -108,6 +109,11 @@ class GraphTrainer(Trainer):
                     self._fwd_bwd_step_module,
                     (inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs),
                 )
+
+            self._traced_step.gm = apply_default_graph_passes(
+                self._traced_step.gm,
+                self._traced_step.example_inputs,
+            )
 
         params_and_buffers = {
             **dict(self._fwd_bwd_step_module.named_parameters(remove_duplicate=False)),


### PR DESCRIPTION
Add `apply_default_graph_passes` in passes.py as the entry point for graph-level optimizations on the traced fwd+bwd graph, called by GraphTrainer after trace_module(). Currently applies tlparse graph logging.

Also propagate stack_trace metadata from forward nodes to backward nodes in `_copy_fwd_metadata_to_bw_nodes`, alongside the existing custom and nn_module_stack propagation, with a corresponding test.