### PR TITLE
Fix UnicodeDecodeError in integration test runner

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -25,7 +25,9 @@ _TEST_SUITES_FUNCTION = {
 
 
 def _run_cmd(cmd):
-    return subprocess.run([cmd], text=True, shell=True, capture_output=True)
+    return subprocess.run(
+        [cmd], encoding="utf-8", errors="replace", shell=True, capture_output=True
+    )
 
 
 def run_single_test(


### PR DESCRIPTION
Summary:
The integration test runner sets `TORCH_TRACE` to capture compile traces,
which produces binary data in subprocess stdout/stderr. Using `text=True`
in `subprocess.run` forces strict UTF-8 decoding that fails on these
binary bytes with errors like:

  'utf-8' codec can't decode byte 0xe1 in position 75424

Replace `text=True` with explicit `encoding="utf-8", errors="replace"`
so binary bytes are gracefully replaced with the Unicode replacement
character instead of crashing the test harness.

This fixes `torchtitan_features_integration` and
`torchtitan_models_integration` CI jobs.

Differential Revision: D99831596


