### PR TITLE
[LoRA]Add LoRA model converter with dynamic class inheritance

### DIFF
--- a/tests/unit_tests/test_model_converter.py
+++ b/tests/unit_tests/test_model_converter.py
@@ -3,8 +3,13 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+from collections import OrderedDict
 
+import pytest
+import torch
+import torch.nn as nn
+
+from torchtitan.components.lora import LoRAConverter
 from torchtitan.components.quantization.float8 import Float8LinearConverter
 from torchtitan.config import ConfigManager
 from torchtitan.distributed import ParallelDims
@@ -66,3 +71,100 @@ def test_build_model_converters_float8_converter():
     assert isinstance(model_converters, ModelConvertersContainer)
     assert len(model_converters.converters) == 1
     assert isinstance(model_converters.converters[0], Float8LinearConverter)
+
+
+def test_lora_before_quantization_raises():
+    """LoRA must come after quantization converters."""
+    with pytest.raises(ValueError, match="LoRA converter must come after"):
+        ModelConvertersContainer.Config(
+            converters=[
+                LoRAConverter.Config(rank=8, alpha=16.0),
+                Float8LinearConverter.Config(emulate=True),
+            ],
+        )
+
+
+def test_lora_freeze_and_training():
+    """LoRA adapters on all linears: correct freeze, trainability, and training."""
+    torch.manual_seed(42)
+    model = nn.Sequential(
+        OrderedDict(
+            [
+                ("fc1", nn.Linear(64, 64)),
+                ("relu", nn.ReLU()),
+                ("fc2", nn.Linear(64, 64)),
+            ]
+        )
+    )
+    converter = LoRAConverter(LoRAConverter.Config(rank=4, alpha=8.0))
+    converter.convert(model)
+
+    # LoRA adapters should be added to all linears
+    assert hasattr(model.fc1, "lora_a")
+    assert hasattr(model.fc2, "lora_a")
+
+    # Base params frozen, LoRA params trainable
+    for name, param in model.named_parameters():
+        if "lora_a" in name or "lora_b" in name:
+            assert param.requires_grad, f"LoRA param '{name}' should be trainable"
+        else:
+            assert not param.requires_grad, f"Base param '{name}' should be frozen"
+
+    # Train for 5 steps: only LoRA params should change
+    base_before = {
+        name: param.data.clone()
+        for name, param in model.named_parameters()
+        if "lora_a" not in name and "lora_b" not in name
+    }
+    optimizer = torch.optim.SGD(
+        [p for p in model.parameters() if p.requires_grad], lr=0.1
+    )
+    for _ in range(5):
+        x = torch.randn(4, 64)
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+    for name, param in model.named_parameters():
+        if name in base_before:
+            assert torch.equal(
+                param.data, base_before[name]
+            ), f"Base param '{name}' changed during training"
+
+
+def test_lora_filter_fqns():
+    """filter_fqns skips matching modules from LoRA conversion."""
+
+    class Attention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.wq = nn.Linear(64, 64)
+            self.wk = nn.Linear(64, 64)
+            self.wv = nn.Linear(64, 64)
+            self.wo = nn.Linear(64, 64)
+
+        def forward(self, x):
+            return self.wo(self.wq(x) + self.wk(x) + self.wv(x))
+
+    class Block(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attention = Attention()
+            self.output = nn.Linear(64, 64)
+
+        def forward(self, x):
+            return self.output(self.attention(x))
+
+    model = Block()
+    converter = LoRAConverter(
+        LoRAConverter.Config(rank=4, alpha=8.0, filter_fqns=["wo", "output"])
+    )
+    converter.convert(model)
+
+    # All linears get LoRA except filtered ones
+    assert hasattr(model.attention.wq, "lora_a")
+    assert hasattr(model.attention.wk, "lora_a")
+    assert hasattr(model.attention.wv, "lora_a")
+    assert not hasattr(model.attention.wo, "lora_a")
+    assert not hasattr(model.output, "lora_a")

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from torchtitan.config import Configurable
+from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
+
+# Module-protocol-compatible Linear for LoRA adapter layers.
+# Uses Module.from_nn_module so that adapters satisfy verify_module_protocol
+# and use reset_parameters() for initialization (no param_init Config needed).
+_LoRALinear = Module.from_nn_module(nn.Linear)
+
+# Cache for dynamically created LoRA classes
+_lora_class_cache: dict[type, type] = {}
+
+
+def apply_lora(linear: nn.Linear, rank: int, alpha: float) -> nn.Linear:
+    """Apply LoRA adapters to a Linear module via dynamic class inheritance.
+
+    Creates (and caches) a LoRA subclass of ``type(linear)`` so that LoRA
+    composes with any Linear variant (e.g. FakeQuantizedLinear).
+    """
+    parent_cls = type(linear)
+    if not issubclass(parent_cls, nn.Linear):
+        raise ValueError(f"apply_lora expects an nn.Linear subclass, got {parent_cls}")
+
+    if parent_cls not in _lora_class_cache:
+
+        class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("LoRALinear should not be instantiated directly.")
+
+            @classmethod
+            def from_linear(
+                cls, linear: nn.Linear, rank: int, alpha: float
+            ) -> "LoRALinear":
+                linear.__class__ = cls
+                linear._init_lora(rank, alpha)  # type: ignore[attr-defined]
+                return linear  # type: ignore[return-value]
+
+            def _init_lora(self, rank: int, alpha: float) -> None:
+                self._lora_scaling = alpha / rank
+                device = self.weight.device
+                dtype = self.weight.dtype
+                self.lora_a = _LoRALinear(
+                    self.in_features,
+                    rank,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                )
+                self.lora_b = _LoRALinear(
+                    rank,
+                    self.out_features,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                )
+                self._init_weight()
+
+            def _init_weight(self) -> None:
+                # pyrefly: ignore [bad-argument-type]
+                nn.init.kaiming_uniform_(self.lora_a.weight, a=math.sqrt(5))
+                nn.init.zeros_(
+                    self.lora_b.weight  # pyrefly: ignore [bad-argument-type]
+                )
+
+            def forward(self, input: torch.Tensor) -> torch.Tensor:
+                base_out = super().forward(input)
+                lora_out = self.lora_b(self.lora_a(input))
+                return base_out + self._lora_scaling * lora_out
+
+        LoRALinear.__name__ = f"LoRA{parent_cls.__name__}"
+        LoRALinear.__qualname__ = f"LoRA{parent_cls.__name__}"
+        _lora_class_cache[parent_cls] = LoRALinear
+
+    # pyrefly: ignore [missing-attribute]
+    return _lora_class_cache[parent_cls].from_linear(linear, rank, alpha)
+
+
+class LoRAConverter(Configurable):
+    """Apply LoRA adapters to all Linear layers in a model."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        rank: int = 8
+        """Rank of the LoRA matrices (lora_a: in_features x rank, lora_b: rank x out_features)."""
+
+        alpha: float = 16.0
+        """Scaling factor. Output is scaled by alpha/rank."""
+
+        filter_fqns: list[str] = field(default_factory=list)
+        """FQNs of Linear modules to skip (substring match).
+        Example: filter_fqns=["output"] to exclude the LM head."""
+
+    def __init__(self, config: Config, **kwargs: Any) -> None:
+        if config.rank <= 0:
+            raise ValueError(f"LoRA rank must be positive, got {config.rank}")
+        self.rank = config.rank
+        self.alpha = config.alpha
+        self.filter_fqns = config.filter_fqns
+        logger.info(f"LoRA training active with rank={self.rank}, alpha={self.alpha}")
+
+    def convert(self, model: nn.Module) -> None:
+        model.requires_grad_(False)
+        self._replace_linears_with_lora(model)
+
+    def _replace_linears_with_lora(self, module: nn.Module) -> None:
+        # Snapshot the module list before mutation so that newly created
+        # lora_a / lora_b children (which are nn.Linear) are not visited.
+        for fqn, child in list(module.named_modules()):
+            if isinstance(child, nn.Linear) and not any(
+                f in fqn for f in self.filter_fqns
+            ):
+                apply_lora(child, self.rank, self.alpha)
+
+        # Patch init_weights to also reinitialize LoRA adapters
+        original_init_weights = getattr(module, "init_weights", None)
+
+        def new_model_init_weights(*args: Any, **kwargs: Any) -> None:
+            if original_init_weights is not None and callable(original_init_weights):
+                original_init_weights(*args, **kwargs)
+            for sub_module in module.modules():
+                if hasattr(sub_module, "_lora_scaling"):
+                    sub_module._init_weight()  # pyrefly: ignore [not-callable]
+
+        object.__setattr__(module, "init_weights", new_model_init_weights)
+
+    def post_optimizer_hook(self, model: nn.Module | list[nn.Module]) -> None:
+        pass

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.lora import LoRAConverter
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import (
@@ -107,6 +108,14 @@ def llama3_debugmodel_float8_emulate() -> Trainer.Config:
                 emulate=True,
             ),
         ],
+    )
+    return config
+
+
+def llama3_debugmodel_lora() -> Trainer.Config:
+    config = llama3_debugmodel()
+    config.model_converters = ModelConvertersContainer.Config(
+        converters=[LoRAConverter.Config()],
     )
     return config
 

--- a/torchtitan/protocols/model_converter.py
+++ b/torchtitan/protocols/model_converter.py
@@ -53,6 +53,10 @@ class ModelConvertersContainer(Configurable, ModelConverter):
         print_after_conversion: bool = False
         """If true, model definition will be printed after converters are applied."""
 
+        def __post_init__(self):
+            _validate_converter_ordering(self.converters)
+            _validate_quantization(self.converters)
+
     def __init__(
         self,
         config: Config,
@@ -60,7 +64,6 @@ class ModelConvertersContainer(Configurable, ModelConverter):
         parallel_dims: ParallelDims,
         model_compile_enabled: bool,
     ):
-        _validate_quantization(config.converters)
         self.converters: list[ModelConverter] = [
             cc.build(
                 parallel_dims=parallel_dims,
@@ -79,6 +82,27 @@ class ModelConvertersContainer(Configurable, ModelConverter):
     def post_optimizer_hook(self, model: nn.Module | list[nn.Module]):
         for mh in self.converters:
             mh.post_optimizer_hook(model)
+
+
+def _validate_converter_ordering(converters: list[Configurable.Config]):
+    """Validates that converters are in the correct order.
+
+    LoRA must come after quantization because quantization replaces nn.Linear
+    with specialized subclasses (e.g. Float8Linear), and LoRA dynamically
+    inherits from whatever linear class it wraps.
+    """
+    from torchtitan.components.lora import LoRAConverter
+
+    seen_lora = False
+    for config in converters:
+        if isinstance(config, LoRAConverter.Config):
+            seen_lora = True
+        elif isinstance(config, QuantizationConverter.Config) and seen_lora:
+            raise ValueError(
+                "LoRA converter must come after quantization converters. "
+                "Quantization replaces nn.Linear with specialized subclasses, "
+                "and LoRA must wrap the final linear class."
+            )
 
 
 def _validate_quantization(converters: list[Configurable.Config]):


### PR DESCRIPTION
### Summary                                                                                                                 
                                                                  
  - Add LoRAConverter model converter that applies low-rank adaptation (LoRA) to all nn.Linear layers in a model          
  - LoRA uses dynamic subclass creation (__class__ swap) to wrap existing Linear layers, preserving compatibility with any nn.Linear subclass (e.g., Float8Linear, FakeQuantizedLinear)                                                           
  - Base model weights are frozen (requires_grad=False), only LoRA adapter weights (lora_a, lora_b) are trainable
  - Patches init_weights on the model to reinitialize LoRA adapters during the meta-device → real-device init flow        
  - Add llama3_debugmodel_lora debug config                                                                               
  - Add converter ordering validation: quantization must come before LoRA 

### Parallelism Compatibility                                                                                               
                                                                                                                          
  FSDP (Data Parallel) — Works out of the box. LoRA adapters (lora_a, lora_b) are registered as child nn.Modules of the wrapped linear, so fully_shard() treats them like any other submodule. Base weights are frozen (requires_grad=False) and LoRA weights are trainable — FSDP only all-gathers/reduces gradients for trainable parameters, so no wasted communication. 
                                                                                                                          
  Pipeline Parallel (PP) — Works. LoRA doesn't change the model's module structure or the number of layers, so pipeline stage splitting is unaffected. Each stage's linear layers independently get LoRA adapters during convert().
                                                                                                                          
  Context Parallel (CP) — Works. CP operates on the attention module's sequence dimension, not on linear layer internals. LoRA adapters participate in the same forward pass as the base linear.                                                                
                                                                                                                        
  Tensor Parallel (TP) — Not supported yet. PyTorch's ColwiseParallel._partition_linear_fn (in                            
  torch/distributed/tensor/parallel/style.py) uses named_parameters(recurse=True), which yields dotted names like
  lora_a.weight from child modules. register_parameter() rejects names containing ".", causing a KeyError. RowwiseParallel
   is safe (it explicitly accesses module.weight and module.bias only). This requires an upstream PyTorch fix to        
  ColwiseParallel._partition_linear_fn — either switching to recurse=False or explicitly accessing
  module.weight/module.bias like RowwiseParallel does. Until then, LoRA should not be used with TP. The debug config
  llama3_debugmodel_lora uses TP degree 1.

  Expert Parallel (EP) — Works in principle. LoRA applies to nn.Linear subclasses, and MoE expert layers use              
  GroupedExperts (not nn.Linear), so LoRA would only wrap the shared/dense linear layers (attention projections, shared
  expert FFN), not the routed experts. EP sharding of the expert dimension is unaffected.        
                                                                                                                          
### Test Plan                                                                                                               
                                                                                                                          
  Unit tests (pytest tests/unit_tests/test_model_converter.py):                                                           
  - test_lora_freeze_and_training: base params frozen, LoRA params trainable, base weights unchanged after 5 training steps                                                                                                                   
  - test_lora_filter_fqns: filter_fqns correctly skips specified modules from LoRA conversion
  - test_lora_before_quantization_raises: converter ordering validation rejects LoRA before quantization 
  - Integration tests, 3D compile test (PP+DP+TP, 8 GPU), 3D compile test (PP+DP+CP, 8 GPU)
  - Loss tests, running full finetune, lora finetune(rank=8), lora finetune(rank=64) on llama3 debugmodel
<img width="1279" height="822" alt="loss_curves" src="https://github.com/user-attachments/assets/d62da84a-0564-4dba-8476-2735f045f8eb" />
