### PR TITLE
[graph_trainer] Fix test_bitwise_deterministic AttributeError on ntokens_seen

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -36,6 +36,7 @@ def build_minimal_trainer(
     trainer.model_config = model_config
     trainer.device = torch.device("cuda")
     trainer.tokenizer = tokenizer
+    trainer.ntokens_seen = 0
 
     if trainer_cls is GraphTrainer:
         trainer.config = SimpleNamespace(


### PR DESCRIPTION
#2990 moved `self.ntokens_seen` accumulation into `post_dataloading_process()`, which is called by `forward_backward_step()`. 

This caused `AttributeError: 'Trainer' object has no attribute 'ntokens_seen'` that broke all test_bitwise_deterministic tests 