### PR TITLE
[GraphTrainer][AutoDev] Fix missing CP wiring in llama3 and deepseek_v3 parallelize

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -16,7 +16,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-
+from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
@@ -138,6 +138,12 @@ def parallelize_deepseekv3(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             pad_multiple=pad_multiple,
+        )
+
+    if parallel_dims.cp_enabled:
+        apply_cp_to_attention_module(
+            [block.attention.inner_attention for block in model.layers.values()],
+            parallel_dims.get_mesh("cp"),
         )
 
     if ac_config.mode != "none":

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -15,6 +15,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
@@ -102,8 +103,16 @@ def parallelize_llama(
             tp_mesh,
             enable_loss_parallel=not parallelism.disable_loss_parallel,
             enable_float8_tensorwise_tp=enable_float8_tensorwise_tp,
+            enable_cp=parallel_dims.cp_enabled,
+            enable_sp=parallelism.enable_sequence_parallel,
         )
         maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+
+    if parallel_dims.cp_enabled:
+        apply_cp_to_attention_module(
+            [block.attention.inner_attention for block in model.layers.values()],
+            parallel_dims.get_mesh("cp"),
+        )
 
     if ac_config.mode != "none":
         apply_graph_ac(compile_config, ac_config)

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -314,6 +314,22 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.context_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+CP",
+            "aot_fx_trace_llama3_fsdp_tp_cp",
+            ngpu=8,
+            skip_rocm_test=True,
+        ),
     ]
 
 
@@ -463,6 +479,20 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.context_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+CP",
+            "aot_fx_trace_deepseek_v3_fsdp_cp",
             ngpu=8,
         ),
     ]


### PR DESCRIPTION
## Summary
- Port the fix from PR #2808 to GraphTrainer's experiment parallelize files
- llama3's `parallelize_llama` was calling `apply_tp()` without passing `enable_cp` and `enable_sp`, causing context parallelism to silently malfunction
- Both llama3 and deepseek_v3 were missing the `apply_cp_to_attention_module()` call that configures attention modules for CP ring attention communication

## Changes
- **llama3/parallelize.py**: Add `enable_cp` and `enable_sp` keyword arguments to the `apply_tp()` call, and add the `apply_cp_to_attention_module()` call after `maybe_enable_async_tp`
- **deepseek_v3/parallelize.py**: Add the `apply_cp_to_attention_module()` call after the TP/EP block (deepseek_v3 already had `enable_cp`/`enable_sp` in its `apply_non_moe_tp()` call)

## Test plan
- [ ] Run `pre-commit run --all-files` (passed, no new issues)
- [ ] Run integration tests with CP enabled for llama3 and deepseek_v3

Ports fix from #2808.