### PR TITLE
[GraphTrainer][AutoDev] Remove compile_with_inductor annotation from qwen3 FlexAttention

### DIFF
--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -39,16 +39,10 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
 
     - Expert Parallel (EP) annotations: Tags "dispatch", "combine", and "compute"
       regions in MoE for debugging purposes (only if MoE layers exist).
-    - Flex attention annotation: Tags FlexAttention.forward with
-      {"compile_with_inductor": "flex_attention"} so the compiler can apply
-      regional inductor pass based on the annotation. Regional inductor is now only
-      supported in AOT mode.
     - AC region annotation: Tags each transformer block's forward with a unique
       ac_region_id so that apply_sac_pass can assign per-block ac_graph_id
       boundaries for the min-cut partitioner.
     """
-    from torchtitan.models.common.attention import FlexAttention
-
     # Annotate MoE EP regions if any layer has MoE enabled
     if any(layer.moe is not None for layer in model.config.layers):
         from torchtitan.distributed.expert_parallel import ExpertParallel
@@ -61,10 +55,6 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
             ExpertParallel._token_combine
         )
         MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
-
-    FlexAttention.forward = annotate_fn({"compile_with_inductor": "flex_attention"})(
-        FlexAttention.forward
-    )
 
     annotate_ac_regions(model)
 


### PR DESCRIPTION
## Summary

- Remove the `compile_with_inductor` annotation on `FlexAttention.forward` in the qwen3 graph_trainer parallelize module to align with llama3 and deepseek_v3 variants, which do not have this annotation.

## Why

The qwen3 `annotate_qwen3` function tagged `FlexAttention.forward` with `{"compile_with_inductor": "flex_attention"}` metadata, but the llama3 and deepseek_v3 graph_trainer variants do not annotate FlexAttention this way. Since `FlexAttention` is a shared component (`torchtitan/models/common/attention.py`), annotating its `forward` method in one model variant but not others causes a global mutation that persists across all models in the same process, which could cause subtle behavioral divergence depending on model initialization order.

This PR removes the annotation from qwen3 so all three graph_trainer model variants are consistent.

## Test plan

- [x] Verified module imports successfully (`from torchtitan.experiments.graph_trainer.qwen3.parallelize import annotate_qwen3, parallelize_qwen3`)
- [x] Pre-commit linting passes (flake8, ufmt, codespell, pydoclint all pass)
- [x] Self-reviewed diff: only the FlexAttention annotation, its import, and its docstring entry were removed; EP and AC annotations are untouched
- [ ] GPU integration tests (requires H100 cluster)