### PR TITLE
[graph_trainer] Refactor Trainer.__init__ for composable subclassing; PrecompileFakeTrainer inherits model build path

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -155,14 +155,12 @@ class PrecompileFakeTrainer(Trainer):
         return parallel_dims
 
     def _init_determinism(self) -> None:
-        config = self.config
-        self.gc_handler = utils.GarbageCollection(
-            gc_freq=config.training.gc_freq, debug=config.training.gc_debug
-        )
         # Match the deterministic mode that the training loop will use.
         # The backward graph captures use_deterministic_algorithms() at
         # compile time and asserts it matches at runtime.
-        if config.debug.deterministic:
+        # We can't call super() here because dist_utils.set_determinism
+        # does DTensor RNG seeding which fails under CooR's fake PG.
+        if self.config.debug.deterministic:
             torch.use_deterministic_algorithms(True)
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
@@ -209,11 +207,11 @@ class PrecompileFakeTrainer(Trainer):
         # compile_on_one_rank=True.  Re-enable for the tracing phase after.
         import torch.distributed.config as dist_config
 
-        model.to_empty(device=utils.device_type)
+        model.to_empty(device=init_device)
         dist_config.compile_on_one_rank = False
         try:
             with torch.no_grad():
-                model.init_weights(buffer_device=None)
+                model.init_weights(buffer_device=buffer_device)
         finally:
             dist_config.compile_on_one_rank = True
         model.train()

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -40,15 +40,13 @@ from typing import Any, cast
 import torch
 import torch.distributed as dist
 
-from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
+from torchtitan.config import ConfigManager
 from torchtitan.distributed import ParallelDims
-from torchtitan.models.common.decoder import Decoder
 from torchtitan.experiments.graph_trainer.common_utils import (
     apply_graph_ac,
     parallelize_inputs,
     register_blockmask_pytree_node,
 )
