### PR TITLE
[AutoDev] Default FlexAttn max_autotune to False

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -274,8 +274,12 @@ class FlexAttention(LocalMapInnerAttention):
         # good kernel_options, then set kernel_options explicitly in the config
         # and keep max_autotune disabled for faster compilation.
         "max_autotune": False,
-        # Sub-feature of max_autotune: applies coordinate descent to further
-        # optimize the kernel configs found by max_autotune's initial search.
+        # When enabled, after max_autotune selects the best kernel config,
+        # coordinate descent iteratively tunes individual parameters (block
+        # sizes, num_warps, num_stages) one at a time -- doubling/halving each
+        # and accepting changes that improve runtime by >0.1%. This can also
+        # run without max_autotune but starts from a weaker baseline config.
+        # See torch/_inductor/runtime/coordinate_descent_tuner.py.
         "coordinate_descent_tuning": False,
         "triton.cudagraphs": False,
     }

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -274,6 +274,8 @@ class FlexAttention(LocalMapInnerAttention):
         # good kernel_options, then set kernel_options explicitly in the config
         # and keep max_autotune disabled for faster compilation.
         "max_autotune": False,
+        # Sub-feature of max_autotune: applies coordinate descent to further
+        # optimize the kernel configs found by max_autotune's initial search.
         "coordinate_descent_tuning": False,
         "triton.cudagraphs": False,
     }

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -270,8 +270,11 @@ class FlexAttention(LocalMapInnerAttention):
         # TODO: turn on wrap_inductor_compiled_regions after PyTorch fix is
         # landed again: https://github.com/pytorch/pytorch/pull/175733.
         "wrap_inductor_compiled_regions": False,
-        "max_autotune": True,
-        "coordinate_descent_tuning": True,
+        # Recommended workflow: run once with max_autotune=True to discover
+        # good kernel_options, then set kernel_options explicitly in the config
+        # and keep max_autotune disabled for faster compilation.
+        "max_autotune": False,
+        "coordinate_descent_tuning": False,
         "triton.cudagraphs": False,
     }
 


### PR DESCRIPTION
## Summary
- Changed `max_autotune` from `True` to `False` in `FlexAttention.inductor_configs`
- Changed `coordinate_descent_tuning` from `True` to `False` (only useful when `max_autotune` is enabled)
- Added a comment explaining the recommended workflow

## Why
The recommended workflow is:
1. Run once with `max_autotune=True` to discover good `kernel_options`
2. Set `kernel_options` explicitly in the config
3. Disable `max_autotune` for faster compilation in subsequent runs

Defaulting to `False` avoids unnecessary autotuning overhead for users who have already determined their kernel options, and makes the first-run experience faster for users who haven't yet tuned.

`coordinate_descent_tuning` is a sub-feature of `max_autotune` and does no useful work when `max_autotune` is disabled, so it is also defaulted to `False` to match.

## Test plan
- [ ] Verify that FlexAttn still works correctly with default config (max_autotune=False)
- [ ] Verify that setting max_autotune=True via inductor config override still enables autotuning
- [ ] Confirm no numerical difference when kernel_options are explicitly set