### PR TITLE
[DO NOT LAND] CI test: no trigger from outside graph_trainer/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- CI trigger test: outside graph_trainer path -->
 <div align="center">
 
 # torchtitan


### PR DESCRIPTION
## Purpose
**This PR is for CI path-filter verification only. Please do not review or land.**

Verifying that graph_trainer workflows do **NOT** trigger when a PR touches files outside `torchtitan/experiments/graph_trainer/**`.

## What changes
Single trivial edit to the repo-root `README.md` (one HTML-comment line added).

## Expected CI behavior
- `GraphTrainer 8 GPU Integration Tests` — **should NOT run**
- `GraphTrainer 8 GPU H100 Integration Tests` — **should NOT run**

(Other CI that triggers on doc or root changes may still run — that's unrelated.)

## Follow-up
This branch / PR will be closed and deleted once the no-trigger behavior is confirmed.