### PR TITLE
ci: pin torchvision alongside torch in vlm 8-GPU workflow

### DIFF
--- a/.github/workflows/integration_test_8gpu_vlm.yaml
+++ b/.github/workflows/integration_test_8gpu_vlm.yaml
@@ -64,8 +64,10 @@ jobs:
         if [ -n "${{ matrix.torch-version }}" ]; then
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
+        # NOTE: reinstall torchvision alongside torch so their ABIs stay in sync;
+        # otherwise transitive `import torchvision` fails at test time.
         python -m pip install --force-reinstall --pre \
-          "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+          "${TORCH_SPEC}" torchvision --index-url ${{ matrix.index-url }}
 
         if [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
           export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"


### PR DESCRIPTION
## What

Add `torchvision` to the `pip install --force-reinstall --pre torch ...` line in the VLM 8-GPU integration test workflow:

- `integration_test_8gpu_vlm.yaml`

Same one-line fix that landed in #3002 for `integration_test_8gpu_transformers_modeling_backend.yaml`.

## Why

Force-reinstalling only `torch` from the nightly index leaves the pre-installed `torchvision` (built against an older nightly) in place. Pip's resolver doesn't catch the resulting ABI break (`pip check` passes), but any code path that does `import torchvision` fails:

```
RuntimeError: operator torchvision::nms does not exist
  File ".../torchvision/_meta_registrations.py", line 163, in <module>
    @torch.library.register_fake("torchvision::nms")
```

The VLM workflow's test entry point pulls `torchvision` transitively (image-utils path through `transformers`), so the ABI break is fatal at import time.

## Scope note

An earlier revision of this PR also patched `features.yaml`, `torchft.yaml`, and `autoparallel.yaml`. Removed — those workflows are red on ROCm for an unrelated reason (DCP planner `EOFError` in `gather_object`, see #3051), and a torchvision pin there would be speculative. Will file separately if/when verified.

## Repro / verification (local, MI325X / `rocm/pytorch:latest`)

| Step | Result |
|---|---|
| Force-reinstall `torch` only from `nightly/rocm7.1` | torch upgraded to 2.13.0.dev, torchvision left at 0.25.0 |
| `import torchvision` | `RuntimeError: operator torchvision::nms does not exist` |
| `pip check` | "No broken requirements" — silent ABI break |
| Apply fix (install `torch torchvision` together) | torch 2.13.0.dev + torchvision 0.27.0.dev |
| `import torchvision` | succeeds |

The exact same shape was previously confirmed and merged for `transformers_modeling_backend.yaml` in #3002.

## Note comment

Per review feedback on #3002, the touched file gets a 2-line `# NOTE:` explaining why `torchvision` is on the install line, so future maintainers don't strip it.
