### PR TITLE
Minor improvements to the tlparse info 

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -509,7 +509,17 @@ def trace_train_step(fn: Callable) -> Callable[..., TracedResult]:
             with stateless._reparametrize_module(module, state):
                 return fn(module, *user_args)
 
-        return minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
+        traced_result = minimal_fx_tracer(_stateless_fn)(
+            extract_module_state(module), *args
+        )
+
+        # Log the raw traced graph before GraphTrainer constructs default passes.
+        from torchtitan.experiments.graph_trainer.tlparse_utils import (
+            tlparse_log_traced_result,
+        )
+
+        tlparse_log_traced_result(traced_result)
+        return traced_result
 
     return _trace_with_module
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -65,7 +65,6 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     return [
-        functools.partial(tlparse_log_graph_pass, graph_name="make_fx_graph_traced"),
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
@@ -121,6 +120,11 @@ def construct_default_graph_passes(
                 tensor_input_indices=traced_result.tensor_input_indices,
             )
         )
+    passes.append(
+        functools.partial(
+            tlparse_log_graph_pass, graph_name="make_fx_graph_after_passes"
+        )
+    )
     return passes
 
 

--- a/torchtitan/experiments/graph_trainer/tlparse_utils.py
+++ b/torchtitan/experiments/graph_trainer/tlparse_utils.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import json
+from typing import Any, TYPE_CHECKING
+
+from torch._logging import trace_structured
+
+if TYPE_CHECKING:
+    from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+        SubclassLayout,
+        TracedResult,
+    )
+
+
+def _tlparse_log_string_artifact(name: str, payload: str) -> None:
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": name,
+            "encoding": "string",
+        },
+        payload_fn=lambda: payload,
+        expect_trace_id=False,
+    )
+
+
+def _summarize_subclass_layouts(
+    layouts: dict[int, SubclassLayout],
+) -> dict[int, dict[str, Any]]:
+    summary = {}
+    for idx, layout in layouts.items():
+        meta = layout.meta
+        summary[idx] = {
+            "num_tensors": layout.num_tensors,
+            "tensor_subclass": None if meta is None else meta.cls.__name__,
+            "attrs": None if meta is None else meta.attrs,
+            "outer_size": None if meta is None else list(meta.outer_size),
+            "outer_stride": None if meta is None else list(meta.outer_stride),
+        }
+    return summary
+
+
+def tlparse_log_traced_result(traced_result: TracedResult) -> None:
+    """Log the traced graph and metadata summary to tlparse.
+
+    Call this after ``trace_train_step`` / ``minimal_fx_tracer`` to emit
+    both the raw FX graph and a JSON summary of the ``TracedResult``.
+    """
+    _tlparse_log_string_artifact(
+        "make_fx_graph_traced",
+        traced_result.gm.print_readable(
+            print_output=False,
+            include_stride=True,
+            include_device=True,
+            expanded_def=True,
+        ),
+    )
+    summary = {
+        "torch_version": __import__("torch").__version__,
+        "torch_cuda_version": __import__("torch").version.cuda,
+        "torch_git_version": __import__("torch").version.git_version,
+        "num_flat_inputs": traced_result.num_flat_inputs,
+        "num_flat_outputs": traced_result.num_flat_outputs,
+        "num_static_inputs": traced_result.num_static_inputs,
+        "state_fqns": traced_result.state_fqns,
+        "input_subclass_layouts": _summarize_subclass_layouts(
+            traced_result.input_subclass_layouts
+        ),
+        "output_subclass_layouts": _summarize_subclass_layouts(
+            traced_result.output_subclass_layouts
+        ),
+        "output_spec": repr(traced_result.output_spec),
+    }
+    _tlparse_log_string_artifact(
+        "make_fx_traced_result_summary", json.dumps(summary, indent=2, sort_keys=True)
+    )


### PR DESCRIPTION
We also want to log the TracedResult artifact which explains what are the state fqns, input layouts, and torch version we are running. Also added extra tlparse entry after all default passes run. 

<img width="1726" height="821" alt="Screenshot 2026-04-13 at 3 18 47 PM" src="https://github.com/user-attachments/assets/bc1537c8-50c9-4945-8995-2f413011b1c2" />


