### PR TITLE
[graph_trainer] Fix permission error in custom codegen by using per-user temp directory

### DIFF
--- a/torchtitan/experiments/graph_trainer/custom_codegen.py
+++ b/torchtitan/experiments/graph_trainer/custom_codegen.py
@@ -576,12 +576,14 @@ def custom_codegen_pass(
         gm: Input graph module.
         example_inputs: Placeholder arg for compiler signature compatibility.
         codegen_dir: Directory for generated code files. Defaults to
-            ``<tempdir>/torchtitan_fx_codegen``.
+            ``<tempdir>/torchtitan_fx_codegen_<uid>``.
     """
     import tempfile
 
     if codegen_dir is None:
-        codegen_dir = os.path.join(tempfile.gettempdir(), "torchtitan_fx_codegen")
+        codegen_dir = os.path.join(
+            tempfile.gettempdir(), f"torchtitan_fx_codegen_{os.getuid()}"
+        )
 
     logger.info("[CUSTOM_CODEGEN] Saving code to %s", codegen_dir)
 


### PR DESCRIPTION
The custom codegen pass writes generated Python files to `/tmp/torchtitan_fx_codegen/`. When one user creates this directory first, other users on the same machine get `PermissionError: [Errno 13]` when trying to create temp files inside it, because NamedTemporaryFile requires write permission on the parent directory.

Fix: append the user's UID to the directory name (`/tmp/torchtitan_fx_codegen_<uid>/`), giving each user their own isolated codegen directory.    