### PR TITLE
[GraphTrainer] Remove model from TracedResult, pass config to graph passes

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -139,6 +139,21 @@ def get_extra_fsdp_pg_name(original_pg_name: str) -> str | None:
     return _EXTRA_FSDP_PG_REGISTRY.get(original_pg_name)
 
 
+def get_default_transformer_block_buckets(
+    n_layers: int,
+) -> list[list[str] | str]:
+    """Get default transformer block buckets for manual bucketing passes.
+
+    Assumes the standard Decoder layout: tok_embeddings, layers.0..N-1,
+    norm, and output (e.g., Llama3, DeepSeekV3, Qwen3).
+    """
+    return [
+        "tok_embeddings",
+        *[f"layers.{i}" for i in range(n_layers)],
+        ["norm", "output"],
+    ]
+
+
 def get_transformer_block_buckets(model) -> list[list[str] | str]:
     """Get transformer block buckets for manual bucketing passes.
 

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -273,9 +273,6 @@ class TracedResult:
         num_flat_outputs: Number of flat graph outputs before subclass rewrapping.
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
-        model: The original nn.Module, cached for downstream passes that need
-            module structure (e.g. transformer block bucketing). Only set when
-            traced via :func:`trace_train_step`.
     """
 
     gm: torch.fx.GraphModule
@@ -287,10 +284,6 @@ class TracedResult:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int] = field(default_factory=list)
-    # TODO: Remove model from TracedResult. TracedResult is becoming a
-    # contract between the trainer and pre-compile, so carrying the original
-    # model is not feasible.
-    model: nn.Module | None = None
 
     @property
     def num_static_inputs(self) -> int:
@@ -501,9 +494,7 @@ def trace_train_step(fn: Callable) -> Callable[..., TracedResult]:
             with stateless._reparametrize_module(module, state):
                 return fn(module, *user_args)
 
-        result = minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
-        result.model = module
-        return result
+        return minimal_fx_tracer(_stateless_fn)(extract_module_state(module), *args)
 
     return _trace_with_module
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -84,11 +84,11 @@ def compile_time_passes(
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
+        selective_activation_remat_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
         ),
-        selective_activation_remat_pass,
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
         # When left uncompiled, flex_attention still runs correctly but
