### PR TITLE
Change logging level for model config

### DIFF
--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -249,9 +249,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
         self.model_config = model_config
 
-        logger.info(
-            f"Building {model_spec.name} {model_spec.flavor} "
-            f"with {json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"
+        logger.info(f"Building {model_spec.name} {model_spec.flavor}")
+        logger.debug(
+            f"Model config:\n"
+            f"{json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"
         )
         with (
             torch.device("meta"),

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -250,10 +250,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.model_config = model_config
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")
-        logger.debug(
-            f"Model config:\n"
-            f"{json.dumps(model_config.to_dict(), indent=2, ensure_ascii=False)}"
-        )
+
         with (
             torch.device("meta"),
             utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]),


### PR DESCRIPTION
The model config print is too long in CI, which is hard to scroll and read the real error message.
Eg: https://github.com/pytorch/torchtitan/actions/runs/24666450657/job/72125280092#step:17:73090