### PR TITLE
Refactor Loss with Scale to fix PP last stage gradients

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import TypeAlias
 
 import torch
+import torch.nn as nn
 
 from torchtitan.config import CompileConfig
 from torchtitan.tools.logging import logger
@@ -51,7 +52,7 @@ class ScaledLoss:
         self._fn = loss_fn
         self._scale: torch.Tensor | None = None
 
-    def set_scale(self, scale: torch.Tensor) -> None:
+    def set_scale(self, scale: torch.Tensor | None) -> None:
         """Set a scaling factor applied to the loss output."""
         self._scale = scale
 
@@ -78,3 +79,253 @@ def build_mse_loss(compile_config: CompileConfig, **kwargs):
         logger.info("Compiling the loss function with torch.compile")
         loss_fn = torch.compile(loss_fn, backend=compile_config.backend)
     return ScaledLoss(loss_fn)
+
+
+class GradAccumulator:
+    """Accumulates chunk gradients into a pre-allocated buffer.
+
+    Instead of collecting chunk gradients in a list and concatenating at the end,
+    this uses a pre-allocated buffer with in-place copies for better memory efficiency.
+
+    Args:
+        shape: Shape of the full gradient buffer (e.g. [B, L, D]).
+        device: Device for the buffer.
+        dtype: Dtype for the buffer.
+        num_chunks: Number of chunks that will be added.
+        seq_dim: The sequence dimension along which chunks are accumulated.
+
+    Usage:
+        accumulator = GradAccumulator((B, L, D), device="cuda", dtype=torch.float32, num_chunks=4)
+        for chunk_grad in chunk_grads:
+            accumulator.add(chunk_grad)
+        full_grad = accumulator.result()
+    """
+
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        *,
+        device: torch.device | str,
+        dtype: torch.dtype,
+        num_chunks: int,
+        seq_dim: int = 1,
+    ):
+        self.num_chunks = num_chunks
+        self.seq_dim = seq_dim
+        self._buffer = torch.zeros(shape, device=device, dtype=dtype)
+        self._next_idx = 0
+
+    def add(self, chunk_grad: torch.Tensor) -> None:
+        """Add the next chunk gradient sequentially.
+
+        Chunks must be added in order (0, 1, 2, ..., num_chunks - 1).
+        """
+        if self._next_idx >= self.num_chunks:
+            raise ValueError(f"Already added {self.num_chunks} chunks, cannot add more")
+
+        # Extract local tensor if DTensor (e.g. when TP is enabled)
+        if hasattr(chunk_grad, "to_local"):
+            chunk_grad = chunk_grad.to_local()
+
+        if chunk_grad.dtype != self._buffer.dtype:
+            chunk_grad = chunk_grad.to(self._buffer.dtype)
+
+        chunk_seq_len = chunk_grad.shape[self.seq_dim]
+        start = self._next_idx * chunk_seq_len
+        end = start + chunk_seq_len
+
+        slices = [slice(None)] * self._buffer.ndim
+        slices[self.seq_dim] = slice(start, end)
+        self._buffer[tuple(slices)] = chunk_grad
+
+        self._next_idx += 1
+
+    def result(self) -> torch.Tensor:
+        """Return the accumulated gradient tensor."""
+        return self._buffer
+
+
+class ChunkedCELoss:
+    """Chunked cross-entropy loss that splits the sequence dimension to reduce peak memory.
+
+    Instead of materializing the full [B, L, V] logits tensor at once, this splits
+    the hidden states into N chunks along the sequence dimension and computes
+    lm_head + cross_entropy_loss on each chunk sequentially. This reduces peak memory
+    from O(B*L*V) to O(B*L/N*V).
+
+    The flow:
+    1. Model forward with skip_lm_head=True to get hidden states [B, L, D]
+    2. Detach hidden states at the boundary
+    3. Split detached hidden states into N chunks along seq dim
+    4. Disable FSDP reshard on lm_head to keep weight unsharded across chunks
+    5. For each chunk: lm_head(chunk) -> ce_loss -> backward()
+    6. Assemble chunk gradients into a full gradient [B, L, D] via GradAccumulator
+    7. Backward through the decoder via hidden_states.backward(accumulated_grad)
+
+    FSDP2 composability:
+        The lm_head's FSDP reshard-after-forward and reshard-after-backward are
+        temporarily disabled during the chunked loop so that the weight stays
+        unsharded across all chunks (avoiding repeated all-gathers). Reduce-scatter
+        fires per-chunk, and FSDP2 accumulates the sharded gradients correctly.
+
+    TP with Loss Parallel:
+        Loss parallel still works within each chunk since the ``loss_parallel()``
+        context wraps the entire chunked computation.
+
+    CP: Further chunks the local sequence dimension. Works out of the box.
+
+    Compile: ce_loss can be compiled independently; lm_head is not compiled.
+
+    Args:
+        num_chunks: Number of chunks to split the sequence into.
+        compile_config: Optional compile config for the CE loss function.
+        pp_enabled: If True, returns a differentiable loss for PP schedule
+            backward. If False, does full backward internally.
+    """
+
+    def __init__(
+        self,
+        num_chunks: int,
+        compile_config: CompileConfig | None = None,
+        pp_enabled: bool = False,
+    ):
+        self.num_chunks = num_chunks
+        self.loss_fn = ScaledLoss(cross_entropy_loss)
+        if (
+            compile_config is not None
+            and compile_config.enable
+            and "loss" in compile_config.components
+        ):
+            logger.info("Compiling the loss function with torch.compile")
+            self.loss_fn = ScaledLoss(
+                torch.compile(cross_entropy_loss, backend=compile_config.backend)
+            )
+        self.pp_enabled = pp_enabled
+        self.lm_head: nn.Module | None = None
+        self._scale: torch.Tensor | None = None
+
+    def init_lm_head(self, model: nn.Module) -> None:
+        """Set the lm_head reference from the model. Must be called before
+        the first __call__, after the model is constructed."""
+        from torchtitan.models.common.decoder import Decoder
+
+        assert isinstance(
+            model, Decoder
+        ), f"ChunkedCELoss requires a Decoder model, got {type(model).__name__}"
+        assert (
+            model.output is not None
+        ), "ChunkedCELoss requires the model to have an output (lm_head) layer"
+        self.lm_head = model.output
+
+    def set_scale(self, scale: torch.Tensor | None) -> None:
+        """Set a scaling factor applied to each chunk's loss before backward."""
+        self._scale = scale
+
+    def __call__(self, pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        """Compute chunked cross-entropy loss.
+
+        Same signature as standard loss functions: ``loss_fn(pred, labels)``.
+        ``pred`` should be hidden states from model forward with
+        ``skip_lm_head=True``. Call ``set_scale()`` before this.
+
+        In non-PP mode: does full backward (lm_head + decoder) internally,
+        returns a detached loss for logging.
+
+        In PP mode: does chunked lm_head backward only, returns a
+        differentiable loss connected to ``pred`` so the PP schedule can
+        backward through the decoder layers.
+        """
+        from torch.distributed._composable.fsdp import FSDPModule
+        from torch.distributed.tensor import DTensor, Replicate
+
+        hidden_states = pred
+        assert self._scale is not None, "Call set_scale() before __call__"
+        scale = self._scale
+        num_chunks = self.num_chunks
+        lm_head = self.lm_head
+        assert lm_head is not None, "Call init_lm_head(model) before __call__"
+        is_fsdp = isinstance(lm_head, FSDPModule)
+
+        # If SP is enabled, hidden states are Shard(1) on the TP mesh.
+        # Redistribute to Replicate before chunking so that the lm_head
+        # receives Replicate input and produces correct Shard(-1) output
+        # for loss parallel.
+        if isinstance(hidden_states, DTensor):
+            placements = hidden_states.placements
+            new_placements = tuple(
+                Replicate() if not isinstance(p, Replicate) else p for p in placements
+            )
+            if new_placements != placements:
+                hidden_states = hidden_states.redistribute(
+                    hidden_states.device_mesh, new_placements
+                )
+
+        # Detach hidden states to stop gradient propagation at this boundary.
+        h_detached = hidden_states.detach().requires_grad_(True)
+
+        # Split hidden states and labels into chunks along seq dim.
+        # Use .contiguous() to break shared storage from torch.chunk(),
+        # otherwise all chunks share the same underlying memory and the
+        # autograd graph retains references, preventing memory from being freed.
+        h_chunks = torch.chunk(h_detached, num_chunks, dim=1)
+        h_chunks = [c.contiguous().detach().requires_grad_(True) for c in h_chunks]
+        label_chunks = torch.chunk(labels, num_chunks, dim=1)
+
+        # Pre-allocate gradient accumulator in fp32 for numerical stability.
+        grad_accumulator = GradAccumulator(
+            h_detached.shape,
+            device=h_detached.device,
+            dtype=torch.float32,
+            num_chunks=len(h_chunks),
+            seq_dim=1,
+        )
+
+        total_loss = hidden_states.new_zeros((), dtype=torch.float32)
+
+        # Disable FSDP reshard on lm_head to keep weight unsharded across
+        # all chunks, avoiding repeated all-gathers. Reduce-scatter fires
+        # per-chunk, and FSDP2 accumulates the sharded gradients correctly.
+        if is_fsdp:
+            lm_head.set_reshard_after_forward(False)
+            lm_head.set_reshard_after_backward(False)
+
+        for h_chunk, label_chunk in zip(h_chunks, label_chunks):
+            logits = lm_head(h_chunk)
+
+            chunk_loss = self.loss_fn(logits, label_chunk)
+            total_loss = total_loss + chunk_loss.detach()
+
+            # Scale loss before backward so gradients are properly normalized
+            (chunk_loss * scale).backward()
+
+            # Collect this chunk's gradient and free it before the next
+            # chunk to keep only one chunk's activations in memory.
+            grad_accumulator.add(h_chunk.grad)
+            h_chunk.grad = None
+            del chunk_loss, logits
+
+        if is_fsdp:
+            lm_head.set_reshard_after_forward(True)
+            lm_head.set_reshard_after_backward(True)
+            lm_head.reshard()
+
+        accumulated_grad = grad_accumulator.result().to(hidden_states.dtype)
+
+        # Wrap as DTensor if hidden_states is a DTensor (TP enabled)
+        if isinstance(hidden_states, DTensor):
+            accumulated_grad = DTensor.from_local(
+                accumulated_grad,
+                device_mesh=hidden_states.device_mesh,
+                placements=hidden_states.placements,
+            )
+
+        if self.pp_enabled:
+            # PP mode: return a differentiable loss so the PP schedule can
+            # backward through the decoder. (h * grad).sum() creates a scalar
+            # connected to hidden_states' autograd graph.
+            decoder_loss = (hidden_states * accumulated_grad).sum()
+            return decoder_loss
+        else:
+            # Non-PP mode: backward through the decoder ourselves.
+            hidden_states.backward(accumulated_grad)
+            return total_loss * scale

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -28,20 +28,47 @@ def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
     )
 
 
