### PR TITLE
Enable lora training with simplefsdp

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -45,37 +45,6 @@ class MixedPrecisionPolicy:
     reduce_dtype: torch.dtype | None = None
 
 
-class _ScaledPartial(Partial):
-    # A subclass of Partial placement that allows user to perform reduction with a custom
-    # factor (reduction_divide_factor) other than the default world size.
-    def __init__(
-        self,
-        reduction_divide_factor: float,
-    ):
-        self.reduction_divide_factor = reduction_divide_factor
-        super().__init__(reduce_op="sum")
-
-    def _reduce_value(
-        self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
-    ) -> torch.Tensor:
-        # for all_reduce in DDP
-        tensor.div_(self.reduction_divide_factor)
-        reduced = super()._reduce_value(tensor, mesh, mesh_dim)
-        return reduced
-
-    def _reduce_shard_value(
-        self,
-        tensor: torch.Tensor,
-        mesh: DeviceMesh,
-        mesh_dim: int,
-        shard_spec: Placement,
-    ) -> torch.Tensor:
-        # for reduce_scatter in FSDP
-        tensor.div_(self.reduction_divide_factor)
-        reduced = super()._reduce_shard_value(tensor, mesh, mesh_dim, shard_spec)
-        return reduced
-
-
 def _distribute_dtensor(
     tensor: DTensor,
     device_mesh: DeviceMesh,
@@ -203,7 +172,6 @@ class ReplicateComputation(Module):
         mode: str,
         mp_policy: MixedPrecisionPolicy | None,
         full_dtensor: bool = False,
-        reduction_divide_factor: float | None = None,
     ) -> None:
         super().__init__()
         self.device_mesh = device_mesh
@@ -211,11 +179,7 @@ class ReplicateComputation(Module):
         self.mode = mode
         self.compute_placements: list[Placement] = [Replicate()] * self.device_mesh.ndim
         self.grad_placements: list[Placement] = [
-            _ScaledPartial(
-                reduction_divide_factor=reduction_divide_factor,
-            )
-            if reduction_divide_factor is not None
-            else Partial(reduce_op="avg")
+            Partial(reduce_op="sum")
         ] * self.device_mesh.ndim
         mp_policy = mp_policy or MixedPrecisionPolicy()
         self.param_dtype: torch.dtype | None = mp_policy.param_dtype
@@ -300,7 +264,6 @@ def data_parallel(
     mode: str = "replicate",
     mp_policy: MixedPrecisionPolicy | None = None,
     shard_dim: int = 0,
-    reduction_divide_factor: float | None = None,
     full_dtensor: bool = False,
     ignored_params: set[nn.Parameter] | None = None,
 ) -> nn.Module:
@@ -371,7 +334,6 @@ def data_parallel(
                 param_sharding,
                 mode,
                 mp_policy=mp_policy,
-                reduction_divide_factor=reduction_divide_factor,
                 full_dtensor=full_dtensor,
             ),
         )

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -45,6 +45,37 @@ class MixedPrecisionPolicy:
     reduce_dtype: torch.dtype | None = None
 
 
+class _ScaledPartial(Partial):
+    # A subclass of Partial placement that allows user to perform reduction with a custom
+    # factor (reduction_divide_factor) other than the default world size.
+    def __init__(
+        self,
+        reduction_divide_factor: float,
+    ):
+        self.reduction_divide_factor = reduction_divide_factor
+        super().__init__(reduce_op="sum")
+
+    def _reduce_value(
+        self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
+    ) -> torch.Tensor:
+        # for all_reduce in DDP
+        tensor.div_(self.reduction_divide_factor)
+        reduced = super()._reduce_value(tensor, mesh, mesh_dim)
+        return reduced
+
+    def _reduce_shard_value(
+        self,
+        tensor: torch.Tensor,
+        mesh: DeviceMesh,
+        mesh_dim: int,
+        shard_spec: Placement,
+    ) -> torch.Tensor:
+        # for reduce_scatter in FSDP
+        tensor.div_(self.reduction_divide_factor)
+        reduced = super()._reduce_shard_value(tensor, mesh, mesh_dim, shard_spec)
+        return reduced
+
+
 def _distribute_dtensor(
     tensor: DTensor,
     device_mesh: DeviceMesh,
@@ -172,6 +203,7 @@ class ReplicateComputation(Module):
         mode: str,
         mp_policy: MixedPrecisionPolicy | None,
         full_dtensor: bool = False,
+        reduction_divide_factor: float | None = None,
     ) -> None:
         super().__init__()
         self.device_mesh = device_mesh
