### PR TITLE
[BE][Typing] Fix pyrefly bad-argument-type errors for PP losses

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -302,12 +302,12 @@ class Validator(BaseValidator):
 
                 # accumulate losses across pipeline microbatches
                 # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
-                loss_sum = (
+                if self.pp_has_last_stage:
+                    assert losses is not None
                     # using sum because loss_fn already uses reduction='sum'
-                    torch.sum(torch.stack(losses)).to(device_type)
-                    if self.pp_has_last_stage
-                    else torch.tensor([-1.0], device=device_type)
-                )
+                    loss_sum = torch.sum(torch.stack(losses)).to(device_type)
+                else:
+                    loss_sum = torch.tensor([-1.0], device=device_type)
             else:
                 with self.validation_context():
                     assert len(model_parts) == 1

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -689,13 +689,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             # accumulate losses across pipeline microbatches
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
-            loss = (
-                # Rescale PP loss to be "local loss sum / global valid tokens)
-                # because each microbathes could have different number of valid tokens
-                (torch.sum(torch.stack(losses)) / global_valid_tokens).to(self.device)
-                if self.pp_has_last_stage
-                else torch.tensor([-1.0], device=self.device)
-            )
+            if self.pp_has_last_stage:
+                assert losses is not None
+                # Rescale PP loss to be "local loss sum / global valid tokens"
+                # because each microbatch could have different number of valid tokens
+                loss = (torch.sum(torch.stack(losses)) / global_valid_tokens).to(
+                    self.device
+                )
+            else:
+                loss = torch.tensor([-1.0], device=self.device)
         else:
             # Non-PP forward / backward
             assert len(model_parts) == 1


### PR DESCRIPTION
The `losses` variable gets type `list[Unknown] | None` from the ternary `(labels, []) if pp_has_last_stage else (None, None)`, which pyrefly cannot narrow inside a subsequent ternary expression passed to `torch.stack()`. Convert to if/else blocks with an explicit assert to let the type checker see the narrowing.

See ex failing lint on https://github.com/pytorch/torchtitan/actions/runs/24088557548/job/70268213611?pr=2803

Authored with Claude