### PR TITLE
[graph_trainer][self_improve] Add nightly scout report for 2026-04-03

### DIFF
--- a/torchtitan/experiments/graph_trainer/reports/2026-04-03.md
+++ b/torchtitan/experiments/graph_trainer/reports/2026-04-03.md
@@ -1,0 +1,72 @@
+# Nightly Scout Report — 2026-04-03
+
+## Action Items (new findings)
+
+- [ ] [P1] **Re-enable regional_inductor integration tests** — `force_non_lazy_backward_lowering`
+  config attr no longer exists in torch nightly (torch 2.12.0a0+git02521a0), suggesting the
+  blocker from pytorch/pytorch#179209 may have landed. Two tests are disabled in
+  `tests/integration_tests.py:254,287` (`aot_llama3_fsdp_tp_flexattn_autobucketing_regional_inductor`
+  and `aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor`). Re-enable and verify they
+  pass on CI. File: `torchtitan/experiments/graph_trainer/tests/integration_tests.py`
+
+- [ ] [P1] **Re-enable test_precompile.py in CI** — The A10 workflow has
+  `test_precompile.py` commented out with "TODO: Currently failing, re-enable once fixed."
+  This leaves precompile code entirely untested in CI. Investigate whether the failure
+  still reproduces, and re-enable if fixed.
+  File: `.github/workflows/integration_test_8gpu_graph_trainer.yaml:76-77`
+
+- [ ] [P2] **Add missing test classes to CI** — `test_trace_module.py` has 6 test classes
+  but CI only runs 3 (`TestTraceModule`, `TestTraceDTensor`, `TestMetadataPropagation`).
+  Missing from CI: `TestTraceModels`, `TestTraceFSDP`, `TestAutogradGradVsBackwardFSDP`.
+  These likely require multi-GPU; add them to the A10 workflow with `torchrun --nproc-per-node=8`.
+  File: `.github/workflows/integration_test_8gpu_graph_trainer.yaml:73`
+
+- [ ] [P2] **Document `aot_fx_trace` mode in README** — `aot_fx_trace` is a supported
+  compilation mode (tested in integration tests, documented in CLAUDE.md run commands) but
+  README.md only mentions AOT and JIT modes. Add a brief section.
+  File: `torchtitan/experiments/graph_trainer/README.md`
+
+## Carried Forward (from prior reports, re-investigated)
+
+Nothing to carry forward — this is the first nightly report.
+
+## Opportunities (things to consider)
+
+- **TorchAOExpertParallel annotation gap**: Graph_trainer's `annotate_fn` patches on
+  `ExpertParallel._token_dispatch/_token_combine` won't affect `TorchAOExpertParallel`
+  (which overrides `_token_dispatch` without calling `super()`). If DeepSeek is ever
+  configured with torchao's expert parallel, EP dispatch/combine annotations will be
+  silently lost. Not urgent since torchao EP isn't used in graph_trainer configs today.
+
+- **`run_precompile_tests.py` not in CI**: This test runner exists but isn't invoked in
+  either workflow. It tests precompile save/load end-to-end with inductor. Consider adding
+  to H100 workflow once precompile is stabilized.
+
+## FYI (awareness, no action needed)
+
+- **Private APIs still work**: `DTensorSpec`, `redistribute_local_tensor`, `_StridedShard`
+  imports in `simple_fsdp.py` are from private paths (`torch.distributed.tensor._dtensor_spec`,
+  `torch.distributed.tensor._redistribute`, `torch.distributed.tensor.placement_types`).
+  All imports resolve in current nightly. No public alternatives available yet.
+
+- **14 TODOs in graph_trainer** — Most are blocked on upstream (async TP, BlockMask DTensor
+  conversion, mesh collapsing, inductor numerics). No upstream progress on these since last check.
+
+- **Core torchtitan delta**: Only 1 commit since yesterday (`f63e5ce5` — rebuild validation
+  dataset each round). Touches `torchtitan/components/validate.py` only. No impact on
+  graph_trainer — it doesn't use or override the Validator class.
+
+## Docs
+
+- README.md missing `aot_fx_trace` mode documentation (see Action Items).
+- CLAUDE.md: all file paths, test commands, and config names verified correct.
+- Run commands in README verified: `run_train.sh` exists, config names registered.
+
+## All Clear
+
+- **Monkey-patches**: All `annotate_fn` patches on FlexAttention, MoE, and ExpertParallel
+  are signature-transparent — no upstream signature changes detected.
+- **Config drift**: `Trainer.Config` fields and `CompileConfig` fields are in sync with
+  `to_graph_trainer_config()` and `GraphTrainerCompileConfig`. No new fields missed.
+- **Code duplication**: graph_trainer properly reuses core utilities (`_get_save_ops`,
+  `get_fsdp_reshard_after_forward_policy`, `maybe_enable_async_tp`). No new duplication detected.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2848
* #2847
* #2846
* #2845
* #2844

First nightly self-improvement scout report. Key findings:
- 2 regional_inductor tests likely unblocked (P1, implemented)
- test_precompile.py re-enabled in CI (P1, implemented)
- 3 missing test classes added to CI (P2, implemented)
- README updated with aot_fx_trace mode (P2, implemented)