### PR TITLE
[DO NOT LAND] CI test: trigger from inside graph_trainer/

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -1,3 +1,4 @@
+<!-- CI trigger test: inside graph_trainer path -->
 ## GraphTrainer
 
 [![integration and numerics tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml?query=branch%3Amain)


### PR DESCRIPTION
## Purpose
**This PR is for CI path-filter verification only. Please do not review or land.**

Verifying that graph_trainer workflows trigger correctly when a PR touches files under `torchtitan/experiments/graph_trainer/**`.

## What changes
Single trivial edit to `torchtitan/experiments/graph_trainer/README.md` (one HTML-comment line added).

## Expected CI behavior
- `GraphTrainer 8 GPU Integration Tests` — **should run**
- `GraphTrainer 8 GPU H100 Integration Tests` — **should run**

## Follow-up
This branch / PR will be closed and deleted once CI has run and the trigger behavior is confirmed.