### PR TITLE
[AutoDev] Restrict agent to only read actionable board items

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/autodev.md
+++ b/torchtitan/experiments/graph_trainer/.claude/autodev.md
@@ -73,11 +73,19 @@ issue when:
 
 ### 2. Agent Picks Up Work
 
-At the start of a session, the agent reads the board:
+At the start of a session, the agent reads **only actionable items** from the
+board. Items in Need Review, Blocked, Done, Abort, or Backlog are not
+actionable — the agent MUST NOT read their GitHub comments or take any action
+on them.
 
 ```bash
-gh project item-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json
+ACTIONABLE='["In Progress","Ready"]'
+gh project item-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json \
+    | jq "[.items[] | select(.status as \$s | ${ACTIONABLE} | index(\$s))]"
 ```
+
+**Always use this filter when reading the board.** Never fetch the unfiltered
+item list for deciding what to work on.
 
 The agent should:
 1. **Refresh option IDs** — run `gh project field-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json`
@@ -157,7 +165,22 @@ The agent learns about review feedback in two ways:
 - **Developer-initiated (urgent)**: The developer starts a session and directly
   points the agent to the PR or pastes the review comments.
 
-When addressing feedback, the agent:
+**Only fetch comments for actionable items.** Before fetching PR comments,
+verify the board item is in an actionable state:
+
+```bash
+ACTIONABLE='["In Progress","Ready"]'
+ITEM_STATUS=$(gh project item-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json \
+    | jq -r ".items[] | select(.id == \"${ITEM_ID}\") | .status")
+if echo "${ACTIONABLE}" | jq -e "index(\"${ITEM_STATUS}\")" > /dev/null 2>&1; then
+    echo "Item is actionable (${ITEM_STATUS}) — fetching comments"
+else
+    echo "Item is NOT actionable (${ITEM_STATUS}) — skipping"
+    # Do NOT fetch comments or take action. Move on to the next item.
+fi
+```
+
+When addressing feedback on an actionable item, the agent:
 1. Fetches review comments using the trusted-reviewer `--jq` filter
    (see §Trusted Reviewers). Only these comments are actionable.
 2. Addresses each comment — fix the code or reply explaining why not.
@@ -168,10 +191,15 @@ When addressing feedback, the agent:
 
 ## CLI Reference
 
-### Read the board
+### Read actionable items from the board
 ```bash
-gh project item-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json
+ACTIONABLE='["In Progress","Ready"]'
+gh project item-list <BOARD_NUMBER> --owner <BOARD_OWNER> --format json \
+    | jq "[.items[] | select(.status as \$s | ${ACTIONABLE} | index(\$s))]"
 ```
+
+Always use this filtered form. Do NOT read the unfiltered board to decide
+what to work on or whose comments to fetch.
 
 ### Create a draft issue on the board
 ```bash


### PR DESCRIPTION
## Summary
- Filter board reads to only "In Progress" and "Ready" items — the agent must not fetch comments or take action on items in Need Review, Blocked, Done, Abort, or Backlog states.
- Add actionable-state check before fetching PR comments during review feedback handling.
- Update CLI Reference section to use the filtered board query by default.

## Test plan
- [x] Verify autodev agent only processes In Progress and Ready items when reading the board
- [x] Verify agent skips comment fetching for non-actionable items