### PR TITLE
[GraphTrainer] Disable JIT/AOT tests due to upstream partitioner regression

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -10,6 +10,12 @@ import os
 from tests.integration_tests import OverrideDefinitions
 from tests.integration_tests.run_tests import run_tests
 
+# TODO: JIT and AOT mode tests are disabled due to an upstream PyTorch
+# partitioner regression ("Node tangents_2 was invalid, but is output")
+# triggered by the full DTensor change (#2149). Re-enable once the
+# partitioner issue is resolved.
+_JIT_AOT_DISABLED = True
+
 
 def _build_llama3_tests() -> list[OverrideDefinitions]:
     """Llama3-based integration tests (run on default A10 machines)."""
@@ -27,6 +33,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             ],
             "JIT 1D+auto_bucketing",
             "jit_1d_auto_bucketing",
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -40,6 +47,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             ],
             "JIT 1D+transformer_block_bucketing",
             "jit_1d_transformer_block_bucketing",
+            disabled=_JIT_AOT_DISABLED,
         ),
         # TODO: re-enable this test once the async TP issue is fixed
         OverrideDefinitions(
@@ -81,6 +89,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT PP+DP+TP 3D test with save/load resume ckpt",
             "jit_pp_dp_tp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -96,6 +105,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT HSDP+TP",
             "jit_hsdp+tp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -111,6 +121,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT HSDP+CP (with dp_shard)",
             "jit_hsdp+cp_with_dp_shard",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -126,6 +137,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+TP+CP",
             "jit_fsdp+tp+cp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -161,6 +173,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT Optional checkpoint",
             "jit_optional_checkpoint",
             ngpu=4,
+            disabled=_JIT_AOT_DISABLED,
         ),
         # === AOT mode tests ===
         OverrideDefinitions(
@@ -176,6 +189,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP",
             "aot_llama3_fsdp_tp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -191,6 +205,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP autobucketing",
             "aot_llama3_fsdp_tp_autobucketing",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -206,6 +221,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP manualbucketing",
             "aot_llama3_fsdp_tp_manualbucketing",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -222,6 +238,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_llama3_fsdp_tp_cudagraph",
             ngpu=8,
             skip_rocm_test=True,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -236,6 +253,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP+FlexAttn",
             "aot_llama3_fsdp_tp_flexattn",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -251,6 +269,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP+FlexAttn autobucketing regional_inductor",
             "aot_llama3_fsdp_tp_flexattn_autobucketing_regional_inductor",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -267,6 +286,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 auto_bucketing+full_inductor_compilation",
             "aot_llama3_auto_bucketing_full_inductor_compilation",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -282,6 +302,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "AOT llama3 FSDP+TP+FlexAttn manualbucketing regional_inductor",
             "aot_llama3_fsdp_tp_flexattn_manualbucketing_regional_inductor",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         # === aot_fx_trace mode tests ===
         # Note: aot_fx_trace applies cudagraph by default, so skip_rocm_test=True.
@@ -334,6 +355,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+EP",
             "jit_fsdp+ep",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -350,6 +372,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+TP+EP+ETP",
             "jit_fsdp+tp+ep+etp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -364,6 +387,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+CP",
             "jit_fsdp+cp",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -396,6 +420,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "AOT deepseek_v3 FSDP+TP+EP",
             "aot_deepseekv3_fsdp_tp_ep",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -412,6 +437,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "AOT deepseek_v3 FSDP+TP+EP+FlexAttention",
             "aot_deepseekv3_fsdp_tp_ep_flexattention",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -429,6 +455,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "AOT deepseek_v3 inductor_decomposition",
             "aot_deepseekv3_inductor_decomposition",
             ngpu=8,
+            disabled=_JIT_AOT_DISABLED,
         ),
         # TODO: DSv3 + cudagraph AOT tests are not included because MoE
         # routing copies tensors to CPU (int64 _to_copy to device='cpu' via

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -152,14 +152,22 @@ def _run_qwen3_moe_loss_compare(test_options_extra: str = "") -> bool:
     )
 
 
+# TODO: JIT and AOT tests are disabled due to an upstream PyTorch
+# partitioner regression ("Node tangents_2 was invalid, but is output")
+# triggered by the full DTensor change (#2149). Re-enable once resolved.
+# See https://www.internalfb.com/intern/paste/P2285018929/
+
+
 class TestGraphTrainerNumerics(unittest.TestCase):
     """Test numerics equivalence between graph_trainer and FSDP2 eager."""
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode aot"),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_auto_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
@@ -167,6 +175,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_manual_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
@@ -174,6 +183,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_cudagraph_aot_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
@@ -181,11 +191,13 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_moe_dsv3_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode aot"),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_moe_dsv3_manual_bucketing_aot_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(
@@ -198,11 +210,13 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             _run_llama3_loss_compare(test_options_extra="--compile.mode aot_fx_trace"),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(test_options_extra="--compile.mode jit"),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_auto_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
@@ -210,6 +224,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_dense_llama3_manual_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_llama3_loss_compare(
@@ -217,12 +232,14 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_moe_dsv3_jit_vs_eager(self):
         """Test graph_trainer.deepseek_v3 matches deepseek_v3 (JIT)."""
         self.assertTrue(
             _run_deepseek_v3_loss_compare(test_options_extra="--compile.mode jit"),
         )
 
+    @unittest.skip("Disabled: upstream partitioner regression (#2149)")
     def test_moe_dsv3_manual_bucketing_jit_vs_eager(self):
         self.assertTrue(
             _run_deepseek_v3_loss_compare(


### PR DESCRIPTION
## Summary
- Disable all JIT and AOT mode integration tests via `_JIT_AOT_DISABLED` flag
- The full DTensor change (#2149) triggers `AssertionError: Node tangents_2 was invalid, but is output` in PyTorch's `default_partition`
- All 6 `aot_fx_trace` mode tests remain enabled and passing

## Test plan
- [x] `PYTHONPATH=. python torchtitan/experiments/graph_trainer/tests/integration_tests.py ~/tmp/integration_test_output --test_suite graph_trainer_default --ngpu 8` — all remaining tests pass