### PR TITLE
[Typing] Pyrefly: --remove-unused-ignores during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
       name: Pyrefly (type checking)
       pass_filenames: false
       language: system
+      args: ["--remove-unused-ignores"]
 
 
 - repo: local
@@ -78,9 +79,9 @@ repos:
     # Check hyperlinks and external links
     - id: lychee-link-checker
       name: lychee-link-checker
-      verbose: true
       language: system
       require_serial: true
+      verbose: true
       entry: |
         /bin/bash -c '
         if ! command -v lychee >/dev/null 2>&1; then
@@ -103,6 +104,7 @@ repos:
         - "--accept=200,403,429,503"
         - "--exclude=http://localhost:.*"
         - "--exclude=http://127.0.0.1:.*"
+        - "--exclude=tcp://localhost:.*"
         - "--max-retries=5"
         - "--retry-wait-time=10"
         - "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"

--- a/scripts/checkpoint_conversion/convert_from_hf.py
+++ b/scripts/checkpoint_conversion/convert_from_hf.py
@@ -25,7 +25,6 @@ def convert_from_hf(input_dir, output_dir, model_name, model_flavor):
         model = model_config.build()
     model = ModelWrapper(model)
 
-    # pyrefly: ignore[bad-instantiation, not-callable]
     sd_adapter = model_spec.state_dict_adapter(model_config, None)
     assert (
         sd_adapter is not None

--- a/scripts/checkpoint_conversion/convert_to_hf.py
+++ b/scripts/checkpoint_conversion/convert_to_hf.py
@@ -33,7 +33,6 @@ def convert_to_hf(
         model = model_config.build()
     model = ModelWrapper(model)
 
-    # pyrefly: ignore[bad-instantiation, not-callable]
     sd_adapter = model_spec.state_dict_adapter(model_config, hf_assets_path)
     assert (
         sd_adapter is not None

--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
@@ -258,9 +258,7 @@ def run_tt(model_flavor, checkpoint_path, tt_inputs, device):
 
     # Replace FlexAttention with SDPA for single-process inference
     # (unfused FlexAttention without torch.compile has poor fp16 numerics).
-    from torchtitan.models.common.attention import (
-        ScaledDotProductAttention,  # pyrefly: ignore [missing-module-attribute]
-    )
+    from torchtitan.models.common.attention import ScaledDotProductAttention
 
     for layer in model.layers.values():
         layer.attention.attn_backend = "sdpa"

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -235,13 +235,10 @@ class HuggingFaceTokenizer(BaseTokenizer):
                 tokenizer = Tokenizer(bpe_model)
 
                 # Configure GPT-2 style components for proper space handling
-                # pyrefly: ignore [read-only]
                 tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(
                     add_prefix_space=False
                 )
-                # pyrefly: ignore [read-only]
                 tokenizer.decoder = decoders.ByteLevel()
-                # pyrefly: ignore [read-only]
                 tokenizer.post_processor = processors.ByteLevel(trim_offsets=True)
 
                 return tokenizer

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -116,7 +116,6 @@ class Validator(BaseValidator):
         self.tokenizer = tokenizer
         self.parallel_dims = parallel_dims
         self.loss_fn = loss_fn
-        # pyrefly: ignore [unexpected-keyword]
         self.dl_config = replace(config.dataloader, infinite=config.steps != -1)
         self.dp_world_size = dp_world_size
         self.dp_rank = dp_rank

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -161,7 +161,6 @@ class ConfigManager:
             DeprecationWarning,
             stacklevel=2,
         )
-        # pyrefly: ignore [unknown-name]
         result: list[str | tuple[str, Any] | tuple[str, Any, Any]] = []
         b_map = {f.name: f for f in fields(base)}
         c_map = {f.name: f for f in fields(custom)}
@@ -196,7 +195,6 @@ class ConfigManager:
         # pyrefly: ignore [missing-attribute]
         if not os.path.exists(self.config.hf_assets_path):
             logger.warning(
-                # pyrefly: ignore [missing-attribute]
                 f"HF assets path {self.config.hf_assets_path} does not exist!"
             )
             old_tokenizer_path = (
@@ -254,10 +252,8 @@ if __name__ == "__main__":
 
     try:
 
-        # pyrefly: ignore[missing-import]
         from rich import print as rprint
 
-        # pyrefly: ignore[missing-import]
         from rich.pretty import Pretty
 
         config_manager = ConfigManager()

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -31,7 +31,6 @@ except ImportError as e:
 
 
 # Global buffer (single buffer per process, recreated if group changes)
-# pyrefly: ignore [bad-assignment]
 _buffer: Buffer = None
 
 # Global cache for dispatch handles, keyed by handle_id
@@ -118,7 +117,6 @@ def _dispatch_op_impl(
     recv_num_tokens_per_expert = torch.tensor(
         recv_num_tokens_per_expert_list, dtype=torch.int32, device="cpu"
     )
-    # pyrefly: ignore [bad-return]
     return recv_x, recv_indices, recv_scores, recv_num_tokens_per_expert, handle_id
 
 

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -181,7 +181,7 @@ def _dispatch_impl(
             _buffer.group_size,
             num_local_experts,
             topk_idx.shape[1],
-            moe_expert_capacity_factor,  # pyrefly: ignore [bad-argument-type]
+            moe_expert_capacity_factor,
             pad_multiple=pad_multiple,
         )
 

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -146,7 +146,6 @@ class ParallelDims:
                 0,
                 dim_degrees,
                 dim_names,
-                # pyrefly: ignore [bad-argument-type]
                 backend_override=backend_override,
             )
 

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -69,13 +69,10 @@ class MultiModalCollator:
 
         padded_patches = torch.zeros(len(all_patches), max_num_patch, patch_dim)
         for i, patches in enumerate(all_patches):
-            # pyrefly: ignore [unsupported-operation]
             padded_patches[i, : patches.shape[0]] = patches
 
-        # pyrefly: ignore [bad-argument-type]
         grid_thw = torch.stack(grid_thw_list, dim=0)  # (num_images, 3)
 
-        # pyrefly: ignore [bad-return]
         return padded_patches, grid_thw
 
     def collate_text(
@@ -113,7 +110,6 @@ class MultiModalCollator:
         if positions.shape[1] < self.seq_len + 1:
             positions = torch.nn.functional.pad(
                 positions,
-                # pyrefly: ignore [bad-argument-type]
                 (0, self.seq_len + 1 - positions.shape[1]),
                 value=0,
             )
@@ -131,12 +127,10 @@ class MultiModalCollator:
         if positions.shape[0] < self.batch_size:
             positions = torch.nn.functional.pad(
                 positions,
-                # pyrefly: ignore [bad-argument-type]
                 (0, 0, 0, self.batch_size - positions.shape[0]),
                 value=0,
             )
 
-        # pyrefly: ignore [bad-return]
         return input_ids[:, :-1], labels[:, 1:], positions[:, :-1]
 
     def __call__(

--- a/torchtitan/hf_datasets/multimodal/mm_datasets.py
+++ b/torchtitan/hf_datasets/multimodal/mm_datasets.py
@@ -152,7 +152,6 @@ def _process_mm_sample(
                 )
                 processed_images.append(processed_img)
                 num_image_tokens.append(num_tokens)
-                # pyrefly: ignore [unsupported-operation]
                 texts[idx] = None
 
     if len(processed_images) != len([_ for _ in images if _ is not None]):
@@ -246,9 +245,7 @@ def _process_cc12_wd_sample(
     images = [image, None]
 
     return _process_mm_sample(
-        # pyrefly: ignore [bad-argument-type]
         texts=texts,
-        # pyrefly: ignore [bad-argument-type]
         images=images,
         tokenizer=tokenizer,
         patch_size=patch_size,

--- a/torchtitan/hf_datasets/multimodal/utils/video.py
+++ b/torchtitan/hf_datasets/multimodal/utils/video.py
@@ -45,11 +45,8 @@ def load_video(
             video_fps = float(stream.average_rate or stream.guessed_rate or 24)
             total_frames = stream.frames
             if total_frames == 0 and stream.duration:
-                # pyrefly: ignore [unsupported-operation]
                 total_frames = int(
-                    # pyrefly: ignore [unsupported-operation]
-                    float(stream.duration * stream.time_base)
-                    * video_fps
+                    float(stream.duration * stream.time_base) * video_fps
                 )
             if total_frames == 0:
                 # No metadata available — decode all frames to count them
@@ -66,7 +63,6 @@ def load_video(
                 nframes = min(nframes, total_frames)
                 indices = np.linspace(0, total_frames - 1, nframes).astype(int).tolist()
                 selected = [all_frames[i] for i in indices]
-                # pyrefly: ignore [bad-return]
                 return torch.from_numpy(np.stack(selected))
 
             duration = total_frames / video_fps
@@ -91,7 +87,6 @@ def load_video(
         if not frames:
             return None
 
-        # pyrefly: ignore [bad-return]
         return torch.from_numpy(np.stack(frames))  # (T, H, W, C)
 
     except Exception as e:

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -525,7 +525,7 @@ class ChatDataLoader(ParallelAwareDataloader):
         dataset = load_dataset(config.dataset_path, **config.load_dataset_kwargs)
 
         chat_ds = ChatDataset(
-            dataset=dataset,  # pyrefly: ignore [bad-argument-type]
+            dataset=dataset,
             tokenizer=tokenizer,
             sample_processor=config.sample_processor,
             seq_len=seq_len,

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -223,8 +223,8 @@ class VarlenAttention(LocalMapInnerAttention):
             xv_packed,
             cu_seq_q,
             cu_seq_k,
-            max_q,  # pyrefly: ignore [bad-argument-type]
-            max_k,  # pyrefly: ignore [bad-argument-type]
+            max_q,
+            max_k,
             scale=scale,
             # window_size=(left, right) controls the attention window relative to each
             # query position. 'left' is how many tokens before the query to attend to,
@@ -360,7 +360,6 @@ class ScaledDotProductAttention(LocalMapInnerAttention):
                 SDPBackend.MATH,
             ]
 
-    # pyrefly: ignore [bad-override]
     def forward(
         self,
         q: torch.Tensor,
@@ -753,7 +752,6 @@ class GQAttention(BaseAttention):
             mask_key = "rope" if self.use_rope else "nope"
             attention_masks = attention_masks[mask_key]
 
-        # pyrefly: ignore [not-callable]
         output = self.inner_attention(
             xq,
             xk,
@@ -763,4 +761,4 @@ class GQAttention(BaseAttention):
             enable_gqa=self.enable_gqa,
         ).contiguous()
         output = output.view(bs, seqlen, -1)
-        return self.wo(output)  # pyrefly: ignore [not-callable]
+        return self.wo(output)

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -227,7 +227,6 @@ def apply_non_moe_tp(
 
     # pyrefly: ignore [not-callable]
     for transformer_block in model.layers.values():
-        # pyrefly: ignore [no-matching-overload]
         layer_plan = {
             "attention_norm": norm_plan,
             "attention": prepare_module_input(

--- a/torchtitan/models/flux/flux_datasets.py
+++ b/torchtitan/models/flux/flux_datasets.py
@@ -269,7 +269,6 @@ class FluxDataset(IterableDataset, Stateful):
 
             # Classifier-free guidance: Replace some of the strings with empty strings.
             # Distinct random seed is initialized at the beginning of training for each FSDP rank.
-            # pyrefly: ignore [missing-attribute]
             dropout_prob = self.prompt_dropout_prob
             if dropout_prob > 0.0:
                 if torch.rand(1).item() < dropout_prob:

--- a/torchtitan/models/flux/inference/infer.py
+++ b/torchtitan/models/flux/inference/infer.py
@@ -23,7 +23,6 @@ def inference(config: FluxTrainer.Config):
     # Distributed processing setup: Each GPU/process handles a subset of prompts
     world_size = int(os.environ["WORLD_SIZE"])
     global_rank = int(os.environ["RANK"])
-    # pyrefly: ignore [missing-attribute]
     original_prompts = open(config.inference.prompts_path).readlines()
     total_prompts = len(original_prompts)
 
@@ -46,14 +45,11 @@ def inference(config: FluxTrainer.Config):
 
     if prompts:
         # Generate images for this process's assigned prompts
-        # pyrefly: ignore [missing-attribute]
         bs = config.inference.local_batch_size
-        # pyrefly: ignore [missing-attribute]
         img_size = config.inference.img_size
 
         output_dir = os.path.join(
             config.dump_folder,
-            # pyrefly: ignore [missing-attribute]
             config.inference.save_img_folder,
         )
         # Create mapping from local indices to global prompt indices
@@ -65,11 +61,8 @@ def inference(config: FluxTrainer.Config):
                 dtype=trainer._dtype,
                 img_height=16 * (img_size // 16),
                 img_width=16 * (img_size // 16),
-                # pyrefly: ignore [missing-attribute]
                 enable_classifier_free_guidance=config.inference.sampling.enable_classifier_free_guidance,
-                # pyrefly: ignore [missing-attribute]
                 denoising_steps=config.inference.sampling.denoising_steps,
-                # pyrefly: ignore [missing-attribute]
                 classifier_free_guidance_scale=config.inference.sampling.classifier_free_guidance_scale,
                 # pyrefly: ignore [bad-argument-type]
                 model=trainer.model_parts[0],

--- a/torchtitan/models/flux/inference/sampling.py
+++ b/torchtitan/models/flux/inference/sampling.py
@@ -96,9 +96,7 @@ def generate_image(
     clip_tokens = tokens["clip"]
     t5_tokens = tokens["t5"]
     if len(prompt) == 1:
-        # pyrefly: ignore [missing-attribute]
         clip_tokens = clip_tokens.unsqueeze(0)
-        # pyrefly: ignore [missing-attribute]
         t5_tokens = t5_tokens.unsqueeze(0)
 
     batch = preprocess_data(
@@ -107,7 +105,6 @@ def generate_image(
         autoencoder=None,
         clip_encoder=clip_encoder,
         t5_encoder=t5_encoder,
-        # pyrefly: ignore [bad-argument-type]
         batch={
             "clip": clip_tokens,
             "t5": t5_tokens,
@@ -118,9 +115,7 @@ def generate_image(
         num_images = len(prompt)
 
         empty_tokens = tokenizer.encode("")
-        # pyrefly: ignore [missing-attribute]
         empty_clip_tokens = empty_tokens["clip"].repeat(num_images, 1)
-        # pyrefly: ignore [missing-attribute]
         empty_t5_tokens = empty_tokens["t5"].repeat(num_images, 1)
 
         empty_batch = preprocess_data(

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -50,7 +50,6 @@ class FluxTrainer(Trainer):
         latent_side_height = img_size // ae_downscale // PATCH_HEIGHT
         seq_len_img = latent_side_width * latent_side_height
 
-        # pyrefly: ignore [missing-attribute]
         seq_len_txt = config.tokenizer.max_t5_encoding_len
         config.training.seq_len = seq_len_img + seq_len_txt
 

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -216,7 +216,6 @@ class GptOssModel(Decoder):
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
-                # pyrefly: ignore [missing-attribute]
                 n_kv_heads = self.layers[0].attention.n_kv_heads
                 if n_heads % tp != 0:
                     raise ValueError(

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -224,5 +224,4 @@ class GptOssMoE(MoE):
             use_grouped_mm=config.experts.use_grouped_mm,
             param_init=config.experts.param_init,
         )
-        # pyrefly: ignore [bad-assignment]
         self.experts = gptoss_experts_config.build()

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -96,7 +96,6 @@ class Llama3Model(Decoder):
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
-                # pyrefly: ignore [missing-attribute]
                 n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
                 if n_heads % tp != 0:
                     raise ValueError(

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -225,7 +225,6 @@ def apply_tp(
                 "attention.qkv_linear.wk": colwise_parallel(),
                 "attention.qkv_linear.wv": colwise_parallel(),
             }
-        # pyrefly: ignore [no-matching-overload]
         layer_plan = {
             "attention_norm": norm_plan,
             "attention": prepare_module_input(
@@ -248,7 +247,6 @@ def apply_tp(
             # pyrefly: ignore [bad-argument-type]
             module=transformer_block,
             device_mesh=tp_mesh,
-            # pyrefly: ignore [bad-argument-type]
             parallelize_plan=layer_plan,
         )
 

--- a/torchtitan/models/llama3/state_dict_adapter.py
+++ b/torchtitan/models/llama3/state_dict_adapter.py
@@ -94,7 +94,6 @@ class Llama3StateDictAdapter(StateDictAdapter):
         n_heads = self.model_config.layers[0].attention.n_heads
         n_kv_heads = (
             self.model_config.layers[0].attention.n_kv_heads
-            # pyrefly: ignore [missing-attribute]
             if self.model_config.layers[0].attention.n_kv_heads is not None
             else n_heads
         )
@@ -145,7 +144,6 @@ class Llama3StateDictAdapter(StateDictAdapter):
                     if abstract_key == "layers.{}.attention.qkv_linear.wq.weight":
                         value = self._permute(value, n_heads)
                     if abstract_key == "layers.{}.attention.qkv_linear.wk.weight":
-                        # pyrefly: ignore [unsupported-operation]
                         key_value_dim = head_dim * n_kv_heads
                         value = self._permute(value, n_kv_heads, key_value_dim, dim)
 
@@ -170,7 +168,6 @@ class Llama3StateDictAdapter(StateDictAdapter):
         n_heads = self.model_config.layers[0].attention.n_heads
         n_kv_heads = (
             self.model_config.layers[0].attention.n_kv_heads
-            # pyrefly: ignore [missing-attribute]
             if self.model_config.layers[0].attention.n_kv_heads is not None
             else n_heads
         )
@@ -191,7 +188,6 @@ class Llama3StateDictAdapter(StateDictAdapter):
                 if abstract_key == "model.layers.{}.self_attn.q_proj.weight":
                     value = self._reverse_permute(value, n_heads)
                 if abstract_key == "model.layers.{}.self_attn.k_proj.weight":
-                    # pyrefly: ignore [unsupported-operation]
                     key_value_dim = head_dim * n_kv_heads
                     value = self._reverse_permute(value, n_kv_heads, key_value_dim, dim)
 
@@ -235,5 +231,4 @@ class Llama3StateDictAdapter(StateDictAdapter):
                 f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
             )
 
-        # pyrefly: ignore [bad-return]
         return state_dict

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -168,7 +168,6 @@ class Llama4Model(Decoder):
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
-                # pyrefly: ignore [missing-attribute]
                 n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
                 if n_heads % tp != 0:
                     raise ValueError(

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -277,7 +277,6 @@ def apply_non_moe_tp(
                 "attention.qkv_linear.wk": colwise_parallel(),
                 "attention.qkv_linear.wv": colwise_parallel(),
             }
-        # pyrefly: ignore [no-matching-overload]
         layer_plan = {
             "attention_norm": norm_plan,
             "attention": prepare_module_input(
@@ -306,7 +305,6 @@ def apply_non_moe_tp(
             # pyrefly: ignore [bad-argument-type]
             module=transformer_block,
             device_mesh=tp_mesh,
-            # pyrefly: ignore [bad-argument-type]
             parallelize_plan=layer_plan,
         )
 

--- a/torchtitan/models/llama4/state_dict_adapter.py
+++ b/torchtitan/models/llama4/state_dict_adapter.py
@@ -98,13 +98,13 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 )
                 hf_state_dict[
                     f"language_model.model.layers.{layer_num}.self_attn.q_proj.weight"
-                ] = wq  # pyrefly: ignore [unsupported-operation]
+                ] = wq
                 hf_state_dict[
                     f"language_model.model.layers.{layer_num}.self_attn.k_proj.weight"
-                ] = wk  # pyrefly: ignore [unsupported-operation]
+                ] = wk
                 hf_state_dict[
                     f"language_model.model.layers.{layer_num}.self_attn.v_proj.weight"
-                ] = wv  # pyrefly: ignore [unsupported-operation]
+                ] = wv
             elif key in to_hf_map:
                 # do direct mapping
                 if key in "layers.{}.moe.experts.w2":
@@ -172,7 +172,6 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 "language_model.model.layers.{}.self_attn.k_proj.weight",
                 "language_model.model.layers.{}.self_attn.v_proj.weight",
             ):
-                # pyrefly: ignore [unsupported-operation]
                 if layer_num not in pending_qkv:
                     # pyrefly: ignore [unsupported-operation]
                     pending_qkv[layer_num] = {}

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -125,7 +125,6 @@ class Qwen3Model(Decoder):
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
-                # pyrefly: ignore [missing-attribute]
                 n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
                 if n_heads % tp != 0:
                     raise ValueError(

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -249,7 +249,6 @@ def apply_non_moe_tp(
                 "attention.q_norm": qk_norm_plan,
                 "attention.k_norm": qk_norm_plan,
             }
-        # pyrefly: ignore [no-matching-overload]
         layer_plan = {
             "attention_norm": norm_plan,
             "attention": prepare_module_input(
@@ -284,7 +283,6 @@ def apply_non_moe_tp(
             # pyrefly: ignore [bad-argument-type]
             module=transformer_block,
             device_mesh=tp_mesh,
-            # pyrefly: ignore [bad-argument-type]
             parallelize_plan=layer_plan,
         )
 

--- a/torchtitan/models/qwen3/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/state_dict_adapter.py
@@ -266,7 +266,6 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 new_key = self.from_hf_map[abstract_key]
                 if new_key is None:
                     continue
-                # pyrefly: ignore [missing-attribute]
                 new_key = new_key.format(layer_num)
                 state_dict[new_key] = value
 

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -84,7 +84,6 @@ class Qwen3VLModel(Qwen3Model):
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
-                # pyrefly: ignore [missing-attribute]
                 n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
                 if n_heads % tp != 0:
                     raise ValueError(
@@ -153,7 +152,6 @@ class Qwen3VLModel(Qwen3Model):
         # each frame is treated like an image in the MRoPE code below
         # Temporal position comes from frame ordering in the sequence
         if grid_thw_videos is not None:
-            # pyrefly: ignore [no-matching-overload]
             grid_thw_videos = torch.repeat_interleave(
                 grid_thw_videos, grid_thw_videos[:, 0], dim=0
             )
@@ -226,7 +224,6 @@ class Qwen3VLModel(Qwen3Model):
 
                 # Process [text tokens][vision tokens] pairs within this document
                 pair_cursor = doc_start
-                # pyrefly: ignore [bad-assignment, no-matching-overload]
                 for vision_start in doc_vision_starts:
                     if sample_tokens[vision_start] == image_token_id:
                         # pyrefly: ignore [unsupported-operation]
@@ -329,7 +326,6 @@ class Qwen3VLModel(Qwen3Model):
             mrope_cos[..., col_indices] = cos_cache[:, col_indices][dim_pos]
             mrope_sin[..., col_indices] = sin_cache[:, col_indices][dim_pos]
 
-        # pyrefly: ignore [bad-return]
         return torch.cat([mrope_cos, mrope_sin], dim=-1).unsqueeze(2)
 
     def _get_vision_embeds(
@@ -352,7 +348,6 @@ class Qwen3VLModel(Qwen3Model):
         """
         # Cast pixel values (float32 from data pipeline) to match the vision
         # encoder's param_dtype set by FSDP2's MixedPrecisionPolicy
-        # pyrefly: ignore [bad-assignment]
         pixel_values = pixel_values.to(
             self.vision_encoder.patch_embed.proj.weight.dtype
         )
@@ -410,13 +405,9 @@ class Qwen3VLModel(Qwen3Model):
                 f"Vision token ID: {vision_token_id}"
             )
 
-        # pyrefly: ignore [bad-argument-type]
         vision_mask_expanded = vision_mask.unsqueeze(-1).expand_as(inputs_embeds)
-        # pyrefly: ignore [bad-assignment]
         inputs_embeds = inputs_embeds.masked_scatter(
-            # pyrefly: ignore [bad-argument-type]
             vision_mask_expanded,
-            # pyrefly: ignore [bad-argument-type]
             vision_embeds,
         )
         return inputs_embeds, True
@@ -552,7 +543,6 @@ class Qwen3VLModel(Qwen3Model):
             vision_pos_masks = video_mask
             deepstack_vision_embeds = deepstack_video_embeds
 
-        # pyrefly: ignore [bad-return]
         return inputs_embeds, vision_pos_masks, deepstack_vision_embeds
 
     def forward(  # pyrefly: ignore [bad-override, bad-param-name-override]

--- a/torchtitan/models/qwen3_vl/state_dict_adapter.py
+++ b/torchtitan/models/qwen3_vl/state_dict_adapter.py
@@ -144,7 +144,6 @@ class Qwen3VLStateDictAdapter(StateDictAdapter):
             else:
                 if tt_key not in to_hf_map:
                     continue
-                # pyrefly: ignore [missing-attribute]
                 if tt_key == "output.weight" and self.model_config.enable_weight_tying:
                     continue
                 hf_key = to_hf_map[tt_key]

--- a/torchtitan/models/qwen3_vl/vision_encoder.py
+++ b/torchtitan/models/qwen3_vl/vision_encoder.py
@@ -14,9 +14,7 @@ from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
 from torchtitan.models.common import Linear
-from torchtitan.models.common.attention import (
-    FlexAttention,  # pyrefly: ignore [missing-module-attribute]
-)
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
 from torchtitan.protocols.module import Module, ModuleDict, ModuleList
 
@@ -100,9 +98,7 @@ def _compute_learned_pos_embeds(
 
     for (h, w), indices in hw_to_indices.items():
         pos_hw = F.interpolate(
-            # pyrefly: ignore [bad-argument-type]
             pos_grid,
-            # pyrefly: ignore [bad-argument-type]
             size=(h, w),
             mode="bilinear",
             align_corners=True,
@@ -129,7 +125,7 @@ def _compute_learned_pos_embeds(
             else:
                 pos_embeds[i, :seq_len] = pos_hw_block
 
-    return pos_embeds  # pyrefly: ignore [bad-return]
+    return pos_embeds
 
 
 def _compute_2d_rope_cache(
@@ -227,7 +223,7 @@ def _compute_2d_rope_cache(
         2
     )  # (N, L, 1, head_dim*2)
 
-    return rope_cache  # pyrefly: ignore [bad-return]
+    return rope_cache
 
 
 class PatchEmbed(Module):
@@ -279,7 +275,6 @@ class VisionRotaryEmbedding(Module):
         self.dim = dim
         self.theta = theta
         inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
-        # pyrefly: ignore [bad-argument-type]
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def _init_self_buffers(self, *, buffer_device: torch.device | None = None) -> None:
@@ -299,7 +294,6 @@ class VisionRotaryEmbedding(Module):
             seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
         )
         freqs = torch.outer(seq, self.inv_freq)
-        # pyrefly: ignore [bad-return]
         return freqs
 
 
@@ -348,7 +342,6 @@ class PatchMerger(Module):
         """
         batch_size, seq_len, _ = x.shape
         if self.use_postshuffle_norm:
-            # pyrefly: ignore [bad-assignment]
             x = x.view(
                 batch_size,
                 seq_len // (self.spatial_merge_size**2),
@@ -409,7 +402,6 @@ class VisionAttention(Module):
 
         q, k = apply_rotary_emb_cos_sin(q, k, rope_cache)
 
-        # pyrefly: ignore [bad-argument-type]
         attn_output = self.flex_attention(q, k, v, attention_masks=attention_mask)
         attn_output = attn_output.reshape(num_vision, max_num_patch, -1)
         return self.proj(attn_output)
@@ -519,7 +511,6 @@ class Qwen3VLVisionEncoder(Module):
         # nn.Parameter (not nn.Embedding) because we interpolate the weight directly
         self.num_position_embeddings = config.num_position_embeddings
         self.pos_embed = nn.Parameter(
-            # pyrefly: ignore [bad-argument-type]
             torch.empty(config.num_position_embeddings, config.dim)
         )
         self.num_grid_per_side = int(config.num_position_embeddings**0.5)
@@ -644,7 +635,6 @@ class Qwen3VLVisionEncoder(Module):
             head_dim,
         )
 
-        # pyrefly: ignore [bad-return]
         return learned_pos, rope_cache
 
     def forward(
@@ -676,7 +666,6 @@ class Qwen3VLVisionEncoder(Module):
         )
         hidden_states = hidden_states + learned_pos
 
-        # pyrefly: ignore [bad-argument-type]
         mask_mod = get_vision_block_mask_mod(num_patch, max_num_patch)
         attention_mask = _compiled_create_block_mask(
             mask_mod,

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -218,7 +218,6 @@ class MoEStateDictAdapter(StateDictAdapter):
             elif isinstance(placement, Shard):
                 # Shards on non-expert dim, keep in sub-mesh
                 sub_mesh_names.append(name)
-                # pyrefly: ignore [bad-argument-type]
                 sub_placements.append(Shard(placement.dim))
             elif isinstance(placement, _StridedShard):
                 # Strided shard on non-expert dim, keep in sub-mesh


### PR DESCRIPTION
Hey there 👋 

I've noticed that pyrefly can do cleanup of unused ignores with:

```bash
pyrefly check --remove-unused-ignores
```

It can be integrated as a part of `pre-commit` step via adding this flag as an arg.

> [!Important]
> Ensure `pass_filenames: false` is set. 
> Pyrefly is designed to check the entire project state, and running it only on a subset of staged files can lead to inconsistent results where it "thinks" an ignore is unused because it can't see the rest of the project.
