### PR TITLE
[graph_trainer] Update bitwise deterministic hashes after fused QKV

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -277,11 +277,11 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757659912109""")
         assert_expected_inline(
             model_hash,
-            """15134607def7232e128240d553c8ee7021a7edbc2ed44d86e927ba61e490b865""",
+            """22b2fc47c014ae4ff5e51da4d32868f869c08fe847772a54ba9931f6a8f7c198""",
         )
         assert_expected_inline(
             grad_hash,
-            """66bbbbc98b4c1635e42a133ac1fbd499a2b8633ca879f4121cf206708c21dbdf""",
+            """a40e4a743e8b631f713fa1b0e8008c548b8723a5a9be43e94de8ba3e09d0b689""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -372,11 +372,11 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757183074951""")
         assert_expected_inline(
             model_hash,
-            """714c6b36b72327f2f11da003a219b6ff84f83e785464133f729e4f82c1913232""",
+            """ebf72718629a5feccaf49bce350f954cc791d8f186b42068b6ce7487db6444bb""",
         )
         assert_expected_inline(
             grad_hash,
-            """2eb6e999ebe213e69f8e85ecabea46ab59be81f0981847c7c8e69765be0d6678""",
+            """b24229db4f090d65088fd3fe9159f82258cfecc17d412eab8662334a3da7c74c""",
         )
 
     def test_aot_fx_trace_vs_eager(self):


### PR DESCRIPTION
## Summary

- Updates hardcoded expected hashes in `test_bitwise_deterministic.py` for `TestLlama3BitwiseDeterministic` and `TestLlama3FlexAttnBitwiseDeterministic`

## Root Cause

`git bisect` identified **#2878** (`ad7a8653` — "Fused QKV GQAttention implementation") as the commit that broke these tests. That PR replaced separate `wq`/`wk`/`wv` projections with a single fused `wqkv` linear in `GQAttention`, which changed the parameter layout and therefore the deterministic model/gradient hashes.

**Verified:**
- Parent commit `aa0214b8` (before #2878): both tests pass
- Commit `ad7a8653` (the PR itself): both tests fail

**Loss values are unchanged** — only the model and gradient hashes differ, confirming the fused QKV change altered parameter layout but not numerics.

## Test plan

- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py::TestLlama3BitwiseDeterministic::test_eager_self_deterministic` passes
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py::TestLlama3FlexAttnBitwiseDeterministic::test_eager_self_deterministic` passes