### PR TITLE
[graph_trainer] Add precompile integration tests to CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -80,6 +80,9 @@ jobs:
         # Run precompile unit tests
         pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -v
 
+        # Run precompile integration tests (Llama3 only; DSv3 runs in H100 workflow)
+        python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile --ngpu 8 --test_name aot_fx_trace_llama3_precompile_fsdp_tp
+
         # Run bitwise deterministic and SAC peak-memory guardrail tests
         pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v
         pytest torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py -v

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -66,6 +66,9 @@ jobs:
         # Run the MoE numerics tests
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "moe"
 
+        # Run precompile integration tests (DSv3 with EP; Llama3 runs in default workflow)
+        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile --ngpu 8 --test_name aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
+
         # Run bitwise deterministic and SAC peak-memory guardrail tests
         pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v
         pytest torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py -v


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #2916
* __->__ #3043

Precompile integration tests (run_precompile_tests.py) were never run
in CI, which allowed the bucketing + CooR incompatibility from #2934 (enabled in https://github.com/pytorch/torchtitan/pull/3036)
to go undetected. Add them to both CI workflows:

- A10 workflow: Llama3 aot_fx_trace precompile test (FSDP+TP)
- H100 workflow: DSv3 aot_fx_trace precompile test (FSDP+TP+EP)

