### PR TITLE
[GraphTrainer][AutoDev] Add bitwise deterministic test to H100 CI workflow

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -67,4 +67,7 @@ jobs:
         # Run the DeepSeek numerics tests
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "dsv3"
 
+        # Run bitwise deterministic guardrail test (includes H100-only hardcoded-hash tests)
+        pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v
+
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint


### PR DESCRIPTION
## Summary
- Add `test_bitwise_deterministic.py` to the H100 CI workflow (`integration_test_8gpu_graph_trainer_h100.yaml`)
- The test includes H100-specific tests gated by `has_cuda_capability(9, 0)` that verify hardcoded expected loss, model hash, and gradient hash values for Llama3 and DeepSeek-v3 debug models
- These tests are skipped on non-H100 machines, so they need to run in the H100 workflow to actually be exercised

## Test plan
- [ ] Verify the H100 CI workflow passes with the new test added
- [ ] Confirm the H100-only tests (`test_eager_self_deterministic`, `test_aot_fx_trace_self_deterministic`) are no longer skipped