### PR TITLE
[RL] Add `gpu_direct_weight_sync` flag to control whether we use GPU direct or not

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -160,9 +160,11 @@ class VLLMGenerator(Actor, Configurable):
         *,
         model_spec: ModelSpec,
         model_path: str,
+        gpu_direct_weight_sync: bool = False,
     ):
         self.config = config
         self.model_spec = model_spec
+        self.gpu_direct_weight_sync = gpu_direct_weight_sync
 
         # Register TorchTitan model with vLLM before any engine creation
         register_model_to_vllm_model_registry(model_spec)
@@ -324,24 +326,20 @@ class VLLMGenerator(Actor, Configurable):
     async def pull_model_state_dict(self, version: int) -> None:
         """Pull latest weights from TorchStore.
 
-        When ``direct_rdma=True``, weights are read directly from the
-        trainer's GPU memory via one-sided RDMA, bypassing StorageVolumes.
-        When ``False``, data is fetched through StorageVolumes (which may
-        themselves use RDMA as their transport internally).
-
-        See ``push_model_state_dict`` for more details on the distinction.
+        When ``direct_rdma=True``, weights are transferred directly from
+        GPU to GPU via one-sided RDMA reads, bypassing StorageVolumes
+        entirely. When ``False``, data goes through StorageVolumes
+        (which may themselves use RDMA as a transport internally).
 
         Args:
             version: New policy version number.
         """
-        from monarch.rdma import is_rdma_available
-
         model_sd = self._get_model().model.state_dict()
         await ts.get_state_dict(
             "model_state_dict",
             user_state_dict=model_sd,
             strict=False,
-            direct_rdma=is_rdma_available(),
+            direct_rdma=self.gpu_direct_weight_sync,
         )
         self.policy_version = version
         logger.debug(

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -160,9 +160,11 @@ class VLLMGenerator(Actor, Configurable):
         *,
         model_spec: ModelSpec,
         model_path: str,
+        gpu_direct_weight_sync: bool = True,
     ):
         self.config = config
         self.model_spec = model_spec
+        self.gpu_direct_weight_sync = gpu_direct_weight_sync
 
         # Register TorchTitan model with vLLM before any engine creation
         register_model_to_vllm_model_registry(model_spec)
@@ -324,24 +326,20 @@ class VLLMGenerator(Actor, Configurable):
     async def pull_model_state_dict(self, version: int) -> None:
         """Pull latest weights from TorchStore.
 
-        When ``direct_rdma=True``, weights are read directly from the
-        trainer's GPU memory via one-sided RDMA, bypassing StorageVolumes.
-        When ``False``, data is fetched through StorageVolumes (which may
-        themselves use RDMA as their transport internally).
-
-        See ``push_model_state_dict`` for more details on the distinction.
+        When ``direct_rdma=True``, weights are transferred directly from
+        GPU to GPU via one-sided RDMA reads, bypassing StorageVolumes
+        entirely. When ``False``, data goes through StorageVolumes
+        (which may themselves use RDMA as a transport internally).
 
         Args:
             version: New policy version number.
         """
-        from monarch.rdma import is_rdma_available
-
         model_sd = self._get_model().model.state_dict()
         await ts.get_state_dict(
             "model_state_dict",
             user_state_dict=model_sd,
             strict=False,
-            direct_rdma=is_rdma_available(),
+            direct_rdma=self.gpu_direct_weight_sync,
         )
         self.policy_version = version
         logger.debug(

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -78,10 +78,12 @@ class PolicyTrainer(Actor, Configurable):
         hf_assets_path: str = "",
         transfer_dtype: str = "",
         kl_coef: float = 0.0,
+        gpu_direct_weight_sync: bool = False,
     ):
         self.config = config
         self.model_spec = model_spec
         self.kl_coef = kl_coef
+        self.gpu_direct_weight_sync = gpu_direct_weight_sync
         # Only cast if transfer dtype differs from training dtype, otherwise
         # staging buffers would be allocated for a no-op cast.
         training_dtype = TORCH_DTYPE_MAP[config.training.dtype]
@@ -249,19 +251,11 @@ class PolicyTrainer(Actor, Configurable):
         GPU to GPU via one-sided RDMA reads, bypassing StorageVolumes
         entirely. When ``False``, data goes through StorageVolumes
         (which may themselves use RDMA as a transport internally).
