### PR TITLE
[graph_trainer][self_improve] Document aot_fx_trace mode in README

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -9,8 +9,9 @@ This experiment demonstrates graph-based distributed training in torchtitan thro
 - Provenance-tracking infrastructure as the user annotation backbone
 - Graph optimization via FX graph passes
 
-The goal is to give users more explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training. Two compilation modes are currently supported:
+The goal is to give users more explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training. Three compilation modes are currently supported:
 - **AOT mode** (`--compile.mode aot`): Explicit joint graph export with a custom graph pass pipeline.
+- **AOT FX Trace mode** (`--compile.mode aot_fx_trace`): Non-strict tracing of the forward + loss + backward via `make_fx`, producing an explicit FX graph without Dynamo. Useful for models or code paths that are difficult to trace with Dynamo.
 - **JIT mode** (`--compile.mode jit`): Standard `torch.compile()` with graph passes registered to custom backends.
 
 ### Prerequisites


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2848
* __->__ #2847
* #2846
* #2845
* #2844

P2 doc fix: README only mentioned AOT and JIT modes but aot_fx_trace is
a supported third compilation mode (tested in integration tests and
documented in CLAUDE.md). Add a brief description.