### PR TITLE
[graph_trainer][self_improve] Re-enable regional_inductor integration tests

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -251,8 +251,6 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP+FlexAttn autobucketing regional_inductor",
             "aot_llama3_fsdp_tp_flexattn_autobucketing_regional_inductor",
             ngpu=8,
-            # TODO: skip for now, re-enable when https://github.com/pytorch/pytorch/pull/179209 is in torch nightly
-            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -284,8 +282,6 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP+FlexAttn manualbucketing regional_inductor",
             "aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor",
             ngpu=8,
-            # TODO: skip for now, re-enable when https://github.com/pytorch/pytorch/pull/179209 is in torch nightly
-            disabled=True,
         ),
         # === aot_fx_trace mode tests ===
         OverrideDefinitions(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2848
* #2847
* #2846
* #2845
* __->__ #2844

P1 fix: The force_non_lazy_backward_lowering config that caused the
serializable + regional_inductor failure (pytorch/pytorch#179209) no
longer exists in torch nightly 2.12.0a0+git02521a0, indicating the
upstream fix has landed. Re-enable the two disabled integration tests:
- aot_llama3_fsdp_tp_flexattn_autobucketing_regional_inductor
- aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor