### PR TITLE
[RL] Two small fixes in `inference_example.py`

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -73,7 +73,7 @@ python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-1.7B --local_dir torch
 
 7. Run inference with torchtitan model definition:
 ```bash
-torchrun --nproc_per_node=2 torchtitan/experiments/rl/inference_example.py
+torchrun --nproc_per_node=4 torchtitan/experiments/rl/inference_example.py
 ```
 
 **NOTE:**: Set `--nproc_per_node` to the world size, which should match the `tensor_parallel_degree` in the `VLLMGenerator` config.

--- a/torchtitan/experiments/rl/inference_example.py
+++ b/torchtitan/experiments/rl/inference_example.py
@@ -11,7 +11,7 @@ Example inference script using TorchTitan models with vLLM LLMEngine.
 This script uses the RL unified config_registry to configure both
 the vLLM engine and sampling parameters.
 
-Run: torchrun --nproc_per_node=2 \
+Run: torchrun --nproc_per_node=4 \
       torchtitan/experiments/rl/inference_example.py
 """
 import os
@@ -78,8 +78,8 @@ def generate():
     vllm_compilation_config = gen_config.compile.get_vllm_compilation_config()
     if vllm_compilation_config is not None:
         engine_kwargs["compilation_config"] = vllm_compilation_config
-    if gen_config.seed is not None:
-        engine_kwargs["seed"] = gen_config.seed
+    if gen_config.debug.seed is not None:
+        engine_kwargs["seed"] = gen_config.debug.seed
     engine_args = EngineArgs(**engine_kwargs)
 
     logger.debug("Initializing LLMEngine from EngineArgs...")


### PR DESCRIPTION
Two fixes in inference_example.py to make it run again:

- `gen_config.seed` needs to be changed to `gen_config.debug.seed` after recent DebugConfig refactor
- Update run command to `--nproc_per_node=4` to match new world size since the TP size in the config was changed from 2 -> 4