### PR TITLE
[GraphTrainer] Fix custom_codegen_pass hang on large models

### DIFF
--- a/torchtitan/experiments/graph_trainer/custom_codegen.py
+++ b/torchtitan/experiments/graph_trainer/custom_codegen.py
@@ -320,6 +320,12 @@ def call(self, *args, **kwargs):
             if node.op in ("call_function", "call_method", "call_module")
         }
 
+        # Pre-compile a single regex to extract the leading identifier from
+        # assignment lines (``name = ...``) or tuple-unpacking lines
+        # (``name, ...``).  This replaces the previous O(lines × nodes)
+        # per-node regex scan with O(lines) extraction + O(1) dict lookup.
+        _leading_ident_re = re.compile(r"^([A-Za-z_]\w*)(?:\s*=\s|\s*,)")
+
         profiled_lines = [signature_line]
         for line in body_lines:
             stripped = line.strip()
@@ -330,14 +336,9 @@ def call(self, *args, **kwargs):
             indent = line[: len(line) - len(line.lstrip())]
 
             matched_node = None
-            for node_name, node in node_info.items():
-                # Use regex to match assignment (node_name = ...) or tuple
-                # unpacking (node_name, ...) patterns precisely, avoiding
-                # false matches on continuation lines of multi-line
-                # expressions.
-                if re.match(rf"^{re.escape(node_name)}(\s*=\s|\s*,)", stripped):
-                    matched_node = node
-                    break
+            m = _leading_ident_re.match(stripped)
+            if m:
+                matched_node = node_info.get(m.group(1))
 
             if matched_node:
                 label = self._get_profiler_label(matched_node).replace('"', '\\"')

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -90,8 +90,7 @@ def construct_default_graph_passes(
         # 3. User-editable codegen: users can directly modify the generated
         #    program on disk for fine-grain scheduling optimizations, with
         #    hot-reload picking up changes at runtime
-        # TODO: Investigate why custom_codegen_pass hangs when dumping codegen file
-        # custom_codegen_pass,
+        custom_codegen_pass,
     ]
 
     # cudagraph should be the last pass.


### PR DESCRIPTION
## Summary
- Fix O(lines × nodes) regex hang in `_generate_profiled_forward` that made `custom_codegen_pass` unusable on large models (Llama 8B+)
- The inner loop compiled a new regex per node per code line (~5k × ~5k = ~25M regex ops for Llama 8B), causing an effective hang at `[CUSTOM_CODEGEN] Saving code to ...`
- Replace with a single pre-compiled regex that extracts the leading identifier + O(1) dict lookup. Codegen pass now completes in ~1s for Llama 8B.
- Re-enables `custom_codegen_pass` in the default pass list (was disabled as a workaround in #2992)

## Test plan
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x` — 37/37 passed (including 4 codegen tests)
- [x] Reproduced hang: Llama 8B profiling run stuck at codegen for 3+ minutes, `py-spy` confirmed stuck in `re.match` at `custom_codegen.py:338`
- [x] Verified fix: same command completes in ~1s for codegen, full 15-step profiling run finishes cleanly