### PR TITLE
introduce param_groups to optimizer config

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -111,13 +111,13 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module qwen3 --config qwen3_debugmodel",
+                    "--module qwen3 --config qwen3_debugmodel_param_groups",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
                 ],
             ],
-            "Qwen3 FSDP+TP",
-            "qwen3_fsdp+tp",
+            "Qwen3 FSDP+TP (param groups)",
+            "qwen3_fsdp+tp_param_groups",
             ngpu=4,
         ),
         OverrideDefinitions(

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -1,0 +1,353 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import unittest
+
+import torch
+import torch.nn as nn
+from torchtitan.components.optimizer import (
+    OptimizersContainer,
+    OptimizersInBackwardContainer,
+    ParamGroupConfig,
+)
+
+
+class SimpleModel(nn.Module):
+    """A small model with diverse parameter names for testing param groups."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(32, 16)
+        self.layers = nn.ModuleDict(
+            {
+                "0": nn.ModuleDict(
+                    {
+                        "attention": nn.Linear(16, 16),
+                        "norm": nn.LayerNorm(16),
+                        "ff": nn.Linear(16, 16),
+                    }
+                ),
+            }
+        )
+        self.output = nn.Linear(16, 32)
+
+    def forward(self, x):
+        x = self.embed_tokens(x)
+        x = self.layers["0"]["attention"](x)
+        x = self.layers["0"]["norm"](x)
+        x = self.layers["0"]["ff"](x)
+        return self.output(x)
+
+
+def _get_param_names_in_group(model, group):
+    """Return the set of parameter FQNs in an optimizer param group."""
+    param_to_name = {p: n for n, p in model.named_parameters()}
+    return {param_to_name[p] for p in group["params"]}
+
+
+class TestParamGroupConfig(unittest.TestCase):
+    def test_default_no_param_groups(self):
+        """Empty param_groups produces a single group with all params."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(lr=1e-3, weight_decay=0.1)
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        self.assertEqual(len(groups), 1)
+        all_params = [p for p in model.parameters() if p.requires_grad]
+        self.assertEqual(len(groups[0]["params"]), len(all_params))
+        self.assertEqual(groups[0]["lr"], 1e-3)
+        self.assertEqual(groups[0]["weight_decay"], 0.1)
+
+    def test_single_pattern_weight_decay_zero(self):
+        """Pattern matching bias params with weight_decay_multiplier=0."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            weight_decay=0.1,
+            param_groups=[
+                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        # Should have 2 groups: default + bias group
+        self.assertEqual(len(groups), 2)
+
+        # Default group: non-bias params
+        default_names = _get_param_names_in_group(model, groups[0])
+        for name in default_names:
+            self.assertFalse(name.endswith(".bias"), f"{name} should not be in default")
+        self.assertEqual(groups[0]["weight_decay"], 0.1)
+        self.assertEqual(groups[0]["lr"], 1e-3)
+
+        # Bias group
+        bias_names = _get_param_names_in_group(model, groups[1])
+        for name in bias_names:
+            self.assertTrue(name.endswith(".bias"), f"{name} should end with .bias")
+        self.assertEqual(groups[1]["weight_decay"], 0.0)
+        self.assertEqual(groups[1]["lr"], 1e-3)
+
+    def test_embed_tokens_pattern(self):
+        """Pattern matching embed_tokens with weight_decay_multiplier=0."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            weight_decay=0.1,
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"embed_tokens\.",
+                    weight_decay_multiplier=0.0,
+                ),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        self.assertEqual(len(groups), 2)
+
+        embed_names = _get_param_names_in_group(model, groups[1])
+        self.assertTrue(
+            all("embed_tokens" in n for n in embed_names),
+            f"Expected embed_tokens params, got {embed_names}",
+        )
+        self.assertEqual(groups[1]["weight_decay"], 0.0)
+
+    def test_lr_multiplier(self):
+        """lr_multiplier correctly scales the base lr."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            weight_decay=0.1,
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"embed_tokens\.",
+                    lr_multiplier=0.1,
+                ),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        # Default group keeps base lr
+        self.assertEqual(groups[0]["lr"], 1e-3)
+        # Embed group gets 10% of base lr
+        self.assertAlmostEqual(groups[1]["lr"], 1e-4)
+
+    def test_first_match_wins(self):
+        """When patterns overlap, the first match wins."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            weight_decay=0.1,
+            param_groups=[
+                # First pattern: all norm params get wd=0
+                ParamGroupConfig(pattern=r".*norm.*", weight_decay_multiplier=0.0),
+                # Second pattern: broader match that also covers norm
+                ParamGroupConfig(pattern=r".*layers.*", lr_multiplier=0.5),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        # Norm params should be in group index 0 (the norm pattern), not group 1
+        norm_group = groups[1]  # first matched group (after default)
+        norm_names = _get_param_names_in_group(model, norm_group)
+        self.assertTrue(all("norm" in n for n in norm_names))
+        # Norm group should have weight_decay=0 (from first pattern)
+        self.assertEqual(norm_group["weight_decay"], 0.0)
+        # And default lr (lr_multiplier=1.0 from first pattern)
+        self.assertEqual(norm_group["lr"], 1e-3)
+
+    def test_betas_override(self):
+        """Per-group betas override works correctly."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            beta1=0.9,
+            beta2=0.95,
+            param_groups=[
+                # Override both betas
+                ParamGroupConfig(pattern=r"embed_tokens\.", beta1=0.85, beta2=0.99),
+                # Override only beta2
+                ParamGroupConfig(pattern=r".*\.bias$", beta2=0.999),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        # Default group keeps global betas
+        self.assertEqual(groups[0]["betas"], (0.9, 0.95))
+        # Embed group: both overridden
+        self.assertEqual(groups[1]["betas"], (0.85, 0.99))
+        # Bias group: only beta2 overridden, beta1 stays global
+        self.assertEqual(groups[2]["betas"], (0.9, 0.999))
+
+    def test_warning_on_zero_matches(self):
+        """Patterns that match no parameters emit a warning."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            param_groups=[
+                ParamGroupConfig(pattern=r"nonexistent_layer"),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            groups = OptimizersContainer._build_param_groups(
+                model, config, default_kwargs
+            )
+
+        self.assertTrue(
+            any("nonexistent_layer" in msg for msg in cm.output),
+            f"Expected warning about unmatched pattern, got: {cm.output}",
+        )
+        # All params should be in the default group
+        self.assertEqual(len(groups), 1)
+
+    def test_all_params_covered(self):
+        """Every requires_grad param appears in exactly one group."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            weight_decay=0.1,
+            param_groups=[
+                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+                ParamGroupConfig(pattern=r".*norm.*", weight_decay_multiplier=0.0),
+            ],
+        )
+        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+
+        all_grouped_params = []
+        for g in groups:
+            all_grouped_params.extend(g["params"])
+        all_model_params = [p for p in model.parameters() if p.requires_grad]
+
+        self.assertEqual(len(all_grouped_params), len(all_model_params))
+        self.assertEqual(
+            set(id(p) for p in all_grouped_params), set(id(p) for p in all_model_params)
+        )
+
+
+class TestOptimizersContainerWithParamGroups(unittest.TestCase):
+    def test_build_optimizer_with_param_groups(self):
+        """End-to-end: build OptimizersContainer with param groups."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            name="AdamW",
+            lr=1e-3,
+            weight_decay=0.1,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        self.assertIsInstance(container, OptimizersContainer)
+
+        # Should have 1 optimizer (one model_part)
+        self.assertEqual(len(container.optimizers), 1)
+        opt = container.optimizers[0]
+        # Should have 2 param groups
+        self.assertEqual(len(opt.param_groups), 2)
+
+    def test_build_optimizer_default_groups(self):
+        """Empty param_groups produces standard single-group behavior."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            name="AdamW",
+            lr=1e-3,
+            weight_decay=0.1,
+            implementation="for-loop",
+        )
+        container = config.build(model_parts=[model])
+        opt = container.optimizers[0]
+        self.assertEqual(len(opt.param_groups), 1)
+
+
+class TestOptimizersInBackwardWithParamGroups(unittest.TestCase):
+    def test_build_with_param_groups(self):
+        """OptimizersInBackwardContainer respects param groups."""
+        model = SimpleModel()
+        config = OptimizersInBackwardContainer.Config(
+            name="AdamW",
+            lr=1e-3,
+            weight_decay=0.1,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        self.assertIsInstance(container, OptimizersInBackwardContainer)
+
+        # Check that bias params have weight_decay=0
+        param_to_name = {p: n for n, p in model.named_parameters()}
+        for opt in container.optimizers:
+            for pg in opt.param_groups:
+                for p in pg["params"]:
+                    name = param_to_name.get(p, "")
+                    if name.endswith(".bias"):
+                        self.assertEqual(
+                            pg["weight_decay"],
+                            0.0,
+                            f"Bias param {name} should have weight_decay=0",
+                        )
+
+
+class TestDCPWithParamGroups(unittest.TestCase):
+    def test_state_dict_round_trip(self):
+        """Optimizer state_dict save/load works with multiple param groups."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            name="AdamW",
+            lr=1e-3,
+            weight_decay=0.1,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+                ParamGroupConfig(pattern=r"embed_tokens\.", lr_multiplier=0.1),
+            ],
+        )
+        container = config.build(model_parts=[model])
+
+        # Run a step to populate optimizer state
+        dummy_input = torch.randint(0, 32, (2, 4))
+        output = model(dummy_input)
+        output.sum().backward()
+        container.step()
+
+        # Save state dict
+        state_dict = container.state_dict()
+        self.assertIsInstance(state_dict, dict)
+        self.assertTrue(len(state_dict) > 0)
+
+        # Load into a fresh container
+        model2 = SimpleModel()
+        container2 = config.build(model_parts=[model2])
+        container2.load_state_dict(state_dict)
+
+        # Verify state was restored by checking optimizer states match
+        state_dict2 = container2.state_dict()
+        self.assertEqual(set(state_dict.keys()), set(state_dict2.keys()))
+
+        for key in state_dict:
+            v1 = state_dict[key]
+            v2 = state_dict2[key]
+            if isinstance(v1, torch.Tensor):
+                self.assertTrue(
+                    torch.equal(v1, v2),
+                    f"State mismatch for key {key}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -5,8 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
+import re
+from collections import defaultdict
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, TypeVar
 
 import torch
@@ -23,17 +25,45 @@ from torch.distributed.tensor import Replicate
 from torch.optim import Optimizer
 from torchtitan.config import Configurable
 from torchtitan.distributed import ParallelDims
+from torchtitan.tools.logging import logger
 
 __all__ = [
     "OptimizersContainer",
     "OptimizersInBackwardContainer",
+    "ParamGroupConfig",
     "register_moe_load_balancing_hook",
 ]
+
+
+@dataclass(kw_only=True, slots=True)
+class ParamGroupConfig:
+    """Configuration for a parameter group with custom optimizer settings.
+
+    Parameters matching the regex pattern will use lr and weight_decay values
+    derived by multiplying the global optimizer values with the specified multipliers.
+    """
+
+    pattern: str
+    """Regex pattern matched against parameter fully qualified names (FQNs).
+    E.g. '.*bias$', '.*norm.*', '.*\\.embed_tokens\\..*'"""
+
+    lr_multiplier: float = 1.0
+    """Multiplied with the global optimizer lr to get this group's lr."""
+
+    weight_decay_multiplier: float = 1.0
+    """Multiplied with the global optimizer weight_decay to get this group's weight_decay."""
+
+    beta1: float | None = None
+    beta2: float | None = None
+    """Override betas for this group. None means use the global optimizer betas.
+    Each can be overridden independently."""
 
 
 T = TypeVar("T", bound=Optimizer)
 
 
+# TODO: Right now this class is biased towards AdamW. We should refactor to
+# support mixed optimizers, including Muon.
 class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     """A container for multiple optimizers.
 
@@ -87,6 +117,12 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         - more info: https://pytorch.org/docs/stable/optim.html
         """
 
+        param_groups: list[ParamGroupConfig] = field(default_factory=list)
+        """Optional per-parameter-group overrides. Each entry specifies a regex
+        pattern matching parameter FQNs and multipliers for lr and weight_decay.
+        Parameters not matching any pattern use the global defaults.
+        Patterns are checked in order; first match wins."""
+
     optimizers: list[T]
     model_parts: list[nn.Module]
 
@@ -109,6 +145,69 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             "foreach": config.implementation == "foreach",
         }
 
