### PR TITLE
Split graph trainer unit tests into dedicated workflows

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -63,22 +63,4 @@ jobs:
 
         python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_default --gpu_arch_type cuda $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 
-
-        # Run the numerics unit tests (dense models only; MoE tests run in the H100 workflow)
-        pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestSimpleFSDP -v
-        pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "dense"
-
-        # Run the graph passes unit tests
-        torchrun --nproc-per-node=8 -m pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestReassignToPgPass -v
-        pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestApplySACPass -v
-
-        # Run the make_fx tracer unit tests
-        pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -k "TestTraceModule or TestTraceDTensor or TestMetadataPropagation"
-
-        # Run precompile unit tests
-        pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
-
-        # Run bitwise deterministic guardrail test
-        pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v
-
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint

--- a/.github/workflows/unit_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/unit_test_8gpu_graph_trainer.yaml
@@ -1,4 +1,4 @@
-name: GraphTrainer 8 GPU H100 Integration Tests
+name: GraphTrainer 8 GPU Unit Tests
 
 on:
   push:
@@ -7,12 +7,12 @@ on:
       - ciflow/8gpu/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
-      - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
+      - '.github/workflows/unit_test_8gpu_graph_trainer.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
-      - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
+      - '.github/workflows/unit_test_8gpu_graph_trainer.yaml'
   schedule:
     # Runs every 12 hours
     - cron: '0 */12 * * *'
@@ -34,12 +34,11 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      runner: linux.aws.h100.8
+      runner: linux.g5.48xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
-      upload-artifact: outputs
       timeout: 45
       script: |
         set -eux
@@ -58,11 +57,10 @@ jobs:
           torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
-        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
-        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
-
-        # Disable Nvlink Sharp. The CI machine seems to be in unstable state to support
-        # NVLS according to several CI runs.
-        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_h100 --gpu_arch_type cuda $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
-
-        rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint
+        # Run each test file in its own pytest invocation to avoid
+        # cross-test pollution (e.g. disable_global_flags from common_utils).
+        pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v -m "not sm90_only"
+        pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -v -m "not sm90_only"
+        pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -v -m "not sm90_only"
+        pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v -m "not sm90_only"
+        pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -m "not sm90_only"

--- a/.github/workflows/unit_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/unit_test_8gpu_graph_trainer_h100.yaml
@@ -1,4 +1,4 @@
-name: GraphTrainer 8 GPU H100 Integration Tests
+name: GraphTrainer 8 GPU H100 Unit Tests
 
 on:
   push:
@@ -7,12 +7,12 @@ on:
       - ciflow/8gpu/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
-      - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
+      - '.github/workflows/unit_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
-      - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
+      - '.github/workflows/unit_test_8gpu_graph_trainer_h100.yaml'
   schedule:
     # Runs every 12 hours
     - cron: '0 */12 * * *'
@@ -39,7 +39,6 @@ jobs:
       gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-20.04-clang12
       repository: pytorch/torchtitan
-      upload-artifact: outputs
       timeout: 45
       script: |
         set -eux
@@ -58,11 +57,13 @@ jobs:
           torch --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
-        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
-        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
-
         # Disable Nvlink Sharp. The CI machine seems to be in unstable state to support
         # NVLS according to several CI runs.
-        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_h100 --gpu_arch_type cuda $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 
-        rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint
+        # Run each test file in its own pytest invocation to avoid
+        # cross-test pollution (e.g. disable_global_flags from common_utils).
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v -m "sm90_only"
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -v -m "sm90_only"
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -v -m "sm90_only"
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v -m "sm90_only"
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v -m "sm90_only"

--- a/torchtitan/experiments/graph_trainer/tests/conftest.py
+++ b/torchtitan/experiments/graph_trainer/tests/conftest.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "sm90_only: mark test as requiring sm_90+ GPU (e.g. H100)",
+    )

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -18,6 +18,7 @@ import unittest
 from collections.abc import Callable
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
 from expecttest import assert_expected_inline
@@ -176,6 +177,7 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_llama)
 
+    @pytest.mark.sm90_only
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -205,6 +207,8 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
 
