### PR TITLE
[GraphTrainer] Changed tagging flex_attn via graph_pass in replace of fx.annotation for better robustness 

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -156,23 +156,51 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     return module_fqns
 
 
-@contextmanager
-def annotate_flex_attention_for_regional_inductor() -> Generator[None, None, None]:
-    """Annotate FlexAttention.forward so regional_inductor compiles flex attention HOPs.
+def annotate_flex_for_regional_inductor() -> None:
+    """Annotate compiled flex attention functions for regional_inductor.
 
-    Uses the same inductor configs as FlexAttention._compiled_flex_attn
+    Annotates ``FlexAttention._compiled_flex_attn`` and
+    ``_compiled_create_block_mask`` with ``compile_with_inductor`` metadata.
+    Uses the same inductor configs as ``FlexAttention._compiled_flex_attn``
     to ensure bitwise-identical kernels between eager and regional_inductor paths.
+
+    For permanent annotations (e.g. in parallelize), call this directly.
+    For temporary annotations (e.g. in tests), use the
+    :func:`annotate_flex_attention_for_regional_inductor` context manager.
     """
+    import torchtitan.models.common.attention as attention_module
     from torchtitan.models.common.attention import FlexAttention
 
-    orig = FlexAttention.forward
-    FlexAttention.forward = annotate_fn(
-        {"compile_with_inductor": {"inductor_configs": FlexAttention.inductor_configs}}
-    )(orig)
+    annotation = {
+        "compile_with_inductor": {"inductor_configs": FlexAttention.inductor_configs}
+    }
+    FlexAttention._compiled_flex_attn = annotate_fn(annotation)(
+        FlexAttention._compiled_flex_attn
+    )
+    attention_module._compiled_create_block_mask = annotate_fn(annotation)(
+        attention_module._compiled_create_block_mask
+    )
+
+
+@contextmanager
+def annotate_flex_attention_for_regional_inductor() -> Generator[None, None, None]:
+    """Context manager: apply flex attention annotations temporarily for tracing.
+
+    Applies the same annotations as :func:`annotate_flex_for_regional_inductor`
+    but restores the originals on exit.
+    """
+    import torchtitan.models.common.attention as attention_module
+    from torchtitan.models.common.attention import FlexAttention
+
+    orig_compiled = FlexAttention._compiled_flex_attn
+    orig_create = attention_module._compiled_create_block_mask
+
+    annotate_flex_for_regional_inductor()
     try:
         yield
     finally:
-        FlexAttention.forward = orig
+        FlexAttention._compiled_flex_attn = orig_compiled
+        attention_module._compiled_create_block_mask = orig_create
 
 
 def apply_graph_ac(

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from collections.abc import Callable
 
 import torch
 import torch.distributed as dist
@@ -154,53 +153,6 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     module_to_name = {m: n for n, m in model.named_modules()}
     module_fqns = convert_modules_to_fqns(module_list, module_to_name)
     return module_fqns
-
-
-def annotate_flex_for_regional_inductor() -> None:
-    """Annotate compiled flex attention functions for regional_inductor.
-
-    Annotates ``FlexAttention._compiled_flex_attn`` and
-    ``_compiled_create_block_mask`` with ``compile_with_inductor`` metadata.
-    Uses the same inductor configs as ``FlexAttention._compiled_flex_attn``
-    to ensure bitwise-identical kernels between eager and regional_inductor paths.
-
-    For permanent annotations (e.g. in parallelize), call this directly.
-    For temporary annotations (e.g. in tests), use the
-    :func:`annotate_flex_attention_for_regional_inductor` context manager.
-    """
-    import torchtitan.models.common.attention as attention_module
-    from torchtitan.models.common.attention import FlexAttention
-
-    annotation = {
-        "compile_with_inductor": {"inductor_configs": FlexAttention.inductor_configs}
-    }
-    FlexAttention._compiled_flex_attn = annotate_fn(annotation)(
-        FlexAttention._compiled_flex_attn
-    )
-    attention_module._compiled_create_block_mask = annotate_fn(annotation)(
-        attention_module._compiled_create_block_mask
-    )
-
-
-@contextmanager
-def annotate_flex_attention_for_regional_inductor() -> Generator[None, None, None]:
-    """Context manager: apply flex attention annotations temporarily for tracing.
-
-    Applies the same annotations as :func:`annotate_flex_for_regional_inductor`
-    but restores the originals on exit.
-    """
-    import torchtitan.models.common.attention as attention_module
-    from torchtitan.models.common.attention import FlexAttention
-
-    orig_compiled = FlexAttention._compiled_flex_attn
-    orig_create = attention_module._compiled_create_block_mask
-
-    annotate_flex_for_regional_inductor()
-    try:
-        yield
-    finally:
-        FlexAttention._compiled_flex_attn = orig_compiled
-        attention_module._compiled_create_block_mask = orig_create
 
 
 def apply_graph_ac(

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -20,6 +20,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_flex_for_regional_inductor,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -51,7 +52,6 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
 
     """
     from torchtitan.distributed.expert_parallel import ExpertParallel
