### PR TITLE
[graph_trainer] Add debug_graph_passes config for per-pass instrumentation

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -72,6 +72,20 @@ python torchtitan/experiments/graph_trainer/tests/integration_tests.py <output_d
     --test_suite graph_trainer_default --ngpu 8
 ```
 
+### Debugging Graph Passes
+
+Add `--compile.debug_graph_passes` to enable per-pass instrumentation:
+timing, before/after tlparse graph dumps, and op-count diff summaries.
+Use with `TORCH_TRACE` and `tlparse` to inspect graphs in the browser.
+
+```bash
+NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh \
+    --compile.mode aot_fx_trace \
+    --compile.debug_graph_passes \
+    --dataloader.dataset c4_test \
+    --training.steps 10
+```
+
 ### Dumping Graph Modules for Debugging
 
 To inspect a `GraphModule` at any point, dump it to a temporary file:
@@ -111,7 +125,9 @@ diff /tmp/my_pass_before.txt /tmp/my_pass_after.txt
 ### Benchmark
 
 Use `./run_train.sh` with a small number of steps. Disable tensorboard,
-profiling, and flight recorder for cleaner timing:
+profiling, and flight recorder for cleaner timing. Always use
+`--dataloader.dataset c4_test` for local runs to avoid downloading the
+full C4 dataset from HuggingFace:
 
 ```bash
 # Llama3 8B aot_fx_trace (8×H100, FSDP+TP, 20 steps)
@@ -119,6 +135,7 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
+    --dataloader.dataset c4_test \
     --metrics.no-enable_tensorboard \
     --profiling.no-enable_profiling \
     --comm.trace_buf_size=0 \
@@ -130,6 +147,7 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./r
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
     --parallelism.expert_parallel_degree=2 \
+    --dataloader.dataset c4_test \
     --metrics.no-enable_tensorboard \
     --profiling.no-enable_profiling \
     --comm.trace_buf_size=0 \
@@ -154,6 +172,7 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
+    --dataloader.dataset c4_test \
     --profiling.enable_profiling \
     --profiling.profile_freq 10
 ```
@@ -174,6 +193,7 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
+    --dataloader.dataset c4_test \
     --profiling.enable_memory_snapshot \
     --profiling.profile_freq 10
 ```

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -40,6 +40,9 @@ class GraphTrainerCompileConfig(CompileConfig):
     enable_passes: bool = True
     """When False, skip all graph passes (both default and user-configured)."""
 
+    debug_graph_passes: bool = False
+    """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/debug_utils.py
+++ b/torchtitan/experiments/graph_trainer/debug_utils.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import annotations
-
 from collections import defaultdict
 
 import torch

--- a/torchtitan/experiments/graph_trainer/pass_debug.py
+++ b/torchtitan/experiments/graph_trainer/pass_debug.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import torch
+
+from torchtitan.tools.logging import logger
+
+
+def _get_node_target_name(node: torch.fx.Node) -> str:
+    """Return a human-readable name for a node's target."""
+    if node.op == "call_function":
+        target = node.target
+        if hasattr(target, "__name__"):
+            return target.__name__
+        return str(target).split(".")[-1]
+    return f"{node.op}:{node.target}"
+
+
+def snapshot_graph(gm: torch.fx.GraphModule) -> dict:
+    """Capture a structural snapshot of a graph for comparison."""
+    op_counts: dict[str, int] = defaultdict(int)
+    num_nodes = 0
+    num_placeholders = 0
+    num_outputs = 0
+
+    for node in gm.graph.nodes:
+        num_nodes += 1
+        if node.op == "placeholder":
+            num_placeholders += 1
+        elif node.op == "output":
+            num_outputs += 1
+        elif node.op == "call_function":
+            op_counts[_get_node_target_name(node)] += 1
+        elif node.op == "get_attr":
+            op_counts["get_attr"] += 1
+
+    return {
+        "op_counts": dict(op_counts),
+        "num_nodes": num_nodes,
+        "num_placeholders": num_placeholders,
+        "num_outputs": num_outputs,
+    }
+
+
+def log_graph_diff(
+    before: dict,
+    after: dict,
+    pass_name: str,
+) -> None:
+    """Log a structured summary of what a graph pass changed."""
+    lines = []
+
+    node_delta = after["num_nodes"] - before["num_nodes"]
+    if node_delta:
+        lines.append(
+            f"  nodes: {before['num_nodes']} -> {after['num_nodes']} ({node_delta:+d})"
+        )
+
+    ph_delta = after["num_placeholders"] - before["num_placeholders"]
+    if ph_delta:
+        lines.append(
+            f"  placeholders: {before['num_placeholders']} -> {after['num_placeholders']} ({ph_delta:+d})"
+        )
+
+    out_delta = after["num_outputs"] - before["num_outputs"]
+    if out_delta:
+        lines.append(
+            f"  outputs: {before['num_outputs']} -> {after['num_outputs']} ({out_delta:+d})"
+        )
+
+    all_ops = sorted(set(before["op_counts"]) | set(after["op_counts"]))
+    changed_ops = []
+    for op in all_ops:
+        b = before["op_counts"].get(op, 0)
+        a = after["op_counts"].get(op, 0)
+        if b != a:
+            changed_ops.append(f"  {op}: {b} -> {a} ({a - b:+d})")
+
+    if changed_ops:
+        lines.append("  op changes:")
+        lines.extend(f"    {line}" for line in changed_ops)
+
+    if not lines:
+        logger.info(f"[{pass_name}] graph unchanged")
+    else:
+        logger.info(f"[{pass_name}] graph diff:\n" + "\n".join(lines))

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -39,11 +39,11 @@ from torch.utils.checkpoint import CheckpointPolicy
 from torchtitan.distributed.activation_checkpoint import _get_save_ops
 from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
