### PR TITLE
[GraphTrainer] Add enable_cudagraph config flag

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -43,6 +43,9 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
+    enable_cudagraph: bool = True
+    """When False, skip the cudagraph pass even if the graph is compatible."""
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -63,7 +63,7 @@ def compile_time_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
     *,
-    cudagraph_compatible: bool = False,
+    use_cudagraph: bool = False,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -99,7 +99,7 @@ def compile_time_passes(
         ),
         regional_inductor_pass,
     ]
-    if cudagraph_compatible:
+    if use_cudagraph:
         # Must run before custom_codegen_pass (last in pre_passes)
         # which replaces the GraphModule's forward().
         # Also must run before cudagraph_pass.
@@ -131,20 +131,20 @@ def construct_default_graph_passes(
     """
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
-    cudagraph_compatible = is_cudagraph_compatible(traced_result.gm)
+    use_cudagraph = config.compile.enable_cudagraph and is_cudagraph_compatible(
+        traced_result.gm
+    )
 
     has_precompile_artifact = bool(config.compile.precompile_artifact_dir)
 
     passes: list[Callable] = []
     if not has_precompile_artifact:
         passes.extend(
-            compile_time_passes(
-                traced_result, config, cudagraph_compatible=cudagraph_compatible
-            )
+            compile_time_passes(traced_result, config, use_cudagraph=use_cudagraph)
         )
 
     # cudagraph should be the last pass.
-    if cudagraph_compatible:
+    if use_cudagraph:
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -48,6 +48,7 @@ def build_minimal_trainer(
                 if compile_joint_passes is None
                 else list(compile_joint_passes),
                 precompile_artifact_dir="",
+                enable_cudagraph=True,
                 debug_graph_passes=False,
             ),
             model_spec=SimpleNamespace(model=model_config),

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -210,7 +210,10 @@ class BitwiseDeterministicBase(unittest.TestCase):
         if enable_passes:
             load_config = SimpleNamespace(
                 model_spec=SimpleNamespace(model=self.model_config),
-                compile=SimpleNamespace(precompile_artifact_dir="precompiled"),
+                compile=SimpleNamespace(
+                    precompile_artifact_dir="precompiled",
+                    enable_cudagraph=True,
+                ),
             )
             passes = construct_default_graph_passes(loaded_result, load_config)
             loaded_result.gm = apply_graph_passes(


### PR DESCRIPTION
when profiling, cudagraph mess up the cuda streams. This flag is for the ease of having a human readable profile.

## Summary
- Add `compile.enable_cudagraph` config option (default `True`) to allow disabling the cudagraph pass via `--compile.no-enable_cudagraph`
- Rename `cudagraph_compatible` to `use_cudagraph` for clarity — it now combines the config flag with the graph compatibility check

## Test plan
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x` — all pass
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x -k "not test_eager_self_deterministic"` — 6/6 pass