### PR TITLE
[rl] Removed patched qwen3 parallel plan to core torchtitan Qwen3 parallel plan

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -43,7 +43,6 @@ import torch.distributed as dist
 
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
-from torchtitan.models.common.decoder import Decoder
 from torchtitan.experiments.graph_trainer.common_utils import (
     apply_graph_ac,
     parallelize_inputs,
@@ -66,6 +65,7 @@ from torchtitan.experiments.graph_trainer.precompile import (
     _FX_TRACE_ARTIFACT_KEY,
 )
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+from torchtitan.models.common.decoder import Decoder
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -43,6 +43,7 @@ import torch.distributed as dist
 
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
+from torchtitan.models.common.decoder import Decoder
 from torchtitan.experiments.graph_trainer.common_utils import (
     apply_graph_ac,
     parallelize_inputs,
@@ -65,7 +66,6 @@ from torchtitan.experiments.graph_trainer.precompile import (
     _FX_TRACE_ARTIFACT_KEY,
 )
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
-from torchtitan.models.common.decoder import Decoder
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -147,7 +147,7 @@ class VLLMGenerator(Actor, Configurable):
             # Generator only supports TP. vLLM handles its own parallelism
             # and we only apply TP via the core parallelize function.
             p = self.parallelism
-            if p.data_parallel_shard_degree not in (1, -1):
+            if p.data_parallel_shard_degree != 1:
                 raise ValueError(
                     f"Generator does not support data parallel sharding, "
                     f"got dp_shard={p.data_parallel_shard_degree}"

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -147,11 +147,6 @@ class VLLMGenerator(Actor, Configurable):
             # Generator only supports TP. vLLM handles its own parallelism
             # and we only apply TP via the core parallelize function.
             p = self.parallelism
-            if p.data_parallel_shard_degree != 1:
-                raise ValueError(
-                    f"Generator does not support data parallel sharding, "
-                    f"got dp_shard={p.data_parallel_shard_degree}"
-                )
             if p.data_parallel_replicate_degree != 1:
                 raise ValueError(
                     f"Generator does not support data parallel replication, "

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -144,14 +144,34 @@ class VLLMGenerator(Actor, Configurable):
         """Debug and determinism settings."""
 
         def __post_init__(self):
-            assert self.parallelism.data_parallel_shard_degree in (1, -1), (
-                f"Generator does not support data parallel sharding, "
-                f"got dp_shard={self.parallelism.data_parallel_shard_degree}"
-            )
-            assert self.parallelism.data_parallel_replicate_degree == 1, (
-                f"Generator does not support data parallel replication, "
-                f"got dp_replicate={self.parallelism.data_parallel_replicate_degree}"
-            )
+            # Generator only supports TP. vLLM handles its own parallelism
+            # and we only apply TP via the core parallelize function.
+            p = self.parallelism
+            if p.data_parallel_shard_degree not in (1, -1):
+                raise ValueError(
+                    f"Generator does not support data parallel sharding, "
+                    f"got dp_shard={p.data_parallel_shard_degree}"
+                )
+            if p.data_parallel_replicate_degree != 1:
+                raise ValueError(
+                    f"Generator does not support data parallel replication, "
+                    f"got dp_replicate={p.data_parallel_replicate_degree}"
+                )
+            if p.pipeline_parallel_degree > 1:
+                raise ValueError(
+                    f"Generator does not support pipeline parallelism, "
+                    f"got pp={p.pipeline_parallel_degree}"
+                )
+            if p.context_parallel_degree > 1:
+                raise ValueError(
+                    f"Generator does not support context parallelism, "
+                    f"got cp={p.context_parallel_degree}"
+                )
+            if p.expert_parallel_degree > 1:
+                raise ValueError(
+                    f"Generator does not support expert parallelism, "
+                    f"got ep={p.expert_parallel_degree}"
+                )
 
     def __init__(
         self,

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -30,6 +30,12 @@ from torchtitan.experiments.rl.sum_digits import SumDigitsEnv
 from torchtitan.models.qwen3 import model_registry
 
 
+# NOTE: All RL configs set disable_loss_parallel=True because:
+# - Trainer: compute_logprobs() calls F.log_softmax over full vocab,
+#   which requires unsharded logits (loss parallel would shard dim=-1).
+# - Generator: vLLM's sampler expects plain tensor logits for sampling.
+
+
 def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-0.6B (6 GPUs: 4 gen + 2 train)."""
     group_size = 8
@@ -51,6 +57,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             ),
             training=TrainingConfig(),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 disable_loss_parallel=True,
             ),
@@ -64,8 +71,10 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=4,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -98,6 +107,7 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
             ),
             training=TrainingConfig(),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 disable_loss_parallel=True,
             ),
@@ -111,8 +121,10 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=4,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -145,6 +157,7 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
             ),
             training=TrainingConfig(dtype="bfloat16"),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=8,
                 disable_loss_parallel=True,
             ),
@@ -158,8 +171,10 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=8,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -191,8 +206,10 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
             ),
             training=TrainingConfig(),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             compile=CompileConfig(enable=True, backend="aot_eager"),
             loss=GRPOLoss.Config(),
@@ -203,8 +220,10 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -243,6 +262,7 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
             # TODO: replace bfloat16 enablement with FSDP2+TP2
             training=TrainingConfig(dtype="bfloat16"),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 enable_sequence_parallel=False,
                 disable_loss_parallel=True,
@@ -258,8 +278,10 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
+                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -30,12 +30,6 @@ from torchtitan.experiments.rl.sum_digits import SumDigitsEnv
 from torchtitan.models.qwen3 import model_registry
 
 
-# NOTE: All RL configs set disable_loss_parallel=True because:
-# - Trainer: compute_logprobs() calls F.log_softmax over full vocab,
-#   which requires unsharded logits (loss parallel would shard dim=-1).
-# - Generator: vLLM's sampler expects plain tensor logits for sampling.
-
-
 def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-0.6B (6 GPUs: 4 gen + 2 train)."""
     group_size = 8
@@ -71,10 +65,8 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
                 tensor_parallel_degree=4,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -124,7 +116,6 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
                 data_parallel_shard_degree=1,
                 tensor_parallel_degree=4,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -171,10 +162,8 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
                 tensor_parallel_degree=8,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -209,7 +198,6 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 data_parallel_shard_degree=1,
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             compile=CompileConfig(enable=True, backend="aot_eager"),
             loss=GRPOLoss.Config(),
@@ -220,10 +208,8 @@ def rl_grpo_qwen3_debug() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
                 tensor_parallel_degree=1,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,
@@ -278,10 +264,8 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
                 cudagraph_mode="piecewise",
             ),
             parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 data_parallel_replicate_degree=1,
-                disable_loss_parallel=True,
             ),
             sampling=SamplingConfig(
                 n=group_size,

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -36,12 +36,6 @@ def generate():
     gen_config = config.generator
     model_path = config.hf_assets_path
 
-    # Patch model_spec to use the RL-specific parallelize function.
-    # TODO: Switch to canonical Qwen3 parallel plan
-    from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
-
-    config.model_spec.parallelize_fn = parallelize_qwen3
-
     # Register TorchTitan model with vLLM before engine creation
     from torchtitan.experiments.rl.models.vllm_registry import (
         register_model_to_vllm_model_registry,

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -416,15 +416,11 @@ class RLTrainer(Configurable):
             generator_dtype=config.generator.model_dtype,
         )
 
-        # Generator uses RL-specific parallelize (TP-only, no FSDP, vLLM-compatible)
-        from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
-
-        gen_model_spec = replace(config.model_spec, parallelize_fn=parallelize_qwen3)
         self.generator = generator_mesh.spawn(
             "generator",
             VLLMGenerator,
             config.generator,
-            model_spec=gen_model_spec,
+            model_spec=config.model_spec,
             model_path=config.hf_assets_path,
         )
 

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -27,7 +27,7 @@ import math
 import os
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 
 import torch
 import torchstore as ts

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -126,7 +126,7 @@ def create_torchtitan_config_from_vllm_config(
         pipeline_parallel_degree=parallel_config.pipeline_parallel_size,
         expert_parallel_degree=1,
         expert_tensor_parallel_degree=1,
-        disable_loss_parallel=True,   # vLLM handles sampling and expects plain tensor logits.
+        disable_loss_parallel=True,  # vLLM handles sampling and expects plain tensor logits.
     )
 
     logger.info(

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -221,14 +221,13 @@ class TorchTitanVLLMModelWrapper(Module):
 
         from torchtitan.config import DebugConfig, TrainingConfig
 
-        if hasattr(self.config, "update_from_config"):
-            self.config.update_from_config(
-                trainer_config=SimpleNamespace(
-                    training=TrainingConfig(),
-                    parallelism=parallelism,
-                    debug=DebugConfig(),
-                )
+        self.config.update_from_config(
+            trainer_config=SimpleNamespace(
+                training=TrainingConfig(),
+                parallelism=parallelism,
+                debug=DebugConfig(),
             )
+        )
 
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()
@@ -237,7 +236,7 @@ class TorchTitanVLLMModelWrapper(Module):
         self.rope_config = self.config.rope
 
         # Apply parallelism using the model's own parallelize function.
-        # AC and compile are explicitly disabled; inference=True skips FSDP.
+        # AC and compile are explicitly disabled; skip_dp=True skips FSDP.
         from torchtitan.config import ActivationCheckpointConfig, CompileConfig
         from torchtitan.protocols.model_converter import ModelConvertersContainer
 
@@ -250,7 +249,7 @@ class TorchTitanVLLMModelWrapper(Module):
             compile_config=CompileConfig(enable=False),
             ac_config=ActivationCheckpointConfig(mode="none"),
             dump_folder="",
-            inference=True,
+            skip_dp=True,
         )
 
         # Pre-extend RoPE cache to cover vLLM's max model length (profiling

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -126,6 +126,7 @@ def create_torchtitan_config_from_vllm_config(
         pipeline_parallel_degree=parallel_config.pipeline_parallel_size,
         expert_parallel_degree=1,
         expert_tensor_parallel_degree=1,
+        disable_loss_parallel=True,   # vLLM handles sampling and expects plain tensor logits.
     )
 
     logger.info(

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -218,14 +218,26 @@ class TorchTitanVLLMModelWrapper(Module):
             vllm_config
         )
 
-        # NOTE: We need to apply parallelize within model.__init__ because vllm
-        # doesn't separate model creation and parallelism application and instead
-        # requires parallelization to be done inside model constructor.
-        self.model = self.parallelize_fn(
-            model=self.model,
+        # Apply parallelism using the model's own parallelize function.
+        # Pass no-op defaults for training-only args (FSDP, AC, compile)
+        # so the core function skips those features.
+        from torchtitan.config import (
+            ActivationCheckpointConfig,
+            CompileConfig,
+            TrainingConfig,
+        )
+        from torchtitan.protocols.model_converter import ModelConvertersContainer
+
+        self.parallelize_fn(
+            self.model,
             parallel_dims=self.parallel_dims,
+            training=TrainingConfig(),
+            model_converters=ModelConvertersContainer.Config(),
             parallelism=parallelism,
-            has_position_id=True,  # vLLM always passes positions explicitly
+            compile_config=CompileConfig(),
+            ac_config=ActivationCheckpointConfig(),
+            dump_folder="",
+            inference=True,
         )
 
         # Pre-extend RoPE cache to cover vLLM's max model length (profiling

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -127,6 +127,7 @@ def create_torchtitan_config_from_vllm_config(
         expert_parallel_degree=1,
         expert_tensor_parallel_degree=1,
         disable_loss_parallel=True,  # vLLM handles sampling and expects plain tensor logits.
+        enable_sequence_parallel=False,
     )
 
     logger.info(
@@ -206,27 +207,38 @@ class TorchTitanVLLMModelWrapper(Module):
         self.config = dataclasses.replace(model_config, layers=new_layers)
         logger.debug(f"Creating model with config: {self.config.to_dict()}")
 
+        # Create ParallelDims and configs from vLLM config at runtime.
+        self.parallel_dims, parallelism = create_torchtitan_config_from_vllm_config(
+            vllm_config
+        )
+
+        # Fill sharding configs on the config BEFORE build so every sub-module
+        # is constructed with its ShardingConfig attached (required by the
+        # declarative model.parallelize() API).
+        # TODO: Refactor update_from_config to accept ParallelismConfig
+        # directly instead of requiring a trainer_config wrapper.
+        from types import SimpleNamespace
+
+        from torchtitan.config import DebugConfig, TrainingConfig
+
+        if hasattr(self.config, "update_from_config"):
+            self.config.update_from_config(
+                trainer_config=SimpleNamespace(
+                    training=TrainingConfig(),
+                    parallelism=parallelism,
+                    debug=DebugConfig(),
+                )
+            )
+
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()
 
         # RoPE config from model for cache extension
         self.rope_config = self.config.rope
 
-        # Create ParallelDims and configs from vLLM config at runtime.
-        # vLLM config contains the tensor_parallel_size from command-line args
-        # and this will be consistent across all worker processes.
-        self.parallel_dims, parallelism = create_torchtitan_config_from_vllm_config(
-            vllm_config
-        )
-
         # Apply parallelism using the model's own parallelize function.
-        # Pass no-op defaults for training-only args (FSDP, AC, compile)
-        # so the core function skips those features.
-        from torchtitan.config import (
-            ActivationCheckpointConfig,
-            CompileConfig,
-            TrainingConfig,
-        )
+        # AC and compile are explicitly disabled; inference=True skips FSDP.
+        from torchtitan.config import ActivationCheckpointConfig, CompileConfig
         from torchtitan.protocols.model_converter import ModelConvertersContainer
 
         self.parallelize_fn(
@@ -235,8 +247,8 @@ class TorchTitanVLLMModelWrapper(Module):
             training=TrainingConfig(),
             model_converters=ModelConvertersContainer.Config(),
             parallelism=parallelism,
-            compile_config=CompileConfig(),
-            ac_config=ActivationCheckpointConfig(),
+            compile_config=CompileConfig(enable=False),
+            ac_config=ActivationCheckpointConfig(mode="none"),
             dump_folder="",
             inference=True,
         )
@@ -379,6 +391,10 @@ class TorchTitanVLLMModelWrapper(Module):
             )
 
         logits = self.model.lm_head(hidden_states)
+
+        # Full DTensor path returns logits as DTensor; vLLM expects plain tensors.
+        if isinstance(logits, DTensor):
+            logits = logits.to_local()
 
         return logits
 

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -118,8 +118,8 @@ def build_trainer_model(
         training=config.trainer.training,
         model_converters=ModelConvertersContainer.Config(),
         parallelism=parallelism,
-        compile_config=CompileConfig(),
-        ac_config=ActivationCheckpointConfig(),
+        compile_config=CompileConfig(enable=False),
+        ac_config=ActivationCheckpointConfig(mode="none"),
         dump_folder="",
     )
     model.to_empty(device=device_type)

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -54,7 +54,6 @@ from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.utils import set_batch_invariance
 from torchtitan.experiments.rl.config_registry import rl_grpo_qwen3_0_6b_batch_invariant
 from torchtitan.experiments.rl.grpo import RLTrainer
-from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
 from torchtitan.experiments.rl.models.vllm_registry import (
     register_model_to_vllm_model_registry,
     VLLM_MODEL_NAME,
@@ -110,8 +109,18 @@ def build_trainer_model(
         with utils.set_default_dtype(TORCH_DTYPE_MAP[config.trainer.training.dtype]):
             model = model_spec.model.build()
 
-    model = parallelize_qwen3(
-        model, parallel_dims=parallel_dims, parallelism=parallelism
+    from torchtitan.config import ActivationCheckpointConfig, CompileConfig
+    from torchtitan.protocols.model_converter import ModelConvertersContainer
+
+    model_spec.parallelize_fn(
+        model,
+        parallel_dims=parallel_dims,
+        training=config.trainer.training,
+        model_converters=ModelConvertersContainer.Config(),
+        parallelism=parallelism,
+        compile_config=CompileConfig(),
+        ac_config=ActivationCheckpointConfig(),
+        dump_folder="",
     )
     model.to_empty(device=device_type)
     with torch.no_grad():
@@ -415,7 +424,6 @@ class TestBitwiseParity(unittest.TestCase):
         if not dist.is_initialized():
             dist_utils.init_distributed(CommConfig())
 
-        config.model_spec.parallelize_fn = parallelize_qwen3
         register_model_to_vllm_model_registry(config.model_spec)
 
         # Test runs trainer and generator in the same process, so limit

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -73,11 +73,6 @@ def parallelize_qwen3(
             pad_multiple=find_pad_multiple(model_converters.converters),
         )
 
-    # Skip FSDP, AC, and compile for inference. FSDP is incompatible
-    # with torch.inference_mode() and unnecessary for inference.
-    if inference:
-        return model
-
     if ac_config.mode != "none":
         apply_ac(
             model,
@@ -89,6 +84,11 @@ def parallelize_qwen3(
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
         apply_compile(model, compile_config)
+
+    # Skip FSDP for inference. FSDP's forward hooks are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if inference:
+        return model
 
     dp_mesh_names = (
         ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -36,6 +36,7 @@ def parallelize_qwen3(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointConfig,
     dump_folder: str,
+    inference: bool = False,
 ):
     assert (
         training.seq_len % parallel_dims.seq_len_divisor == 0
@@ -71,6 +72,11 @@ def parallelize_qwen3(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             pad_multiple=find_pad_multiple(model_converters.converters),
         )
+
+    # Skip FSDP, AC, and compile for inference. FSDP is incompatible
+    # with torch.inference_mode() and unnecessary for inference.
+    if inference:
+        return model
 
     if ac_config.mode != "none":
         apply_ac(

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -36,7 +36,7 @@ def parallelize_qwen3(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointConfig,
     dump_folder: str,
-    inference: bool = False,
+    skip_dp: bool = False,
 ):
     assert (
         training.seq_len % parallel_dims.seq_len_divisor == 0
@@ -85,9 +85,10 @@ def parallelize_qwen3(
     if model_compile_enabled:
         apply_compile(model, compile_config)
 
-    # Skip FSDP for inference. FSDP's forward hooks are incompatible with torch.inference_mode() used by vLLM.
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
     # AC and compile are disabled via config (mode="none", enable=False).
-    if inference:
+    if skip_dp:
         return model
 
     dp_mesh_names = (


### PR DESCRIPTION
As titled. 


We need to skip FSDP because FSDP's forward hooks (unshard/reshard) use in-place operations that conflict with torch.inference_mode(). vLLM runs the model forward under @torch.inference_mode() during KV cache profiling and generation. 

Also inference don't need mixed precision (now) because all computation / weights are in bf16
