### PR TITLE
[graph_trainer] Add CP support to CooR precompile

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -352,13 +352,18 @@ def _precompile_aot_fx_trace(
         parallel_dims=parallel_dims,
     )
 
-    # TODO: Add CP support — call prepare_context_parallel_input here
-    # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence
-    # dimension, matching the trainer's post_dataloading_process.
     if parallel_dims.cp_enabled:
-        raise NotImplementedError(
-            "CooR precompile does not yet support context parallelism. "
-            "Set --parallelism.context_parallel_degree 1."
+        from torchtitan.distributed.context_parallel import (
+            prepare_context_parallel_input,
+        )
+
+        dummy_inputs, dummy_labels, extra_kwargs = prepare_context_parallel_input(
+            dummy_inputs,
+            dummy_labels,
+            extra_kwargs,
+            parallel_dims.get_mesh("cp"),
+            device,
+            config.parallelism.context_parallel_load_balancer,
         )
 
     # Enable loss_parallel when TP is active and loss_parallel is not

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -47,6 +47,7 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
     regional_precompile_dir = tempfile.mkdtemp(prefix="precompile_regional_")
     fx_trace_precompile_dir = tempfile.mkdtemp(prefix="fx_trace_precompile_")
     dsv3_fx_trace_precompile_dir = tempfile.mkdtemp(prefix="dsv3_fx_trace_precompile_")
+    cp_fx_trace_precompile_dir = tempfile.mkdtemp(prefix="cp_fx_trace_precompile_")
     return [
         PrecompileTestDefinition(
             precompile_command=(
@@ -144,6 +145,30 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             ],
             test_descr="aot_fx_trace deepseek_v3 precompile FSDP+TP+EP",
             test_name="aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep",
+            ngpu=8,
+        ),
+        PrecompileTestDefinition(
+            precompile_command=(
+                "python -m torchtitan.experiments.graph_trainer.precompile_main"
+                " --module graph_trainer.llama3"
+                " --config graph_trainer_llama3_debugmodel"
+                " --compile.mode aot_fx_trace"
+                f" --compile.precompile_artifact_dir {cp_fx_trace_precompile_dir}"
+                " --parallelism.data_parallel_shard_degree 2"
+                " --parallelism.tensor_parallel_degree 2"
+                " --parallelism.context_parallel_degree 2"
+            ),
+            override_args=[
+                "--module graph_trainer.llama3",
+                "--config graph_trainer_llama3_debugmodel",
+                "--compile.mode aot_fx_trace",
+                f"--compile.precompile_artifact_dir {cp_fx_trace_precompile_dir}",
+                "--parallelism.data_parallel_shard_degree 2",
+                "--parallelism.tensor_parallel_degree 2",
+                "--parallelism.context_parallel_degree 2",
+            ],
+            test_descr="aot_fx_trace llama3 precompile FSDP+TP+CP",
+            test_name="aot_fx_trace_llama3_precompile_fsdp_tp_cp",
             ngpu=8,
         ),
     ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3042
* #2916

Add context parallel support to the precompile path by calling
prepare_context_parallel_input after build_forward_extra_kwargs,
matching the trainer's post_dataloading_process.

prepare_context_parallel_input uses _context_parallel_shard which
is already CooR-safe (no rank-specific operations), so no additional
adaptation is needed.