### PR TITLE
Trigger CI when draft PR is marked ready for review

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -7,6 +7,7 @@ on:
       - 'torchtitan/experiments/rl/**'
       - '.github/workflows/integration_test_4gpu_rl.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/rl/**'
       - '.github/workflows/integration_test_4gpu_rl.yaml'

--- a/.github/workflows/integration_test_4gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_4gpu_rl_h100.yaml
@@ -7,6 +7,7 @@ on:
       - 'torchtitan/experiments/rl/**'
       - '.github/workflows/integration_test_4gpu_rl_h100.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/rl/**'
       - '.github/workflows/integration_test_4gpu_rl_h100.yaml'

--- a/.github/workflows/integration_test_8gpu_autoparallel.yaml
+++ b/.github/workflows/integration_test_8gpu_autoparallel.yaml
@@ -9,6 +9,7 @@ on:
       - 'torchtitan/experiments/autoparallel/**'
       - '.github/workflows/integration_test_8gpu_autoparallel.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/autoparallel/**'
       - '.github/workflows/integration_test_8gpu_autoparallel.yaml'

--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'torchtitan/experiments/**'
   schedule:

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -9,6 +9,7 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -9,6 +9,7 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ main ]
     paths-ignore:
       - 'torchtitan/experiments/**'

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ main ]
     paths-ignore:
       - 'torchtitan/experiments/**'

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -10,6 +10,7 @@ on:
       - 'torchtitan/components/checkpoint.py'
       - '.github/workflows/integration_test_8gpu_torchft.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/ft/**'
       - 'torchtitan/components/checkpoint.py'

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -9,6 +9,7 @@ on:
       - 'torchtitan/experiments/transformers_modeling_backend/**'
       - '.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/transformers_modeling_backend/**'
       - '.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml'

--- a/.github/workflows/integration_test_8gpu_vlm.yaml
+++ b/.github/workflows/integration_test_8gpu_vlm.yaml
@@ -9,6 +9,7 @@ on:
       - 'torchtitan/experiments/vlm/**'
       - '.github/workflows/integration_test_8gpu_vlm.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/vlm/**'
       - '.github/workflows/integration_test_8gpu_vlm.yaml'


### PR DESCRIPTION
Add types: [opened, synchronize, reopened, ready_for_review] to pull_request triggers in all integration test workflows. Without this, CI skips draft PRs (via the draft == false check) but does not re-trigger when the PR is marked ready — requiring a manual push or close/reopen to start CI.

draft:
<img width="813" height="233" alt="Screenshot 2026-04-11 at 12 13 55" src="https://github.com/user-attachments/assets/badf8492-be5d-453d-9ea6-19c901c2c524" />

click "ready for review"
<img width="609" height="265" alt="Screenshot 2026-04-11 at 12 14 08" src="https://github.com/user-attachments/assets/e7360bba-7e3c-45c8-921c-922de7cb925a" />
