### PR TITLE
[DO NOT REVIEW] Restore maybe_enable_amp for graph trainer after PR #2900

### DIFF
--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -31,6 +31,7 @@ class ParallelDims:
 
     _meshes: dict[str, DeviceMesh] = field(default_factory=dict)
     _world_mesh: DeviceMesh | None = None
+    _force_fsdp_mesh: bool = True
 
     @classmethod
     def from_config(
@@ -77,7 +78,7 @@ class ParallelDims:
             assert etp == tp or etp == 1, "Currently we only support ETP=TP or ETP=1"
 
     def _mesh_exist(self, name: str, degree: int) -> bool:
-        if name == "fsdp":
+        if name == "fsdp" and self._force_fsdp_mesh:
             # Always keep fsdp mesh with real backend so fully_shard()
             # can apply MixedPrecisionPolicy even at degree 1.
             return True

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -21,7 +21,7 @@ from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 
-from torchtitan.config import CommConfig, DebugConfig
+from torchtitan.config import CommConfig, DebugConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
@@ -289,6 +289,29 @@ def get_train_context(enable_loss_parallel: bool) -> TrainContext:
             yield
 
     return context
+
+
+def maybe_enable_amp(
+    parallel_dims: ParallelDims, mixed_precision_param: str, device_type: str
+) -> contextlib.AbstractContextManager[None] | torch.autocast:
+    if parallel_dims.fsdp_enabled or parallel_dims.dp_replicate_enabled:
+        # FSDP handles mixed precision internally
+        logger.info("Mixed precision training is handled by fully_shard or replicate")
+        return contextlib.nullcontext()
+    else:
+        if parallel_dims.tp_enabled or parallel_dims.pp_enabled:
+            logger.warning(
+                "Mixed precision training with TP or PP is only supported when FSDP/HSDP/CP/DDP is enabled."
+            )
+            logger.info("Mixed precision training is disabled")
+            return contextlib.nullcontext()
+        else:
+            # the following code will only be executed for single-device training
+            logger.info("Mixed precision training is handled by AMP")
+            return torch.autocast(
+                device_type,
+                dtype=TORCH_DTYPE_MAP[mixed_precision_param],
+            )
 
 
 def init_fake_mode(world_size: int, comm_mode: str = "fake_backend"):

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -13,6 +13,7 @@ Requires a CUDA GPU. Run with:
     pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x
 """
 
+import contextlib
 import copy
 import unittest
 from collections.abc import Callable
@@ -76,6 +77,7 @@ def _build_trainer(
     trainer.loss_fn = cross_entropy_loss
     trainer.parallel_dims = SimpleNamespace(pp_enabled=False, cp_enabled=False)
     trainer.train_context = get_train_context(False)
+    trainer.maybe_enable_amp = contextlib.nullcontext()
     trainer.model_config = model_config
     trainer.device = torch.device("cuda")
     trainer.tokenizer = HuggingFaceTokenizer(tokenizer_path=_TOKENIZER_PATH)

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -10,6 +10,9 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed.parallel_dims import ParallelDims
+
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -52,8 +55,19 @@ class GraphTrainer(Trainer):
             default_factory=GraphTrainerCompileConfig
         )
 
+    def init_distributed(self) -> ParallelDims:
+        parallel_dims = super().init_distributed()
+        parallel_dims._force_fsdp_mesh = False
+        return parallel_dims
+
     def __init__(self, config):
         super().__init__(config)
+
+        self.maybe_enable_amp = dist_utils.maybe_enable_amp(
+            self.parallel_dims,
+            config.training.mixed_precision_param,
+            self.device.type,
+        )
 
         if self.config.compile.mode == "aot_fx_trace" and self.parallel_dims.pp_enabled:
             raise ValueError(
@@ -108,7 +122,7 @@ class GraphTrainer(Trainer):
         if self._traced_step is None:
             fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
             maybe_register_blockmask_pytree_node()
-            with self.train_context():
+            with self.train_context(), self.maybe_enable_amp:
                 self._traced_step = trace_train_step(fwd_bwd_fn)(
                     model,
                     inputs,
@@ -125,7 +139,7 @@ class GraphTrainer(Trainer):
                     self._traced_step.example_inputs,
                     passes,
                 )
-        with self.train_context():
+        with self.train_context(), self.maybe_enable_amp:
             outputs = run_traced_train_step(
                 self._traced_step,
                 model,


### PR DESCRIPTION
PR #2900 removed maybe_enable_amp from the base Trainer and graph trainer. While it was already a nullcontext for all FSDP configs, restore it to keep graph trainer behavior identical to before #2900.