### PR TITLE
[GraphTrainer] Add log_activation_memory_policy to inspect per-tensor memory policy

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -59,7 +59,8 @@ as new branches in `tag_with_memory_policy_pass`.
 prints all forward nodes consumed by backward, grouped by layer with
 identical patterns consolidated. Shows memory, dtype, policy
 (SAVE/RECOMPUTE/OFFLOAD), shape, submodule, target op, and source location.
-It runs automatically at the end of `tag_with_memory_policy_pass`.
+It runs automatically at the end of `tag_with_memory_policy_pass`,
+logging to both `logger.debug` and tlparse (via `trace_structured`).
 
 ## Don't Modify Core for This Experiment
 

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -98,6 +98,26 @@ python torchtitan/experiments/graph_trainer/tests/integration_tests.py <output_d
     --test_suite graph_trainer_default --ngpu 8
 ```
 
+### Listing Activations Saved for Backward
+
+`list_activations_pass` (`list_activations.py`) prints all forward nodes
+consumed by backward, grouped by layer with identical patterns consolidated.
+Shows memory, dtype, shape, submodule, target op, and source location.
+Useful for understanding activation memory and informing SAC/offload policies.
+
+Add it to `compile_time_passes` before `selective_activation_remat_pass`:
+
+```python
+from torchtitan.experiments.graph_trainer.list_activations import list_activations_pass
+
+passes: list[Callable] = [
+    ...
+    list_activations_pass,
+    selective_activation_remat_pass,
+    ...
+]
+```
+
 ### Debugging Graph Passes
 
 Add `--compile.debug_graph_passes` to enable per-pass instrumentation:

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -23,11 +23,17 @@ bound during pass construction in `construct_default_graph_passes` via
 parameters. The apply function is a generic pass runner and must not contain
 pass-specific arguments.
 
-## Memory Policy Framework
+## Flexible Memory Policy Framework
 
-`tag_with_memory_policy_pass` is the unified framework for activation memory
-management — selective activation checkpointing (SAC), CPU offload, and
-mixtures of both. It is a two-step process:
+PyTorch's module-level `torch.utils.checkpoint` and eager SAC make
+coarse save-or-recompute decisions for an entire module's output, and
+composing activation checkpointing with CPU offload is difficult. This
+framework instead operates on the FX graph at individual tensor
+granularity: each activation can independently be saved, recomputed, or
+offloaded, and different strategies mix freely within a single layer.
+
+`tag_with_memory_policy_pass` is the unified entry point. It is a
+two-step process:
 
 1. **Tag nodes.** Each saved forward activation is tagged with one of:
    - `MUST_SAVE` — keep the activation in GPU memory.
@@ -48,6 +54,13 @@ mixtures of both. It is a two-step process:
 The `--compile.memory_policy` config selects the tagging strategy.
 New policies (e.g. budget-aware mixed SAC + offload) should be added
 as new branches in `tag_with_memory_policy_pass`.
+
+**Inspecting tags:** `log_activation_memory_policy` (`log_activation_memory_policy.py`)
+prints all forward nodes consumed by backward, grouped by layer with
+identical patterns consolidated. Shows memory, dtype, policy
+(SAVE/RECOMPUTE/OFFLOAD), shape, submodule, target op, and source location.
+It runs automatically at the end of `tag_with_memory_policy_pass` when
+`--compile.debug_graph_passes` is enabled.
 
 ## Don't Modify Core for This Experiment
 
@@ -96,26 +109,6 @@ pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py 
 # Integration tests (8 GPUs)
 python torchtitan/experiments/graph_trainer/tests/integration_tests.py <output_dir> \
     --test_suite graph_trainer_default --ngpu 8
-```
-
-### Listing Activations Saved for Backward
-
-`list_activations_pass` (`list_activations.py`) prints all forward nodes
-consumed by backward, grouped by layer with identical patterns consolidated.
-Shows memory, dtype, shape, submodule, target op, and source location.
-Useful for understanding activation memory and informing SAC/offload policies.
-
-Add it to `compile_time_passes` before `selective_activation_remat_pass`:
-
-```python
-from torchtitan.experiments.graph_trainer.list_activations import list_activations_pass
-
-passes: list[Callable] = [
-    ...
-    list_activations_pass,
-    selective_activation_remat_pass,
-    ...
-]
 ```
 
 ### Debugging Graph Passes

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -59,8 +59,7 @@ as new branches in `tag_with_memory_policy_pass`.
 prints all forward nodes consumed by backward, grouped by layer with
 identical patterns consolidated. Shows memory, dtype, policy
 (SAVE/RECOMPUTE/OFFLOAD), shape, submodule, target op, and source location.
