### PR TITLE
Update tracer backward patcher

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -378,7 +378,7 @@ def minimal_fx_tracer(fn: Callable) -> Callable[..., TracedResult]:
 
             state_for_fn = dict(zip(state_fqns, state_wrapped, strict=True))
             user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
-            with torch.compiler._patch_autograd_grad():
+            with torch.compiler._patch_engine_backward():
                 result = fn(state_for_fn, *user_list)
 
             flat_outs, output_spec = pytree.tree_flatten(result)


### PR DESCRIPTION
For all use cases of non-strict tracer, just patching autograd.grad is not enough. We should patch the whole entry point to backward. 