### PR TITLE
[graph_trainer] Joint graph bucketing and prefetching compose with SAC

### DIFF
--- a/torchtitan/experiments/graph_trainer/bucketing.py
+++ b/torchtitan/experiments/graph_trainer/bucketing.py
@@ -1,0 +1,266 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import heapq
+from collections import Counter, defaultdict
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch._dynamo.graph_deduplication import _stable_topological_sort
+from torch._inductor.fx_passes.bucketing import BucketMode
+from torch._inductor.fx_passes.overlap_manual_scheduling import ManualOverlapScheduler
+from torch._inductor.fx_passes.overlap_scheduling import is_compute_node
+from torch.utils._ordered_set import OrderedSet
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _is_backward_node,
+    _is_recomputed_node,
+    _MODULE_FQN,
+)
+
+
+class JointManualOverlapScheduler(ManualOverlapScheduler):
+    """Manual overlap scheduler for joint forward+backward graphs.
+
+    For the aot_fx_trace path we trace a joint forward+backward graph and
+    want to bucket + reorder both directions in a single pass over the
+    graph. This subclass of :class:`ManualOverlapScheduler` produces the
+    same bucketing and prefetch pattern as invoking the upstream
+    ``manual_overlap_bucketing`` twice (once per direction).
+
+    Overrides :meth:`_manual_bucket_collectives` to split each module's
+    collectives by direction before handing them to the bucketer.
+
+    Overrides :meth:`_manual_reorder_graph` to track per-direction state
+    so a single reversed walk emits correct AG prefetch edges for both
+    forward and backward regions.
+
+    The caller supplies:
+
+    * ``module_stack_fn`` — must return a non-empty module stack for both
+      forward and backward nodes belonging to ``module_bucket_plans``
+      (i.e. do not filter by direction; that is this class's job).
+    * ``is_backward_fn`` — returns ``True`` for nodes that should be
+      treated as backward, including SAC-recomputed forward ops that are
+      emitted into the backward section.
+    """
+
+    def __init__(
+        self,
+        gm: fx.GraphModule,
+        module_bucket_plans: list[list[str] | str],
+        insert_overlap_deps: bool,
+        *,
+        is_backward_fn: Callable[[fx.Node], bool],
+        module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]],
+        bucket_mode: BucketMode | None = None,
+    ) -> None:
+        super().__init__(
+            gm,
+            module_bucket_plans,
+            insert_overlap_deps,
+            module_stack_fn=module_stack_fn,
+            bucket_mode=bucket_mode,
+        )
+        self._is_backward_fn = is_backward_fn
+
+    def _manual_bucket_collectives(self) -> None:
+        """Bucket per module, splitting by direction to keep fwd/bwd buckets disjoint."""
+        self._obtain_nodes_in_subgraph()
+        for nodes in self.nodes_in_subgraph:
+            fwd_nodes = [n for n in nodes if not self._is_backward_fn(n)]
+            bwd_nodes = [n for n in nodes if self._is_backward_fn(n)]
+            if fwd_nodes:
+                self.bucketer.manual_bucket_collectives(nodes=fwd_nodes)
+            if bwd_nodes:
+                self.bucketer.manual_bucket_collectives(nodes=bwd_nodes)
+
+        _stable_topological_sort(self.graph, {})
+        self.graph.lint()
+        self.nodes = list(self.graph.nodes)
+        self.in_degree = Counter(user for node in self.nodes for user in node.users)
+
+    def _manual_reorder_graph(self) -> None:
+        """Reorder pass with separate fwd/bwd buffers so AG pairing never
+        crosses the fwd/bwd boundary. RS pairing is unchanged — RSs only
+        occur in backward and are already direction-scoped.
+        """
+        overlap_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+
+        self._schedule_rs_prefetch(overlap_deps)
+        self._schedule_ag_prefetch(overlap_deps)
+
+        _stable_topological_sort(self.graph, overlap_deps)
+        self.graph.lint()
+
+        if self.insert_overlap_deps:
+            from torch._inductor.fx_passes.control_dependencies import (
+                preserve_node_ordering,
+            )
+
+            preserve_node_ordering(self.graph, overlap_deps)
+
+    def _schedule_rs_prefetch(
+        self,
+        overlap_deps: dict[fx.Node, OrderedSet[fx.Node]],
+    ) -> None:
+        """Top-down scheduling loop that emits RS prefetch edges.
+
+        RSs only occur in backward, so no direction tracking is needed.
+        Populates ``self.scheduled`` in topological order for the
+        subsequent reversed walk.
+        """
+        delayed_rs_wait_nodes: list[fx.Node] = []
+        current_rs_start_nodes: list[fx.Node] = []
+
+        self.node_idx = {n: i for i, n in enumerate(self.nodes)}
+        self.on_path_ready = []
+        self.scheduled = OrderedSet()
+        for node in self.nodes:
+            if self.in_degree[node] == 0:
+                self._add_to_ready_queue(node)
+
+        while self.on_path_ready:
+            _, node = heapq.heappop(self.on_path_ready)
+            node_type = self.bucketer.bucketed_node_types.get(node, "")
+
+            if node in self.scheduled:
+                continue
+
+            if node_type == "bucketed_reduce_scatter":
+                current_rs_start_nodes.append(node)
+            elif node_type == "bucketed_reduce_scatter_wait":
+                if current_rs_start_nodes:
+                    for delayed in delayed_rs_wait_nodes:
+                        for rs_start in current_rs_start_nodes:
+                            overlap_deps[delayed].add(rs_start)
+                    delayed_rs_wait_nodes.clear()
+                    current_rs_start_nodes.clear()
+                delayed_rs_wait_nodes.append(node)
+
+            self._schedule(node)
+
+    def _schedule_ag_prefetch(
+        self,
+        overlap_deps: dict[fx.Node, OrderedSet[fx.Node]],
+    ) -> None:
+        """Reversed walk that emits per-direction AG prefetch edges.
+
+        Uses separate fwd/bwd buffers so AG pairing never crosses the
+        fwd/bwd boundary. Consumes ``self.scheduled`` produced by
+        :meth:`_emit_rs_prefetch`.
+        """
+        self.scheduled = OrderedSet(reversed(list(self.scheduled)))
+
+        bwd_scope: OrderedSet[fx.Node] = OrderedSet()
+        fwd_scope: OrderedSet[fx.Node] = OrderedSet()
+        for sublist in self.nodes_in_subgraph:
+            for n in sublist:
+                if self._is_backward_fn(n):
+                    bwd_scope.add(n)
+                else:
+                    fwd_scope.add(n)
+
+        bwd_picked: list[fx.Node] = []
+        fwd_picked: list[fx.Node] = []
+        bwd_last_compute: fx.Node | None = None
+        fwd_last_compute: fx.Node | None = None
+
+        for node in self.scheduled:
+            node_type = self.bucketer.bucketed_node_types.get(node, "")
+            is_bwd = self._is_backward_fn(node)
+            picked = bwd_picked if is_bwd else fwd_picked
+
+            if node_type == "bucketed_all_gather":
+                picked.append(node)
+                continue
+
+            if node_type == "bucketed_all_gather_wait":
+                if picked:
+                    for ag in picked:
+                        overlap_deps[self.bucketer.node_to_wait_map[node]].add(ag)
+                picked.clear()
+
+            if is_compute_node(node):
+                # Track per-direction last_compute so orphan bwd all-gathers
+                # attach to a bwd-region compute and orphan fwd all-gathers
+                # attach to a fwd-region compute.
+                if is_bwd and node in bwd_scope:
+                    bwd_last_compute = node
+                elif not is_bwd and node in fwd_scope:
+                    fwd_last_compute = node
+
+        # Trailing block, applied once per direction. Attaches any orphan
+        # AG starts (those whose wait was not matched during the reversed
+        # walk of their direction) to the last compute in that direction,
+        # unless they are already an ancestor of it.
+        self._apply_trailing_block(bwd_picked, bwd_last_compute, overlap_deps)
+        self._apply_trailing_block(fwd_picked, fwd_last_compute, overlap_deps)
+
+    def _apply_trailing_block(
+        self,
+        picked: list[fx.Node],
+        last_compute: fx.Node | None,
+        overlap_deps: dict[fx.Node, OrderedSet[fx.Node]],
+    ) -> None:
+        if last_compute is None or not picked:
+            return
+        if OrderedSet(picked) & OrderedSet(self.node_ancestors[last_compute]):
+            return
+        for ag in picked:
+            overlap_deps[last_compute].add(ag)
+
+
+def joint_transformer_block_bucketing_reordering_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    module_bucket_plans: list[list[str] | str],
+    insert_overlap_deps: bool = False,
+    bucket_mode: BucketMode | None = None,
+) -> torch.fx.GraphModule:
+    """Run joint-graph manual bucketing and reordering.
+
+    Joint-graph equivalent of
+    ``torch._inductor.fx_passes.overlap_manual_scheduling.manual_overlap_bucketing``.
+    Buckets forward all-gathers, backward all-gathers, and backward reduce-scatters
+    of each module into separate buckets per transformer block and emits prefetching.
+
+    Args:
+        gm: joint forward+backward graph module.
+        example_inputs: unused, required by the pass interface.
+        module_bucket_plans: list of module FQNs (or lists of FQNs); each
+            entry defines one bucketing scope whose collectives should be
+            merged into a single bucket per direction per collective type.
+        insert_overlap_deps: if ``True``, insert explicit control deps via
+            ``preserve_node_ordering`` after the topological sort.
+        bucket_mode: bucket mode forwarded to the underlying bucketer;
+            defaults to ``"custom_ops"`` via the parent class.
+    """
+
+    def _is_backward(node: torch.fx.Node) -> bool:
+        return _is_backward_node(node) or _is_recomputed_node(node)
+
+    def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+        if not fqn:
+            return []
+        return [(fqn, torch.nn.Module)]
+
+    overlapped_gm = JointManualOverlapScheduler(
+        gm,
+        module_bucket_plans,
+        insert_overlap_deps,
+        is_backward_fn=_is_backward,
+        module_stack_fn=_stack_fn,
+        bucket_mode=bucket_mode,
+    ).run()
+    overlapped_gm.recompile()
+    return overlapped_gm

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -25,6 +25,14 @@ def _is_backward_node(node: torch.fx.Node) -> bool:
     return node.meta.get("autograd_backward", False)
 
 
