### PR TITLE
Fix RoPE position inconsistencies across chunked samples

### DIFF
--- a/tests/unit_tests/test_dataloader.py
+++ b/tests/unit_tests/test_dataloader.py
@@ -79,7 +79,7 @@ class TestParallelAwareDataloader(unittest.TestCase):
         last_batch_input, last_batch_label = batches[-1]
         self.assertEqual(last_batch_input["input"].tolist(), [96, 97, 98, 99])
         self.assertEqual(last_batch_label.tolist(), [96, 97, 98, 99])
-        
+
     def test_validate_kwargs_rejects_invalid_kwargs(self):
         """Test that passing invalid kwargs raises ValueError."""
         dataset = DummyDataset()
@@ -154,11 +154,11 @@ class TestParallelAwareDataloader(unittest.TestCase):
             dp_world_size=1,
             dp_rank=0,
             tokenizer=tokenizer,
-            seq_len=(seq_len:=512),
+            seq_len=(seq_len := 512),
             local_batch_size=8,
         )
 
-        for batch,_ in zip(map(lambda x:x[0], dataloader), range(10)):
+        for batch, _ in zip(map(lambda x: x[0], dataloader), range(10)):
             batch_input_ids = batch["input"]
             batch_positions = batch["positions"]
             for input_ids, positions in zip(batch_input_ids, batch_positions):

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -32,6 +32,7 @@ def _process_c4_text(sample: dict[str, Any]) -> str:
     """Process C4 dataset sample text."""
     return sample["text"]
 
+
 # Add your dataset here - more information at docs/datasets.md
 DATASETS = {
     "c4": DatasetConfig(
@@ -114,8 +115,8 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
     def _normalize_positions(self, positions: list[int]) -> list[int]:
         offset = positions[0]
         if offset > 0:
-            for i,p in enumerate(positions):
-                if p == 0: 
+            for i, p in enumerate(positions):
+                if p == 0:
                     break
                 positions[i] = p - offset
         return positions
@@ -143,9 +144,11 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
 
                 while len(self._inputs_buffer) >= max_buffer_token_len:
                     x = torch.LongTensor(self._inputs_buffer[:max_buffer_token_len])
-                    pos = torch.LongTensor(self._normalize_positions(
-                        self._positions_buffer[:max_buffer_token_len]
-                    ))
+                    pos = torch.LongTensor(
+                        self._normalize_positions(
+                            self._positions_buffer[:max_buffer_token_len]
+                        )
+                    )
                     # update buffers to the remaining tokens
                     self._inputs_buffer = self._inputs_buffer[max_buffer_token_len:]
                     self._positions_buffer = self._positions_buffer[


### PR DESCRIPTION
### Summary

This PR removes the modulo-based logic previously used to wrap RoPE positions:

```python
self._positions_buffer.extend(
    i % self.seq_len for i in range(len(sample_tokens))
)
```

Although this prevented RoPE indices from exceeding the cache size, it introduced inconsistencies in positional encoding across split samples.

---

### Problem

Using modulo to reset positions can break positional continuity when a single logical sequence is split across multiple chunks.

For example:

```text
tokens:    [tx ,ty ,tz ,t0 ,t1 ,t2 ,t3 ,t4 ,t5 ,t6 ,t7 ]
positions: [x  ,y  ,z  ,0  ,1  ,2  ,3  ,4  ,5  ,6  ,7  ]

tokens:    [t8 ,t9 ,t10,t11,t12,t13,t14,t0 ,t1 ,t2 ,t3 ]
positions: [8  ,9  ,10 ,0  ,1  ,2  ,3  ,0  ,1  ,2  ,3  ]
```

Here, the sequence `t0–t14` is split across two chunks. In the second chunk, positions are reset mid-sequence due to the modulo operation,even though the tokens belong to the same original sequence. This results in inconsistent positional encodings.

Since different samples in a batch cannot attend to each other, positional resets should align strictly with sample boundaries, not occur within a continued sequence.

---

### Changes

#### 1. Removed modulo-based position wrapping

Eliminated `% seq_len` to preserve positional continuity within sequences.

#### 2. Introduced `_normalize_positions`

Adds a normalization step that ensures each sequence starts at position 0. This is applied in the dataloader.

#### 3. Added position validation tests

New test verify that:

* Positions are monotonically increasing within a sequence
* Positions reset to 0 after an EOS token
* Each sequence starts at position 0
* BOS tokens are always assigned position 0
* Positions remain within valid bounds (≤ sequence length)
