### PR TITLE
ci: install torchvision alongside torch in transformers backend workflow

### DIFF
--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -64,6 +64,8 @@ jobs:
         if [ -n "${{ matrix.torch-version }}" ]; then
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
+        # NOTE: reinstall torchvision alongside torch so their ABIs stay in sync;
+        # otherwise transformers' transitive `import torchvision` fails at test time.
         python -m pip install --force-reinstall --pre \
           "${TORCH_SPEC}" torchvision --index-url ${{ matrix.index-url }}
 

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -65,7 +65,7 @@ jobs:
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
         python -m pip install --force-reinstall --pre \
-          "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+          "${TORCH_SPEC}" torchvision --index-url ${{ matrix.index-url }}
 
         if [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
           export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"


### PR DESCRIPTION
## Summary

The ROCm path of `integration_test_8gpu_transformers_modeling_backend.yaml` reinstalls `torch` from the ROCm nightly index but doesn't reinstall `torchvision`, leaving the docker image's stale `torchvision==0.26.0` (built against `torch==2.11.0`). pip's resolver flags this explicitly:

```
torchvision 0.26.0 requires torch==2.11.0,
  but you have torch 2.12.0.dev20260411+rocm7.1 which is incompatible.
```

When `transformers.modeling_utils` eagerly imports torchvision (via `loss_for_object_detection.py` → `image_transforms.py` → `image_utils.py`), the registration `@torch.library.register_fake("torchvision::nms")` fails because the op doesn't exist in the freshly-installed torch nightly:

```
RuntimeError: operator torchvision::nms does not exist
```

This crashes the test at import time, before any GPU code runs.

## Reproduction

Failing scheduled run on `main`: https://github.com/pytorch/torchtitan/actions/runs/24270213946/job/70873527337

Reproduced locally on MI325X with `rocm/pytorch:latest`:
```bash
pip install --force-reinstall --pre torch \
  --index-url https://download.pytorch.org/whl/nightly/rocm7.1
python -c "import torchvision"
# RuntimeError: operator torchvision::nms does not exist
```

After the fix:
```bash
pip install --force-reinstall --pre torch torchvision \
  --index-url https://download.pytorch.org/whl/nightly/rocm7.1
python -c "import torchvision; print(torchvision.__version__)"
# OK
```

## Test plan

- [ ] CI's ROCm `build-test (rocm, linux.rocm.gpu.gfx942.8, ...)` job goes green on this PR
- [ ] CUDA `build-test (cuda, ...)` job stays green (no regression)

## Note on a separate latent issue

While reproducing, I also hit an unrelated `TypeError: HFTransformerModel.Config field 'transformers_version' must be keyword-only` at `model.py:83` with `transformers >= 5.5.x` (inherited from `PretrainedConfig`). That's downstream of this fix — CI's docker image currently has an older `transformers` so it doesn't trigger yet. Worth filing separately once this lands and the ROCm path actually gets that far.