-    from torchtitan.models.common.attention import FlexAttention
     from torchtitan.models.common.moe import MoE
 
     ExpertParallel._token_dispatch = annotate_fn({"EP": "dispatch"})(
@@ -62,10 +62,7 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     )
     MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
 
-    FlexAttention.forward = annotate_fn({"compile_with_inductor": "flex_attention"})(
-        FlexAttention.forward
-    )
-
+    annotate_flex_for_regional_inductor()
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -16,18 +16,15 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
-    annotate_flex_for_regional_inductor,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
-
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,
@@ -42,10 +39,6 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
 
     - Expert Parallel (EP) annotations: Tags "dispatch", "combine", and "compute"
       regions in MoE for debugging purposes.
-    - Flex attention annotation: Tags FlexAttention.forward with
-      {"compile_with_inductor": "flex_attention"} so the compiler can apply
-      regional inductor pass based on the annotation. Regional inductor is now only
-      supported in AOT mode.
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
@@ -62,7 +55,6 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     )
     MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
 
-    annotate_flex_for_regional_inductor()
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -20,7 +20,6 @@ from torch._functorch.aot_autograd import (
     JointWithDescriptors,
 )
 from torch._guards import tracing, TracingContext
-
 from torch.utils._pytree import TreeSpec
 
 from torchtitan.config import CompileConfig
