### PR TITLE
[GPT-OSS] re-enable gptoss test with compile

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -195,9 +195,6 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "qwen3_vl_moe_fsdp+tp+ep",
             ngpu=8,
         ),
-        # Integration Test Cases for gpt-oss
-        # TODO: re-enable compile after fixing
-        # https://github.com/pytorch/torchtitan/issues/2776
         OverrideDefinitions(
             [
                 [
@@ -206,7 +203,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.expert_parallel_degree 4",
                     "--parallelism.expert_tensor_parallel_degree 1",
-                    # "--compile.enable",
+                    "--compile.enable",
                 ],
             ],
             "Gpt-oss FSDP+TP+EP+compile",


### PR DESCRIPTION
As titled, to fix https://github.com/pytorch/torchtitan/issues/2776