### PR TITLE
Skip parallelize_fn for seed checkpoint creation

### DIFF
--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -24,6 +24,7 @@ class OverrideDefinitions:
     ngpu: int = 4
     disabled: bool = False
     skip_rocm_test: bool = False
+    timeout: int | None = None
 
     def __repr__(self):
         return self.test_descr

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -607,6 +607,18 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "sft",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--checkpoint.enable",
+                    "--checkpoint.create_seed_checkpoint",
+                ],
+            ],
+            "Seed checkpoint creation",
+            "seed_checkpoint",
+            ngpu=1,
+            timeout=30,
+        ),
     ]
 
     return integration_tests_flavors

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -24,9 +24,14 @@ _TEST_SUITES_FUNCTION = {
 }
 
 
-def _run_cmd(cmd):
+def _run_cmd(cmd, timeout=None):
     return subprocess.run(
-        [cmd], encoding="utf-8", errors="replace", shell=True, capture_output=True
+        [cmd],
+        encoding="utf-8",
+        errors="replace",
+        shell=True,
+        capture_output=True,
+        timeout=timeout,
     )
 
 
@@ -69,7 +74,13 @@ def run_single_test(
                 f"./scripts/generate/run_llama_generate.sh --out > {output_dir}/{test_name}/generated_output.json"
             )
 
-        result = _run_cmd(cmd)
+        try:
+            result = _run_cmd(cmd, timeout=test_flavor.timeout)
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"\nTest timed out after {test_flavor.timeout}s: {test_flavor.test_descr}.\n"
+                f"Command: {cmd}\n"
+            ) from e
         if result.stdout:
             logger.info(result.stdout)
         if result.returncode != 0:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -392,17 +392,19 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 color=color,
             )
         else:
-            # apply Tensor/Context/Expert Parallel, activation checkpointing, torch.compile, Data Parallel
-            model = model_spec.parallelize_fn(
-                model,
-                parallel_dims=parallel_dims,
-                training=config.training,
-                model_converters=config.model_converters,
-                parallelism=config.parallelism,
-                compile_config=config.compile,
-                ac_config=config.activation_checkpoint,
-                dump_folder=config.dump_folder,
-            )
+            if not config.checkpoint.create_seed_checkpoint:
+                # Skip parallelize_fn for seed checkpoints — nothing from
+                # it is needed (AC, compile, nD parallelism, mixed precision, etc.).
+                model = model_spec.parallelize_fn(
+                    model,
+                    parallel_dims=parallel_dims,
+                    training=config.training,
+                    model_converters=config.model_converters,
+                    parallelism=config.parallelism,
+                    compile_config=config.compile,
+                    ac_config=config.activation_checkpoint,
+                    dump_folder=config.dump_folder,
+                )
 
             model.to_empty(device=init_device)
             with torch.no_grad():


### PR DESCRIPTION
Follow up on CI timeout https://github.com/pytorch/torchtitan/actions/runs/24217297179/job/70700751227 — TestGraphTrainerNumerics hangs during seed checkpoint creation 
                                                                                                                                                                                                                                 
[PR #2900](https://github.com/pytorch/torchtitan/pull/2900) applies fully_shard when world size = 1. This triggered a pytorch side DTensor/nn.init bug: https://github.com/pytorch/pytorch/issues/180088

Beyond pytorch side fix, it also makes sense to skip parallelize_fn for seed checkpoints — nothing from it is needed (AC, compile, nD parallelism, mixed precision, etc.). Seed checkpoints only initialize weights and save.                                                    
   
Also adds a seed checkpoint test with a 30s timeout