### PR TITLE
[graph_trainer] Add CUDA graph kernel annotation pass

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -69,6 +69,10 @@ jobs:
         # Run the graph passes unit tests
         torchrun --nproc-per-node=8 -m pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestReassignToPgPass -v
         pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestApplySACPass -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestAnnotateModuleFqns -v
+
+        # Run kernel annotation profiler tests (skips if cuda-compat < 13.1)
+        pytest torchtitan/experiments/graph_trainer/tests/test_profiler.py -v
 
         # Run the make_fx tracer unit tests
         pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -71,6 +71,10 @@ jobs:
         # Run the graph passes unit tests
         torchrun --nproc-per-node=8 -m pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestReassignToPgPass -v
         pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestApplySACPass -v
+        pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestAnnotateModuleFqns -v
+
+        # Run kernel annotation profiler tests (skips if cuda-compat < 13.1)
+        pytest torchtitan/experiments/graph_trainer/tests/test_profiler.py -v
 
         # Run the make_fx tracer unit tests
         pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -208,3 +208,19 @@ This verifies that the aot_fx_trace path produces bitwise identical losses
 and gradients across runs, and matches eager numerics exactly. Any change
 that breaks this test must be investigated and fixed before proceeding with
 other tests.
+
+### CUDA Graph Kernel Annotations
+
+The `insert_kernel_annotations_pass` labels CUDA graph kernels with their
+originating `nn.Module` path in profiler traces. It runs automatically in the
+`aot_fx_trace` path (bundled with the cudagraph pass). The post-processor
+is attached via ``Profiler.Config.trace_post_processors`` (see
+``cudagraph_annotate_trace_post_processor``) so exported traces are
+annotated automatically — no manual post-processing is needed.
+
+Requirements: `cuda-python` package and CUDA toolkit/driver >= 13.1
+(or `cuda-compat >= 13.1` on `LD_LIBRARY_PATH`). The pass is a no-op when
+these are unavailable.
+
+To view annotated traces, open the exported JSON in https://ui.perfetto.dev.
+Kernel events will have `module_fqn` fields like `layers.0.attention.wq`.

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -188,3 +188,18 @@ This verifies that the aot_fx_trace path produces bitwise identical losses
 and gradients across runs, and matches eager numerics exactly. Any change
 that breaks this test must be investigated and fixed before proceeding with
 other tests.
+
+### CUDA Graph Kernel Annotations
+
+The `insert_kernel_annotations_pass` labels CUDA graph kernels with their
+originating `nn.Module` path in profiler traces. It runs automatically in the
+`aot_fx_trace` path (bundled with the cudagraph pass). The profiler
+post-processes the trace automatically via `_maybe_annotate_trace` in
+`torchtitan/tools/profiling.py` — no manual post-processing is needed.
+
+Requirements: `cuda-python` package and CUDA toolkit/driver >= 13.1
+(or `cuda-compat >= 13.1` on `LD_LIBRARY_PATH`). The pass is a no-op when
+these are unavailable.
+
+To view annotated traces, open the exported JSON in https://ui.perfetto.dev.
+Kernel events will have `module_fqn` fields like `layers.0.attention.wq`.

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -25,7 +25,10 @@ def annotate_module_fqns(model: nn.Module) -> None:
     """Annotate all modules' forward with their fully-qualified names.
 
     Every named submodule (excluding the root) gets its forward method wrapped
-    with annotate_fn so that FX nodes carry the module_fqn metadata.
+    with ``annotate_fn`` so that FX nodes carry ``module_fqn`` in
+    ``node.meta["custom"]``.
+
+    Call once after model construction, before tracing/compilation.
     """
     for fqn, submodule in model.named_modules():
         if fqn:  # skip root module

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -18,6 +18,29 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
 _AC_REGION_ID = "ac_region_id"
+_MODULE_FQN = "module_fqn"
+
+
+def annotate_module_fqns(model: nn.Module) -> None:
+    """Annotate all modules' forward with their fully-qualified names.
+
+    Every named submodule (excluding the root) gets its forward method wrapped
+    with ``annotate_fn`` so that FX nodes carry ``module_fqn`` in
+    ``node.meta["custom"]``.
+
+    Call once after model construction, before tracing/compilation.
+
+    .. note::
+
+        When traced via ``trace_train_step``, multiple instances of the
+        **same class with no parameters** may all receive the first instance's
+        FQN.  This is because ``_reparametrize_module`` with an empty state
+        dict causes ``make_fx`` to collapse the ``annotate_fn`` contexts for
+        parameterless same-class instances.
+    """
+    for fqn, submodule in model.named_modules():
+        if fqn:  # skip root module
+            submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
 
 
 def annotate_ac_regions(model: nn.Module) -> None:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -62,6 +62,7 @@ def to_graph_trainer_config(
     from the graph_trainer model_registry. The compile field is removed and
     left as the GraphTrainer.Config default; callers should explicitly set it.
     """
+    from .cudagraph import cudagraph_annotate_trace_post_processor
     from .trainer import GraphTrainer
 
     d = {f.name: getattr(base_config, f.name) for f in fields(base_config)}
@@ -88,5 +89,12 @@ def to_graph_trainer_config(
     ac = d.get("activation_checkpoint")
     if ac is not None and ac.mode != "none":
         d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
+
+    # Merge CUDA graph kernel annotations into profiler traces when profiling
+    # is active.  No-op otherwise (and no-op when requirements aren't met).
+    # It's also a no-op if there is CUDA graph is not enabled.
+    profiler = d.get("profiler")
+    if profiler is not None:
+        profiler.trace_post_processor = cudagraph_annotate_trace_post_processor()
 
     return GraphTrainer.Config(**d)

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -66,6 +66,7 @@ def to_graph_trainer_config(
     from the graph_trainer model_registry. The compile field is removed and
     left as the GraphTrainerConfig default; callers should explicitly set it.
     """
+    from .cudagraph import cudagraph_annotate_trace_post_processor
     from .trainer import GraphTrainer
 
     d = {f.name: getattr(base_config, f.name) for f in fields(base_config)}
@@ -77,5 +78,14 @@ def to_graph_trainer_config(
     ac = d.get("activation_checkpoint")
     if ac is not None and ac.mode != "none":
         d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
+
+    # Merge CUDA graph kernel annotations into profiler traces when profiling
+    # is active.  No-op otherwise (and no-op when requirements aren't met).
+    # It's also a no-op if there is CUDA graph is not enabled.
+    profiling = d.get("profiling")
+    if profiling is not None:
+        profiling.trace_post_processors.append(
+            cudagraph_annotate_trace_post_processor()
+        )
 
     return GraphTrainer.Config(**d)

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -11,7 +11,7 @@ This module provides a cudagraph pass that can be applied to graph modules
 during compilation.
 """
 
-import logging
+import json
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -21,7 +21,8 @@ from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
 from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
-logger = logging.getLogger(__name__)
+from torchtitan.config.function import Function
+from torchtitan.tools.logging import logger
 
 
 class _CUDAGraphManager:
@@ -31,6 +32,10 @@ class _CUDAGraphManager:
         self._initialized = False
         self._cudagraph_wrappers: list["CUDAGraphWrapper"] = []
         self._teardown_called = False
+        # toolsId (graph_id << 32 | node_id) -> list of annotation dicts
+        # (e.g. [{"module_fqn": "layers.0.attention.wq"}]).
+        self.all_annotations: dict[int, list] = {}
+        self.enable_annotations: bool = False
 
     def maybe_initialize(self) -> None:
         if self._initialized:
@@ -98,6 +103,54 @@ def cudagraph_teardown() -> None:
     See Note [explicit cudagraph teardown] for more details.
     """
     _cg_manager.teardown()
+
+
+def get_cudagraph_annotations() -> dict[int, list]:
+    """Return all kernel annotations accumulated across CUDA graph captures."""
+    return _cg_manager.all_annotations
+
+
+def enable_cudagraph_annotations() -> None:
+    """Enable kernel annotation capture on subsequent CUDA graph recordings."""
+    _cg_manager.enable_annotations = True
+
+
+def cudagraph_annotate_trace_post_processor() -> Function.Config:
+    """Return a ``Function.Config`` that merges captured CUDA graph kernel
+    annotations into a profiler trace file.
+
+    Attach this to ``Profiler.Config.trace_post_processor`` so that exported
+    profiler traces automatically carry ``module_fqn`` fields on graphed kernel
+    events.
+    """
+    return Function.Config(fn=_cudagraph_annotate_trace_file)
+
+
+def _cudagraph_annotate_trace_file(trace_path: str) -> None:
+    """Post-process a profiler trace with CUDA graph kernel annotations."""
+    annotations = _cg_manager.all_annotations
+    if not annotations:
+        return
+
+    try:
+        from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
+            annotate_trace,
+        )
+    except ImportError:
+        logger.warning(
+            "torch.cuda._annotate_cuda_graph_trace not available. "
+            "Upgrade PyTorch to enable trace CUDA graph kernel annotation."
+        )
+        return
+
+    with open(trace_path) as f:
+        trace = json.load(f)
+
+    count = annotate_trace(trace, annotations)
+    if count > 0:
+        with open(trace_path, "w") as f:
+            json.dump(trace, f)
+        logger.info(f"Annotated {count} CUDAGraph kernel event(s) in profiler trace")
 
 
 class CUDAGraphWrapper:
@@ -219,9 +272,15 @@ class CUDAGraphWrapper:
                 self._cudagraph,
                 pool=_cg_manager.graph_pool,
                 stream=_cg_manager.stream,
+                enable_annotations=_cg_manager.enable_annotations,
             ):
                 # `output` is managed by pytorch's cudagraph pool
                 self._output = self._runnable(*args)
