### PR TITLE
[GraphTrainer] Support transformer_block_bucketing in aot_fx_trace mode

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -18,6 +18,18 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
 _AC_REGION_ID = "ac_region_id"
+_MODULE_FQN = "module_fqn"
+
+
+def annotate_module_fqns(model: nn.Module) -> None:
+    """Annotate all modules' forward with their fully-qualified names.
+
+    Every named submodule (excluding the root) gets its forward method wrapped
+    with annotate_fn so that FX nodes carry the module_fqn metadata.
+    """
+    for fqn, submodule in model.named_modules():
+        if fqn:  # skip root module
+            submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
 
 
 def annotate_ac_regions(model: nn.Module) -> None:

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -19,6 +19,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -55,6 +56,7 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     )
     MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
 
+    annotate_module_fqns(model)
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -16,6 +16,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -32,10 +33,14 @@ from torchtitan.tools.logging import logger
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
+    - Module FQN annotation: Tags each submodule's forward with its
+      fully-qualified name so that the transformer_block_bucketing pass
+      can identify which graph nodes belong to which module.
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
     """
+    annotate_module_fqns(model)
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -273,6 +273,9 @@ class TracedResult:
         num_flat_outputs: Number of flat graph outputs before subclass rewrapping.
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
+        model: The original nn.Module, cached for downstream passes that need
+            module structure (e.g. transformer block bucketing). Only set when
+            traced via :func:`trace_train_step`.
     """
 
     gm: torch.fx.GraphModule
@@ -284,6 +287,10 @@ class TracedResult:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int] = field(default_factory=list)
+    # TODO: Remove model from TracedResult. TracedResult is becoming a
+    # contract between the trainer and pre-compile, so carrying the original
+    # model is not feasible.
+    model: nn.Module | None = None
 
     @property
     def num_static_inputs(self) -> int:
@@ -380,6 +387,7 @@ def minimal_fx_tracer(fn: Callable) -> Callable[..., TracedResult]:
             user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
             with torch.compiler._patch_autograd_grad():
                 result = fn(state_for_fn, *user_list)
+
             flat_outs, output_spec = pytree.tree_flatten(result)
             num_flat_outputs = len(flat_outs)
             unwrapped_outs, output_layouts = _unwrap_subclasses(flat_outs)
@@ -493,7 +501,9 @@ def trace_train_step(fn: Callable) -> Callable[..., TracedResult]:
             with stateless._reparametrize_module(module, state):
                 return fn(module, *user_args)
 
-        return minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
+        result = minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
+        result.model = module
+        return result
 
     return _trace_with_module
 

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -273,6 +273,9 @@ class TracedResult:
         num_flat_outputs: Number of flat graph outputs before subclass rewrapping.
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
+        model: The original nn.Module, cached for downstream passes that need
+            module structure (e.g. transformer block bucketing). Only set when
+            traced via :func:`trace_train_step`.
     """
 
     gm: torch.fx.GraphModule
@@ -284,6 +287,7 @@ class TracedResult:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int] = field(default_factory=list)
+    model: nn.Module | None = None
 
     @property
     def num_static_inputs(self) -> int:
@@ -380,6 +384,7 @@ def minimal_fx_tracer(fn: Callable) -> Callable[..., TracedResult]:
             user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
             with torch.compiler._patch_autograd_grad():
                 result = fn(state_for_fn, *user_list)
+
             flat_outs, output_spec = pytree.tree_flatten(result)
             num_flat_outputs = len(flat_outs)
             unwrapped_outs, output_layouts = _unwrap_subclasses(flat_outs)
@@ -493,7 +498,9 @@ def trace_train_step(fn: Callable) -> Callable[..., TracedResult]:
             with stateless._reparametrize_module(module, state):
                 return fn(module, *user_args)
 
-        return minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
+        result = minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
+        result.model = module
+        return result
 
     return _trace_with_module
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -37,7 +37,7 @@ from torch.fx.passes.regional_inductor import regional_inductor
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.distributed.activation_checkpoint import _get_save_ops
-from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID
+from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID, _MODULE_FQN
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
@@ -71,12 +71,20 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime
     """
