### PR TITLE
[rl] Remove call to get_model_state_dict in push_model_state_dict

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -410,14 +410,11 @@ class PolicyTrainer(Actor, Configurable):
         means "skip StorageVolumes and let the destination read directly
         from the source's GPU memory".
 
-        Uses get_model_state_dict() to unshard FSDP state before pushing.
         """
         from monarch.rdma import is_rdma_available
 
-        full_sd = get_model_state_dict(self.model)
-
         await ts.put_state_dict(
-            full_sd,
+            self.model.state_dict(),
             "model_state_dict",
             direct_rdma=is_rdma_available(),
             transfer_dtype=self._transfer_dtype,


### PR DESCRIPTION
The trainer refactor (#2985) changed push_model_state_dict to call get_model_state_dict() instead of `model.state_dict()`. While the end result of these calls are the same (returns sharded state_dict with DTensors), calling `get_model_state_dict` adds some overhead.

Average push time over 10 steps for Qwen3 0.6B:
with `get_model_state_dict()`: 0.0170s
with `model.state_dict()`: 0.008s

Revert to previous way of calling self.model.state_dict() directly.