### PR TITLE
[graph_trainer] Standardize Graph Pass Signature

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -6,13 +6,14 @@ apply here too unless overridden below.
 
 ## Graph Pass Signature
 
-All graph passes must follow the signature:
+All graph passes must follow this signature:
 ```python
 def my_pass(gm: torch.fx.GraphModule, example_inputs, *, other_kwargs) -> torch.fx.GraphModule:
 ```
-The first two positional args are always `(gm, example_inputs)`. Any additional
-parameters must be keyword-only. The pass must return the (possibly transformed)
-`GraphModule`.
+- The first two positional args are always `(gm, example_inputs)`.
+- Any additional parameters must be **keyword-only** (after `*`).
+- The pass must return the (possibly transformed) `GraphModule`.
+- Passes that don't need `example_inputs` should still accept it (use `example_inputs=None`).
 
 ## Don't Modify Core for This Experiment
 

--- a/torchtitan/experiments/graph_trainer/jit_backend.py
+++ b/torchtitan/experiments/graph_trainer/jit_backend.py
@@ -147,7 +147,9 @@ def get_compile_backend_with_passes(
     def joint_ac_pass(
         gm: torch.fx.GraphModule, example_inputs: Any
     ) -> torch.fx.GraphModule:
-        return fsdp_reshard_after_fwd_pass(gm, fsdp_reshard_after_forward)
+        return fsdp_reshard_after_fwd_pass(
+            gm, example_inputs, reshard_after_forward=fsdp_reshard_after_forward
+        )
 
     def graph_trainer_custom_pass(*args, **kwargs):
         # the ac pass has to operate in a joint graph before partitioner for ac

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -17,8 +17,6 @@ Pass Types:
 
 import operator
 from collections import defaultdict
-from collections.abc import Sequence
-from typing import Any
 
 import torch
 from torch._functorch.aot_autograd import JointWithDescriptors
@@ -28,6 +26,7 @@ from torch._inductor.fx_passes.bucketing import (
 )
 from torch._inductor.fx_passes.overlap_manual_scheduling import manual_overlap_bucketing
 from torch._inductor.fx_passes.overlap_scheduling import schedule_overlap_bucketing
+from torch._inductor.output_code import OutputCode
 from torch._logging import trace_structured
 from torch.fx.passes.regional_inductor import regional_inductor
 from torch.utils.checkpoint import CheckpointPolicy
@@ -54,7 +53,7 @@ def apply_default_graph_passes(
 
 
 def autobucketing_reordering_pass(
-    gm: torch.fx.GraphModule, example_inputs=None
+    gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
     """
     Apply autobucketing and reordering optimization.
@@ -68,7 +67,10 @@ def autobucketing_reordering_pass(
 
 
 def transformer_block_bucketing_reordering_pass(
-    gm: torch.fx.GraphModule, example_inputs, fsdp_manual_buckets
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    fsdp_manual_buckets,
 ) -> torch.fx.GraphModule:
     """
     Apply aten-level manual bucketing and reordering optimization.
@@ -97,7 +99,7 @@ def _ops_filter_with_distributed(name: str) -> bool:
 
 
 def regional_inductor_pass(
-    gm: torch.fx.GraphModule, example_inputs, *, serializable: bool = False
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, serializable: bool = False
 ) -> torch.fx.GraphModule:
     """
     Apply regional inductor compilation based on user annotation.
@@ -126,7 +128,7 @@ def regional_inductor_pass(
 
 
 def cudagraph_pass(
-    gm: torch.fx.GraphModule, example_inputs: Sequence[Any], is_forward: bool
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, is_forward: bool
 ) -> torch.fx.GraphModule:
     """
     Apply cudagraph.
@@ -150,7 +152,7 @@ def cudagraph_pass(
 
 
 def validate_flex_attn_annotation_pass(
-    gm: torch.fx.GraphModule,
+    gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
     """Verify user annotations show up in the graph."""
     for node in gm.graph.nodes:
@@ -164,6 +166,8 @@ def validate_flex_attn_annotation_pass(
 
 def apply_sac_pass(
     gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
     op_list_to_save: set | None = None,
 ) -> torch.fx.GraphModule:
     """
@@ -260,7 +264,10 @@ def apply_sac_pass(
 
 # Apply activation checkpointing on joint graph before partitioner
 def fsdp_reshard_after_fwd_pass(
-    gm: torch.fx.GraphModule, reshard_after_forward: bool
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    reshard_after_forward: bool,
 ) -> torch.fx.GraphModule:
     # this pass implements simplefsdp's fsdp_reshard_after_forward behavior
     # when fsdp_reshard_after_forward set to True, it will annotate simple_fsdp AG
@@ -274,6 +281,8 @@ def fsdp_reshard_after_fwd_pass(
 
 def inductor_decomposition_pass(
     gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
     joint_with_descriptors: JointWithDescriptors,
 ) -> torch.fx.GraphModule:
     """
@@ -370,8 +379,8 @@ def inductor_decomposition_pass(
 
 
 def full_inductor_compilation_pass(
-    gm: torch.fx.GraphModule, example_inputs
-) -> torch.fx.GraphModule:
+    gm: torch.fx.GraphModule, example_inputs: tuple
+) -> OutputCode:
     """
     Apply full Inductor compilation with code generation.
 
@@ -382,14 +391,17 @@ def full_inductor_compilation_pass(
         example_inputs: Example inputs for compilation
 
     Returns:
-        The compiled graph module
+        The compiled OutputCode from Inductor
     """
+    # TODO: This pass returns OutputCode instead of GraphModule, violating the
+    # unified graph pass signature convention. Should be addressed to comply.
     return compile_fx_inner(gm, example_inputs)
 
 
 def reassign_to_pg_pass(
     gm: torch.fx.GraphModule,
-    example_inputs,
+    example_inputs: tuple | None = None,
+    *,
     source_pg_name: str,
     target_pg_name: str,
 ) -> torch.fx.GraphModule:
@@ -428,7 +440,7 @@ def reassign_to_pg_pass(
 
 def tlparse_log_graph_pass(
     gm: torch.fx.GraphModule,
-    example_inputs: Sequence[Any],
+    example_inputs: tuple | None = None,
     *,
     graph_name: str,
 ) -> torch.fx.GraphModule:

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -133,7 +133,12 @@ class TestReassignToPgPass(FSDPTest):
         self.assertGreater(ag_before, 0, "Expected AG nodes with FSDP PG name")
 
         # Apply the pass
-        reassign_to_pg_pass(bw_gm, bw_example_inputs, fsdp_pg_name, target_pg_name)
+        reassign_to_pg_pass(
+            bw_gm,
+            bw_example_inputs,
+            source_pg_name=fsdp_pg_name,
+            target_pg_name=target_pg_name,
+        )
 
         # After: AG nodes should use the target PG
         ag_with_old = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
@@ -154,7 +159,12 @@ class TestReassignToPgPass(FSDPTest):
         bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
 
         total_before = self._count_all_ag_nodes(bw_gm)
-        reassign_to_pg_pass(bw_gm, bw_example_inputs, fsdp_pg_name, "new_pg")
+        reassign_to_pg_pass(
+            bw_gm,
+            bw_example_inputs,
+            source_pg_name=fsdp_pg_name,
+            target_pg_name="new_pg",
+        )
         total_after = self._count_all_ag_nodes(bw_gm)
 
         self.assertEqual(total_before, total_after)
@@ -171,7 +181,12 @@ class TestReassignToPgPass(FSDPTest):
         ag_before = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
 
         # Use a non-matching source PG name
-        reassign_to_pg_pass(bw_gm, bw_example_inputs, "nonexistent_pg", "target_pg")
+        reassign_to_pg_pass(
+            bw_gm,
+            bw_example_inputs,
+            source_pg_name="nonexistent_pg",
+            target_pg_name="target_pg",
+        )
 
         # FSDP AG nodes should be unchanged
         ag_after = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
@@ -200,7 +215,12 @@ class TestReassignToPgPass(FSDPTest):
         self.assertGreater(ag_before, 0)
 
         # Reassign to the real extra PG
-        reassign_to_pg_pass(bw_gm, bw_example_inputs, fsdp_pg_name, extra_pg_name)
+        reassign_to_pg_pass(
+            bw_gm,
+            bw_example_inputs,
+            source_pg_name=fsdp_pg_name,
+            target_pg_name=extra_pg_name,
+        )
 
         ag_old = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
         ag_new = self._count_ag_nodes_with_pg(bw_gm, extra_pg_name)


### PR DESCRIPTION
## Graph Pass Signature

All graph passes must follow this signature:
```python
def my_pass(gm: torch.fx.GraphModule, example_inputs, *, other_kwargs) -> torch.fx.GraphModule:
```
- The first two positional args are always `(gm, example_inputs)`.
- Any additional parameters must be **keyword-only** (after `*`).
- The pass must return the (possibly transformed) `GraphModule`.
- Passes that don't need `example_inputs` should still accept it (use `example_inputs=None`).