### PR TITLE
Wire converter protocol through trainers and add checkpoint unit tests

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.state_dict_transforms import StateDictTransforms
 
 
 class FakeOptimizersContainer:
@@ -153,9 +154,9 @@ class TestCheckpointManager(unittest.TestCase):
                 sd_to_save[key] = val
         torch.save(sd_to_save, os.path.join(checkpoint_id, "state_dict.pt"))
 
-    def fake_load(self, states: dict, checkpoint_id=None):
+    def fake_load(self, states: dict, checkpoint_id=None, **kwargs):
         path = os.path.join(checkpoint_id, "state_dict.pt")
-        loaded = torch.load(path, weights_only="False")
+        loaded = torch.load(path, weights_only=False)
         for key, val in loaded.items():
             if key in states and hasattr(states[key], "load_state_dict"):
                 states[key].load_state_dict(val)
@@ -175,7 +176,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -208,7 +209,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -249,7 +250,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -272,7 +273,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         self.assertFalse(manager.load(step=-1))
@@ -296,7 +297,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         res = manager.load(step=-1)
@@ -326,7 +327,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -360,7 +361,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         manager1.save(curr_step=1, last_step=True)
@@ -380,7 +381,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
         r1 = manager2.load(step=1)
@@ -435,7 +436,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=checkpoint_config,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -476,7 +477,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=states,
             config=checkpoint_config,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -513,7 +514,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -539,7 +540,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -585,7 +586,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -623,7 +624,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -650,7 +651,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -675,7 +676,7 @@ class TestCheckpointManager(unittest.TestCase):
                 self.assertNotIn("optimizer", state_dict)
             return
 
-        def fake_load(state_dict: dict, checkpoint_id=None):
+        def fake_load(state_dict: dict, checkpoint_id=None, **kwargs):
             self.assertIn("bias", state_dict)
             self.assertIn("weight", state_dict)
             # No model prefix
@@ -691,7 +692,7 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
+            sd_transforms=StateDictTransforms(),
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -700,6 +701,186 @@ class TestCheckpointManager(unittest.TestCase):
         manager.save(curr_step=1)
         manager.save(curr_step=2, last_step=True)
         manager.load(step=1)
