### PR TITLE
Add HF adapter checkpoint tests and loss_compare checkpoint resume su…

### DIFF
--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -573,6 +573,8 @@ def run_training(
 
     run_with_realtime_output(full_cmd, log_file, env)
 
+    return log_file
+
 
 # =============================================================================
 # LOG PROCESSING AND ANALYSIS

--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -156,9 +156,9 @@ def extract_losses_from_tensorboard(
 ) -> dict[int, float]:
     """Extract full-precision loss values from TensorBoard event files.
 
-    Reads all timestamped subdirectories under the TB folder and merges
-    their losses.  Normally there is one subdir (single training run),
-    but checkpoint resume produces two (phase 1 + phase 2).
+    The TB directory is cleared before each run (see ``run_training``), so
+    there is exactly one timestamped subdirectory.  We find it and point
+    ``EventAccumulator`` at it directly.
 
     Args:
         job_dump_folder: The --job-dump-folder value (e.g., "outputs")
@@ -173,34 +173,35 @@ def extract_losses_from_tensorboard(
     if not os.path.exists(base_path):
         raise FileNotFoundError(f"TensorBoard path does not exist: {base_path}")
 
-    # Find timestamped subdirectories (e.g., "20260306-1618").
-    # Normally one subdir per run; checkpoint resume produces two.
+    # Find the single timestamped subdirectory (e.g., "20260306-1618")
     subdirs = [
         d for d in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, d))
     ]
-    if not subdirs:
-        raise RuntimeError(f"No subdirectories found under {base_path}")
+    if len(subdirs) == 1:
+        event_dir = os.path.join(base_path, subdirs[0])
+    else:
+        # Should not happen since we clear the directory before each run
+        raise RuntimeError(
+            f"Expected exactly one subdirectory under {base_path}, "
+            f"found {len(subdirs)}: {subdirs}"
+        )
+
+    log_print(f"Loading TensorBoard events from: {event_dir}")
+
+    event_acc = EventAccumulator(event_dir)
+    event_acc.Reload()
 
     scalar_tag = TB_LOSS_TAG
-    losses: dict[int, float] = {}
+    available_tags = event_acc.Tags().get("scalars", [])
 
-    for subdir in sorted(subdirs):
-        event_dir = os.path.join(base_path, subdir)
-        log_print(f"Loading TensorBoard events from: {event_dir}")
+    if scalar_tag not in available_tags:  # pyrefly: ignore [not-iterable]
+        raise KeyError(
+            f"Scalar tag '{scalar_tag}' not found in TensorBoard events. "
+            f"Available tags: {available_tags}"
+        )
 
-        event_acc = EventAccumulator(event_dir)
-        event_acc.Reload()
-
-        available_tags = event_acc.Tags().get("scalars", [])
-        if scalar_tag not in available_tags:  # pyrefly: ignore [not-iterable]
-            raise KeyError(
-                f"Scalar tag '{scalar_tag}' not found in {event_dir}. "
-                f"Available tags: {available_tags}"
-            )
-
-        scalars = event_acc.Scalars(scalar_tag)
-        for scalar in scalars:
-            losses[scalar.step] = scalar.value
+    scalars = event_acc.Scalars(scalar_tag)
+    losses = {scalar.step: scalar.value for scalar in scalars}
 
     log_print(f"Extracted {len(losses)} steps from TensorBoard events")
     return losses
@@ -543,15 +544,8 @@ def run_training(
     job_dump_folder: str,
     ngpus: int,
     tb_folder: str = "tb",
-    checkpoint_resume_interval: int | None = None,
 ) -> str:
-    """Run training for a specific scenario. Returns the log file path.
-
-    When ``checkpoint_resume_interval`` is set, training runs in two phases:
-    phase 1 trains to the interval step and saves a checkpoint, phase 2
-    resumes from the checkpoint and trains to ``steps``.  TensorBoard data
-    from both phases is preserved so that losses for all steps are available.
-    """
+    """Run training for a specific scenario. Returns the log file path."""
     log_file = get_log_path(scenario, output_folder)
     log_print(
         f"Running training with {scenario} commit and logging output " f"to {log_file}"
@@ -563,57 +557,21 @@ def run_training(
         log_print(f"Removing stale TensorBoard directory: {tb_dir}")
         shutil.rmtree(tb_dir)
 
+    # Build the final command
+    full_cmd = build_training_command(
+        module,
+        config,
+        options,
+        steps,
+        enable_seed_checkpoint,
+        job_dump_folder,
+        tb_folder=tb_folder,
+    )
+
     env = os.environ.copy()
     env["NGPU"] = str(ngpus)
 
-    if checkpoint_resume_interval is not None:
-        # Phase 1: train to checkpoint interval and save
-        log_print(
-            f"Checkpoint resume mode: phase 1 — "
-            f"train {checkpoint_resume_interval} steps and save checkpoint"
-        )
-        phase1_cmd = build_training_command(
-            module,
-            config,
-            f"{options} --checkpoint.enable",
-            checkpoint_resume_interval,
-            enable_seed_checkpoint,
-            job_dump_folder,
-            tb_folder=tb_folder,
-        )
-        run_with_realtime_output(phase1_cmd, log_file, env)
-
-        # Phase 2: resume from checkpoint, train to final step
-        # Don't clear TB — we want losses from both phases
-        log_print(
-            f"Checkpoint resume mode: phase 2 — "
-            f"resume from step {checkpoint_resume_interval}, train to step {steps}"
-        )
-        phase2_log = get_log_path(f"{scenario}_resume", output_folder)
-        phase2_cmd = build_training_command(
-            module,
-            config,
-            f"{options} --checkpoint.enable",
-            steps,
-            enable_seed_checkpoint,
-            job_dump_folder,
-            tb_folder=tb_folder,
-        )
-        run_with_realtime_output(phase2_cmd, phase2_log, env)
-    else:
-        # Build the final command
-        full_cmd = build_training_command(
-            module,
-            config,
-            options,
-            steps,
-            enable_seed_checkpoint,
-            job_dump_folder,
-            tb_folder=tb_folder,
-        )
-        run_with_realtime_output(full_cmd, log_file, env)
-
-    return log_file
+    run_with_realtime_output(full_cmd, log_file, env)
 
 
 # =============================================================================
@@ -1100,7 +1058,6 @@ def run_scenario(
     job_dump_folder: str,
     ngpus: int,
     tb_folder: str = "tb",
-    checkpoint_resume_interval: int | None = None,
 ) -> str:
     """Run training for a specific scenario (baseline or test).
 
@@ -1116,8 +1073,6 @@ def run_scenario(
         job_dump_folder: Job dump folder path
         ngpus: Number of GPUs to use
         tb_folder: TensorBoard subfolder name for this scenario
-        checkpoint_resume_interval: If set, run training in two phases
-            (save at this step, then resume to ``steps``).
 
     Returns:
         Path to the log file
@@ -1135,7 +1090,6 @@ def run_scenario(
         job_dump_folder,
         ngpus,
         tb_folder=tb_folder,
-        checkpoint_resume_interval=checkpoint_resume_interval,
     )
 
     return log_file
@@ -1208,7 +1162,7 @@ def main() -> None:
             args.job_dump_folder,
         )
         # Run baseline training
-        baseline_log = run_scenario(
+        baseline_log, _ = run_scenario(
             "baseline",
             args.baseline_commit,
             args.baseline_module,
@@ -1248,25 +1202,67 @@ def main() -> None:
         test_log = None
         test_losses = None
         if not baseline_only_mode:
-            test_log = run_scenario(
-                "test",
-                args.test_commit,
-                args.test_module,
-                args.test_config,
-                args.test_options,
-                args.steps,
-                enable_seed_checkpoint,
-                args.output_folder,
-                args.job_dump_folder,
-                args.test_ngpus,
-                tb_folder=test_tb_folder,
-                checkpoint_resume_interval=checkpoint_resume_interval,
-            )
+            if checkpoint_resume_interval is not None:
+                # Two-phase test: train to checkpoint, save, resume to final step.
+                # Phase 1: train to checkpoint interval
+                ckpt_options = f"{args.test_options} --checkpoint.enable"
+                run_scenario(
+                    "test_phase1",
+                    args.test_commit,
+                    args.test_module,
+                    args.test_config,
+                    ckpt_options,
+                    checkpoint_resume_interval,
+                    enable_seed_checkpoint,
+                    args.output_folder,
+                    args.job_dump_folder,
+                    args.test_ngpus,
+                    tb_folder=test_tb_folder,
+                )
+                phase1_losses = extract_losses_from_tensorboard(
+                    args.job_dump_folder, test_tb_folder
+                )
 
-            # Extract test losses from TensorBoard (full precision)
-            test_losses = extract_losses_from_tensorboard(
-                args.job_dump_folder, test_tb_folder
-            )
+                # Phase 2: resume from checkpoint, train to final step
+                run_scenario(
+                    "test_phase2",
+                    args.test_commit,
+                    args.test_module,
+                    args.test_config,
+                    ckpt_options,
+                    args.steps,
+                    enable_seed_checkpoint,
+                    args.output_folder,
+                    args.job_dump_folder,
+                    args.test_ngpus,
+                    tb_folder=test_tb_folder,
+                )
+                phase2_losses = extract_losses_from_tensorboard(
+                    args.job_dump_folder, test_tb_folder
+                )
+
+                # Merge: phase 1 (steps 1..interval) + phase 2 (steps interval+1..final)
+                test_losses = phase1_losses
+                test_losses.update(phase2_losses)
+            else:
+                run_scenario(
+                    "test",
+                    args.test_commit,
+                    args.test_module,
+                    args.test_config,
+                    args.test_options,
+                    args.steps,
+                    enable_seed_checkpoint,
+                    args.output_folder,
+                    args.job_dump_folder,
+                    args.test_ngpus,
+                    tb_folder=test_tb_folder,
+                )
+
+                # Extract test losses from TensorBoard (full precision)
+                test_losses = extract_losses_from_tensorboard(
+                    args.job_dump_folder, test_tb_folder
+                )
         log_print()
 
         # Assert losses are equal if requested

--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -1164,7 +1164,7 @@ def main() -> None:
             args.job_dump_folder,
         )
         # Run baseline training
-        baseline_log, _ = run_scenario(
+        baseline_log = run_scenario(
             "baseline",
             args.baseline_commit,
             args.baseline_module,

--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -58,6 +58,14 @@ Example usages:
 10. Run baseline with specific options and export the losses:
     loss_compare.py . . --baseline-options='--parallelism.dp=2' \
         --export-result=my_config_losses.txt
+
+11. Verify checkpoint resume produces identical loss:
+    loss_compare.py . . --test-checkpoint-resume --steps=20 \
+        --import-result=tests/assets/losses/llama3_cuda.txt --assert-equal
+
+12. Verify checkpoint resume with custom interval:
+    loss_compare.py . . --test-checkpoint-resume --test-checkpoint-interval=5 \
+        --steps=20 --assert-equal
 """
 
 import argparse
@@ -148,9 +156,9 @@ def extract_losses_from_tensorboard(
 ) -> dict[int, float]:
     """Extract full-precision loss values from TensorBoard event files.
 
-    The TB directory is cleared before each run (see ``run_training``), so
-    there is exactly one timestamped subdirectory.  We find it and point
-    ``EventAccumulator`` at it directly.
+    Reads all timestamped subdirectories under the TB folder and merges
+    their losses.  Normally there is one subdir (single training run),
+    but checkpoint resume produces two (phase 1 + phase 2).
 
     Args:
         job_dump_folder: The --job-dump-folder value (e.g., "outputs")
@@ -165,35 +173,34 @@ def extract_losses_from_tensorboard(
     if not os.path.exists(base_path):
         raise FileNotFoundError(f"TensorBoard path does not exist: {base_path}")
 
-    # Find the single timestamped subdirectory (e.g., "20260306-1618")
+    # Find timestamped subdirectories (e.g., "20260306-1618").
+    # Normally one subdir per run; checkpoint resume produces two.
     subdirs = [
         d for d in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, d))
     ]
-    if len(subdirs) == 1:
-        event_dir = os.path.join(base_path, subdirs[0])
-    else:
-        # Should not happen since we clear the directory before each run
-        raise RuntimeError(
-            f"Expected exactly one subdirectory under {base_path}, "
-            f"found {len(subdirs)}: {subdirs}"
-        )
-
-    log_print(f"Loading TensorBoard events from: {event_dir}")
-
-    event_acc = EventAccumulator(event_dir)
-    event_acc.Reload()
+    if not subdirs:
+        raise RuntimeError(f"No subdirectories found under {base_path}")
 
     scalar_tag = TB_LOSS_TAG
-    available_tags = event_acc.Tags().get("scalars", [])
+    losses: dict[int, float] = {}
 
-    if scalar_tag not in available_tags:  # pyrefly: ignore [not-iterable]
-        raise KeyError(
-            f"Scalar tag '{scalar_tag}' not found in TensorBoard events. "
-            f"Available tags: {available_tags}"
-        )
+    for subdir in sorted(subdirs):
+        event_dir = os.path.join(base_path, subdir)
+        log_print(f"Loading TensorBoard events from: {event_dir}")
 
-    scalars = event_acc.Scalars(scalar_tag)
-    losses = {scalar.step: scalar.value for scalar in scalars}
+        event_acc = EventAccumulator(event_dir)
+        event_acc.Reload()
+
+        available_tags = event_acc.Tags().get("scalars", [])
+        if scalar_tag not in available_tags:  # pyrefly: ignore [not-iterable]
+            raise KeyError(
+                f"Scalar tag '{scalar_tag}' not found in {event_dir}. "
+                f"Available tags: {available_tags}"
+            )
+
+        scalars = event_acc.Scalars(scalar_tag)
+        for scalar in scalars:
+            losses[scalar.step] = scalar.value
 
     log_print(f"Extracted {len(losses)} steps from TensorBoard events")
     return losses
@@ -225,6 +232,7 @@ def validate_arguments(
     assert_equal: bool,
     export_result: str | None,
     import_result: str | None,
+    test_checkpoint_resume: bool = False,
 ) -> bool:
     """Validate command line arguments.
 
@@ -239,7 +247,11 @@ def validate_arguments(
     options_differ = baseline_options != test_options
 
     all_identical = not (
-        commits_differ or configs_differ or modules_differ or options_differ
+        commits_differ
+        or configs_differ
+        or modules_differ
+        or options_differ
+        or test_checkpoint_resume
     )
 
     # Determine baseline-only mode:
@@ -531,8 +543,15 @@ def run_training(
     job_dump_folder: str,
     ngpus: int,
     tb_folder: str = "tb",
+    checkpoint_resume_interval: int | None = None,
 ) -> str:
-    """Run training for a specific scenario. Returns the log file path."""
+    """Run training for a specific scenario. Returns the log file path.
+
+    When ``checkpoint_resume_interval`` is set, training runs in two phases:
+    phase 1 trains to the interval step and saves a checkpoint, phase 2
+    resumes from the checkpoint and trains to ``steps``.  TensorBoard data
+    from both phases is preserved so that losses for all steps are available.
+    """
     log_file = get_log_path(scenario, output_folder)
     log_print(
         f"Running training with {scenario} commit and logging output " f"to {log_file}"
@@ -544,21 +563,55 @@ def run_training(
         log_print(f"Removing stale TensorBoard directory: {tb_dir}")
         shutil.rmtree(tb_dir)
 
-    # Build the final command
-    full_cmd = build_training_command(
-        module,
-        config,
-        options,
-        steps,
-        enable_seed_checkpoint,
-        job_dump_folder,
-        tb_folder=tb_folder,
-    )
-
     env = os.environ.copy()
     env["NGPU"] = str(ngpus)
 
-    run_with_realtime_output(full_cmd, log_file, env)
+    if checkpoint_resume_interval is not None:
+        # Phase 1: train to checkpoint interval and save
+        log_print(
+            f"Checkpoint resume mode: phase 1 — "
+            f"train {checkpoint_resume_interval} steps and save checkpoint"
+        )
+        phase1_cmd = build_training_command(
+            module,
+            config,
+            f"{options} --checkpoint.enable",
+            checkpoint_resume_interval,
+            enable_seed_checkpoint,
+            job_dump_folder,
+            tb_folder=tb_folder,
+        )
+        run_with_realtime_output(phase1_cmd, log_file, env)
+
+        # Phase 2: resume from checkpoint, train to final step
+        # Don't clear TB — we want losses from both phases
+        log_print(
+            f"Checkpoint resume mode: phase 2 — "
+            f"resume from step {checkpoint_resume_interval}, train to step {steps}"
+        )
+        phase2_log = get_log_path(f"{scenario}_resume", output_folder)
+        phase2_cmd = build_training_command(
+            module,
+            config,
+            f"{options} --checkpoint.enable",
+            steps,
+            enable_seed_checkpoint,
+            job_dump_folder,
+            tb_folder=tb_folder,
+        )
+        run_with_realtime_output(phase2_cmd, phase2_log, env)
+    else:
+        # Build the final command
+        full_cmd = build_training_command(
+            module,
+            config,
+            options,
+            steps,
+            enable_seed_checkpoint,
+            job_dump_folder,
+            tb_folder=tb_folder,
+        )
+        run_with_realtime_output(full_cmd, log_file, env)
 
     return log_file
 
@@ -992,6 +1045,24 @@ Examples:
         default=8,
         help="Number of GPUs for test run (default: 8)",
     )
+    parser.add_argument(
+        "--test-checkpoint-resume",
+        action="store_true",
+        help=(
+            "Run the test scenario in two phases: train to checkpoint "
+            "interval and save, then resume to --steps.  Verifies that "
+            "checkpoint save/load does not corrupt training state."
+        ),
+    )
+    parser.add_argument(
+        "--test-checkpoint-interval",
+        type=int,
+        default=0,
+        help=(
+            "Checkpoint interval for --test-checkpoint-resume. "
+            "Defaults to steps // 2 if not specified."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1029,6 +1100,7 @@ def run_scenario(
     job_dump_folder: str,
     ngpus: int,
     tb_folder: str = "tb",
+    checkpoint_resume_interval: int | None = None,
 ) -> str:
     """Run training for a specific scenario (baseline or test).
 
@@ -1044,6 +1116,8 @@ def run_scenario(
         job_dump_folder: Job dump folder path
         ngpus: Number of GPUs to use
         tb_folder: TensorBoard subfolder name for this scenario
+        checkpoint_resume_interval: If set, run training in two phases
+            (save at this step, then resume to ``steps``).
 
     Returns:
         Path to the log file
@@ -1061,6 +1135,7 @@ def run_scenario(
         job_dump_folder,
         ngpus,
         tb_folder=tb_folder,
+        checkpoint_resume_interval=checkpoint_resume_interval,
     )
 
     return log_file
@@ -1083,6 +1158,7 @@ def main() -> None:
         args.assert_equal,
         args.export_result,
         args.import_result,
+        args.test_checkpoint_resume,
     )
 
     # Setup environment
@@ -1151,6 +1227,23 @@ def main() -> None:
             args.job_dump_folder, baseline_tb_folder
         )
 
+        # Resolve checkpoint resume interval
+        checkpoint_resume_interval = None
+        if args.test_checkpoint_resume:
+            checkpoint_resume_interval = args.test_checkpoint_interval
+            if checkpoint_resume_interval <= 0:
+                checkpoint_resume_interval = args.steps // 2
+            if checkpoint_resume_interval >= args.steps:
+                log_print(
+                    f"Error: --test-checkpoint-interval ({checkpoint_resume_interval}) "
+                    f"must be less than --steps ({args.steps})"
+                )
+                sys.exit(1)
+            log_print(
+                f"Checkpoint resume enabled: save at step "
+                f"{checkpoint_resume_interval}, resume to step {args.steps}"
+            )
+
         # Run test training (skip in baseline-only mode)
         test_log = None
         test_losses = None
@@ -1167,6 +1260,7 @@ def main() -> None:
                 args.job_dump_folder,
                 args.test_ngpus,
                 tb_folder=test_tb_folder,
+                checkpoint_resume_interval=checkpoint_resume_interval,
             )
 
             # Extract test losses from TensorBoard (full precision)

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -714,8 +714,6 @@ class TestCheckpointManager(unittest.TestCase):
 
         Catches: adapter receiving incomplete state dict → incomplete HF checkpoint.
         """
-        from torch.distributed.checkpoint import HuggingFaceStorageWriter
-
         mock_adapter = mock.Mock()
         mock_adapter.to_hf.side_effect = lambda sd: {
             f"hf_{k}": v for k, v in sd.items()
@@ -746,10 +744,11 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertIn("weight", to_hf_arg)
         self.assertIn("bias", to_hf_arg)
 
-        # Verify dcp.save received HF-transformed keys and used HF writer
+        # Verify dcp.save was called (with HF storage writer, not checkpoint_id)
         mock_save.assert_called_once()
         _, kw = mock_save.call_args
-        self.assertIsInstance(kw.get("storage_writer"), HuggingFaceStorageWriter)
+        self.assertIsNotNone(kw.get("storage_writer"))
+        self.assertIsNone(kw.get("checkpoint_id"))
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -701,6 +701,118 @@ class TestCheckpointManager(unittest.TestCase):
         manager.save(curr_step=2, last_step=True)
         manager.load(step=1)
 
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+    )
+    def test_hf_save_calls_adapter_to_hf_with_all_model_keys(
+        self, mock_get_sd, mock_save, mock_rank
+    ):
+        """HF save must pass all model keys to sd_adapter.to_hf().
+
+        Catches: adapter receiving incomplete state dict → incomplete HF checkpoint.
+        """
+        from torch.distributed.checkpoint import HuggingFaceStorageWriter
+
+        mock_adapter = mock.Mock()
+        mock_adapter.to_hf.side_effect = lambda sd: {
+            f"hf_{k}": v for k, v in sd.items()
+        }
+        mock_adapter.fqn_to_index_mapping = None
+        mock_adapter.hf_assets_path = None
+
+        cfg = self.trainer_config.checkpoint
+        cfg.last_save_model_only = True
+        cfg.last_save_in_hf = True
+        cfg.keep_latest_k = 0
+
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=cfg,
+            sd_adapter=mock_adapter,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        manager.save(curr_step=10, last_step=True)
+
+        # Verify to_hf was called with all model keys
+        mock_adapter.to_hf.assert_called_once()
+        to_hf_arg = mock_adapter.to_hf.call_args[0][0]
+        self.assertIn("weight", to_hf_arg)
+        self.assertIn("bias", to_hf_arg)
+
+        # Verify dcp.save received HF-transformed keys and used HF writer
+        mock_save.assert_called_once()
+        _, kw = mock_save.call_args
+        self.assertIsInstance(kw.get("storage_writer"), HuggingFaceStorageWriter)
+        manager.close()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch(
+        "torchtitan.components.checkpoint.get_model_state_dict",
+        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+    )
+    def test_hf_load_passes_all_model_keys_to_adapter(
+        self, mock_get_sd, mock_load, mock_rank
+    ):
+        """HF load must pass all model keys to sd_adapter.to_hf() for container creation.
+
+        Catches: adapter receiving incomplete state dict → missing keys not loaded
+        from HF checkpoint, or FQN mismatch causing silent param loss.
+        """
+        mock_adapter = mock.Mock()
+        # to_hf: record keys received, return HF-shaped containers
+        mock_adapter.to_hf.side_effect = lambda sd: {
+            f"hf_{k}": v for k, v in sd.items()
+        }
+        # from_hf: simulate reverse mapping
+        mock_adapter.from_hf.side_effect = lambda sd: {
+            k.removeprefix("hf_"): v for k, v in sd.items()
+        }
+        mock_adapter.get_hf_storage_reader.return_value = mock.Mock()
+        mock_adapter.fqn_to_index_mapping = None
+        mock_adapter.hf_assets_path = self.test_folder
+
+        # dcp.load is a no-op (just accept the containers)
+        mock_load.side_effect = lambda *a, **kw: None
+
+        cfg = self.trainer_config.checkpoint
+        cfg.initial_load_in_hf = True
+        cfg.initial_load_model_only = True
+        cfg.initial_load_path = self.test_folder
+        # Use a non-existent folder so load() takes the initial_load_path branch
+        # instead of trying to resume from an existing checkpoint folder.
+        cfg.folder = "nonexistent_ckpt"
+
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=cfg,
+            sd_adapter=mock_adapter,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        manager.load(step=-1)
+
+        # Verify to_hf received all model keys for container creation
+        mock_adapter.to_hf.assert_called_once()
+        to_hf_arg = mock_adapter.to_hf.call_args[0][0]
+        self.assertIn("weight", to_hf_arg)
+        self.assertIn("bias", to_hf_arg)
+
+        # Verify from_hf was called and result passed to load_state_dict
+        mock_adapter.from_hf.assert_called_once()
+        mock_adapter.get_hf_storage_reader.assert_called_once()
+        manager.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -705,19 +705,20 @@ class TestCheckpointManager(unittest.TestCase):
     @mock.patch("torchtitan.components.checkpoint.dcp.save")
     @mock.patch(
         "torchtitan.components.checkpoint.get_model_state_dict",
-        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+        side_effect=lambda m: dict(m.named_parameters()),
     )
-    def test_hf_save_calls_adapter_to_hf_with_all_model_keys(
+    def test_hf_save_adapter_receives_all_model_keys(
         self, mock_get_sd, mock_save, mock_rank
     ):
-        """HF save must pass all model keys to sd_adapter.to_hf().
+        """to_hf must receive all model keys when saving in HF format."""
+        received_keys = []
 
-        Catches: adapter receiving incomplete state dict → incomplete HF checkpoint.
-        """
+        def fake_to_hf(sd):
+            received_keys.extend(sd.keys())
+            return {f"hf_{k}": v for k, v in sd.items()}
+
         mock_adapter = mock.Mock()
-        mock_adapter.to_hf.side_effect = lambda sd: {
-            f"hf_{k}": v for k, v in sd.items()
-        }
+        mock_adapter.to_hf.side_effect = fake_to_hf
         mock_adapter.fqn_to_index_mapping = None
         mock_adapter.hf_assets_path = None
 
@@ -738,56 +739,55 @@ class TestCheckpointManager(unittest.TestCase):
         )
         manager.save(curr_step=10, last_step=True)
 
-        # Verify to_hf was called with all model keys
         mock_adapter.to_hf.assert_called_once()
-        to_hf_arg = mock_adapter.to_hf.call_args[0][0]
-        self.assertIn("weight", to_hf_arg)
-        self.assertIn("bias", to_hf_arg)
+        self.assertIn("weight", received_keys)
+        self.assertIn("bias", received_keys)
 
-        # Verify dcp.save was called (with HF storage writer, not checkpoint_id)
         mock_save.assert_called_once()
-        _, kw = mock_save.call_args
-        self.assertIsNotNone(kw.get("storage_writer"))
-        self.assertIsNone(kw.get("checkpoint_id"))
+        saved_sd = mock_save.call_args[0][0]
+        self.assertIn("hf_weight", saved_sd)
+        self.assertIn("hf_bias", saved_sd)
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch(
+        "torchtitan.components.checkpoint.set_model_state_dict",
+    )
     @mock.patch("torchtitan.components.checkpoint.dcp.load")
     @mock.patch(
         "torchtitan.components.checkpoint.get_model_state_dict",
-        side_effect=lambda m: {"weight": m.weight, "bias": m.bias},
+        side_effect=lambda m: dict(m.named_parameters()),
     )
-    def test_hf_load_passes_all_model_keys_to_adapter(
-        self, mock_get_sd, mock_load, mock_rank
+    def test_hf_load_roundtrip_to_hf_then_from_hf(
+        self, mock_get_sd, mock_load, mock_set_sd, mock_rank
     ):
-        """HF load must pass all model keys to sd_adapter.to_hf() for container creation.
+        """HF load must: to_hf (container) → dcp.load → from_hf → load_state_dict."""
+        call_order = []
 
-        Catches: adapter receiving incomplete state dict → missing keys not loaded
-        from HF checkpoint, or FQN mismatch causing silent param loss.
-        """
+        def fake_to_hf(sd):
+            call_order.append("to_hf")
+            return {f"hf_{k}": v for k, v in sd.items()}
+
+        def fake_from_hf(sd):
+            call_order.append("from_hf")
+            return {k.removeprefix("hf_"): v for k, v in sd.items()}
+
+        def fake_dcp_load(*args, **kwargs):
+            call_order.append("dcp_load")
+
         mock_adapter = mock.Mock()
-        # to_hf: record keys received, return HF-shaped containers
-        mock_adapter.to_hf.side_effect = lambda sd: {
-            f"hf_{k}": v for k, v in sd.items()
-        }
-        # from_hf: simulate reverse mapping
-        mock_adapter.from_hf.side_effect = lambda sd: {
-            k.removeprefix("hf_"): v for k, v in sd.items()
-        }
+        mock_adapter.to_hf.side_effect = fake_to_hf
+        mock_adapter.from_hf.side_effect = fake_from_hf
         mock_adapter.get_hf_storage_reader.return_value = mock.Mock()
         mock_adapter.fqn_to_index_mapping = None
         mock_adapter.hf_assets_path = self.test_folder
-
-        # dcp.load is a no-op (just accept the containers)
-        mock_load.side_effect = lambda *a, **kw: None
+        mock_load.side_effect = fake_dcp_load
 
         cfg = self.trainer_config.checkpoint
         cfg.initial_load_in_hf = True
         cfg.initial_load_model_only = True
         cfg.initial_load_path = self.test_folder
-        # Use a non-existent folder so load() takes the initial_load_path branch
-        # instead of trying to resume from an existing checkpoint folder.
-        cfg.folder = "nonexistent_ckpt"
+        cfg.folder = os.path.join(self.base_temp_dir, "nonexistent_ckpt")
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
@@ -801,15 +801,19 @@ class TestCheckpointManager(unittest.TestCase):
         )
         manager.load(step=-1)
 
-        # Verify to_hf received all model keys for container creation
-        mock_adapter.to_hf.assert_called_once()
-        to_hf_arg = mock_adapter.to_hf.call_args[0][0]
-        self.assertIn("weight", to_hf_arg)
-        self.assertIn("bias", to_hf_arg)
+        self.assertEqual(call_order, ["to_hf", "dcp_load", "from_hf"])
 
-        # Verify from_hf was called and result passed to load_state_dict
+        mock_adapter.to_hf.assert_called_once()
+        to_hf_keys = set(mock_adapter.to_hf.call_args[0][0].keys())
+        self.assertEqual(to_hf_keys, {"weight", "bias"})
+
         mock_adapter.from_hf.assert_called_once()
-        mock_adapter.get_hf_storage_reader.assert_called_once()
+        from_hf_keys = set(mock_adapter.from_hf.call_args[0][0].keys())
+        self.assertEqual(from_hf_keys, {"hf_weight", "hf_bias"})
+
+        mock_set_sd.assert_called_once()
+        loaded_sd = mock_set_sd.call_args[1]["model_state_dict"]
+        self.assertEqual(set(loaded_sd.keys()), {"weight", "bias"})
         manager.close()
 
 


### PR DESCRIPTION
  ### Summary                                                         
                                                                                                             
  - Add unit tests for the HF save/load adapter integration in CheckpointManager, covering the  sd_adapter.to_hf/from_hf roundtrip that previously had no test coverage
  - Add --test-checkpoint-resume to loss_compare.py for verifying checkpoint save/load doesn't corrupt training state                                                                                             
  
  ### Test plan                                                                                                  
                                                                  
  - pytest tests/unit_tests/test_checkpoint.py -x — all tests pass (including 2 new HF adapter tests)        
  - pre-commit run --all-files — no new lint failures
  - loss_compare.py . . --test-checkpoint-resume --steps=20 --assert-equal — verify checkpoint resume produces identical loss                                                                                    
                                                                                                             
  ### Details                                                                                                    
                                                                  
  New checkpoint tests:                                                                                      
  - test_hf_save_adapter_receives_all_model_keys — verifies to_hf receives all model keys and dcp.save gets HF-keyed state dict                                                                                        
  - test_hf_load_roundtrip_to_hf_then_from_hf — verifies the full load sequence: to_hf (build container) → dcp.load → from_hf → load_state_dict, including call ordering and data flow through each step              
                                                                                                             
  loss_compare.py checkpoint resume:
  - --test-checkpoint-resume runs training in two phases: train to checkpoint interval and save, then resume to final step                                                                                             
  - --test-checkpoint-interval controls the save point (defaults to steps // 2)                              
  - Merged losses from both phases are compared against baseline to verify bit-exact resume