### PR TITLE
[CI] Fix graph_trainer CI triggering on every PR

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,8 @@
   - scripts/**
   - tests/**
   - torchtitan/**
+
+"ciflow/graph_trainer":
+  - torchtitan/experiments/graph_trainer/**
+  - .github/workflows/integration_test_8gpu_graph_trainer.yaml
+  - .github/workflows/integration_test_8gpu_graph_trainer_h100.yaml

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,3 +1,4 @@
 ciflow_push_tags:
   - ciflow/8gpu
+  - ciflow/graph_trainer
 labeler_config: labeler.yml

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     tags:
-      - ciflow/8gpu/*
+      - ciflow/graph_trainer/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     tags:
-      - ciflow/8gpu/*
+      - ciflow/graph_trainer/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'


### PR DESCRIPTION
▎ Summary

  ▎ Graph trainer workflows (integration_test_8gpu_graph_trainer.yaml,                      
  integration_test_8gpu_graph_trainer_h100.yaml) triggered on every PR, even those not 
  touching graph_trainer code. Two issues:                                                  
                                                                                          
  ▎ - Wrong scope: Both listened for ciflow/8gpu/* tags, which fire on any PR touching      
  torchtitan/**. The paths filter doesn't properly gate tag push events, so the workflows 
  ran unconditionally.                                                                      
  ▎ - Double-trigger: Each graph_trainer PR update triggered twice — once via pull_request 
  (synchronize) and once via ciflow/8gpu/* tag push, in different concurrency groups so     
  cancel-in-progress doesn't help.
                                                                                            
  ▎ Fixes:                                                                                
  ▎ 1. Replace ciflow/8gpu/* with a new ciflow/graph_trainer/* tag. Auto-labeling in 
  labeler.yml only matches torchtitan/experiments/graph_trainer/**, so the tag is only      
  pushed for graph_trainer PRs.
  ▎ 2. Restrict pull_request trigger to ready_for_review only — the ciflow tag path already 
  handles opened/synchronize/reopened; ready_for_review is kept because the ciflow probot   
  doesn't listen for that event.
                                                                                            
  ▎ Non-graph_trainer workflows are unchanged. The main H100 workflow                       
  (integration_test_8gpu_h100.yaml) keeps both triggers since they run different test 
  matrices (CUDA via pull_request, ROCm via ciflow/8gpu/* tag per set-matrix.yaml).         
                                                                                          
  ▎ Test plan

  ▎ - Verify graph trainer CI no longer triggers on PRs that don't touch                    
  torchtitan/experiments/graph_trainer/**
  ▎ - Verify graph trainer CI triggers exactly once per graph_trainer PR update (via ciflow 
  tag, no duplicate from pull_request synchronize)                                          
  ▎ - Verify draft→ready transition still triggers CI via ready_for_review