### PR TITLE
Rewrite model state dict adapters with explicit RENAME/LAYER_RENAME pattern

### DIFF
--- a/torchtitan/models/deepseek_v3/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/state_dict_adapter.py
@@ -4,24 +4,34 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import re
 from typing import Any
 
 import torch
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 
-from torch.distributed.tensor import DTensor
-
 from torchtitan.models.utils import MoEStateDictAdapter
 
 from .model import DeepSeekV3Model
 
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_HF_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.")
+
 
 class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
-    """
-    StateDictAdapter for DeepSeekV3 model.
-    """
+    _HF_EXPERT_RE = re.compile(
+        r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+    )
+    _PROJ_TO_HF = {
+        "moe.experts.w1": "gate_proj",
+        "moe.experts.w3": "up_proj",
+        "moe.experts.w2": "down_proj",
+    }
+    _PROJ_FROM_HF = {
+        "gate_proj": "moe.experts.w1",
+        "up_proj": "moe.experts.w3",
+        "down_proj": "moe.experts.w2",
+    }
 
     def __init__(
         self,
@@ -29,62 +39,20 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
         hf_assets_path: str | None,
     ):
         super().__init__(model_config, hf_assets_path)
-        self.from_hf_map = {
-            "model.embed_tokens.weight": "tok_embeddings.weight",
-            # Attention Module
-            "model.layers.{}.self_attn.kv_a_proj_with_mqa.weight": "layers.{}.attention.wkv_a.weight",
-            "model.layers.{}.self_attn.kv_a_layernorm.weight": "layers.{}.attention.kv_norm.weight",
-            "model.layers.{}.self_attn.kv_b_proj.weight": "layers.{}.attention.wkv_b.weight",
-            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-            # MLP Module
-            "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
-            "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
-            "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
-            # Transformer Layer
-            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE Module
-            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1",
-            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3",
-            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2",
-            "model.layers.{}.mlp.gate.weight": "layers.{}.moe.router.gate.weight",
-            "model.layers.{}.mlp.shared_experts.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
-            "model.layers.{}.mlp.shared_experts.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",
-            "model.layers.{}.mlp.shared_experts.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
-            "model.layers.{}.mlp.gate.e_score_correction_bias": "layers.{}.moe.expert_bias",
-            "model.norm.weight": "norm.weight",
-            "lm_head.weight": "output.weight",
-        }
-
-        # Adjustments for from_hf_map based on model architecture
-        if model_config.layers[0].attention.q_lora_rank != 0:
-            self.from_hf_map.update(
-                {
-                    "model.layers.{}.self_attn.q_a_proj.weight": "layers.{}.attention.wq_a.weight",
-                    "model.layers.{}.self_attn.q_a_layernorm.weight": "layers.{}.attention.q_norm.weight",
-                    "model.layers.{}.self_attn.q_b_proj.weight": "layers.{}.attention.wq_b.weight",
-                }
-            )
-        else:
-            self.from_hf_map.update(
-                {
-                    "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
-                }
-            )
+        self.model_config = model_config
+        # pyrefly: ignore [missing-attribute]
+        self._has_q_lora = model_config.layers[0].attention.q_lora_rank != 0
 
     def get_hf_storage_reader(
         self, path: str, from_quantized: bool = False
     ) -> HuggingFaceStorageReader:
-        """
-        Override default get_hf_storage_reader function to return QuantizedHFStorageReader.
-        """
+        # NOTE: Now we use Quantized HF storage reader to read DeepSeek-V3 671B model.
+        # If loading checkpoints without quantization, use HuggingFaceStorageReader instead
         if from_quantized:
             from torch.distributed.checkpoint.quantized_hf_storage import (
                 QuantizedHuggingFaceStorageReader,
             )
 
-            # NOTE: Now we use Quantized HF storage reader to read DeepSeek-V3 671B model.
-            # If loading checkpoints without quantization, use HuggingFaceStorageReader instead
             BLOCK_SIZE = 128
             return QuantizedHuggingFaceStorageReader(
                 path=path,
@@ -96,123 +64,112 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
             return HuggingFaceStorageReader(path)
 
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        1. Convert between the HF shape and the torchtitan shape.
-        2. Split the GroupedExperts' weight into separate expert's weight.
-        """
-        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+        """Convert torchtitan state dict to HF format.
 
-        hf_state_dict = {}
+        Renames FQNs and splits 3D GroupedExperts weights into individual
+        2D per-expert weights.
+        """
+        RENAME = {
+            "tok_embeddings.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "output.weight": "lm_head.weight",
+        }
+        LAYER_RENAME = {
+            "attention.wkv_a.weight": "self_attn.kv_a_proj_with_mqa.weight",
+            "attention.kv_norm.weight": "self_attn.kv_a_layernorm.weight",
+            "attention.wkv_b.weight": "self_attn.kv_b_proj.weight",
+            "attention.wo.weight": "self_attn.o_proj.weight",
+            "feed_forward.w1.weight": "mlp.gate_proj.weight",
+            "feed_forward.w3.weight": "mlp.up_proj.weight",
+            "feed_forward.w2.weight": "mlp.down_proj.weight",
+            "attention_norm.weight": "input_layernorm.weight",
+            "ffn_norm.weight": "post_attention_layernorm.weight",
+            "moe.router.gate.weight": "mlp.gate.weight",
+            "moe.expert_bias": "mlp.gate.e_score_correction_bias",
+            "moe.shared_experts.w1.weight": "mlp.shared_experts.gate_proj.weight",
+            "moe.shared_experts.w3.weight": "mlp.shared_experts.up_proj.weight",
+            "moe.shared_experts.w2.weight": "mlp.shared_experts.down_proj.weight",
+        }
+
+        hf: dict[str, Any] = {}
 
         for key, value in state_dict.items():
-            if "moe.experts" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_abstract_key = to_hf_map[abstract_key]
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            elif m := _LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-                # Store the GroupedExperts Weight metadata for from_hf()
-                if isinstance(value, DTensor):
-                    self.grouped_expert_weight_placements[
-                        abstract_key
-                    ] = value.placements
-                    self.grouped_expert_weight_shape[abstract_key] = value.shape
-                    self.grouped_expert_weight_mesh[abstract_key] = value.device_mesh
+                if suffix in LAYER_RENAME:
+                    hf[f"model.layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+                # Attention — Q projection (depends on q_lora_rank)
+                elif suffix == "attention.wq_a.weight" and self._has_q_lora:
+                    hf[f"model.layers.{layer}.self_attn.q_a_proj.weight"] = value
+                elif suffix == "attention.q_norm.weight" and self._has_q_lora:
+                    hf[f"model.layers.{layer}.self_attn.q_a_layernorm.weight"] = value
+                elif suffix == "attention.wq_b.weight" and self._has_q_lora:
+                    hf[f"model.layers.{layer}.self_attn.q_b_proj.weight"] = value
+                elif suffix == "attention.wq.weight" and not self._has_q_lora:
+                    hf[f"model.layers.{layer}.self_attn.q_proj.weight"] = value
+                # MoE experts (3D GroupedExperts → individual 2D experts)
+                elif suffix in self._PROJ_TO_HF:
+                    self._experts_to_hf(suffix, layer, value, hf)
 
-                    # Split GroupedExperts weight to local individual expert weights
-                    local_expert_fqn = self._get_local_experts_weights(
-                        new_abstract_key,
-                        abstract_key,
-                        layer_num,
-                        value,
-                    )
-                    hf_state_dict.update(local_expert_fqn)
-
-                else:
-                    # keep this path for offline conversion
-                    moe_layer = next(
-                        l for l in self.model_config.layers if l.moe is not None
-                    )
-                    split_values = self._split_experts_weights(
-                        value,
-                        moe_layer.moe.num_experts,
-                    )
-
-                    for expert_num in range(0, moe_layer.moe.num_experts):
-                        new_key = new_abstract_key.format(layer_num, expert_num)
-                        hf_state_dict[new_key] = split_values[expert_num].squeeze()
-
-            elif "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = to_hf_map[abstract_key]
-                new_key = new_key.format(layer_num)
-                hf_state_dict[new_key] = value
-
-            else:
-                new_key = to_hf_map[key]
-                hf_state_dict[new_key] = value
-
-        return hf_state_dict
+        return hf
 
     def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        1. When loading from HF checkpoint, dequantize the weights from float8 to float32.
-        2. Convert between the HF shape and the torchtitan shape.
-        3. Concat separate expert's weight into GroupedExperts' weight.
-        """
+        """Convert HF state dict to torchtitan format.
 
-        state_dict = {}
-        expert_weights_by_layer = {}  # {layer: {abstract_key: {expert_id: tensor}}}
+        Renames FQNs and concatenates individual 2D per-expert weights
+        back into 3D GroupedExperts weights. Dequantization (if needed) is
+        handled by QuantizedHuggingFaceStorageReader during load.
+        """
+        RENAME = {
+            "model.embed_tokens.weight": "tok_embeddings.weight",
+            "model.norm.weight": "norm.weight",
+            "lm_head.weight": "output.weight",
+        }
+        LAYER_RENAME = {
+            "self_attn.kv_a_proj_with_mqa.weight": "attention.wkv_a.weight",
+            "self_attn.kv_a_layernorm.weight": "attention.kv_norm.weight",
+            "self_attn.kv_b_proj.weight": "attention.wkv_b.weight",
+            "self_attn.o_proj.weight": "attention.wo.weight",
+            "mlp.gate_proj.weight": "feed_forward.w1.weight",
+            "mlp.up_proj.weight": "feed_forward.w3.weight",
+            "mlp.down_proj.weight": "feed_forward.w2.weight",
+            "input_layernorm.weight": "attention_norm.weight",
+            "post_attention_layernorm.weight": "ffn_norm.weight",
+            "mlp.gate.weight": "moe.router.gate.weight",
+            "mlp.gate.e_score_correction_bias": "moe.expert_bias",
+            "mlp.shared_experts.gate_proj.weight": "moe.shared_experts.w1.weight",
+            "mlp.shared_experts.up_proj.weight": "moe.shared_experts.w3.weight",
+            "mlp.shared_experts.down_proj.weight": "moe.shared_experts.w2.weight",
+        }
+
+        sd: dict[str, Any] = {}
+        expert_weights_by_layer: dict[str, dict[str, dict[int, Any]]] = {}
 
         for key, value in hf_state_dict.items():
-            if "mlp.experts" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=2)
-                layer_num, expert_num = re.findall(r"\d+", key)
-                titan_abstract_key = self.from_hf_map[abstract_key]
-                new_key = titan_abstract_key.format(layer_num)
+            # Check for MoE expert keys first
+            if self._experts_from_hf(key, value, sd, expert_weights_by_layer):
+                continue
 
