### PR TITLE
fix CP `n_tokens_seen` overcounting

### DIFF
--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -134,7 +134,8 @@ class FluxTrainer(Trainer):
             input_dict, labels = batch
             bsz = labels.shape[0]
             ntokens_batch = bsz * self.config.training.seq_len
-            self.ntokens_seen += ntokens_batch
+            # Divide by cp_degree, because CP ranks process the same tokens
+            self.ntokens_seen += ntokens_batch // self.parallel_dims.cp
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -134,8 +134,6 @@ class FluxTrainer(Trainer):
             input_dict, labels = batch
             bsz = labels.shape[0]
             ntokens_batch = bsz * self.config.training.seq_len
-            # Divide by cp_degree, because CP ranks process the same tokens
-            self.ntokens_seen += ntokens_batch // self.parallel_dims.cp
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
@@ -237,6 +235,10 @@ class FluxTrainer(Trainer):
                 None,  # No attention masks for Flux
                 load_balancer_type=None,
             )
+
+        # Accumulate after CP sharding so the count reflects the actual
+        # unique tokens this rank processes (not the full pre-split sequence).
+        self.ntokens_seen += bsz * self.config.training.seq_len // self.parallel_dims.cp
 
         with self.train_context():
             latent_noise_pred = model(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -540,7 +540,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 raise DataloaderExhaustedError() from ex
             input_dict, labels = batch
             ntokens_batch = labels.numel()
-            self.ntokens_seen += ntokens_batch
+            # Divide by cp_degree, because CP ranks process the same tokens
+            self.ntokens_seen += ntokens_batch // self.parallel_dims.cp
+
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -540,9 +540,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 raise DataloaderExhaustedError() from ex
             input_dict, labels = batch
             ntokens_batch = labels.numel()
-            # Divide by cp_degree, because CP ranks process the same tokens
-            self.ntokens_seen += ntokens_batch // self.parallel_dims.cp
-
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
@@ -645,6 +642,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.device,
                 self.config.parallelism.context_parallel_load_balancer,
             )
+
+        # Accumulate after CP sharding so labels.numel() reflects the actual
+        # unique tokens this rank processes (not the full pre-split sequence).
+        self.ntokens_seen += labels.numel()
 
         return inputs, labels, extra_inputs, extra_kwargs
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchtitan/issues/2983

Before (DP=4, CP=1): `torchrun --nproc_per_node=4 --local-rank 0 -m torchtitan.train --module llama3 --config llama3_debugmodel_flex_attn --training.steps 5 --metrics.log_freq 1 --parallelism.data_parallel_shard_degree 4 --parallelism.context_parallel_degree 1 --training.global_batch_size 32 --training.seq_len 2048`
```
[titan] 2026-04-15 16:43:45,087 - root - INFO - [DEBUG] n_tokens_seen: 327680.0
[titan] 2026-04-15 16:43:45,087 - root - INFO - [31mstep:  5  [32mloss:  5.59510  [38;2;180;60;0mgrad_norm:  2.4778  [38;2;54;234;195mmemory:  1.09GiB(1.38%)  [34mtps: 104,455  [36mtflops: 7.48  [35mmfu: 2.40%[39m
```

Before (DP=2, CP=2): `torchrun --nproc_per_node=4 --local-rank 0 -m torchtitan.train --module llama3 --config llama3_debugmodel_flex_attn --training.steps 5 --metrics.log_freq 1 --parallelism.data_parallel_shard_degree 2 --parallelism.context_parallel_degree 2 --training.global_batch_size 32 --training.seq_len 2048`
```
[titan] 2026-04-15 16:37:32,439 - root - INFO - [DEBUG] n_tokens_seen: 655360.0
[titan] 2026-04-15 16:37:32,440 - root - INFO - [31mstep:  5  [32mloss:  5.63218  [38;2;180;60;0mgrad_norm:  2.4113  [38;2;54;234;195mmemory:  0.65GiB(0.82%)  [34mtps: 50,305  [36mtflops: 3.60  [35mmfu: 1.15%[39m
```

After (DP=4, CP=1):
```
[titan] 2026-04-15 16:44:35,135 - root - INFO - [DEBUG] n_tokens_seen: 327680.0
[titan] 2026-04-15 16:44:35,135 - root - INFO - [31mstep:  5  [32mloss:  5.60330  [38;2;180;60;0mgrad_norm:  2.2935  [38;2;54;234;195mmemory:  1.09GiB(1.38%)  [34mtps: 102,444  [36mtflops: 7.33  [35mmfu: 2.35%[39m
```

After (DP=2, CP=2):
```
[titan] 2026-04-15 16:45:17,312 - root - INFO - [DEBUG] n_tokens_seen: 327680.0
[titan] 2026-04-15 16:45:17,312 - root - INFO - [31mstep:  5  [32mloss:  5.58680  [38;2;180;60;0mgrad_norm:  2.2043  [38;2;54;234;195mmemory:  0.65GiB(0.82%)  [34mtps: 49,120  [36mtflops: 3.52  [35mmfu: 1.13%[39m
```