### PR TITLE
[profiler] Suppress Callable field from tyro CLI parsing

### DIFF
--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -10,9 +10,8 @@ import time
 from dataclasses import dataclass
 from typing import Annotated
 
-import tyro
 import torch
-
+import tyro
 from torchtitan.config import Configurable
 from torchtitan.config.function import Function
 from torchtitan.tools.logging import logger

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -8,7 +8,9 @@ import os
 import pickle
 import time
 from dataclasses import dataclass
+from typing import Annotated
 
+import tyro
 import torch
 
 from torchtitan.config import Configurable
@@ -169,10 +171,13 @@ class Profiler(Configurable):
         save_memory_snapshot_folder: str = "memory_snapshot"
         """Memory snapshot files location."""
 
-        trace_post_processor: Function.Config | None = None
+        trace_post_processor: Annotated[
+            Function.Config | None, tyro.conf.Suppress
+        ] = None
         """Optional hook invoked with the trace path after each export.
 
         Wraps ``fn(trace_path: str) -> None``.
+        Set programmatically (not via CLI) — tyro cannot parse Callable types.
         """
 
     def __init__(


### PR DESCRIPTION
## Summary

Fixes a crash introduced by #2926 where `trace_post_processor: Function.Config | None` in `Profiler.Config` causes `tyro.cli()` to fail because tyro cannot parse `Callable[..., Any]` types from CLI arguments.

**Error:**
```
Invalid input to tyro.cli()
Unsupported type annotation for field profiler.trace-post-processor.fn
with type collections.abc.Callable[..., typing.Any]
```

**Fix:** Annotate `trace_post_processor` with `tyro.conf.Suppress`, matching the existing pattern used for:
- `model_spec` in `trainer.py:62`
- `sample_processor` in `text_datasets.py:502`

The field defaults to `None` and is only set programmatically by `CUDAGraphWrapper`, never via CLI.

## Test plan

- [ ] Verify `python -m torchtitan.train ...` no longer crashes at config parsing
- [ ] Verify graph_trainer still works (trace_post_processor set programmatically)