### PR TITLE
[graph_trainer] Fix CUDAGraph warmup to stay on current stream

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -17,7 +17,6 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import torch
-from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
 from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
@@ -182,14 +181,16 @@ class CUDAGraphWrapper:
     def __call__(self, *args):
         if not self._has_warmup:
             self._has_warmup = True
-            device = torch.cuda.current_device()
 
-            # warmup in cudagraph memory pool to avoid fragmentation
-            # across eager memory pool and cudagraph memory pool.
-            with _use_cuda_memory_pool_manager(
-                device, _cg_manager.graph_pool, _cg_manager.stream
-            ):
-                out = self._runnable(*args)
+            # Warmup: run the function once on the current stream to
+            # trigger lazy kernel compilation and workspace allocation.
+            # We stay on the current stream (rather than switching to
+            # _cg_manager.stream) so NCCL collectives execute normally.
+            # Recording (next call) uses _cg_manager.stream with the
+            # graph pool, where NCCL ops are captured, not executed.
+            torch.cuda.synchronize()
+            out = self._runnable(*args)
+            torch.cuda.synchronize()
             return out
 
         if self._cudagraph is None:
@@ -198,15 +199,14 @@ class CUDAGraphWrapper:
             self._input_addresses = [
                 x.data_ptr() if isinstance(x, torch.Tensor) else None for x in args
             ]
-
+            torch.cuda.synchronize()
             self._cudagraph = torch.cuda.CUDAGraph()
-
             with torch.cuda.graph(
                 self._cudagraph,
                 pool=_cg_manager.graph_pool,
                 stream=_cg_manager.stream,
+                capture_error_mode="thread_local",
             ):
-                # `output` is managed by pytorch's cudagraph pool
                 self._output = self._runnable(*args)
 
         if self._should_check_address:

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import torch
+from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
 from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
@@ -181,16 +182,17 @@ class CUDAGraphWrapper:
     def __call__(self, *args):
         if not self._has_warmup:
             self._has_warmup = True
+            device = torch.cuda.current_device()
 
-            # Warmup: run the function once on the current stream to
-            # trigger lazy kernel compilation and workspace allocation.
-            # We stay on the current stream (rather than switching to
-            # _cg_manager.stream) so NCCL collectives execute normally.
-            # Recording (next call) uses _cg_manager.stream with the
-            # graph pool, where NCCL ops are captured, not executed.
-            torch.cuda.synchronize()
-            out = self._runnable(*args)
-            torch.cuda.synchronize()
+            # Warmup on the current stream so NCCL collectives execute
+            # normally, but allocate from the graph memory pool to avoid
+            # fragmentation between eager and graph pools. We pass
+            # current_stream (not _cg_manager.stream) so no stream
+            # switch occurs — NCCL stays on the stream it was init'd on.
+            with _use_cuda_memory_pool_manager(
+                device, _cg_manager.graph_pool, torch.cuda.current_stream()
+            ):
+                out = self._runnable(*args)
             return out
 
         if self._cudagraph is None:
@@ -199,7 +201,6 @@ class CUDAGraphWrapper:
             self._input_addresses = [
                 x.data_ptr() if isinstance(x, torch.Tensor) else None for x in args
             ]
-            torch.cuda.synchronize()
             self._cudagraph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(
                 self._cudagraph,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #2922

The warmup phase was running on `_cg_manager.stream` via
`_use_cuda_memory_pool_manager`, which caused NCCL collectives to
execute on a non-default stream. On multi-node IB/RoCE setups this
leads to illegal memory access errors because NCCL expects to run
on the stream it was initialized with.

Fix by passing `torch.cuda.current_stream()` to
`_use_cuda_memory_pool_manager` instead of `_cg_manager.stream`. This
keeps NCCL collectives on the correct stream while still directing
warmup allocations into the graph memory pool (avoiding fragmentation
between eager and graph pools).

Also remove a redundant `torch.cuda.synchronize()` before graph
recording — `torch.cuda.graph.__enter__` already performs a full
device sync. Add `capture_error_mode="thread_local"` for better
error reporting during graph capture.