-                # Store the expert's weight in expert_weights_by_layer for concatenating later.
-                if layer_num not in expert_weights_by_layer:
-                    expert_weights_by_layer[layer_num] = {}
-                if titan_abstract_key not in expert_weights_by_layer[layer_num]:
-                    expert_weights_by_layer[layer_num][titan_abstract_key] = {}
-                expert_weights_by_layer[layer_num][titan_abstract_key][
-                    int(expert_num)
-                ] = value
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            elif m := _HF_LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-                # Use stored metadata to decide path (online vs offline)
-                # Online mode: local_experts_indices was populated during to_hf()
-                if titan_abstract_key in self.local_experts_indices:
-                    stacked_value = self._concatenate_expert_weights_dtensor(
-                        expert_weights_by_layer,
-                        titan_abstract_key,
-                        layer_num,
-                    )
-                else:  # keep this path to be compatible with offline conversion
-                    stacked_value = self._concatenate_expert_weights(
-                        expert_weights_by_layer,
-                        titan_abstract_key,
-                        layer_num,
-                        next(
-                            l for l in self.model_config.layers if l.moe is not None
-                        ).moe.num_experts,
-                    )
+                if suffix in LAYER_RENAME:
+                    sd[f"layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+                # Attention — Q projection (depends on q_lora_rank)
+                elif suffix == "self_attn.q_a_proj.weight" and self._has_q_lora:
+                    sd[f"layers.{layer}.attention.wq_a.weight"] = value
+                elif suffix == "self_attn.q_a_layernorm.weight" and self._has_q_lora:
+                    sd[f"layers.{layer}.attention.q_norm.weight"] = value
+                elif suffix == "self_attn.q_b_proj.weight" and self._has_q_lora:
+                    sd[f"layers.{layer}.attention.wq_b.weight"] = value
+                elif suffix == "self_attn.q_proj.weight" and not self._has_q_lora:
+                    sd[f"layers.{layer}.attention.wq.weight"] = value
 
-                if stacked_value is not None:
-                    state_dict[new_key] = stacked_value
-
-            elif "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = self.from_hf_map[abstract_key]
-                new_key = new_key.format(layer_num)
-                state_dict[new_key] = value
-
-            else:
-                new_key = self.from_hf_map[key]
-                state_dict[new_key] = value
-
-        return state_dict
+        return sd

--- a/torchtitan/models/flux/model/state_dict_adapter.py
+++ b/torchtitan/models/flux/model/state_dict_adapter.py
@@ -9,18 +9,22 @@ import logging
 import os
 import re
 
-from collections import defaultdict
 from typing import Any
 
 import torch
-from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 
 from .model import FluxModel
 
 logger = logging.getLogger()
 
+_SINGLE_BLOCK_RE = re.compile(r"^single_blocks\.(\d+)\.")
+_DOUBLE_BLOCK_RE = re.compile(r"^double_blocks\.(\d+)\.")
+_HF_SINGLE_BLOCK_RE = re.compile(r"^single_transformer_blocks\.(\d+)\.")
+_HF_DOUBLE_BLOCK_RE = re.compile(r"^transformer_blocks\.(\d+)\.")
 
-class FluxStateDictAdapter(StateDictAdapter):
+
+class FluxStateDictAdapter(BaseStateDictAdapter):
     """
     State dict adapter for Flux model to convert between HuggingFace safetensors format
     and torchtitan DCP format.
@@ -29,52 +33,178 @@ class FluxStateDictAdapter(StateDictAdapter):
     """
 
     def __init__(self, model_config: FluxModel.Config, hf_assets_path: str | None):
-        super().__init__(model_config, hf_assets_path)
-        # Build fqn to index mapping if hf_assets_path
-        if hf_assets_path:
-            # If directory is multimodal ensure that hf_assets_path is to the folder containing transformer's safetensors
-            if os.path.exists(os.path.join(hf_assets_path, "model_index.json")):
-                hf_assets_path = os.path.join(hf_assets_path, "transformers")
-
-            # Check if safetensors index file exists
-            index_files = [
-                "model.safetensors.index.json",
-                "diffusion_pytorch_model.safetensors.index.json",
-            ]
-
-            hf_safetensors_indx = None
-            for index_file in index_files:
-                mapping_path = os.path.join(hf_assets_path, index_file)
-                if os.path.exists(mapping_path):
-                    with open(mapping_path, "r") as f:
-                        hf_safetensors_indx = json.load(f)
-                    break
-            if hf_safetensors_indx is None:
-                logger.warning(
-                    f"no safetensors index file found at hf_assets_path: {hf_assets_path}. \
-                    Defaulting to saving a single safetensors file if checkpoint is saved in HF format.",
-                )
-
-            if hf_safetensors_indx:
-                self.fqn_to_index_mapping = {}
-                for hf_key, raw_indx in hf_safetensors_indx["weight_map"].items():
-                    # pyrefly: ignore [missing-attribute]
-                    indx = re.search(r"\d+", raw_indx).group(0)
-                    self.fqn_to_index_mapping[hf_key] = indx
-            else:
-                self.fqn_to_index_mapping = None
-
+        # Flux needs custom index file resolution (multimodal subdirs,
+        # diffusion_pytorch_model.safetensors.index.json), so skip the
+        # base class index loading by passing hf_assets_path=None.
+        super().__init__()
         self.model_config = model_config
         self.hf_assets_path = hf_assets_path
 
-        # mapping containing direct 1 to 1 mappings from HF to torchtitan
-        self.from_hf_map_direct = {
+        if not hf_assets_path:
+            self.fqn_to_index_mapping = None
+            return
+
+        # Multimodal repos store transformer weights in a subdirectory
+        if os.path.exists(os.path.join(hf_assets_path, "model_index.json")):
+            hf_assets_path = os.path.join(hf_assets_path, "transformers")
+
+        index_files = [
+            "model.safetensors.index.json",
+            "diffusion_pytorch_model.safetensors.index.json",
+        ]
+
+        hf_safetensors_indx = None
+        for index_file in index_files:
+            mapping_path = os.path.join(hf_assets_path, index_file)
+            if os.path.exists(mapping_path):
+                with open(mapping_path, "r") as f:
+                    hf_safetensors_indx = json.load(f)
+                break
+        if hf_safetensors_indx is None:
+            logger.warning(
+                f"no safetensors index file found at hf_assets_path: {hf_assets_path}. "
+                "Defaulting to saving a single safetensors file if checkpoint is saved in HF format.",
+            )
+
+        if hf_safetensors_indx:
+            self.fqn_to_index_mapping = {}
+            for hf_key, raw_indx in hf_safetensors_indx["weight_map"].items():
+                # pyrefly: ignore [missing-attribute]
+                indx = re.search(r"\d+", raw_indx).group(0)
+                self.fqn_to_index_mapping[hf_key] = indx
+        else:
+            self.fqn_to_index_mapping = None
+
+    # Original flux implementation and HF swap shift and scale
+    # https://github.com/huggingface/diffusers/blob/main/scripts/convert_flux_to_diffusers.py#L63-L68
+    def _swap_scale_shift(self, weight):
+        shift, scale = weight.chunk(2, dim=0)
+        new_weight = torch.cat([scale, shift], dim=0)
+        return new_weight
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert TorchTitan DCP state dict to HuggingFace safetensors format."""
+        RENAME = {
+            "img_in.bias": "x_embedder.bias",
+            "img_in.weight": "x_embedder.weight",
+            "txt_in.bias": "context_embedder.bias",
+            "txt_in.weight": "context_embedder.weight",
+            "final_layer.linear.bias": "proj_out.bias",
+            "final_layer.linear.weight": "proj_out.weight",
+            "vector_in.in_layer.bias": "time_text_embed.text_embedder.linear_1.bias",
+            "vector_in.in_layer.weight": "time_text_embed.text_embedder.linear_1.weight",
+            "time_in.in_layer.bias": "time_text_embed.timestep_embedder.linear_1.bias",
+            "time_in.in_layer.weight": "time_text_embed.timestep_embedder.linear_1.weight",
+            "vector_in.out_layer.bias": "time_text_embed.text_embedder.linear_2.bias",
+            "vector_in.out_layer.weight": "time_text_embed.text_embedder.linear_2.weight",
+            "time_in.out_layer.bias": "time_text_embed.timestep_embedder.linear_2.bias",
+            "time_in.out_layer.weight": "time_text_embed.timestep_embedder.linear_2.weight",
+        }
+        SINGLE_BLOCK_RENAME = {
+            "norm.key_norm.weight": "attn.norm_k.weight",
+            "norm.query_norm.weight": "attn.norm_q.weight",
+            "modulation.lin.bias": "norm.linear.bias",
+            "modulation.lin.weight": "norm.linear.weight",
+            "linear2.bias": "proj_out.bias",
+            "linear2.weight": "proj_out.weight",
+        }
+        DOUBLE_BLOCK_RENAME = {
+            "txt_attn.norm.key_norm.weight": "attn.norm_added_k.weight",
+            "txt_attn.norm.query_norm.weight": "attn.norm_added_q.weight",
+            "img_attn.norm.key_norm.weight": "attn.norm_k.weight",
+            "img_attn.norm.query_norm.weight": "attn.norm_q.weight",
+            "txt_attn.proj.bias": "attn.to_add_out.bias",
+            "txt_attn.proj.weight": "attn.to_add_out.weight",
+            "img_attn.proj.bias": "attn.to_out.0.bias",
+            "img_attn.proj.weight": "attn.to_out.0.weight",
+            "img_mlp.0.bias": "ff.net.0.proj.bias",
+            "img_mlp.0.weight": "ff.net.0.proj.weight",
+            "img_mlp.2.bias": "ff.net.2.bias",
+            "img_mlp.2.weight": "ff.net.2.weight",
+            "txt_mlp.0.bias": "ff_context.net.0.proj.bias",
+            "txt_mlp.0.weight": "ff_context.net.0.proj.weight",
+            "txt_mlp.2.bias": "ff_context.net.2.bias",
+            "txt_mlp.2.weight": "ff_context.net.2.weight",
+            "img_mod.lin.bias": "norm1.linear.bias",
+            "img_mod.lin.weight": "norm1.linear.weight",
+            "txt_mod.lin.bias": "norm1_context.linear.bias",
+            "txt_mod.lin.weight": "norm1_context.linear.weight",
+        }
+
+        hf: dict[str, Any] = {}
+
+        for key, value in state_dict.items():
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            # adaLN modulation — swap scale/shift
+            elif key == "final_layer.adaLN_modulation.1.bias":
+                hf["norm_out.linear.bias"] = self._swap_scale_shift(value)
+            elif key == "final_layer.adaLN_modulation.1.weight":
+                hf["norm_out.linear.weight"] = self._swap_scale_shift(value)
+
+            # -- Single blocks --
+            elif m := _SINGLE_BLOCK_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in SINGLE_BLOCK_RENAME:
+                    hf[
+                        f"single_transformer_blocks.{layer}.{SINGLE_BLOCK_RENAME[suffix]}"
+                    ] = value
+                # Combined linear1 → split into q, k, v, mlp
+                elif suffix in ("linear1.bias", "linear1.weight"):
+                    mlp_hidden_dim = int(
+                        self.model_config.hidden_size * self.model_config.mlp_ratio
+                    )
+                    split_plan = [
+                        self.model_config.hidden_size,
+                        self.model_config.hidden_size,
+                        self.model_config.hidden_size,
+                        mlp_hidden_dim,
+                    ]
+                    q, k, v, mlp = torch.split(value, split_plan, dim=0)
+                    param = suffix.split(".")[1]  # "bias" or "weight"
+                    hf[f"single_transformer_blocks.{layer}.attn.to_q.{param}"] = q
+                    hf[f"single_transformer_blocks.{layer}.attn.to_k.{param}"] = k
+                    hf[f"single_transformer_blocks.{layer}.attn.to_v.{param}"] = v
+                    hf[f"single_transformer_blocks.{layer}.proj_mlp.{param}"] = mlp
+
+            # -- Double blocks --
+            elif m := _DOUBLE_BLOCK_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in DOUBLE_BLOCK_RENAME:
+                    hf[
+                        f"transformer_blocks.{layer}.{DOUBLE_BLOCK_RENAME[suffix]}"
+                    ] = value
+                # Combined qkv → split into q, k, v
+                elif suffix in (
+                    "txt_attn.qkv.bias",
+                    "txt_attn.qkv.weight",
+                    "img_attn.qkv.bias",
+                    "img_attn.qkv.weight",
+                ):
+                    q, k, v = torch.split(value, self.model_config.hidden_size, dim=0)
+                    param = suffix.split(".")[-1]  # "bias" or "weight"
+                    if suffix.startswith("txt_attn"):
+                        hf[f"transformer_blocks.{layer}.attn.add_q_proj.{param}"] = q
+                        hf[f"transformer_blocks.{layer}.attn.add_k_proj.{param}"] = k
+                        hf[f"transformer_blocks.{layer}.attn.add_v_proj.{param}"] = v
+                    else:
+                        hf[f"transformer_blocks.{layer}.attn.to_q.{param}"] = q
+                        hf[f"transformer_blocks.{layer}.attn.to_k.{param}"] = k
+                        hf[f"transformer_blocks.{layer}.attn.to_v.{param}"] = v
+
+        return hf
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert HuggingFace safetensors state dict to TorchTitan DCP format."""
+        RENAME = {
             "x_embedder.bias": "img_in.bias",
             "x_embedder.weight": "img_in.weight",
             "context_embedder.bias": "txt_in.bias",
             "context_embedder.weight": "txt_in.weight",
-            "norm_out.linear.bias": "final_layer.adaLN_modulation.1.bias",
-            "norm_out.linear.weight": "final_layer.adaLN_modulation.1.weight",
             "proj_out.bias": "final_layer.linear.bias",
             "proj_out.weight": "final_layer.linear.weight",
             "time_text_embed.text_embedder.linear_1.bias": "vector_in.in_layer.bias",
@@ -85,209 +215,122 @@ class FluxStateDictAdapter(StateDictAdapter):
             "time_text_embed.text_embedder.linear_2.weight": "vector_in.out_layer.weight",
             "time_text_embed.timestep_embedder.linear_2.bias": "time_in.out_layer.bias",
             "time_text_embed.timestep_embedder.linear_2.weight": "time_in.out_layer.weight",
-            "single_transformer_blocks.{}.attn.norm_k.weight": "single_blocks.{}.norm.key_norm.weight",
-            "single_transformer_blocks.{}.attn.norm_q.weight": "single_blocks.{}.norm.query_norm.weight",
-            "single_transformer_blocks.{}.norm.linear.bias": "single_blocks.{}.modulation.lin.bias",
-            "single_transformer_blocks.{}.norm.linear.weight": "single_blocks.{}.modulation.lin.weight",
-            "single_transformer_blocks.{}.proj_out.bias": "single_blocks.{}.linear2.bias",
-            "single_transformer_blocks.{}.proj_out.weight": "single_blocks.{}.linear2.weight",
-            "transformer_blocks.{}.attn.norm_added_k.weight": "double_blocks.{}.txt_attn.norm.key_norm.weight",
-            "transformer_blocks.{}.attn.norm_added_q.weight": "double_blocks.{}.txt_attn.norm.query_norm.weight",
-            "transformer_blocks.{}.attn.norm_k.weight": "double_blocks.{}.img_attn.norm.key_norm.weight",
-            "transformer_blocks.{}.attn.norm_q.weight": "double_blocks.{}.img_attn.norm.query_norm.weight",
-            "transformer_blocks.{}.attn.to_add_out.bias": "double_blocks.{}.txt_attn.proj.bias",
-            "transformer_blocks.{}.attn.to_add_out.weight": "double_blocks.{}.txt_attn.proj.weight",
-            "transformer_blocks.{}.attn.to_out.0.bias": "double_blocks.{}.img_attn.proj.bias",
-            "transformer_blocks.{}.attn.to_out.0.weight": "double_blocks.{}.img_attn.proj.weight",
-            "transformer_blocks.{}.ff.net.0.proj.bias": "double_blocks.{}.img_mlp.0.bias",
-            "transformer_blocks.{}.ff.net.0.proj.weight": "double_blocks.{}.img_mlp.0.weight",
-            "transformer_blocks.{}.ff.net.2.bias": "double_blocks.{}.img_mlp.2.bias",
-            "transformer_blocks.{}.ff.net.2.weight": "double_blocks.{}.img_mlp.2.weight",
-            "transformer_blocks.{}.ff_context.net.0.proj.bias": "double_blocks.{}.txt_mlp.0.bias",
-            "transformer_blocks.{}.ff_context.net.0.proj.weight": "double_blocks.{}.txt_mlp.0.weight",
-            "transformer_blocks.{}.ff_context.net.2.bias": "double_blocks.{}.txt_mlp.2.bias",
-            "transformer_blocks.{}.ff_context.net.2.weight": "double_blocks.{}.txt_mlp.2.weight",
-            "transformer_blocks.{}.norm1.linear.bias": "double_blocks.{}.img_mod.lin.bias",
-            "transformer_blocks.{}.norm1.linear.weight": "double_blocks.{}.img_mod.lin.weight",
-            "transformer_blocks.{}.norm1_context.linear.bias": "double_blocks.{}.txt_mod.lin.bias",
-            "transformer_blocks.{}.norm1_context.linear.weight": "double_blocks.{}.txt_mod.lin.weight",
+        }
+        SINGLE_BLOCK_RENAME = {
+            "attn.norm_k.weight": "norm.key_norm.weight",
+            "attn.norm_q.weight": "norm.query_norm.weight",
+            "norm.linear.bias": "modulation.lin.bias",
+            "norm.linear.weight": "modulation.lin.weight",
+            "proj_out.bias": "linear2.bias",
+            "proj_out.weight": "linear2.weight",
+        }
+        DOUBLE_BLOCK_RENAME = {
+            "attn.norm_added_k.weight": "txt_attn.norm.key_norm.weight",
+            "attn.norm_added_q.weight": "txt_attn.norm.query_norm.weight",
+            "attn.norm_k.weight": "img_attn.norm.key_norm.weight",
+            "attn.norm_q.weight": "img_attn.norm.query_norm.weight",
+            "attn.to_add_out.bias": "txt_attn.proj.bias",
+            "attn.to_add_out.weight": "txt_attn.proj.weight",
+            "attn.to_out.0.bias": "img_attn.proj.bias",
+            "attn.to_out.0.weight": "img_attn.proj.weight",
+            "ff.net.0.proj.bias": "img_mlp.0.bias",
+            "ff.net.0.proj.weight": "img_mlp.0.weight",
+            "ff.net.2.bias": "img_mlp.2.bias",
+            "ff.net.2.weight": "img_mlp.2.weight",
+            "ff_context.net.0.proj.bias": "txt_mlp.0.bias",
+            "ff_context.net.0.proj.weight": "txt_mlp.0.weight",
+            "ff_context.net.2.bias": "txt_mlp.2.bias",
+            "ff_context.net.2.weight": "txt_mlp.2.weight",
+            "norm1.linear.bias": "img_mod.lin.bias",
+            "norm1.linear.weight": "img_mod.lin.weight",
+            "norm1_context.linear.bias": "txt_mod.lin.bias",
+            "norm1_context.linear.weight": "txt_mod.lin.weight",
         }
 
-        # combination plan to keep track of the order of layers to be combined
-        self.combination_plan = {
-            "single_blocks.{}.linear1.bias": [
-                "single_transformer_blocks.{}.attn.to_q.bias",
-                "single_transformer_blocks.{}.attn.to_k.bias",
-                "single_transformer_blocks.{}.attn.to_v.bias",
-                "single_transformer_blocks.{}.proj_mlp.bias",
-            ],
-            "single_blocks.{}.linear1.weight": [
-                "single_transformer_blocks.{}.attn.to_q.weight",
-                "single_transformer_blocks.{}.attn.to_k.weight",
-                "single_transformer_blocks.{}.attn.to_v.weight",
-                "single_transformer_blocks.{}.proj_mlp.weight",
-            ],
-            "double_blocks.{}.txt_attn.qkv.bias": [
-                "transformer_blocks.{}.attn.add_q_proj.bias",
-                "transformer_blocks.{}.attn.add_k_proj.bias",
-                "transformer_blocks.{}.attn.add_v_proj.bias",
-            ],
-            "double_blocks.{}.txt_attn.qkv.weight": [
-                "transformer_blocks.{}.attn.add_q_proj.weight",
-                "transformer_blocks.{}.attn.add_k_proj.weight",
-                "transformer_blocks.{}.attn.add_v_proj.weight",
-            ],
-            "double_blocks.{}.img_attn.qkv.bias": [
-                "transformer_blocks.{}.attn.to_q.bias",
-                "transformer_blocks.{}.attn.to_k.bias",
-                "transformer_blocks.{}.attn.to_v.bias",
-            ],
-            "double_blocks.{}.img_attn.qkv.weight": [
-                "transformer_blocks.{}.attn.to_q.weight",
-                "transformer_blocks.{}.attn.to_k.weight",
-                "transformer_blocks.{}.attn.to_v.weight",
-            ],
-        }
+        sd: dict[str, Any] = {}
+        # Collect combination keys: {tt_fqn: list of (order_index, value)}
+        to_combine: dict[str, list[tuple[int, torch.Tensor]]] = {}
 
-        # reverse of combination plan: maps fqns to the fqn they are combined into
-        self.reverse_combination_plan = {
-            value: key
-            for key, value_list in self.combination_plan.items()
-            for value in value_list
-        }
-
-    # original flux implementation and HF swap shift and scale
-    # https://github.com/huggingface/diffusers/blob/main/scripts/convert_flux_to_diffusers.py#L63-L68
-    def _swap_scale_shift(self, weight):
-        shift, scale = weight.chunk(2, dim=0)
-        new_weight = torch.cat([scale, shift], dim=0)
-        return new_weight
-
-    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        """Convert TorchTitan DCP state dict to HuggingFace safetensors format."""
-
-        to_hf_map_direct = {
-            v: k for k, v in self.from_hf_map_direct.items() if v is not None
-        }
-        hf_state_dict = {}
-
-        for key, value in state_dict.items():
-            # Extract layer_num and abstract key if necessary
-            if "blocks" in key:
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                key = re.sub(r"(\d+)", "{}", key, count=1)
-            else:
-                layer_num = None
-
-            if key in to_hf_map_direct:
-                # handle direct mapping
-                new_key = to_hf_map_direct[key]
-
-                # perform swap to be compatible with HF
-                if key in [
-                    "final_layer.adaLN_modulation.1.weight",
-                    "final_layer.adaLN_modulation.1.bias",
-                ]:
-                    value = self._swap_scale_shift(value)
-
-                if new_key is None:
-                    continue
-                if layer_num:
-                    new_key = new_key.format(layer_num)
-
-                hf_state_dict[new_key] = value
-
-            elif key in self.combination_plan:
-                # handle splitting layers
-                if key in [
-                    "single_blocks.{}.linear1.bias",
-                    "single_blocks.{}.linear1.weight",
-                ]:
-                    mlp_hidden_dim = int(
-                        self.model_config.hidden_size * self.model_config.mlp_ratio
-                    )
-                    split_plan = [
-                        self.model_config.hidden_size,
-                        self.model_config.hidden_size,
-                        self.model_config.hidden_size,
-                        mlp_hidden_dim,
-                    ]
-                    # split into q, k, v, mlp
-                    split_vals = torch.split(
-                        value,
-                        split_plan,
-                        dim=0,
-                    )
-                else:
-                    # split into q, k, v
-                    split_vals = torch.split(
-                        value, self.model_config.hidden_size, dim=0
-                    )
-
-                new_keys = (
-                    abstract_key.format(layer_num)
-                    for abstract_key in self.combination_plan[key]
-                )
-
-                for new_key, value in zip(new_keys, split_vals):
-                    hf_state_dict[new_key] = value
-
-        return hf_state_dict
-
-    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        """Convert HuggingFace safetensors state dict to TorchTitan DCP format."""
-        state_dict = {}
-
-        # Keeps track of HF fqn values to combine into one TT fqn later
-        # {tt_fqn : {hf_fqn1 : value}, {hf_fqn2 : value}, ...}
-        to_combine = defaultdict(dict)
+        def _collect(tt_fqn: str, order_index: int, val: torch.Tensor) -> None:
+            if tt_fqn not in to_combine:
+                to_combine[tt_fqn] = []
+            to_combine[tt_fqn].append((order_index, val))
 
         for key, value in hf_state_dict.items():
-            # extract layer_num and abstract key if necessary
-            if "blocks" in key:
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                key = re.sub(r"(\d+)", "{}", key, count=1)
-            else:
-                layer_num = None
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            # adaLN modulation — swap scale/shift
+            elif key == "norm_out.linear.bias":
+                sd["final_layer.adaLN_modulation.1.bias"] = self._swap_scale_shift(
+                    value
+                )
+            elif key == "norm_out.linear.weight":
+                sd["final_layer.adaLN_modulation.1.weight"] = self._swap_scale_shift(
+                    value
+                )
 
-            if key in self.from_hf_map_direct:
-                new_key = self.from_hf_map_direct[key]
+            # -- Single blocks --
+            elif m := _HF_SINGLE_BLOCK_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-                # perform swap to be compatible with HF
-                if key in [
-                    "norm_out.linear.weight",
-                    "norm_out.linear.bias",
-                ]:
-                    value = self._swap_scale_shift(value)
-                if new_key is None:
-                    continue
-                if layer_num:
-                    new_key = new_key.format(layer_num)
+                if suffix in SINGLE_BLOCK_RENAME:
+                    sd[f"single_blocks.{layer}.{SINGLE_BLOCK_RENAME[suffix]}"] = value
+                # Combination keys: q(0), k(1), v(2), mlp(3) → linear1
+                elif suffix == "attn.to_q.bias":
+                    _collect(f"single_blocks.{layer}.linear1.bias", 0, value)
+                elif suffix == "attn.to_k.bias":
+                    _collect(f"single_blocks.{layer}.linear1.bias", 1, value)
+                elif suffix == "attn.to_v.bias":
+                    _collect(f"single_blocks.{layer}.linear1.bias", 2, value)
+                elif suffix == "proj_mlp.bias":
+                    _collect(f"single_blocks.{layer}.linear1.bias", 3, value)
+                elif suffix == "attn.to_q.weight":
+                    _collect(f"single_blocks.{layer}.linear1.weight", 0, value)
+                elif suffix == "attn.to_k.weight":
+                    _collect(f"single_blocks.{layer}.linear1.weight", 1, value)
+                elif suffix == "attn.to_v.weight":
+                    _collect(f"single_blocks.{layer}.linear1.weight", 2, value)
+                elif suffix == "proj_mlp.weight":
+                    _collect(f"single_blocks.{layer}.linear1.weight", 3, value)
 
-                state_dict[new_key] = value
-            elif key in self.reverse_combination_plan:
-                # collect the layers that need to be combined
-                tt_abstract_key = self.reverse_combination_plan[key]
-                if tt_abstract_key is None:
-                    continue
-                to_combine[tt_abstract_key.format(layer_num)][
-                    key.format(layer_num)
-                ] = value
+            # -- Double blocks --
+            elif m := _HF_DOUBLE_BLOCK_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-        # combine collected values
-        for tt_fqn, hf_fqn_map in to_combine.items():
-            # pyrefly: ignore [missing-attribute]
-            layer_num = re.search(r"\d+", tt_fqn).group(0)
-            tt_abstract_key = re.sub(r"(\d+)", "{}", tt_fqn, count=1)
-            combine_values = []
-            # use combination_plan to ensure correct order before concatenation
-            for hf_abstract_key in self.combination_plan[tt_abstract_key]:
-                hf_key = hf_abstract_key.format(layer_num)
-                combine_values.append(hf_fqn_map[hf_key])
+                if suffix in DOUBLE_BLOCK_RENAME:
+                    sd[f"double_blocks.{layer}.{DOUBLE_BLOCK_RENAME[suffix]}"] = value
+                # Combination keys — txt_attn qkv: q(0), k(1), v(2)
+                elif suffix == "attn.add_q_proj.bias":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.bias", 0, value)
+                elif suffix == "attn.add_k_proj.bias":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.bias", 1, value)
+                elif suffix == "attn.add_v_proj.bias":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.bias", 2, value)
+                elif suffix == "attn.add_q_proj.weight":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.weight", 0, value)
+                elif suffix == "attn.add_k_proj.weight":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.weight", 1, value)
+                elif suffix == "attn.add_v_proj.weight":
+                    _collect(f"double_blocks.{layer}.txt_attn.qkv.weight", 2, value)
+                # Combination keys — img_attn qkv: q(0), k(1), v(2)
+                elif suffix == "attn.to_q.bias":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.bias", 0, value)
+                elif suffix == "attn.to_k.bias":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.bias", 1, value)
+                elif suffix == "attn.to_v.bias":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.bias", 2, value)
+                elif suffix == "attn.to_q.weight":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.weight", 0, value)
+                elif suffix == "attn.to_k.weight":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.weight", 1, value)
+                elif suffix == "attn.to_v.weight":
+                    _collect(f"double_blocks.{layer}.img_attn.qkv.weight", 2, value)
 
-            value = torch.cat(combine_values, dim=0)
-            state_dict[tt_fqn] = value
+        # Concatenate combination groups in sorted order
+        for tt_fqn, parts in to_combine.items():
+            parts.sort(key=lambda x: x[0])
+            sd[tt_fqn] = torch.cat([v for _, v in parts], dim=0)
 
-        return state_dict
+        return sd

--- a/torchtitan/models/gpt_oss/state_dict_adapter.py
+++ b/torchtitan/models/gpt_oss/state_dict_adapter.py
@@ -13,106 +13,117 @@ from torchtitan.models.utils import MoEStateDictAdapter
 
 from .model import GptOssModel
 
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_HF_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.")
+
 
 class GptOssStateDictAdapter(MoEStateDictAdapter):
+    """Pure FQN rename — no value transforms needed.
+
+    Warning: Conversion does not support saving to MXFP4 quantization format.
+    One can save into unquantized HF checkpoints with ``last_save_in_hf = true``.
+    For loading from quantized checkpoints, the QuantizedHuggingFaceStorageReader
+    handles dequantization during load.
+    """
+
     def __init__(self, model_config: GptOssModel.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
-        self.from_hf_map = {
+        self.model_config = model_config
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        RENAME = {
+            "tok_embeddings.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "output.weight": "lm_head.weight",
+        }
+        LAYER_RENAME = {
+            "attention.wq.weight": "self_attn.q_proj.weight",
+            "attention.wq.bias": "self_attn.q_proj.bias",
+            "attention.wk.weight": "self_attn.k_proj.weight",
+            "attention.wk.bias": "self_attn.k_proj.bias",
+            "attention.wv.weight": "self_attn.v_proj.weight",
+            "attention.wv.bias": "self_attn.v_proj.bias",
+            "attention.wo.weight": "self_attn.o_proj.weight",
+            "attention.wo.bias": "self_attn.o_proj.bias",
+            "attention.sinks": "self_attn.sinks",
+            "attention_norm.weight": "input_layernorm.weight",
+            "ffn_norm.weight": "post_attention_layernorm.weight",
+            "moe.experts.mlp1_weight": "mlp.experts.gate_up_proj_blocks",
+            "moe.experts.mlp1_bias": "mlp.experts.gate_up_proj_bias",
+            "moe.experts.mlp2_weight": "mlp.experts.down_proj_blocks",
+            "moe.experts.mlp2_bias": "mlp.experts.down_proj_bias",
+            "moe.router.gate.weight": "mlp.router.weight",
+            "moe.router.gate.bias": "mlp.router.bias",
+        }
+
+        hf: dict[str, Any] = {}
+
+        for key, value in state_dict.items():
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            elif m := _LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in LAYER_RENAME:
+                    hf[f"model.layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+
+        return hf
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        RENAME = {
             "model.embed_tokens.weight": "tok_embeddings.weight",
-            # Attention module
-            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
-            "model.layers.{}.self_attn.q_proj.bias": "layers.{}.attention.wq.bias",
-            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
-            "model.layers.{}.self_attn.k_proj.bias": "layers.{}.attention.wk.bias",
-            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
-            "model.layers.{}.self_attn.v_proj.bias": "layers.{}.attention.wv.bias",
-            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-            "model.layers.{}.self_attn.o_proj.bias": "layers.{}.attention.wo.bias",
-            "model.layers.{}.self_attn.sinks": "layers.{}.attention.sinks",
-            # Transformer layer
-            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE
-            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.experts.mlp1_weight",
-            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.experts.mlp1_bias",
-            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.experts.mlp2_weight",
-            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.experts.mlp2_bias",
-            "model.layers.{}.mlp.router.weight": "layers.{}.moe.router.gate.weight",
-            "model.layers.{}.mlp.router.bias": "layers.{}.moe.router.gate.bias",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "output.weight",
         }
+        LAYER_RENAME = {
+            "self_attn.q_proj.weight": "attention.wq.weight",
+            "self_attn.q_proj.bias": "attention.wq.bias",
+            "self_attn.k_proj.weight": "attention.wk.weight",
+            "self_attn.k_proj.bias": "attention.wk.bias",
+            "self_attn.v_proj.weight": "attention.wv.weight",
+            "self_attn.v_proj.bias": "attention.wv.bias",
+            "self_attn.o_proj.weight": "attention.wo.weight",
+            "self_attn.o_proj.bias": "attention.wo.bias",
+            "self_attn.sinks": "attention.sinks",
+            "input_layernorm.weight": "attention_norm.weight",
+            "post_attention_layernorm.weight": "ffn_norm.weight",
+            "mlp.experts.gate_up_proj_blocks": "moe.experts.mlp1_weight",
+            "mlp.experts.gate_up_proj_bias": "moe.experts.mlp1_bias",
+            "mlp.experts.down_proj_blocks": "moe.experts.mlp2_weight",
+            "mlp.experts.down_proj_bias": "moe.experts.mlp2_bias",
+            "mlp.router.weight": "moe.router.gate.weight",
+            "mlp.router.bias": "moe.router.gate.bias",
+        }
+
+        sd: dict[str, Any] = {}
+
+        for key, value in hf_state_dict.items():
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            elif m := _HF_LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in LAYER_RENAME:
+                    sd[f"layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+
+        return sd
 
     def get_hf_storage_reader(
         self, path: str, from_quantized: bool = False
     ) -> HuggingFaceStorageReader:
-        """
-        Override default get_hf_storage_reader function to return QuantizedHFStorageReader.
-        """
+        # NOTE: Now we use Quantized HF storage reader to read GPT-OSS model where
+        # expert weights are saved in MXFP4 format.
+        # If loading checkpoints without quantization, use HuggingFaceStorageReader instead
         if from_quantized:
             from torch.distributed.checkpoint.quantized_hf_storage import (
                 QuantizedHuggingFaceStorageReader,
             )
 
-            # NOTE: Now we use Quantized HF storage reader to read GPT-OSS model where
-            # expert weights are saved in MXFP4 format.
-            # If loading checkpoints without quantization, use HuggingFaceStorageReader instead
             return QuantizedHuggingFaceStorageReader(
                 path=path,
                 thread_count=4,
             )
         else:
             return HuggingFaceStorageReader(path)
-
-    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        Convert from a tt model state dict to a hf format state dict.
-
-        Only map keys without changing shapes to the same as MXFP4 checkpoint.
-        For loading from quantized checkpoints, the QuantizedHuggingFaceStorageReader
-            will handle dequantization during load.
-
-        Warning: Conversion does not support saving to mxfp4 quantization format.
-                 One can save into unquantized hf checkpoints with last_save_in_hf = true.
-        """
-        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
-        hf_state_dict = {}
-
-        for key, value in state_dict.items():
-            if "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                if abstract_key not in to_hf_map:
-                    continue
-                # pyrefly: ignore
-                layer_num = re.search(r"\d+", key).group(0)
-                hf_key = to_hf_map[abstract_key]
-                hf_key = hf_key.format(layer_num)
-                hf_state_dict[hf_key] = value
-            else:
-                if key not in to_hf_map:
-                    continue
-                hf_key = to_hf_map[key]
-                hf_state_dict[hf_key] = value
-
-        return hf_state_dict
-
-    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        Convert from hf format state dict to tt model state dict.
-        """
-
-        state_dict = {}
-
-        for key, value in hf_state_dict.items():
-            if "layers" in key:
-                # pyrefly: ignore
-                layer_num = re.search(r"\d+", key).group(0)
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                tt_key = self.from_hf_map[abstract_key]
-                tt_key = tt_key.format(layer_num)
-                state_dict[tt_key] = value
-            else:
-                tt_key = self.from_hf_map[key]
-                state_dict[tt_key] = value
-
-        return state_dict

--- a/torchtitan/models/llama3/state_dict_adapter.py
+++ b/torchtitan/models/llama3/state_dict_adapter.py
@@ -4,44 +4,44 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import re
 from typing import Any
 
-logger = logging.getLogger()
-
-from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 
 from .model import Llama3Model
 
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_HF_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.")
 
-class Llama3StateDictAdapter(StateDictAdapter):
+
+class Llama3StateDictAdapter(BaseStateDictAdapter):
     def __init__(
         self,
         model_config: Llama3Model.Config,
         hf_assets_path: str | None,
     ):
-        super().__init__(model_config, hf_assets_path)
+        super().__init__(hf_assets_path)
 
         self.model_config = model_config
-        self.hf_assets_path = hf_assets_path
-        self.from_hf_map = {
-            "model.embed_tokens.weight": "tok_embeddings.weight",
-            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
-            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
-            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
-            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-            "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
-            "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
-            "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
-            "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
-            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            "model.norm.weight": "norm.weight",
-            "lm_head.weight": "output.weight",
-        }
 
-    # HuggingFace permutation function (exact copy from their conversion script)
+        n_heads = model_config.layers[0].attention.n_heads
+        n_kv_heads = (
+            model_config.layers[0].attention.n_kv_heads
+            # pyrefly: ignore [missing-attribute]
+            if model_config.layers[0].attention.n_kv_heads is not None
+            else n_heads
+        )
+        dim = model_config.dim
+        head_dim = dim // n_heads
+        self._n_heads = n_heads
+        self._n_kv_heads = n_kv_heads
+        # pyrefly: ignore [unsupported-operation]
+        self._key_value_dim = head_dim * n_kv_heads
+        self._dim = dim
+
+    # -- RoPE permutation helpers --
+
     def _permute(self, w, n_heads_arg, dim1=None, dim2=None):
         if dim1 is None:
             dim1 = w.shape[0]
@@ -66,88 +66,95 @@ class Llama3StateDictAdapter(StateDictAdapter):
         )
 
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+        RENAME = {
+            "tok_embeddings.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "output.weight": "lm_head.weight",
+        }
+        LAYER_RENAME = {
+            "attention.wv.weight": "self_attn.v_proj.weight",
+            "attention.wo.weight": "self_attn.o_proj.weight",
+            "feed_forward.w1.weight": "mlp.gate_proj.weight",
+            "feed_forward.w3.weight": "mlp.up_proj.weight",
+            "feed_forward.w2.weight": "mlp.down_proj.weight",
+            "attention_norm.weight": "input_layernorm.weight",
+            "ffn_norm.weight": "post_attention_layernorm.weight",
+        }
 
-        n_heads = self.model_config.layers[0].attention.n_heads
-        n_kv_heads = (
-            self.model_config.layers[0].attention.n_kv_heads
-            # pyrefly: ignore [missing-attribute]
-            if self.model_config.layers[0].attention.n_kv_heads is not None
-            else n_heads
-        )
-        dim = self.model_config.dim
-        head_dim = dim // n_heads
-        hf_state_dict = {}
-
+        hf: dict[str, Any] = {}
         for key, value in state_dict.items():
-            if "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = to_hf_map[abstract_key]
-                # We need to permute the weights in wq and wk layer in order to account for the difference between
-                # the native Llama and huggingface RoPE implementation.
-                if abstract_key == "layers.{}.attention.wq.weight":
-                    value = self._permute(value, n_heads)
-                if abstract_key == "layers.{}.attention.wk.weight":
-                    # pyrefly: ignore [unsupported-operation]
-                    key_value_dim = head_dim * n_kv_heads
-                    value = self._permute(value, n_kv_heads, key_value_dim, dim)
+            if self.model_config.enable_weight_tying and key == "output.weight":
+                continue
 
-                if new_key is None:
-                    continue
-                new_key = new_key.format(layer_num)
-            else:
-                if self.model_config.enable_weight_tying and key == "output.weight":
-                    continue
-                new_key = to_hf_map[key]
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            elif m := _LAYER_RE.match(key):
+                layer, suffix = m.group(1), key[m.end() :]
+                if suffix in LAYER_RENAME:
+                    hf[f"model.layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+                # Permute wq and wk to account for the difference between
+                # the native Llama and HuggingFace RoPE implementations.
+                elif suffix == "attention.wq.weight":
+                    hf[f"model.layers.{layer}.self_attn.q_proj.weight"] = self._permute(
+                        value, self._n_heads
+                    )
+                elif suffix == "attention.wk.weight":
+                    hf[f"model.layers.{layer}.self_attn.k_proj.weight"] = self._permute(
+                        value,
+                        self._n_kv_heads,
+                        self._key_value_dim,
+                        self._dim,
+                    )
 
-            hf_state_dict[new_key] = value
-
-        return hf_state_dict
+        return hf
 
     def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        RENAME = {
+            "model.embed_tokens.weight": "tok_embeddings.weight",
+            "model.norm.weight": "norm.weight",
+            "lm_head.weight": "output.weight",
+        }
+        LAYER_RENAME = {
+            "self_attn.v_proj.weight": "attention.wv.weight",
+            "self_attn.o_proj.weight": "attention.wo.weight",
+            "self_attn.rotary_emb.inv_freq": None,  # drop
+            "mlp.gate_proj.weight": "feed_forward.w1.weight",
+            "mlp.up_proj.weight": "feed_forward.w3.weight",
+            "mlp.down_proj.weight": "feed_forward.w2.weight",
+            "input_layernorm.weight": "attention_norm.weight",
+            "post_attention_layernorm.weight": "ffn_norm.weight",
+        }
+
+        sd: dict[str, Any] = {}
+        for key, value in hf_state_dict.items():
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            elif m := _HF_LAYER_RE.match(key):
+                layer, suffix = m.group(1), key[m.end() :]
+                if suffix in LAYER_RENAME:
+                    target = LAYER_RENAME[suffix]
+                    if target is not None:
+                        sd[f"layers.{layer}.{target}"] = value
+                # Reverse-permute wq and wk to account for the difference
+                # between the native Llama and HuggingFace RoPE implementations.
+                elif suffix == "self_attn.q_proj.weight":
+                    sd[f"layers.{layer}.attention.wq.weight"] = self._reverse_permute(
+                        value, self._n_heads
+                    )
+                elif suffix == "self_attn.k_proj.weight":
+                    sd[f"layers.{layer}.attention.wk.weight"] = self._reverse_permute(
+                        value,
+                        self._n_kv_heads,
+                        self._key_value_dim,
+                        self._dim,
+                    )
+
+        # Weight tying: copy embedding as output if lm_head absent
         if (
             self.model_config.enable_weight_tying
-            and "lm_head.weight" not in hf_state_dict
+            and "output.weight" not in sd
+            and "tok_embeddings.weight" in sd
         ):
-            assert "model.embed_tokens.weight" in hf_state_dict
-            hf_state_dict["lm_head.weight"] = hf_state_dict["model.embed_tokens.weight"]
+            sd["output.weight"] = sd["tok_embeddings.weight"]
 
-        n_heads = self.model_config.layers[0].attention.n_heads
-        n_kv_heads = (
-            self.model_config.layers[0].attention.n_kv_heads
-            # pyrefly: ignore [missing-attribute]
-            if self.model_config.layers[0].attention.n_kv_heads is not None
-            else n_heads
-        )
-        dim = self.model_config.dim
-        head_dim = dim // n_heads
-        state_dict = {}
-
-        for key, value in hf_state_dict.items():
-            if "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = self.from_hf_map[abstract_key]
-
-                # We need to permute the weights in wq and wk layer in order to account for the difference between
-                # the native Llama and huggingface RoPE implementation.
-                if abstract_key == "model.layers.{}.self_attn.q_proj.weight":
-                    value = self._reverse_permute(value, n_heads)
-                if abstract_key == "model.layers.{}.self_attn.k_proj.weight":
-                    # pyrefly: ignore [unsupported-operation]
-                    key_value_dim = head_dim * n_kv_heads
-                    value = self._reverse_permute(value, n_kv_heads, key_value_dim, dim)
-
-                if new_key is None:
-                    continue
-                new_key = new_key.format(layer_num)
-            else:
-                new_key = self.from_hf_map[key]
-
-            # pyrefly: ignore [unsupported-operation]
-            state_dict[new_key] = value
-        # pyrefly: ignore [bad-return]
-        return state_dict
+        return sd

--- a/torchtitan/models/llama4/state_dict_adapter.py
+++ b/torchtitan/models/llama4/state_dict_adapter.py
@@ -4,142 +4,117 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import re
 from collections import defaultdict
 from typing import Any
 
 import torch
 
-logger = logging.getLogger()
-
-from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+from torchtitan.models.utils import MoEStateDictAdapter
 
 from .model import Llama4Model
 
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_HF_LAYER_RE = re.compile(r"^language_model\.model\.layers\.(\d+)\.")
 
-class Llama4StateDictAdapter(StateDictAdapter):
+
+class Llama4StateDictAdapter(MoEStateDictAdapter):
     def __init__(self, model_config: Llama4Model.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
-
         self.model_config = model_config
-        self.hf_assets_path = hf_assets_path
-        self.from_hf_map = {
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        RENAME = {
+            "tok_embeddings.weight": "language_model.model.embed_tokens.weight",
+            "norm.weight": "language_model.model.norm.weight",
+            "output.weight": "language_model.lm_head.weight",
+        }
+        LAYER_RENAME = {
+            "attention.wq.weight": "self_attn.q_proj.weight",
+            "attention.wk.weight": "self_attn.k_proj.weight",
+            "attention.wv.weight": "self_attn.v_proj.weight",
+            "attention.wo.weight": "self_attn.o_proj.weight",
+            "attention_norm.weight": "input_layernorm.weight",
+            "ffn_norm.weight": "post_attention_layernorm.weight",
+            "moe.router.gate.weight": "feed_forward.router.weight",
+            "moe.shared_experts.w1.weight": "feed_forward.shared_expert.gate_proj.weight",
+            "moe.shared_experts.w2.weight": "feed_forward.shared_expert.down_proj.weight",
+            "moe.shared_experts.w3.weight": "feed_forward.shared_expert.up_proj.weight",
+        }
+
+        hf: dict[str, Any] = {}
+        # Collect w1/w3 per layer for gate_up_proj combination
+        to_combine: dict[str, dict[str, torch.Tensor]] = defaultdict(dict)
+
+        for key, value in state_dict.items():
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            elif m := _LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in LAYER_RENAME:
+                    hf[
+                        f"language_model.model.layers.{layer}.{LAYER_RENAME[suffix]}"
+                    ] = value
+                # MoE expert bias — no HF equivalent, drop
+                elif suffix == "moe.expert_bias":
+                    pass
+                # MoE experts: w2 (down_proj) — transpose for HF format
+                elif suffix == "moe.experts.w2":
+                    hf[
+                        f"language_model.model.layers.{layer}.feed_forward.experts.down_proj"
+                    ] = value.transpose(-1, -2)
+                # MoE experts: w1, w3 — collect for gate_up_proj combination
+                elif suffix in ("moe.experts.w1", "moe.experts.w3"):
+                    hf_fqn = f"language_model.model.layers.{layer}.feed_forward.experts.gate_up_proj"
+                    to_combine[hf_fqn][suffix] = value
+
+        # Combine w1 + w3 → gate_up_proj (transposed, then concatenated)
+        for hf_fqn, parts in to_combine.items():
+            w1 = parts["moe.experts.w1"].transpose(-1, -2)
+            w3 = parts["moe.experts.w3"].transpose(-1, -2)
+            hf[hf_fqn] = torch.cat([w1, w3], dim=-1)
+
+        return hf
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        RENAME = {
             "language_model.model.embed_tokens.weight": "tok_embeddings.weight",
             "language_model.model.norm.weight": "norm.weight",
             "language_model.lm_head.weight": "output.weight",
-            "language_model.model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
-            "language_model.model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
-            "language_model.model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
-            "language_model.model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-            "language_model.model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-            "language_model.model.layers.{}.feed_forward.router.weight": "layers.{}.moe.router.gate.weight",
-            "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2",
-            None: "layers.{}.moe.expert_bias",
-            "language_model.model.layers.{}.feed_forward.shared_expert.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
-            "language_model.model.layers.{}.feed_forward.shared_expert.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
-            "language_model.model.layers.{}.feed_forward.shared_expert.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",
-            "language_model.model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
+        }
+        LAYER_RENAME = {
+            "self_attn.q_proj.weight": "attention.wq.weight",
+            "self_attn.k_proj.weight": "attention.wk.weight",
+            "self_attn.v_proj.weight": "attention.wv.weight",
+            "self_attn.o_proj.weight": "attention.wo.weight",
+            "input_layernorm.weight": "attention_norm.weight",
+            "post_attention_layernorm.weight": "ffn_norm.weight",
+            "feed_forward.router.weight": "moe.router.gate.weight",
+            "feed_forward.shared_expert.gate_proj.weight": "moe.shared_experts.w1.weight",
+            "feed_forward.shared_expert.down_proj.weight": "moe.shared_experts.w2.weight",
+            "feed_forward.shared_expert.up_proj.weight": "moe.shared_experts.w3.weight",
         }
 
-    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
-
-        hf_state_dict = {}
-
-        # Keeps track of TT fqn values to combine into one HF fqn later
-        # {hf_fqn : {tt_fqn1 : value}, {tt_fqn2 : value}, ...}
-        to_combine = defaultdict(dict)
-        for key, value in state_dict.items():
-            if "layers" in key:
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                key = re.sub(r"(\d+)", "{}", key, count=1)
-            else:
-                layer_num = None
-
-            if key in to_hf_map:
-                # do direct mapping
-                if key in "layers.{}.moe.experts.w2":
-                    # we transpose the expert weights for torchtitan optimization purpose
-                    value = value.transpose(-1, -2)
-
-                new_key = to_hf_map[key]
-                if new_key is None:
-                    continue
-                if layer_num:
-                    new_key = new_key.format(layer_num)
-                hf_state_dict[new_key] = value
-            elif key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
-            ]:
-                # handle collecting values to combine
-                hf_abstract_key = (
-                    "language_model.model.layers.{}.feed_forward.experts.gate_up_proj"
-                )
-                # pyrefly: ignore [unnecessary-comparison]
-                if hf_abstract_key is None:
-                    continue
-                to_combine[hf_abstract_key.format(layer_num)][
-                    key.format(layer_num)
-                ] = value
-
-        # combine collected values
-        for hf_fqn, tt_fqn_map in to_combine.items():
-            # pyrefly: ignore [missing-attribute]
-            layer_num = re.search(r"\d+", hf_fqn).group(0)
-            combine_values = []
-            # put into correct order to combine
-            for tt_abstract_key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
-            ]:
-                tt_key = tt_abstract_key.format(layer_num)
-                # we transpose the expert weights for torchtitan optimization purpose
-                combine_values.append(tt_fqn_map[tt_key].transpose(-1, -2))
-
-            value = torch.cat(combine_values, dim=-1)
-            hf_state_dict[hf_fqn] = value
-
-        return hf_state_dict
-
-    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        state_dict = {}
+        sd: dict[str, Any] = {}
 
         for key, value in hf_state_dict.items():
-            if "layers" in key:
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                key = re.sub(r"(\d+)", "{}", key, count=1)
-            else:
-                layer_num = None
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            elif m := _HF_LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-            if key in self.from_hf_map:
-                # do direct mapping
-                if (
-                    key
-                    == "language_model.model.layers.{}.feed_forward.experts.down_proj"
-                ):
-                    # we transpose the expert weights for torchtitan optimization purpose
-                    value = value.transpose(-1, -2)
+                if suffix in LAYER_RENAME:
+                    sd[f"layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+                # MoE experts: down_proj → w2 (transpose back)
+                elif suffix == "feed_forward.experts.down_proj":
+                    sd[f"layers.{layer}.moe.experts.w2"] = value.transpose(-1, -2)
+                # MoE experts: gate_up_proj → split into w1 + w3 (transpose back)
+                elif suffix == "feed_forward.experts.gate_up_proj":
+                    w1, w3 = value.chunk(2, dim=-1)
+                    sd[f"layers.{layer}.moe.experts.w1"] = w1.transpose(-1, -2)
+                    sd[f"layers.{layer}.moe.experts.w3"] = w3.transpose(-1, -2)
 
-                new_key = self.from_hf_map[key]
-                if new_key is None:
-                    continue
-                if layer_num:
-                    new_key = new_key.format(layer_num)
-                state_dict[new_key] = value
-            elif (
-                key
-                == "language_model.model.layers.{}.feed_forward.experts.gate_up_proj"
-            ):
-                # handle splitting values
-                w1, w3 = value.chunk(2, dim=-1)
-                # we transpose the expert weights for torchtitan optimization purpose
-                w1, w3 = w1.transpose(-1, -2), w3.transpose(-1, -2)
-                # split_vals = [val.transpose(-1, -2) for val in split_vals]
-                state_dict["layers.{}.moe.experts.w1".format(layer_num)] = w1
-                state_dict["layers.{}.moe.experts.w3".format(layer_num)] = w3
-
-        return state_dict
+        return sd

--- a/torchtitan/models/qwen3/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/state_dict_adapter.py
@@ -4,189 +4,137 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""
-This script is adapted from torchtitan/models/llama3/model/state_dict_adapter.py.
-
-We can use this script to adapt the checkpoint from HF to the format that we can load into the torchtitan model and vice versa.
-This can enable us to do a parity test with the HF implementation and make sure that our results are
-aligned with the HF implementation.
-
-"""
 import re
 from typing import Any
-
-from torch.distributed.tensor import DTensor
 
 from torchtitan.models.utils import MoEStateDictAdapter
 
 from .model import Qwen3Model
 
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_HF_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.")
+
 
 class Qwen3StateDictAdapter(MoEStateDictAdapter):
+    _HF_EXPERT_RE = re.compile(
+        r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+    )
+    _PROJ_TO_HF = {
+        "moe.experts.w1": "gate_proj",
+        "moe.experts.w3": "up_proj",
+        "moe.experts.w2": "down_proj",
+    }
+    _PROJ_FROM_HF = {
+        "gate_proj": "moe.experts.w1",
+        "up_proj": "moe.experts.w3",
+        "down_proj": "moe.experts.w2",
+    }
+
     def __init__(self, model_config: Qwen3Model.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
-        self.from_hf_map = {
+        self.model_config = model_config
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert torchtitan state dict to HF format.
+
+        Renames FQNs and splits 3D GroupedExperts weights into individual
+        2D per-expert weights.
+        """
+        RENAME = {
+            "tok_embeddings.weight": "model.embed_tokens.weight",
+            "norm.weight": "model.norm.weight",
+            "output.weight": "lm_head.weight",
+        }
+        LAYER_RENAME = {
+            "attention.wq.weight": "self_attn.q_proj.weight",
+            "attention.wk.weight": "self_attn.k_proj.weight",
+            "attention.wv.weight": "self_attn.v_proj.weight",
+            "attention.wo.weight": "self_attn.o_proj.weight",
+            "attention.q_norm.weight": "self_attn.q_norm.weight",
+            "attention.k_norm.weight": "self_attn.k_norm.weight",
+            "feed_forward.w1.weight": "mlp.gate_proj.weight",
+            "feed_forward.w3.weight": "mlp.up_proj.weight",
+            "feed_forward.w2.weight": "mlp.down_proj.weight",
+            "attention_norm.weight": "input_layernorm.weight",
+            "ffn_norm.weight": "post_attention_layernorm.weight",
+            "moe.router.gate.weight": "mlp.gate.weight",
+        }
+
+        hf: dict[str, Any] = {}
+
+        for key, value in state_dict.items():
+            # Skip output.weight when weight tying is enabled
+            # pyrefly: ignore [missing-attribute]
+            if self.model_config.enable_weight_tying and key == "output.weight":
+                continue
+
+            if key in RENAME:
+                hf[RENAME[key]] = value
+            elif m := _LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
+
+                if suffix in LAYER_RENAME:
+                    hf[f"model.layers.{layer}.{LAYER_RENAME[suffix]}"] = value
+                # MoE experts (3D GroupedExperts → individual 2D experts)
+                elif suffix in self._PROJ_TO_HF:
+                    self._experts_to_hf(suffix, layer, value, hf)
+
+        return hf
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert HF state dict to torchtitan format.
+
+        Renames FQNs and concatenates individual 2D per-expert weights
+        back into 3D GroupedExperts weights.
+        """
+        RENAME = {
             "model.embed_tokens.weight": "tok_embeddings.weight",
-            # Attention module
-            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
-            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
-            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
-            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-            "model.layers.{}.self_attn.q_norm.weight": "layers.{}.attention.q_norm.weight",
-            "model.layers.{}.self_attn.k_norm.weight": "layers.{}.attention.k_norm.weight",
-            "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
-            # MLP module for non-MoE
-            "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
-            "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
-            "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
-            # Transformer layer
-            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE
-            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1",
-            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3",
-            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2",
-            "model.layers.{}.mlp.gate.weight": "layers.{}.moe.router.gate.weight",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "output.weight",
         }
+        LAYER_RENAME = {
+            "self_attn.q_proj.weight": "attention.wq.weight",
+            "self_attn.k_proj.weight": "attention.wk.weight",
+            "self_attn.v_proj.weight": "attention.wv.weight",
+            "self_attn.o_proj.weight": "attention.wo.weight",
+            "self_attn.q_norm.weight": "attention.q_norm.weight",
+            "self_attn.k_norm.weight": "attention.k_norm.weight",
+            "self_attn.rotary_emb.inv_freq": None,  # drop
+            "mlp.gate_proj.weight": "feed_forward.w1.weight",
+            "mlp.up_proj.weight": "feed_forward.w3.weight",
+            "mlp.down_proj.weight": "feed_forward.w2.weight",
+            "input_layernorm.weight": "attention_norm.weight",
+            "post_attention_layernorm.weight": "ffn_norm.weight",
+            "mlp.gate.weight": "moe.router.gate.weight",
+        }
 
-    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        1. Convert between the HF shape and the torchtitan shape.
-        2. Split the GroupedExperts' weight into separate expert's wegiht.
-        """
-        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
-        hf_state_dict = {}
+        sd: dict[str, Any] = {}
+        expert_weights_by_layer: dict[str, dict[str, dict[int, Any]]] = {}
 
-        for key, value in state_dict.items():
-            if "moe.experts" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                if abstract_key not in to_hf_map:
-                    continue
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_abstract_key = to_hf_map[abstract_key]
+        for key, value in hf_state_dict.items():
+            # Check for MoE expert keys first
+            if self._experts_from_hf(key, value, sd, expert_weights_by_layer):
+                continue
 
-                # Store the GroupedExperts Weight metadata for from_hf()
-                if isinstance(value, DTensor):
-                    self.grouped_expert_weight_placements[
-                        abstract_key
-                    ] = value.placements
-                    self.grouped_expert_weight_shape[abstract_key] = value.shape
-                    self.grouped_expert_weight_mesh[abstract_key] = value.device_mesh
+            if key in RENAME:
+                sd[RENAME[key]] = value
+            elif m := _HF_LAYER_RE.match(key):
+                layer = m.group(1)
+                suffix = key[m.end() :]
 
-                    # Split GroupedExperts weight to local individual expert weights
-                    local_expert_fqn = self._get_local_experts_weights(
-                        new_abstract_key,
-                        abstract_key,
-                        layer_num,
-                        value,
-                    )
-                    hf_state_dict.update(local_expert_fqn)
+                if suffix in LAYER_RENAME:
+                    target = LAYER_RENAME[suffix]
+                    if target is not None:
+                        sd[f"layers.{layer}.{target}"] = value
 
-                else:
-                    # keep this path for offline conversion
-                    moe_layer = next(
-                        l for l in self.model_config.layers if l.moe is not None
-                    )
-                    split_values = self._split_experts_weights(
-                        value,
-                        moe_layer.moe.num_experts,
-                    )
-
-                    for expert_num in range(moe_layer.moe.num_experts):
-                        new_key = new_abstract_key.format(layer_num, expert_num)
-                        hf_state_dict[new_key] = split_values[expert_num].squeeze()
-
-            elif "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                if abstract_key not in to_hf_map:
-                    continue
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = to_hf_map[abstract_key]
-                new_key = new_key.format(layer_num)
-                hf_state_dict[new_key] = value
-
-            else:
-                if key not in to_hf_map:
-                    continue
-                # pyrefly: ignore [missing-attribute]
-                if self.model_config.enable_weight_tying and key == "output.weight":
-                    continue
-                new_key = to_hf_map[key]
-                hf_state_dict[new_key] = value
-
-        return hf_state_dict
-
-    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        """
-        1. Convert between the HF shape and the torchtitan shape.
-        2. Concate separate expert's wegiht into GroupedExperts' weight.
-        """
-
-        state_dict = {}
-        expert_weights_by_layer = {}  # {layer: {abstract_key: {expert_id: tensor}}}
-
+        # Weight tying: copy embedding as output if lm_head absent
         if (
             # pyrefly: ignore [missing-attribute]
             self.model_config.enable_weight_tying
-            and "lm_head.weight" not in hf_state_dict
+            and "output.weight" not in sd
+            and "tok_embeddings.weight" in sd
         ):
-            assert "model.embed_tokens.weight" in hf_state_dict
-            hf_state_dict["lm_head.weight"] = hf_state_dict["model.embed_tokens.weight"]
+            sd["output.weight"] = sd["tok_embeddings.weight"]
 
-        for key, value in hf_state_dict.items():
-            if "mlp.experts" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=2)
-                layer_num, expert_num = re.findall(r"\d+", key)
-                titan_abstract_key = self.from_hf_map[abstract_key]
-                assert titan_abstract_key is not None
-                new_key = titan_abstract_key.format(layer_num)
-
-                # Store the expert's weight in expert_weights_by_layer for concatenating later.
-                if layer_num not in expert_weights_by_layer:
-                    expert_weights_by_layer[layer_num] = {}
-                if titan_abstract_key not in expert_weights_by_layer[layer_num]:
-                    expert_weights_by_layer[layer_num][titan_abstract_key] = {}
-                expert_weights_by_layer[layer_num][titan_abstract_key][
-                    int(expert_num)
-                ] = value
-
-                # Use stored metadata to decide path (online vs offline)
-                # Online mode: local_experts_indices was populated during to_hf()
-                if titan_abstract_key in self.local_experts_indices:
-                    stacked_value = self._concatenate_expert_weights_dtensor(
-                        expert_weights_by_layer,
-                        titan_abstract_key,
-                        layer_num,
-                    )
-                else:  # keep this path to be compatible with offline conversion
-                    stacked_value = self._concatenate_expert_weights(
-                        expert_weights_by_layer,
-                        titan_abstract_key,
-                        layer_num,
-                        next(
-                            l for l in self.model_config.layers if l.moe is not None
-                        ).moe.num_experts,
-                    )
-
-                if stacked_value is not None:
-                    state_dict[new_key] = stacked_value
-
-            elif "layers" in key:
-                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                new_key = self.from_hf_map[abstract_key]
-                # pyrefly: ignore [missing-attribute]
-                new_key = new_key.format(layer_num)
-                state_dict[new_key] = value
-
-            else:
-                new_key = self.from_hf_map[key]
-                # pyrefly: ignore [unsupported-operation]
-                state_dict[new_key] = value
-
-        return state_dict
+        return sd

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import re
+from typing import Any
+
 import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -11,34 +14,144 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import _StridedShard, Replicate, Shard
 
 from torchtitan.models.common.decoder import Decoder
-from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 
 from torchtitan.tools.logging import logger
 
 
-class MoEStateDictAdapter(StateDictAdapter):
+class MoEStateDictAdapter(BaseStateDictAdapter):
+    """StateDictAdapter for MoE models.
+
+    Provides DTensor-aware utilities for converting between torchtitan's 3D
+    GroupedExperts weights (``[num_experts, ...]``) and HuggingFace formats.
+
+    Different HF models store experts differently:
+    - Per-expert 2D weights (Qwen3, DeepSeekV3): needs 3D↔2D split/concat
+    - 3D tensors with transforms (Llama4): transpose + concat, no decomposition
+    - 3D block renames (GptOss): pure key renames
+
+    Subclasses that need 3D↔2D decomposition override ``_HF_EXPERT_RE``,
+    ``_PROJ_TO_HF``, and ``_PROJ_FROM_HF``, then call ``_experts_to_hf`` /
+    ``_experts_from_hf``. Models that don't need decomposition keep the
+    empty defaults and handle expert keys in their own ``to_hf`` / ``from_hf``.
     """
-    StateDictAdapter for MoE models.
-    HF MoE models store experts as a module list each with 2D weights. In torchtitan, we
-    store experts as a 3D param with the first dimension being num_experts. The functions
-    in this class help convert 3D param into list of 2D params so that the checkpoint
-    can be loaded without incurring local memory overhead, and then concatenate
-    the results back to 3D param.
-    """
+
+    # Subclasses that need 3D↔2D expert decomposition override these.
+    # Models with 3D↔3D expert formats (Llama4, GptOss) keep the defaults.
+    _HF_EXPERT_RE: re.Pattern | None = None
+    _PROJ_TO_HF: dict[str, str] = {}
+    _PROJ_FROM_HF: dict[str, str] = {}
 
     def __init__(
         self,
         model_config: Decoder.Config,
         hf_assets_path: str | None,
     ):
-        super().__init__(model_config, hf_assets_path)
+        super().__init__(hf_assets_path)
         self.model_config = model_config
-        self.hf_assets_path = hf_assets_path
         # Store metadata for GroupedExperts <-> individual experts conversion
         self.grouped_expert_weight_placements = {}  # {titan_abstract_key: placements}
         self.grouped_expert_weight_shape = {}  # {titan_abstract_key: shape}
         self.grouped_expert_weight_mesh = {}  # {titan_abstract_key: device_mesh}
         self.local_experts_indices = {}  # {titan_abstract_key: (start_idx, end_idx)}
+
+    # ------------------------------------------------------------------
+    # Shared helpers for 3D GroupedExperts <-> individual 2D HF experts
+    # ------------------------------------------------------------------
+
+    def _experts_to_hf(
+        self,
+        suffix: str,
+        layer: str,
+        value: Any,
+        hf: dict[str, Any],
+        *,
+        hf_layer_prefix: str = "model.layers",
+    ) -> None:
+        """Convert a 3D GroupedExperts weight to individual 2D HF expert weights.
+
+        Handles both DTensor (distributed) and plain tensor (offline) cases.
+        Results are written directly into *hf*.
+        """
+        hf_proj = self._PROJ_TO_HF[suffix]
+        titan_abstract_key = f"layers.{{}}.{suffix}"
+        hf_abstract_key = f"{hf_layer_prefix}.{{}}.mlp.experts.{{}}.{hf_proj}.weight"
+
+        if isinstance(value, DTensor):
+            self.grouped_expert_weight_placements[titan_abstract_key] = value.placements
+            self.grouped_expert_weight_shape[titan_abstract_key] = value.shape
+            self.grouped_expert_weight_mesh[titan_abstract_key] = value.device_mesh
+            local_expert_fqn = self._get_local_experts_weights(
+                hf_abstract_key,
+                titan_abstract_key,
+                layer,
+                value,
+            )
+            hf.update(local_expert_fqn)
+        else:
+            # pyrefly: ignore [missing-attribute]
+            moe_layer = next(
+                l for l in self.model_config.layers if l.moe is not None
+            )
+            num_experts = moe_layer.moe.num_experts
+            split_values = self._split_experts_weights(value, num_experts)
+            for expert_num in range(num_experts):
+                hf[
+                    f"{hf_layer_prefix}.{layer}.mlp.experts.{expert_num}.{hf_proj}.weight"
+                ] = split_values[expert_num].squeeze()
+
+    def _experts_from_hf(
+        self,
+        key: str,
+        value: Any,
+        sd: dict[str, Any],
+        expert_weights_by_layer: dict[str, dict[str, dict[int, Any]]],
+    ) -> bool:
+        """Collect an individual HF expert weight and concatenate when complete.
+
+        Returns True if *key* matched an expert pattern (handled), False otherwise.
+        """
+        if self._HF_EXPERT_RE is None:
+            return False
+        em = self._HF_EXPERT_RE.match(key)
+        if em is None:
+            return False
+
+        layer = em.group(1)
+        expert_num = int(em.group(2))
+        proj = em.group(3)
+        titan_suffix = self._PROJ_FROM_HF[proj]
+        titan_abstract_key = f"layers.{{}}.{titan_suffix}"
+        new_key = f"layers.{layer}.{titan_suffix}"
+
+        if layer not in expert_weights_by_layer:
+            expert_weights_by_layer[layer] = {}
+        if titan_abstract_key not in expert_weights_by_layer[layer]:
+            expert_weights_by_layer[layer][titan_abstract_key] = {}
+        expert_weights_by_layer[layer][titan_abstract_key][expert_num] = value
+
+        # Concatenate when all experts are collected
+        if titan_abstract_key in self.local_experts_indices:
+            stacked = self._concatenate_expert_weights_dtensor(
+                expert_weights_by_layer,
+                titan_abstract_key,
+                layer,
+            )
+        else:
+            # pyrefly: ignore [missing-attribute]
+            moe_layer = next(
+                l for l in self.model_config.layers if l.moe is not None
+            )
+            stacked = self._concatenate_expert_weights(
+                expert_weights_by_layer,
+                titan_abstract_key,
+                layer,
+                moe_layer.moe.num_experts,
+            )
+        if stacked is not None:
+            sd[new_key] = stacked
+
+        return True
 
     def _calculate_strided_shard_shard_indices(
         self,

--- a/torchtitan/protocols/__init__.py
+++ b/torchtitan/protocols/__init__.py
@@ -10,16 +10,15 @@ from .model import BaseModel
 from .model_converter import ModelConverter, ModelConvertersContainer
 from .model_spec import FaultTolerantModelSpec, ModelSpec
 from .module import Module
-from .state_dict_adapter import BaseStateDictAdapter, StateDictAdapter
+from .state_dict_adapter import BaseStateDictAdapter
 
 __all__ = [
     "BaseModel",
+    "BaseStateDictAdapter",
     "Configurable",
     "FaultTolerantModelSpec",
     "ModelConverter",
     "ModelConvertersContainer",
     "ModelSpec",
     "Module",
-    "StateDictAdapter",
-    "BaseStateDictAdapter",
 ]

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -14,29 +14,52 @@ from torch.distributed.checkpoint import HuggingFaceStorageReader
 
 from torchtitan.tools.logging import logger
 
-from .model import BaseModel
-
 
 class BaseStateDictAdapter(ABC):
     """Abstract base class for state dict transformations.
 
     This class defines the interface for converting between native model
-    state dict format and other model state dict formats.
+    state dict format and other model state dict formats (e.g. HuggingFace).
+
+    Subclasses implement ``to_hf`` and ``from_hf`` as explicit procedural
+    conversions — each adapter reads one function and sees every key rename
+    and value transform for that model.
+
+    The base class constructor is lightweight — it only handles
+    ``hf_assets_path`` and ``fqn_to_index_mapping``. Model-specific
+    concerns like ``model_config`` are handled by subclasses.
+
     Args:
-        model_config: for initializing the model's memory space
         hf_assets_path: path to HF assets folder containing tokenizer, model weights, etc.
     """
 
     fqn_to_index_mapping: dict[Any, int] | None
     hf_assets_path: str | None
 
-    @abstractmethod
-    def __init__(
-        self,
-        model_config: BaseModel.Config,
-        hf_assets_path: str | None,
-    ):
-        pass
+    def __init__(self, hf_assets_path: str | None = None):
+        self.hf_assets_path = hf_assets_path
+        if hf_assets_path:
+            mapping_path = os.path.join(hf_assets_path, "model.safetensors.index.json")
+            try:
+                with open(mapping_path, "r") as f:
+                    hf_safetensors_indx = json.load(f)
+            except FileNotFoundError:
+                logger.warning(
+                    f"model.safetensors.index.json not found at hf_assets_path: {mapping_path}. "
+                    "Defaulting to saving a single safetensors file if checkpoint is saved in HF format"
+                )
+                hf_safetensors_indx = None
+
+            if hf_safetensors_indx:
+                self.fqn_to_index_mapping = {}
+                for hf_key, raw_indx in hf_safetensors_indx["weight_map"].items():
+                    # pyrefly: ignore [missing-attribute]
+                    indx = re.search(r"\d+", raw_indx).group(0)
+                    self.fqn_to_index_mapping[hf_key] = int(indx)
+            else:
+                self.fqn_to_index_mapping = None
+        else:
+            self.fqn_to_index_mapping = None
 
     @abstractmethod
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -62,57 +85,18 @@ class BaseStateDictAdapter(ABC):
         """
         pass
 
-    @abstractmethod
     def get_hf_storage_reader(
         self, path: str, from_quantized: bool = False
     ) -> HuggingFaceStorageReader:
-        """Returns hf storage reader to read HF checkpoint
+        """Returns hf storage reader to read HF checkpoint.
 
         Args:
             path: the path to read HF checkpoint
+            from_quantized: whether loading from quantized checkpoint format
 
         Returns:
             The HuggingFace storage reader to read from HF checkpoint
-
         """
-        pass
-
-
-class StateDictAdapter(BaseStateDictAdapter):
-    """State dict adapter base class which provides convenient default behavior to build fqn_to_index_mapping"""
-
-    def __init__(
-        self,
-        model_config: BaseModel.Config,
-        hf_assets_path: str | None,
-    ):
-        self.hf_assets_path = hf_assets_path
-        if hf_assets_path:
-            mapping_path = os.path.join(hf_assets_path, "model.safetensors.index.json")
-            try:
-                with open(mapping_path, "r") as f:
-                    hf_safetensors_indx = json.load(f)
-            except FileNotFoundError:
-                logger.warning(
-                    f"model.safetensors.index.json not found at hf_assets_path: {mapping_path}. \
-                    Defaulting to saving a single safetensors file if checkpoint is saved in HF format"
-                )
-                hf_safetensors_indx = None
-
-            if hf_safetensors_indx:
-                self.fqn_to_index_mapping = {}
-                for hf_key, raw_indx in hf_safetensors_indx["weight_map"].items():
-                    # pyrefly: ignore [missing-attribute]
-                    indx = re.search(r"\d+", raw_indx).group(0)
-                    self.fqn_to_index_mapping[hf_key] = int(indx)
-            else:
-                self.fqn_to_index_mapping = None
-        else:
-            self.fqn_to_index_mapping = None
-
-    def get_hf_storage_reader(
-        self, path: str, from_quantized: bool = False
-    ) -> HuggingFaceStorageReader:
         if from_quantized:
             logger.warning(
                 "Loading from quantized checkpoint format is not supported for this model."


### PR DESCRIPTION
- Collapse BaseStateDictAdapter + StateDictAdapter into a single BaseStateDictAdapter, removing model_config from the base class
- Rewrite all 6 model adapters' to_hf()/from_hf() from the old from_hf_map dict-based approach to explicit procedural code with RENAME/LAYER_RENAME dicts                                                                                   
- Extract shared MoE expert 3D↔2D decomposition into MoEStateDictAdapter (_experts_to_hf/_experts_from_hf), deduplicating code between DeepSeekV3 and Qwen3

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2896
* #2895
* __->__ #2894