@@ -548,9 +547,9 @@ def get_joint_custom_passes_from_config(
         List of joint custom pass functions
     """
     from torchtitan.experiments.graph_trainer.passes import (
+        annotate_flex_attention_for_regional_inductor_pass,
         AVAILABLE_JOINT_PASSES,
         fsdp_reshard_after_fwd_pass,
-        validate_flex_attn_annotation_pass,
     )
 
     joint_custom_passes = []
@@ -560,7 +559,7 @@ def get_joint_custom_passes_from_config(
     # annotations. The validation is only relevant for regional_inductor.
     pass_names = getattr(compile_config, "passes", [])
     if "full_inductor_compilation" not in pass_names:
-        joint_custom_passes.append(validate_flex_attn_annotation_pass)
+        joint_custom_passes.append(annotate_flex_attention_for_regional_inductor_pass)
 
     # Handle joint passes from config (excluding inductor_decomposition)
     joint_pass_names = getattr(compile_config, "joint_passes", [])

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -16,7 +16,6 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
-    annotate_flex_for_regional_inductor,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -33,15 +32,10 @@ from torchtitan.tools.logging import logger
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
-    - Flex attention annotation: Tags FlexAttention.forward and compiled flex
-      attention functions with compile_with_inductor so the compiler can apply
-      regional inductor pass based on the annotation.
-
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
     """
-    annotate_flex_for_regional_inductor()
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.fx.traceback import annotate_fn
-
 from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -18,11 +16,11 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_flex_for_regional_inductor,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
-
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,
@@ -35,21 +33,15 @@ from torchtitan.tools.logging import logger
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
-    - Flex attention annotation: Tags FlexAttention.forward with
-      {"compile_with_inductor": "flex_attention"} so the compiler can apply
-      regional inductor pass based on the annotation. Regional inductor is now only
-      supported in AOT mode.
+    - Flex attention annotation: Tags FlexAttention.forward and compiled flex
+      attention functions with compile_with_inductor so the compiler can apply
+      regional inductor pass based on the annotation.
 
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
     """
-    from torchtitan.models.common.attention import FlexAttention
-
-    FlexAttention.forward = annotate_fn({"compile_with_inductor": "flex_attention"})(
-        FlexAttention.forward
-    )
-
+    annotate_flex_for_regional_inductor()
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -232,26 +232,12 @@ def validate_flex_attn_annotation_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
     """Verify user annotations show up in the graph."""
-    from pathlib import Path
-    import tempfile
-
-    output_path = Path(tempfile.gettempdir()) / "validate_flex_attn_debug.txt"
-    lines = []
     for node in gm.graph.nodes:
         if node.target in {
             torch.ops.higher_order.flex_attention,
             torch.ops.higher_order.flex_attention_backward,
         }:
-            custom = node.meta.get("custom", {})
-            lines.append(
-                f"node={node.name} target={node.target} custom={custom}"
-            )
-            assert "compile_with_inductor" in custom, (
-                f"{node.name} missing compile_with_inductor annotation. "
-                f"custom={custom}, all meta keys={list(node.meta.keys())}"
-            )
-    output_path.write_text("\n".join(lines) if lines else "No flex_attention nodes found")
-    print(f"[DEBUG] validate_flex_attn dump: {output_path}")
+            assert "compile_with_inductor" in node.meta.get("custom", {})
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -228,16 +228,38 @@ def cudagraph_pass(
     return gm
 
 
-def validate_flex_attn_annotation_pass(
+def annotate_flex_attention_for_regional_inductor_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
-    """Verify user annotations show up in the graph."""
+    """Tag flex attention HOPs with compile_with_inductor for regional_inductor.
+
+    Annotates three sets of nodes so that regional_inductor correctly
+    scoops and compiles flex attention regions:
+    1. The HOP node itself (flex_attention / flex_attention_backward)
+    2. The get_attr nodes referencing score_mod / mask_mod submodules.
+    3. All nodes inside those submodule graphs.
+    """
+    from torchtitan.models.common.attention import FlexAttention
+
+    annotation = {"inductor_configs": FlexAttention.inductor_configs}
     for node in gm.graph.nodes:
-        if node.target in {
+        if node.target not in {
             torch.ops.higher_order.flex_attention,
             torch.ops.higher_order.flex_attention_backward,
         }:
-            assert "compile_with_inductor" in node.meta.get("custom", {})
+            continue
+        node.meta.setdefault("custom", {})["compile_with_inductor"] = annotation
+        for inp in node.all_input_nodes:
+            if inp.op != "get_attr":
+                continue
+            submod = getattr(gm, inp.target, None)
+            if not isinstance(submod, torch.fx.GraphModule):
+                continue
+            inp.meta.setdefault("custom", {})["compile_with_inductor"] = annotation
+            for sub_node in submod.graph.nodes:
+                sub_node.meta.setdefault("custom", {})[
+                    "compile_with_inductor"
+                ] = annotation
     return gm
 
 
@@ -566,6 +588,6 @@ AVAILABLE_COMPILER_PASSES = {
 AVAILABLE_JOINT_PASSES = {
     "inductor_decomposition": inductor_decomposition_pass,
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
-    "validate_flex_attn_annotation": validate_flex_attn_annotation_pass,
+    "annotate_flex_attention_for_regional_inductor": annotate_flex_attention_for_regional_inductor_pass,
     "apply_sac": apply_sac_pass,
 }

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -232,12 +232,26 @@ def validate_flex_attn_annotation_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
     """Verify user annotations show up in the graph."""
+    from pathlib import Path
+    import tempfile
+
+    output_path = Path(tempfile.gettempdir()) / "validate_flex_attn_debug.txt"
+    lines = []
     for node in gm.graph.nodes:
         if node.target in {
             torch.ops.higher_order.flex_attention,
             torch.ops.higher_order.flex_attention_backward,
         }:
-            assert "compile_with_inductor" in node.meta.get("custom", {})
+            custom = node.meta.get("custom", {})
+            lines.append(
+                f"node={node.name} target={node.target} custom={custom}"
+            )
+            assert "compile_with_inductor" in custom, (
+                f"{node.name} missing compile_with_inductor annotation. "
+                f"custom={custom}, all meta keys={list(node.meta.keys())}"
+            )
+    output_path.write_text("\n".join(lines) if lines else "No flex_attention nodes found")
+    print(f"[DEBUG] validate_flex_attn dump: {output_path}")
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import contextlib
 import unittest
 from collections import Counter
 
@@ -13,7 +12,6 @@ import torch.nn as nn
 from torch.testing._internal.common_fsdp import FSDPTest
 
 from torchtitan.experiments.graph_trainer.common_utils import (
-    annotate_flex_attention_for_regional_inductor,
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
@@ -24,6 +22,9 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     run_traced,
     run_traced_train_step,
     trace_train_step,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    annotate_flex_attention_for_regional_inductor_pass,
 )
 
 
@@ -75,6 +76,8 @@ def _apply_regional_inductor(traced_result):
     """Apply regional_inductor to compile annotated HOP regions in the traced graph."""
     from torch.fx.graph import CodeGen
     from torch.fx.passes.regional_inductor import regional_inductor
+
+    annotate_flex_attention_for_regional_inductor_pass(traced_result.gm)
 
     fake_mode = None
     for node in traced_result.gm.graph.nodes:
@@ -537,16 +540,10 @@ class TestTraceModels(unittest.TestCase):
     ):
         train_step = make_train_step(get_loss)
 
-        maybe_regional_inductor = (
-            annotate_flex_attention_for_regional_inductor()
-            if use_regional_inductor
-            else contextlib.nullcontext()
-        )
         maybe_register_blockmask_pytree_node()
-        with maybe_regional_inductor:
-            traced: TracedResult = trace_train_step(train_step)(
-                model_ref, *fwd_args, labels
-            )
+        traced: TracedResult = trace_train_step(train_step)(
+            model_ref, *fwd_args, labels
+        )
 
         if check_collective_ops:
             ag = sum(
@@ -753,12 +750,11 @@ class TestTraceModels(unittest.TestCase):
             "sliding_window_mask": sliding_window_mask,
         }
         maybe_register_blockmask_pytree_node()
-        with annotate_flex_attention_for_regional_inductor():
 
-            def forward(model, tokens, attn_masks):
-                return model(tokens, attn_masks)
+        def forward(model, tokens, attn_masks):
+            return model(tokens, attn_masks)
 
-            traced = trace_train_step(forward)(model, tokens, attn_masks)
+        traced = trace_train_step(forward)(model, tokens, attn_masks)
 
         flex_nodes = [
             n
@@ -766,6 +762,8 @@ class TestTraceModels(unittest.TestCase):
             if "flex_attention" in str(n.target) and "backward" not in str(n.target)
         ]
         self.assertGreater(len(flex_nodes), 0, "No FlexAttentionHOP nodes found")
+
+        annotate_flex_attention_for_regional_inductor_pass(traced.gm)
 
         for node in flex_nodes:
             custom = node.meta.get("custom", {})
@@ -846,14 +844,8 @@ class TestTraceFSDP(FSDPTest):
 
         train_step = make_train_step(get_loss)
 
-        maybe_regional_inductor = (
-            annotate_flex_attention_for_regional_inductor()
-            if use_regional_inductor
-            else contextlib.nullcontext()
-        )
         maybe_register_blockmask_pytree_node()
-        with maybe_regional_inductor:
-            traced = trace_train_step(train_step)(model_ref, *fwd_args, labels)
+        traced = trace_train_step(train_step)(model_ref, *fwd_args, labels)
 
         ag = sum(
             1

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -544,7 +544,9 @@ class TestTraceModels(unittest.TestCase):
         )
         maybe_register_blockmask_pytree_node()
         with maybe_regional_inductor:
-            traced = trace_train_step(train_step)(model_ref, *fwd_args, labels)
+            traced: TracedResult = trace_train_step(train_step)(
+                model_ref, *fwd_args, labels
+            )
 
         if check_collective_ops:
             ag = sum(


### PR DESCRIPTION
## Summary

Moves flex attention annotation from a pre-tracing function/context-manager
(`annotate_flex_for_regional_inductor` / `annotate_flex_attention_for_regional_inductor`
in `common_utils.py`) to a post-tracing graph pass
(`annotate_flex_attention_for_regional_inductor_pass` in `passes.py`).

**Why:** The previous approach annotated Python-level functions before tracing,
which required a context manager to temporarily patch and restore
`FlexAttention._compiled_flex_attn` and `_compiled_create_block_mask`.
A graph pass is simpler — it directly tags the relevant FX nodes after tracing,
with no monkey-patching or cleanup needed.

**What the pass does:** Annotates three sets of nodes with
`compile_with_inductor` (including `inductor_configs` from `FlexAttention`)
so that `regional_inductor` correctly scoops and compiles flex attention regions:
1. The HOP nodes (`flex_attention` / `flex_attention_backward`)
2. The `get_attr` nodes referencing score_mod / mask_mod submodules
3. All nodes inside those submodule graphs

**Changes:**
- Add `annotate_flex_attention_for_regional_inductor_pass` graph pass in `passes.py`
- Remove `annotate_flex_for_regional_inductor()` and its context manager from `common_utils.py`
- Remove pre-tracing annotation calls from `llama3/parallelize.py` and `deepseek_v3/parallelize.py`
- Wire up the pass in `graph_utils.py` (applied as a joint pass before regional_inductor)
- Update tests to use the graph pass instead of the context manager

## Test plan
- [x] `test_passes.py` — passed
- [x] `test_precompile.py` — passed
- [x] `test_trace_module.py` — 27/28 passed (1 pre-existing failure in `test_peak_memory_identical_fsdp`)
- [x] `test_numerics.py` — passed
- [x] `test_bitwise_deterministic.py` — passed
- [x] `pre-commit run --all-files` — passed