### PR TITLE
Update .md files to use --profiler

### DIFF
--- a/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
+++ b/benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md
@@ -33,7 +33,7 @@ Runs were invoked with the following, where `NUM_NODES` was `4` and `8`.
     --quantize.linear.float8.enable_fsdp_float8_all_gather \
     --quantize.linear.float8.precompute_float8_dynamic_scale_for_fsdp \
     --quantize.linear.float8.force_recompute_fp8_weight_in_bwd \
-    --profiling.profile_freq 1000000
+    --profiler.profile_freq 1000000
     --training.steps 2000
 ```
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -2,12 +2,12 @@
 
 Launch training job with the following command (or alternatively set configs in your config_registry function)
 ```
-MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh --profiling.enable_memory_snapshot --profiling.save_memory_snapshot_folder memory_snapshot
+MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh --profiler.enable_memory_snapshot --profiler.save_memory_snapshot_folder memory_snapshot
 ```
-* `--profiling.enable_memory_snapshot`: to enable memory profiling
-* `--profiling.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`./outputs/memory_snapshot/` by default)
+* `--profiler.enable_memory_snapshot`: to enable memory profiling
+* `--profiler.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`./outputs/memory_snapshot/` by default)
 	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
-	+ Regular snapshots (taken every `profiling.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
+	+ Regular snapshots (taken every `profiler.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
 
 You can find the saved pickle files in your output folder.
 To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).
@@ -21,15 +21,15 @@ For example, given the following in your config_registry function:
 ```python
 def my_config() -> Trainer.Config:
     return Trainer.Config(
-        profiling=ProfilingConfig(enable_memory_snapshot=True),
+        profiler=Profiler.Config(enable_memory_snapshot=True),
         # ...
     )
 ```
 You can override it at runtime via CLI with:
 
 ```bash
---profiling.no_enable_memory_snapshot
---profiling.no-enable-memory-snapshot  # Equivalent
+--profiler.no_enable_memory_snapshot
+--profiler.no-enable-memory-snapshot  # Equivalent
 ```
 
 > Note: `--enable_memory_snapshot=False` will **not** work. Use `--no_enable_memory_snapshot` instead.
@@ -45,7 +45,7 @@ python -m torchtitan.config.manager --module llama3 --config llama3_8b [your cli
 For example,
 
 ```bash
-python -m torchtitan.config.manager --module llama3 --config llama3_8b --profiling.enable_memory_snapshot
+python -m torchtitan.config.manager --module llama3 --config llama3_8b --profiler.enable_memory_snapshot
 ```
 
 To list all available CLI flags and usage:

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -137,7 +137,7 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --parallelism.tensor_parallel_degree=2 \
     --dataloader.dataset c4_test \
     --metrics.no-enable_tensorboard \
-    --profiling.no-enable_profiling \
+    --profiler.no-enable_profiling \
     --comm.trace_buf_size=0 \
     --training.steps 20
 
@@ -149,7 +149,7 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./r
     --parallelism.expert_parallel_degree=2 \
     --dataloader.dataset c4_test \
     --metrics.no-enable_tensorboard \
-    --profiling.no-enable_profiling \
+    --profiler.no-enable_profiling \
     --comm.trace_buf_size=0 \
     --training.steps 20
 ```
@@ -163,8 +163,8 @@ step: 20  loss: 11.83506  grad_norm:  9.6669  memory: 48.87GiB(51.44%)  tps: 4,3
 
 ### Profiling
 
-Add `--profiling.enable_profiling` to any `./run_train.sh` command.
-Set `--profiling.profile_freq` to control which step is captured
+Add `--profiler.enable_profiling` to any `./run_train.sh` command.
+Set `--profiler.profile_freq` to control which step is captured
 (default: 10). Traces are saved to `{dump_folder}/profile_traces/`.
 
 ```bash
@@ -173,13 +173,13 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
     --dataloader.dataset c4_test \
-    --profiling.enable_profiling \
-    --profiling.profile_freq 10
+    --profiler.enable_profiling \
+    --profiler.profile_freq 10
 ```
 
 ### Memory Snapshot
 
-Add `--profiling.enable_memory_snapshot` to capture a memory snapshot.
+Add `--profiler.enable_memory_snapshot` to capture a memory snapshot.
 The snapshot fires at every `profile_freq`-th step and is saved to
 `{dump_folder}/memory_snapshot/` (default: `./outputs/memory_snapshot/`).
 Each rank produces its own file:
@@ -194,8 +194,8 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
     --parallelism.data_parallel_shard_degree=4 \
     --parallelism.tensor_parallel_degree=2 \
     --dataloader.dataset c4_test \
-    --profiling.enable_memory_snapshot \
-    --profiling.profile_freq 10
+    --profiler.enable_memory_snapshot \
+    --profiler.profile_freq 10
 ```
 
 ### Bitwise Deterministic Guardrail


### PR DESCRIPTION
## Summary
- Update CLI flag references from `--profiling.*` to `--profiler.*` in docs, benchmarks, and `.claude/` files to match the config rename from `ProfilingConfig` to `Profiler.Config` landed in #3020

## Changed files
- `docs/debugging.md` — CLI flags, inline code references, and config example
- `torchtitan/experiments/graph_trainer/.claude/CLAUDE.md` — CLI flags in example commands
- `benchmarks/llama3-8b_h200_202506_trainy-whitefiber.md` — CLI flag in benchmark command
