### PR TITLE
Set cast_forward_inputs=False for LLM model's MixedPrecisionPolicy 

### DIFF
--- a/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
+++ b/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
@@ -96,7 +96,11 @@ def parallelize_llama(
 
     param_dtype = TORCH_DTYPE_MAP[training.mixed_precision_param]
     reduce_dtype = TORCH_DTYPE_MAP[training.mixed_precision_reduce]
-    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        cast_forward_inputs=False,
+    )
     with AutoParallel(
         model,
         input_fn,

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -26,6 +26,7 @@ from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
+
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -22,6 +22,7 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
+
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -333,7 +333,11 @@ def apply_fsdp(
             - "never" will disable `reshard_after_forward` for all forward passes.
 
     """
-    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        cast_forward_inputs=False,
+    )
     fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
     if cpu_offload:
         fsdp_config["offload_policy"] = CPUOffloadPolicy()

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -297,7 +297,11 @@ def apply_fsdp(
             - "never" will disable `reshard_after_forward` for all forward passes.
 
     """
-    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        cast_forward_inputs=False,
+    )
     fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
     if cpu_offload:
         # pyrefly: ignore[bad-typed-dict-key]
@@ -356,7 +360,11 @@ def apply_replicate(
     param_dtype: torch.dtype,
     reduce_dtype: torch.dtype,
 ):
-    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        cast_forward_inputs=False,
+    )
     replicate_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
 
     if model.tok_embeddings is not None:

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -344,7 +344,11 @@ def apply_fsdp(
             - "never" will disable `reshard_after_forward` for all forward passes.
 
     """
-    mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        cast_forward_inputs=False,
+    )
     fsdp_config: dict[str, Any] = {"mesh": dp_mesh, "mp_policy": mp_policy}
     if cpu_offload:
         fsdp_config["offload_policy"] = CPUOffloadPolicy()


### PR DESCRIPTION
Summary

- Set `cast_forward_inputs=False` on all `MixedPrecisionPolicy` instances. By default, FSDP2's `cast_forward_inputs=True` casts all forward inputs to param_dtype (e.g. bfloat16). In torchtitan, `TransformerBlock.forward(x, freqs_cis, attention_masks, positions)` is wrapped by `fully_shard`, and the `freqs_cis` (RoPE cache) is precomputed as float32 (cos/sin RoPE). Casting `freqs_cis` to bfloat16 would lose necessary precision in the cos/sin case. 

- For the other forward inputs: x (intermediate activations) is already in param_dtype from the preceding FSDP-wrapped module's output or the embedding layer, so the cast is a no-op. `attention_masks` and `positions` are not floating-point tensors, so FSDP2's cast_forward_inputs skips them.

-  `cast_forward_inputs=False` is only safe for LLM models where all float inputs to FSDP-wrapped modules are already in param_dtype. Image models (Flux, VLM) receive external float32 inputs (pixel values, timesteps, text embeddings) from preprocessing that genuinely need to be cast to param_dtype, so they retain the default `cast_forward_inputs=True`.

Test Plan:

```
pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py 
```

Will wait the numerics tests in graph_trainer to be re-enabled first and then land this PR.