### PR TITLE
[GraphTrainer][AutoDev] Accept float inputs in CUDAGraphWrapper

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -160,11 +160,12 @@ class CUDAGraphWrapper:
     def _check_input_types(self, inputs) -> None:
         for i, inp in enumerate(inputs):
             if not (
-                isinstance(inp, (torch.Tensor, int, torch._C.Generator))
+                isinstance(inp, (torch.Tensor, int, float, torch._C.Generator))
                 or is_opaque_value(inp)
             ):
                 raise ValueError(
                     "args must be tensor, integer (for dynamic shapes), "
+                    "float (for scalar constants), "
                     "Generator (for random number generator), "
                     "or opaque object, "
                     f"but found {type(inp)} with value {inp!r} at index {i}"


### PR DESCRIPTION
## Summary

- Add `float` to the supported input types in `CUDAGraphWrapper._check_input_types`
- The aot_fx_trace joint graph can produce float-valued inputs (e.g. `global_valid_tokens` scaling factor), which previously caused a `ValueError` during CUDA graph recording
- Float inputs are treated as static constants baked into the graph at recording time (they are not in `_input_indices_to_copy`, so they won't be updated on replay)

## Context

Spun off from [PR #2868](https://github.com/pytorch/torchtitan/pull/2868) review feedback. The original error was:
```
ValueError: args must be tensor, integer (for dynamic shapes), Generator (for random number generator), or opaque object, but found <class 'float'> with value 65536.0 at index 117
```

## Test plan

- [x] `pre-commit run --all-files` passes (all hooks green)
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x` — 12/12 passed
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -x` — 24/24 passed