### PR TITLE
[FSDP2] lazy import FSDPMeshInfo/ShardPlacementResult for older PyTorch

### DIFF
--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -10,10 +10,6 @@ import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
-from torch.distributed.fsdp._fully_shard._fsdp_common import (
-    FSDPMeshInfo,
-    ShardPlacementResult,
-)
 from torch.distributed.tensor import Partial, Replicate, Shard
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
@@ -430,6 +426,11 @@ def apply_fsdp(
                 )
             else:
                 # ep_degree > 1: per-param mesh
+                from torch.distributed.fsdp._fully_shard._fsdp_common import (
+                    FSDPMeshInfo,
+                    ShardPlacementResult,
+                )
+
                 assert edp_mesh is not None
                 edp_mesh_info = FSDPMeshInfo(mesh=edp_mesh, shard_mesh_dim=0)
                 dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)


### PR DESCRIPTION
import new fsdp2 feature inside `ep_degree > 1`, where they are actually used

this make sure older PyTorch still runs

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/fbsource/fbcode/pytorch/torchtitan/fb/six_cluster/.venv/lib/python3.12/site-packages/torchtitan/experiments/rl/config_registry.py", line 24, in <module>
    from torchtitan.models.qwen3 import model_registry
  File "/fbsource/fbcode/pytorch/torchtitan/fb/six_cluster/.venv/lib/python3.12/site-packages/torchtitan/models/qwen3/__init__.py", line 27, in <module>
    from .parallelize import parallelize_qwen3
  File "/fbsource/fbcode/pytorch/torchtitan/fb/six_cluster/.venv/lib/python3.12/site-packages/torchtitan/models/qwen3/parallelize.py", line 39, in <module>
    from torchtitan.models.llama4.parallelize import apply_fsdp, apply_moe_ep_tp
  File "/fbsource/fbcode/pytorch/torchtitan/fb/six_cluster/.venv/lib/python3.12/site-packages/torchtitan/models/llama4/__init__.py", line 24, in <module>
    from .parallelize import parallelize_llama
  File "/fbsource/fbcode/pytorch/torchtitan/fb/six_cluster/.venv/lib/python3.12/site-packages/torchtitan/models/llama4/parallelize.py", line 13, in <module>
    from torch.distributed.fsdp._fully_shard._fsdp_common import (
ImportError: cannot import name 'ShardPlacementResult' from 'torch.distributed.fsdp._fully_shard._fsdp_common' 
```

Co-authored-by: Danielle Pintz <daniellepintz@users.noreply.github.com>