### PR TITLE
[GraphTrainer][AutoDev] Add remove_transpose_pairs_pass graph pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -42,6 +42,7 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_detach_pass,
     remove_identity_slice_pass,
     remove_identity_view_pass,
+    remove_transpose_pairs_pass,
 )
 from torchtitan.experiments.graph_trainer.reshard_after_forward import (
     annotate_fsdp_all_gather,
@@ -71,6 +72,7 @@ def construct_default_graph_passes(
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
+        remove_transpose_pairs_pass,
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
         # When left uncompiled, flex_attention still runs correctly but

--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -155,3 +155,79 @@ def remove_identity_slice_pass(
     gm.graph.lint()
     gm.recompile()
     return gm
+
+
+def remove_transpose_pairs_pass(
+    gm: torch.fx.GraphModule, example_inputs=None
+) -> torch.fx.GraphModule:
+    """Remove canceling transpose pairs from the graph.
+
+    Two patterns are handled:
+
+    1. ``aten.t.default(aten.t.default(x))`` -> ``x``
+       (2D matrix transpose applied twice is identity)
+
+    2. ``aten.transpose.int(aten.transpose.int(x, d0, d1), d0, d1)`` -> ``x``
+       (transposing the same pair of dimensions twice is identity)
+
+    Only pairs where the inner transpose has exactly one user (the outer
+    transpose) are removed, to avoid breaking other consumers.
+
+    Args:
+        gm: The traced graph module.
+        example_inputs: Unused, accepted for pass interface compatibility.
+
+    Returns:
+        The graph module with canceling transpose pairs removed.
+    """
+    count = 0
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function":
+            continue
+
+        if node.target is torch.ops.aten.t.default:
+            inner = node.args[0]
+            if not isinstance(inner, torch.fx.Node):
+                continue
+            if inner.op != "call_function":
+                continue
+            if inner.target is not torch.ops.aten.t.default:
+                continue
+            if len(inner.users) != 1:
+                continue
+
+            original_input = inner.args[0]
+            node.replace_all_uses_with(original_input)
+            gm.graph.erase_node(node)
+            gm.graph.erase_node(inner)
+            count += 1
+
+        elif node.target is torch.ops.aten.transpose.int:
+            inner = node.args[0]
+            if not isinstance(inner, torch.fx.Node):
+                continue
+            if inner.op != "call_function":
+                continue
+            if inner.target is not torch.ops.aten.transpose.int:
+                continue
+            if len(inner.users) != 1:
+                continue
+
+            # Check that both transpositions use the same set of dimensions.
+            outer_dims = set(node.args[1:3])
+            inner_dims = set(inner.args[1:3])
+            if outer_dims != inner_dims:
+                continue
+
+            original_input = inner.args[0]
+            node.replace_all_uses_with(original_input)
+            gm.graph.erase_node(node)
+            gm.graph.erase_node(inner)
+            count += 1
+
+    if count > 0:
+        gm.graph.lint()
+        gm.recompile()
+        logger.info(f"Removed {count} canceling transpose pair(s) from the graph")
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -25,6 +25,7 @@ from torchtitan.experiments.graph_trainer.passes import (
     remove_detach_pass,
     remove_identity_slice_pass,
     remove_identity_view_pass,
+    remove_transpose_pairs_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
 from torchtitan.models.common.linear import Linear
@@ -894,6 +895,142 @@ class TestRemoveIdentitySlicePass(TestCase):
         self.assertEqual(self._count_slice_nodes(gm), 2)
         remove_identity_slice_pass(gm)
         self.assertEqual(self._count_slice_nodes(gm), 0)
+
+
+class TestRemoveTransposePairsPass(TestCase):
+    """Unit tests for the remove_transpose_pairs_pass graph pass."""
+
+    def _count_transpose_nodes(self, gm):
+        """Count aten.t and aten.transpose.int call_function nodes."""
+        targets = {torch.ops.aten.t.default, torch.ops.aten.transpose.int}
+        return sum(
+            1 for n in gm.graph.nodes if n.op == "call_function" and n.target in targets
+        )
+
+    def _count_call_function_nodes(self, gm):
+        """Count all call_function nodes."""
+        return sum(1 for n in gm.graph.nodes if n.op == "call_function")
+
+    def test_t_pair_removed(self):
+        """t(t(x)) pair is removed."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        graph.output(t2)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 2)
+
+        remove_transpose_pairs_pass(gm)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 0)
+
+    def test_transpose_int_pair_removed(self):
+        """transpose(transpose(x, d0, d1), d0, d1) pair is removed."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.transpose.int, args=(x, 0, 1))
+        t2 = graph.call_function(torch.ops.aten.transpose.int, args=(t1, 0, 1))
+        graph.output(t2)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 2)
+
+        remove_transpose_pairs_pass(gm)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 0)
+
+    def test_transpose_int_swapped_dims_removed(self):
+        """transpose(transpose(x, d0, d1), d1, d0) pair is removed (same set of dims)."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.transpose.int, args=(x, 0, 1))
+        t2 = graph.call_function(torch.ops.aten.transpose.int, args=(t1, 1, 0))
+        graph.output(t2)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        remove_transpose_pairs_pass(gm)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 0)
+
+    def test_transpose_int_different_dims_preserved(self):
+        """transpose pairs with different dimensions are not removed."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.transpose.int, args=(x, 0, 1))
+        t2 = graph.call_function(torch.ops.aten.transpose.int, args=(t1, 1, 2))
+        graph.output(t2)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        remove_transpose_pairs_pass(gm)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 2)
+
+    def test_multi_use_inner_preserved(self):
+        """Inner transpose with multiple users is not removed."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(t1,))
+        graph.output((t2, relu))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        remove_transpose_pairs_pass(gm)
+
+        # Both t nodes should still be present since t1 has two users
+        self.assertEqual(self._count_transpose_nodes(gm), 2)
+
+    def test_standalone_transpose_preserved(self):
+        """A single transpose without a matching pair is preserved."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        graph.output(t1)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        remove_transpose_pairs_pass(gm)
+
+        self.assertEqual(self._count_transpose_nodes(gm), 1)
+
+    def test_numerics_preserved_t(self):
+        """Numerics are preserved after removing t(t(x)) pairs."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(relu,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        neg = graph.call_function(torch.ops.aten.neg.default, args=(t2,))
+        graph.output(neg)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x_val = torch.randn(3, 4)
+        expected = gm(x_val)
+
+        remove_transpose_pairs_pass(gm)
+
+        actual = gm(x_val)
+        self.assertEqual(actual, expected)
+
+    def test_numerics_preserved_transpose_int(self):
+        """Numerics are preserved after removing transpose.int pairs."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        t1 = graph.call_function(torch.ops.aten.transpose.int, args=(relu, 0, 2))
+        t2 = graph.call_function(torch.ops.aten.transpose.int, args=(t1, 0, 2))
+        neg = graph.call_function(torch.ops.aten.neg.default, args=(t2,))
+        graph.output(neg)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x_val = torch.randn(2, 3, 4)
+        expected = gm(x_val)
+
+        remove_transpose_pairs_pass(gm)
+
+        actual = gm(x_val)
+        self.assertEqual(actual, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `remove_transpose_pairs_pass` graph pass that removes canceling transpose pairs from traced forward-backward graphs
- Handles two patterns: `t(t(x)) -> x` and `transpose(transpose(x, d0, d1), d0, d1) -> x`
- Only removes pairs where the inner transpose has exactly one user to avoid breaking other consumers
- Registered in the default pass list after view simplification passes and before the flex attention annotation pass

## Test plan
- [x] Added `TestRemoveTransposePairsPass` test class with 8 tests covering:
  - `t(t(x))` pairs are removed
  - `transpose.int` pairs with same dims are removed (both orderings)
  - Non-canceling transpose pairs (different dims) are preserved
  - Multi-use inner transposes are preserved
  - Standalone transposes are preserved
  - Numerics are preserved for both `t` and `transpose.int` patterns
- [x] All 41 tests in `test_passes.py` pass
- [x] Pre-commit checks pass (flake8, ufmt, pydoclint, codespell)