-
 from torchtitan.experiments.graph_trainer.compile import (
     _make_precompile_callback,
     _SERIALIZABLE_PASSES,
@@ -65,436 +63,426 @@ from torchtitan.experiments.graph_trainer.precompile import (
     _FX_TRACE_ARTIFACT_KEY,
 )
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+from torchtitan.models.common.decoder import Decoder
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
+from torchtitan.trainer import Trainer
 
 
-def _common_setup(config):
-    """Common setup for all precompile modes: fake PG, CooR, model build."""
-    compile_config = config.compile
+class PrecompileFakeTrainer(Trainer):
+    """Lightweight trainer for single-process precompilation.
 
-    if not compile_config.precompile_artifact_dir:
-        raise ValueError(
-            "precompile_main requires --compile.precompile_artifact_dir to be set."
-        )
+    Subclasses Trainer to inherit the model build/parallelize/init path
+    but uses a fake distributed backend with compile-on-one-rank (CooR)
+    instead of real multi-GPU communication.  No optimizer, dataloader,
+    checkpointer, or training loop are created.
+    """
 
-    parallelism = config.parallelism
-    dp_replicate = parallelism.data_parallel_replicate_degree
-    dp_shard = parallelism.data_parallel_shard_degree
-    cp = parallelism.context_parallel_degree
-    tp = parallelism.tensor_parallel_degree
-    pp = parallelism.pipeline_parallel_degree
+    def __init__(self, config):
+        compile_config = config.compile
 
-    # dp_shard=-1 means "use remaining ranks" which can't be inferred
-    # in single-process mode. The compiled graph bakes in tensor shapes
-    # that depend on dp_shard, so the exact value must match training.
-    if dp_shard < 0:
-        raise ValueError(
-            "precompile_main requires an explicit "
-            "--parallelism.data_parallel_shard_degree (not -1). "
-            "Set it to the value you will use during torchrun training."
-        )
-    world_size = dp_replicate * dp_shard * cp * tp * pp
-
-    logger.info(f"Initializing single-process precompile with world_size={world_size}")
-
-    # rank must be 0 because --virtual-local-rank maps every torchrun rank
-    # to local rank 0, so the precompiled artifact needs to match that setup.
-    # Fake backend produces correct collective output shapes without real
-    # communication, letting us trace distributed ops on a single process.
-    dist.init_process_group("fake", rank=0, world_size=world_size)
-
-    # CooR must be enabled globally (not just during tracing) so that the
-    # parallelization phase (TP, FSDP mesh setup) also uses symbolic
-    # coordinates rather than hardcoding rank-specific values.
-    import torch.distributed.config as dist_config
-
-    dist_config.compile_on_one_rank = True
-
-    # Match the deterministic mode that the training loop will use.
-    # The backward graph captures use_deterministic_algorithms() at
-    # compile time and asserts it matches at runtime.
-    if config.debug.deterministic:
-        torch.use_deterministic_algorithms(True)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-
-    device = torch.device("cuda:0")
-    torch.cuda.set_device(device)
-
-    parallel_dims = ParallelDims(
-        dp_shard=dp_shard,
-        dp_replicate=dp_replicate,
-        cp=cp,
-        tp=tp,
-        pp=pp,
-        ep=parallelism.expert_parallel_degree,
-        etp=parallelism.expert_tensor_parallel_degree,
-        world_size=world_size,
-    )
-    parallel_dims.build_mesh()
-
-    model_spec = config.model_spec
-    if model_spec is None:
-        raise ValueError(
-            "model_spec must be set. Pass --module to specify the model "
-            "(e.g. --module graph_trainer.llama3)."
-        )
-
-    # TODO: Factor the model setup below with the training path so precompile
-    # and training share a single implementation of build/parallelize/init.
-    model_config = model_spec.model
-    model_config.update_from_config(trainer_config=config)
-
-    logger.info(f"Building {model_spec.name} {model_spec.flavor} on meta device")
-    with (
-        torch.device("meta"),
-        utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]),
-    ):
-        model = model_config.build()
-
-    model.verify_module_protocol()
-
-    # For aot_fx_trace, apply_compile inside parallelize_fn is a no-op
-    # (returns model unchanged), so we pass the real compile_config.
-    # This lets side effects from parallelize_fn (e.g. apply_graph_ac
-    # adding "apply_sac" to joint_passes) be visible to
-    # compute_config_fingerprint later without needing a manual hack.
-    # For aot, apply_compile would try to load a non-existent artifact,
-    # so we suppress it with a copy that has enable=False. This
-    # complexity goes away once we complete the migration to
-    # aot_fx_trace and remove the aot code path.
-    if compile_config.mode == "aot":
-        parallelize_compile_config = dataclasses.replace(compile_config, enable=False)
-    else:
-        parallelize_compile_config = compile_config
-
-    model = model_spec.parallelize_fn(
-        model,
-        parallel_dims=parallel_dims,
-        training=config.training,
-        model_converters=config.model_converters,
-        parallelism=parallelism,
-        compile_config=parallelize_compile_config,
-        ac_config=config.activation_checkpoint,
-        dump_folder=config.dump_folder,
-    )
-
-    # CooR must be disabled during init_weights because DTensor RNG ops
-    # (weight initialization seeding) raise NotImplementedError under
-    # compile_on_one_rank=True. Re-enable for the tracing phase after.
-    device_type = utils.device_type
-    model.to_empty(device=device_type)
-    dist_config.compile_on_one_rank = False
-    try:
-        with torch.no_grad():
-            model.init_weights(buffer_device=None)
-    finally:
-        dist_config.compile_on_one_rank = True
-    model.train()
-
-    logger.info("Model parallelized and materialized")
-
-    tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
-
-    return (
-        model,
-        model_config,
-        model_spec,
-        compile_config,
-        parallel_dims,
-        device,
-        tokenizer,
-    )
-
-
-def _precompile_aot(
-    config,
-    model,
-    model_config,
-    model_spec,
-    compile_config,
-    parallel_dims,
-    device,
-    tokenizer,
-):
-    """AOT mode precompilation: joint graph export + Inductor."""
-    # Only one pass in the pipeline needs to produce serializable OutputCode.
-    if not (_SERIALIZABLE_PASSES & set(compile_config.passes)):
-        raise ValueError(
-            "precompile_main requires at least one pass that produces "
-            "serializable output "
-            f"({', '.join(sorted(_SERIALIZABLE_PASSES))}) in --compile.passes."
-        )
-
-    # Augment compile_config with AC joint passes to match the training
-    # path, which calls apply_graph_ac during parallelization. Without
-    # this the SAC pass won't run and the config fingerprint will differ.
-    if config.activation_checkpoint.mode != "none":
-        apply_graph_ac(compile_config, config.activation_checkpoint)
-
-    register_blockmask_pytree_node()
-
-    from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
-
-    fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
-        config.parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
-    )
-
-    from .precompile import compute_config_fingerprint
-
-    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
-    config_fingerprint = compute_config_fingerprint(
-        model, compile_config, parallel_dims
-    )
-
-    joint_custom_passes = get_joint_custom_passes_from_config(
-        parallel_dims, compile_config, fsdp_reshard_after_forward
-    )
-    compiler_passes = get_compiler_passes_from_config(
-        model, compile_config, parallel_dims
-    )
-    fw_compiler, bw_compiler = make_compiler_with_passes(
-        compiler_passes, dump_folder=config.dump_folder
-    )
-
-    on_compile = _make_precompile_callback(
-        model,
-        compile_config,
-        parallel_dims,
-        storage=storage,
-        config_fingerprint=config_fingerprint,
-    )
-
-    model_joint_graph_builder = functools.partial(
-        joint_graph_builder,
-        fw_compiler=fw_compiler,
-        bw_compiler=bw_compiler,
-        joint_custom_passes=joint_custom_passes,
-        dump_folder=config.dump_folder,
-        compile_config=compile_config,
-        serializable=True,
-        on_compile=on_compile,
-    )
-
-    compiled_model = CompiledModule(
-        model, parallel_dims, model_joint_graph_builder, parallelize_inputs
-    )
-
-    # Forward pass triggers AOT compilation; the backward graph is compiled
-    # eagerly (not lazily) because serializable=True sets
-    # force_non_lazy_backward_lowering=True in aot_compile_joint.
-    seq_len = config.training.seq_len
-    local_batch_size = config.training.local_batch_size
-    vocab_size = model_config.vocab_size
-
-    dummy_input = torch.randint(
-        0, vocab_size, (local_batch_size, seq_len), device=device
-    )
-    logger.info("Running forward pass to trigger AOT compilation...")
-    compiled_model(dummy_input)
-
-    logger.info(
-        f"Precompile complete. Artifact saved to "
-        f"{compile_config.precompile_artifact_dir}/{_ARTIFACT_KEY}.bin"
-    )
-
-
-def _precompile_aot_fx_trace(
-    config,
-    model,
-    model_config,
-    model_spec,
-    compile_config,
-    parallel_dims,
-    device,
-    tokenizer,
-):
-    """aot_fx_trace mode precompilation: make_fx tracing + Inductor."""
-    from torchtitan.experiments.graph_trainer.make_fx_tracer import trace_train_step
-    from torchtitan.experiments.graph_trainer.precompile import (
-        compute_config_fingerprint,
-        precompile_fx_trace_save,
-    )
-    from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
-
-    loss_fn = model_spec.build_loss_fn(compile_config, parallel_dims=parallel_dims)
-
-    fwd_bwd_fn = make_fwd_bwd_step(loss_fn)
-
-    seq_len = config.training.seq_len
-    local_batch_size = config.training.local_batch_size
-    vocab_size = model_config.vocab_size
-
-    dummy_inputs = torch.randint(
-        0, vocab_size, (local_batch_size, seq_len), device=device
-    )
-    dummy_labels = torch.randint(
-        0, vocab_size, (local_batch_size, seq_len), device=device
-    )
-    # The trainer computes global_valid_tokens via dist_sum (an
-    # all-reduce + .item()), which returns a Python float. Use the
-    # same type here so make_fx bakes it as a graph constant — not a
-    # graph input — identical to the non-precompile runtime trace.
-    global_batch_size = (
-        local_batch_size
-        * parallel_dims.dp_shard
-        * parallel_dims.dp_replicate
-        * parallel_dims.cp
-    )
-    dummy_global_valid_tokens = float(global_batch_size * seq_len)
-    extra_inputs: dict[str, torch.Tensor] = {}
-    extra_kwargs: dict[str, Any] = {}
-
-    if isinstance(model_config, Decoder.Config) and model_config.layers:
-        attn_config = model_config.layers[0].attention
-        mask_type = getattr(attn_config, "mask_type", "causal")
-
-        if mask_type == "block_causal" or parallel_dims.cp_enabled:
-            extra_kwargs["positions"] = torch.arange(
-                0, dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
-            ).expand(dummy_inputs.shape)
-
-        inner_attention = getattr(attn_config, "inner_attention", None)
-        if inner_attention is not None:
-            from torchtitan.models.common.attention import (
-                FlexAttention,
-                VarlenAttention,
+        if not compile_config.precompile_artifact_dir:
+            raise ValueError(
+                "PrecompileFakeTrainer requires "
+                "--compile.precompile_artifact_dir to be set."
             )
 
-            if isinstance(
-                inner_attention,
-                (FlexAttention.Config, VarlenAttention.Config),
-            ):
-                assert (
-                    tokenizer is not None
-                ), "tokenizer is required for flex/varlen attention"
-                extra_kwargs["attention_masks"] = cast(
-                    Decoder, model
-                ).get_attention_masks(
-                    input_batch=dummy_inputs,
-                    tokenizer=tokenizer,
-                    extra_inputs=extra_inputs or {},
+        mode = compile_config.mode
+        if mode not in ("aot", "aot_fx_trace"):
+            raise ValueError(
+                f"PrecompileFakeTrainer only supports --compile.mode aot or "
+                f"aot_fx_trace, got '{mode}'."
+            )
+
+        self.compile_config = compile_config
+        self._tokenizer_lazy = None
+
+        super().__init__(config)
+
+    # -- Overrides for device/distributed/determinism --
+
+    def _init_device(self) -> None:
+        self.device = torch.device("cuda:0")
+        torch.cuda.set_device(self.device)
+
+    def init_distributed(self) -> ParallelDims:
+        parallelism = self.config.parallelism
+        dp_replicate = parallelism.data_parallel_replicate_degree
+        dp_shard = parallelism.data_parallel_shard_degree
+        cp = parallelism.context_parallel_degree
+        tp = parallelism.tensor_parallel_degree
+        pp = parallelism.pipeline_parallel_degree
+
+        # dp_shard=-1 means "use remaining ranks" which can't be inferred
+        # in single-process mode.  The compiled graph bakes in tensor shapes
+        # that depend on dp_shard, so the exact value must match training.
+        if dp_shard < 0:
+            raise ValueError(
+                "PrecompileFakeTrainer requires an explicit "
+                "--parallelism.data_parallel_shard_degree (not -1). "
+                "Set it to the value you will use during torchrun training."
+            )
+        world_size = dp_replicate * dp_shard * cp * tp * pp
+
+        logger.info(
+            f"Initializing single-process precompile with world_size={world_size}"
+        )
+
+        # rank must be 0 because --virtual-local-rank maps every torchrun rank
+        # to local rank 0, so the precompiled artifact needs to match that setup.
+        # Fake backend produces correct collective output shapes without real
+        # communication, letting us trace distributed ops on a single process.
+        dist.init_process_group("fake", rank=0, world_size=world_size)
+
+        # CooR must be enabled globally (not just during tracing) so that the
+        # parallelization phase (TP, FSDP mesh setup) also uses symbolic
+        # coordinates rather than hardcoding rank-specific values.
+        import torch.distributed.config as dist_config
+
+        dist_config.compile_on_one_rank = True
+
+        parallel_dims = ParallelDims(
+            dp_shard=dp_shard,
+            dp_replicate=dp_replicate,
+            cp=cp,
+            tp=tp,
+            pp=pp,
+            ep=parallelism.expert_parallel_degree,
+            etp=parallelism.expert_tensor_parallel_degree,
+            world_size=world_size,
+        )
+        parallel_dims.build_mesh()
+        return parallel_dims
+
+    def _init_determinism(self) -> None:
+        config = self.config
+        self.gc_handler = utils.GarbageCollection(
+            gc_freq=config.training.gc_freq, debug=config.training.gc_debug
+        )
+        # Match the deterministic mode that the training loop will use.
+        # The backward graph captures use_deterministic_algorithms() at
+        # compile time and asserts it matches at runtime.
+        if config.debug.deterministic:
+            torch.use_deterministic_algorithms(True)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+
+    # -- Overrides for model build hooks --
+
+    def _build_data_pipeline(self) -> None:
+        pass
+
+    @property
+    def tokenizer(self):
+        if self._tokenizer_lazy is None:
+            self._tokenizer_lazy = self.config.tokenizer.build(
+                tokenizer_path=self.config.hf_assets_path
+            )
+        return self._tokenizer_lazy
+
+    @tokenizer.setter
+    def tokenizer(self, value):
+        self._tokenizer_lazy = value
+
+    def _get_compile_config_for_parallelize(self):
+        # For aot_fx_trace, apply_compile inside parallelize_fn is a no-op
+        # (returns model unchanged), so we pass the real compile_config.
+        # This lets side effects from parallelize_fn (e.g. apply_graph_ac
+        # adding "apply_sac" to joint_passes) be visible to
+        # compute_config_fingerprint later without needing a manual hack.
+        # For aot, apply_compile would try to load a non-existent artifact,
+        # so we suppress it with a copy that has enable=False.  This
+        # complexity goes away once we complete the migration to
+        # aot_fx_trace and remove the aot code path.
+        if self.compile_config.mode == "aot":
+            return dataclasses.replace(self.compile_config, enable=False)
+        return self.compile_config
+
+    def _init_model_weights(
+        self,
+        model: torch.nn.Module,
+        init_device: str,
+        buffer_device: torch.device | None,
+    ) -> None:
+        # CooR must be disabled during init_weights because DTensor RNG ops
+        # (weight initialization seeding) raise NotImplementedError under
+        # compile_on_one_rank=True.  Re-enable for the tracing phase after.
+        import torch.distributed.config as dist_config
+
+        model.to_empty(device=utils.device_type)
+        dist_config.compile_on_one_rank = False
+        try:
+            with torch.no_grad():
+                model.init_weights(buffer_device=None)
+        finally:
+            dist_config.compile_on_one_rank = True
+        model.train()
+
+    # -- Override to skip training infrastructure --
+
+    def _build_training_infrastructure(self) -> None:
+        self.model = self.model_parts[0]
+
+    # -- Precompile-specific methods --
+
+    def _make_dummy_inputs(self):
+        seq_len = self.config.training.seq_len
+        local_batch_size = self.config.training.local_batch_size
+        vocab_size = self.model_config.vocab_size
+
+        dummy_inputs = torch.randint(
+            0, vocab_size, (local_batch_size, seq_len), device=self.device
+        )
+        dummy_labels = torch.randint(
+            0, vocab_size, (local_batch_size, seq_len), device=self.device
+        )
+        return dummy_inputs, dummy_labels
+
+    def precompile(self):
+        if self.compile_config.mode == "aot":
+            self._precompile_aot()
+        elif self.compile_config.mode == "aot_fx_trace":
+            self._precompile_aot_fx_trace()
+        else:
+            raise AssertionError(f"unexpected mode: {self.compile_config.mode}")
+
+    def _precompile_aot(self):
+        config = self.config
+        compile_config = self.compile_config
+
+        if not (_SERIALIZABLE_PASSES & set(compile_config.passes)):
+            raise ValueError(
+                "PrecompileFakeTrainer requires at least one pass that produces "
+                "serializable output "
+                f"({', '.join(sorted(_SERIALIZABLE_PASSES))}) in --compile.passes."
+            )
+
+        # Augment compile_config with AC joint passes to match the training
+        # path, which calls apply_graph_ac during parallelization.  Without
+        # this the SAC pass won't run and the config fingerprint will differ.
+        if config.activation_checkpoint.mode != "none":
+            apply_graph_ac(compile_config, config.activation_checkpoint)
+
+        register_blockmask_pytree_node()
+
+        from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
+
+        fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
+            config.parallelism.fsdp_reshard_after_forward,
+            self.parallel_dims.pp_enabled,
+        )
+
+        from .precompile import compute_config_fingerprint
+
+        storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+        config_fingerprint = compute_config_fingerprint(
+            self.model, compile_config, self.parallel_dims
+        )
+
+        joint_custom_passes = get_joint_custom_passes_from_config(
+            self.parallel_dims, compile_config, fsdp_reshard_after_forward
+        )
+        compiler_passes = get_compiler_passes_from_config(
+            self.model, compile_config, self.parallel_dims
+        )
+        fw_compiler, bw_compiler = make_compiler_with_passes(
+            compiler_passes, dump_folder=config.dump_folder
+        )
+
+        on_compile = _make_precompile_callback(
+            self.model,
+            compile_config,
+            self.parallel_dims,
+            storage=storage,
+            config_fingerprint=config_fingerprint,
+        )
+
+        model_joint_graph_builder = functools.partial(
+            joint_graph_builder,
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+            joint_custom_passes=joint_custom_passes,
+            dump_folder=config.dump_folder,
+            compile_config=compile_config,
+            serializable=True,
+            on_compile=on_compile,
+        )
+
+        compiled_model = CompiledModule(
+            self.model,
+            self.parallel_dims,
+            model_joint_graph_builder,
+            parallelize_inputs,
+        )
+
+        # Forward pass triggers AOT compilation; the backward graph is compiled
+        # eagerly (not lazily) because serializable=True sets
+        # force_non_lazy_backward_lowering=True in aot_compile_joint.
+        dummy_inputs, _ = self._make_dummy_inputs()
+
+        logger.info("Running forward pass to trigger AOT compilation...")
+        compiled_model(dummy_inputs)
+
+        logger.info(
+            f"Precompile complete. Artifact saved to "
+            f"{compile_config.precompile_artifact_dir}/{_ARTIFACT_KEY}.bin"
+        )
+
+    def _precompile_aot_fx_trace(self):
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import trace_train_step
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+            precompile_fx_trace_save,
+        )
+        from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
+
+        config = self.config
+        compile_config = self.compile_config
+        model = self.model
+        parallel_dims = self.parallel_dims
+
+        fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
+
+        dummy_inputs, dummy_labels = self._make_dummy_inputs()
+
+        # The trainer computes global_valid_tokens via dist_sum over the
+        # "batch" mesh (dp_shard * dp_replicate), using local_valid_tokens
+        # counted from full sequences BEFORE CP sharding.  So CP must NOT
+        # be included here — the batch mesh doesn't cover CP ranks.
+        global_batch_size = (
+            config.training.local_batch_size
+            * parallel_dims.dp_shard
+            * parallel_dims.dp_replicate
+        )
+        dummy_global_valid_tokens = float(global_batch_size * config.training.seq_len)
+        extra_inputs: dict[str, torch.Tensor] = {}
+        extra_kwargs: dict[str, Any] = {}
+
+        if isinstance(self.model_config, Decoder.Config) and self.model_config.layers:
+            attn_config = self.model_config.layers[0].attention
+            mask_type = getattr(attn_config, "mask_type", "causal")
+
+            if mask_type == "block_causal" or parallel_dims.cp_enabled:
+                extra_kwargs["positions"] = torch.arange(
+                    0,
+                    dummy_inputs.shape[1],
+                    dtype=torch.int32,
+                    device=dummy_inputs.device,
+                ).expand(dummy_inputs.shape)
+
+            inner_attention = getattr(attn_config, "inner_attention", None)
+            if inner_attention is not None:
+                from torchtitan.models.common.attention import (
+                    FlexAttention,
+                    VarlenAttention,
                 )
 