+def _is_recomputed_node(node: torch.fx.Node) -> bool:
+    # TODO: Workaround — recomputed nodes (from SAC) should carry
+    # autograd_backward=True but remat_using_tags_for_fwd_loss_bwd_graph
+    # copies metadata from the original forward node. Fix upstream to
+    # tag recomputed nodes with autograd_backward=True.
+    return node.name.endswith("_recomputed")
+
+
 def _get_layer_id(node: torch.fx.Node) -> int:
     """Extract the layer index from the node's module_fqn metadata.
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -37,10 +37,13 @@ from torch.fx.passes.regional_inductor import regional_inductor
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.distributed.activation_checkpoint import _get_save_ops
+from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
+from torchtitan.experiments.graph_trainer.bucketing import (
+    joint_transformer_block_bucketing_reordering_pass,
+)
 from torchtitan.experiments.graph_trainer.common_utils import (
     _get_layer_id,
     _is_backward_node,
-    _MODULE_FQN,
     _NOT_IN_LAYERS,
 )
 from torchtitan.experiments.graph_trainer.cpu_offload import (
@@ -99,7 +102,7 @@ def compile_time_passes(
         selective_activation_remat_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
-            fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
+            module_bucket_plans=get_default_transformer_block_buckets(n_layers),
         ),
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
@@ -239,70 +242,6 @@ def transformer_block_bucketing_reordering_pass(
         gm, module_bucket_plans=fsdp_manual_buckets, insert_overlap_deps=False
     )
     gm.recompile()
-    return gm
-
-
-def joint_transformer_block_bucketing_reordering_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-    *,
-    fsdp_manual_buckets,
-) -> torch.fx.GraphModule:
-    """Apply manual bucketing and reordering on a joint fwd+bwd graph.
-
-    The joint graph is processed in two passes to ensure each direction's
-    collectives are bucketed independently and reordering uses the correct
-    execution order (forward order for fwd, reversed order for bwd).
-
-    Used by the aot_fx_trace mode where forward and backward are in a
-    single graph.
-    """
-
-    def _make_module_fqn_stack_fn(
-        *, bwd: bool
-    ) -> Callable[[torch.fx.Node], list[tuple[str, type]]]:
-        """Create a module_stack_fn that filters nodes by forward/backward direction.
-
-        Recomputed nodes (from SAC remat) have autograd_backward=False
-        (copied from their original forward node) but serve the backward
-        pass. We identify them by the ``_recomputed`` name suffix and
-        route them to the backward bucketing pass.
-        """
-
-        def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
-            # TODO: Workaround — recomputed nodes should carry
-            # autograd_backward=True but remat_using_tags_for_fwd_loss_bwd_graph
-            # copies metadata from the original forward node. Fix upstream to
-            # tag recomputed nodes with autograd_backward=True.
-            is_recomputed = node.name.endswith("_recomputed")
-            is_bwd = node.meta.get("autograd_backward", False) or is_recomputed
-            if is_bwd != bwd:
-                return []
-            fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
-            if not fqn:
-                return []
-            return [(fqn, torch.nn.Module)]
-
-        return _stack_fn
-
-    # Forward graph pass: bucket and reorder forward collectives
-    manual_overlap_bucketing(
-        gm,
-        module_bucket_plans=fsdp_manual_buckets,
-        insert_overlap_deps=False,
-        module_stack_fn=_make_module_fqn_stack_fn(bwd=False),
-    )
-
-    # Backward pass: bucket and reorder backward collectives.
-    manual_overlap_bucketing(
-        gm,
-        module_bucket_plans=fsdp_manual_buckets,
-        insert_overlap_deps=False,
-        module_stack_fn=_make_module_fqn_stack_fn(bwd=True),
-    )
-
-    gm.recompile()
-
     return gm
 
 
@@ -630,21 +569,16 @@ def annotate_flex_attention_for_regional_inductor_pass(
     return gm
 
 
-def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
+def _make_default_memory_policy(
+    save_ops: set | None = None,
+    *,
+    fsdp_reshard_after_forward: bool = True,
+) -> Callable:
     """Create a SAC policy function from a set of op targets to save."""
     if save_ops is None:
         save_ops = _get_save_ops()
-        # TODO: Temporary workaround — saving FSDP all_gathers prevents
-        # re-communication during backward recomputation. Without this,
-        # recomputed all_gather nodes in the backward region cause
-        # manual_overlap_bucketing to produce incorrect prefetch ordering.
-        # The proper fix has two parts:
-        # 1. Allow users to configure reshard_after_forward behavior
-        #    (equivalent to eager FSDP's parallelism.fsdp_reshard_after_forward)
-        #    which controls whether parameters are resharded after forward.
-        # 2. Fix manual_overlap_bucketing to handle recomputed all_gathers
-        #    in the backward region correctly.
-        save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
+        if not fsdp_reshard_after_forward:
+            save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         if node.target in save_ops:
@@ -803,7 +737,15 @@ def tag_with_memory_policy_pass(
     """
     memory_policy = config.compile.memory_policy
     if memory_policy == "default":