@@ -179,7 +211,11 @@ class ReplicateComputation(Module):
         self.mode = mode
         self.compute_placements: list[Placement] = [Replicate()] * self.device_mesh.ndim
         self.grad_placements: list[Placement] = [
-            Partial(reduce_op="sum")
+            _ScaledPartial(
+                reduction_divide_factor=reduction_divide_factor,
+            )
+            if reduction_divide_factor is not None
+            else Partial(reduce_op="avg")
         ] * self.device_mesh.ndim
         mp_policy = mp_policy or MixedPrecisionPolicy()
         self.param_dtype: torch.dtype | None = mp_policy.param_dtype
@@ -264,11 +300,13 @@ def data_parallel(
     mode: str = "replicate",
     mp_policy: MixedPrecisionPolicy | None = None,
     shard_dim: int = 0,
+    reduction_divide_factor: float | None = None,
     full_dtensor: bool = False,
+    ignored_params: set[nn.Parameter] | None = None,
 ) -> nn.Module:
     param_sharding: tuple[Placement, ...]
     if mode == "replicate":
-        param_sharding = (Replicate(),)
+        param_sharding = (Replicate(),) * device_mesh.ndim
     elif mode == "fully_shard":
         param_sharding = (Shard(shard_dim),)
     elif mode == "hybrid_shard":
@@ -289,6 +327,14 @@ def data_parallel(
         if "SimpleFSDP" in mod.__class__.__name__:
             continue
 
+        # Skip parameters that are explicitly ignored (e.g., shared or frozen weights).
+        if ignored_params is not None:
+            params_dict = {
+                p_name: p for p_name, p in params_dict.items() if p not in ignored_params
+            }
+            if not params_dict:
+                continue
+
         for p_name, p in params_dict.items():
             if p is not None and p.numel() > 0:
                 distribute_tensor_func = (
@@ -297,7 +343,9 @@ def data_parallel(
                 mod.register_parameter(
                     p_name,
                     nn.Parameter(
-                        distribute_tensor_func(p, device_mesh, param_sharding)
+                        distribute_tensor_func(p, device_mesh, param_sharding),
+                        # Preserve the requires_grad flag of the original parameter.
+                        requires_grad=p.requires_grad,
                     ),
                 )
 
@@ -323,6 +371,7 @@ def data_parallel(
                 param_sharding,
                 mode,
                 mp_policy=mp_policy,
+                reduction_divide_factor=reduction_divide_factor,
                 full_dtensor=full_dtensor,
             ),
         )

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -265,11 +265,11 @@ def data_parallel(
     mp_policy: MixedPrecisionPolicy | None = None,
     shard_dim: int = 0,
     full_dtensor: bool = False,
-    ignored_params: set[nn.Parameter] | None = None,
+    ignored_modules: set[nn.Parameter] | None = None,
 ) -> nn.Module:
     param_sharding: tuple[Placement, ...]
     if mode == "replicate":
-        param_sharding = (Replicate(),) * device_mesh.ndim
+        param_sharding = (Replicate(),)
     elif mode == "fully_shard":
         param_sharding = (Shard(shard_dim),)
     elif mode == "hybrid_shard":
@@ -291,9 +291,9 @@ def data_parallel(
             continue
 
         # Skip parameters that are explicitly ignored (e.g., shared or frozen weights).
-        if ignored_params is not None:
+        if ignored_modules is not None:
             params_dict = {
-                p_name: p for p_name, p in params_dict.items() if p not in ignored_params
+                p_name: p for p_name, p in params_dict.items() if p not in ignored_modules
             }
             if not params_dict:
                 continue


### PR DESCRIPTION
Added ignored_modules to data_parallel API in simpleFSDP: 

It allows explicitly passing parameters (like lora adaptor) into ignored_modules that FSDP should completely skip over. We will then do DDP over those parameter via another wrapper of data_parallel API.