+
+            if _cg_manager.enable_annotations:
+                from torch.cuda._graph_annotations import get_kernel_annotations
+
+                _cg_manager.all_annotations.update(get_kernel_annotations())
 
         if self._should_check_address:
             self._check_static_inputs_address()

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -11,7 +11,7 @@ This module provides a cudagraph pass that can be applied to graph modules
 during compilation.
 """
 
-import logging
+import json
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -21,7 +21,8 @@ from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
 from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
-logger = logging.getLogger(__name__)
+from torchtitan.config.function import Function
+from torchtitan.tools.logging import logger
 
 
 class _CUDAGraphManager:
@@ -31,6 +32,10 @@ class _CUDAGraphManager:
         self._initialized = False
         self._cudagraph_wrappers: list["CUDAGraphWrapper"] = []
         self._teardown_called = False
+        # toolsId (graph_id << 32 | node_id) -> list of annotation dicts
+        # (e.g. [{"module_fqn": "layers.0.attention.wq"}]).
+        self.all_annotations: dict[int, list] = {}
+        self.enable_annotations: bool = False
 
     def maybe_initialize(self) -> None:
         if self._initialized:
@@ -98,6 +103,54 @@ def cudagraph_teardown() -> None:
     See Note [explicit cudagraph teardown] for more details.
     """
     _cg_manager.teardown()
+
+
+def get_cudagraph_annotations() -> dict[int, list]:
+    """Return all kernel annotations accumulated across CUDA graph captures."""
+    return _cg_manager.all_annotations
+
+
+def enable_cudagraph_annotations() -> None:
+    """Enable kernel annotation capture on subsequent CUDA graph recordings."""
+    _cg_manager.enable_annotations = True
+
+
+def cudagraph_annotate_trace_post_processor() -> Function.Config:
+    """Return a ``Function.Config`` that merges captured CUDA graph kernel
+    annotations into a profiler trace file.
+
+    Attach this to ``ProfilingConfig.trace_post_processors`` so that exported
+    profiler traces automatically carry ``module_fqn`` fields on graphed kernel
+    events.
+    """
+    return Function.Config(fn=_cudagraph_annotate_trace_file)
+
+
+def _cudagraph_annotate_trace_file(trace_path: str) -> None:
+    """Post-process a profiler trace with CUDA graph kernel annotations."""
+    annotations = _cg_manager.all_annotations
+    if not annotations:
+        return
+
+    try:
+        from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
+            annotate_trace,
+        )
+    except ImportError:
+        logger.warning(
+            "torch.cuda._annotate_cuda_graph_trace not available. "
+            "Upgrade PyTorch to enable trace CUDA graph kernel annotation."
+        )
+        return
+
+    with open(trace_path) as f:
+        trace = json.load(f)
+
+    count = annotate_trace(trace, annotations)
+    if count > 0:
+        with open(trace_path, "w") as f:
+            json.dump(trace, f)
+        logger.info(f"Annotated {count} CUDAGraph kernel event(s) in profiler trace")
 
 
 class CUDAGraphWrapper:
@@ -219,9 +272,15 @@ class CUDAGraphWrapper:
                 self._cudagraph,
                 pool=_cg_manager.graph_pool,
                 stream=_cg_manager.stream,
+                enable_annotations=_cg_manager.enable_annotations,
             ):
                 # `output` is managed by pytorch's cudagraph pool
                 self._output = self._runnable(*args)
+
+            if _cg_manager.enable_annotations:
+                from torch.cuda._graph_annotations import get_kernel_annotations
+
+                _cg_manager.all_annotations.update(get_kernel_annotations())
 
         if self._should_check_address:
             self._check_static_inputs_address()

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -43,7 +43,8 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
-
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name for downstream passes.
     """
     from torchtitan.models.common.moe import MoE
     from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -19,6 +19,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -42,6 +43,9 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name so that insert_kernel_annotations_pass can label
+      CUDA graph kernels with their originating module.
 
     """
     from torchtitan.distributed.expert_parallel import ExpertParallel
@@ -56,6 +60,7 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
 
     annotate_ac_regions(model)