-It runs automatically at the end of `tag_with_memory_policy_pass` when
-`--compile.debug_graph_passes` is enabled.
+It runs automatically at the end of `tag_with_memory_policy_pass`.
 
 ## Don't Modify Core for This Experiment
 

--- a/torchtitan/experiments/graph_trainer/list_activations.py
+++ b/torchtitan/experiments/graph_trainer/list_activations.py
@@ -1,0 +1,317 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Read-only graph pass that lists all activations saved for backward."""
+
+from __future__ import annotations
+
+import operator
+import re
+from collections import defaultdict
+
+import torch
+
+from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+from torchtitan.experiments.graph_trainer.passes import (
+    _get_layer_id,
+    _is_backward_node,
+    _NOT_IN_LAYERS,
+)
+from torchtitan.tools.logging import logger
+
+_PASSTHROUGH_TARGETS = frozenset(
+    {
+        operator.getitem,
+        torch.ops._c10d_functional.wait_tensor.default,
+    }
+)
+
+
+def _resolve_producing_op(node: torch.fx.Node) -> torch.fx.Node:
+    """Walk through getitem/wait_tensor to find the real producing op."""
+    while node.target in _PASSTHROUGH_TARGETS:
+        parent = node.args[0]
+        if not isinstance(parent, torch.fx.Node) or parent.op != "call_function":
+            break
+        node = parent
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_shape(val: object) -> str:
+    if isinstance(val, torch.Tensor):
+        return str(list(val.shape))
+    if isinstance(val, (tuple, list)):
+        parts = [_format_shape(v) for v in val]
+        return "(" + ", ".join(parts) + ")"
+    return "?"
+
+
+def _tensor_nbytes(val: object) -> int:
+    if isinstance(val, torch.Tensor):
+        try:
+            # int() can fail on symbolic shapes (e.g. MoE token dispatch)
+            return int(val.numel() * val.element_size())
+        except Exception:
+            return 0
+    if isinstance(val, (tuple, list)):
+        return sum(_tensor_nbytes(v) for v in val)
+    return 0
+
+
+def _tensor_dtype(val: object) -> str:
+    if isinstance(val, torch.Tensor):
+        return str(val.dtype).replace("torch.", "")
+    if isinstance(val, (tuple, list)):
+        dtypes = {_tensor_dtype(v) for v in val} - {"?"}
+        if len(dtypes) == 1:
+            return dtypes.pop()
+        if dtypes:
+            return "/".join(sorted(dtypes))
+    return "?"
+
+
+def _format_bytes(nbytes: int) -> str:
+    if nbytes >= 1 << 30:
+        return f"{nbytes / (1 << 30):.2f} GiB"
+    if nbytes >= 1 << 20:
+        return f"{nbytes / (1 << 20):.2f} MiB"
+    if nbytes >= 1 << 10:
+        return f"{nbytes / (1 << 10):.2f} KiB"
+    return f"{nbytes} B"
+
+
+_REPO_ROOT = "torchtitan/"
+
+
+def _parse_stack_frames(
+    stack_trace: str,
+) -> list[tuple[str, str, str]]:
+    raw_lines = stack_trace.strip().splitlines()
+    frames = []
+    i = 0
+    while i < len(raw_lines):
+        line = raw_lines[i].strip()
+        if line.startswith("File "):
+            parts = line.split(", ")
+            path = parts[0].removeprefix("File ").strip('"')
+            lineno = parts[1].removeprefix("line ").strip() if len(parts) >= 2 else "?"
+            code = ""
+            if i + 1 < len(raw_lines) and not raw_lines[i + 1].strip().startswith(
+                "File "
+            ):
+                code = raw_lines[i + 1].strip()
+                i += 1
+            frames.append((path, lineno, code))
+        i += 1
+    return frames
+
+
+def _format_stack_trace(stack_trace: str | None) -> str:
+    """Extract the last torchtitan frame, falling back to the last frame."""
+    if not stack_trace:
+        return ""
+    frames = _parse_stack_frames(stack_trace)
+    if not frames:
+        return ""
+
+    chosen = None
+    for path, lineno, code in reversed(frames):
+        if _REPO_ROOT in path:
+            chosen = (path, lineno, code)
+            break
+    if chosen is None:
+        chosen = frames[-1]
+
+    path, lineno, code = chosen
+    idx = path.find(_REPO_ROOT)
+    if idx >= 0:
+        path = path[idx + len(_REPO_ROOT) :]
+    else:
+        path = path.rsplit("/", 1)[-1]
+
+    loc = f"{path}:{lineno}"
+    if code:
+        return f"{loc}  {code}"
+    return loc
+
+
+def _format_original_aten(node: torch.fx.Node) -> str:
+    original = node.meta.get("original_aten")
+    if original is None or str(original) == str(node.target):
+        return ""
+    return str(original)
+
+
+# ---------------------------------------------------------------------------
+# Layer consolidation helpers
+# ---------------------------------------------------------------------------
+
+
+# Matches PyTorch symbolic shape variables (s0, u12, etc.)
+_SYM_VAR_RE = re.compile(r"\b[su]\d+\b")
+
+
+def _normalize_shape(shape: str) -> str:
+    return _SYM_VAR_RE.sub("S", shape)
+
+
+def _layer_fingerprint(activations: list[dict]) -> tuple:
+    """Return a hashable fingerprint for a layer's activation pattern."""
+    return tuple(
+        (
+            act["target"],
+            _normalize_shape(act["shape"]),
+            act["dtype"],
+            act["original_aten"],
+        )
+        for act in activations
+    )
+
+
+def _strip_layer_prefix(fqn: str) -> str:
+    """Strip ``layers.<N>.`` prefix to get the relative submodule path."""
+    parts = fqn.split(".", 2)
+    if parts[0] == "layers" and len(parts) >= 3:
+        return parts[2]
+    return fqn
+
+
+# ---------------------------------------------------------------------------
+# Pass entry point
+# ---------------------------------------------------------------------------
+
+
+def list_activations_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple | None = None
+) -> torch.fx.GraphModule:
+    """List all activation nodes whose outputs are consumed by backward nodes.
+
+    Layers with identical activation patterns (same ops, shapes, and dtypes)
+    are consolidated and printed once. Non-layer nodes are always printed
+    individually.
+    This is a read-only pass — the graph is not modified.
+    """
+    activations_by_layer: dict[int, list[dict]] = defaultdict(list)
+
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if _is_backward_node(node):
+            continue
+
+        num_bwd_users = sum(1 for u in node.users if _is_backward_node(u))
+        if num_bwd_users == 0:
+            continue
+
+        layer_id = _get_layer_id(node)
+        val = node.meta.get("val")
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+
+        producer = _resolve_producing_op(node)
+
+        activations_by_layer[layer_id].append(
+            {
+                "name": node.name,
+                "target": str(producer.target),
+                "shape": _format_shape(val),
+                "dtype": _tensor_dtype(val),
+                "nbytes": _tensor_nbytes(val),
+                "fqn": fqn,
+                "original_aten": _format_original_aten(producer),
+                "source": _format_stack_trace(producer.meta.get("stack_trace")),
+            }
+        )
+
+    # Group numbered layers by fingerprint
+    fingerprint_to_layers: dict[tuple, list[int]] = defaultdict(list)
+    for layer_id, acts in sorted(activations_by_layer.items()):
+        if layer_id == _NOT_IN_LAYERS:
+            continue
+        fingerprint_to_layers[_layer_fingerprint(acts)].append(layer_id)
+
+    def _fmt_target(act: dict) -> str:
+        aten = act["original_aten"]
+        if aten:
+            return f"{act['target']}  (← {aten})"
+        return act["target"]
+
+    def _fmt_row(idx: int, act: dict, submodule: str) -> str:
+        return (
+            f"  {idx:<3} {_format_bytes(act['nbytes']):>10}  {act['dtype']:<10} "
+            f"{act['shape']:<25} {submodule:<30} "
+            f"{_fmt_target(act):<55} {act['source']}"
+        )
+
+    header = (
+        f"  {'#':<3} {'Memory':>10}  {'DType':<10} {'Shape':<25} "
+        f"{'SubModule':<30} {'Target':<55} {'Source'}"
+    )
+    sep = "-" * len(header)
+    lines = [sep, header, sep]
+
+    total_activations = 0
+    total_bytes = 0
+
+    # Print non-layer activations
+    if _NOT_IN_LAYERS in activations_by_layer:
+        other_acts = activations_by_layer[_NOT_IN_LAYERS]
+        other_bytes = sum(act["nbytes"] for act in other_acts)
+        lines.append(
+            f"[non-layer] ({len(other_acts)} activations, {_format_bytes(other_bytes)})"
+        )
+        for i, act in enumerate(other_acts):
+            lines.append(_fmt_row(i, act, act["fqn"]))
+            total_activations += 1
+            total_bytes += act["nbytes"]
+        lines.append("")
+
+    # Print consolidated layer groups
+    for fingerprint, layer_ids in sorted(
+        fingerprint_to_layers.items(), key=lambda kv: kv[1][0]
+    ):
+        representative = activations_by_layer[layer_ids[0]]
+        num_layers = len(layer_ids)
+        layer_bytes = sum(act["nbytes"] for act in representative)
+
+        if num_layers == 1:
+            label = f"[layer {layer_ids[0]}]"
+        else:
+            first, last = layer_ids[0], layer_ids[-1]
+            label = f"[layers {first}-{last}] (x{num_layers}, same pattern)"
+
+        lines.append(
+            f"{label} ({len(representative)} activations, "
+            f"{_format_bytes(layer_bytes)} each, "
+            f"{_format_bytes(layer_bytes * num_layers)} total)"
+        )
+        for i, act in enumerate(representative):
+            sub = _strip_layer_prefix(act["fqn"])
+            lines.append(_fmt_row(i, act, sub))
+        total_activations += len(representative) * num_layers
+        total_bytes += layer_bytes * num_layers
+        lines.append("")
+
+    num_layers = sum(len(ids) for ids in fingerprint_to_layers.values())
+    has_non_layer = _NOT_IN_LAYERS in activations_by_layer
+    scope = f"{num_layers} layer(s)" + (" + non-layer" if has_non_layer else "")
+    lines.append(sep)
+    lines.append(
+        f"Total: {total_activations} activations, "
+        f"{_format_bytes(total_bytes)} across {scope}"
+    )
+    lines.append(sep)
+
+    logger.info(
+        "Activation listing (forward nodes with backward consumers):\n"
+        + "\n".join(lines)
+    )
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/list_activations.py
+++ b/torchtitan/experiments/graph_trainer/list_activations.py
@@ -13,6 +13,7 @@ import re
 from collections import defaultdict
 
 import torch
