### PR TITLE
[Bug][EP][compile] non_blocking=True D2H race in input_splits under per-layer torch.compile

### DIFF
--- a/tests/unit_tests/test_compile_moe.py
+++ b/tests/unit_tests/test_compile_moe.py
@@ -9,7 +9,7 @@ import unittest
 import torch
 
 from torchtitan.config import CompileConfig
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
@@ -47,12 +47,13 @@ class TestApplyCompile(unittest.TestCase):
         Calls apply_compile multiple times, as in the case with PP.
         But patches should only happen once
         """
-        unused_model1 = TinyModel(num_layers=2, dim=128)
-        unused_model2 = TinyModel(num_layers=2, dim=128)
         compile_config = CompileConfig(backend="eager")
 
-        apply_compile_sparse(unused_model1, compile_config, ep_enabled=True)
-        apply_compile_sparse(unused_model2, compile_config, ep_enabled=True)
+        model1 = TinyModel(num_layers=2, dim=128)
+        model2 = TinyModel(num_layers=2, dim=128)
+
+        apply_compile(model1, compile_config)
+        apply_compile(model2, compile_config)
 
         from torchtitan.models.common import moe as moe_module
 
@@ -74,9 +75,7 @@ class TestApplyCompile(unittest.TestCase):
             w1, w2, w3, x, num_tokens_per_expert
         )
 
-        print(f"Input shape: {x.shape}")
-        print(f"Output shape: {output.shape}")
-        print(f"Num tokens per expert: {num_tokens_per_expert}")
+        self.assertEqual(output.shape, x.shape)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -7,12 +7,8 @@
 import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    CheckpointWrapper,
-)
 
 from torchtitan.config import CompileConfig
-from torchtitan.models.common import moe as moe_module
 from torchtitan.tools.logging import logger
 
 
@@ -24,43 +20,13 @@ FakeTensorMode.__init__ = torch.compiler.disable(  # type: ignore[method-assign]
 )
 
 
-def apply_compile_dense(model: nn.Module, compile_config: CompileConfig) -> None:
+def apply_compile(model: nn.Module, compile_config: CompileConfig) -> None:
     """
     Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
     repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for dense (non-MoE) models. It compiles each TransformerBlock as a whole.
     """
-    # Skip replaying forward side effects (e.g. RoPE cache updates) during
-    # the AC recompute in backward. Eager AC replays the forward python
-    # side-effects in backward, but torch.compile has no easy way to reapply
-    # python mutations in the backward. Setting this flag accepts this eager
-    # and compile divergence by skipping reapplication of side effects.
-    torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = (
-        True  # pyrefly: ignore [bad-assignment]
-    )
-
-    # pyrefly: ignore [missing-attribute]
-    for layer_id, transformer_block in model.layers.named_children():
-        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    logger.info("Compiling each TransformerBlock with torch.compile")
-
-
-def apply_compile_sparse(
-    model: nn.Module, compile_config: CompileConfig, ep_enabled: bool
-) -> None:
-    """
-    Apply torch.compile to each TransformerBlock, which makes compilation efficient due to
-    repeated structure. Alternatively one can compile the whole model (after applying DP).
-
-    This is for MoE (sparse) models. It compiles sub-modules individually to avoid
-    graph breaks from FSDP(GroupedExperts).
-    """
-    # Needed for torch.compile to avoid graph breaking on dynamic shapes in
-    # token-choice MoE, but it is experimental.
+    # Needed for torch.compile to handle data-dependent dynamic shapes in
+    # token-choice MoE dispatch. Harmless for dense models.
     torch._dynamo.config.capture_scalar_outputs = True
     # Skip replaying forward side effects (e.g. RoPE cache updates) during
     # the AC recompute in backward. Eager AC replays the forward python
@@ -73,77 +39,6 @@ def apply_compile_sparse(
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
-        if transformer_block.moe_enabled:
-            # If it is a MoE layer, FSDP(GroupedExperts) will cause a graph break
-            # So we must weave compile wrappers around those FSDP hooks to
-            # prevent AC from falling back the whole graph to eager.
-            # TODO: Fix Compile(AC(graph break))
-
-            if isinstance(transformer_block, CheckpointWrapper):
-                # TODO: Make CheckpointWrapper a transparent wrapper
-                # unwrap so that .named_children() works
-                block = transformer_block._checkpoint_wrapped_module
-            else:
-                block = transformer_block
-
-            for attr_name, submod in block.named_children():
-                assert getattr(block, attr_name) == getattr(
-                    transformer_block, attr_name
-                )
-
-                if isinstance(submod, moe_module.MoE):
-                    # avoid graph breaking on the GroupedExperts' FSDP hooks
-                    # by wrapping each submod's forward instead of their __call__
-                    moe = submod
-                    for attr_name, submod in moe.named_children():
-                        if attr_name == "experts":
-                            # NOTE: We don't compile token dispatch and token combine due to an issue on B200:
-                            # https://github.com/pytorch/torchtitan/issues/1940
-                            continue
-                        submod.compile(backend=compile_config.backend, fullgraph=True)
-                else:
-                    submod.compile(backend=compile_config.backend, fullgraph=True)
-        else:
-            # If it's not a MoE layer, there is no FSDP(GroupedExperts)
-            # So we can compile the whole block
-            transformer_block.compile(
-                backend=compile_config.backend,
-                fullgraph=True,
-            )
-
-        # pyrefly: ignore [missing-attribute]
-        model.layers.register_module(layer_id, transformer_block)
-
-    # Patch some globals only once (apply_compile_sparse is called multiple times for PP setup)
-    already_patched = (
-        "_run_experts_grouped_mm_dynamic"
-        in moe_module._run_experts_grouped_mm.__qualname__
-    )
-    if not already_patched:
-        moe_module._run_experts_grouped_mm = torch.compile(
-            moe_module._run_experts_grouped_mm,
-            backend=compile_config.backend,
-            fullgraph=True,
-        )
-
-        if ep_enabled:
-            compiled_fn = moe_module._run_experts_grouped_mm
-
-            # keep function logic in sync with `already_patched` above
-            def _run_experts_grouped_mm_dynamic(
-                w1: torch.Tensor,
-                w2: torch.Tensor,
-                w3: torch.Tensor,
-                x: torch.Tensor,
-                num_tokens_per_expert: torch.Tensor,
-            ) -> torch.Tensor:
-                # dynamic number of tokens in expert parallel
-                torch._dynamo.mark_dynamic(x, 0)
-                return compiled_fn(w1, w2, w3, x, num_tokens_per_expert)
-
-            moe_module._run_experts_grouped_mm = _run_experts_grouped_mm_dynamic
-
-    # NOTE: We don't compile for loop code path due to an issue with unbacked symints:
-    # https://github.com/pytorch/pytorch/issues/166460
+        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
 
     logger.info("Compiling each TransformerBlock with torch.compile")

--- a/torchtitan/distributed/expert_parallel.py
+++ b/torchtitan/distributed/expert_parallel.py
@@ -37,10 +37,10 @@ def _generate_permute_indices(
     Output layout: (e0,r0), (e0,r1), ..., (e1,r0), (e1,r1), ...  (expert-major)
     """
     device = tokens_per_expert_group.device
