### PR TITLE
[ci fix] torchvision channel

### DIFF
--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -64,8 +64,10 @@ jobs:
         if [ -n "${{ matrix.torch-version }}" ]; then
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
+        # torchvision must be installed from the nightly channel alongside torch
+        # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
         python -m pip install --force-reinstall --pre \
-          "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+          "${TORCH_SPEC}" torchvision --index-url ${{ matrix.index-url }}
 
         if [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
           export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"


### PR DESCRIPTION
Similar to the fix in https://github.com/pytorch/torchtitan/pull/2959

Fix ` RuntimeError: operator torchvision::nms does not exist`. 
https://github.com/pytorch/torchtitan/actions/runs/24593052832/job/71917713051?pr=3020

The integration_test_8gpu_transformers_modeling_backend.yaml installs only torch (no torchvision), so the old torchvision 0.26.0 stays and is incompatible with the nightly torch.