+@pytest.mark.sm90_only
+@unittest.skipUnless(has_cuda_capability(9, 0), "Requires sm_90+ GPU")
 class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for DeepSeek-v3 debug model."""
 
@@ -245,6 +249,8 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
 # kernel config divergence between eager and traced paths, and triton shared
 # memory OOMs for large head dims (DSv3). Investigate after stabilizing
 # max_autotune with regional_inductor.
+@pytest.mark.sm90_only
+@unittest.skipUnless(has_cuda_capability(9, 0), "Requires sm_90+ GPU")
 @unittest.skip("max_autotune breaks FlexAttn bitwise tests")
 class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for Llama3 with FlexAttention (debugmodel_flex_attn).
@@ -285,6 +291,8 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
 
+@pytest.mark.sm90_only
+@unittest.skipUnless(has_cuda_capability(9, 0), "Requires sm_90+ GPU")
 @unittest.skip("max_autotune breaks FlexAttn bitwise tests")
 class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for DSv3 with FlexAttention (debugmodel_flex_attn).

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import unittest
 
+import pytest
 import torch
 from torch.distributed._composable.fsdp import fully_shard
 from torch.testing._internal.common_fsdp import FSDPTest
@@ -16,6 +17,7 @@ from torch.testing._internal.common_fsdp import FSDPTest
 from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.tools.utils import has_cuda_capability
 
 
 STEPS = 20
@@ -181,11 +183,15 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_dsv3_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode aot"),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_dsv3_manual_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
@@ -217,12 +223,16 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_dsv3_jit_vs_eager(self):
         """Test graph_trainer.deepseek_v3 matches deepseek_v3 (JIT)."""
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode jit"),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_dsv3_manual_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
@@ -230,6 +240,8 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_dsv3_aot_fx_trace_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
@@ -242,6 +254,8 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             _run_qwen3_loss_compare(test_options_extra="--compile.mode aot_fx_trace"),
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_moe_qwen3_aot_fx_trace_vs_eager(self):
         self.assertTrue(
             _run_qwen3_moe_loss_compare(

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -7,6 +7,7 @@
 import unittest
 from collections import Counter
 
+import pytest
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_fsdp import FSDPTest
@@ -26,6 +27,8 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
 )
+
+from torchtitan.tools.utils import has_cuda_capability
 
 
 def get_loss(logits, labels):
@@ -647,6 +650,8 @@ class TestTraceModels(unittest.TestCase):
         config = qwen3_configs["debugmodel"]()
         self._run_model_test(Qwen3Model, config)
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_qwen3_moe(self):
         from torchtitan.models.qwen3 import qwen3_configs
         from torchtitan.models.qwen3.model import Qwen3Model
@@ -654,6 +659,8 @@ class TestTraceModels(unittest.TestCase):
         config = qwen3_configs["debugmodel_moe"]()
         self._run_model_test(Qwen3Model, config)
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_deepseek_v3(self):
         from torchtitan.models.deepseek_v3 import deepseekv3_configs
         from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
@@ -661,6 +668,8 @@ class TestTraceModels(unittest.TestCase):
         config = deepseekv3_configs["debugmodel"]()
         self._run_model_test(DeepSeekV3Model, config)
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_llama4(self):
         from torchtitan.models.llama4 import llama4_configs
         from torchtitan.models.llama4.model import Llama4Model
@@ -673,6 +682,8 @@ class TestTraceModels(unittest.TestCase):
             use_regional_inductor=True,
         )
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_gpt_oss(self):
         from torch.nn.attention.flex_attention import and_masks
 
@@ -911,6 +922,8 @@ class TestTraceFSDP(FSDPTest):
         config = qwen3_configs["debugmodel"]()
         self._run_fsdp_model_test(Qwen3Model, config)
 
+    @pytest.mark.sm90_only
+    @unittest.skipUnless(has_cuda_capability(9, 0), "MoE tests require H100 (sm_90+)")
     def test_deepseek_v3_fsdp(self):
         from torchtitan.models.deepseek_v3 import deepseekv3_configs
         from torchtitan.models.deepseek_v3.model import DeepSeekV3Model


### PR DESCRIPTION
Motivation: The number of graph_trainer tests is growing fast, and the current setup mixes unit tests and integration tests in the same workflow YAML files. This means every new unit test requires manually editing the workflow YAML to add a pytest invocation otherwise the test  silently has no CI coverage. 

Summary 
- Extract graph_trainer unit tests from integration test workflows into two new dedicated unit test workflows (unit_test_8gpu_graph_trainer.yaml for A10G, unit_test_8gpu_graph_trainer_h100.yaml for H100) 
- Introduce @pytest.mark.sm90_only marker and conftest.py to route tests by GPU architecture: non-H100 workflow runs pytest -m "not sm90_only", H100 workflow runs pytest -m "sm90_only
- Add @unittest.skipUnless(has_cuda_capability(9, 0), ...) guards to all sm90-dependent tests/classes for graceful skipping on local non-H100 machines                                                                                                                      
- Integration test workflows now only run integration tests           