+from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
 from torchtitan.experiments.graph_trainer.passes import (
@@ -143,6 +144,21 @@ def _format_stack_trace(stack_trace: str | None) -> str:
     return loc
 
 
+_POLICY_SHORT_NAMES = {
+    CheckpointPolicy.MUST_SAVE: "SAVE",
+    CheckpointPolicy.PREFER_RECOMPUTE: "RECOMPUTE",
+    CheckpointPolicy.MUST_RECOMPUTE: "RECOMPUTE!",
+    CheckpointPolicy.MUST_CPU_OFFLOAD: "OFFLOAD",
+}
+
+
+def _format_policy(node: torch.fx.Node) -> str:
+    policy = node.meta.get("recompute")
+    if policy is None:
+        return ""
+    return _POLICY_SHORT_NAMES.get(policy, str(policy))
+
+
 def _format_original_aten(node: torch.fx.Node) -> str:
     original = node.meta.get("original_aten")
     if original is None or str(original) == str(node.target):
@@ -170,6 +186,7 @@ def _layer_fingerprint(activations: list[dict]) -> tuple:
             act["target"],
             _normalize_shape(act["shape"]),
             act["dtype"],
+            act["policy"],
             act["original_aten"],
         )
         for act in activations
@@ -224,6 +241,7 @@ def list_activations_pass(
                 "shape": _format_shape(val),
                 "dtype": _tensor_dtype(val),
                 "nbytes": _tensor_nbytes(val),
+                "policy": _format_policy(node),
                 "fqn": fqn,
                 "original_aten": _format_original_aten(producer),
                 "source": _format_stack_trace(producer.meta.get("stack_trace")),
@@ -246,12 +264,13 @@ def list_activations_pass(
     def _fmt_row(idx: int, act: dict, submodule: str) -> str:
         return (
             f"  {idx:<3} {_format_bytes(act['nbytes']):>10}  {act['dtype']:<10} "
-            f"{act['shape']:<25} {submodule:<30} "
+            f"{act['policy']:<12} {act['shape']:<25} {submodule:<30} "
             f"{_fmt_target(act):<55} {act['source']}"
         )
 
     header = (
-        f"  {'#':<3} {'Memory':>10}  {'DType':<10} {'Shape':<25} "
+        f"  {'#':<3} {'Memory':>10}  {'DType':<10} "
+        f"{'Policy':<12} {'Shape':<25} "
         f"{'SubModule':<30} {'Target':<55} {'Source'}"
     )
     sep = "-" * len(header)

--- a/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
@@ -15,10 +15,10 @@ from collections import defaultdict
 import torch
 from torch.utils.checkpoint import CheckpointPolicy
 
-from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
-from torchtitan.experiments.graph_trainer.passes import (
+from torchtitan.experiments.graph_trainer.common_utils import (
     _get_layer_id,
     _is_backward_node,
+    _MODULE_FQN,
     _NOT_IN_LAYERS,
 )
 from torchtitan.tools.logging import logger
@@ -33,7 +33,9 @@ _PASSTHROUGH_TARGETS = frozenset(
 
 def _resolve_producing_op(node: torch.fx.Node) -> torch.fx.Node:
     """Walk through getitem/wait_tensor to find the real producing op."""
-    while node.target in _PASSTHROUGH_TARGETS:
+    seen: set[torch.fx.Node] = set()
+    while node.target in _PASSTHROUGH_TARGETS and node not in seen:
+        seen.add(node)
         parent = node.args[0]
         if not isinstance(parent, torch.fx.Node) or parent.op != "call_function":
             break
@@ -55,15 +57,24 @@ def _format_shape(val: object) -> str:
     return "?"
 
 
+_SYMBOLIC_NBYTES = -1
+
+
 def _tensor_nbytes(val: object) -> int:
+    """Return byte count, or ``_SYMBOLIC_NBYTES`` for symbolic shapes."""
     if isinstance(val, torch.Tensor):
         try:
-            # int() can fail on symbolic shapes (e.g. MoE token dispatch)
             return int(val.numel() * val.element_size())
         except Exception:
-            return 0
+            return _SYMBOLIC_NBYTES
     if isinstance(val, (tuple, list)):
-        return sum(_tensor_nbytes(v) for v in val)
+        total = 0
+        for v in val:
+            n = _tensor_nbytes(v)
+            if n == _SYMBOLIC_NBYTES:
+                return _SYMBOLIC_NBYTES
+            total += n
+        return total
     return 0
 
 
@@ -80,6 +91,8 @@ def _tensor_dtype(val: object) -> str:
 
 
 def _format_bytes(nbytes: int) -> str:
+    if nbytes == _SYMBOLIC_NBYTES:
+        return "symbolic"
     if nbytes >= 1 << 30:
         return f"{nbytes / (1 << 30):.2f} GiB"
     if nbytes >= 1 << 20:
@@ -95,6 +108,7 @@ _REPO_ROOT = "torchtitan/"
 def _parse_stack_frames(
     stack_trace: str,
 ) -> list[tuple[str, str, str]]:
+    # Assumes CPython traceback format: 'File "path", line N\n  code'
     raw_lines = stack_trace.strip().splitlines()
     frames = []
     i = 0
@@ -155,8 +169,7 @@ _POLICY_SHORT_NAMES = {
 def _format_policy(node: torch.fx.Node) -> str:
     policy = node.meta.get("recompute")
     if policy is None:
-        # Untagged activations are kept in GPU memory by default.
-        return _POLICY_SHORT_NAMES[CheckpointPolicy.MUST_SAVE]
+        return "SAVE*"
     return _POLICY_SHORT_NAMES.get(policy, str(policy))
 
 
@@ -277,20 +290,24 @@ def log_activation_memory_policy(
     sep = "-" * len(header)
     lines = [sep, header, sep]
 
+    def _sum_concrete_bytes(acts: list[dict]) -> int:
+        return sum(a["nbytes"] for a in acts if a["nbytes"] != _SYMBOLIC_NBYTES)
+
     total_activations = 0
     total_bytes = 0
 
     # Print non-layer activations
     if _NOT_IN_LAYERS in activations_by_layer:
         other_acts = activations_by_layer[_NOT_IN_LAYERS]
-        other_bytes = sum(act["nbytes"] for act in other_acts)
+        other_bytes = _sum_concrete_bytes(other_acts)
         lines.append(
             f"[non-layer] ({len(other_acts)} activations, {_format_bytes(other_bytes)})"
         )
         for i, act in enumerate(other_acts):
             lines.append(_fmt_row(i, act, act["fqn"]))
             total_activations += 1
-            total_bytes += act["nbytes"]
+            if act["nbytes"] != _SYMBOLIC_NBYTES:
+                total_bytes += act["nbytes"]
         lines.append("")
 
     # Print consolidated layer groups
@@ -299,7 +316,7 @@ def log_activation_memory_policy(
     ):
         representative = activations_by_layer[layer_ids[0]]
         num_layers = len(layer_ids)
-        layer_bytes = sum(act["nbytes"] for act in representative)
+        layer_bytes = _sum_concrete_bytes(representative)
 
         if num_layers == 1:
             label = f"[layer {layer_ids[0]}]"
@@ -328,6 +345,8 @@ def log_activation_memory_policy(
         f"{_format_bytes(total_bytes)} across {scope}"
     )
     lines.append(sep)
+
+    lines.append("SAVE* = untagged (kept in GPU memory by default)")
 
     logger.info(
         "Activation listing (forward nodes with backward consumers):\n"

--- a/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
@@ -55,6 +55,10 @@ def _format_shape(val: object) -> str:
     if isinstance(val, (tuple, list)):
         parts = [_format_shape(v) for v in val]
         return "(" + ", ".join(parts) + ")"
+    if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return "SymInt"
+    if isinstance(val, (int, float, bool)):
+        return "Scalar"
     return "?"
 
 
@@ -83,11 +87,15 @@ def _tensor_dtype(val: object) -> str:
     if isinstance(val, torch.Tensor):
         return str(val.dtype).replace("torch.", "")
     if isinstance(val, (tuple, list)):
-        dtypes = {_tensor_dtype(v) for v in val} - {"?"}
+        dtypes = {_tensor_dtype(v) for v in val} - {"?", "Scalar", "SymInt"}
         if len(dtypes) == 1:
             return dtypes.pop()
         if dtypes:
             return "/".join(sorted(dtypes))
+    if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return "SymInt"
+    if isinstance(val, (int, float, bool)):
+        return "Scalar"
     return "?"
 
 
@@ -243,8 +251,8 @@ def log_activation_memory_policy(
         if num_bwd_users == 0:
             continue
 
-        layer_id = _get_layer_id(node)
         val = node.meta.get("val")
+        layer_id = _get_layer_id(node)
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
 
         producer = _resolve_producing_op(node)
@@ -273,7 +281,7 @@ def log_activation_memory_policy(
     def _fmt_target(act: dict) -> str:
         aten = act["original_aten"]
         if aten:
-            return f"{act['target']}  (← {aten})"
+            return f"{act['target']}  (<- {aten})"
         return act["target"]
 
     def _fmt_row(idx: int, act: dict, submodule: str) -> str:
@@ -350,7 +358,7 @@ def log_activation_memory_policy(
     lines.append("SAVE* = untagged (kept in GPU memory by default)")
 
     output = "\n".join(lines)
-    logger.info(
+    logger.debug(
         "Activation listing (forward nodes with backward consumers):\n" + output
     )
 

--- a/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
@@ -13,6 +13,7 @@ import re
 from collections import defaultdict
 
 import torch
+from torch._logging import trace_structured
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.experiments.graph_trainer.common_utils import (
@@ -348,9 +349,19 @@ def log_activation_memory_policy(
 
     lines.append("SAVE* = untagged (kept in GPU memory by default)")
 
+    output = "\n".join(lines)
     logger.info(
-        "Activation listing (forward nodes with backward consumers):\n"
-        + "\n".join(lines)
+        "Activation listing (forward nodes with backward consumers):\n" + output
+    )
+
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "activation_memory_policy",
+            "encoding": "string",
+        },
+        payload_fn=lambda: output,
+        expect_trace_id=False,
     )
 
     return gm

--- a/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/log_activation_memory_policy.py
@@ -155,7 +155,8 @@ _POLICY_SHORT_NAMES = {
 def _format_policy(node: torch.fx.Node) -> str:
     policy = node.meta.get("recompute")
     if policy is None:
-        return ""
+        # Untagged activations are kept in GPU memory by default.
+        return _POLICY_SHORT_NAMES[CheckpointPolicy.MUST_SAVE]
     return _POLICY_SHORT_NAMES.get(policy, str(policy))
 
 
@@ -206,7 +207,7 @@ def _strip_layer_prefix(fqn: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def list_activations_pass(
+def log_activation_memory_policy(
     gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
     """List all activation nodes whose outputs are consumed by backward nodes.

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -53,6 +53,9 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
     snapshot_graph,
 )
+from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
+    log_activation_memory_policy,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_detach_pass,
@@ -824,10 +827,6 @@ def tag_with_memory_policy_pass(
         tag_all_offloadable_activations(gm)
     else:
         raise ValueError(f"Unknown memory_policy: {memory_policy!r}")
-
-    from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
-        log_activation_memory_policy,
-    )
 
     log_activation_memory_policy(gm)
     return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -146,6 +146,10 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
+    from torchtitan.experiments.graph_trainer.list_activations import (
+        list_activations_pass,
+    )
+
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
@@ -155,6 +159,7 @@ def compile_time_passes(
             tag_with_memory_policy_pass,
             config=config,
         ),
+        list_activations_pass,
         # TODO: currently either SAC or CPU offload is used, not both at the
         # same time. Composability between these two passes is untested.
         apply_cpu_offload_pass,
@@ -773,7 +778,8 @@ def apply_sac_pass(
                 and _is_recomputable(user)
                 and _get_layer_id(user) > node_layer_id
             ):
-                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+                # Hacky demo to show that we can force an activation to be offloaded
+                node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD
                 boundary_saves += 1
                 break
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -825,12 +825,11 @@ def tag_with_memory_policy_pass(
     else:
         raise ValueError(f"Unknown memory_policy: {memory_policy!r}")
 
-    if config.compile.debug_graph_passes:
-        from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
-            log_activation_memory_policy,
-        )
+    from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
+        log_activation_memory_policy,
+    )
 
-        log_activation_memory_policy(gm)
+    log_activation_memory_policy(gm)
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -773,8 +773,7 @@ def apply_sac_pass(
                 and _is_recomputable(user)
                 and _get_layer_id(user) > node_layer_id
             ):
-                # Hacky demo to show that we can force an activation to be offloaded
-                node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD
+                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
                 boundary_saves += 1
                 break
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -146,10 +146,6 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
-    from torchtitan.experiments.graph_trainer.list_activations import (
-        list_activations_pass,
-    )
-
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
@@ -159,7 +155,6 @@ def compile_time_passes(
             tag_with_memory_policy_pass,
             config=config,
         ),
-        list_activations_pass,
         # TODO: currently either SAC or CPU offload is used, not both at the
         # same time. Composability between these two passes is untested.
         apply_cpu_offload_pass,
@@ -830,6 +825,13 @@ def tag_with_memory_policy_pass(
         tag_all_offloadable_activations(gm)
     else:
         raise ValueError(f"Unknown memory_policy: {memory_policy!r}")
+
+    if config.compile.debug_graph_passes:
+        from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
+            log_activation_memory_policy,
+        )
+
+        log_activation_memory_policy(gm)
     return gm
 
 


### PR DESCRIPTION
## Summary
- Add a read-only diagnostic (`log_activation_memory_policy.py`) that lists all forward activations consumed by backward, showing the per-tensor memory policy (SAVE/RECOMPUTE/OFFLOAD) assigned by `tag_with_memory_policy_pass`
- Layers with identical activation patterns (ops, shapes, dtypes, policies) are consolidated into a single block
- Shows memory size, dtype, policy, shape, submodule, target op (with `original_aten` when decomposed), and source location
- Update CLAUDE.md: add Flexible Memory Policy Framework overview contrasting with module-level checkpoint and eager SAC

## Example output (Llama3 debugmodel, FSDP+TP)
```
[rank0]:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[rank0]:  #       Memory  DType      Policy       Shape                     SubModule                      Target                                                  Source
[rank0]:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[rank0]:[non-layer] (8 activations, 76.66 MiB)
[rank0]:  0     4.00 MiB  bfloat16   SAVE         [8, 1024, 256]                                           _c10d_functional.reduce_scatter_tensor.default          ...
[rank0]:  1        512 B  bfloat16   RECOMPUTE    [256]                     norm                           _c10d_functional.all_gather_into_tensor.default         ...
[rank0]:  ...
[rank0]:
[rank0]:[layers 0-4] (x5, same pattern) (31 activations, 117.50 MiB each, 587.50 MiB total)
[rank0]:  0        512 B  bfloat16   RECOMPUTE    [256]                     attention_norm                 _c10d_functional.all_gather_into_tensor.default         ...
[rank0]:  ...
[rank0]:  12    4.00 MiB  bfloat16   SAVE         [8, 8, 2048, 16]          attention.inner_attention      aten._scaled_dot_product_cudnn_attention.default        ...
[rank0]:  ...
[rank0]:
[rank0]:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[rank0]:Total: 194 activations, 781.66 MiB across 6 layer(s) + non-layer
[rank0]:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
<img width="2027" height="1182" alt="image" src="https://github.com/user-attachments/assets/23ce6425-2053-4afa-95d3-36fcbfc6fd69" />

another policy
<img width="2006" height="1177" alt="image" src="https://github.com/user-attachments/assets/d58776f1-12a1-4a5b-861e-9ee425428b31" />


## Test plan
- [x] Verified on Llama3 8B (FSDP+TP, 8×H100): 32 layers consolidated, 1000 activations, 38.68 GiB
- [x] Verified on DeepSeek-v3 debugmodel (FSDP+TP+EP, 8×H100): layer 0 (dense) separate, layers 1-5 (MoE) consolidated despite symbolic shapes
- [x] Pass is read-only — graph unchanged after pass
- [x] `pre-commit run --all-files` passes