### PR TITLE
[CI] Scope graph_trainer CI to graph_trainer files

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -4,12 +4,34 @@ on:
   push:
     branches: [ main ]
     paths:
+      - '.ci/docker/**'
+      - 'scripts/**'
+      - 'tests/**'
       - 'torchtitan/experiments/graph_trainer/**'
+      - 'torchtitan/__init__.py'
+      - 'torchtitan/trainer.py'
+      - 'torchtitan/components/**'
+      - 'torchtitan/config/**'
+      - 'torchtitan/distributed/**'
+      - 'torchtitan/models/**'
+      - 'torchtitan/protocols/**'
+      - 'torchtitan/tools/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - '.ci/docker/**'
+      - 'scripts/**'
+      - 'tests/**'
       - 'torchtitan/experiments/graph_trainer/**'
+      - 'torchtitan/__init__.py'
+      - 'torchtitan/trainer.py'
+      - 'torchtitan/components/**'
+      - 'torchtitan/config/**'
+      - 'torchtitan/distributed/**'
+      - 'torchtitan/models/**'
+      - 'torchtitan/protocols/**'
+      - 'torchtitan/tools/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'
   schedule:
     # Runs every 12 hours

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -4,12 +4,34 @@ on:
   push:
     branches: [ main ]
     paths:
+      - '.ci/docker/**'
+      - 'scripts/**'
+      - 'tests/**'
       - 'torchtitan/experiments/graph_trainer/**'
+      - 'torchtitan/__init__.py'
+      - 'torchtitan/trainer.py'
+      - 'torchtitan/components/**'
+      - 'torchtitan/config/**'
+      - 'torchtitan/distributed/**'
+      - 'torchtitan/models/**'
+      - 'torchtitan/protocols/**'
+      - 'torchtitan/tools/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - '.ci/docker/**'
+      - 'scripts/**'
+      - 'tests/**'
       - 'torchtitan/experiments/graph_trainer/**'
+      - 'torchtitan/__init__.py'
+      - 'torchtitan/trainer.py'
+      - 'torchtitan/components/**'
+      - 'torchtitan/config/**'
+      - 'torchtitan/distributed/**'
+      - 'torchtitan/models/**'
+      - 'torchtitan/protocols/**'
+      - 'torchtitan/tools/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   schedule:
     # Runs every 12 hours


### PR DESCRIPTION
1. PR touching `torchtitan/experiments/graph_trainer/**`
  - the normal `pull_request` path still runs the main graph_trainer workflow on CUDA
  - the dedicated `ciflow/graph_trainer/*` tag-triggered path goes through `set-matrix`, which adds ROCm coverage for graph_trainer CI
  - the separate `GraphTrainer 8 GPU H100 Integration Tests` workflow in `integration_test_8gpu_graph_trainer_h100.yaml` still runs for
  graph-trainer-related changes, but PR updates no longer double-trigger it because its direct PR trigger is limited to
  `ready_for_review`

  2. PR touching files unrelated to graph_trainer CI
  - no graph_trainer workflow should run from `ciflow/graph_trainer/*`, because that label/tag is scoped to graph_trainer-related paths
  - no accidental graph_trainer trigger should come from broad `ciflow/8gpu/*`, because the graph_trainer workflows no longer listen to
  that tag