### PR TITLE
Increase timeout for features test to 60 minutes.

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -46,7 +46,7 @@ jobs:
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 45
+      timeout: 60
       script: |
         set -eux
 

--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -46,7 +46,7 @@ jobs:
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 60
+      timeout: ${{ matrix.gpu-arch-type == 'rocm' && 60 || 45 }} # TODO: change it to 45min when MI350 label is added.
       script: |
         set -eux
 


### PR DESCRIPTION
In this PR, we have increased the timeout for features test to 60 minutes. This is the timeout failure we are seeing for features test https://github.com/pytorch/torchtitan/actions/runs/24430483234/job/71373655959. The increased timeout is helping features test to pass on ROCm CI https://github.com/pytorch/torchtitan/actions/runs/24541348555/job/71747650589. 

This is a temporary fix for ROCm CI timeout issue. We are working towards enabling MI350 label and replace the existing MI325 label. Hopefully it shouldn't result in a timeout. But we need to enable it and check. 
This is the draft PR for enabling MI350 label https://github.com/pytorch/torchtitan/pull/2740

The failing transformers test seems unrelated to the timeout change made in features test https://github.com/pytorch/torchtitan/actions/runs/24466095345/job/71493479334?pr=2982.