### PR TITLE
[graph_trainer][self_improve] Re-enable test_precompile.py in CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -73,7 +73,6 @@ jobs:
         pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"
 
         # Run precompile unit tests
-        # TODO: Currently failing, re-enable once fixed.
-        # pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
 
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2848
* #2847
* #2846
* __->__ #2845
* #2844

P1 fix: test_precompile.py was disabled in CI with "Currently failing,
re-enable once fixed." All 24 tests now pass locally on torch nightly
2.12.0a0+git02521a0. Re-enable the pytest invocation in the A10 GPU
workflow.