### PR TITLE
[MoE][3/n]swap to torchao dispatcher and set pad_multiple during config time

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -270,26 +270,36 @@ class Float8GroupedMMConverter(QuantizationConverter):
                 "torchao installation does not have MoE training support. Please install torchao nightly build."
             ) from e
 
+        from torchtitan.components.quantization import PAD_MULTIPLE_MAP
+        from torchtitan.models.common.token_dispatcher import (
+            AllToAllTokenDispatcher,
+            DeepEPTokenDispatcher,
+            TorchAOTokenDispatcher,
+        )
+        from torchtitan.protocols.module import Module
+
         def convert_fn(mod: nn.Module) -> nn.Module:
             config = Float8TrainingOpConfig()
             quantize_(mod, config=config)
             return mod
 
-        from torchtitan.models.common.token_dispatcher import (
-            AllToAllTokenDispatcher,
-            TorchAOTokenDispatcher,
-        )
-        from torchtitan.protocols.module import Module
-
         for fqn, config in model_config.walk(Module.Config):
             if any(target_fqn in fqn for target_fqn in self.fqns):
                 config._convert_fn = convert_fn
-
-        # Swap AllToAllTokenDispatcher -> TorchAOTokenDispatcher for
-        # matching FQNs so grouped GEMMs use padded token dispatch.
-        for fqn, config in model_config.walk(AllToAllTokenDispatcher.Config):
-            if any(target_fqn in fqn for target_fqn in self.fqns):
-                config.__class__ = TorchAOTokenDispatcher.Config
+                if hasattr(config, "token_dispatcher") and isinstance(
+                    config.token_dispatcher, AllToAllTokenDispatcher.Config
+                ):
+                    td = config.token_dispatcher
+                    config.token_dispatcher = TorchAOTokenDispatcher.Config(
+                        num_experts=td.num_experts,
+                        top_k=td.top_k,
+                        score_before_experts=td.score_before_experts,
+                        pad_multiple=PAD_MULTIPLE_MAP["float8"],
+                    )
+                elif hasattr(config, "token_dispatcher") and isinstance(
+                    config.token_dispatcher, DeepEPTokenDispatcher.Config
+                ):
+                    config.token_dispatcher.pad_multiple = PAD_MULTIPLE_MAP["float8"]
 
         logger.info(
             f"Converted MoE layers matching FQNS {self.fqns} "

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -92,31 +92,42 @@ class MXFP8Converter(QuantizationConverter):
             MXFP8TrainingRecipe,
         )
         from torchao.quantization.quant_api import quantize_
-
-        def convert_fn(mod: nn.Module) -> nn.Module:
-            recipe = MXFP8TrainingRecipe(self.config.recipe_name)
-            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-            mxfp8_op_config.pad_token_groups_for_grouped_mm = (
-                self.pad_token_groups_for_grouped_mm
-            )
-            quantize_(mod, config=mxfp8_op_config)
-            return mod
-
+        from torchtitan.components.quantization import PAD_MULTIPLE_MAP
         from torchtitan.models.common.token_dispatcher import (
             AllToAllTokenDispatcher,
+            DeepEPTokenDispatcher,
             TorchAOTokenDispatcher,
         )
         from torchtitan.protocols.module import Module
 
-        for fqn, config in model_config.walk(Module.Config):
-            if any(target_fqn in fqn for target_fqn in self.config.fqns):
-                config._convert_fn = convert_fn
+        pad_token_groups = self.pad_token_groups_for_grouped_mm
+        recipe_name = self.config.recipe_name
 
