### PR TITLE
[GraphTrainer][Reland] Introduce CPU offload pass for activation memory savings

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -18,6 +18,27 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
 _MODULE_FQN = "module_fqn"
+_NOT_IN_LAYERS = -1
+
+
+def _is_backward_node(node: torch.fx.Node) -> bool:
+    return node.meta.get("autograd_backward", False)
+
+
+def _get_layer_id(node: torch.fx.Node) -> int:
+    """Extract the layer index from the node's module_fqn metadata.
+
+    Nodes under ``layers.<N>`` return ``N``.
+    All other nodes (tok_embeddings, norm, output) return ``_NOT_IN_LAYERS``.
+    """
+    fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+    parts = fqn.split(".")
+    if parts[0] == "layers" and len(parts) >= 2:
+        try:
+            return int(parts[1])
+        except ValueError:
+            pass
+    return _NOT_IN_LAYERS
 
 
 def annotate_module_fqns(model: nn.Module) -> None:

--- a/torchtitan/experiments/graph_trainer/cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/cpu_offload.py
@@ -1,0 +1,384 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU offload pass for activation offloading in graph_trainer.
+
+Uses upstream custom ops (ao::offload, ao::reload, ao::wait_tensor) from
+``torch._functorch._activation_offloading.offload_ops`` for async GPU<->CPU
+transfers with event-based synchronization, and graph passes that insert
+them around saved activations to reduce GPU memory.
+
+Offload pattern (forward):
+    cpu = ao.offload(gpu_tensor)
+    ... forward consumers use gpu_tensor ...
+    cpu = ao.wait_tensor(cpu, keepalive=gpu_tensor)
+
+Reload pattern (backward):
+    gpu = ao.reload(cpu, device)
+    gpu = ao.wait_tensor(gpu)
+    ... backward consumers use gpu ...
+
+This module works with the make_fx traced joint fwd+bwd graph, using
+``meta["custom"]["module_fqn"]`` for layer boundaries and
+``meta["autograd_backward"]`` to distinguish forward from backward nodes.
+"""
+
+import operator
+
+import torch
+
+# Import upstream custom ops for async activation offloading.
+# Registering the ops is a side-effect of importing the module.
+import torch._functorch._activation_offloading.offload_ops  # noqa: F401
+import torch.fx
+from torch.fx import Node
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
+    _is_backward_node,
+    _NOT_IN_LAYERS,
+)
+from torchtitan.tools.logging import logger
+
+aten = torch.ops.aten
+
+
+# ============================================================
+# Node eligibility
+# ============================================================
+
+# View ops by overloadpacket -- matches all overloads (e.g. aten.view.default,
+# aten.view.dtype). Views share storage with input, so offloading doesn't free
+# the base tensor's memory.
+_VIEW_OPS = frozenset(
+    {
+        aten.t,
+        aten.transpose,
+        aten.view,
+        aten.reshape,
+        aten.unsqueeze,
+        aten.squeeze,
+        aten.slice,
+        aten.select,
+        aten.expand,
+        aten.permute,
+        aten.as_strided,
+        aten.alias,
+        aten.split,
+    }
+)
+
+_MIN_OFFLOAD_BYTES = 4096  # 4 KB minimum to justify offload overhead
+
+
+def _get_aten_target(node: Node) -> object:
+    """Get the overloadpacket for an aten op node, for overload-agnostic matching."""
+    target = node.target
+    if hasattr(target, "overloadpacket"):
+        return target.overloadpacket
+    return target
+
+
+def _is_view(node: Node) -> bool:
+    """Check if a node produces a view (aliased memory, not a new allocation)."""
+    return _get_aten_target(node) in _VIEW_OPS
+
+
+def _is_collective_or_wait(node: Node) -> bool:
+    """Check if a node is a distributed collective or wait op."""
+    target = node.target
+    ns = getattr(target, "namespace", None)
+    return ns == "_c10d_functional"
+
+
+def _tensor_is_contiguous(val: torch.Tensor) -> bool:
+    """Check contiguity, handling symbolic FakeTensors gracefully."""
+    try:
+        return bool(val.is_contiguous())
+    except Exception:
+        # Symbolic shapes can't be evaluated statically; assume contiguous
+        return True
+
+
+def _tensor_bytes(val: torch.Tensor) -> int:
+    """Get tensor size in bytes, handling symbolic FakeTensors gracefully."""
+    try:
+        nbytes = val.nelement() * val.element_size()
+        # Force evaluation to a concrete int; symbolic expressions may
+        # raise GuardOnDataDependentSymNode when compared with <.
+        return int(nbytes)
+    except Exception:
+        # Symbolic shapes can't be evaluated; assume large enough
+        return _MIN_OFFLOAD_BYTES
+
+
+def _has_offloadable_tensor(node: Node) -> bool:
+    """Check if a node produces a tensor worth offloading (large, contiguous)."""
+    val = node.meta.get("val")
+    if not isinstance(val, torch.Tensor):
+        return False
+    if not _tensor_is_contiguous(val):
+        return False
+    if _tensor_bytes(val) < _MIN_OFFLOAD_BYTES:
+        return False
+    return True
+
+
+def _can_offload_node(node: Node) -> bool:
+    """Check if a node's output can be profitably offloaded to CPU.
+
+    Excludes views (offloading doesn't free base tensor memory), small tensors
+    (overhead exceeds benefit), non-contiguous tensors, and collective/wait ops.
+
+    getitem nodes are allowed -- they unpack multi-output ops and produce
+    real tensors, not views.
+    """
+    if node.op != "call_function":
+        return False
+    if node.target is operator.getitem:
+        return _has_offloadable_tensor(node)
+    if _is_view(node):
+        return False
+    if _is_collective_or_wait(node):
+        return False
+    return _has_offloadable_tensor(node)
+
+
+# ============================================================
+# Forward/backward node classification for make_fx traced graphs
+# ============================================================
+
+
+def _classify_forward_backward(
+    gm: torch.fx.GraphModule,
+) -> tuple[set[Node], set[Node]]:
+    """Classify nodes in a make_fx traced joint graph as forward or backward.
+
+    Uses ``autograd_backward`` metadata set by PyTorch's autograd engine during
+    make_fx tracing.
+
+    Returns:
+        Tuple of (forward_nodes, backward_nodes).
+    """
+    forward_nodes: set[Node] = set()
+    backward_nodes: set[Node] = set()
+
+    for node in gm.graph.nodes:
+        if node.op not in ("call_function", "get_attr"):
+            continue
+        if _is_backward_node(node):
+            backward_nodes.add(node)
+        else:
+            forward_nodes.add(node)
+
+    return forward_nodes, backward_nodes
+
+
+# ============================================================
+# Tagging pass
+# ============================================================
+
+
+def tag_all_offloadable_activations(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Tag all saved activations eligible for CPU offloading.
+
+    This is a reference implementation that offloads all offloadable
+    activations. In practice, users should tag activations via annotations
+    or graph passes for more fine-grained control over which activations
+    are offloaded.
+
+    Sets ``node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD`` on
+    eligible nodes. Eligibility requires:
+      1. Node is a forward node (not ``autograd_backward``)
+      2. Node has a layer index derivable from ``meta["custom"]["module_fqn"]``
+      3. Passes ``_can_offload_node`` (not a view, not tiny, etc.)
+      4. Has at least one backward consumer
+
+    The last layer is skipped when multiple layers exist, since its activations
+    are consumed immediately in backward (offloading adds overhead with no
+    benefit).
+
+    Args:
+        gm: The GraphModule containing the full fwd+bwd graph.
+        example_inputs: Example inputs (unused, required by graph pass interface).
+
+    Returns:
+        The GraphModule with eligible nodes tagged for offload.
+    """
+    forward_nodes, _ = _classify_forward_backward(gm)
+
+    # Find all layer IDs to determine the last layer
+    all_layer_ids: set[int] = set()
+    for node in gm.graph.nodes:
+        lid = _get_layer_id(node)
+        if lid != _NOT_IN_LAYERS:
+            all_layer_ids.add(lid)
+    last_layer_id = max(all_layer_ids) if len(all_layer_ids) > 1 else _NOT_IN_LAYERS
+
+    tagged = 0
+    total_bytes = 0
+
+    for node in gm.graph.nodes:
+        if node not in forward_nodes:
+            continue
+        layer_id = _get_layer_id(node)
+        # Skip the last layer: its activations are consumed immediately in
+        # backward, so offloading adds overhead with no memory benefit.
+        if layer_id == _NOT_IN_LAYERS or layer_id == last_layer_id:
+            continue
+        if not _can_offload_node(node):
+            continue
+
+        # Check for backward consumers
+        has_backward_users = any(_is_backward_node(u) for u in node.users)
+        if not has_backward_users:
+            continue
+
+        node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD
+        tagged += 1
+        total_bytes += _tensor_bytes(node.meta["val"])
+
+    logger.info(
+        f"CPU offload: tagged {tagged} activations for offload "
+        f"({total_bytes / 1024 / 1024:.2f} MB)"
+    )
+    return gm
+
+
+# ============================================================
+# Graph passes
+# ============================================================
+
+
+def apply_cpu_offload_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Insert ao offload/reload/wait_tensor ops for nodes tagged ``MUST_CPU_OFFLOAD``.
+
+    Reads ``node.meta["recompute"] is CheckpointPolicy.MUST_CPU_OFFLOAD`` (set by
+    ``tag_all_offloadable_activations``) and inserts:
+      Forward:  cpu = ao.offload(gpu_tensor)
+                cpu = ao.wait_tensor(cpu, keepalive=gpu_tensor)
+      Backward: gpu = ao.reload(cpu, device)
+                gpu = ao.wait_tensor(gpu)
+    Then redirects backward consumers to use the reloaded tensor.
+
+    The reload device is inferred from the original tensor's device
+    (from ``node.meta["val"].device``) before offloading.
+
+    Args:
+        gm: The GraphModule containing the full fwd+bwd graph.
+        example_inputs: Example inputs (unused, required by graph pass interface).
+
+    Returns:
+        The transformed GraphModule with offload/reload ops inserted.
+    """
+    # 1. Collect nodes tagged for offload, with their backward consumers
+    offloadable: list[tuple[Node, list[Node]]] = []
+    for node in gm.graph.nodes:
+        if node.meta.get("recompute") is not CheckpointPolicy.MUST_CPU_OFFLOAD:
+            continue
+        bwd_users = [u for u in node.users if _is_backward_node(u)]
+        if not bwd_users:
+            continue
+        offloadable.append((node, bwd_users))
+
+    if not offloadable:
+        return gm
+
+    # 2. Build position index for ordering queries (only used for pre-existing
+    # nodes; newly inserted nodes never appear in bwd_users).
+    node_to_index: dict[Node, int] = {n: i for i, n in enumerate(gm.graph.nodes)}
+
+    # 3. Insert offload/reload/wait_tensor ops
+    total_bytes = 0
+
+    for node, bwd_users in offloadable:
+        val = node.meta.get("val")
+        assert (
+            val is not None
+        ), f"Node {node.name} tagged for offload has no 'val' metadata"
+
+        device = val.device
+
+        # --- Forward: async GPU->CPU offload right after production ---
+        with gm.graph.inserting_after(node):
+            offload_node = gm.graph.call_function(
+                torch.ops.ao.offload.default,
+                args=(node,),
+            )
+            offload_node.meta["val"] = val.to(torch.device("cpu"))
+
+        # --- Forward: wait_tensor for D2H completion (initially after offload) ---
+        with gm.graph.inserting_after(offload_node):
+            wait_offload_node = gm.graph.call_function(
+                torch.ops.ao.wait_tensor.default,
+                args=(offload_node, node),
+            )
+            wait_offload_node.meta["val"] = offload_node.meta["val"]
+
+        # --- Backward: async CPU->GPU reload + wait before first consumer ---
+        first_consumer = min(bwd_users, key=lambda n: node_to_index[n])
+
+        with gm.graph.inserting_before(first_consumer):
+            reload_node = gm.graph.call_function(
+                torch.ops.ao.reload.default,
+                args=(wait_offload_node, device),
+            )
+            reload_node.meta["val"] = val
+            reload_node.meta["autograd_backward"] = True
+
+        with gm.graph.inserting_before(first_consumer):
+            wait_node = gm.graph.call_function(
+                torch.ops.ao.wait_tensor.default,
+                args=(reload_node,),
+            )
+            wait_node.meta["val"] = val
+            wait_node.meta["autograd_backward"] = True
+
+        # Redirect backward consumers to the reloaded tensor
+        for user in bwd_users:
+            user.replace_input_with(node, wait_node)
+
+        logger.debug(
+            f"CPU offload: offloading {node.name} "
+            f"({_tensor_bytes(val) / 1024:.1f} KB, {val.shape})"
+        )
+        total_bytes += _tensor_bytes(val)
+
+    gm.graph.lint()
+    gm.recompile()
+    logger.info(
+        f"CPU offload: offloaded {len(offloadable)} tensors "
+        f"({total_bytes / 1024 / 1024:.2f} MB)"
+    )
+    return gm
+
+
+def cpu_offload_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Two-phase CPU offload pass: tag eligible activations, then insert ops.
+
+    This is the top-level entry point conforming to the graph pass signature.
+    It first tags eligible activations with ``tag_all_offloadable_activations``,
+    then inserts offload/reload/wait ops with ``apply_cpu_offload_pass``.
+
+    Args:
+        gm: The GraphModule containing the full fwd+bwd graph.
+        example_inputs: Example inputs (unused, required by pass interface).
+
+    Returns:
+        The transformed GraphModule with offload/reload ops inserted.
+    """
+    tag_all_offloadable_activations(gm)
+    return apply_cpu_offload_pass(gm, example_inputs)

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -37,7 +37,13 @@ from torch.fx.passes.regional_inductor import regional_inductor
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.distributed.activation_checkpoint import _get_save_ops
-from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
+    _is_backward_node,
+    _MODULE_FQN,
+    _NOT_IN_LAYERS,
+)
+from torchtitan.experiments.graph_trainer.cpu_offload import cpu_offload_pass
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
@@ -53,12 +59,6 @@ from torchtitan.experiments.graph_trainer.reshard_after_forward import (
     annotate_fsdp_all_gather,
 )
 from torchtitan.tools.logging import logger
