### PR TITLE
[GraphTrainer][AutoDev] Add remove_detach_pass to simplify traced graphs

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -438,6 +438,28 @@ def reassign_to_pg_pass(
     return gm
 
 
+def remove_detach_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple | None = None
+) -> torch.fx.GraphModule:
+    """Remove ``aten.detach.default`` nodes from the graph.
+
+    In traced fwd+bwd graphs there is no autograd context, so detach is a
+    semantic no-op.  Removing these nodes simplifies the graph for downstream
+    passes and reduces memory overhead.
+    """
+    count = 0
+    for node in list(gm.graph.nodes):
+        if node.op == "call_function" and node.target == torch.ops.aten.detach.default:
+            node.replace_all_uses_with(node.args[0])
+            gm.graph.erase_node(node)
+            count += 1
+    if count > 0:
+        gm.graph.lint()
+        gm.recompile()
+        logger.info(f"Removed {count} detach nodes")
+    return gm
+
+
 def tlparse_log_graph_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
@@ -478,6 +500,7 @@ def tlparse_log_graph_pass(
 
 # Registry mapping pass names to pass functions (for AOT mode fwd/bwd passes)
 AVAILABLE_COMPILER_PASSES = {
+    "remove_detach": remove_detach_pass,
     "auto_bucketing": autobucketing_reordering_pass,
     "transformer_block_bucketing": transformer_block_bucketing_reordering_pass,
     "regional_inductor": regional_inductor_pass,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -22,6 +22,7 @@ from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.passes import (
     apply_sac_pass,
     reassign_to_pg_pass,
+    remove_detach_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
 from torchtitan.models.common.linear import Linear
@@ -404,6 +405,65 @@ class TestApplySACPass(TestCase):
         for node, (target, policy) in zip(nodes, expected):
             self.assertEqual(node.target, target)
             self.assertEqual(node.meta["recompute"], policy, f"node {node.name}")
+
+
+class TestRemoveDetachPass(TestCase):
+    """Unit tests for the remove_detach_pass graph pass."""
+
+    def _build_gm_with_detach(self):
+        """Build a GraphModule with detach nodes interleaved with compute ops.
+
+        Graph: placeholder(x) -> relu -> detach -> neg -> detach -> output
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        detach1 = graph.call_function(torch.ops.aten.detach.default, args=(relu,))
+        neg = graph.call_function(torch.ops.aten.neg.default, args=(detach1,))
+        detach2 = graph.call_function(torch.ops.aten.detach.default, args=(neg,))
+        graph.output(detach2)
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def _count_detach_nodes(self, gm):
+        return sum(
+            1
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.detach.default
+        )
+
+    def test_detach_nodes_removed(self):
+        """All aten.detach.default nodes should be erased from the graph."""
+        gm = self._build_gm_with_detach()
+        self.assertEqual(self._count_detach_nodes(gm), 2)
+
+        remove_detach_pass(gm)
+
+        self.assertEqual(self._count_detach_nodes(gm), 0)
+
+    def test_output_unchanged(self):
+        """The graph should produce the same output after removing detach nodes."""
+        gm = self._build_gm_with_detach()
+        x = torch.randn(4, 4)
+        expected = gm(x)
+
+        remove_detach_pass(gm)
+
+        result = gm(x)
+        torch.testing.assert_close(result, expected)
+
+    def test_noop_when_no_detach(self):
+        """When there are no detach nodes, the pass should be a no-op."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        graph.output(relu)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        node_count_before = len(list(gm.graph.nodes))
+        remove_detach_pass(gm)
+        node_count_after = len(list(gm.graph.nodes))
+
+        self.assertEqual(node_count_before, node_count_after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `remove_detach_pass` that removes `aten.detach.default` no-op nodes from traced fwd+bwd graphs
- Registered as `"remove_detach"` in `AVAILABLE_COMPILER_PASSES`
- In traced graphs, detach has no semantic meaning (no autograd context) — removing them saves ~2 GiB memory and simplifies the graph for downstream passes
- Source: PR #2862 (autoresearch experiments on Llama3 8B)

## Test plan
- [ ] Unit test in `test_passes.py` verifying detach nodes are removed and graph output is unchanged
- [ ] `test_bitwise_deterministic.py` passes (numerics unchanged)
- [ ] `pre-commit run --all-files` clean

Board item: https://github.com/orgs/pytorch/projects/161