### PR TITLE
[graph_trainer][self_improve] Add missing test_trace_module classes to CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -71,6 +71,9 @@ jobs:
 
         # Run the make_fx tracer unit tests
         pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"
+        pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py::TestTraceModels -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py::TestTraceFSDP -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py::TestAutogradGradVsBackwardFSDP -v
 
         # Run precompile unit tests
         pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2848
* #2847
* __->__ #2846
* #2845
* #2844

P2 coverage gap: test_trace_module.py has 6 test classes but CI only ran
3 (TestTraceModule, TestTraceDTensor, TestMetadataPropagation). Add the
remaining 3 classes (TestTraceModels, TestTraceFSDP,
TestAutogradGradVsBackwardFSDP) to the A10 GPU workflow. TestTraceFSDP
and TestAutogradGradVsBackwardFSDP extend FSDPTest which handles
multi-process spawning internally.