### PR TITLE
[Typing] Remove unused pyrefly ignores in token_dispatcher

### DIFF
--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -359,7 +359,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             input_starts[seg_ids]
             + torch.arange(
                 total, device=device
-            )  # pyrefly: ignore [no-matching-overload]
+            )
             - output_starts[seg_ids]
         )
 
@@ -492,7 +492,7 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
             num_tokens_per_expert_group,
             ep_size,
             num_local_experts,
-            self.pad_multiple,  # pyrefly: ignore [bad-argument-type]
+            self.pad_multiple,
         )
         return (
             input_shape,

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -357,9 +357,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         output_starts = segment_lens.cumsum(0) - segment_lens
         permuted_indices = (
             input_starts[seg_ids]
-            + torch.arange(
-                total, device=device
-            )
+            + torch.arange(total, device=device)
             - output_starts[seg_ids]
         )
 


### PR DESCRIPTION
## Summary

- Removes 2 unused `pyrefly: ignore` comments in `torchtitan/models/common/token_dispatcher.py` that were causing lint CI to fail on every PR with Python changes

## Context

PR #3010 added `--remove-unused-ignores` to the pyrefly pre-commit hook and cleaned up existing unused ignores. However, the MoE token dispatcher (#2842) was merged between when #3010 was CI-tested and when it was merged, so the 2 ignores in `token_dispatcher.py` were not covered by the cleanup.

In CI, `search-path = ["../pytorch"]` resolves to a non-existent directory, so pyrefly considers these 2 ignores unused. The `--remove-unused-ignores` flag then modifies the file, causing the hook to fail with "files were modified by this hook".

The 2 removed ignores:
1. `# pyrefly: ignore [no-matching-overload]` on `torch.arange(total, device=device)` (line 362)
2. `# pyrefly: ignore [bad-argument-type]` on `self.pad_multiple` (line 495)

## Test plan

- [x] Lint CI passes (this PR fixes the broken lint check)