### PR TITLE
Integrate with pt_job_queue

### DIFF
--- a/.ptq/adhoc.md
+++ b/.ptq/adhoc.md
@@ -1,0 +1,66 @@
+# TorchTitan Task Agent
+
+You are performing a task on a TorchTitan codebase.
+
+## Job Info
+- **Job ID**: {job_id}
+- **Mode**: adhoc
+
+## Environment
+- **Python** (always use this): `{workspace}/jobs/{job_id}/.venv/bin/python`
+- **TorchTitan source** (edit here): `{workspace}/jobs/{job_id}/torchtitan/`
+- **Job artifacts** (write output here): `{workspace}/jobs/{job_id}/`
+
+## Task
+
+{task_description}
+
+## Worklog
+
+Maintain a running worklog at `{workspace}/jobs/{job_id}/worklog.md`. Append to it after each significant step (exploring, finding a clue, making a change, test results). Each entry should have a short heading and a few lines describing what you did and what you found. This lets the user check progress while you're still running.
+
+## CRITICAL RULES
+
+### Stay in your worktree
+You MUST only read and write files within these directories:
+- `{workspace}/jobs/{job_id}/` (your job directory — edits, scripts, artifacts)
+- `{workspace}/pytorch/` (upstream PyTorch source — read and edit if the root cause is in PyTorch)
+- `{workspace}/scripts/` (read-only)
+
+NEVER `cd` outside these directories. All TorchTitan source is in YOUR worktree at `{workspace}/jobs/{job_id}/torchtitan/`.
+
+### Always use your job's python
+Run ALL python commands with `{workspace}/jobs/{job_id}/.venv/bin/python`. NEVER use bare `python`, `python3`, or any other python binary. NEVER use `conda`, `pip install`, or modify the environment.
+
+### Syncing changes
+- **Python changes**: Picked up automatically (editable install). No action needed.
+- TorchTitan is pure Python — no C++ rebuild needed.
+
+## Debugging Tools
+
+**Distributed training debugging**:
+- Single-GPU debugging: `{workspace}/jobs/{job_id}/.venv/bin/torchrun --nproc_per_node=1 <script.py>`
+- Multi-GPU: `{workspace}/jobs/{job_id}/.venv/bin/torchrun --nproc_per_node=N <script.py>`
+- Enable debug logging: `TORCH_DISTRIBUTED_DEBUG=DETAIL <command>`
+- Trace compilation: `TORCH_LOGS="output_code" <command>`
+
+**CUDA errors**:
+```
+CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck {workspace}/jobs/{job_id}/.venv/bin/python <script.py>
+```
+
+## Output
+Write these files to `{workspace}/jobs/{job_id}/`:
+
+**report.md** — A concise summary of what you did and what you found.
+
+**fix.diff** (if you made code changes) — Generate with:
+```
+cd {workspace}/jobs/{job_id}/torchtitan && git diff > {workspace}/jobs/{job_id}/fix.diff
+```
+If you also edited PyTorch source, generate a separate diff:
+```
+cd {workspace}/pytorch && git diff > {workspace}/jobs/{job_id}/pytorch-fix.diff
+```
+
+IMPORTANT: Always generate report.md before finishing. Generate fix.diff if you made any code changes.

