### PR TITLE
[GraphTrainer][AutoDev] Remove unused standalone GraphTrainerConfig dataclass

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -52,22 +52,15 @@ class GraphTrainerCompileConfig(CompileConfig):
     """
 
 
-@dataclass(kw_only=True, slots=True)
-class GraphTrainerConfig(Trainer.Config):
-    compile: GraphTrainerCompileConfig = field(
-        default_factory=GraphTrainerCompileConfig
-    )
-
-
 def to_graph_trainer_config(
     base_config: Trainer.Config,
     model_registry: Callable[[str], ModelSpec],
-) -> GraphTrainerConfig:
-    """Convert a base Trainer.Config to a GraphTrainerConfig.
+) -> "GraphTrainer.Config":
+    """Convert a base Trainer.Config to a GraphTrainer.Config.
 
     Copies all fields from the base config and replaces the model_spec with one
     from the graph_trainer model_registry. The compile field is removed and
-    left as the GraphTrainerConfig default; callers should explicitly set it.
+    left as the GraphTrainer.Config default; callers should explicitly set it.
     """
     from .trainer import GraphTrainer
 


### PR DESCRIPTION
## Summary

- Remove the unused standalone `GraphTrainerConfig` dataclass from `configs.py` (was lines 55-59)
- Fix the `to_graph_trainer_config()` return type annotation to accurately reflect `GraphTrainer.Config` instead of the removed class
- Update docstring references accordingly

## Why

The standalone `GraphTrainerConfig` class was dead code that caused confusion. `GraphTrainer.Config` (nested inside `trainer.py`) is the actual config class used everywhere. The `to_graph_trainer_config()` function already returned `GraphTrainer.Config(...)` on line 84, making the `GraphTrainerConfig` return type annotation inaccurate. No code outside `configs.py` ever imported or referenced `GraphTrainerConfig`.

## Verification

- Grepped the entire codebase: `GraphTrainerConfig` was only referenced within `configs.py` itself (class definition, return type, and docstring)
- All config_registry files (llama3, deepseek_v3, qwen3) only import `GraphTrainerCompileConfig` and `to_graph_trainer_config` -- no breakage
- `pre-commit run --all-files` passes (pre-existing Pyrefly failure unrelated to this change)
- Module imports successfully after the change
- No behavioral change: `to_graph_trainer_config()` still returns `GraphTrainer.Config` instances as before

## Test plan

- [x] Verified `pre-commit run --all-files` passes (no new failures)
- [x] Verified module imports correctly after change
- [x] Verified `GraphTrainerConfig` is no longer importable (confirmed removal)
- [ ] GPU tests (`test_passes.py`, `test_precompile.py`, `test_numerics.py`) require multi-GPU environment -- should be validated by CI