-
-        Note: we couple ``is_rdma_available()`` with ``direct_rdma`` here,
-        but the two concepts are not identical — StorageVolumes can also
-        use RDMA as their transport layer. ``direct_rdma`` specifically
-        means "skip StorageVolumes and let the destination read directly
-        from the source's GPU memory".
         """
-        from monarch.rdma import is_rdma_available
-
         await ts.put_state_dict(
             self.model.state_dict(),
             "model_state_dict",
-            direct_rdma=is_rdma_available(),
+            direct_rdma=self.gpu_direct_weight_sync,
             transfer_dtype=self._transfer_dtype,
         )
 

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -78,10 +78,12 @@ class PolicyTrainer(Actor, Configurable):
         hf_assets_path: str = "",
         transfer_dtype: str = "",
         kl_coef: float = 0.0,
+        gpu_direct_weight_sync: bool = True,
     ):
         self.config = config
         self.model_spec = model_spec
         self.kl_coef = kl_coef
+        self.gpu_direct_weight_sync = gpu_direct_weight_sync
         # Only cast if transfer dtype differs from training dtype, otherwise
         # staging buffers would be allocated for a no-op cast.
         training_dtype = TORCH_DTYPE_MAP[config.training.dtype]
@@ -249,19 +251,11 @@ class PolicyTrainer(Actor, Configurable):
         GPU to GPU via one-sided RDMA reads, bypassing StorageVolumes
         entirely. When ``False``, data goes through StorageVolumes
         (which may themselves use RDMA as a transport internally).
-
-        Note: we couple ``is_rdma_available()`` with ``direct_rdma`` here,
-        but the two concepts are not identical — StorageVolumes can also
-        use RDMA as their transport layer. ``direct_rdma`` specifically
-        means "skip StorageVolumes and let the destination read directly
-        from the source's GPU memory".
         """
-        from monarch.rdma import is_rdma_available
-
         await ts.put_state_dict(
             self.model.state_dict(),
             "model_state_dict",
-            direct_rdma=is_rdma_available(),
+            direct_rdma=self.gpu_direct_weight_sync,
             transfer_dtype=self._transfer_dtype,
         )
 

--- a/torchtitan/experiments/rl/simple_grpo_sum_digits.py
+++ b/torchtitan/experiments/rl/simple_grpo_sum_digits.py
@@ -131,6 +131,11 @@ class RLTrainer(Configurable):
         """KL divergence penalty coefficient. When > 0, a frozen reference model
         is built and KL divergence is added to the policy gradient loss."""
 
+        gpu_direct_weight_sync: bool = True
+        """Use GPU-direct RDMA for weight transfer between trainer and generator.
+        When True, weights are transferred directly from GPU to GPU, bypassing
+        TorchStore StorageVolumes. Requires RDMA-capable hardware."""
+
         trainer: PolicyTrainer.Config = field(default_factory=PolicyTrainer.Config)
         """PolicyTrainer config. Controls optimizer, training, parallelism"""
 
@@ -324,6 +329,7 @@ class RLTrainer(Configurable):
             hf_assets_path=config.hf_assets_path,
             transfer_dtype=config.generator.model_dtype,
             kl_coef=config.kl_coef,
+            gpu_direct_weight_sync=config.gpu_direct_weight_sync,
         )
         self.generator = generator_mesh.spawn(
             "generator",
@@ -331,6 +337,7 @@ class RLTrainer(Configurable):
             config.generator,
             model_spec=config.model_spec,
             model_path=config.hf_assets_path,
+            gpu_direct_weight_sync=config.gpu_direct_weight_sync,
         )
         self.grader = grader_mesh.spawn(
             "grader",


### PR DESCRIPTION
Add a configurable flag to control whether weight sync between trainer and generator uses GPU-direct RDMA or goes through TorchStore StorageVolumes. Previously this was hardcoded to `is_rdma_available()`.

Defaults to True. Disable with --no_gpu_direct_weight_sync in CLI.

# Test Plan
## With GPU Direct (default):
```
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b
```
```
Weight sync: push=0.010s, total=0.086s
```

## Without GPU direct:
```
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b --no-gpu_direct_weight_sync
```
```
Weight sync: push=0.096s, total=4.109s
```