### PR TITLE
Update `torchtitan/models/README.md` to reflect current folder structure

### DIFF
--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -7,35 +7,32 @@ For offline explorations, we recommend the same steps, unless otherwise noted.
 Please refer to the [Llama 3 folder](llama3) as an example.
 
 The folder should be organized as follows
-- `model` folder: a self-contained folder of model definition
-  - `model.py`
-    - NOTE: Please adhere to the guiding principles and write single-device model code.
-    - NOTE: We prioritize readability over flexibility. The preferred style is to not share modules among different models, except for the most common and complicated ones.
-    - Define a Model class inheriting from a base model (e.g. `Decoder` from `torchtitan/models/common/decoder.py`).
-    - The model class should contain a nested `Config` dataclass (inheriting from the base model's `Config`) that holds all architecture hyperparameters.
-      - `get_nparams_and_flops()` will be used to understand model size and compute throughput.
-      - `update_from_config()` updates the model config from training configs (e.g. syncing seq_len, handling hardware-specific settings).
-    - `__init__()` consumes the `Config` to build the model.
-    - Parameter initialization is handled by the `param_init` system on each module's `Config`. Set `param_init` (a `dict[str, Callable]` mapping parameter names to init functions) on every sub-config in the model config registry. `init_states()` auto-recurses into all submodules, so manual recursive calls are not needed. Override `_init_self_buffers()` for device-aware buffer initialization (e.g., RoPE, MoE).
-    - Add additional files to reduce the complexity of `model.py` if it grows too large or complex, e.g. moe.py to host the `MoE`, `Router`, and `GroupedExperts` modules.
-  - `state_dict_adapter.py`
-    - Inherit [`BaseStateDictAdapter`](/torchtitan/protocols/state_dict_adapter.py) to implement state dict mappings between `torchtitan` model definition and other model definitions (e.g. from HuggingFace so that we can save / load model checkpoints in HF formats).
-    - There are multiple ways such adapters could be used
-      - Checkpoint conversion scripts in `scripts/checkpoint_conversion/` will use them to adapt state dicts containing non-sharded `torch.Tensor` on CPU.
-      - During training, [`CheckpointManager`](/torchtitan/components/checkpoint.py) will use them to adapt state dicts containing (potentially sharded) `DTensor` on GPUs to save / load checkpoints in HF format.
-      - In post-training, `to_hf()` helps convert a torchtitan model to HF model, which can be used for inference by other frameworks.
-    - This is optional for offline exploration.
-- `infra` folder: containing the functions used to parallelize the model using PyTorch native techniques
-  - `parallelize.py`
-    - apply training techniques in the following order
-      - TP (and EP if the model has MoE architecture)
-      - activation checkpointing
-      - `torch.compile`
-      - FSDP /  HSDP
-      - NOTE: currently CP support for language models is enabled via a context manager in `torchtitan/train.py`. Ideally no extra work is needed to enable CP.
-  - `pipeline.py` (optional if model size is small)
-    - apply PP
-  - Include other util files if necessary.
+- `model.py`
+  - NOTE: Please adhere to the guiding principles and write single-device model code.
+  - NOTE: We prioritize readability over flexibility. The preferred style is to not share modules among different models, except for the most common and complicated ones.
+  - Define a Model class inheriting from a base model (e.g. `Decoder` from `torchtitan/models/common/decoder.py`).
+  - The model class should contain a nested `Config` dataclass (inheriting from the base model's `Config`) that holds all architecture hyperparameters.
+    - `get_nparams_and_flops()` will be used to understand model size and compute throughput.
+    - `update_from_config()` updates the model config from training configs (e.g. syncing seq_len, handling hardware-specific settings).
+  - `__init__()` consumes the `Config` to build the model.
+  - Parameter initialization is handled by the `param_init` system on each module's `Config`. Set `param_init` (a `dict[str, Callable]` mapping parameter names to init functions) on every sub-config in the model config registry. `init_states()` auto-recurses into all submodules, so manual recursive calls are not needed. Override `_init_self_buffers()` for device-aware buffer initialization (e.g., RoPE, MoE).
+  - Add additional files to reduce the complexity of `model.py` if it grows too large or complex, e.g. moe.py to host the `MoE`, `Router`, and `GroupedExperts` modules.
+- `state_dict_adapter.py`
+  - Inherit [`BaseStateDictAdapter`](/torchtitan/protocols/state_dict_adapter.py) to implement state dict mappings between `torchtitan` model definition and other model definitions (e.g. from HuggingFace so that we can save / load model checkpoints in HF formats).
+  - There are multiple ways such adapters could be used
+    - Checkpoint conversion scripts in `scripts/checkpoint_conversion/` will use them to adapt state dicts containing non-sharded `torch.Tensor` on CPU.
+    - During training, [`CheckpointManager`](/torchtitan/components/checkpoint.py) will use them to adapt state dicts containing (potentially sharded) `DTensor` on GPUs to save / load checkpoints in HF format.
+    - In post-training, `to_hf()` helps convert a torchtitan model to HF model, which can be used for inference by other frameworks.
+  - This is optional for offline exploration.
+- `parallelize.py`
+  - apply training techniques in the following order
+    - TP (and EP if the model has MoE architecture)
+    - activation checkpointing
+    - `torch.compile`
+    - FSDP /  HSDP
+    - NOTE: currently CP support for language models is enabled via a context manager in `torchtitan/train.py`. Ideally no extra work is needed to enable CP.
+- `pipeline.py` (optional if model size is small)
+  - apply PP
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: Model.Config]`.
   - Define `model_registry(flavor)` to return a [`ModelSpec`](/torchtitan/protocols/model_spec.py), consisting of


### PR DESCRIPTION
Hey there 👋 

Looks like in https://github.com/pytorch/torchtitan/pull/2386 a flat folder structure for each model was introduced.
Now there are no `model` or `infra` sub-folder in each model's folder.
(With one exception - `flux` model. It decided to go rogue.)

But the `torchtitan/models/README.md` hasn't been updated to reflect these changes.