-
-_NOT_IN_LAYERS = -1
-
-
-def _is_backward_node(node: torch.fx.Node) -> bool:
-    return node.meta.get("autograd_backward", False)
 
 
 def compile_time_passes(
@@ -86,6 +86,8 @@ def compile_time_passes(
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
+        # TODO: uncomment after sorting out common tagging API between offload and sac
+        # cpu_offload_pass,
         selective_activation_remat_pass,
         # TODO: bucketing is failing for DSv3, allgather prefetching
         # for Llama3 is not working.
@@ -610,22 +612,6 @@ def annotate_flex_attention_for_regional_inductor_pass(
     return gm
 
 
-def _get_layer_id(node: torch.fx.Node) -> int:
-    """Extract the layer index from the node's module_fqn metadata.
-
-    Nodes under ``layers.<N>`` return ``N``.
-    All other nodes (tok_embeddings, norm, output) return ``_NOT_IN_LAYERS``.
-    """
-    fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
-    parts = fqn.split(".")
-    if parts[0] == "layers" and len(parts) >= 2:
-        try:
-            return int(parts[1])
-        except ValueError:
-            pass
-    return _NOT_IN_LAYERS
-
-
 def apply_sac_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
@@ -989,4 +975,5 @@ AVAILABLE_JOINT_PASSES = {
     "inductor_decomposition": inductor_decomposition_pass,
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
     "apply_sac": apply_sac_pass,
+    "cpu_offload": cpu_offload_pass,
 }

--- a/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.testing._internal.common_utils import TestCase
+from torch.utils.checkpoint import CheckpointPolicy
+
+
+class TestCpuOffloadPass(TestCase):
+    """Unit tests for the CPU offload pass on synthetic FX graphs.
+
+    Tests use hand-built graphs that simulate the joint fwd+bwd structure
+    produced by make_fx, with ``autograd_backward`` for forward/backward
+    classification and ``module_fqn`` for layer boundaries.
+    """
+
+    def _make_fake_val(self, shape=(64, 64), dtype=torch.float32, device="cuda:0"):
+        """Create a real tensor for use as node.meta["val"].
+
+        The offload pass reads .nelement(), .element_size(), .is_contiguous(),
+        .device, and .to() from node metadata values.
+        """
+        return torch.empty(shape, dtype=dtype, device=device)
+
+    def _build_joint_graph(self, num_layers=3, ops_per_layer=2):
+        """Build a synthetic joint fwd+bwd graph with layer annotations.
+
+        Structure per layer:
+          Forward: mm -> relu
+          Backward: mm_bwd -> relu_bwd
+
+        All nodes get ``module_fqn = "layers.<layer_id>.block"`` in their custom
+        metadata. Backward nodes have ``autograd_backward = True``.
+
+        Forward mm nodes have backward consumers (relu_bwd uses fwd mm output),
+        making them eligible for offloading.
+
+        Returns:
+            (gm, fwd_nodes, bwd_nodes) where fwd/bwd_nodes are lists of nodes
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        fwd_nodes = []
+        bwd_nodes = []
+        last_fwd = x
+
+        # Forward pass: layer 0 -> layer N-1
+        for layer_id in range(num_layers):
+            for op_idx in range(ops_per_layer):
+                if op_idx == 0:
+                    node = graph.call_function(
+                        torch.ops.aten.mm.default, args=(last_fwd, last_fwd)
+                    )
+                else:
+                    node = graph.call_function(
+                        torch.ops.aten.relu.default, args=(last_fwd,)
+                    )
+                node.meta["autograd_backward"] = False
+                node.meta["custom"] = {"module_fqn": f"layers.{layer_id}.block"}
+                node.meta["val"] = self._make_fake_val()
+                fwd_nodes.append(node)
+                last_fwd = node
+
+        # Backward pass: layer N-1 -> layer 0
+        last_bwd = last_fwd
+        for layer_id in reversed(range(num_layers)):
+            for op_idx in reversed(range(ops_per_layer)):
+                # Backward node: uses the corresponding forward node's output
+                fwd_idx = layer_id * ops_per_layer + op_idx
+                fwd_node = fwd_nodes[fwd_idx]
+                node = graph.call_function(
+                    torch.ops.aten.mm.default, args=(last_bwd, fwd_node)
+                )
+                node.meta["autograd_backward"] = True
+                node.meta["custom"] = {"module_fqn": f"layers.{layer_id}.block"}
+                node.meta["val"] = self._make_fake_val()
+                bwd_nodes.append(node)
+                last_bwd = node
+
+        graph.output(last_bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        return gm, fwd_nodes, bwd_nodes
+
+    def test_tag_all_offloadable_activations_basic(self):
+        """Forward nodes with backward consumers should be tagged MUST_CPU_OFFLOAD."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        gm, fwd_nodes, bwd_nodes = self._build_joint_graph(num_layers=3)
+        tag_all_offloadable_activations(gm)
+
+        # Last layer (layer 2) should NOT be tagged (skipped)
+        # Layers 0 and 1 should have some tagged nodes
+        tagged_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        ]
+        self.assertGreater(len(tagged_nodes), 0, "Expected some nodes to be tagged")
+
+        # Verify no last-layer nodes are tagged
+        for node in tagged_nodes:
+            fqn = node.meta.get("custom", {}).get("module_fqn", "")
+            self.assertNotIn(
+                "layers.2", fqn, "Last layer nodes should not be tagged for offload"
+            )
+
+    def test_tag_no_backward_consumers(self):
+        """Forward nodes without backward consumers should NOT be tagged."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        # Build a graph with only forward nodes (no backward)
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        node1 = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        node1.meta["autograd_backward"] = False
+        node1.meta["custom"] = {"module_fqn": "layers.0.block"}
+        node1.meta["val"] = self._make_fake_val()
+
+        node2 = graph.call_function(torch.ops.aten.relu.default, args=(node1,))
+        node2.meta["autograd_backward"] = False
+        node2.meta["custom"] = {"module_fqn": "layers.0.block"}
+        node2.meta["val"] = self._make_fake_val()
+
+        graph.output(node2)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+
+        tagged = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        ]
+        self.assertEqual(
+            len(tagged), 0, "No nodes should be tagged without bwd consumers"
+        )
+
+    def test_offload_pass_noop_when_no_tags(self):
+        """cpu_offload_pass should be a no-op when no nodes are tagged."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import cpu_offload_pass
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+        node = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        node.meta["val"] = self._make_fake_val()
+        graph.output(node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        node_count_before = len(list(gm.graph.nodes))
+        gm = cpu_offload_pass(gm)
+        node_count_after = len(list(gm.graph.nodes))
+
+        self.assertEqual(
+            node_count_before, node_count_after, "No-op pass should not add nodes"
+        )
+
+    def test_offload_reload_ops_inserted(self):
+        """Verify offload/reload/wait_tensor ops are inserted for tagged nodes."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        gm, fwd_nodes, bwd_nodes = self._build_joint_graph(num_layers=3)
+        tag_all_offloadable_activations(gm)
+
+        # Count tagged nodes before applying offload pass
+        tagged_count = sum(
+            1
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        )
+        self.assertGreater(tagged_count, 0)
+
+        gm = apply_cpu_offload_pass(gm)
+
+        # Verify offload, reload, and wait_tensor ops were inserted
+        offload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.offload.default
+        ]
+        reload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.reload.default
+        ]
+        wait_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.wait_tensor.default
+        ]
+
+        self.assertGreater(len(offload_ops), 0, "Expected offload ops")
+        self.assertGreater(len(reload_ops), 0, "Expected reload ops")
+        # Each offloaded tensor gets 2 waits: one for offload, one for reload
+        self.assertEqual(
+            len(wait_ops),
+            len(offload_ops) + len(reload_ops),
+            "Each offload/reload should have a matching wait_tensor",
+        )
+
+    def test_view_ops_not_tagged(self):
+        """View ops should never be tagged for offload."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        # Forward: mm -> view (layer 0)
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = self._make_fake_val()
+
+        view = graph.call_function(torch.ops.aten.view.default, args=(mm, [64, 64]))
+        view.meta["autograd_backward"] = False
+        view.meta["custom"] = {"module_fqn": "layers.0.block"}
+        view.meta["val"] = self._make_fake_val()
+
+        # Forward layer 1 to avoid single-layer skip
+        mm2 = graph.call_function(torch.ops.aten.mm.default, args=(view, view))
+        mm2.meta["autograd_backward"] = False
+        mm2.meta["custom"] = {"module_fqn": "layers.1.block"}
+        mm2.meta["val"] = self._make_fake_val()
+
+        # Backward: uses view output
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(mm2, view))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
+        bwd.meta["val"] = self._make_fake_val()
+
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+
+        # The view node should not be tagged
+        view_node = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.aten.view.default
+        ]
+        self.assertEqual(len(view_node), 1)
+        self.assertIsNot(
+            view_node[0].meta.get("recompute"),
+            CheckpointPolicy.MUST_CPU_OFFLOAD,
+            "View ops should not be tagged for offload",
+        )
+
+    def test_small_tensors_not_tagged(self):
+        """Tensors smaller than _MIN_OFFLOAD_BYTES should not be tagged."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        # Small tensor: 2x2 float32 = 16 bytes < 4096
+        small_val = self._make_fake_val(shape=(2, 2))
+        x.meta["val"] = small_val
+
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = small_val
+
+        mm2 = graph.call_function(torch.ops.aten.mm.default, args=(mm, mm))
+        mm2.meta["autograd_backward"] = False
+        mm2.meta["custom"] = {"module_fqn": "layers.1.block"}
+        mm2.meta["val"] = small_val
+
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(mm2, mm))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
+        bwd.meta["val"] = small_val
+
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+
+        tagged = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        ]
+        self.assertEqual(len(tagged), 0, "Small tensors should not be tagged")
+
+    def test_single_layer_tagged(self):
+        """With only one layer, nodes are still tagged (last-layer skip only applies with multiple layers)."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        gm, _, _ = self._build_joint_graph(num_layers=1)
+        tag_all_offloadable_activations(gm)
+
+        tagged = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        ]
+        self.assertGreater(
+            len(tagged), 0, "Single layer nodes can be tagged (last_layer_id=None)"
+        )

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -39,6 +39,12 @@ from torchtitan.experiments.graph_trainer.passes import (
     remove_identity_view_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.experiments.graph_trainer.tests.test_cpu_offload import (  # noqa: F401
+    TestCpuOffloadPass,
+)
+from torchtitan.experiments.graph_trainer.tests.test_custom_codegen import (  # noqa: F401
+    TestCustomCodegenPass,
+)
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleList
 
@@ -265,7 +271,10 @@ class TestApplySACPass(TestCase):
                 # If the next op is getitem, wrap in a tuple so getitem has
                 # a proper tuple/list input.
                 if i + 1 < len(op_targets) and op_targets[i + 1] is operator.getitem:
-                    _make_tuple = lambda x: (x, x)
+
+                    def _make_tuple(x):
+                        return (x, x)
+
                     last = graph.call_function(_make_tuple, args=(last,))
         graph.output(last)
         return torch.fx.GraphModule(torch.nn.Module(), graph)
@@ -885,12 +894,6 @@ class TestRemoveIdentitySlicePass(TestCase):
         self.assertEqual(self._count_slice_nodes(gm), 2)
         remove_identity_slice_pass(gm)
         self.assertEqual(self._count_slice_nodes(gm), 0)
-
-
-# Import TestCustomCodegenPass so it's discoverable when running this file
-from torchtitan.experiments.graph_trainer.tests.test_custom_codegen import (  # noqa: F401
-    TestCustomCodegenPass,
-)
 
 
 class TestAnnotateModuleFqns(TestCase):


### PR DESCRIPTION
Actually landing https://github.com/pytorch/torchtitan/pull/3015 to main this time


Adds a graph-level CPU offload pass that asynchronously transfers activation tensors to CPU during forward and reloads them during backward, reducing peak GPU memory usage.

- Define offload/reload/wait_tensor op insertions using upstream torch._functorch._activation_offloading.offload_ops
- Use CheckpointPolicy.MUST_CPU_OFFLOAD from torch.utils.checkpoint
- Use meta["custom"]["ac_region_id"] as layer boundary markers and seq_nr for forward/backward node classification
- Skip view ops, small tensors (<4KB), collectives, and the last layer
- No-op when no nodes are tagged
- Handle symbolic FakeTensors (DSv3 MoE) gracefully
- Integrate into apply_default_graph_passes (make_fx path) and AVAILABLE_JOINT_PASSES registry (AOT path)
- 7 unit tests covering tagging, op insertion, edge cases, and no-op behavior

ghstack-source-id: f1489271fc39a128f138e8760b3263ead3637993
Pull Request resolved: https://github.com/pytorch/torchtitan/pull/3015