### PR TITLE
[CI] Upgrade CUDA nightly from cu128 to cu130

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -75,7 +75,7 @@ jobs:
         # torchvision must be installed from the nightly channel alongside torch
         # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
         uv pip install torch torchvision vllm xformers --pre \
-          --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+          --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
           --index-strategy unsafe-best-match
         uv pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 

--- a/.github/workflows/integration_test_4gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_4gpu_rl_h100.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -69,7 +69,7 @@ jobs:
         # torchvision must be installed from the nightly channel alongside torch
         # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
         uv pip install torch torchvision vllm xformers --pre \
-          --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
+          --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
           --index-strategy unsafe-best-match
         uv pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       runner: linux.g5.48xlarge.nvidia.gpu
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -55,7 +55,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         python -m pip install --force-reinstall --pre \
-          torch --index-url https://download.pytorch.org/whl/nightly/cu128
+          torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
@@ -55,7 +55,7 @@ jobs:
         pip config --user set global.progress_bar off
 
         python -m pip install --force-reinstall --pre \
-          torch --index-url https://download.pytorch.org/whl/nightly/cu128
+          torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies and lint utilities
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
-          python -m pip install --force-reinstall --pre --index-url https://download.pytorch.org/whl/nightly/cu128 torch
+          python -m pip install --force-reinstall --pre --index-url https://download.pytorch.org/whl/nightly/cu130 torch
           pre-commit install-hooks
 
       - name: Get changed files

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -66,9 +66,9 @@ jobs:
             "name": "cuda",
             "runner": "${CUDA_RUNNER}",
             "gpu-arch-type": "cuda",
-            "gpu-arch-version": "12.8",
+            "gpu-arch-version": "13.0",
             "docker-image": "torchtitan-ubuntu-20.04-clang12",
-            "index-url": "https://download.pytorch.org/whl/nightly/cu128",
+            "index-url": "https://download.pytorch.org/whl/nightly/cu130",
             "torch-version": ""
           }
           EOF


### PR DESCRIPTION
The cu128 nightly index is lagging ~6 days behind cu130, causing CI to test against stale PyTorch builds.