-    total = tokens_per_expert_group.sum()
 
     # [R, E] matrix of token counts per (rank, expert)
     t_mat = tokens_per_expert_group.view(num_ranks, experts_per_rank)
+    num_tokens_per_expert = t_mat.sum(0)
 
     # Where each (r, e) segment starts in the input (rank-major order)
     input_starts = (tokens_per_expert_group.cumsum(0) - tokens_per_expert_group).view(
@@ -57,13 +57,16 @@ def _generate_permute_indices(
         segment_lens
     )
     output_starts = segment_lens.cumsum(0) - segment_lens
+    # seg_ids.shape[0] == segment_lens.sum(), but reuses the unbacked symint
+    # already created by repeat_interleave. Computing the sum separately would
+    # introduce a second symint for the same value, producing an Eq(u1, u2)
+    # constraint that inductor cannot lower.
     permuted_indices = (
         input_starts[seg_ids]
-        + torch.arange(total, device=device)  # pyrefly: ignore [no-matching-overload]
+        + torch.arange(seg_ids.shape[0], device=device)
         - output_starts[seg_ids]
     )
 
-    num_tokens_per_expert = t_mat.sum(0)
     return permuted_indices, num_tokens_per_expert
 
 

--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -26,7 +26,7 @@ from torch.distributed.tensor.parallel import (
 from torchtitan.config import ParallelismConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.tensor_parallel import NoParallel
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ def parallelize_qwen3(
         and compile_config.enable
         and "model" in compile_config.components
     ):
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     return model
 

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -27,7 +27,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.llama3.parallelize import disable_fsdp_gradient_division
@@ -93,7 +93,7 @@ def parallelize_hf_transformers(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     dp_mesh_dim_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/experiments/vlm/infra/parallelize.py
+++ b/torchtitan/experiments/vlm/infra/parallelize.py
@@ -20,7 +20,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.models.llama3.parallelize import disable_fsdp_gradient_division
 from torchtitan.protocols.model_converter import ModelConvertersContainer
@@ -75,8 +75,8 @@ def parallelize_vlm(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if compile_config.enable:
-        apply_compile_dense(model, compile_config)
-        apply_compile_dense(model.encoder, compile_config)
+        apply_compile(model, compile_config)
+        apply_compile(model.encoder, compile_config)
 
     names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
     apply_fsdp(

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -33,8 +33,9 @@ def _run_experts_for_loop(
 
     # a tuple of tensors indexed by experts
     # each with shape (tokens_per_expert(varying), dim)
+    # requires https://github.com/pytorch/pytorch/pull/179315 for torch.compile to work
     x_splits = torch.split(
-        x[: sum(num_tokens_per_expert_list)],
+        x,
         split_size_or_sections=num_tokens_per_expert_list,
         dim=0,
     )

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -25,7 +25,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
@@ -134,7 +134,7 @@ def parallelize_deepseekv3(
         )
 
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -28,7 +28,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     ExpertParallel,
@@ -124,7 +124,7 @@ def parallelize_gptoss(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -31,7 +31,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_dense
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
@@ -115,7 +115,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_dense(model, compile_config)
+        apply_compile(model, compile_config)
 
     names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
     dp_mesh = parallel_dims.get_mesh(names)

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -30,7 +30,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.expert_parallel import (
     DeepEPExpertParallel,
@@ -156,7 +156,7 @@ def parallelize_llama(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -31,7 +31,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 
-from torchtitan.distributed.compile import apply_compile_sparse
+from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_attention_module
 from torchtitan.distributed.tensor_parallel import NoParallel
 from torchtitan.models.llama4.parallelize import apply_fsdp, apply_moe_ep_tp
@@ -121,7 +121,7 @@ def parallelize_qwen3(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
-        apply_compile_sparse(model, compile_config, parallel_dims.ep_enabled)
+        apply_compile(model, compile_config)
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]


### PR DESCRIPTION
this is needed for per-layer compilation https://github.com/pytorch/torchtitan/pull/2741

repro command: `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b ./run_train.sh --compile.enable --compile.components model,loss  --parallelism.expert_parallel_degree 4 --training.steps 20`

error: `RuntimeError: Eq(u27 + u28 + u29 + u30, 98304)`

clauded guessed root cause: 
```
inductor does not insert a proper CUDA synchronization between a              
  non_blocking=True D2H copy and the subsequent .item() call that reads the CPU tensor

torchtitan/distributed/expert_parallel.py:166 (and the identical pattern at line 504 for TorchAOExpertParallel):        
  .to(torch.device("cpu"), non_blocking=True)
```

raw error stack:
```
      File "torch/distributed/elastic/multiprocessing/errors/__init__.py", line 367, in wrapper                             
        return f(*args, **kwargs)                                                                                           
      File "torchtitan/trainer.py", line 843, in train                                                                      
        self.train_step(data_iterator)                                                                                      
      File "torchtitan/trainer.py", line 753, in train_step                                                                 
        loss = self.forward_backward_step(                                                                                  
      File "torchtitan/trainer.py", line 701, in forward_backward_step                                                      
        pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)                                                     
      File "torch/nn/modules/module.py", line 1778, in _wrapped_call_impl                                                   
        return self._call_impl(*args, **kwargs)                                                                             
      File "torch/nn/modules/module.py", line 1884, in _call_impl                                                           
        return inner()                                                                                                      
      File "torch/nn/modules/module.py", line 1832, in inner                                                                
        result = forward_call(*args, **kwargs)
      File "torchtitan/models/common/decoder.py", line 134, in forward                                                      
        h = layer(h, self.freqs_cis, attention_masks, positions)                                                            
      File "torch/nn/modules/module.py", line 1776, in _wrapped_call_impl                                                   
        return self._compiled_call_impl(*args, **kwargs)                                                                    
      File "torch/_dynamo/eval_frame.py", line 1041, in compile_wrapper                                                     
        return fn(*args, **kwargs)                                                                                          
      File "torch/nn/modules/module.py", line 1884, in _call_impl                                                         
        return inner()                                                                                                      
      File "torch/nn/modules/module.py", line 1832, in inner                                                              
        result = forward_call(*args, **kwargs)                                                                              
      File "torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py", line 143, in forward                         
      File "torch/_dynamo/eval_frame.py", line 1277, in _fn                                                                 
        return fn(*args, **kwargs)                                                                                          
      File "torch/_functorch/aot_autograd.py", line 1273, in forward                                                        
        return compiled_fn(full_args)                                                                                       
      File "torch/_functorch/_aot_autograd/runtime_wrappers.py", line 777, in runtime_wrapper                             
        all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)                                                 
      File "torch/_functorch/_aot_autograd/runtime_wrappers.py", line 506, in run                                         
        return call_func_at_runtime_with_args(                                                                              
      File "torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args                         
        out = normalize_as_list(f(args))                                                                                    
      File "torch/_functorch/_aot_autograd/utils.py", line 93, in g                                                       
        return f(*args)                                                                                                     
      File "torch/autograd/function.py", line 596, in apply                                                               
        return super().apply(*args, **kwargs)                                                                               
      File "torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2844, in forward
        fw_outs = call_func_at_runtime_with_args(                                                                           
      File "torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args                           
        out = normalize_as_list(f(args))
      File "torch/_functorch/_aot_autograd/runtime_wrappers.py", line 850, in wrapper                                       
        return compiled_fn(runtime_args)                                                                                    
      File "<subclass_wrapper>", line 42, in inner_fn
      File "torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1055, in inner_fn                                     
        outs = compiled_fn(args)                                                                                            
      File "torch/_inductor/output_code.py", line 710, in __call__
        return self.current_callable(inputs)                                                                                
      File "torch/_inductor/utils.py", line 3495, in run                                                                  
        out = model(new_inputs)                                                                                             
      File "/tmp/torchinductor_weif/.../c22q3ucc33sz....py", line 2394, in call
        raise RuntimeError('Eq(u27 + u28 + u29 + u30, 98304)')                                                              
    RuntimeError: Eq(u27 + u28 + u29 + u30, 98304)   
```