### PR TITLE
[GraphTrainer]Enable regional_inductor for GraphTrainer

### DIFF
--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -560,7 +560,14 @@ def get_joint_custom_passes_from_config(
     # annotations. The validation is only relevant for regional_inductor.
     pass_names = getattr(compile_config, "passes", [])
     if "full_inductor_compilation" not in pass_names:
-        joint_custom_passes.append(annotate_flex_attention_for_regional_inductor_pass)
+        from torchtitan.models.common.attention import FlexAttention
+
+        joint_custom_passes.append(
+            functools.partial(
+                annotate_flex_attention_for_regional_inductor_pass,
+                flex_compile_config=FlexAttention.inductor_configs,
+            )
+        )
 
     # Handle joint passes from config (excluding inductor_decomposition)
     joint_pass_names = getattr(compile_config, "joint_passes", [])

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -197,6 +197,8 @@ def construct_default_graph_passes(
     Returns:
         An ordered list of graph passes ready to apply.
     """
+    from torchtitan.models.common.attention import FlexAttention
+
     passes: list[Callable] = [
         functools.partial(tlparse_log_graph_pass, graph_name="make_fx_graph_traced"),
         remove_detach_pass,
@@ -206,7 +208,10 @@ def construct_default_graph_passes(
         # produce bitwise identical results to the eager Trainer path.
         # When left uncompiled, flex_attention still runs correctly but
         # produces different numerical results.
-        annotate_flex_attention_for_regional_inductor_pass,
+        functools.partial(
+            annotate_flex_attention_for_regional_inductor_pass,
+            flex_compile_config=FlexAttention.inductor_configs,
+        ),
         regional_inductor_pass,
     ]
 
@@ -430,7 +435,8 @@ def annotate_flex_attention_for_regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
     *,
-    inductor_configs: dict | None = None,
+    flex_compile_config: dict | None,
+    mask_compile_config: dict | None = None,
 ) -> torch.fx.GraphModule:
     """Tag flex attention HOPs with compile_with_inductor for regional_inductor.
 
@@ -443,16 +449,25 @@ def annotate_flex_attention_for_regional_inductor_pass(
     Args:
         gm: The graph module to annotate.
         example_inputs: Example inputs (unused, required by pass interface).
-        inductor_configs: Per-region inductor config overrides for flex
-            attention nodes. Defaults to ``FlexAttention.inductor_configs``.
+        flex_compile_config: Inductor config dict for flex attention HOP
+            nodes and their get_attr submodule references. When provided,
+            wrapped as ``{"inductor_configs": flex_compile_config}``.
+            When None, nodes are tagged with an empty annotation.
+        mask_compile_config: Inductor config dict for nodes inside mask_mod
+            subgraphs. When provided, wrapped as
+            ``{"inductor_configs": mask_compile_config}``.
+            When None, nodes are tagged with an empty annotation.
     """
-    if inductor_configs is None:
-        from torchtitan.models.common.attention import FlexAttention
-
-        inductor_configs = FlexAttention.inductor_configs
-
-    flex_compile_config = {"inductor_configs": inductor_configs}
-    mask_compile_config = {}
+    flex_compile_annotation: dict = (
+        {"inductor_configs": flex_compile_config}
+        if flex_compile_config is not None
+        else {}
+    )
+    mask_compile_annotation: dict = (
+        {"inductor_configs": mask_compile_config}
+        if mask_compile_config is not None
+        else {}
+    )
 
     for node in gm.graph.nodes:
         if node.target not in {
@@ -462,7 +477,7 @@ def annotate_flex_attention_for_regional_inductor_pass(
             continue
         node.meta.setdefault("custom", {})[
             "compile_with_inductor"
-        ] = flex_compile_config
+        ] = flex_compile_annotation
         for inp in node.all_input_nodes:
             if inp.op != "get_attr":
                 continue
@@ -471,13 +486,13 @@ def annotate_flex_attention_for_regional_inductor_pass(
                 continue
             inp.meta.setdefault("custom", {})[
                 "compile_with_inductor"
-            ] = flex_compile_config
+            ] = flex_compile_annotation
 
             # Following are the nodes in mask_mod subgraph
             for sub_node in submod.graph.nodes:
                 sub_node.meta.setdefault("custom", {})[
                     "compile_with_inductor"
-                ] = mask_compile_config
+                ] = mask_compile_annotation
     return gm
 
 
@@ -806,6 +821,5 @@ AVAILABLE_COMPILER_PASSES = {
 AVAILABLE_JOINT_PASSES = {
     "inductor_decomposition": inductor_decomposition_pass,
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
-    "annotate_flex_attention_for_regional_inductor": annotate_flex_attention_for_regional_inductor_pass,
     "apply_sac": apply_sac_pass,
 }

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -197,11 +197,6 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
             """66bbbbc98b4c1635e42a133ac1fbd499a2b8633ca879f4121cf206708c21dbdf""",
         )
 
-    # TODO: OOMs during flex_attention compilation on non-H100 GPUs.
-    # Revisit when GraphTrainer addresses peak memory during compilation.
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "OOMs during flex_attention compilation on < H100"
-    )
     def test_aot_fx_trace_vs_eager(self):
         """aot_fx_trace and eager produce bitwise identical losses and grads."""
         run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)
@@ -238,11 +233,6 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
             """30d87367fe7227032c71fe4fab7d5162bbc4b7311a4049711f2edd02442679f6""",
         )
 
-    # TODO: OOMs during flex_attention compilation on non-H100 GPUs.
-    # Revisit when GraphTrainer addresses peak memory during compilation.
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "OOMs during flex_attention compilation on < H100"
-    )
     def test_aot_fx_trace_vs_eager(self):
         """aot_fx_trace and eager produce bitwise identical losses and grads."""
         run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)
@@ -283,11 +273,6 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
             """d4c46d7717cb303c7b19e97cd6b4be4af79d73acabafcba6bb1f6ca244159096""",
         )
 
-    # TODO: OOMs during flex_attention compilation on non-H100 GPUs.
-    # Revisit when GraphTrainer addresses peak memory during compilation.
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "OOMs during flex_attention compilation on < H100"
-    )
     def test_aot_fx_trace_vs_eager(self):
         """aot_fx_trace with passes and eager produce bitwise identical results."""
         run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -77,7 +77,12 @@ def _apply_regional_inductor(traced_result):
     from torch.fx.graph import CodeGen
     from torch.fx.passes.regional_inductor import regional_inductor
 
-    annotate_flex_attention_for_regional_inductor_pass(traced_result.gm)
+    from torchtitan.models.common.attention import FlexAttention
+
+    annotate_flex_attention_for_regional_inductor_pass(
+        traced_result.gm,
+        flex_compile_config=FlexAttention.inductor_configs,
+    )
 
     fake_mode = None
     for node in traced_result.gm.graph.nodes:
@@ -763,7 +768,12 @@ class TestTraceModels(unittest.TestCase):
         ]
         self.assertGreater(len(flex_nodes), 0, "No FlexAttentionHOP nodes found")
 
-        annotate_flex_attention_for_regional_inductor_pass(traced.gm)
+        from torchtitan.models.common.attention import FlexAttention
+
+        annotate_flex_attention_for_regional_inductor_pass(
+            traced.gm,
+            flex_compile_config=FlexAttention.inductor_configs,
+        )
 
         for node in flex_nodes:
             custom = node.meta.get("custom", {})


### PR DESCRIPTION
## Summary

Enables `regional_inductor` compilation for FlexAttention HOPs in the GraphTrainer `aot_fx_trace` path. Previously, FlexAttention higher-order ops were left uncompiled after `make_fx` tracing, producing different numerical results than eager. With this PR, `annotate_flex_attention_for_regional_inductor_pass` tags FlexAttention nodes with `compile_with_inductor` metadata, and `regional_inductor_pass` compiles those tagged regions into fused Triton kernels — achieving **bitwise identical** results to the eager Trainer path for all models (Llama3, DeepSeek-v3, and their FlexAttention variants).

### Changes

**`passes.py`**
- Add `annotate_flex_attention_for_regional_inductor_pass` and `regional_inductor_pass` to `construct_default_graph_passes` default pass list
- `annotate_flex_attention_for_regional_inductor_pass`: accept optional `inductor_configs` kwarg (defaults to `FlexAttention.inductor_configs`); use empty config for mask_mod subgraph nodes
- `regional_inductor_pass`: create `TracingContext` from graph's `FakeTensorMode` (required when called outside `torch.compile`); set `eager_numerics.division_rounding = True` for bitwise-equal numerics; reset codegen after compilation to restore default calling convention


**`test_bitwise_deterministic.py`**
- Remove `test_graph_trainer_enable_passes_true_vs_false` (no longer meaningful — passes are always on)
- Add `test_aot_fx_trace_vs_eager` to FlexAttention test classes (now that they match bitwise)
- Convert FlexAttn self-deterministic tests to use eager Trainer with updated expected hashes
- Make `model_flavor` a required field on the base class (no default)

**`test_trace_module.py`**
- Fix pre-existing bug: `llama3_configs["debugmodel"]` → `llama3_configs["debugmodel"]()` (missing function call)

## Test plan

- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x` — all 8 tests pass (Llama3, DSv3, Llama3-FlexAttn, DSv3-FlexAttn × {eager self-deterministic, eager vs aot_fx_trace})
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -x` — passes with the `debugmodel` config fix
- [x] 8-GPU integration tests via CI (`ciflow/8gpu`)