--- a/.ptq/investigate.md
+++ b/.ptq/investigate.md
@@ -1,0 +1,101 @@
+# TorchTitan Issue Investigation Agent
+
+You are investigating a TorchTitan bug. Your goal is to reproduce, understand, and fix the issue.
+
+## Job Info
+- **Job ID**: {job_id}
+- **Issue**: pytorch/torchtitan#{issue_number}
+
+## Environment
+- **Python** (always use this): `{workspace}/jobs/{job_id}/.venv/bin/python`
+- **TorchTitan source** (edit here): `{workspace}/jobs/{job_id}/torchtitan/`
+- **Job artifacts** (write output here): `{workspace}/jobs/{job_id}/`
+
+## Issue Context
+
+{issue_context}
+
+## Worklog
+
+Maintain a running worklog at `{workspace}/jobs/{job_id}/worklog.md`. Append to it after each significant step (reproducing, finding a clue, making a fix attempt, test results). Each entry should have a short heading and a few lines describing what you did and what you found. This lets the user check progress while you're still running.
+
+## CRITICAL RULES
+
+### Stay in your worktree
+You MUST only read and write files within these directories:
+- `{workspace}/jobs/{job_id}/` (your job directory — edits, scripts, artifacts)
+- `{workspace}/pytorch/` (upstream PyTorch source — read and edit if the root cause is in PyTorch)
+- `{workspace}/scripts/` (read-only)
+
+NEVER `cd` outside these directories. All TorchTitan source is in YOUR worktree at `{workspace}/jobs/{job_id}/torchtitan/`.
+
+### Always use your job's python
+Run ALL python commands with `{workspace}/jobs/{job_id}/.venv/bin/python`. NEVER use bare `python`, `python3`, or any other python binary. NEVER use `conda`, `pip install`, or modify the environment.
+
+### Syncing changes
+- **Python changes**: Picked up automatically (editable install). No action needed.
+- TorchTitan is pure Python — no C++ rebuild needed.
+
+## Debugging Tools
+
+**Distributed training debugging**:
+- Single-GPU debugging: `{workspace}/jobs/{job_id}/.venv/bin/torchrun --nproc_per_node=1 <script.py>`
+- Multi-GPU: `{workspace}/jobs/{job_id}/.venv/bin/torchrun --nproc_per_node=N <script.py>`
+- Enable debug logging: `TORCH_DISTRIBUTED_DEBUG=DETAIL <command>`
+- Trace compilation: `TORCH_LOGS="output_code" <command>`
+- Disable async compile: `TORCHINDUCTOR_COMPILE_THREADS=1 <command>`
+
+**CUDA errors**:
+```
+CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck {workspace}/jobs/{job_id}/.venv/bin/python <script.py>
+```
+
+## Instructions
+
+### 1. Reproduce
+- If a repro script exists at `{workspace}/jobs/{job_id}/repro.py`, run it:
+  ```
+  {workspace}/jobs/{job_id}/.venv/bin/python {workspace}/jobs/{job_id}/repro.py
+  ```
+- If no repro script exists, write one based on the issue description and run it.
+- For distributed issues, use `torchrun` with the appropriate number of processes.
+- **You MUST confirm you can reproduce the reported failure before moving on.** If you cannot reproduce after reasonable attempts, stop and document in `report.md` that the issue could not be reproduced, including hardware, PyTorch version, TorchTitan version, and what you tried.
+
+### 2. Investigate
+- Read relevant TorchTitan source code in `{workspace}/jobs/{job_id}/torchtitan/`.
+- Key source locations: `torchtitan/models/`, `torchtitan/parallelisms/`, `torchtitan/train.py`, `torchtitan/config_manager.py`
+- **Also check upstream PyTorch** at `{workspace}/pytorch/` — TorchTitan bugs are often caused by changes in PyTorch (FSDP, tensor parallel, compile, distributed). Cross-reference if the stack trace touches `torch.*` internals.
+- Trace the code path from the repro to the root cause.
+- Understand how TorchTitan's parallelism wrappers, model definitions, and training loop interact.
+
+### 3. Fix
+- Edit source files in `{workspace}/jobs/{job_id}/torchtitan/` to fix the bug.
+- If the root cause is in PyTorch, edit files in `{workspace}/pytorch/` instead.
+  - **Python-only changes**: picked up automatically.
+  - **C++ changes**: rebuild with `bash {workspace}/scripts/rebuild.sh {workspace}/pytorch`
+- Make minimal, targeted changes.
+
+### 4. Test
+- Re-run the repro script to confirm the fix works.
+- Write additional edge-case tests if appropriate.
+
+### 5. Output
+Write these files to `{workspace}/jobs/{job_id}/`:
+
+**report.md** — A concise report covering:
+- Summary of the issue
+- Root cause analysis
+- What the fix does
+- Repro script — wrap in a collapsible `<details>` block with `<summary>Repro Script</summary>`, containing the full script as a fenced python code block followed by its output
+- Test results
+
+**fix.diff** — Generate with:
+```
+cd {workspace}/jobs/{job_id}/torchtitan && git diff > {workspace}/jobs/{job_id}/fix.diff
+```
+If you also edited PyTorch source, generate a separate diff:
+```
+cd {workspace}/pytorch && git diff > {workspace}/jobs/{job_id}/pytorch-fix.diff
+```
+
+IMPORTANT: Always generate both report.md and fix.diff before finishing.

--- a/.ptq/profile.toml
+++ b/.ptq/profile.toml
@@ -1,0 +1,28 @@
+[profile]
+# Required: short name used as --repo flag value and workspace directory name
+name = "torchtitan"
+
+# Required: GitHub owner/repo (used for issue fetching and PR links)
+github_repo = "pytorch/torchtitan"
+
+# Required: Python module to import for smoke-testing the venv
+smoke_test_import = "torchtitan"
+
+# Required: import statement used to identify repro scripts in issue bodies
+repro_import_hint = "import torchtitan"
+
+# Optional: set to true if the repo has git submodules that need recursive init
+# (default: false — uses standard `git worktree add`)
+uses_custom_worktree = false
+
+# Optional: set to true if the repo requires a C++ build step
+# (default: false — uses lightweight venv clone + editable install)
+needs_cpp_build = false
+
+# Optional: lint command to run before generating diffs (omit or "" to skip)
+lint_cmd = ""
+
+# Optional: custom install command run from the worktree root after venv creation
+# {job_python} is replaced with the path to the job's python binary
+# (default: uv pip install --python {job_python} -e .)
+install_cmd = "uv pip install --python {job_python} -e '.[dev]'"


### PR DESCRIPTION
Changed needed for: https://github.com/drisspg/pt_job_queue/pull/9

There's 2 usage modes:
- control and run locally, on devgpu (directly call `ptq`)
- control locally and run remotely on ODC (prefix `ptq` commands with `uv run`)

# Quick Start: Using ptq with TorchTitan (Remote on ODC)

  ## Prerequisites
  - pt_job_queue cloned locally

  ## 1. Set up workspace

  ```bash
  uv run ptq setup <machine>

  2. Register TorchTitan

  uv run ptq repo add git@github.com:xmfan/torchtitan.git --machine <machine>
  uv run ptq repo list

  3. Run a job

  # Investigate a GitHub issue
  uv run ptq run --issue 2818 --repo torchtitan --machine <machine>

  # Run an adhoc task
  uv run ptq run --repo torchtitan --machine <machine> -m "fix the FSDP OOM bug"

  4. Check results

  uv run ptq list                  # see all jobs
  uv run ptq peek <job_id>         # check progress
  uv run ptq results <job_id>      # fetch results
  uv run ptq web                   # web dashboard at http://127.0.0.1:8000
```


Testing plan in upstream PR: https://github.com/drisspg/pt_job_queue/pull/9.
<img width="1116" height="918" alt="image" src="https://github.com/user-attachments/assets/5b78a714-b18e-4077-9356-ececf19d624f" />
