### PR TITLE
Update pytorch nightly to cu13

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -75,7 +75,7 @@ jobs:
         # torchvision must be installed from the nightly channel alongside torch
         # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
         uv pip install torch torchvision vllm xformers --pre \
-          --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+          --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
           --index-strategy unsafe-best-match
         uv pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 

--- a/.github/workflows/integration_test_4gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_4gpu_rl_h100.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -63,13 +63,14 @@ jobs:
         uv pip install --no-deps "git+https://github.com/thinking-machines-lab/batch_invariant_ops.git@main"
 
         # 3. Install Flash Attention 3 (required for H100/H200)
-        uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/test/cu128
+        uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/test/cu130
 
         # 4. Install PyTorch nightly, vllm, and xformers
+
         # torchvision must be installed from the nightly channel alongside torch
         # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
         uv pip install torch torchvision vllm xformers --pre \
-          --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+          --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
           --index-strategy unsafe-best-match
         uv pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       runner: linux.g5.48xlarge.nvidia.gpu
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -55,7 +55,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         python -m pip install --force-reinstall --pre \
-          torch --index-url https://download.pytorch.org/whl/nightly/cu128
+          torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -55,7 +55,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         python -m pip install --force-reinstall --pre \
-          torch --index-url https://download.pytorch.org/whl/nightly/cu128
+          torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies and lint utilities
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
-          python -m pip install --force-reinstall --pre --index-url https://download.pytorch.org/whl/nightly/cu128 torch
+          python -m pip install --force-reinstall --pre --index-url https://download.pytorch.org/whl/nightly/cu130 torch
           pre-commit install-hooks
 
       - name: Get changed files

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -66,9 +66,9 @@ jobs:
             "name": "cuda",
             "runner": "${CUDA_RUNNER}",
             "gpu-arch-type": "cuda",
-            "gpu-arch-version": "12.8",
+            "gpu-arch-version": "13.0",
             "docker-image": "torchtitan-ubuntu-20.04-clang12",
-            "index-url": "https://download.pytorch.org/whl/nightly/cu128",
+            "index-url": "https://download.pytorch.org/whl/nightly/cu130",
             "torch-version": ""
           }
           EOF

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ pip install --pre torchdata --index-url https://download.pytorch.org/whl/nightly
 
 ### Nightly builds
 
-This method requires the nightly build of PyTorch. You can replace `cu128` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).
+This method requires the nightly build of PyTorch. You can replace `cu130` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).
 
 ```sh
-pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 --force-reinstall
-pip install --pre torchtitan --index-url https://download.pytorch.org/whl/nightly/cu128
+pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu130 --force-reinstall
+pip install --pre torchtitan --index-url https://download.pytorch.org/whl/nightly/cu130
 ```
 
 ### Stable releases

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,8 +8,8 @@ Currently we follow a lightweight release process.
   - In the tag section, add a new tag for the release. The tag should use the version number with a `v` prefix (for example, `v0.1.0`). Make sure to select the `main` branch as the target.
   - In the release notes
     - include proper nightly versions for `torch` and `torchao`, which can be found in [latest CI](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu.yaml) test log "Run script in container" section. E.g.
-        - "Successfully installed ... `torch-2.8.0.dev20250605+cu128`"
-        - "Successfully installed `torchao-0.12.0.dev20250605+cu128`"
+        - "Successfully installed ... `torch-2.8.0.dev20250605+cu130`"
+        - "Successfully installed `torchao-0.12.0.dev20250605+cu130`"
     - describe the release at a high level compared to the last release, e.g.
       - "added an experiment for multimodal LLM training"
       - or simply state "this is a regular release"
@@ -22,6 +22,6 @@ The general instruction on managing releases can be found [here](https://docs.gi
 ## Nightly Builds
 Nightly builds are automatically triggered by a [nightly GitHub workflow](/.github/workflows/build_whl_and_publish.yaml) and can be installed by
 ```bash
-pip install --pre torchtitan --index-url https://download.pytorch.org/whl/nightly/cu128
+pip install --pre torchtitan --index-url https://download.pytorch.org/whl/nightly/cu130
 ```
-You can replace `cu128` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).
+You can replace `cu130` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).

