### PR TITLE
Fix: reproducible training resume across epoch boundaries for map and streaming datasets

### DIFF
--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -9,11 +9,12 @@ import unittest
 
 from copy import deepcopy
 
-from datasets import Dataset
+import torch
+from datasets import Dataset, load_dataset
 
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
-from torchtitan.hf_datasets.text_datasets import ChatDataset
+from torchtitan.hf_datasets.text_datasets import ChatDataset, ChatDataLoader
 
 # Path to the test tokenizer and fixture data
 _ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "assets")
@@ -313,19 +314,19 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
         self.assertEqual(state["epoch"], 0)
 
         # Restore and verify the dataset can produce valid packed batches
-        chat_ds2 = ChatDataset(
+        chat_ds_resumed = ChatDataset(
             dataset=ds,
             tokenizer=tokenizer,
             sample_processor=_process_sample,
             seq_len=seq_len,
             infinite=False,
         )
-        chat_ds2.load_state_dict(state)
+        chat_ds_resumed.load_state_dict(state)
 
-        self.assertEqual(chat_ds2._sample_idx, state["sample_idx"])
-        self.assertEqual(chat_ds2._epoch, state["epoch"])
+        self.assertEqual(chat_ds_resumed._sample_idx, state["sample_idx"])
+        self.assertEqual(chat_ds_resumed._epoch, state["epoch"])
 
-        remaining = list(chat_ds2)
+        remaining = list(chat_ds_resumed)
         self.assertGreater(len(remaining), 0, "Restored dataset should produce batches")
         for batch, labels in remaining:
             self.assertEqual(batch["input"].shape[0], seq_len)
@@ -333,41 +334,64 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
             self.assertEqual(labels.shape[0], seq_len)
 
     def test_yield_same_data_multi_epoch(self):
-        tokenizer = _load_tokenizer()
-        ds = _load_dataset()
-        seq_len = 128
-        chat_ds = ChatDataset(
-            dataset=ds,
-            tokenizer=tokenizer,
-            sample_processor=_process_sample,
-            seq_len=seq_len,
-            infinite=True,
-        )
+        def _build_dataloader(streaming, batch_size, seq_len, world_size, rank):
+            tokenizer_config = HuggingFaceTokenizer.Config()
+            dl_config = ChatDataLoader.Config(
+                dataset_path="json",
+                load_dataset_kwargs = {
+                    "data_files": _DATA_PATH,
+                    "split": "train",
+                    "streaming": streaming,
+                },
+                sample_processor=_process_sample,
+                infinite=True
+                )
 
-        # Consume at least 2 epochs
-        it = iter(chat_ds)
-        for i in range(25):
-            next(it)
-
-        state = deepcopy(chat_ds.state_dict())
-
-        # Restore
-        chat_ds2 = ChatDataset(
-            dataset=ds,
-            tokenizer=tokenizer,
-            sample_processor=_process_sample,
-            seq_len=seq_len,
-            infinite=True,
-        )
-        chat_ds2.load_state_dict(state)
-
-        # verify yield gives same input data
-        # test assertion seveal times in order to empty potential input buffer.
-        it2 = iter(chat_ds2)
-        for _ in range(10):
-            self.assertEqual(
-                next(it)[0]["input"].tolist(), next(it2)[0]["input"].tolist()
+            return dl_config.build(
+                dp_world_size=world_size,
+                dp_rank=rank,
+                tokenizer=tokenizer_config.build(tokenizer_path=_TOKENIZER_PATH),
+                seq_len=seq_len,
+                local_batch_size=batch_size,
             )
+
+        for streaming in [True, False]:
+            for world_size in [2, 4]:
+                for rank in range(world_size):
+                    batch_size = 1
+                    seq_len = 128
+                    dl = _build_dataloader(streaming, batch_size,seq_len, world_size, rank)
+
+                    # Consume at least 2 epochs
+                    it = iter(dl)
+                    for i in range(25):
+                        next(it)
+
+                    state = deepcopy(dl.state_dict())
+                    # Restore
+                    dl_resumed = _build_dataloader(streaming, batch_size,seq_len, world_size, rank)
+                    dl_resumed.load_state_dict(state)
+                    # verify yield gives same input data
+                    # test assertion seveal times in order to empty potential input buffer.
+                    it_resumed = iter(dl_resumed)
+
+
+                    expected, expected_labels = next(it)
+                    input_ids, labels = next(it_resumed)
+                    for _ in range(10):
+                        expected_input_ids, expected_labels = next(it)
+                        input_ids, labels = next(it_resumed)
+                        assert torch.equal(
+                            input_ids["input"], expected_input_ids["input"]
+                        )
+                        assert torch.equal(
+                            input_ids["positions"],
+                            expected_input_ids["positions"],
+                        )
+                        assert torch.equal(labels, expected_labels)
+                        self.assertEqual(
+                            next(it)[0]["input"].tolist(), next(it_resumed)[0]["input"].tolist()
+                        )
 
 
 class TestChatDatasetInfiniteLooping(unittest.TestCase):

--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -10,11 +10,11 @@ import unittest
 from copy import deepcopy
 
 import torch
-from datasets import Dataset, load_dataset
+from datasets import Dataset
 
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
-from torchtitan.hf_datasets.text_datasets import ChatDataset, ChatDataLoader
+from torchtitan.hf_datasets.text_datasets import ChatDataLoader, ChatDataset
 
 # Path to the test tokenizer and fixture data
 _ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "assets")
@@ -338,14 +338,14 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
             tokenizer_config = HuggingFaceTokenizer.Config()
             dl_config = ChatDataLoader.Config(
                 dataset_path="json",
-                load_dataset_kwargs = {
+                load_dataset_kwargs={
                     "data_files": _DATA_PATH,
                     "split": "train",
                     "streaming": streaming,
                 },
                 sample_processor=_process_sample,
-                infinite=True
-                )
+                infinite=True,
+            )
 
             return dl_config.build(
                 dp_world_size=world_size,
@@ -360,25 +360,28 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                 for rank in range(world_size):
                     batch_size = 1
                     seq_len = 128
-                    dl = _build_dataloader(streaming, batch_size,seq_len, world_size, rank)
+                    dl = _build_dataloader(
+                        streaming, batch_size, seq_len, world_size, rank
+                    )
 
                     # Consume at least 2 epochs
                     it = iter(dl)
-                    for i in range(25):
+                    for _ in range(8):
                         next(it)
 
                     state = deepcopy(dl.state_dict())
                     # Restore
-                    dl_resumed = _build_dataloader(streaming, batch_size,seq_len, world_size, rank)
+                    dl_resumed = _build_dataloader(
+                        streaming, batch_size, seq_len, world_size, rank
+                    )
                     dl_resumed.load_state_dict(state)
                     # verify yield gives same input data
                     # test assertion seveal times in order to empty potential input buffer.
                     it_resumed = iter(dl_resumed)
 
-
                     expected, expected_labels = next(it)
                     input_ids, labels = next(it_resumed)
-                    for _ in range(10):
+                    for _ in range(3):
                         expected_input_ids, expected_labels = next(it)
                         input_ids, labels = next(it_resumed)
                         assert torch.equal(
@@ -390,7 +393,8 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                         )
                         assert torch.equal(labels, expected_labels)
                         self.assertEqual(
-                            next(it)[0]["input"].tolist(), next(it_resumed)[0]["input"].tolist()
+                            next(it)[0]["input"].tolist(),
+                            next(it_resumed)[0]["input"].tolist(),
                         )
 
 

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -42,7 +42,8 @@ class TestDatasetCheckpointing(unittest.TestCase):
                     )
 
                     it = iter(dl)
-                    for _ in range(250):
+                    # consume and trigger re-looping
+                    for _ in range(2050):
                         next(it)
                     state = dl.state_dict()
 
@@ -67,7 +68,7 @@ class TestDatasetCheckpointing(unittest.TestCase):
 
     def _build_dataloader(self, dataset_name, batch_size, seq_len, world_size, rank):
         tokenizer_config = HuggingFaceTokenizer.Config()
-        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name)
+        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name, infinite=True)
 
         return dl_config.build(
             dp_world_size=world_size,

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -68,7 +68,9 @@ class TestDatasetCheckpointing(unittest.TestCase):
 
     def _build_dataloader(self, dataset_name, batch_size, seq_len, world_size, rank):
         tokenizer_config = HuggingFaceTokenizer.Config()
-        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name, infinite=True)
+        dl_config = HuggingFaceTextDataLoader.Config(
+            dataset=dataset_name, infinite=True
+        )
 
         return dl_config.build(
             dp_world_size=world_size,

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -38,7 +38,8 @@ class TestDatasetCheckpointing(unittest.TestCase):
                     )
 
                     it = iter(dl)