-        # Swap AllToAllTokenDispatcher -> TorchAOTokenDispatcher for
-        # matching FQNs so grouped GEMMs use padded token dispatch.
-        for fqn, config in model_config.walk(AllToAllTokenDispatcher.Config):
-            if any(target_fqn in fqn for target_fqn in self.config.fqns):
-                config.__class__ = TorchAOTokenDispatcher.Config
+        def convert_fn(mod: nn.Module) -> nn.Module:
+            recipe = MXFP8TrainingRecipe(recipe_name)
+            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+            mxfp8_op_config.pad_token_groups_for_grouped_mm = pad_token_groups
+            quantize_(mod, config=mxfp8_op_config)
+            return mod
+
+        fqns = self.config.fqns
+        for fqn, config in model_config.walk(Module.Config):
+            if any(target_fqn in fqn for target_fqn in fqns):
+                config._convert_fn = convert_fn
+                if hasattr(config, "token_dispatcher") and isinstance(
+                    config.token_dispatcher, AllToAllTokenDispatcher.Config
+                ):
+                    td = config.token_dispatcher
+                    config.token_dispatcher = TorchAOTokenDispatcher.Config(
+                        num_experts=td.num_experts,
+                        top_k=td.top_k,
+                        score_before_experts=td.score_before_experts,
+                        pad_multiple=PAD_MULTIPLE_MAP["mxfp8"],
+                    )
+                elif hasattr(config, "token_dispatcher") and isinstance(
+                    config.token_dispatcher, DeepEPTokenDispatcher.Config
+                ):
+                    config.token_dispatcher.pad_multiple = PAD_MULTIPLE_MAP["mxfp8"]
 
         logger.info(
             f"Converted layers matching FQNS {self.config.fqns} "

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
-
 from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
@@ -461,12 +460,11 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
 
     @dataclass(kw_only=True, slots=True)
     class Config(AllToAllTokenDispatcher.Config):
-        pass
+        pad_multiple: int
 
     def __init__(self, config: Config):
         super().__init__(config)
-        # TODO: should be set at config time, not at runtime by apply_moe_ep_tp.
-        self.pad_multiple: int
+        self.pad_multiple = config.pad_multiple
 
     def _permute(
         self, routed_input, num_tokens_per_expert_group, ep_size, num_local_experts
@@ -560,16 +558,16 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
 
         comm_backend: str
         non_blocking_capacity_factor: float | None = None
+        pad_multiple: int | None = None
+        """Alignment size for token groups needed by quantized grouped GEMMs
+        (e.g. 16 for FP8, 32 for MXFP8). Only supported with hybridep.
+        None means no padding. Set by quantization converters at config time."""
 
     def __init__(self, config: Config):
         super().__init__(config)
         self.comm_backend = config.comm_backend
         self.non_blocking_capacity_factor = config.non_blocking_capacity_factor
-        # TODO: should be set at config time, not at runtime by apply_moe_ep_tp.
-        # pad_multiple: Alignment size for token groups needed by quantized
-        # grouped GEMMs (e.g. 16 for FP8, 32 for MXFP8). Only supported
-        # with hybridep. None means no padding.
-        self.pad_multiple: int | None = None
+        self.pad_multiple = config.pad_multiple
         # Set by ExpertParallel / ExpertTensorParallel._partition_fn()
         self.ep_group: dist.ProcessGroup | None = None
 

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -15,7 +15,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 
-from torchtitan.components.quantization import find_pad_multiple
 from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -107,7 +106,6 @@ def parallelize_deepseekv3(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             comm_backend=comm_backend,
-            pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
     if parallel_dims.cp_enabled:

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -18,7 +18,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 
-from torchtitan.components.quantization import find_pad_multiple
 from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -42,7 +41,6 @@ from torchtitan.models.gpt_oss.model import GptOssModel
 from torchtitan.models.llama4.parallelize import apply_fsdp
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
-
 from .expert_parallel import GptossExpertTensorParallel, GptossTensorParallel
 
 
@@ -104,7 +102,6 @@ def parallelize_gptoss(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             etp_enabled=parallel_dims.etp_enabled,
             enable_sp=True,
-            pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
     if parallel_dims.cp_enabled:
@@ -265,7 +262,6 @@ def apply_moe_ep_tp(
     ep_etp_mesh: DeviceMesh | None,
     etp_enabled: bool,
     enable_sp: bool = True,
-    pad_multiple: int | None = None,
 ):
     assert ep_mesh is not None or tp_mesh is not None
 
@@ -320,11 +316,6 @@ def apply_moe_ep_tp(
                 if isinstance(dispatcher, AllToAllTokenDispatcher):
                     dispatcher.sp_size = tp_mesh.size()
                     dispatcher.sp_rank = tp_mesh.get_local_rank()
-            if isinstance(dispatcher, TorchAOTokenDispatcher):
-                assert (
-                    pad_multiple is not None
-                ), "pad_multiple must be set for TorchAOTokenDispatcher"
-                dispatcher.pad_multiple = pad_multiple
         else:
             # pyrefly: ignore [missing-attribute]
             dispatcher = transformer_block.moe.experts.token_dispatcher

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -20,7 +20,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 
-from torchtitan.components.quantization import find_pad_multiple
 from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -48,10 +47,8 @@ from torchtitan.distributed.tensor_parallel import (
     NoParallel,
 )
 from torchtitan.models.common.attention import FusedQKVLinear
-
 from torchtitan.models.common.token_dispatcher import (
     AllToAllTokenDispatcher,
-    DeepEPTokenDispatcher,
     TorchAOTokenDispatcher,
 )
 from torchtitan.models.llama4.model import Llama4Model
@@ -136,7 +133,6 @@ def parallelize_llama(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             comm_backend=comm_backend,
             enable_sp=True,
-            pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
     if parallel_dims.cp_enabled:
@@ -530,7 +526,6 @@ def apply_moe_ep_tp(
     ep_etp_mesh: DeviceMesh | None,
     comm_backend: str = "standard",
     enable_sp: bool = True,
-    pad_multiple: int | None = None,
 ):
     assert ep_mesh is not None or tp_mesh is not None
 
@@ -600,15 +595,6 @@ def apply_moe_ep_tp(
             assert ep_etp_mesh is None
             experts_mesh = ep_mesh
             if comm_backend in ("deepep", "hybridep"):
-                # pyrefly: ignore [missing-attribute]
-                dispatcher = transformer_block.moe.experts.token_dispatcher
-                assert isinstance(dispatcher, DeepEPTokenDispatcher)
-                if comm_backend == "deepep" and pad_multiple is not None:
-                    raise ValueError(
-                        "DeepEP does not support pad_multiple. "
-                        "Use hybridep or standard comm backend instead."
-                    )
-                dispatcher.pad_multiple = pad_multiple
                 logger.info(f"Applying {comm_backend.upper()} to MoE layer")
             # sp_size and sp_rank are set for sequence-parallel token splitting
             # when EP borrows from TP (ETP=1).
@@ -619,11 +605,6 @@ def apply_moe_ep_tp(
                 if isinstance(dispatcher, AllToAllTokenDispatcher):
                     dispatcher.sp_size = tp_mesh.size()
                     dispatcher.sp_rank = tp_mesh.get_local_rank()
-            if isinstance(dispatcher, TorchAOTokenDispatcher):
-                assert (
-                    pad_multiple is not None
-                ), "pad_multiple must be set for TorchAOTokenDispatcher"
-                dispatcher.pad_multiple = pad_multiple
         else:
             # pyrefly: ignore [missing-attribute]
             dispatcher = transformer_block.moe.experts.token_dispatcher

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -20,7 +20,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 
-from torchtitan.components.quantization import find_pad_multiple
 from torchtitan.components.quantization.float8 import find_float8_linear_config
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -98,7 +97,6 @@ def parallelize_qwen3(
             ep_mesh=parallel_dims.get_optional_mesh("ep"),
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
-            pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
     if parallel_dims.cp_enabled:

--- a/torchtitan/models/qwen3_vl/parallelize.py
+++ b/torchtitan/models/qwen3_vl/parallelize.py
@@ -14,7 +14,6 @@ This module applies PT-D parallelisms and various training techniques
 import torch
 import torch._inductor.config
 import torch.nn as nn
-
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed.tensor import distribute_tensor, Replicate, Shard
@@ -26,8 +25,6 @@ from torch.distributed.tensor.parallel import (
     SequenceParallel,
 )
 
-from torchtitan.components.quantization import find_pad_multiple
-
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
@@ -35,7 +32,6 @@ from torchtitan.config import (
     TORCH_DTYPE_MAP,
     TrainingConfig,
 )
-
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.compile import apply_compile
@@ -316,7 +312,6 @@ def parallelize_qwen3_vl(
             etp_mesh=parallel_dims.get_optional_mesh("etp"),
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             enable_sp=False,
-            pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
     # Apply activation checkpointing


### PR DESCRIPTION
## Summary

Move `pad_multiple` from runtime assignment to config time, and have quantization converters handle `TorchAOTokenDispatcher` selection.

Previously, `pad_multiple` was set at runtime by `apply_moe_ep_tp` in the parallelize code, and `TorchAOTokenDispatcher` was selected at config construction time in `make_token_dispatcher_config`. Now both are handled by the quantization converters in `convert_config()`:

- Converters swap `AllToAllTokenDispatcher.Config` → `TorchAOTokenDispatcher.Config` with the correct `pad_multiple` (16 for FP8, 32 for MXFP8)
- Converters set `pad_multiple` on `DeepEPTokenDispatcher.Config` for hybridep, with validation that regular deepep does not support `pad_multiple`

This removes the need for parallelize code to know about quantization padding requirements.

Addresses https://github.com/pytorch/torchtitan/pull/2960#discussion_r3089759076.

**Changes:**
- `TorchAOTokenDispatcher.Config`: add `pad_multiple: int` field, read in `__init__` (resolves the TODO)
- `DeepEPTokenDispatcher.Config`: add `pad_multiple: int | None = None` field, read in `__init__`
- `Float8GroupedMMConverter.convert_config()` / `MXFP8Converter.convert_config()`: swap token dispatcher config and set `pad_multiple`
- Validation: raise `ValueError` if `comm_backend == "deepep"` with quantized grouped GEMMs (deepep does not support `pad_multiple`)

## Test plan
- [ ] `pytest tests/unit_tests/test_model_converter.py`
- [ ] `pytest tests/unit_tests/test_linear.py`
- [ ] Full unit test suite (219 passed, 0 new failures)
- [ ] Verify float8 training produces identical loss before vs after:
```
NCCL_NVLS_ENABLE=0 python scripts/loss_compare.py . main --baseline-module='llama3' --baseline-config='llama3_debugmodel_float8' --baseline-ngpus=8 --test-module='llama3' --test-config='llama3_debugmodel_float8' --test-ngpus=8 --assert-equal --no-seed-checkpoint
```