-        apply_sac_pass(gm, policy_fn=_make_default_memory_policy())
+        fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
+            config.parallelism.fsdp_reshard_after_forward,
+            pp_enabled=config.parallelism.pipeline_parallel_degree > 1,
+        )
+        default_policy_fn = functools.partial(
+            _make_default_memory_policy,
+            fsdp_reshard_after_forward=fsdp_reshard_after_forward,
+        )
+        apply_sac_pass(gm, policy_fn=default_policy_fn())
     elif memory_policy == "eager":
         apply_sac_pass(gm, policy_fn=_make_eager_memory_policy())
     elif memory_policy == "cpu_offload_all":

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -419,10 +419,12 @@ def _precompile_aot_fx_trace(
     # Apply precompile-time graph passes (cleanup + regional_inductor)
     # so compiled Triton kernels are baked into the serialized artifact.
     # cudagraph is excluded — it runs at load time on each rank.
+    from torchtitan.experiments.graph_trainer.bucketing import (
+        joint_transformer_block_bucketing_reordering_pass,
+    )
     from torchtitan.experiments.graph_trainer.passes import (
         apply_graph_passes,
         compile_time_passes,
-        joint_transformer_block_bucketing_reordering_pass,
     )
 
     passes = compile_time_passes(traced_result, config)

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -26,6 +26,7 @@ def build_minimal_trainer(
     compile_passes: list[str] | None = None,
     compile_joint_passes: list[str] | None = None,
     tokenizer=None,
+    fsdp_reshard_after_forward: str = "default",
 ) -> Trainer:
     """Build the minimal Trainer/GraphTrainer needed for single-GPU test steps."""
     trainer = object.__new__(trainer_cls)
@@ -55,6 +56,10 @@ def build_minimal_trainer(
             model_spec=SimpleNamespace(model=model_config),
             activation_checkpoint=ActivationCheckpointConfig(
                 mode=activation_checkpoint_mode
+            ),
+            parallelism=SimpleNamespace(
+                pipeline_parallel_degree=1,
+                fsdp_reshard_after_forward=fsdp_reshard_after_forward,
             ),
         )
         trainer._fwd_bwd_step_module = None

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -192,6 +192,10 @@ class BitwiseDeterministicBase(unittest.TestCase):
             config = SimpleNamespace(
                 model_spec=SimpleNamespace(model=self.model_config),
                 compile=SimpleNamespace(memory_policy="default"),
+                parallelism=SimpleNamespace(
+                    pipeline_parallel_degree=1,
+                    fsdp_reshard_after_forward="default",
+                ),
             )
             passes = compile_time_passes(traced_result, config)
             traced_result.gm = apply_graph_passes(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -457,8 +457,8 @@ class TestBucketingPrefetchOrder(FSDPTest):
                 layer_ids.append(found_lid)
         return layer_ids
 
-    def test_forward_allgather_prefetch_follows_layer_order(self):
-        """Bucketed forward all_gather starts must appear in layer order 0→N."""
+    def _run_and_get_layer_ids(self, fsdp_reshard_after_forward: str):
+        """Run a single forward+backward step and return bucketed AG layer ids."""
         from torchtitan.components.tokenizer import HuggingFaceTokenizer
         from torchtitan.experiments.graph_trainer.llama3 import (
             model_registry as llama3_model_registry,
@@ -513,6 +513,7 @@ class TestBucketingPrefetchOrder(FSDPTest):
             model_config,
             GraphTrainer,
             tokenizer=HuggingFaceTokenizer(tokenizer_path="./tests/assets/tokenizer"),
+            fsdp_reshard_after_forward=fsdp_reshard_after_forward,
         )
 
         inputs = torch.randint(
@@ -535,14 +536,55 @@ class TestBucketingPrefetchOrder(FSDPTest):
 
         layer_ids = self._get_bucketed_ag_layer_order(trainer._traced_step.gm)
         self.assertGreater(len(layer_ids), 0, "No layer all_gather nodes found")
+        return layer_ids
 
-        # Forward layer order must be monotonically non-decreasing
+    def test_forward_allgather_prefetch_follows_layer_order(self):
+        """Without reshard-after-forward, all all_gathers are in forward and
+        must appear in non-decreasing layer order 0 → N."""
+        layer_ids = self._run_and_get_layer_ids(fsdp_reshard_after_forward="never")
+
         for i in range(1, len(layer_ids)):
             self.assertGreaterEqual(
                 layer_ids[i],
                 layer_ids[i - 1],
                 f"Forward all_gather prefetch order violated: "
                 f"layer {layer_ids[i]} before layer {layer_ids[i - 1]} "
+                f"(full order: {layer_ids})",
+            )
+
+    def test_allgather_prefetch_with_reshard_after_forward(self):
+        """With reshard-after-forward, backward also issues all_gathers.
+        The graph-order sequence must be forward (0 → N) then backward (N → 0)."""
+        layer_ids = self._run_and_get_layer_ids(fsdp_reshard_after_forward="always")
+
+        # Split forward (ascending) and backward (descending) at the peak.
+        peak = max(range(len(layer_ids)), key=lambda i: layer_ids[i])
+        forward_ids = layer_ids[: peak + 1]
+        backward_ids = layer_ids[peak:]
+
+        # Backward all_gathers should exist when reshard-after-forward is on.
+        self.assertGreater(
+            len(backward_ids),
+            1,
+            f"Expected backward all_gathers with reshard-after-forward, "
+            f"got order: {layer_ids}",
+        )
+
+        for i in range(1, len(forward_ids)):
+            self.assertGreaterEqual(
+                forward_ids[i],
+                forward_ids[i - 1],
+                f"Forward all_gather prefetch order violated: "
+                f"layer {forward_ids[i]} before layer {forward_ids[i - 1]} "
+                f"(full order: {layer_ids})",
+            )
+
+        for i in range(1, len(backward_ids)):
+            self.assertLessEqual(
+                backward_ids[i],
+                backward_ids[i - 1],
+                f"Backward all_gather prefetch order violated: "
+                f"layer {backward_ids[i]} after layer {backward_ids[i - 1]} "
                 f"(full order: {layer_ids})",
             )
 


### PR DESCRIPTION
Joint-graph bucketing and prefetching replaces the two separate `manual_overlap_bucketing` calls in `joint_transformer_block_bucketing_reordering_pass` with a single `joint_manual_overlap_bucketing` pass over the joint fwd+bwd graph.

1. The `JointManualOverlapScheduler` subclasses upstream `ManualOverlapScheduler`:
- Splits each module's collectives by direction in so fwd and bwd buckets stay disjoint.
- Splits the AG-prefetch reversed walk into per-direction so AG pairing never crosses the fwd/bwd boundary. RS prefetch is unchanged (RSs only occur in backward).
- Recomputed SAC nodes (which carry forward `autograd_backward` metadata) are still routed to backward via an `is_backward_fn` that checks the `_recomputed` name suffix.

 2. SAC composes with `fsdp_reshard_after_forward`. The default memory policy previously always added `all_gather_into_tensor` to `save_ops` as a workaround. That's now gated on `fsdp_reshard_after_forward`.

Test Plan:
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_deepseek_v3_16b ./run_train.sh --compile.mode aot_fx_trace --compile.no-enable_cudagraph --profiler.profile_freq 15 --profiler.enable_profiling --training.steps 20
```

correct overlap and reshard-after-forward behavior on llama3-8b 
<img width="1766" height="120" alt="Screenshot 2026-04-27 at 11 51 50 AM" src="https://github.com/user-attachments/assets/9296b4c2-8a83-4e09-8b4e-e9b5dadc3fbb" />