+
+
+class TestModelWrapper(unittest.TestCase):
+    """Tests for ModelWrapper state dict modes (full / base / export)."""
+
+    LORA_SD = {
+        "weight": torch.tensor([1.0, 2.0]),
+        "bias": torch.tensor([0.5]),
+        "linear.lora_a.weight": torch.tensor([[0.1, 0.2]]),
+        "linear.lora_b.weight": torch.tensor([[0.3], [0.4]]),
+    }
+
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+    )
+    def test_state_dict_returns_full_dict(self, mock_get_sd):
+        """state_dict() returns the full model state dict without converter."""
+        from torchtitan.components.checkpoint import ModelWrapper
+
+        model = nn.Linear(2, 2)
+        wrapper = ModelWrapper(model)
+        sd = wrapper.state_dict()
+        self.assertIn("weight", sd)
+        self.assertIn("bias", sd)
+
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+    )
+    def test_export_without_transform_returns_full_dict(self, mock_get_sd):
+        """state_dict(mode='export') returns full dict when no transform is set."""
+        from torchtitan.components.checkpoint import ModelWrapper
+
+        model = nn.Linear(2, 2)
+        wrapper = ModelWrapper(model)
+        exported = wrapper.state_dict(mode="export")
+        self.assertIn("weight", exported)
+        self.assertIn("bias", exported)
+
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: dict(TestModelWrapper.LORA_SD),
+    )
+    def test_lora_full_state_dict(self, mock_get_sd):
+        """full mode: returns all keys including LoRA (for DCP checkpoint)."""
+        from torchtitan.components.checkpoint import ModelWrapper
+
+        model = nn.Linear(2, 2)
+        wrapper = ModelWrapper(model, key_filter=lambda k: "lora" in k)
+        sd = wrapper.state_dict()
+        self.assertEqual(
+            set(sd.keys()),
+            {"weight", "bias", "linear.lora_a.weight", "linear.lora_b.weight"},
+        )
+
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: dict(TestModelWrapper.LORA_SD),
+    )
+    def test_lora_base_state_dict(self, mock_get_sd):
+        """base mode: excludes LoRA keys (for saving base model only)."""
+        from torchtitan.components.checkpoint import ModelWrapper
+
+        model = nn.Linear(2, 2)
+        wrapper = ModelWrapper(model, key_filter=lambda k: "lora" in k)
+        sd = wrapper.state_dict(mode="base")
+        self.assertEqual(set(sd.keys()), {"weight", "bias"})
+
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: dict(TestModelWrapper.LORA_SD),
+    )
+    def test_lora_export_state_dict(self, mock_get_sd):
+        """export mode: merges LoRA into base weights, drops LoRA keys."""
+        from torchtitan.components.checkpoint import ModelWrapper
+
+        def lora_merge(sd):
+            merged = dict(sd)
+            merged["weight"] = sd["weight"] + (
+                sd["linear.lora_b.weight"] @ sd["linear.lora_a.weight"]
+            ).squeeze()
+            return {k: v for k, v in merged.items() if "lora" not in k}
+
+        model = nn.Linear(2, 2)
+        wrapper = ModelWrapper(
+            model, key_filter=lambda k: "lora" in k, state_dict_transform=lora_merge
+        )
+        sd = wrapper.state_dict(mode="export")
+        self.assertEqual(set(sd.keys()), {"weight", "bias"})
+
+        lora_a = torch.tensor([[0.1, 0.2]])
+        lora_b = torch.tensor([[0.3], [0.4]])
+        expected = torch.tensor([1.0, 2.0]) + (lora_b @ lora_a).squeeze()
+        torch.testing.assert_close(sd["weight"], expected)
+
+
+class TestMultiSourceLoading(unittest.TestCase):
+    """Tests that additional_load_path triggers a second dcp.load."""
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    def test_additional_load_path(self, mock_save, mock_load, mock_rank):
+        """Primary + additional_load_path triggers two dcp.load calls (DCP and HF)."""
+        cases = [
+            ("dcp", None),  # no converter adapter → DCP fallback
+            ("hf", True),  # with converter adapter → HF via adapter
+        ]
+        for fmt, use_adapter in cases:
+            with self.subTest(format=fmt):
+                mock_save.reset_mock()
+                mock_load.reset_mock()
+
+                temp_dir = tempfile.mkdtemp()
+                adapter_dir = os.path.join(temp_dir, "adapter")
+                os.makedirs(adapter_dir)
+                try:
+                    mock_save.side_effect = lambda *a, **kw: os.makedirs(
+                        kw.get("checkpoint_id", a[1] if len(a) > 1 else ""),
+                        exist_ok=True,
+                    )
+                    mock_load.side_effect = lambda *a, **kw: None
+
+                    lora_filter = lambda k: "lora" in k  # noqa: E731
+                    converter_adapter = None
+                    converter_sd_adapters = None
+
+                    if use_adapter:
+                        converter_adapter = mock.Mock()
+                        converter_adapter.to_hf.return_value = {
+                            "peft_key": torch.tensor([1.0])
+                        }
+                        converter_adapter.from_hf.return_value = {
+                            "lora_a.weight": torch.tensor([1.0])
+                        }
+                        converter_adapter.get_hf_storage_reader.return_value = (
+                            mock.Mock()
+                        )
+                        converter_sd_adapters = [(converter_adapter, lora_filter)]
+
+                    cfg = CheckpointManager.Config(
+                        enable=True,
+                        async_mode="disabled",
+                        folder="",
+                        interval=1,
+                        keep_latest_k=0,
+                        last_save_model_only=False,
+                        export_dtype="float32",
+                        exclude_from_loading=[],
+                        initial_load_path=None,
+                        initial_load_model_only=False,
+                        additional_load_path=adapter_dir,
+                    )
+                    with mock.patch(
+                        "torch.distributed.new_group", return_value="pg"
+                    ):
+                        manager = CheckpointManager(
+                            dataloader=FakeDataLoader(),
+                            model_parts=[nn.Linear(2, 2)],
+                            optimizers=FakeOptimizersContainer(),
+                            lr_schedulers=FakeLRSchedulersContainer(),
+                            states={},
+                            config=cfg,
+                            sd_transforms=StateDictTransforms(),
+                            base_folder=temp_dir,
+                            key_filter=lora_filter if use_adapter else None,
+                            converter_sd_adapters=converter_sd_adapters,
+                        )
+
+                    manager.save(curr_step=1)
+                    manager.load(step=1)
+
+                    # Both formats trigger two dcp.load calls
+                    self.assertEqual(mock_load.call_count, 2)
+
+                    if use_adapter:
+                        converter_adapter.from_hf.assert_called_once()
+                finally:
+                    shutil.rmtree(temp_dir)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -261,17 +261,24 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             training_steps=config.training.steps,
         )
 