-                    for _ in range(250):
+                    # consume and trigger re-looping
+                    for _ in range(2050):
                         next(it)
                     state = dl.state_dict()
 
@@ -63,7 +64,7 @@ class TestDatasetCheckpointing(unittest.TestCase):
 
     def _build_dataloader(self, dataset_name, batch_size, seq_len, world_size, rank):
         tokenizer_config = HuggingFaceTokenizer.Config()
-        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name)
+        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name, infinite=True)
 
         return dl_config.build(
             dp_world_size=world_size,

--- a/tests/unit_tests/test_dataset_checkpointing.py
+++ b/tests/unit_tests/test_dataset_checkpointing.py
@@ -64,7 +64,9 @@ class TestDatasetCheckpointing(unittest.TestCase):
 
     def _build_dataloader(self, dataset_name, batch_size, seq_len, world_size, rank):
         tokenizer_config = HuggingFaceTokenizer.Config()
-        dl_config = HuggingFaceTextDataLoader.Config(dataset=dataset_name, infinite=True)
+        dl_config = HuggingFaceTextDataLoader.Config(
+            dataset=dataset_name, infinite=True
+        )
 
         return dl_config.build(
             dp_world_size=world_size,

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -208,7 +208,12 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
                 )
         else:
             assert "data" in state_dict
-            self._data.load_state_dict(state_dict["data"])
+            data_state = state_dict["data"]
+            # HuggingFace IterableDataset sync epoch
+            saved_epoch = data_state.get("epoch", 0)
+            if saved_epoch != self._data.epoch:
+                self._data.set_epoch(saved_epoch)
+            self._data.load_state_dict(data_state)
 
     def state_dict(self):
         _state_dict: dict[str, Any] = {
@@ -319,6 +324,8 @@ class ChatDataset(IterableDataset, Stateful):
         self._inputs_buffer: list[int] = []
         self._labels_buffer: list[int] = []
         self._positions_buffer: list[int] = []
+        self._pending_input_ids: list[int] = []
+        self._pending_label_ids: list[int] = []
 
         self._logged_first_sample = False
 
@@ -409,6 +416,18 @@ class ChatDataset(IterableDataset, Stateful):
         The model's flex/varlen attention mask uses these EOS positions to
         prevent cross-document attention.
         """
+        # resume from ckpt edge case
+        if self._pending_input_ids:
+            input_ids = self._pending_input_ids
+            label_ids = self._pending_label_ids
+            self._pending_input_ids = []
+            self._pending_label_ids = []
+            self._inputs_buffer.extend(input_ids)
+            self._labels_buffer.extend(label_ids)
+            self._positions_buffer.extend(range(len(input_ids)))
+            self._sample_idx += 1
+            if len(self._inputs_buffer) == self.seq_len:
+                yield self._flush_buffers()
         while True:
             for sample in self._get_data_iter():
                 # pyrefly: ignore [bad-argument-type]
@@ -426,8 +445,14 @@ class ChatDataset(IterableDataset, Stateful):
                     self._inputs_buffer.extend([self._eos_id] * pad_len)
                     self._labels_buffer.extend([IGNORE_INDEX] * pad_len)
                     self._positions_buffer.extend(range(pad_len))
-
+                    self._pending_input_ids = input_ids
+                    self._pending_label_ids = label_ids
                     yield self._flush_buffers()
+                    # resumed generator continues here or fresh generator handles pending at top (resume path)
+                    input_ids = self._pending_input_ids
+                    label_ids = self._pending_label_ids
+                    self._pending_input_ids = []
+                    self._pending_label_ids = []
 
                 # Add example to buffer with positions resetting to 0
                 self._inputs_buffer.extend(input_ids)
@@ -481,6 +506,8 @@ class ChatDataset(IterableDataset, Stateful):
             "inputs_buffer": self._inputs_buffer,
             "labels_buffer": self._labels_buffer,
             "positions_buffer": self._positions_buffer,
+            "pending_input_ids": self._pending_input_ids,
+            "pending_label_ids": self._pending_label_ids,
         }
 
         if isinstance(self._data, Dataset):
@@ -495,6 +522,8 @@ class ChatDataset(IterableDataset, Stateful):
         self._inputs_buffer = state_dict["inputs_buffer"]
         self._labels_buffer = state_dict["labels_buffer"]
         self._positions_buffer = state_dict["positions_buffer"]
+        self._pending_input_ids = state_dict["pending_input_ids"]
+        self._pending_label_ids = state_dict["pending_label_ids"]
 
         if isinstance(self._data, Dataset):
             self._sample_idx = state_dict["sample_idx"]
@@ -505,7 +534,12 @@ class ChatDataset(IterableDataset, Stateful):
                 )
         else:
             assert "data" in state_dict
-            self._data.load_state_dict(state_dict["data"])
+            data_state = state_dict["data"]
+            # HuggingFace IterableDataset sync epoch
+            saved_epoch = data_state.get("epoch", 0)
+            if saved_epoch != self._data.epoch:
+                self._data.set_epoch(saved_epoch)
+            self._data.load_state_dict(data_state)
 
 
 class ChatDataLoader(ParallelAwareDataloader):

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -211,8 +211,7 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
             data_state = state_dict["data"]
             # HuggingFace IterableDataset sync epoch
             saved_epoch = data_state.get("epoch", 0)
-            if saved_epoch != self._data.epoch:
-                self._data.set_epoch(saved_epoch)
+            self._data.set_epoch(saved_epoch)
             self._data.load_state_dict(data_state)
 
     def state_dict(self):
@@ -537,8 +536,7 @@ class ChatDataset(IterableDataset, Stateful):
             data_state = state_dict["data"]
             # HuggingFace IterableDataset sync epoch
             saved_epoch = data_state.get("epoch", 0)
-            if saved_epoch != self._data.epoch:
-                self._data.set_epoch(saved_epoch)
+            self._data.set_epoch(saved_epoch)
             self._data.load_state_dict(data_state)
 
 

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -188,7 +188,12 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
             self._sample_idx = state_dict["sample_idx"]
         else:
             assert "data" in state_dict
-            self._data.load_state_dict(state_dict["data"])
+            data_state = state_dict["data"]
+            # HuggingFace IterableDataset sync epoch
+            saved_epoch = data_state.get("epoch", 0)
+            if saved_epoch != self._data.epoch:
+                self._data.set_epoch(saved_epoch)
+            self._data.load_state_dict(data_state)
 
     def state_dict(self):
         _state_dict: dict[str, Any] = {
@@ -299,6 +304,8 @@ class ChatDataset(IterableDataset, Stateful):
         self._inputs_buffer: list[int] = []
         self._labels_buffer: list[int] = []
         self._positions_buffer: list[int] = []
+        self._pending_input_ids: list[int] = []
+        self._pending_label_ids: list[int] = []
 
         self._logged_first_sample = False
 
@@ -389,6 +396,18 @@ class ChatDataset(IterableDataset, Stateful):
         The model's flex/varlen attention mask uses these EOS positions to
         prevent cross-document attention.
         """
+        # resume from ckpt edge case
+        if self._pending_input_ids:
+            input_ids = self._pending_input_ids
+            label_ids = self._pending_label_ids
+            self._pending_input_ids = []
+            self._pending_label_ids = []
+            self._inputs_buffer.extend(input_ids)
+            self._labels_buffer.extend(label_ids)
+            self._positions_buffer.extend(range(len(input_ids)))
+            self._sample_idx += 1
+            if len(self._inputs_buffer) == self.seq_len:
+                yield self._flush_buffers()
         while True:
             for sample in self._get_data_iter():
                 # pyrefly: ignore [bad-argument-type]
@@ -406,8 +425,14 @@ class ChatDataset(IterableDataset, Stateful):
                     self._inputs_buffer.extend([self._eos_id] * pad_len)
                     self._labels_buffer.extend([IGNORE_INDEX] * pad_len)
                     self._positions_buffer.extend(range(pad_len))
-
+                    self._pending_input_ids = input_ids
+                    self._pending_label_ids = label_ids
                     yield self._flush_buffers()
+                    # resumed generator continues here or fresh generator handles pending at top (resume path)
+                    input_ids = self._pending_input_ids
+                    label_ids = self._pending_label_ids
+                    self._pending_input_ids = []
+                    self._pending_label_ids = []
 
                 # Add example to buffer with positions resetting to 0
                 self._inputs_buffer.extend(input_ids)
@@ -461,6 +486,8 @@ class ChatDataset(IterableDataset, Stateful):
             "inputs_buffer": self._inputs_buffer,
             "labels_buffer": self._labels_buffer,
             "positions_buffer": self._positions_buffer,
+            "pending_input_ids": self._pending_input_ids,
+            "pending_label_ids": self._pending_label_ids,
         }
 
         if isinstance(self._data, Dataset):
@@ -475,6 +502,8 @@ class ChatDataset(IterableDataset, Stateful):
         self._inputs_buffer = state_dict["inputs_buffer"]
         self._labels_buffer = state_dict["labels_buffer"]
         self._positions_buffer = state_dict["positions_buffer"]
+        self._pending_input_ids = state_dict["pending_input_ids"]
+        self._pending_label_ids = state_dict["pending_label_ids"]
 
         if isinstance(self._data, Dataset):
             self._sample_idx = state_dict["sample_idx"]
@@ -485,7 +514,12 @@ class ChatDataset(IterableDataset, Stateful):
                 )
         else:
             assert "data" in state_dict
