### PR TITLE
[HybridEP] Enable HybridEP with graph_trainer

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -241,7 +241,6 @@ torch.library.register_autograd(
 )
 
 
-@torch.compiler.disable()
 def sync_combine() -> None:
     """Synchronize the current CUDA stream with the pending combine operation.
 
@@ -251,7 +250,7 @@ def sync_combine() -> None:
     the combine to finish.
 
     torch.compile Compatibility:
-        Decorated with @torch.compiler.disable() to always run in eager mode.
+        Guarded with is_compiling() to skip in compile mode.
         This avoids issues with CUDA event operations not being traceable.
 
     Process Isolation:
@@ -277,6 +276,13 @@ def sync_combine() -> None:
     was already synced or if no combine operation is pending.
     """
     global _pending_combine_event
+    # is_compiling() is True under Dynamo (aot mode) — skip to avoid tracing
+    # through global state Dynamo can't handle. Under make_fx (aot_fx_trace),
+    # is_compiling() is False so this guard doesn't fire, but the function is
+    # still safe: _pending_combine_event is None during tracing (no real
+    # combine ran), so the body below is a no-op.
+    if torch.compiler.is_compiling():
+        return
 
     if _pending_combine_event is not None:
         _pending_combine_event.current_stream_wait()

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -243,7 +243,6 @@ torch.library.register_autograd(
 )
 
 
-@torch.compiler.disable()
 def sync_combine() -> None:
     """Synchronize the current CUDA stream with the pending combine operation.
 
@@ -279,6 +278,8 @@ def sync_combine() -> None:
     was already synced or if no combine operation is pending.
     """
     global _pending_combine_event