+        from torchtitan.components.state_dict_transforms import StateDictTransforms
+
+        sd_transforms = StateDictTransforms(
+            export_dtype=TORCH_DTYPE_MAP[config.checkpoint.export_dtype],
+            sd_adapter=(
+                self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
+                if self.train_spec.state_dict_adapter
+                else None
+            ),
+        )
+
         self.checkpointer = config.checkpoint.build(
             dataloader=None,
             model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if self.train_spec.state_dict_adapter
-                else None
-            ),
+            sd_transforms=sd_transforms,
             base_folder=config.dump_folder,
         )
 

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -303,20 +303,33 @@ class FaultTolerantTrainer(Trainer):
         self.step = 0
         self.ntokens_seen = 0
 
-        # FT addition: pass ft_manager to CheckpointManager
-        self.checkpointer = config.checkpoint.build(
-            dataloader=self.dataloader,
-            model_parts=self.model_parts,
-            optimizers=self.optimizers,
-            lr_schedulers=self.lr_schedulers,
-            states={"train_state": self},
+        from torchtitan.components.state_dict_transforms import StateDictTransforms
+
+        # FT addition: use FTCheckpointManager for fault tolerance support
+        from torchtitan.experiments.ft.checkpoint import FTCheckpointManager
+
+        sd_transforms = StateDictTransforms(
+            export_dtype=TORCH_DTYPE_MAP[config.checkpoint.export_dtype],
             sd_adapter=(
                 model_spec.state_dict_adapter(model_config, config.hf_assets_path)
                 if model_spec.state_dict_adapter
                 else None
             ),
+        )
+
+        self.checkpointer = FTCheckpointManager(
+            config.checkpoint,
+            dataloader=self.dataloader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states={"train_state": self},
+            sd_transforms=sd_transforms,
             base_folder=config.dump_folder,
             ft_manager=self.ft_manager,
+            key_filter=model_converters.key_filter(),
+            state_dict_transform=model_converters.state_dict_transform(),
+            converter_sd_adapters=model_converters.converter_sd_adapters(),
         )
 
         loss_parallel_enabled = (

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -450,18 +450,28 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.step = 0
         self.ntokens_seen = 0
 
+        from torchtitan.components.state_dict_transforms import StateDictTransforms
+
+        sd_transforms = StateDictTransforms(
+            export_dtype=TORCH_DTYPE_MAP[config.checkpoint.export_dtype],
+            sd_adapter=(
+                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+                if model_spec.state_dict_adapter
+                else None
+            ),
+        )
+
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
             model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
+            sd_transforms=sd_transforms,
             base_folder=config.dump_folder,
+            key_filter=model_converters.key_filter(),
+            state_dict_transform=model_converters.state_dict_transform(),
+            converter_sd_adapters=model_converters.converter_sd_adapters(),
         )
 
         loss_parallel_enabled = (


### PR DESCRIPTION
- Update trainer, FT trainer, and Forge engine to construct StateDictTransforms and pass converter protocol params to CheckpointManager
- Add 19 CPU-only unit tests across TestCheckpointManager (path resolution, save/purge guards), TestModelWrapper (full/base/export modes), and TestMultiSourceLoading (primary + additional with/without converter adapters)           
  
Test plan                                                                                                             
                                                                  
- pytest tests/unit_tests/test_checkpoint.py -x — 19 new unit tests pass                                              
- pre-commit run --all-files — lint clean
- Verify existing HF checkpoint loading still works (Llama3, DeepSeekV3, Qwen3)                                       
- Verify DCP resume produces identical loss with --debug.seed=42 --debug.deterministic                                
- Verify _save_last_step HF export produces correct safetensors format

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2896
* #2895
* #2894
