### PR TITLE
Enable 2 tier compilation with flex attention

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -267,9 +267,7 @@ class FlexAttention(LocalMapInnerAttention):
         kernel_options: dict = field(default_factory=dict)
 
     inductor_configs: ClassVar[dict[str, bool]] = {
-        # TODO: turn on wrap_inductor_compiled_regions after PyTorch fix is
-        # landed again: https://github.com/pytorch/pytorch/pull/175733.
-        "wrap_inductor_compiled_regions": False,
+        "wrap_inductor_compiled_regions": True,
         # Recommended workflow: run once with max_autotune=True to discover
         # good kernel_options, then set kernel_options explicitly in the config
         # and keep max_autotune disabled for faster compilation.


### PR DESCRIPTION
Addressing: https://github.com/pytorch/torchtitan/issues/2463

Enabling CI for 2 tier regional inductor compilation over flex-attention.

PR was landed https://github.com/pytorch/pytorch/pull/176666

