### PR TITLE
Fix memory snapshot hang with aot_fx_trace codegen

### DIFF
--- a/torchtitan/tools/profiling.py
+++ b/torchtitan/tools/profiling.py
@@ -171,7 +171,10 @@ def maybe_enable_memory_snapshot(
         class MemoryProfiler:
             def __init__(self, step_num: int, freq: int):
                 device_module.memory._record_memory_history(
-                    max_entries=MEMORY_SNAPSHOT_MAX_ENTRIES
+                    max_entries=MEMORY_SNAPSHOT_MAX_ENTRIES,
+                    # Use stacks="all" if you need C++ stacks, but you might
+                    # run into unwind problems (RuntimeError: stoi).
+                    stacks="python",
                 )
                 # when resume training, we start from the last step
                 self.step_num = step_num


### PR DESCRIPTION
## Summary
- The C++ stack unwinder crashes with `RuntimeError: stoi` when `_record_memory_history` uses the default `stacks="all"` and the memory snapshot tries to symbolize frames from `aot_fx_trace` custom codegen (`/tmp/torchtitan_fx_codegen/`).
- Root cause: `torch/csrc/profiler/unwind/unwind.cpp:427` calls `std::stoi(lineno_str)` on a frame where the line number portion is not a valid integer, causing an unhandled exception.
- Fix: use `stacks="python"` to collect only Python stack frames, avoiding the buggy C++ unwinder path. Python frames are the useful ones for debugging memory allocations anyway.

## Test plan
- [x] Reproduced the crash: `--profiling.enable_memory_snapshot` with `aot_fx_trace` on Llama3 8B hangs at "Dumping memory snapshot" and produces 0-byte pickle files.
- [x] Verify the fix: re-run the same command and confirm non-empty `.pickle` files are produced and the run completes cleanly.