+    @staticmethod
+    def _build_param_groups(
+        model: nn.Module,
+        config: Config,
+        default_kwargs: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Build PyTorch param groups from model parameters and config.
+
+        Each parameter is assigned to the first matching ParamGroupConfig pattern,
+        or to the default group if no pattern matches. Returns a list of dicts
+        with "params" key and optimizer kwargs, suitable for passing to an optimizer.
+        """
+        if not config.param_groups:
+            params = [p for p in model.parameters() if p.requires_grad]
+            return [{"params": params, **default_kwargs}]
+
+        compiled_patterns = [re.compile(pg.pattern) for pg in config.param_groups]
+
+        # group_index -> list of params; None means default group
+        grouped_params: dict[int | None, list[nn.Parameter]] = defaultdict(list)
+
+        for name, param in model.named_parameters():
+            if not param.requires_grad:
+                continue
+            matched_index = None
+            for i, pat in enumerate(compiled_patterns):
+                if pat.search(name):
+                    matched_index = i
+                    break
+            grouped_params[matched_index].append(param)
+
+        # Warn for patterns that matched nothing
+        for i, pg in enumerate(config.param_groups):
+            if i not in grouped_params:
+                logger.warning(
+                    f"Optimizer param_groups pattern '{pg.pattern}' "
+                    f"matched no parameters"
+                )
+
+        result = []
+        # Default group first (unmatched params)
+        if None in grouped_params:
+            result.append({"params": grouped_params[None], **default_kwargs})
+
+        # Then each matched group in pattern order
+        for i, pg in enumerate(config.param_groups):
+            if i not in grouped_params:
+                continue
+            group_kwargs = {**default_kwargs}
+            group_kwargs["lr"] = default_kwargs["lr"] * pg.lr_multiplier
+            group_kwargs["weight_decay"] = (
+                default_kwargs["weight_decay"] * pg.weight_decay_multiplier
+            )
+            if pg.beta1 is not None or pg.beta2 is not None:
+                default_beta1, default_beta2 = default_kwargs["betas"]
+                group_kwargs["betas"] = (
+                    pg.beta1 if pg.beta1 is not None else default_beta1,
+                    pg.beta2 if pg.beta2 is not None else default_beta2,
+                )
+            result.append({"params": grouped_params[i], **group_kwargs})
+
+        return result
+
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         optimizer_cls = self._resolve_optimizer_cls(config.name)
         optimizer_kwargs = self._build_optimizer_kwargs(config)
@@ -116,9 +215,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         self.optimizers = []
         self.model_parts = model_parts
         for model in self.model_parts:
-            params = [p for p in model.parameters() if p.requires_grad]
-            self.optimizers.append(optimizer_cls(params, **optimizer_kwargs))
-            all_params.extend(params)
+            param_groups = self._build_param_groups(model, config, optimizer_kwargs)
+            self.optimizers.append(optimizer_cls(param_groups))
+            for group in param_groups:
+                all_params.extend(group["params"])
         self._validate_length(len(self.model_parts))
         self._post_init(all_params, optimizer_kwargs)
 
@@ -193,11 +293,20 @@ class OptimizersInBackwardContainer(OptimizersContainer):
         all_params = []
         self.model_parts = model_parts
 
+        # Build a mapping from param -> effective kwargs using param group config
+        param_to_kwargs: dict[nn.Parameter, dict[str, Any]] = {}
+        for model in self.model_parts:
+            param_groups = self._build_param_groups(model, config, optimizer_kwargs)
+            for group in param_groups:
+                group_kwargs = {k: v for k, v in group.items() if k != "params"}
+                for p in group["params"]:
+                    param_to_kwargs[p] = group_kwargs
+
         optim_dict = {}
         for model in self.model_parts:
             for p in model.parameters():
                 if p.requires_grad:
-                    optim_dict[p] = optimizer_cls([p], **optimizer_kwargs)
+                    optim_dict[p] = optimizer_cls([p], **param_to_kwargs[p])
                 all_params.append(p)
 
         def optim_hook(param) -> None:

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -7,7 +7,7 @@
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.config import (
     ActivationCheckpointConfig,
     ParallelismConfig,
@@ -48,6 +48,28 @@ def qwen3_debugmodel() -> Trainer.Config:
             mode="selective",
         ),
     )
+
+
+def qwen3_debugmodel_param_groups() -> Trainer.Config:
+    config = qwen3_debugmodel()
+    config.optimizer = OptimizersContainer.Config(
+        lr=8e-4,
+        param_groups=[
+            ParamGroupConfig(
+                pattern=r"tok_embeddings\.",
+                weight_decay_multiplier=0.0,
+            ),
+            ParamGroupConfig(
+                pattern=r"\.bias$",
+                weight_decay_multiplier=0.0,
+            ),
+            ParamGroupConfig(
+                pattern=r"(?:attention_norm|ffn_norm|norm)\.",
+                weight_decay_multiplier=0.0,
+            ),
+        ],
+    )
+    return config
 
 
 def qwen3_debugmodel_flex() -> Trainer.Config:


### PR DESCRIPTION
It is common to have different learning rates and weight decay rates for different parameters in the model.

Requested in https://github.com/pytorch/torchtitan/issues/2599, and as an alternative approach to https://github.com/pytorch/torchtitan/pull/2600.

In this PR we put `param_groups` as a `list[ParaGroupConfig]` into the optimizer config, to override lr and weight decay with multipliers based on regex matching.
