### PR TITLE
[Qwen3 VL] reduce memory use of debugmodels

### DIFF
--- a/torchtitan/models/qwen3_vl/README.md
+++ b/torchtitan/models/qwen3_vl/README.md
@@ -13,7 +13,7 @@ Qwen3-VL combines:
 
 - `tok_embeddings` produces text token embeddings of shape `B×S`.
 - `vision_encoder` produces visual token embeddings of shape `N×L`.
-- Valid visual tokens (excluding padding) are scattered into the placeholder positions in the text sequence, as illustrated below (credit: @lkhphuc).
+- Valid visual tokens (excluding padding) are scattered into the placeholder positions in the text sequence, as illustrated below (credit: [@lkhphuc](https://github.com/lkhphuc)).
 
 <img width="1398" height="840" alt="VLM Architecture" src="https://github.com/user-attachments/assets/63fcbbc1-c587-4a63-8246-411cb72f5789" />
 
@@ -32,7 +32,7 @@ pip install av torchvision
 | Variant | LLM dim | Layers | ViT dim | ViT layers | Patch size | MoE |
 |---------|---------|--------|---------|------------|------------|-----|
 | debugmodel | 256 | 4 | 256 | 4 | 16 | No |
-| debugmodel_moe | 256 | 1 | 256 | 4 | 16 | Yes (64 experts) |
+| debugmodel_moe | 256 | 1 | 256 | 4 | 16 | Yes (8 experts) |
 | 2B | 2048 | 28 | 1024 | 24 | 16 | No |
 | 8B | 4096 | 36 | 1152 | 27 | 16 | No |
 | 30B-A3B | 2048 | 48 | 1152 | 27 | 16 | Yes (128 experts) |

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -316,8 +316,8 @@ def _debugmodel_moe(
             n_kv_heads=2,
             head_dim=head_dim,
             moe_hidden_dim=768,
-            num_experts=64,
-            top_k=8,
+            num_experts=8,
+            top_k=4,
             moe_comm_backend=moe_comm_backend,
         ),
         vision_encoder=_vl_vision_encoder_config(

--- a/torchtitan/models/qwen3_vl/config_registry.py
+++ b/torchtitan/models/qwen3_vl/config_registry.py
@@ -51,8 +51,8 @@ def qwen3_vl_debugmodel() -> Trainer.Config:
             min_lr_factor=0.0,
         ),
         training=TrainingConfig(
-            local_batch_size=8,
-            seq_len=2048,
+            local_batch_size=1,
+            seq_len=512,
             steps=10,
         ),
         checkpoint=CheckpointManager.Config(
@@ -75,8 +75,8 @@ def qwen3_vl_debugmodel_moe() -> Trainer.Config:
         optimizer=OptimizersContainer.Config(lr=3e-3),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
-            local_batch_size=4,
-            seq_len=4096,
+            local_batch_size=1,
+            seq_len=512,
             steps=10,
         ),
         parallelism=ParallelismConfig(
@@ -106,7 +106,7 @@ def qwen3_vl_2b() -> Trainer.Config:
         training=TrainingConfig(
             local_batch_size=8,
             seq_len=4096,
-            steps=100,
+            steps=1000,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
@@ -135,7 +135,7 @@ def qwen3_vl_8b() -> Trainer.Config:
         training=TrainingConfig(
             local_batch_size=4,
             seq_len=4096,
-            steps=100,
+            steps=1000,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
@@ -160,11 +160,11 @@ def qwen3_vl_30b_a3b() -> Trainer.Config:
         model_spec=model_registry("30B-A3B", moe_comm_backend="standard"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
         optimizer=OptimizersContainer.Config(lr=3e-4),
-        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,
             seq_len=4096,
-            steps=100,
+            steps=1000,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,


### PR DESCRIPTION
To fix ci ooms on a10g machines: https://github.com/pytorch/torchtitan/issues/3025.