### PR TITLE
[rl] Add torchcomms installation to setup instructions and remove xformers

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -48,10 +48,10 @@ uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/t
 uv pip install --no-deps "git+https://github.com/thinking-machines-lab/batch_invariant_ops.git@main"
 ```
 
-4. Install PyTorch nightly for torchtitan, and pre-built vllm wheels (based on PyTorch nightly version).
+4. Install PyTorch nightly, pre-built vllm wheel (based on PyTorch nightly version), and torchcomms nightly.
 ```bash
 # Install vllm with nightly torch
-uv pip install torch vllm xformers  --pre \
+uv pip install torch vllm torchcomms  --pre \
 --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
 --index-strategy unsafe-best-match
 ```


### PR DESCRIPTION
Add torchcomms installation to README instructions, for testing with TorchStore weight sync.
Also remove xformers installation as it does not appear to be used (please correct me if I'm wrong).

# Test Plan
- Create a new env following README

RL training works:
```
python torchtitan/experiments/rl/simple_grpo_sum_digits.py --module rl --config rl_grpo_qwen3_0_6b
```

```
uv pip show torchcomms

Name: torchcomms
Version: 0.2.0.dev20260407+cu128
```