+    annotate_module_fqns(model)
 
 
 # Adapted from llama4/infra/parallelize.py

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -34,8 +34,7 @@ def annotate_llama(model: GraphTrainerLlama3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
     - Module FQN annotation: Tags each submodule's forward with its
-      fully-qualified name so that the transformer_block_bucketing pass
-      can identify which graph nodes belong to which module.
+      fully-qualified name for downstream passes.
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -16,6 +16,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -35,8 +36,12 @@ def annotate_llama(model: GraphTrainerLlama3Model) -> None:
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name so that insert_kernel_annotations_pass can label
+      CUDA graph kernels with their originating module.
     """
     annotate_ac_regions(model)
+    annotate_module_fqns(model)
 
 
 def parallelize_llama(

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -61,6 +61,8 @@ def _is_backward_node(node: torch.fx.Node) -> bool:
 
 def compile_time_passes(
     traced_result: "TracedResult",
+    *,
+    cudagraph_compatible: bool = False,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -76,7 +78,7 @@ def compile_time_passes(
     # )
     from torchtitan.models.common.attention import FlexAttention
 
-    return [
+    passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
@@ -95,17 +97,23 @@ def compile_time_passes(
             flex_compile_config=FlexAttention.inductor_configs,
         ),
         regional_inductor_pass,
-        # TODO: Switch to upstream PyTorch implementation when
-        # https://github.com/pytorch/pytorch/pull/178246 lands.
-        # custom_codegen_pass saves the FX graph to disk for:
-        # 1. Debugging: inspect the generated graph code directly
-        # 2. Profiling provenance: dual-path codegen with _RecordFunctionFast
-        #    gives fine-grained operator-level attribution in profiler traces
-        # 3. User-editable codegen: users can directly modify the generated
-        #    program on disk for fine-grain scheduling optimizations, with
-        #    hot-reload picking up changes at runtime
-        custom_codegen_pass,
     ]
+    if cudagraph_compatible:
+        # Must run before custom_codegen_pass (last in pre_passes)
+        # which replaces the GraphModule's forward().
+        # Also must run before cudagraph_pass.
+        passes.append(insert_kernel_annotations_pass)
+    # TODO: Switch to upstream PyTorch implementation when
+    # https://github.com/pytorch/pytorch/pull/178246 lands.
+    # custom_codegen_pass saves the FX graph to disk for:
+    # 1. Debugging: inspect the generated graph code directly
+    # 2. Profiling provenance: dual-path codegen with _RecordFunctionFast
+    #    gives fine-grained operator-level attribution in profiler traces
+    # 3. User-editable codegen: users can directly modify the generated
+    #    program on disk for fine-grain scheduling optimizations, with
+    #    hot-reload picking up changes at runtime
+    passes.append(custom_codegen_pass)
+    return passes
 
 
 def construct_default_graph_passes(
@@ -124,11 +132,16 @@ def construct_default_graph_passes(
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
     passes: list[Callable] = []
-    if not precompiled:
-        passes.extend(compile_time_passes(traced_result))
+    cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
 
-    # cudagraph should be the last pass.
-    if is_cudagraph_compatible(traced_result.gm):
+    if not precompiled:
+        passes.extend(
+            compile_time_passes(
+                traced_result, cudagraph_compatible=cudagraph_compatible
+            )
+        )
+
+    if cudagraph_compatible:
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(
@@ -376,6 +389,96 @@ def regional_inductor_pass(
     # regional_inductor may switch to boxed calling convention; reset to
     # default so the graph can be called with positional args as usual.
     gm.graph.set_codegen(torch.fx.graph.CodeGen())
+    gm.recompile()
+    return gm
+
+
+def insert_kernel_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Insert mark_kernels() calls at module boundaries in the FX graph.
+
+    Reads ``node.meta["custom"]["module_fqn"]`` (set via
+    ``annotate_module_fqns``) and inserts enter/exit calls so that
+    CUDA graph capture records the annotations.
+
+    Requires ``cuda-python`` package and CUDA toolkit/driver >= 13.1
+    (or cuda-compat >= 13.1).  Returns the graph unchanged when unavailable.
+
+    Also enables annotation capture on :class:`CUDAGraphWrapper` so that
+    ``enable_annotations=True`` is passed to ``torch.cuda.graph()``.
+
+    Alternative approaches:
+
+    1. **fx.Interpreter**: During cudagraph capture, run the graph via an
+       ``fx.Interpreter`` subclass that reads ``module_fqn`` metadata and
+       calls ``mark_kernels`` enter/exit around each node — avoids mutating
+       the graph.
+    2. **Custom CodeGen**: Use a custom ``torch.fx.graph.CodeGen`` to emit
+       enter/exit lines (or ``with`` blocks) directly in the generated
+       Python code.
+
+    The current graph-pass approach is the least invasive.
+    """
+    from torch.cuda._graph_annotations import _is_tools_id_unavailable
+
+    from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+    from torchtitan.experiments.graph_trainer.cudagraph import (
+        enable_cudagraph_annotations,
+    )
+
+    def _enter(annotation: dict) -> object:
+        from torch.cuda._graph_annotations import mark_kernels
+
+        ctx = mark_kernels(annotation)
+        ctx.__enter__()
+        return ctx
+
+    def _exit(ctx: object) -> None:
+        ctx.__exit__(None, None, None)  # type: ignore[union-attr]
+
+    if _is_tools_id_unavailable():
+        return gm
+
+    enable_cudagraph_annotations()
+
+    graph = gm.graph
+    current_fqn: str | None = None
+    current_ctx_node = None
+
+    for node in list(graph.nodes):
+        fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+
+        if fqn != current_fqn:
+            # Close previous scope
+            if current_ctx_node is not None:
+                with graph.inserting_before(node):
+                    exit_node = graph.call_function(_exit, (current_ctx_node,))
+                    exit_node.meta["custom"] = {}
+                current_ctx_node = None
+
+            # Open new scope
+            if fqn is not None:
+                with graph.inserting_before(node):
+                    enter_node = graph.call_function(
+                        _enter,
+                        ({_MODULE_FQN: fqn},),
+                    )
+                    enter_node.meta["custom"] = {}
+                current_ctx_node = enter_node
+
+            current_fqn = fqn
+
+    # Close any trailing scope (before output/return)
+    if current_ctx_node is not None:
+        output_nodes = [n for n in graph.nodes if n.op == "output"]
+        if output_nodes:
+            with graph.inserting_before(output_nodes[0]):
+                exit_node = graph.call_function(_exit, (current_ctx_node,))
+                exit_node.meta["custom"] = {}
+
+    graph.lint()
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -112,11 +112,22 @@ def construct_default_graph_passes(
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
     passes: list[Callable] = []
+    cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
+
     if not precompiled:
-        passes.extend(compile_time_passes(traced_result))
+        pre_passes = compile_time_passes(traced_result)
+        # insert_kernel_annotations must run before custom_codegen_pass
+        # (which saves code to disk and replaces forward with a loaded
+        # module) so that the inserted mark_kernels enter/exit calls end
+        # up in the saved graph.
+        if cudagraph_compatible:
+            pre_passes = _insert_before_custom_codegen(
+                pre_passes, insert_kernel_annotations_pass
+            )
+        passes.extend(pre_passes)
 
     # cudagraph should be the last pass.
-    if is_cudagraph_compatible(traced_result.gm):
+    if cudagraph_compatible:
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(
@@ -127,6 +138,26 @@ def construct_default_graph_passes(
             )
         )
     return passes
+
+
+def _insert_before_custom_codegen(
+    passes: list[Callable], new_pass: Callable
+) -> list[Callable]:
+    """Return a new pass list with ``new_pass`` inserted before custom_codegen_pass.
+
+    If custom_codegen_pass is not present, appends ``new_pass`` at the end.
+    """
+    result: list[Callable] = []
+    inserted = False
+    for p in passes:
+        name = getattr(p, "__name__", "")
+        if not inserted and name == "custom_codegen_pass":
+            result.append(new_pass)
+            inserted = True
+        result.append(p)
+    if not inserted:
+        result.append(new_pass)
+    return result
 
 
 def apply_graph_passes(
@@ -287,6 +318,96 @@ def regional_inductor_pass(
     # regional_inductor may switch to boxed calling convention; reset to
     # default so the graph can be called with positional args as usual.
     gm.graph.set_codegen(torch.fx.graph.CodeGen())
+    gm.recompile()
+    return gm
+
+
+def insert_kernel_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Insert mark_kernels() calls at module boundaries in the FX graph.
+
+    Reads ``node.meta["custom"]["module_fqn"]`` (set via
+    ``annotate_module_fqns``) and inserts enter/exit calls so that
+    CUDA graph capture records the annotations.
+
+    Requires ``cuda-python`` package and CUDA toolkit/driver >= 13.1
+    (or cuda-compat >= 13.1).  Returns the graph unchanged when unavailable.
+
+    Also enables annotation capture on :class:`CUDAGraphWrapper` so that
+    ``enable_annotations=True`` is passed to ``torch.cuda.graph()``.
+
+    Alternative approaches:
+
+    1. **fx.Interpreter**: During cudagraph capture, run the graph via an
+       ``fx.Interpreter`` subclass that reads ``module_fqn`` metadata and
+       calls ``mark_kernels`` enter/exit around each node — avoids mutating
+       the graph.
+    2. **Custom CodeGen**: Use a custom ``torch.fx.graph.CodeGen`` to emit
+       enter/exit lines (or ``with`` blocks) directly in the generated
+       Python code.
+
+    The current graph-pass approach is the least invasive.
+    """
+    from torch.cuda._graph_annotations import _is_tools_id_unavailable
+
+    from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+    from torchtitan.experiments.graph_trainer.cudagraph import (
+        enable_cudagraph_annotations,
+    )
+
+    def _enter(annotation: dict) -> object:
+        from torch.cuda._graph_annotations import mark_kernels
+
+        ctx = mark_kernels(annotation)
+        ctx.__enter__()
+        return ctx
+
+    def _exit(ctx: object) -> None:
+        ctx.__exit__(None, None, None)  # type: ignore[union-attr]
+
+    if _is_tools_id_unavailable():
+        return gm
+
+    enable_cudagraph_annotations()
+
+    graph = gm.graph
+    current_fqn: str | None = None
+    current_ctx_node = None
+
+    for node in list(graph.nodes):
+        fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+
+        if fqn != current_fqn:
+            # Close previous scope
+            if current_ctx_node is not None:
+                with graph.inserting_before(node):
+                    exit_node = graph.call_function(_exit, (current_ctx_node,))
+                    exit_node.meta["custom"] = {}
+                current_ctx_node = None
+
+            # Open new scope
+            if fqn is not None:
+                with graph.inserting_before(node):
+                    enter_node = graph.call_function(
+                        _enter,
+                        ({_MODULE_FQN: fqn},),
+                    )
+                    enter_node.meta["custom"] = {}
+                current_ctx_node = enter_node
+
+            current_fqn = fqn
+
+    # Close any trailing scope (before output/return)
+    if current_ctx_node is not None:
+        output_nodes = [n for n in graph.nodes if n.op == "output"]
+        if output_nodes:
+            with graph.inserting_before(output_nodes[0]):
+                exit_node = graph.call_function(_exit, (current_ctx_node,))
+                exit_node.meta["custom"] = {}
+
+    graph.lint()
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -43,6 +43,8 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name for downstream passes.
     """
     # Annotate MoE EP regions if any layer has MoE enabled
     if any(layer.moe is not None for layer in model.config.layers):

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -19,6 +19,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -46,6 +47,9 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name so that insert_kernel_annotations_pass can label
+      CUDA graph kernels with their originating module.
     """
     from torchtitan.models.common.attention import FlexAttention
 
@@ -67,6 +71,7 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
     )
 
     annotate_ac_regions(model)
+    annotate_module_fqns(model)
 
 
 def parallelize_qwen3(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
+from unittest.mock import patch
 
 import torch
 from torch._functorch.aot_autograd import aot_compile_joint_with_descriptors
@@ -12,15 +13,27 @@ from torch._guards import tracing
 from torch._inductor.fx_passes.bucketing import (
     is_all_gather_into_tensor as is_all_gather,
 )
+from torch.cuda._graph_annotations import _is_tools_id_unavailable
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.traceback import preserve_node_meta
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import TestCase
 from torch.utils.checkpoint import checkpoint, CheckpointPolicy
 
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _AC_REGION_ID,
+    _MODULE_FQN,
+    annotate_module_fqns,
+)
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    trace_train_step,
+)
 from torchtitan.experiments.graph_trainer.passes import (
     apply_sac_pass,
+    insert_kernel_annotations_pass,
     reassign_to_pg_pass,
     remove_detach_pass,
     remove_identity_slice_pass,
@@ -900,6 +913,235 @@ class TestRemoveIdentitySlicePass(TestCase):
 from torchtitan.experiments.graph_trainer.tests.test_custom_codegen import (  # noqa: F401
     TestCustomCodegenPass,
 )
+
+
+class TestAnnotateModuleFqns(TestCase):
+    """Unit tests for annotate_module_fqns and insert_kernel_annotations_pass."""
+
+    def _trace_and_get_fqns(self, model, *args):
+        """Trace fwd+bwd with trace_train_step and return module_fqn annotations."""
+
+        def fwd_step(model, *inputs):
+            pred = model(inputs[0])
+            loss = pred.sum()
+            params = [p for p in model.parameters() if p.requires_grad]
+            grads = torch.autograd.grad(loss, params)
+            return [loss] + list(grads)
+
+        traced = trace_train_step(fwd_step)(model, *args)
+        fqns = set()
+        for node in traced.gm.graph.nodes:
+            fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+            if fqn:
+                fqns.add(fqn)
+        return fqns
+
+    def test_annotate_transformer_like_model(self):
+        """Module FQNs survive trace_train_step for a transformer-like model
+        with distinct submodule classes (norm, attention, ffn)."""
+
+        class Norm(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.norm = torch.nn.LayerNorm(dim)
+
+            def forward(self, x):
+                return self.norm(x)
+
+        class Attention(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.wq = torch.nn.Linear(dim, dim, bias=False)
+                self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x):
+                return self.wo(torch.relu(self.wq(x)))
+
+        class FFN(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.w1 = torch.nn.Linear(dim, dim * 2, bias=False)
+                self.w2 = torch.nn.Linear(dim * 2, dim, bias=False)
+
+            def forward(self, x):
+                return self.w2(torch.relu(self.w1(x)))
+
+        class TransformerBlock(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.attention_norm = Norm(dim)
+                self.attention = Attention(dim)
+                self.ffn_norm = Norm(dim)
+                self.feed_forward = FFN(dim)
+
+            def forward(self, x):
+                h = x + self.attention(self.attention_norm(x))
+                return h + self.feed_forward(self.ffn_norm(h))
+
+        class Model(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.layer = TransformerBlock(dim)
+
+            def forward(self, x):
+                return self.layer(x)
+
+        dim = 16
+        model = Model(dim)
+        annotate_module_fqns(model)
+        fqns = self._trace_and_get_fqns(model, torch.randn(4, dim))
+
+        # Verify key module paths are present.  The Norm wrapper has no
+        # ops of its own, so its inner LayerNorm gets the deepest path.
+        self.assertIn("layer.attention_norm.norm", fqns)
+        self.assertIn("layer.attention", fqns)
+        self.assertIn("layer.attention.wq", fqns)
+        self.assertIn("layer.attention.wo", fqns)
+        self.assertIn("layer.ffn_norm.norm", fqns)
+        self.assertIn("layer.feed_forward", fqns)
+        self.assertIn("layer.feed_forward.w1", fqns)
+        self.assertIn("layer.feed_forward.w2", fqns)
+
+    def test_same_class_instances_get_distinct_fqns(self):
+        """Two parameterless instances of the same class get distinct fqns.
+
+        Uses minimal_fx_tracer directly (not trace_train_step) because
+        parameterless models cannot produce gradients via autograd.grad.
+        """
+
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = Block()
+                self.b = Block()
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        model = Model()
+        annotate_module_fqns(model)
+
+        def fwd_only(state, x):
+            return model(x)
+
+        traced = minimal_fx_tracer(fwd_only)({}, torch.randn(4))
+        fqns = set()
+        for node in traced.gm.graph.nodes:
+            fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+            if fqn:
+                fqns.add(fqn)
+
+        self.assertIn("a", fqns)
+        self.assertIn("b", fqns)
+
+    def test_same_class_parameterless_works_with_make_fx(self):
+        """Same-class parameterless instances get distinct fqns with plain make_fx."""
+
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = Block()
+                self.b = Block()
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        model = Model()
+        annotate_module_fqns(model)
+
+        with preserve_node_meta():
+            gm = make_fx(model)(torch.randn(4))
+
+        fqns = set()
+        for node in gm.graph.nodes:
+            fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+            if fqn:
+                fqns.add(fqn)
+
+        self.assertIn("a", fqns)
+        self.assertIn("b", fqns)
+
+    def test_same_class_instances_with_params_get_distinct_fqns(self):
+        """Two instances of the same class with parameters get distinct fqns."""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.nn.Linear(4, 4)
+                self.b = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        model = Model()
+        annotate_module_fqns(model)
+        fqns = self._trace_and_get_fqns(model, torch.randn(2, 4))
+
+        self.assertIn("a", fqns)
+        self.assertIn("b", fqns)
+
+    def _build_annotated_gm(self):
+        """Build a GraphModule with module_fqn annotations on its nodes."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        n1 = graph.call_function(torch.relu, (x,))
+        n1.meta["custom"] = {_MODULE_FQN: "attn"}
+        n2 = graph.call_function(torch.sigmoid, (n1,))
+        n2.meta["custom"] = {_MODULE_FQN: "attn"}
+        n3 = graph.call_function(torch.tanh, (n2,))
+        n3.meta["custom"] = {_MODULE_FQN: "ffn"}
+        graph.output(n3)
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def test_insert_kernel_annotations_pass_inserts_calls(self):
+        """When tools ID is available, the pass inserts enter/exit calls."""
+        if _is_tools_id_unavailable():
+            self.skipTest("cudaGraphNodeGetToolsId not available")
+
+        gm = self._build_annotated_gm()
+        num_before = sum(1 for n in gm.graph.nodes if n.op == "call_function")
+
+        insert_kernel_annotations_pass(gm)
+
+        num_after = sum(1 for n in gm.graph.nodes if n.op == "call_function")
+        # 2 scopes (attn, ffn) = 2 enters + 2 exits = 4 new nodes
+        self.assertEqual(num_after - num_before, 4)
+
+    def test_insert_kernel_annotations_pass_noop_when_unavailable(self):
+        """When tools ID is unavailable, the pass leaves the graph unchanged."""
+        gm = self._build_annotated_gm()
+        num_before = len(list(gm.graph.nodes))
+
+        with patch(
+            "torch.cuda._graph_annotations._is_tools_id_unavailable",
+            return_value=True,
+        ):
+            insert_kernel_annotations_pass(gm)
+
+        num_after = len(list(gm.graph.nodes))
+        self.assertEqual(num_before, num_after)
+
+    def test_insert_kernel_annotations_pass_noop_without_metadata(self):
+        """The pass should not insert anything when no custom metadata exists."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        n1 = graph.call_function(torch.relu, (x,))
+        graph.output(n1)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        num_before = len(list(gm.graph.nodes))
+        insert_kernel_annotations_pass(gm)
+        num_after = len(list(gm.graph.nodes))
+
+        self.assertEqual(num_before, num_after)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/tests/test_profiler.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_profiler.py
@@ -1,0 +1,214 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
+    annotate_trace,
+)
+from torch.cuda._graph_annotations import _is_tools_id_unavailable
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.config.function import Function
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
+    annotate_module_fqns,
+)
+from torchtitan.experiments.graph_trainer.cudagraph import (
+    cudagraph_teardown,
+    get_cudagraph_annotations,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_train_step,
+    trace_train_step,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    apply_graph_passes,
+    construct_default_graph_passes,
+)
+from torchtitan.tools.profiler import Profiler
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+class TestKernelAnnotationsE2E(TestCase):
+    """E2E test: trace fwd+bwd → insert annotations → cudagraph → profile → check trace."""
+
+    def test_profiler_trace_has_module_fqn_annotations(self):
+        """After the full pipeline (trace_train_step → insert_kernel_annotations
+        → cudagraph → profile), the profiler trace should contain
+        ``module_fqn`` fields on graphed kernel events."""
+        if _is_tools_id_unavailable():
+            self.skipTest("cudaGraphNodeGetToolsId not available")
+
+        # Simple model with annotated submodules.
+        class FFN(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.norm = torch.nn.LayerNorm(16)
+                self.ffn = FFN()
+
+            def forward(self, x):
+                return self.ffn(self.norm(x))
+
+        model = Model().cuda()
+        annotate_module_fqns(model)
+
+        x = torch.randn(4, 16, device="cuda")
+        labels = torch.randn(4, 16, device="cuda")
+
+        # Trace fwd + loss + bwd via trace_train_step.
+        def fwd_bwd_step(model, inputs, labels):
+            pred = model(inputs)
+            loss = torch.nn.functional.mse_loss(pred, labels)
+            params = [p for p in model.parameters() if p.requires_grad]
+            grads = torch.autograd.grad(loss, params)
+            return [loss] + list(grads)
+
+        traced = trace_train_step(fwd_bwd_step)(model, x, labels)
+
+        # Verify module_fqn metadata survived tracing.
+        fqns_in_graph = set()
+        for node in traced.gm.graph.nodes:
+            fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+            if fqn:
+                fqns_in_graph.add(fqn)
+        self.assertIn("norm", fqns_in_graph)
+        self.assertIn("ffn", fqns_in_graph)
+
+        # Apply passes (annotation + cudagraph).
+        passes = construct_default_graph_passes(traced)
+        traced.gm = apply_graph_passes(traced.gm, traced.example_inputs, passes)
+
+        # Run: warmup + capture + replay.
+        run_traced_train_step(traced, model, x, labels)  # warmup + capture
+        run_traced_train_step(traced, model, x, labels)  # replay
+
+        # Check annotations were captured.
+        annotations = get_cudagraph_annotations()
+        self.assertGreater(len(annotations), 0, "No annotations captured")
+
+        all_fqns = set()
+        for ann_list in annotations.values():
+            for ann in ann_list:
+                if isinstance(ann, dict) and _MODULE_FQN in ann:
+                    all_fqns.add(ann[_MODULE_FQN])
+        self.assertIn("norm", all_fqns)
+        self.assertIn("ffn", all_fqns)
+
+        # Profile and check the trace.
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            run_traced_train_step(traced, model, x, labels)
+            torch.cuda.synchronize()
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+        prof.export_chrome_trace(trace_path)
+
+        with open(trace_path) as f:
+            trace = json.load(f)
+
+        count = annotate_trace(trace, annotations)
+        self.assertGreater(count, 0, "annotate_trace matched 0 events")
+
+        # Verify module_fqn fields appear on graphed kernel events.
+        # Since trace_train_step traces fwd+bwd into a single graph,
+        # backward kernels (e.g. layer_norm_backward) should also carry
+        # annotations from _copy_fwd_metadata_to_bw_nodes.
+        fqns_in_trace = set()
+        for e in trace["traceEvents"]:
+            args = e.get("args", {})
+            if args.get("graph node id", 0) != 0 and _MODULE_FQN in args:
+                fqns_in_trace.add(args[_MODULE_FQN])
+
+        self.assertIn("norm", fqns_in_trace)
+        self.assertIn("ffn", fqns_in_trace)
+
+        # Backward kernels should also be annotated (via
+        # _copy_fwd_metadata_to_bw_nodes).  Verify by checking the order:
+        # forward annotations appear first (norm → ffn), then backward
+        # annotations appear in reverse order (ffn → norm).
+        ordered_fqns = []
+        for tid in sorted(annotations.keys(), key=lambda t: t & 0xFFFFFFFF):
+            for ann in annotations[tid]:
+                if isinstance(ann, dict) and _MODULE_FQN in ann:
+                    fqn = ann[_MODULE_FQN]
+                    if not ordered_fqns or ordered_fqns[-1] != fqn:
+                        ordered_fqns.append(fqn)
+
+        # Forward: norm → ffn.linear → ffn; backward (reverse): ffn.linear
+        # → norm.  All three fqns should appear, and norm/ffn.linear should
+        # appear in both fwd and bwd (at least twice each).
+        for expected_fqn in ("norm", "ffn", "ffn.linear"):
+            self.assertIn(expected_fqn, ordered_fqns, f"Missing '{expected_fqn}'")
+        for expected_fqn in ("norm", "ffn.linear"):
+            positions = [i for i, f in enumerate(ordered_fqns) if f == expected_fqn]
+            self.assertGreaterEqual(
+                len(positions),
+                2,
+                f"Expected '{expected_fqn}' in both fwd and bwd, "
+                f"got positions {positions} in {ordered_fqns}",
+            )
+
+        # Cleanup.
+        os.unlink(trace_path)
+        cudagraph_teardown()
+
+
+class TestTracePostProcessorConfig(TestCase):
+    """Verify Profiler.Config.trace_post_processor runs on every trace export."""
+
+    def test_post_processor_called_with_trace_path(self):
+        """Function.Config in trace_post_processor is invoked with the
+        exported trace file path."""
+
+        calls: list[tuple[str, bool]] = []
+
+        def record_call(trace_path: str) -> None:
+            calls.append((trace_path, os.path.exists(trace_path)))
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "torch.distributed.get_rank", return_value=0
+        ):
+            config = Profiler.Config(
+                enable_profiling=True,
+                save_traces_folder="traces",
+                profile_freq=4,
+                profiler_warmup=1,
+                profiler_active=1,
+                trace_post_processor=Function.Config(fn=record_call),
+            )
+            profiler = config.build(global_step=0, base_folder=tmp)
+
+            with profiler:
+                for _ in range(4):
+                    profiler.step()
+
+        self.assertEqual(len(calls), 1, f"Expected 1 call, got {calls}")
+        path, existed = calls[0]
+        self.assertTrue(path.endswith("rank0_trace.json"))
+        self.assertTrue(existed, f"Trace file {path} did not exist when callback ran")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/graph_trainer/tests/test_profiler.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_profiler.py
@@ -1,0 +1,214 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
+    annotate_trace,
+)
+from torch.cuda._graph_annotations import _is_tools_id_unavailable
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.config.function import Function
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
+    annotate_module_fqns,
+)
+from torchtitan.experiments.graph_trainer.cudagraph import (
+    cudagraph_teardown,
+    get_cudagraph_annotations,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    run_traced_train_step,
+    trace_train_step,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    apply_graph_passes,
+    construct_default_graph_passes,
+)
+from torchtitan.tools.profiling import maybe_enable_profiling, ProfilingConfig
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+class TestKernelAnnotationsE2E(TestCase):
+    """E2E test: trace fwd+bwd → insert annotations → cudagraph → profile → check trace."""
+
+    def test_profiler_trace_has_module_fqn_annotations(self):
+        """After the full pipeline (trace_train_step → insert_kernel_annotations
+        → cudagraph → profile), the profiler trace should contain
+        ``module_fqn`` fields on graphed kernel events."""
+        if _is_tools_id_unavailable():
+            self.skipTest("cudaGraphNodeGetToolsId not available")
+
+        # Simple model with annotated submodules.
+        class FFN(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.norm = torch.nn.LayerNorm(16)
+                self.ffn = FFN()
+
+            def forward(self, x):
+                return self.ffn(self.norm(x))
+
+        model = Model().cuda()
+        annotate_module_fqns(model)
+
+        x = torch.randn(4, 16, device="cuda")
+        labels = torch.randn(4, 16, device="cuda")
+
+        # Trace fwd + loss + bwd via trace_train_step.
+        def fwd_bwd_step(model, inputs, labels):
+            pred = model(inputs)
+            loss = torch.nn.functional.mse_loss(pred, labels)
+            params = [p for p in model.parameters() if p.requires_grad]
+            grads = torch.autograd.grad(loss, params)
+            return [loss] + list(grads)
+
+        traced = trace_train_step(fwd_bwd_step)(model, x, labels)
+
+        # Verify module_fqn metadata survived tracing.
+        fqns_in_graph = set()
+        for node in traced.gm.graph.nodes:
+            fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+            if fqn:
+                fqns_in_graph.add(fqn)
+        self.assertIn("norm", fqns_in_graph)
+        self.assertIn("ffn", fqns_in_graph)
+
+        # Apply passes (annotation + cudagraph).
+        passes = construct_default_graph_passes(traced)
+        traced.gm = apply_graph_passes(traced.gm, traced.example_inputs, passes)
+
+        # Run: warmup + capture + replay.
+        run_traced_train_step(traced, model, x, labels)  # warmup + capture
+        run_traced_train_step(traced, model, x, labels)  # replay
+
+        # Check annotations were captured.
+        annotations = get_cudagraph_annotations()
+        self.assertGreater(len(annotations), 0, "No annotations captured")
+
+        all_fqns = set()
+        for ann_list in annotations.values():
+            for ann in ann_list:
+                if isinstance(ann, dict) and _MODULE_FQN in ann:
+                    all_fqns.add(ann[_MODULE_FQN])
+        self.assertIn("norm", all_fqns)
+        self.assertIn("ffn", all_fqns)
+
+        # Profile and check the trace.
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            run_traced_train_step(traced, model, x, labels)
+            torch.cuda.synchronize()
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            trace_path = f.name
+        prof.export_chrome_trace(trace_path)
+
+        with open(trace_path) as f:
+            trace = json.load(f)
+
+        count = annotate_trace(trace, annotations)
+        self.assertGreater(count, 0, "annotate_trace matched 0 events")
+
+        # Verify module_fqn fields appear on graphed kernel events.
+        # Since trace_train_step traces fwd+bwd into a single graph,
+        # backward kernels (e.g. layer_norm_backward) should also carry
+        # annotations from _copy_fwd_metadata_to_bw_nodes.
+        fqns_in_trace = set()
+        for e in trace["traceEvents"]:
+            args = e.get("args", {})
+            if args.get("graph node id", 0) != 0 and _MODULE_FQN in args:
+                fqns_in_trace.add(args[_MODULE_FQN])
+
+        self.assertIn("norm", fqns_in_trace)
+        self.assertIn("ffn", fqns_in_trace)
+
+        # Backward kernels should also be annotated (via
+        # _copy_fwd_metadata_to_bw_nodes).  Verify by checking the order:
+        # forward annotations appear first (norm → ffn), then backward
+        # annotations appear in reverse order (ffn → norm).
+        ordered_fqns = []
+        for tid in sorted(annotations.keys(), key=lambda t: t & 0xFFFFFFFF):
+            for ann in annotations[tid]:
+                if isinstance(ann, dict) and _MODULE_FQN in ann:
+                    fqn = ann[_MODULE_FQN]
+                    if not ordered_fqns or ordered_fqns[-1] != fqn:
+                        ordered_fqns.append(fqn)
+
+        # Forward: norm → ffn.linear → ffn; backward (reverse): ffn.linear
+        # → norm.  All three fqns should appear, and norm/ffn.linear should
+        # appear in both fwd and bwd (at least twice each).
+        for expected_fqn in ("norm", "ffn", "ffn.linear"):
+            self.assertIn(expected_fqn, ordered_fqns, f"Missing '{expected_fqn}'")
+        for expected_fqn in ("norm", "ffn.linear"):
+            positions = [i for i, f in enumerate(ordered_fqns) if f == expected_fqn]
+            self.assertGreaterEqual(
+                len(positions),
+                2,
+                f"Expected '{expected_fqn}' in both fwd and bwd, "
+                f"got positions {positions} in {ordered_fqns}",
+            )
+
+        # Cleanup.
+        os.unlink(trace_path)
+        cudagraph_teardown()
+
+
+class TestTracePostProcessorConfig(TestCase):
+    """Verify ProfilingConfig.trace_post_processors runs on every trace export."""
+
+    def test_post_processors_called_with_trace_path(self):
+        """Each Function.Config in trace_post_processors is invoked with the
+        exported trace file path."""
+
+        calls: list[tuple[str, bool]] = []
+
+        def record_call(trace_path: str) -> None:
+            # Record path + whether the exported file exists at call time.
+            calls.append((trace_path, os.path.exists(trace_path)))
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "torch.distributed.get_rank", return_value=0
+        ):
+            config = ProfilingConfig(
+                enable_profiling=True,
+                save_traces_folder="traces",
+                profile_freq=4,
+                profiler_warmup=1,
+                profiler_active=1,
+                trace_post_processors=[Function.Config(fn=record_call)],
+            )
+
+            with maybe_enable_profiling(config, global_step=0, base_folder=tmp) as prof:
+                for _ in range(4):
+                    prof.step()
+
+        self.assertEqual(len(calls), 1, f"Expected 1 call, got {calls}")
+        path, existed = calls[0]
+        self.assertTrue(path.endswith("rank0_trace.json"))
+        self.assertTrue(existed, f"Trace file {path} did not exist when callback ran")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import torch
 
 from torchtitan.config import Configurable
+from torchtitan.config.function import Function
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
 
@@ -168,6 +169,12 @@ class Profiler(Configurable):
         save_memory_snapshot_folder: str = "memory_snapshot"
         """Memory snapshot files location."""
 
+        trace_post_processor: Function.Config | None = None
+        """Optional hook invoked with the trace path after each export.
+
+        Wraps ``fn(trace_path: str) -> None``.
+        """
+
     def __init__(
         self,
         config: Config,
@@ -269,6 +276,9 @@ class Profiler(Configurable):
         }
 
         rank = torch.distributed.get_rank()
+        post_processor = (
+            cfg.trace_post_processor.build() if cfg.trace_post_processor else None
+        )
 
         def trace_handler(prof):
             curr_trace_dir_name = "iteration_" + str(prof.step_num)
@@ -281,6 +291,10 @@ class Profiler(Configurable):
 
             output_file = os.path.join(curr_trace_dir, f"rank{rank}_trace.json")
             prof.export_chrome_trace(output_file)
+
+            if post_processor is not None:
+                post_processor(output_file)
+
             logger.info(
                 f"Finished dumping profiler traces in {time.monotonic() - begin:.2f} seconds"
             )

--- a/torchtitan/tools/profiling.py
+++ b/torchtitan/tools/profiling.py
@@ -8,9 +8,10 @@ import contextlib
 import os
 import pickle
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
+from torchtitan.config.function import Function
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
 
@@ -71,6 +72,13 @@ class ProfilingConfig:
     save_memory_snapshot_folder: str = "memory_snapshot"
     """Memory snapshot files location"""
 
+    trace_post_processors: list[Function.Config] = field(default_factory=list)
+    """Callbacks invoked with the trace path after each export.
+
+    Experiments can attach post-processors. Each entry is a
+    ``Function.Config`` wrapping ``fn(trace_path: str) -> None``.
+    """
+
 
 @contextlib.contextmanager
 def maybe_enable_profiling(
@@ -102,6 +110,9 @@ def maybe_enable_profiling(
         }
 
         rank = torch.distributed.get_rank()
+        post_processors = [
+            cfg.build() for cfg in profiling_config.trace_post_processors
+        ]
 
         def trace_handler(prof):
             curr_trace_dir_name = "iteration_" + str(prof.step_num)
@@ -114,6 +125,10 @@ def maybe_enable_profiling(
 
             output_file = os.path.join(curr_trace_dir, f"rank{rank}_trace.json")
             prof.export_chrome_trace(output_file)
+
+            for post_processor in post_processors:
+                post_processor(output_file)
+
             logger.info(
                 f"Finished dumping profiler traces in {time.monotonic() - begin:.2f} seconds"
             )


### PR DESCRIPTION

Need https://github.com/pytorch/pytorch/pull/179867  and cuda 13.1 driver/compat 

## [graph_trainer] Add CUDA graph kernel annotation pass

### Summary

Adds a compiler pass that automatically labels CUDA graph kernels with their originating `nn.Module` path in profiler traces. When enabled, Perfetto/chrome traces show which component each kernel belongs to (e.g., `layers.0.attention.wq`, `layers.0.feed_forward.w1`, `norm`). Both forward and backward kernels are annotated.

No model code changes required — module paths are derived from the existing `nn.Module` hierarchy.

### How it works

1. **`annotate_module_fqns(model)`** walks the `nn.Module` tree and wraps each submodule's `forward` with `torch.fx.traceback.annotate_fn({"module_fqn": fqn})`. This sets `node.meta["custom"]["module_fqn"]` on all FX nodes during tracing — surviving dynamo, `make_fx`, and export tracers. Backward nodes receive the metadata via `_copy_fwd_metadata_to_bw_nodes`.

2. **`insert_kernel_annotations_pass`** reads the `module_fqn` metadata from FX nodes and inserts `mark_kernels()` enter/exit calls at module boundaries in the graph. Bundled with `cudagraph_pass` — runs automatically whenever cudagraph is used. No-op when `cuda-python` or `cuda-compat >= 13.1` is unavailable.

3. **`CUDAGraphWrapper`** captures the annotations during CUDA graph recording when the pass is active, and registers a trace post-processor with the core profiler.

4. **Profiler integration** — `profiling.py` exposes `register_trace_post_processor()` so experiment code can hook into trace export without core importing from experiments. The annotation post-processor merges kernel annotations into the trace automatically.

### Usage

The annotation pass runs automatically in `aot_fx_trace` mode when cudagraph is compatible. Profiler traces come out pre-annotated:

```bash
NGPU=1 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel ./run_train.sh \
    --compile.mode aot_fx_trace \
    --profiling.enable_profiling \
    --profiling.profile_freq 4
```

Open the exported trace at `outputs/.../rank0_trace.json` in https://ui.perfetto.dev to see module labels on each kernel.

### Example output (Llama3 debug model, 6 layers)

```
tok_embeddings                      → embedding gather
layers.0.attention_norm             → RMSNorm
layers.0.attention.wq/.wk/.wv      → Q/K/V projections
layers.0.attention                  → RoPE, reshapes
layers.0.attention.inner_attention  → flash_fwd_kernel
layers.0.attention.wo               → output projection
layers.0.ffn_norm                   → RMSNorm
layers.0.feed_forward.w1/.w3       → gate/up projections
layers.0.feed_forward               → silu + mul
layers.0.feed_forward.w2            → down projection
norm                                → final RMSNorm
output                              → output linear
```

### Requirements

Requires PyTorch with `torch.cuda._graph_annotations` module and `enable_annotations` kwarg on `torch.cuda.graph()`. Falls back gracefully when unavailable (pass is a no-op).

### Files changed

| File | Change |
|------|--------|
| `common_utils.py` | Add `annotate_module_fqns()` and `_MODULE_FQN` constant |
| `passes.py` | Add `insert_kernel_annotations_pass` (bundled with cudagraph pass), with alternative approaches documented |
| `cudagraph.py` | Add `enable_annotations` flag, `enable_cudagraph_annotations()`, `get_cudagraph_annotations()`, trace post-processor registration |
| `llama3/parallelize.py` | Call `annotate_module_fqns(model)` in `annotate_llama()` |
| `deepseek_v3/parallelize.py` | Call `annotate_module_fqns(model)` in `annotate_deepseekv3()` |
| `qwen3/parallelize.py` | Call `annotate_module_fqns(model)` in `annotate_qwen3()` |
| `tools/profiling.py` | Add `register_trace_post_processor()` callback API (no experiment imports) |
| `models/common/attention.py` | Remove unused `import os` + `DISABLE_LLVM_OPT` |
| `tests/test_passes.py` | 5 unit tests: transformer-like model with `trace_train_step`, pass insertion, no-op when unavailable, no-op without metadata, xfail for same-class instances |
| `tests/profiler_tests.py` | E2E test: `trace_train_step` fwd+bwd → pass → cudagraph → profile → verify `module_fqn` in trace for both fwd and bwd kernels |
| `.github/workflows/integration_test_8gpu_graph_trainer.yaml` | Add annotation tests to CI |

### Test plan

```bash
# Unit tests (single GPU):
python -m torchtitan.experiments.graph_trainer.tests.test_passes TestAnnotateModuleFqns -v

# E2E profiler test (single GPU, requires cuda-compat >= 13.1):
LD_LIBRARY_PATH=$CONDA_PREFIX/cuda-compat:$LD_LIBRARY_PATH \
    python -m torchtitan.experiments.graph_trainer.tests.profiler_tests -v

# Full training run (single GPU):
NGPU=1 LD_LIBRARY_PATH=$CONDA_PREFIX/cuda-compat:$LD_LIBRARY_PATH \
    torchrun --nproc_per_node=1 --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
    -m torchtitan.train --module graph_trainer.llama3 --config graph_trainer_llama3_debugmodel \
    --compile.mode aot_fx_trace \
    --training.steps 4 --profiler.enable_profiling --profiler.profile_freq 4
```

Authored with Claude.


Example:

```
NGPU=4 LD_LIBRARY_PATH=/home/shangdiy/.conda/envs/pytorch-3.12/cuda-compat:$LD_LIBRARY_PATH \
  torchrun --nproc_per_node=1 --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
      -m torchtitan.train \
      --module graph_trainer.llama3 \
      --config graph_trainer_llama3_debugmodel \
      --compile.mode aot_fx_trace \
      --training.steps 4 \
      --profiler.enable_profiling \
      --profiler.save_traces_folder agent_space/traces \
      --profiler.profile_freq 4 
```

Result: 

https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fshangdiy_22d012fd-21e5-412f-aa06-d17a32426030_rank0_trace.json

<img width="1232" height="726" alt="Screenshot 2026-04-14 at 1 48 16 PM" src="https://github.com/user-attachments/assets/fe8e62f4-97cd-4f8d-866e-ff648af0e065" />