--- a/torchtitan/experiments/graph_trainer/.claude/nightly_scout.md
+++ b/torchtitan/experiments/graph_trainer/.claude/nightly_scout.md
@@ -198,7 +198,7 @@ hash from `torch/version.py`:
 
 ```bash
 pip download torch==<version> \
-    --index-url https://download.pytorch.org/whl/nightly/cu128 \
+    --index-url https://download.pytorch.org/whl/nightly/cu130 \
     --no-deps -d /tmp/torch_wheel --python-version 3.12 --only-binary :all:
 
 unzip -p /tmp/torch_wheel/torch-<version>-cp312-cp312-manylinux_2_28_x86_64.whl \

--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -16,11 +16,11 @@ The goal is to give users more explicit control over the compiler stack in terms
 
 ### Prerequisites
 
-GraphTrainer requires the latest PyTorch nightly, which can be installed (e.g., for CUDA 12.8) via:
+GraphTrainer requires the latest PyTorch nightly, which can be installed (e.g., for CUDA 13.0) via:
 ```bash
-pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128 --force-reinstall
+pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu130 --force-reinstall
 ```
-You can replace `cu128` with another version of CUDA or an AMD GPU (e.g. `rocm6.3`).
+You can replace `cu130` with another version of CUDA or an AMD GPU (e.g. `rocm6.3`).
 
 ### Quick Start
 

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -311,11 +311,11 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.4749956130981445""")
         assert_expected_inline(
             model_hash,
-            """2dcc779af7bc5aeae2d39eff3898180a8156549b2f1582d77e8db237689e0c67""",
+            """09bb71bafdd888cf46c5f5c7ccddb5441266f843f9a2255d1569121613035be9""",
         )
         assert_expected_inline(
             grad_hash,
-            """b3f5b911dea6c9d36f508b08300220d7f39f142a7c34a49b7ef2543abb2065dc""",
+            """8bb6e647c3edaa229cc65872086ccc5c4e1b7f1647bb01da4506ab777a64a0db""",
         )
 
     # TODO: OOMs during flex_attention compilation on A100 GPUs.

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -38,7 +38,7 @@ uv pip install pygtrie portpicker
 2. Install Flash Attention 3 kernels:
 ```bash
 # Flash Attention v3 (recommended for H100/H200 and newer GPUs)
-uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/test/cu128
+uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/test/cu130
 ```
 
 **NOTE:** FA2 is bundled with PyTorch and will be used automatically on older GPUs (e.g. A100) that don't support FA3.
@@ -52,11 +52,11 @@ uv pip install --no-deps "git+https://github.com/thinking-machines-lab/batch_inv
 ```bash
 # Install vllm with nightly torch
 uv pip install torch vllm torchcomms  --pre \
---extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+--extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
 --index-strategy unsafe-best-match
 ```
 
-**NOTE:** The pre-built vLLM wheels are only compatible with CUDA 12.8, though they should work with most older CUDA versions. Alternatively, you can install the corresponding vLLM pre-built wheels directly from https://download.pytorch.org/whl/nightly/cu128, for example: `uv pip install vllm-1.0.0.dev20260219+cu130-<suffix>.whl`. Ensure the build version number (e.g., `dev20260219`) matches your PyTorch nightly installation.
+**NOTE:** The pre-built vLLM wheels are only compatible with CUDA 13.0, though they should work with most older CUDA versions. Alternatively, you can install the corresponding vLLM pre-built wheels directly from https://download.pytorch.org/whl/nightly/cu130, for example: `uv pip install vllm-1.0.0.dev20260219+cu130-<suffix>.whl`. Ensure the build version number (e.g., `dev20260219`) matches your PyTorch nightly installation.
 
 
 5. Install TorchTitan in editable mode:


### PR DESCRIPTION
CUDA 12.8 is deprecated so we need 13 to get new nightlies in TorchTitan