### PR TITLE
[GraphTrainer] Disable FSDP bucketing pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -74,12 +74,7 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime
     """
-    from torchtitan.experiments.graph_trainer.common_utils import (
-        get_default_transformer_block_buckets,
-    )
     from torchtitan.models.common.attention import FlexAttention
-
-    n_layers = len(config.model_spec.model.layers)
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -74,7 +74,12 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime
     """
+    # from torchtitan.experiments.graph_trainer.common_utils import (
+    #     get_default_transformer_block_buckets,
+    # )
     from torchtitan.models.common.attention import FlexAttention
+
+    # n_layers = len(config.model_spec.model.layers)
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -85,10 +85,12 @@ def compile_time_passes(
         remove_identity_view_pass,
         remove_identity_slice_pass,
         selective_activation_remat_pass,
-        functools.partial(
-            joint_transformer_block_bucketing_reordering_pass,
-            fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
-        ),
+        # TODO: bucketing is failing for DSv3, allgather prefetching
+        # for Llama3 is not working.
+        # functools.partial(
+        #     joint_transformer_block_bucketing_reordering_pass,
+        #     fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
+        # ),
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
         # When left uncompiled, flex_attention still runs correctly but


### PR DESCRIPTION
## Summary
- Disable `joint_transformer_block_bucketing_reordering_pass` in `compile_time_passes` — bucketing is failing for DeepSeek-v3 and allgather prefetching for Llama3 is not working.

## Test plan
- [ ] Verify Llama3 aot_fx_trace training runs without the bucketing pass
- [ ] Verify DeepSeek-v3 aot_fx_trace training runs without the bucketing pass