### PR TITLE
Gate H100.8 CI workflows behind ciflow/h100.8 label

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,3 +1,4 @@
 ciflow_push_tags:
   - ciflow/8gpu
+  - ciflow/h100.8
 labeler_config: labeler.yml

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -7,7 +7,7 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   build-test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.aws.h100.8

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -7,7 +7,7 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
     branches: [ main ]
     paths-ignore:
       - 'torchtitan/experiments/**'

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled]
     branches: [ main ]
     paths-ignore:
       - 'torchtitan/experiments/**'
@@ -31,6 +31,7 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-rocm: linux.rocm.gpu.gfx942.8

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -3,8 +3,6 @@ name: 8 GPU Integration Test on H100
 on:
   push:
     branches: [ main ]
-    tags:
-      - ciflow/8gpu/*
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:


### PR DESCRIPTION
## Summary

H100.8 runners are scarce and the job queue is very long, blocking PRs. This PR gates H100 CI workflows behind a `ciflow/h100.8` label so they only run on PRs when a maintainer explicitly requests it.

**Changes to 2 workflows:**
- `integration_test_8gpu_h100.yaml` — PR trigger narrowed from `[opened, synchronize, reopened, ready_for_review]` to `[labeled]` only, with a job-level `if` checking for the `ciflow/h100.8` label
- `integration_test_8gpu_graph_trainer_h100.yaml` — same trigger change, replacing the draft-PR check with the `ciflow/h100.8` label check

**Trigger behavior after this PR:**

| Event | `h100.yaml` | `graph_trainer_h100.yaml` |
|---|---|---|
| Push to `main` (merge) | Runs (with `paths-ignore: experiments/`) | Runs (with `paths: graph_trainer/`) |
| Cron schedule | Runs (every 6h) | Runs (every 12h) |
| PR labeled `ciflow/h100.8` | Runs if PR touches core (non-experiments) files | Runs if PR touches `graph_trainer/` files |
| PR opened / pushed / reopened | **Skipped** | **Skipped** |

**Note:** The `ciflow/h100.8` label needs to be created in the repo settings.

## Test plan
- [ ] Verify that opening a new PR does NOT trigger the two H100 workflows
<img width="841" height="153" alt="image" src="https://github.com/user-attachments/assets/fd45173d-5919-4e0c-989e-8274641aa185" />

- [ ] Verify that adding the `ciflow/h100.8` label to a PR triggers the appropriate H100 workflow(s)
- [ ] Verify that push-to-main and cron schedules still trigger normally