-    # TODO: Add CP support — call prepare_context_parallel_input here
-    # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence
-    # dimension, matching the trainer's post_dataloading_process.
-    if parallel_dims.cp_enabled:
-        raise NotImplementedError(
-            "CooR precompile does not yet support context parallelism. "
-            "Set --parallelism.context_parallel_degree 1."
+                if isinstance(
+                    inner_attention,
+                    (FlexAttention.Config, VarlenAttention.Config),
+                ):
+                    extra_kwargs["attention_masks"] = cast(
+                        Decoder, model
+                    ).get_attention_masks(
+                        input_batch=dummy_inputs,
+                        tokenizer=self.tokenizer,
+                        extra_inputs=extra_inputs,
+                    )
+
+        if parallel_dims.cp_enabled:
+            from torchtitan.distributed.context_parallel import (
+                prepare_context_parallel_input,
+            )
+
+            dummy_inputs, dummy_labels, extra_kwargs = prepare_context_parallel_input(
+                dummy_inputs,
+                dummy_labels,
+                extra_kwargs,
+                parallel_dims.get_mesh("cp"),
+                self.device,
+                config.parallelism.context_parallel_load_balancer,
+            )
+
+        # Enable loss_parallel when TP is active and loss_parallel is not
+        # disabled.  This matches the training path which wraps tracing +
+        # execution inside train_context() → loss_parallel().  Without it,
+        # cross_entropy fails with "mixed torch.Tensor and DTensor" because
+        # the TP-parallelized model outputs Shard'd DTensors but labels
+        # remain plain tensors.
+        loss_parallel_enabled = (
+            parallel_dims.tp_enabled and not config.parallelism.disable_loss_parallel
+        )
+        loss_parallel_ctx = (
+            torch.distributed.tensor.parallel.loss_parallel()
+            if loss_parallel_enabled
+            else contextlib.nullcontext()
         )
 
-    # Enable loss_parallel when TP is active and loss_parallel is not
-    # disabled. This matches the training path which wraps tracing +
-    # execution inside train_context() → loss_parallel(). Without it,
-    # cross_entropy fails with "mixed torch.Tensor and DTensor" because
-    # the TP-parallelized model outputs Shard'd DTensors but labels
-    # remain plain tensors.
-    loss_parallel_enabled = (
-        parallel_dims.tp_enabled and not config.parallelism.disable_loss_parallel
-    )
-    loss_parallel_ctx = (
-        torch.distributed.tensor.parallel.loss_parallel()
-        if loss_parallel_enabled
-        else contextlib.nullcontext()
-    )
-
-    logger.info("Tracing fwd+loss+bwd via make_fx...")
-    with loss_parallel_ctx:
-        traced_result = trace_train_step(fwd_bwd_fn)(
-            model,
-            dummy_inputs,
-            dummy_labels,
-            dummy_global_valid_tokens,
-            extra_inputs,
-            extra_kwargs,
+        logger.info("Tracing fwd+loss+bwd via make_fx...")
+        with loss_parallel_ctx:
+            traced_result = trace_train_step(fwd_bwd_fn)(
+                model,
+                dummy_inputs,
+                dummy_labels,
+                dummy_global_valid_tokens,
+                extra_inputs,
+                extra_kwargs,
+            )
+        logger.info(
+            f"Traced graph has {len(list(traced_result.gm.graph.nodes))} nodes, "
+            f"{len(traced_result.state_fqns)} state entries"
         )
-    logger.info(
-        f"Traced graph has {len(list(traced_result.gm.graph.nodes))} nodes, "
-        f"{len(traced_result.state_fqns)} state entries"
-    )
 
-    # Apply precompile-time graph passes (cleanup + regional_inductor)
-    # so compiled Triton kernels are baked into the serialized artifact.
-    # cudagraph is excluded — it runs at load time on each rank.
-    from torchtitan.experiments.graph_trainer.passes import (
-        apply_graph_passes,
-        compile_time_passes,
-    )
+        # Apply precompile-time graph passes (cleanup + regional_inductor)
+        # so compiled Triton kernels are baked into the serialized artifact.
+        # cudagraph is excluded — it runs at load time on each rank.
+        from torchtitan.experiments.graph_trainer.passes import (
+            apply_graph_passes,
+            compile_time_passes,
+        )
 
-    passes = compile_time_passes(traced_result, config)
-    traced_result.gm = apply_graph_passes(
-        traced_result.gm, traced_result.example_inputs, passes
-    )
-    logger.info(
-        f"Applied {len(passes)} precompile graph passes, "
-        f"graph now has {len(list(traced_result.gm.graph.nodes))} nodes"
-    )
+        passes = compile_time_passes(traced_result, config)
+        traced_result.gm = apply_graph_passes(
+            traced_result.gm, traced_result.example_inputs, passes
+        )
+        logger.info(
+            f"Applied {len(passes)} precompile graph passes, "
+            f"graph now has {len(list(traced_result.gm.graph.nodes))} nodes"
+        )
 
-    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
-    config_fingerprint = compute_config_fingerprint(
-        model, compile_config, parallel_dims
-    )
+        storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+        config_fingerprint = compute_config_fingerprint(
+            model, compile_config, parallel_dims
+        )
 
-    precompile_fx_trace_save(
-        traced_result,
-        storage,
-        config_fingerprint=config_fingerprint,
-    )
+        precompile_fx_trace_save(
+            traced_result,
+            storage,
+            config_fingerprint=config_fingerprint,
+        )
 
-    logger.info(
-        f"Precompile complete. Artifact saved to "
-        f"{compile_config.precompile_artifact_dir}/{_FX_TRACE_ARTIFACT_KEY}.bin"
-    )
+        logger.info(
+            f"Precompile complete. Artifact saved to "
+            f"{compile_config.precompile_artifact_dir}/{_FX_TRACE_ARTIFACT_KEY}.bin"
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        super().close()
+        dist.destroy_process_group()
 
 
 def main():
     config_manager = ConfigManager()
     config = config_manager.parse_args()
 
-    mode = config.compile.mode
-    if mode not in ("aot", "aot_fx_trace"):
-        raise ValueError(
-            f"precompile_main only supports --compile.mode aot or aot_fx_trace, "
-            f"got '{mode}'."
-        )
-
-    (
-        model,
-        model_config,
-        model_spec,
-        compile_config,
-        parallel_dims,
-        device,
-        tokenizer,
-    ) = _common_setup(config)
-
-    if mode == "aot":
-        _precompile_aot(
-            config,
-            model,
-            model_config,
-            model_spec,
-            compile_config,
-            parallel_dims,
-            device,
-            tokenizer,
-        )
-    elif mode == "aot_fx_trace":
-        _precompile_aot_fx_trace(
-            config,
-            model,
-            model_config,
-            model_spec,
-            compile_config,
-            parallel_dims,
-            device,
-            tokenizer,
-        )
-
-    dist.destroy_process_group()
+    with PrecompileFakeTrainer(config) as trainer:
+        trainer.precompile()
 
 
 if __name__ == "__main__":

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -196,57 +196,78 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         assert (
             config.model_spec is not None
         ), "model_spec must be set before creating Trainer"
-        model_spec = config.model_spec
 
+        self._init_device()
+        self.parallel_dims = self.init_distributed()
+        config.maybe_log()
+        self._init_determinism()
+        self._build_model()
+        self._build_training_infrastructure()
+
+    def _init_device(self) -> None:
         device_module, device_type = utils.device_module, utils.device_type
         # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
-        # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
 
-        # init distributed and build meshes
-        self.parallel_dims = parallel_dims = self.init_distributed()
-
-        # Logging needs to happen after distributed initialized
-        config.maybe_log()
-
-        if parallel_dims.dp_enabled:
-            batch_mesh = parallel_dims.get_mesh("batch")
-            batch_degree, batch_rank = batch_mesh.size(), batch_mesh.get_local_rank()
-        else:
-            batch_degree, batch_rank = 1, 0
-
-        # take control of garbage collection to avoid stragglers
+    def _init_determinism(self) -> None:
+        config = self.config
         self.gc_handler = utils.GarbageCollection(
             gc_freq=config.training.gc_freq, debug=config.training.gc_debug
         )
-
-        # Set random seed, and maybe enable deterministic mode
-        # (mainly for debugging, expect perf loss).
         dist_utils.set_determinism(
-            parallel_dims,
+            self.parallel_dims,
             self.device,
             config.debug,
             distinct_seed_mesh_dims=["pp"],
         )
-        # build tokenizer
-        self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
 
-        # build dataloader
+    def _build_model(self) -> None:
+        parallel_dims = self.parallel_dims
+
+        if parallel_dims.dp_enabled:
+            batch_mesh = parallel_dims.get_mesh("batch")
+            self._batch_degree = batch_mesh.size()
+            self._batch_rank = batch_mesh.get_local_rank()
+        else:
+            self._batch_degree = 1
+            self._batch_rank = 0
+
+        self._build_data_pipeline()
+        self._build_and_parallelize_model()
+
+    def _build_data_pipeline(self) -> None:
+        config = self.config
+        self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
         self.dataloader = config.dataloader.build(
-            dp_world_size=batch_degree,
-            dp_rank=batch_rank,
+            dp_world_size=self._batch_degree,
+            dp_rank=self._batch_rank,
             tokenizer=self.tokenizer,
             seq_len=config.training.seq_len,
             local_batch_size=config.training.local_batch_size,
         )
 
-        # build model (using meta init)
+    def _get_compile_config_for_parallelize(self):
+        return self.config.compile
+
+    def _init_model_weights(
+        self,
+        model: torch.nn.Module,
+        init_device: str,
+        buffer_device: torch.device | None,
+    ) -> None:
+        model.to_empty(device=init_device)
+        with torch.no_grad():
+            cast(BaseModel, model).init_weights(buffer_device=buffer_device)
+        model.train()
+
+    def _build_and_parallelize_model(self) -> None:
+        config = self.config
+        model_spec = config.model_spec
+        parallel_dims = self.parallel_dims
+
         model_config = model_spec.model
-        # set the model args from training job configs
-        model_config.update_from_config(
-            trainer_config=config,
-        )
+        model_config.update_from_config(trainer_config=config)
         self.model_config = model_config
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")
@@ -257,52 +278,29 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         ):
             model = model_config.build()
 
-        # Build the collection of model converters. No-op if converters empty
         model_compile_enabled = (
             config.compile.enable and "model" in config.compile.components
         )
-        model_converters = config.model_converters.build(
+        self._model_converters = config.model_converters.build(
             parallel_dims=parallel_dims,
             model_compile_enabled=model_compile_enabled,
         )
-        model_converters.convert(model)
+        self._model_converters.convert(model)
 
-        # Verify all submodules satisfy the Module protocol
         # TODO: move this to module validate().
-        # This is current put here to verify module build and
-        # converter, which should guanrantee Module protocol.
-        # On the other hand, some parallelism wrappers don't
-        # have this guanrantee, e.g., fully_shard.
         model.verify_module_protocol()
 
-        # Check if any converter uses quantization (FP8, MX, etc.)
-        has_quantization = any(
+        self._has_quantization = any(
             isinstance(cc, QuantizationConverter.Config)
             for cc in config.model_converters.converters
         )
 
-        # metrics logging
-        self.metrics_processor = config.metrics.build(
-            parallel_dims=parallel_dims,
-            dump_folder=config.dump_folder,
-            pp_schedule=config.parallelism.pipeline_parallel_schedule,
-            config_dict=config.to_dict(),
-            has_quantization=has_quantization,
-        )
-        color = self.metrics_processor.color
-
-        # calculate model size and flops per token
         (
-            model_param_count,
-            self.metrics_processor.num_flops_per_token,
+            self._model_param_count,
+            self._num_flops_per_token,
         ) = model_config.get_nparams_and_flops(model, config.training.seq_len)
 
-        logger.info(
-            f"{color.blue}Model {model_spec.name} {model_spec.flavor} "
-            f"{color.red}size: {model_param_count:,} total parameters{color.reset}"
-        )
-
-        # move sharded model to CPU/GPU and initialize weights via DTensor
+        device_type = utils.device_type
         buffer_device: torch.device | None
         if config.checkpoint.create_seed_checkpoint:
             init_device = "cpu"
@@ -318,28 +316,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             config.compile, parallel_dims=parallel_dims
         )
 
-        # verify batch sizes
-        global_batch_size = config.training.global_batch_size
-        if global_batch_size < 0:
-            # This global batch size results in 1 gradient accumulation
-            # step.
-            global_batch_size = config.training.local_batch_size * batch_degree
-        assert global_batch_size > 0
-        assert (
-            global_batch_size % (config.training.local_batch_size * batch_degree) == 0
-        ), (
-            f"global batch size must be multiple of local batch size times "
-            f"data-parallel degree ({global_batch_size} "
-            f"% ({config.training.local_batch_size} * {batch_degree}) != 0)"
-        )
+        parallelize_compile_config = self._get_compile_config_for_parallelize()
 
-        # calculate gradient accumulation steps
-        self.gradient_accumulation_steps = global_batch_size // (
-            config.training.local_batch_size * batch_degree
-        )
-        assert self.gradient_accumulation_steps > 0
-
-        # apply parallelisms and initialization
         if parallel_dims.pp_enabled:
             if not model_spec.pipelining_fn:
                 raise RuntimeError(
@@ -347,7 +325,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     f"does not support pipelining"
                 )
 
-            # apply both Pipeline Parallel and SPMD-style scaling techniques
             (
                 self.pp_schedule,
                 self.model_parts,
@@ -359,68 +336,92 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 training=config.training,
                 model_converters=config.model_converters,
                 parallelism=config.parallelism,
-                compile_config=config.compile,
+                compile_config=parallelize_compile_config,
                 ac_config=config.activation_checkpoint,
                 dump_folder=config.dump_folder,
                 device=self.device,
-                model_config=model_config,
+                model_config=self.model_config,
                 parallelize_fn=model_spec.parallelize_fn,
                 loss_fn=self.loss_fn,
             )
-            # when PP is enabled, `model` obj is no longer used after this point,
-            # model_parts is used instead
             del model
 
             for m in self.model_parts:
-                m.to_empty(device=init_device)
-                with torch.no_grad():
-                    # TODO: Change this back to init_weights once
-                    # autoparallel contains the wrap_init_states
-                    cast(BaseModel, m).init_weights(buffer_device=buffer_device)
-                m.train()
-
-            # confirm that user will be able to view loss metrics on the console
-            ensure_pp_loss_visible(
-                parallel_dims=parallel_dims,
-                pp_schedule=config.parallelism.pipeline_parallel_schedule,
-                color=color,
-            )
+                self._init_model_weights(m, init_device, buffer_device)
         else:
             if not config.checkpoint.create_seed_checkpoint:
-                # Skip parallelize_fn for seed checkpoints — nothing from
-                # it is needed (AC, compile, nD parallelism, mixed precision, etc.).
                 model = model_spec.parallelize_fn(
                     model,
                     parallel_dims=parallel_dims,
                     training=config.training,
                     model_converters=config.model_converters,
                     parallelism=config.parallelism,
-                    compile_config=config.compile,
+                    compile_config=parallelize_compile_config,
                     ac_config=config.activation_checkpoint,
                     dump_folder=config.dump_folder,
                 )
 
-            model.to_empty(device=init_device)
-            with torch.no_grad():
-                # TODO: Change this back to init_weights once
-                # autoparallel contains the wrap_init_states
-                cast(BaseModel, model).init_weights(buffer_device=buffer_device)
-            model.train()
-
+            self._init_model_weights(model, init_device, buffer_device)
             self.model_parts = [model]
 
-        # initialize device memory monitor and get peak flops for MFU calculation
+    def _build_training_infrastructure(self) -> None:
+        config = self.config
+        model_spec = config.model_spec
+        parallel_dims = self.parallel_dims
+        batch_degree = self._batch_degree
+        batch_rank = self._batch_rank
+
+        self.metrics_processor = config.metrics.build(
+            parallel_dims=parallel_dims,
+            dump_folder=config.dump_folder,
+            pp_schedule=config.parallelism.pipeline_parallel_schedule,
+            config_dict=config.to_dict(),
+            has_quantization=self._has_quantization,
+        )
+        color = self.metrics_processor.color
+
+        self.metrics_processor.num_flops_per_token = self._num_flops_per_token
+
+        logger.info(
+            f"{color.blue}Model {model_spec.name} {model_spec.flavor} "
+            f"{color.red}size: {self._model_param_count:,} total parameters"
+            f"{color.reset}"
+        )
+
+        if parallel_dims.pp_enabled:
+            ensure_pp_loss_visible(
+                parallel_dims=parallel_dims,
+                pp_schedule=config.parallelism.pipeline_parallel_schedule,
+                color=color,
+            )
+
         device_memory_monitor = self.metrics_processor.device_memory_monitor
         gpu_peak_flops = utils.get_peak_flops(device_memory_monitor.device_name)
         logger.info(f"Peak FLOPS used for computing MFU: {gpu_peak_flops:.3e}")
         device_mem_stats = device_memory_monitor.get_peak_stats()
         logger.info(
-            f"{device_type.upper()} memory usage for model: "
+            f"{utils.device_type.upper()} memory usage for model: "
             f"{device_mem_stats.max_reserved_gib:.2f}GiB"
             f"({device_mem_stats.max_reserved_pct:.2f}%)"
         )
 
-        # build optimizer after applying parallelisms to the model
+        global_batch_size = config.training.global_batch_size
+        if global_batch_size < 0:
+            global_batch_size = config.training.local_batch_size * batch_degree
+        assert global_batch_size > 0
+        assert (
+            global_batch_size % (config.training.local_batch_size * batch_degree) == 0
+        ), (
+            f"global batch size must be multiple of local batch size times "
+            f"data-parallel degree ({global_batch_size} "
+            f"% ({config.training.local_batch_size} * {batch_degree}) != 0)"
+        )
+
+        self.gradient_accumulation_steps = global_batch_size // (
+            config.training.local_batch_size * batch_degree
+        )
+        assert self.gradient_accumulation_steps > 0
+
         self.optimizers = config.optimizer.build(model_parts=self.model_parts)
         if model_spec.post_optimizer_build_fn is not None:
             model_spec.post_optimizer_build_fn(
@@ -430,19 +431,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             optimizers=self.optimizers,
             training_steps=config.training.steps,
         )
-        # Post optimizer step model converters hook.
-        # e.g. calculate float8 dynamic amax/scale for all-parameter for FSDP2
-        # where it issues a single all-reduce for all parameters at once for better performance
         self.optimizers.register_step_post_hook(
-            lambda *args, **kwargs: model_converters.post_optimizer_hook(
+            lambda *args, **kwargs: self._model_converters.post_optimizer_hook(
                 self.model_parts
             )
         )
         self.metrics_processor.optimizers = self.optimizers
         self.metrics_processor.model_parts = self.model_parts
 
-        # Initialize trainer states that will be saved in checkpoint.
-        # These attributes must be initialized before checkpoint loading.
         self.step = 0
         self.ntokens_seen = 0
 
@@ -453,7 +449,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
             sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+                model_spec.state_dict_adapter(self.model_config, config.hf_assets_path)
                 if model_spec.state_dict_adapter
                 else None
             ),
@@ -465,7 +461,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
         self.train_context = dist_utils.get_train_context(loss_parallel_enabled)
 
-        # Build validator if validation is configured
         if config.validator.enable:
             pp_schedule, pp_has_first_stage, pp_has_last_stage = (
                 (

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -200,6 +200,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self._init_device()
         self.parallel_dims = self.init_distributed()
         config.maybe_log()
+        self._init_gc()
         self._init_determinism()
         self._build_model()
         self._build_training_infrastructure()
@@ -210,15 +211,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         device_module.set_device(self.device)
 
-    def _init_determinism(self) -> None:
+    def _init_gc(self) -> None:
         config = self.config
         self.gc_handler = utils.GarbageCollection(
             gc_freq=config.training.gc_freq, debug=config.training.gc_debug
         )
+
+    def _init_determinism(self) -> None:
         dist_utils.set_determinism(
             self.parallel_dims,
             self.device,
-            config.debug,
+            self.config.debug,
             distinct_seed_mesh_dims=["pp"],
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3055

`PrecompileFakeTrainer` previously duplicated ~80 lines of model setup
logic from `Trainer.__init__` via a standalone `_common_setup` function.
Any change to the model build path (adding a converter step, changing
parallelize args, etc.) had to be made in both places independently.

This PR eliminates that duplication by:
1. Splitting `Trainer.__init__` into composable, overridable methods
2. Making `PrecompileFakeTrainer` a `Trainer` subclass that inherits the
   shared model build sequence and overrides only what differs

### Previously duplicated, now shared via `_build_and_parallelize_model`
- `model_config.update_from_config()`
- Meta-init + `model_config.build()`
- `model_converters.build()` + `.convert()` (new: previously skipped by precompile)
- `model.verify_module_protocol()`
- `model_spec.build_loss_fn()`
- `model_spec.parallelize_fn()` with TP, FSDP, AC, compile
- `model.to_empty()` → `init_weights()` → `train()` (via `_init_model_weights` hook)

### `Trainer.__init__` method decomposition
- `_init_device()`: device setup (overridable)
- `_init_determinism()`: GC + determinism (overridable)
- `_build_model()` → `_build_data_pipeline()` + `_build_and_parallelize_model()`
  - `_get_compile_config_for_parallelize()`: hook
  - `_init_model_weights()`: hook
- `_build_training_infrastructure()`: optimizer/checkpoint/metrics (overridable)

### `PrecompileFakeTrainer` overrides
| Method | Override behavior |
|--------|------------------|
| `_init_device` | `cuda:0`, no `LOCAL_RANK` |
| `init_distributed` | fake PG + CooR |
| `_init_determinism` | manual torch flags, no DTensor RNG seeding |
| `_build_data_pipeline` | no-op |
| `_get_compile_config_for_parallelize` | disable compile for aot mode |
| `_init_model_weights` | CooR toggle around `init_weights` |
| `_build_training_infrastructure` | no-op |

`precompile_main.py`: 501 → 489 lines; the 80 lines of model build
logic are now single-sourced in `Trainer`.

Also adds CP support to the `aot_fx_trace` precompile path and fixes
`dummy_global_valid_tokens` to exclude the CP dimension, matching the
training path's `dist_sum` over the "batch" mesh.

## Test plan
- E2E bitwise equivalence (8×H100, FSDP2+TP2+CP2, llama3 debugmodel,
  deterministic, 5 steps): precompile vs per-rank JIT produces
  identical losses (`8.12891, 7.80780, 7.05110, 6.18951, 5.45349`)
- Loss comparison: https://pxl.cl/9vZ7F
- Test script: https://www.internalfb.com/intern/paste/P2283727930/