@@ -126,15 +126,17 @@ def construct_default_graph_passes(
     When ``precompile_artifact_dir`` is unset, returns the full list: cleanup,
     FlexAttention annotation, regional_inductor, and cudagraph.
 
-    When ``precompile_artifact_dir`` is set, the artifact already has cleanup
-    and regional_inductor baked in, so only cudagraph is returned.
+    When ``precompile_artifact_dir`` is set, the artifact has graph
+    transformed during precompile phase, so only cudagraph is returned.
     """
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
     cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
 
+    has_precompile_artifact = bool(config.compile.precompile_artifact_dir)
+
     passes: list[Callable] = []
-    if not config.compile.precompile_artifact_dir:
+    if not has_precompile_artifact:
         passes.extend(
             compile_time_passes(
                 traced_result, config, cudagraph_compatible=cudagraph_compatible

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -117,24 +117,6 @@ def compile_time_passes(
     return passes
 
 
-def runtime_passes(traced_result: "TracedResult") -> list[Callable]:
-    """Passes that must run at load time (not baked into precompile artifacts)."""
-    from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
-
-    passes: list[Callable] = []
-    if is_cudagraph_compatible(traced_result.gm):
-        static_input_indices = list(range(traced_result.num_static_inputs))
-        passes.append(
-            functools.partial(
-                cudagraph_pass,
-                is_forward=True,
-                static_input_indices=static_input_indices,
-                tensor_input_indices=traced_result.tensor_input_indices,
-            )
-        )
-    return passes
-
-
 def construct_default_graph_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
@@ -160,7 +142,16 @@ def construct_default_graph_passes(
         )
 
     # cudagraph should be the last pass.
-    passes.extend(runtime_passes(traced_result))
+    if cudagraph_compatible:
+        static_input_indices = list(range(traced_result.num_static_inputs))
+        passes.append(
+            functools.partial(
+                cudagraph_pass,
+                is_forward=True,
+                static_input_indices=static_input_indices,
+                tensor_input_indices=traced_result.tensor_input_indices,
+            )
+        )
     return passes
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -61,6 +61,7 @@ def _is_backward_node(node: torch.fx.Node) -> bool:
 
 def compile_time_passes(
     traced_result: "TracedResult",
+    config: "GraphTrainer.Config",
     *,
     cudagraph_compatible: bool = False,
 ) -> list[Callable]:
@@ -73,20 +74,20 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime
     """
-    # from torchtitan.experiments.graph_trainer.common_utils import (
-    #     get_transformer_block_buckets,
-    # )
+    from torchtitan.experiments.graph_trainer.common_utils import (
+        get_default_transformer_block_buckets,
+    )
     from torchtitan.models.common.attention import FlexAttention
 
+    n_layers = len(config.model_spec.model.layers)
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
-        # TODO: turn on after debugging composability with SAC pass
-        # functools.partial(
-        #     joint_transformer_block_bucketing_reordering_pass,
-        #     fsdp_manual_buckets=get_transformer_block_buckets(traced_result.model),
-        # ),
+        functools.partial(
+            joint_transformer_block_bucketing_reordering_pass,
+            fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
+        ),
         selective_activation_remat_pass,
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
@@ -116,32 +117,12 @@ def compile_time_passes(
     return passes
 
 
-def construct_default_graph_passes(
-    traced_result: "TracedResult",
-    *,
-    precompiled: bool = False,
-) -> list[Callable]:
-    """Build the pass list for the aot_fx_trace path.
-
-    When ``precompiled=False`` (default), returns the full list: cleanup,
-    FlexAttention annotation, regional_inductor, and cudagraph.
-
-    When ``precompiled=True``, the artifact already has cleanup and
-    regional_inductor baked in, so only cudagraph is returned.
-    """
+def runtime_passes(traced_result: "TracedResult") -> list[Callable]:
+    """Passes that must run at load time (not baked into precompile artifacts)."""
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
     passes: list[Callable] = []
-    cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
-
-    if not precompiled:
-        passes.extend(
-            compile_time_passes(
-                traced_result, cudagraph_compatible=cudagraph_compatible
-            )
-        )
-
-    if cudagraph_compatible:
+    if is_cudagraph_compatible(traced_result.gm):
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(
@@ -151,6 +132,35 @@ def construct_default_graph_passes(
                 tensor_input_indices=traced_result.tensor_input_indices,
             )
         )
+    return passes
+
+
+def construct_default_graph_passes(
+    traced_result: "TracedResult",
+    config: "GraphTrainer.Config",
+) -> list[Callable]:
+    """Build the pass list for the aot_fx_trace path.
+
+    When ``precompile_artifact_dir`` is unset, returns the full list: cleanup,
+    FlexAttention annotation, regional_inductor, and cudagraph.
+
+    When ``precompile_artifact_dir`` is set, the artifact already has cleanup
+    and regional_inductor baked in, so only cudagraph is returned.
+    """
+    from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
+
+    cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
+
+    passes: list[Callable] = []
+    if not config.compile.precompile_artifact_dir:
+        passes.extend(
+            compile_time_passes(
+                traced_result, config, cudagraph_compatible=cudagraph_compatible
+            )
+        )
+
+    # cudagraph should be the last pass.
+    passes.extend(runtime_passes(traced_result))
     return passes
 
 

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -358,7 +358,7 @@ def _precompile_aot_fx_trace(
         compile_time_passes,
     )
 
-    passes = compile_time_passes(traced_result)
+    passes = compile_time_passes(traced_result, config)
     traced_result.gm = apply_graph_passes(
         traced_result.gm, traced_result.example_inputs, passes
     )

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -50,6 +50,7 @@ def build_minimal_trainer(
                 precompile_artifact_dir="",
                 debug_graph_passes=False,
             ),
+            model_spec=SimpleNamespace(model=model_config),
             activation_checkpoint=ActivationCheckpointConfig(
                 mode=activation_checkpoint_mode
             ),

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -157,7 +157,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         from torchtitan.experiments.graph_trainer.passes import (
             apply_graph_passes,
             compile_time_passes,
-            runtime_passes,
+            construct_default_graph_passes,
         )
         from torchtitan.experiments.graph_trainer.precompile import (
             precompile_fx_trace_load,
@@ -208,7 +208,11 @@ class BitwiseDeterministicBase(unittest.TestCase):
 
         # Step 4: Apply load-time passes (cudagraph)
         if enable_passes:
-            passes = runtime_passes(loaded_result)
+            load_config = SimpleNamespace(
+                model_spec=SimpleNamespace(model=self.model_config),
+                compile=SimpleNamespace(precompile_artifact_dir="precompiled"),
+            )
+            passes = construct_default_graph_passes(loaded_result, load_config)
             loaded_result.gm = apply_graph_passes(
                 loaded_result.gm,
                 loaded_result.example_inputs,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -17,6 +17,7 @@ import copy
 import tempfile
 import unittest
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import torch
 import torch.nn as nn
@@ -156,7 +157,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         from torchtitan.experiments.graph_trainer.passes import (
             apply_graph_passes,
             compile_time_passes,
-            construct_default_graph_passes,
+            runtime_passes,
         )
         from torchtitan.experiments.graph_trainer.precompile import (
             precompile_fx_trace_load,
@@ -188,7 +189,10 @@ class BitwiseDeterministicBase(unittest.TestCase):
         # Step 2: Apply compile-time passes (cleanup + regional_inductor)
         # before saving, so compiled Triton kernels are baked in
         if enable_passes:
-            passes = compile_time_passes(traced_result)
+            config = SimpleNamespace(
+                model_spec=SimpleNamespace(model=self.model_config),
+            )
+            passes = compile_time_passes(traced_result, config)
             traced_result.gm = apply_graph_passes(
                 traced_result.gm,
                 traced_result.example_inputs,
@@ -204,7 +208,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
 
         # Step 4: Apply load-time passes (cudagraph)
         if enable_passes:
-            passes = construct_default_graph_passes(loaded_result, precompiled=True)
+            passes = runtime_passes(loaded_result)
             loaded_result.gm = apply_graph_passes(
                 loaded_result.gm,
                 loaded_result.example_inputs,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -161,7 +161,7 @@ class GraphTrainer(Trainer):
             if self.config.compile.enable_passes:
                 passes = construct_default_graph_passes(
                     self._traced_step,
-                    precompiled=bool(self.config.compile.precompile_artifact_dir),
+                    self.config,
                 )
                 self._traced_step.gm = apply_graph_passes(
                     self._traced_step.gm,


### PR DESCRIPTION
## Summary
- Remove `model: nn.Module` field from `TracedResult` — it was carrying the original model just for bucketing, but `TracedResult` is becoming a serialization contract between trainer and pre-compile where carrying a live module isn't feasible.
- Add `get_default_transformer_block_buckets(n_layers)` that builds bucket FQNs from the layer count alone (standard Decoder layout: `tok_embeddings`, `layers.0..N-1`, `["norm", "output"]`).
- Extract `runtime_passes()` for load-time-only passes (cudagraph), separate from `compile_time_passes`.
- `compile_time_passes` and `construct_default_graph_passes` now take `config` (GraphTrainer.Config) instead of `model`/`n_layers`/`precompiled`, deriving what they need from config fields.

## Test plan
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x -k "not test_eager_self_deterministic"` — 6/6 pass (the skipped test has a pre-existing hash mismatch on main)
- [x] `pre-commit run --all-files` — flake8, ufmt, codespell all pass (pyrefly has pre-existing errors in unrelated files)