-from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
-from torchtitan.experiments.graph_trainer.pass_debug import (
+from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
     snapshot_graph,
 )
+from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_detach_pass,
     remove_identity_slice_pass,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import functools
 import operator
+import time
 from collections import defaultdict
 from collections.abc import Callable
 
@@ -39,6 +40,10 @@ from torchtitan.distributed.activation_checkpoint import _get_save_ops
 from torchtitan.experiments.graph_trainer.common_utils import _AC_REGION_ID
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+from torchtitan.experiments.graph_trainer.pass_debug import (
+    log_graph_diff,
+    snapshot_graph,
+)
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_detach_pass,
     remove_identity_slice_pass,
@@ -69,7 +74,6 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     return [
-        functools.partial(tlparse_log_graph_pass, graph_name="make_fx_graph_traced"),
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
@@ -133,6 +137,8 @@ def apply_graph_passes(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
     passes: list[Callable],
+    *,
+    compile_config: "GraphTrainerCompileConfig | None" = None,
 ) -> torch.fx.GraphModule:
     """Apply graph passes to the traced fwd+bwd graph.
 
@@ -141,9 +147,32 @@ def apply_graph_passes(
         example_inputs: Example (fake) inputs matching the graph signature.
         passes: Ordered list of pass callables, each with signature
             ``(gm, example_inputs, **kwargs) -> gm``.
+        compile_config: Optional compile config. When provided and
+            ``debug_graph_passes`` is True, logs timing, op-count diffs,
+            and before/after graphs to tlparse for each pass.
     """
+    debug = compile_config is not None and compile_config.debug_graph_passes
+    tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced")
     for pass_fn in passes:
+        pass_name = (
+            pass_fn.func.__name__
+            if isinstance(pass_fn, functools.partial)
+            else pass_fn.__name__
+        )
+        if debug:
+            tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}")
+            before_snapshot = snapshot_graph(gm)
+            start = time.perf_counter()
         gm = pass_fn(gm, example_inputs)
+        assert isinstance(
+            gm, torch.fx.GraphModule
+        ), f"Pass {pass_name} returned {type(gm).__name__}, expected GraphModule"
+        if debug:
+            elapsed = time.perf_counter() - start
+            logger.info(f"Pass {pass_name} took {elapsed:.3f}s")
+            tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}")
+            after_snapshot = snapshot_graph(gm)
+            log_graph_diff(before_snapshot, after_snapshot, pass_name)
     return gm
 
 
@@ -741,6 +770,7 @@ def tlparse_log_graph_pass(
             include_stride=True,
             include_device=True,
             expanded_def=True,
+            additional_meta=["autograd_backward"],
         ),
         expect_trace_id=False,
     )

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -47,6 +47,7 @@ def build_minimal_trainer(
                 if compile_joint_passes is None
                 else list(compile_joint_passes),
                 precompile_artifact_dir="",
+                debug_graph_passes=False,
             ),
             activation_checkpoint=ActivationCheckpointConfig(
                 mode=activation_checkpoint_mode

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -167,6 +167,7 @@ class GraphTrainer(Trainer):
                     self._traced_step.gm,
                     self._traced_step.example_inputs,
                     passes,
+                    compile_config=self.config.compile,
                 )
         with self.train_context():
             outputs = run_traced_train_step(


### PR DESCRIPTION
## Summary
- Add `--compile.debug_graph_passes` flag to `GraphTrainerCompileConfig` that enables per-pass instrumentation: timing, before/after tlparse graph dumps, and op-count diff summaries
- New `pass_debug.py` module with `snapshot_graph` and `log_graph_diff` utilities for structured graph comparison
- Add assert that every pass returns a `GraphModule`
- Always log initial `make_fx_graph_traced` graph to tlparse (moved from `compile_time_passes` to `apply_graph_passes`)
- Add `additional_meta=["autograd_backward"]` to `tlparse_log_graph_pass` for better graph readability
- Add `--dataloader.dataset c4_test` to all local dev commands in CLAUDE.md to avoid unnecessary HuggingFace dataset downloads

## Test plan
- [x] Run `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x` to verify no regression
- [x] Run with `--compile.debug_graph_passes` and verify tlparse output shows before/after graphs and op-count diffs per pass
- [x] Run without the flag and verify no debug output is emitted (only `make_fx_graph_traced` tlparse artifact)

sample tlp: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmp68GlQ1/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000