+    # from torchtitan.experiments.graph_trainer.common_utils import (
+    #     get_transformer_block_buckets,
+    # )
     from torchtitan.models.common.attention import FlexAttention
 
     return [
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
+        # TODO: turn on after debugging composability with SAC pass
+        # functools.partial(
+        #     joint_transformer_block_bucketing_reordering_pass,
+        #     fsdp_manual_buckets=get_transformer_block_buckets(traced_result.model),
+        # ),
         selective_activation_remat_pass,
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
@@ -202,6 +210,58 @@ def transformer_block_bucketing_reordering_pass(
     manual_overlap_bucketing(
         gm, module_bucket_plans=fsdp_manual_buckets, insert_overlap_deps=False
     )
+    gm.recompile()
+    return gm
+
+
+def joint_transformer_block_bucketing_reordering_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    fsdp_manual_buckets,
+) -> torch.fx.GraphModule:
+    """Apply manual bucketing and reordering on a joint fwd+bwd graph.
+
+    The joint graph is processed in two passes to ensure each direction's
+    collectives are bucketed independently and reordering uses the correct
+    execution order (forward order for fwd, reversed order for bwd).
+
+    Used by the aot_fx_trace mode where forward and backward are in a
+    single graph.
+    """
+
+    def _make_module_fqn_stack_fn(
+        *, bwd: bool
+    ) -> Callable[[torch.fx.Node], list[tuple[str, type]]]:
+        """Create a module_stack_fn that filters nodes by forward/backward direction."""
+
+        def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
+            is_bwd = node.meta.get("autograd_backward", False)
+            if is_bwd != bwd:
+                return []
+            fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+            if not fqn:
+                return []
+            return [(fqn, torch.nn.Module)]
+
+        return _stack_fn
+
+    # Forward graph pass: bucket and reorder forward collectives
+    manual_overlap_bucketing(
+        gm,
+        module_bucket_plans=fsdp_manual_buckets,
+        insert_overlap_deps=False,
+        module_stack_fn=_make_module_fqn_stack_fn(bwd=False),
+    )
+
+    # Backward backward pass: bucket and reorder backward collectives
+    manual_overlap_bucketing(
+        gm,
+        module_bucket_plans=fsdp_manual_buckets,
+        insert_overlap_deps=False,
+        module_stack_fn=_make_module_fqn_stack_fn(bwd=True),
+    )
+
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -36,7 +36,7 @@ from torch.fx.passes.regional_inductor import regional_inductor
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.distributed.activation_checkpoint import _get_save_ops
-from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID
+from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID, _MODULE_FQN
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
@@ -66,6 +66,9 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime
     """
+    from torchtitan.experiments.graph_trainer.common_utils import (
+        get_transformer_block_buckets,
+    )
     from torchtitan.models.common.attention import FlexAttention
 
     return [
@@ -74,6 +77,10 @@ def compile_time_passes(
         remove_identity_view_pass,
         remove_identity_slice_pass,
         selective_activation_remat_pass,
+        functools.partial(
+            joint_transformer_block_bucketing_reordering_pass,
+            fsdp_manual_buckets=get_transformer_block_buckets(traced_result.model),
+        ),
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
         # When left uncompiled, flex_attention still runs correctly but
@@ -173,6 +180,62 @@ def transformer_block_bucketing_reordering_pass(
     manual_overlap_bucketing(
         gm, module_bucket_plans=fsdp_manual_buckets, insert_overlap_deps=False
     )
+    gm.recompile()
+    return gm
+
+
+def joint_transformer_block_bucketing_reordering_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    fsdp_manual_buckets,
+) -> torch.fx.GraphModule:
+    """Apply manual bucketing and reordering on a joint fwd+bwd graph.
+
+    The joint graph is processed in two passes to ensure each direction's
+    collectives are bucketed independently and reordering uses the correct
+    execution order (forward order for fwd, reversed order for bwd).
+
+    Used by the aot_fx_trace mode where forward and backward are in a
+    single graph.
+    """
+
+    def _make_module_fqn_stack_fn(
+        *, bwd: bool
+    ) -> Callable[[torch.fx.Node], list[tuple[str, type]]]:
+        """Create a module_stack_fn that filters nodes by forward/backward direction."""
+
+        def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
+            is_bwd = node.meta.get("autograd_backward", False)
+            if is_bwd != bwd:
+                return []
+            fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+            if not fqn:
+                return []
+            return [(fqn, torch.nn.Module)]
+
+        return _stack_fn
+
+    # Forward pass: bucket and reorder in forward execution order
+    manual_overlap_bucketing(
+        gm,
+        module_bucket_plans=fsdp_manual_buckets,
+        insert_overlap_deps=False,
+        module_stack_fn=_make_module_fqn_stack_fn(bwd=False),
+    )
+
+    # keep it until https://github.com/pytorch/pytorch/pull/180579 lands
+    for node in gm.graph.nodes:
+        node.meta.pop("manual_bucket_node_type", None)
+
+    # Backward pass: bucket and reorder backward collectives separately
+    manual_overlap_bucketing(
+        gm,
+        module_bucket_plans=fsdp_manual_buckets,
+        insert_overlap_deps=False,
+        module_stack_fn=_make_module_fqn_stack_fn(bwd=True),
+    )
+
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -19,6 +19,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -56,6 +57,7 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
         )
         MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
 
+    annotate_module_fqns(model)
     annotate_ac_regions(model)
 
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -19,6 +19,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_ac_regions,
+    annotate_module_fqns,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -66,6 +67,7 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
         FlexAttention.forward
     )
 
+    annotate_module_fqns(model)
     annotate_ac_regions(model)
 
 


### PR DESCRIPTION
## Summary

Enable `transformer_block_bucketing` pass in `aot_fx_trace` compile mode. Previously this only worked in `aot` and `jit` modes because `aot_fx_trace` traces a joint fwd+bwd graph where `nn_module_stack` metadata alone isn't sufficient to correctly identify and separate forward vs backward nodes for bucketing.                                                                                                                                                                                                                                                    

**Root cause:** In the joint graph produced by `aot_fx_trace`, forward and backward collectives coexist. The existing `manual_overlap_bucketing` pass needs to bucket each direction independently — forward collectives in forward execution order, backward collectives in reverse order — but had no way to distinguish them.

**Solution:** Leverage the existing `annotate_fn` mechanism (already used for AC region tagging) to:
  1. Tag each bucket-level submodule's forward with its FQN (`annotate_module_fqns`)
  2. Mark backward nodes with `is_bwd=True` during metadata propagation                                                                                                                                                                                                                
  3. Provide a direction-aware `module_stack_fn` to `manual_overlap_bucketing` that filters by fwd/bwd

A new `joint_transformer_block_bucketing_reordering_pass` applies bucketing in two passes — once for forward nodes, once for backward — so each direction's collectives are bucketed and reordered independently.