-            self._data.load_state_dict(state_dict["data"])
+            data_state = state_dict["data"]
+            # HuggingFace IterableDataset sync epoch
+            saved_epoch = data_state.get("epoch", 0)
+            if saved_epoch != self._data.epoch:
+                self._data.set_epoch(saved_epoch)
+            self._data.load_state_dict(data_state)
 
 
 class ChatDataLoader(ParallelAwareDataloader):


### PR DESCRIPTION
## Fix: reproducible training resume across epoch boundaries

### Problem
Resuming from a checkpoint taken after at least one full epoch re-loop produced wrong data for streaming datasets in both `HuggingFaceTextDataset` and `ChatDataset`.

Two bugs fixed:

**1. HuggingFace epoch guard mismatch** — HF's `IterableDataset` restores shard position only if `self.epoch == self._starting_state_dict["epoch"]`. A freshly constructed dataset starts at epoch 0, so the guard silently fails for checkpoints taken at epoch N > 0, restarting iteration from shard 0. Fixed by calling `set_epoch(saved_epoch)` before `load_state_dict`.

**2. In-flight sample lost at yield boundary (`ChatDataset`)** — when a sample didn't fit the current buffer, it lived only in the suspended generator frame. On resume, a fresh generator lost it, skipping one sample. Fixed by persisting the in-flight sample in `_pending_input_ids`/`_pending_label_ids` and consuming it at generator startup.

### Changes
- `HuggingFaceTextDataset.load_state_dict`: sync HF epoch before restoring state
- `ChatDataset.load_state_dict`: same fix for streaming path
- `ChatDataset`: add pending sample to checkpoint state
- Tests: consume >1 epoch to exercise the re-loop resume path