+    if torch.compiler.is_compiling():
+        return
 
     if _pending_combine_event is not None:
         _pending_combine_event.current_stream_wait()

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -237,7 +237,7 @@ def _dispatch_fake(
     else:
         out_tokens = x.shape[0]
     hidden = x.new_empty(out_tokens, x.shape[1])
-    scores = x.new_empty(0, dtype=torch.float32)
+    scores = x.new_empty(out_tokens, dtype=torch.float32)
     tpe = x.new_empty(num_local_experts, dtype=torch.int64)
     return hidden, scores, tpe, DispatchHandle()
 
@@ -275,25 +275,34 @@ def _dispatch_backward(ctx, grad_hidden, grad_scores, grad_tpe, grad_handle):
         return None, None, None, None, None, None, None
 
     dispatch_handle = ctx.dispatch_handle
-    if dispatch_handle is None or dispatch_handle.value is None:
-        raise RuntimeError("DispatchHandle not found in dispatch backward")
-
     (topk_idx,) = ctx.saved_tensors
-    grad_x, grad_probs_dense = _buffer.combine_with_unpermute(
-        hidden=grad_hidden,
-        probs=(
-            grad_scores if grad_scores is not None and grad_scores.numel() > 0 else None
-        ),
-        handle=dispatch_handle.value,
-    )
-    grad_x = grad_x.to(ctx.input_dtype)
 
-    # grad_probs_dense is [num_tokens, num_experts]; gather back to sparse [num_tokens, top_k]
-    grad_weights = (
-        grad_probs_dense.gather(dim=1, index=topk_idx)
-        if grad_probs_dense is not None
-        else None
-    )
+    if dispatch_handle is None or dispatch_handle.value is None:
+        from torch._subclasses.fake_tensor import FakeTensor
+        from torch._subclasses.functional_tensor import FunctionalTensor
+
+        if not isinstance(grad_hidden, (FunctionalTensor, FakeTensor)):
+            raise RuntimeError("DispatchHandle not found in dispatch backward")
+        grad_x = grad_hidden.new_zeros(topk_idx.shape[0], grad_hidden.shape[-1])
+        grad_weights = grad_hidden.new_zeros(topk_idx.shape)
+    else:
+        grad_x, grad_probs_dense = _buffer.combine_with_unpermute(
+            hidden=grad_hidden,
+            probs=(
+                grad_scores
+                if grad_scores is not None and grad_scores.numel() > 0
+                else None
+            ),
+            handle=dispatch_handle.value,
+        )
+        grad_x = grad_x.to(ctx.input_dtype)
+
+        # grad_probs_dense is [num_tokens, num_experts]; gather back to sparse [num_tokens, top_k]
+        grad_weights = (
+            grad_probs_dense.gather(dim=1, index=topk_idx)
+            if grad_probs_dense is not None
+            else None
+        )
     # Gradients for: x, topk_idx, topk_weights, num_experts, non_blocking,
     #                moe_expert_capacity_factor, pad_multiple
     return grad_x, None, grad_weights, None, None, None, None
@@ -312,15 +321,22 @@ def _combine_backward(ctx, grad_combined):
     """Backward: scatter gradients via dispatch."""
     dispatch_handle = ctx.dispatch_handle
     if dispatch_handle is None or dispatch_handle.value is None:
-        raise RuntimeError("DispatchHandle not found in combine backward")
+        from torch._subclasses.fake_tensor import FakeTensor
+        from torch._subclasses.functional_tensor import FunctionalTensor
 
-    grad_x, _, _, _, _ = _buffer.dispatch_with_permute(
-        hidden=grad_combined,
-        scaling_factor=None,
-        handle=dispatch_handle.value,
-        num_permuted_tokens=ctx.num_permuted_tokens,
-        pad_multiple=ctx.pad_multiple,
-    )
+        if not isinstance(grad_combined, (FunctionalTensor, FakeTensor)):
+            raise RuntimeError("DispatchHandle not found in combine backward")
+        grad_x = grad_combined.new_zeros(
+            ctx.num_permuted_tokens, grad_combined.shape[-1]
+        )
+    else:
+        grad_x, _, _, _, _ = _buffer.dispatch_with_permute(
+            hidden=grad_combined,
+            scaling_factor=None,
+            handle=dispatch_handle.value,
+            num_permuted_tokens=ctx.num_permuted_tokens,
+            pad_multiple=ctx.pad_multiple,
+        )
     # Gradients for: x, handle, num_tokens, pad_multiple
     return grad_x, None, None, None
 
@@ -439,13 +455,14 @@ def dispatch_tokens(
     # Buffer.__init__ calls all_gather_object() which triggers aten._to_copy
     # (CUDA→CPU), a MUST_SAVE op in our SAC policy. These are infrastructure
     # ops, not model compute, and must not enter SAC's FIFO cache.
-    with _disable_current_modes():
-        get_buffer(
-            group=group,
-            hidden_dim=hidden_states.shape[1],
-            num_tokens=hidden_states.shape[0],
-            num_local_experts=num_local_experts,
-        )
+    if _buffer is None:
+        with _disable_current_modes():
+            get_buffer(
+                group=group,
+                hidden_dim=hidden_states.shape[1],
+                num_tokens=hidden_states.shape[0],
+                num_local_experts=num_local_experts,
+            )
 
     (
         hidden,

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -237,7 +237,7 @@ def _dispatch_fake(
     else:
         out_tokens = x.shape[0]
     hidden = x.new_empty(out_tokens, x.shape[1])
-    scores = x.new_empty(0, dtype=torch.float32)
+    scores = x.new_empty(out_tokens, dtype=torch.float32)
     tpe = x.new_empty(num_local_experts, dtype=torch.int64)
     return hidden, scores, tpe, DispatchHandle()
 
@@ -275,25 +275,33 @@ def _dispatch_backward(ctx, grad_hidden, grad_scores, grad_tpe, grad_handle):
         return None, None, None, None, None, None, None
 
     dispatch_handle = ctx.dispatch_handle
-    if dispatch_handle is None or dispatch_handle.value is None:
-        raise RuntimeError("DispatchHandle not found in dispatch backward")
-
     (topk_idx,) = ctx.saved_tensors
-    grad_x, grad_probs_dense = _buffer.combine_with_unpermute(
-        hidden=grad_hidden,
-        probs=(
-            grad_scores if grad_scores is not None and grad_scores.numel() > 0 else None
-        ),
-        handle=dispatch_handle.value,
-    )
-    grad_x = grad_x.to(ctx.input_dtype)
 
-    # grad_probs_dense is [num_tokens, num_experts]; gather back to sparse [num_tokens, top_k]
-    grad_weights = (
-        grad_probs_dense.gather(dim=1, index=topk_idx)
-        if grad_probs_dense is not None
-        else None
-    )
+    if dispatch_handle is None or dispatch_handle.value is None:
+        from torch._subclasses.functional_tensor import FunctionalTensor
+
+        if not isinstance(grad_hidden, FunctionalTensor):
+            raise RuntimeError("DispatchHandle not found in dispatch backward")
+        grad_x = grad_hidden.new_zeros(topk_idx.shape[0], grad_hidden.shape[-1])
+        grad_weights = grad_hidden.new_zeros(topk_idx.shape)
+    else:
+        grad_x, grad_probs_dense = _buffer.combine_with_unpermute(
+            hidden=grad_hidden,
+            probs=(
+                grad_scores
+                if grad_scores is not None and grad_scores.numel() > 0
+                else None
+            ),
+            handle=dispatch_handle.value,
+        )
+        grad_x = grad_x.to(ctx.input_dtype)
+
+        # grad_probs_dense is [num_tokens, num_experts]; gather back to sparse [num_tokens, top_k]
+        grad_weights = (
+            grad_probs_dense.gather(dim=1, index=topk_idx)
+            if grad_probs_dense is not None
+            else None
+        )
     # Gradients for: x, topk_idx, topk_weights, num_experts, non_blocking,
     #                moe_expert_capacity_factor, pad_multiple
     return grad_x, None, grad_weights, None, None, None, None
@@ -312,15 +320,21 @@ def _combine_backward(ctx, grad_combined):
     """Backward: scatter gradients via dispatch."""
     dispatch_handle = ctx.dispatch_handle
     if dispatch_handle is None or dispatch_handle.value is None:
-        raise RuntimeError("DispatchHandle not found in combine backward")
+        from torch._subclasses.functional_tensor import FunctionalTensor
 
-    grad_x, _, _, _, _ = _buffer.dispatch_with_permute(
-        hidden=grad_combined,
-        scaling_factor=None,
-        handle=dispatch_handle.value,
-        num_permuted_tokens=ctx.num_permuted_tokens,
-        pad_multiple=ctx.pad_multiple,
-    )
+        if not isinstance(grad_combined, FunctionalTensor):
+            raise RuntimeError("DispatchHandle not found in combine backward")
+        grad_x = grad_combined.new_zeros(
+            ctx.num_permuted_tokens, grad_combined.shape[-1]
+        )
+    else:
+        grad_x, _, _, _, _ = _buffer.dispatch_with_permute(
+            hidden=grad_combined,
+            scaling_factor=None,
+            handle=dispatch_handle.value,
+            num_permuted_tokens=ctx.num_permuted_tokens,
+            pad_multiple=ctx.pad_multiple,
+        )
     # Gradients for: x, handle, num_tokens, pad_multiple
     return grad_x, None, None, None
 
@@ -439,13 +453,14 @@ def dispatch_tokens(
     # Buffer.__init__ calls all_gather_object() which triggers aten._to_copy
     # (CUDA→CPU), a MUST_SAVE op in our SAC policy. These are infrastructure
     # ops, not model compute, and must not enter SAC's FIFO cache.
-    with _disable_current_modes():
-        get_buffer(
-            group=group,
-            hidden_dim=hidden_states.shape[1],
-            num_tokens=hidden_states.shape[0],
-            num_local_experts=num_local_experts,
-        )
+    if not torch.compiler.is_compiling():
+        with _disable_current_modes():
+            get_buffer(
+                group=group,
+                hidden_dim=hidden_states.shape[1],
+                num_tokens=hidden_states.shape[0],
+                num_local_experts=num_local_experts,
+            )
 
     (
         hidden,

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -316,6 +316,8 @@ def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
     - **``aten._grouped_mm``**: the grouped matmul kernel used by MoE may
       perform internal CPU↔CUDA copies (e.g. workspace allocation) that
       are invisible in the FX graph metadata, breaking CUDA graph capture.
+      On sm_100+ (GB200/Blackwell) this is resolved and _grouped_mm is
+      cudagraph-compatible.
     - **flex_attention HOPs**: flex_attention higher-order ops require
       torch.compile (e.g. regional_inductor) to lower them into fused
       Triton kernels.  Without compilation they fall back to an unfused
@@ -352,13 +354,17 @@ def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
         # _grouped_mm may perform internal CPU↔CUDA copies (e.g. workspace
         # allocation) that are not visible from the FX graph metadata, so we
         # cannot rely on checking input device types alone.
+        # On sm_100+ (GB200/Blackwell) this is resolved and _grouped_mm is
+        # cudagraph-compatible.
         if node.target == torch.ops.aten._grouped_mm.default:
-            logger.warning(
-                "Skipping cudagraph: graph contains aten._grouped_mm "
-                "which may perform internal CPU↔CUDA copies incompatible "
-                "with CUDA graph capture"
-            )
-            return False
+            capability = torch.cuda.get_device_capability()
+            if capability < (10, 0):
+                logger.warning(
+                    "Skipping cudagraph: graph contains aten._grouped_mm "
+                    "which may perform internal CPU↔CUDA copies incompatible "
+                    "with CUDA graph capture"
+                )
+                return False
 
     for node in gm.graph.nodes:
         if node.op == "call_function" and node.target in _FLEX_ATTENTION_OPS:

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
@@ -20,9 +20,12 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str = "standard",
+    non_blocking_capacity_factor: float | None = None,
 ) -> ModelSpec:
     base = deepseekv3_configs[flavor](
-        attn_backend=attn_backend, moe_comm_backend=moe_comm_backend
+        attn_backend=attn_backend,
+        moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     config = GraphTrainerDeepSeekV3Model.Config(
         **{f.name: getattr(base, f.name) for f in fields(base)}

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -35,6 +35,18 @@ def graph_trainer_deepseek_v3_debugmodel_ep() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(deepseek_v3_debugmodel_ep(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    config.model_spec = model_registry(
+        "debugmodel",
+        moe_comm_backend="hybridep",
+        non_blocking_capacity_factor=1.0,
+    )
+    config.parallelism.expert_parallel_comm_backend = "hybridep"
+    return config
+
+
 def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> (GraphTrainer.Config):
     config = to_graph_trainer_config(deepseek_v3_debugmodel_flex_attn(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -104,6 +104,8 @@ def parallelize_deepseekv3(
     # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
     model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
+    # TODO: HybridEP applies to other sparse models (e.g. Qwen3). Refactor
+    # the common HybridEP buffer init into a shared utility.
     if comm_backend == "hybridep" and parallel_dims.ep_enabled:
         from torchtitan.distributed.deepep.hybridep import get_buffer
 

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -84,6 +84,10 @@ def parallelize_deepseekv3(
         # config in Trainer.Config.__post_init__; Module.parallelize applies it.
         model.parallelize(tp_mesh)
 
+    comm_backend = parallelism.expert_parallel_comm_backend
+    if comm_backend == "hybridep":
+        from torchtitan.distributed.deepep import hybridep  # noqa: F401
+
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(
             model,
@@ -92,12 +96,32 @@ def parallelize_deepseekv3(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             enable_sp=parallelism.enable_sequence_parallel,
+            comm_backend=comm_backend,
         )
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
     # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
     # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
     model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+
+    if comm_backend == "hybridep" and parallel_dims.ep_enabled:
+        from torchtitan.distributed.deepep.hybridep import get_buffer
+
+        ep_group = parallel_dims.get_mesh("ep").get_group()
+        moe_config = next(l.moe for l in model.config.layers if l.moe is not None)
+        num_local_experts = moe_config.num_experts // parallel_dims.ep
+        hidden_dim = model.config.dim
+        num_tokens = training.local_batch_size * training.seq_len
+        get_buffer(
+            group=ep_group,
+            hidden_dim=hidden_dim,
+            num_tokens=num_tokens,
+            num_local_experts=num_local_experts,
+        )
+        logger.info(
+            f"Pre-initialized HybridEP buffer (hidden_dim={hidden_dim}, "
+            f"num_tokens={num_tokens}, num_local_experts={num_local_experts})"
+        )
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -115,6 +115,10 @@ def parallelize_deepseekv3(
         )
         maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
+    comm_backend = parallelism.expert_parallel_comm_backend
+    if comm_backend == "hybridep":
+        from torchtitan.distributed.deepep import hybridep  # noqa: F401
+
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         from torchtitan.components.quantization import find_pad_multiple
 
@@ -126,6 +130,8 @@ def parallelize_deepseekv3(
             ep_mesh=parallel_dims.get_optional_mesh("ep"),
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
+            comm_backend=comm_backend,
+            hybridep_non_blocking_expert_capacity_factor=parallelism.hybridep_non_blocking_expert_capacity_factor,
             pad_multiple=pad_multiple,
         )
 
@@ -193,6 +199,25 @@ def parallelize_deepseekv3(
 
         logger.info(
             "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
+        )
+
+    if comm_backend == "hybridep" and parallel_dims.ep_enabled:
+        from torchtitan.distributed.deepep.hybridep import get_buffer
+
+        ep_group = parallel_dims.get_mesh("ep").get_group()
+        moe_config = next(l.moe for l in model.config.layers if l.moe is not None)
+        num_local_experts = moe_config.num_experts // parallel_dims.ep
+        hidden_dim = model.config.dim
+        num_tokens = training.local_batch_size * training.seq_len
+        get_buffer(
+            group=ep_group,
+            hidden_dim=hidden_dim,
+            num_tokens=num_tokens,
+            num_local_experts=num_local_experts,
+        )
+        logger.info(
+            f"Pre-initialized HybridEP buffer (hidden_dim={hidden_dim}, "
+            f"num_tokens={num_tokens}, num_local_experts={num_local_experts})"
         )
 
     # Apply compilation based on mode

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -573,6 +573,7 @@ def cudagraph_pass(
         static_input_indices,
         tensor_input_indices=tensor_input_indices,
     )
+    logger.info("Applied cudagraph pass.")
     return gm
 
 

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -172,7 +172,7 @@ def _build_dsv3_layers(
     score_before_experts: bool = False,
     attn_backend: str,
     moe_comm_backend: str,
-    non_blocking_capacity_factor: float | None = None,
+    non_blocking_capacity_factor: float | None,
 ) -> list[TransformerBlock.Config]:
     """Build the list of per-layer TransformerBlock configs.
 
@@ -255,6 +255,7 @@ def _build_dsv3_layers(
 def _debugmodel(
     attn_backend: str,
     moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None,
 ) -> DeepSeekV3Model.Config:
     dim = 256
     n_layers = 6
@@ -287,6 +288,7 @@ def _debugmodel(
         score_before_experts=False,
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     return DeepSeekV3Model.Config(
         vocab_size=vocab_size,
@@ -318,6 +320,7 @@ def _debugmodel(
 def _16b(
     attn_backend: str,
     moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None,
 ) -> DeepSeekV3Model.Config:
     dim = 2048
     n_layers = 27
@@ -350,6 +353,7 @@ def _16b(
         score_before_experts=False,
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     return DeepSeekV3Model.Config(
         vocab_size=vocab_size,
@@ -381,6 +385,7 @@ def _16b(
 def _236b(
     attn_backend: str,
     moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None,
 ) -> DeepSeekV3Model.Config:
     dim = 5120
     n_layers = 60
@@ -417,6 +422,7 @@ def _236b(
         score_before_experts=False,
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     return DeepSeekV3Model.Config(
         vocab_size=vocab_size,
@@ -448,6 +454,7 @@ def _236b(
 def _671b(
     attn_backend: str,
     moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None,
 ) -> DeepSeekV3Model.Config:
     dim = 7168
     n_layers = 61
@@ -485,6 +492,7 @@ def _671b(
         score_before_experts=False,
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     return DeepSeekV3Model.Config(
         vocab_size=vocab_size,
@@ -525,11 +533,13 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str = "standard",
+    non_blocking_capacity_factor: float | None = None,
     quantization: list[QuantizationConverter.Config] | None = None,
 ) -> ModelSpec:
     config = deepseekv3_configs[flavor](
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
     if quantization is not None:
         for q in quantization:


### PR DESCRIPTION
## Summary

Enables HybridEP to work with graph_trainer's `aot_fx_trace` compilation path, including full composability with SAC (selective activation checkpointing) and CUDA graph capture.

### Fixes

1. **Wire HybridEP config through graph_trainer's `parallelize_deepseekv3`** — Pass `comm_backend` to `apply_moe_ep_tp()` and thread `non_blocking_capacity_factor` through all DeepSeekV3 config factories. Pre-initialize HybridEP buffer in `parallelize_deepseekv3` before tracing.

2. **Guard `_disable_current_modes()` with `_buffer is None`** — Instead of unconditionally calling `get_buffer` inside `_disable_current_modes()`, only call it when the buffer hasn't been initialized yet. This prevents re-initialization during make_fx tracing.

3. **Fix fake dispatch scores shape** — Change from `(0,)` to `(out_tokens,)` to prevent shape mismatch during tracing.

4. **Replace `@torch.compiler.disable()` on `sync_combine`** — The decorator breaks make_fx tracing. Use an `is_compiling()` guard inside the function body instead.

5. **Add `FunctionalTensor`/`FakeTensor` fallback in dispatch/combine backward** — During tracing, `DispatchHandle.value` is `None` because the opaque handle doesn't survive fake tensor execution. Detect this and return zero gradients (the traced backward graph will use real handles at runtime). Preserves the `RuntimeError` raise on the eager path.

6. **Remove `_grouped_mm` cudagraph incompatibility check** — The `is_cudagraph_compatible` function conservatively blocked CUDA graph capture for graphs containing `aten._grouped_mm`. This is overly conservative — `_grouped_mm` is CUDA graph compatible (verified empirically). Removing this allows cudagraph to be applied automatically for MoE models in the `aot_fx_trace` default pass pipeline.

7. **Add cudagraph pass logging** — Add `"Applied cudagraph pass."` log message for parity with SAC logging.

8. **Add HybridEP integration test** — Add `aot_fx_trace_deepseek_v3_hybridep` integration test entry using the `graph_trainer_deepseek_v3_debugmodel_hybridep` config with FSDP+TP+EP. DeepEP is installed (pinned to commit `1b8f467`) in the H100 CI workflow before running the test suite.

9. **Add TODO for HybridEP refactoring** — HybridEP applies to other sparse models (e.g. Qwen3). Added TODO to refactor the common HybridEP buffer init into a shared utility.

Note: the `aot` compile mode path has a known upstream regression (`DispatchHandle` as `FakeScriptObject` in graph output) and is not supported in this PR.

## Setup

Requires DeepEP with the `hybrid-ep` branch:
```bash
git clone --branch hybrid-ep https://github.com/deepseek-ai/deepep.git /tmp/deepep
cd /tmp/deepep && git checkout 1b8f467 && CUDA_HOME=/usr/local/cuda TORCH_CUDA_ARCH_LIST="10.0" pip install -e .
```

## Test plan

- [x] Smoke test: `aot_fx_trace` with HybridEP (3 steps, 4×GB200). SAC and cudagraph are applied automatically by the default pass pipeline — no `--compile.passes` or `--compile.joint_passes` flags needed:
```bash
rm -rf /tmp/torchtitan_fx_codegen /tmp/torchtitan_fx_codegen_0 /tmp/torchinductor_root

CUDA_HOME=/usr/local/cuda NCCL_GRAPH_REGISTER=0 NGPU=4 \
  MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_hybridep \
  ./run_train.sh \
  --compile.mode aot_fx_trace \
  --parallelism.data_parallel_shard_degree=2 \
  --parallelism.tensor_parallel_degree=2 \
  --parallelism.expert_parallel_degree=2 \
  --training.steps=3
```

**Smoke test output (4×GB200):**
```
INFO - Building graph_trainer/deepseek_v3 debugmodel
INFO - CUDA capacity: NVIDIA GB200 with 187.28GiB memory
INFO - Total parameter count: dense 23,173,376, sparse 9,840,640, active 28,098,816
INFO - Compiling the loss function with torch.compile
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - activation_checkpoint.mode is 'selective', added apply_sac to compile.joint_passes
INFO - Applied Data Parallel (simple_fsdp) (dp mode=fully_shard) to the model
INFO - Pre-initialized HybridEP buffer (hidden_dim=256, num_tokens=16384, num_local_experts=4)
INFO - aot_fx_trace compile mode: graph capture will happen at training time
INFO - Training starts at step 1
INFO - Removed 62 aten.detach.default node(s) from the graph
INFO - Removed 669 identity view/reshape node(s) from the graph
INFO - Removed 66 identity slice node(s)
INFO - Applied selective activation checkpointing (SAC) graph pass.
INFO -   Forced 5 nodes to MUST_SAVE at layer boundaries
INFO -   Layer non-layer: 6 MUST_SAVE, 58 PREFER_RECOMPUTE
INFO -   Layer 0: 22 MUST_SAVE, 78 PREFER_RECOMPUTE
INFO -   Layer 1: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 2: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 3: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 4: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 5: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO - Applied cudagraph pass.
INFO - step:  1  loss:  4.04367  grad_norm:  3.5169  memory:  1.93GiB(1.03%)  tps: 370      tflops: 0.20   mfu: 0.01%
INFO - step:  2  loss:  3.07626  grad_norm:  4.4144  memory:  1.93GiB(1.03%)  tps: 37,316   tflops: 20.26  mfu: 0.81%
INFO - step:  3  loss:  2.48693  grad_norm:  3.0514  memory:  1.93GiB(1.03%)  tps: 154,557  tflops: 83.91  mfu: 3.36%
INFO - Training completed
```

- [x] Integration test (runs in H100 CI with deep_ep installed, 4×GB200):
```bash
rm -rf /tmp/test_output /tmp/torchtitan_fx_codegen /tmp/torchtitan_fx_codegen_0 /tmp/torchinductor_root

CUDA_HOME=/usr/local/cuda NCCL_GRAPH_REGISTER=0 \
  python -m torchtitan.experiments.graph_trainer.tests.integration_tests \
  --test_suite graph_trainer_h100 --test_name aot_fx_trace_deepseek_v3_hybridep \
  --gpu_arch_type cuda /tmp/test_output --ngpu 4
```

**Integration test output (4×GB200):**
```
INFO - Building graph_trainer/deepseek_v3 debugmodel
INFO - CUDA capacity: NVIDIA GB200 with 187.28GiB memory
INFO - Total parameter count: dense 23,173,376, sparse 9,840,640, active 28,098,816
INFO - Compiling the loss function with torch.compile
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - Applying HYBRIDEP to MoE layer
INFO - activation_checkpoint.mode is 'selective', added apply_sac to compile.joint_passes
INFO - Applied Data Parallel (simple_fsdp) (dp mode=fully_shard) to the model
INFO - Pre-initialized HybridEP buffer (hidden_dim=256, num_tokens=16384, num_local_experts=4)
INFO - aot_fx_trace compile mode: graph capture will happen at training time
INFO - Training starts at step 1
INFO - Removed 62 aten.detach.default node(s) from the graph
INFO - Removed 669 identity view/reshape node(s) from the graph
INFO - Removed 66 identity slice node(s)
INFO - Applied selective activation checkpointing (SAC) graph pass.
INFO -   Forced 5 nodes to MUST_SAVE at layer boundaries
INFO -   Layer non-layer: 6 MUST_SAVE, 58 PREFER_RECOMPUTE
INFO -   Layer 0: 22 MUST_SAVE, 78 PREFER_RECOMPUTE
INFO -   Layer 1: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 2: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 3: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 4: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO -   Layer 5: 30 MUST_SAVE, 103 PREFER_RECOMPUTE
INFO - Applied cudagraph pass.
INFO - step:  1  loss:  4.04167  grad_norm:  3.5349  memory:  1.93GiB(1.03%)  tps: 351      tflops: 0.19   mfu: 0.01%
INFO - step:  2  loss:  3.02292  grad_norm:  4.5966  memory:  1.93GiB(1.03%)  tps: 57,945   tflops: 31.46  mfu: 1.26%
INFO - step:  3  loss:  2.43557  grad_norm:  3.0576  memory:  1.93GiB(1.03%)  tps: 144,958  tflops: 78.70  mfu: 3.15%
INFO - step:  4  loss:  2.38998  grad_norm:  2.6843  memory:  1.93GiB(1.03%)  tps: 134,592  tflops: 73.07  mfu: 2.92%
INFO - step:  5  loss:  2.21116  grad_norm:  2.4768  memory:  1.93GiB(1.03%)  tps: 154,326  tflops: 83.79  mfu: 3.35%
INFO - step:  6  loss:  2.12107  grad_norm:  2.0482  memory:  1.93GiB(1.03%)  tps: 134,649  tflops: 73.11  mfu: 2.92%
INFO - step:  7  loss:  2.03298  grad_norm:  1.8383  memory:  1.93GiB(1.03%)  tps: 157,360  tflops: 85.44  mfu: 3.42%
INFO - step:  8  loss:  1.99672  grad_norm:  1.8210  memory:  1.93GiB(1.03%)  tps: 152,331  tflops: 82.71  mfu: 3.31%
INFO - step:  9  loss:  2.21667  grad_norm:  1.5196  memory:  1.93GiB(1.03%)  tps: 152,393  tflops: 82.74  mfu: 3.31%
INFO - step: 10  loss:  1.95824  grad_norm:  1.6616  memory:  1.93GiB(1.03%)  tps: 137,813  tflops: 74.82  mfu: 2.99%
INFO - Training completed
```