### PR TITLE
[Bugfix] Reenable llvm with triton pin update

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-
-# TODO: Re-enable once we have closed
-# https://github.com/pytorch/torchtitan/issues/2722
-os.environ.setdefault("DISABLE_LLVM_OPT", "1")
-
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import ClassVar, NamedTuple


### PR DESCRIPTION
Fixes #2722

## Summary

After https://github.com/pytorch/pytorch/pull/179586 lands, the llvm change caused flex attention failure should be resolved

This PR this removes the coarse grained disable that we needed to unblock CI

## Test plan

See CI 


For local repro, try 
```bash
NGPU=8 LOG_RANK=0,1,2,3,4,5,6,7 ./run_train.sh  --module graph_trainer.deepseek_v3 --config graph_trainer_deepseek_v3_debugmodel --compile.mode aot --parallelism.data_parallel_shard_degree 4 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4 --parallelism.expert_tensor_parallel_degree 1 --compile.joint_passes inductor_decomposition

```