+def mse_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    """Common MSE loss function with sum reduction for Transformer models training."""
+    return torch.nn.functional.mse_loss(
+        pred.float(), labels.float().detach(), reduction="sum"
+    )
+
+
+class ScaledLoss:
+    """Wraps a loss function with optional per-step scaling.
+
+    Supports ``set_scale()`` to inject a scaling factor (e.g.
+    ``1 / global_valid_tokens``) before each step. This unifies
+    gradient scaling across PP and non-PP paths: both can call
+    ``set_scale()`` then ``loss_fn(pred, labels)`` and get correctly
+    normalized gradients without the caller needing to scale separately.
+
+    When no scale is set, the loss is returned unscaled (raw sum).
+    """
+
+    def __init__(self, loss_fn: LossFunction):
+        self._fn = loss_fn
+        self._scale: torch.Tensor | None = None
+
+    def set_scale(self, scale: torch.Tensor) -> None:
+        """Set a scaling factor applied to the loss output."""
+        self._scale = scale
+
+    def __call__(self, pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        loss = self._fn(pred, labels)
+        if self._scale is not None:
+            loss = loss * self._scale
+        return loss
+
+
 def build_cross_entropy_loss(compile_config: CompileConfig, **kwargs):
     del kwargs  # delete any unused arguments
     loss_fn = cross_entropy_loss
     if compile_config.enable and "loss" in compile_config.components:
         logger.info("Compiling the loss function with torch.compile")
         loss_fn = torch.compile(loss_fn, backend=compile_config.backend)
-    return loss_fn
-
-
-def mse_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-    """Common MSE loss function with sum reduction for Transformer models training."""
-    return torch.nn.functional.mse_loss(
-        pred.float(), labels.float().detach(), reduction="sum"
-    )
+    return ScaledLoss(loss_fn)
 
 
 def build_mse_loss(compile_config: CompileConfig, **kwargs):
@@ -50,4 +77,4 @@ def build_mse_loss(compile_config: CompileConfig, **kwargs):
     if compile_config.enable and "loss" in compile_config.components:
         logger.info("Compiling the loss function with torch.compile")
         loss_fn = torch.compile(loss_fn, backend=compile_config.backend)
-    return loss_fn
+    return ScaledLoss(loss_fn)

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.dataloader import BaseDataLoader
-from torchtitan.components.loss import IGNORE_INDEX, LossFunction
+from torchtitan.components.loss import IGNORE_INDEX, ScaledLoss
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.config import Configurable, ParallelismConfig
@@ -101,7 +101,7 @@ class Validator(BaseValidator):
         dp_rank: int,
         tokenizer: BaseTokenizer,
         parallel_dims: ParallelDims,
-        loss_fn: LossFunction,
+        loss_fn: ScaledLoss,
         validation_context: ValidationContext,
         metrics_processor: MetricsProcessor,
         seq_len: int,
@@ -273,6 +273,9 @@ class Validator(BaseValidator):
             else:
                 global_valid_tokens = local_valid_tokens.float()
 
+            # Set loss scale for this batch
+            self.loss_fn.set_scale(1.0 / global_valid_tokens)
+
             if parallel_dims.pp_enabled:
                 assert self.pp_schedule is not None
                 assert self.pp_has_first_stage is not None
@@ -301,17 +304,19 @@ class Validator(BaseValidator):
                 # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
                 if self.pp_has_last_stage:
                     assert losses is not None
-                    # using sum because loss_fn already uses reduction='sum'
-                    loss_sum = torch.sum(torch.stack(losses)).to(device_type)
+                    loss = torch.sum(torch.stack(losses)).to(device_type)
                 else:
-                    loss_sum = torch.tensor([-1.0], device=device_type)
+                    loss = torch.tensor([-1.0], device=device_type)
             else:
                 with self.validation_context():
                     assert len(model_parts) == 1
                     predictions = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
-                    loss_sum = self.loss_fn(predictions, labels)
+                    loss = self.loss_fn(predictions, labels)
 
-            accumulated_losses.append(loss_sum.detach() / global_valid_tokens)
+            # Reset scale after use
+            self.loss_fn.set_scale(None)
+
+            accumulated_losses.append(loss.detach())
             num_steps += 1
 
         # Compute average loss

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -20,7 +20,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.dataloader import BaseDataLoader, DataloaderExhaustedError
-from torchtitan.components.loss import IGNORE_INDEX, LossFunction
+from torchtitan.components.loss import IGNORE_INDEX, ScaledLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
 from torchtitan.components.optimizer import (
@@ -172,7 +172,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     # TODO: we should make this list[BaseModel / Decoder] but this will affect many components.
     # will do this in a separate PR
     model_parts: list[torch.nn.Module]
-    loss_fn: LossFunction
+    loss_fn: ScaledLoss
     optimizers: OptimizersContainer
     lr_schedulers: LRSchedulersContainer
     validator: BaseValidator

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -705,6 +705,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 del pred
                 loss.backward()
 
+        # Reset scale so it doesn't leak into validation or other callers.
+        self.loss_fn.set_scale(None)
+
         # The returned loss here is local SUM loss / global_valid_tokens
         return loss
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -660,6 +660,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             input_dict, labels
         )
 
+        # Set loss scale so gradients are properly normalized.
+        # This applies to both PP and non-PP paths uniformly.
+        self.loss_fn.set_scale(1.0 / global_valid_tokens)
+
         if parallel_dims.pp_enabled:
             # Pipeline Parallel forward / backward inside step() call
             with self.train_context():
@@ -687,11 +691,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
             if self.pp_has_last_stage:
                 assert losses is not None
-                # Rescale PP loss to be "local loss sum / global valid tokens"
-                # because each microbatch could have different number of valid tokens
-                loss = (torch.sum(torch.stack(losses)) / global_valid_tokens).to(
-                    self.device
-                )
+                loss = torch.sum(torch.stack(losses)).to(self.device)
             else:
                 loss = torch.tensor([-1.0], device=self.device)
         else:
@@ -699,12 +699,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             assert len(model_parts) == 1
             with self.train_context():
                 pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
-                # Compute loss sum (reduction='sum')
-                loss_sum = self.loss_fn(pred, labels)
-
-                # Scale the loss by the inverse of the total weight denominator before backward
-                # This ensures gradients are properly normalized across all microbatches
-                loss = loss_sum / global_valid_tokens
+                loss = self.loss_fn(pred, labels)
 
                 # need to free pred before bwd to avoid peaking memory
                 del pred


### PR DESCRIPTION
fix #2972 

There's 2 option to fix:
1. Add scaling to the loss function classes (clean, self-contained)
```
  class CrossEntropyLoss:
      def __init__(self, ...):
          self._scale = None

      def set_scale(self, scale: torch.Tensor) -> None:
          self._scale = scale

      def __call__(self, pred, labels):
          loss = self._fn(pred, labels)
          if self._scale is not None:
              return loss * self._scale
          return loss
```
Then in the trainer, before each step:
  `self.loss_fn.set_scale(1.0 / global_valid_tokens)`

Works for both PP and non-PP. Non-PP can also use this instead of the explicit loss_sum / global_valid_tokens in the trainer, unifying both paths.

2. Upstream fix in PyTorch's PP schedule: Add a loss_scale parameter to the schedule or allow _compute_loss to accept additional context. This is the right long-term fix but requires a PyTorch PR.

This PR go with Option 1. 

## Test
<img width="587" height="424" alt="Screenshot 2026-04-15 at 10 57 36 AM" src="https://github.com/user-attachments/assets/0e2d0afd-4205-4cb2-b5ae-cf833826f006" />

