### PR TITLE
[GraphTrainer][AutoDev] ILP-based SAC policy for optimal activation checkpointing

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -46,6 +46,14 @@ class GraphTrainerCompileConfig(CompileConfig):
     enable_cudagraph: bool = True
     """When False, skip the cudagraph pass even if the graph is compatible."""
 
+    memory_budget: float = 0.5
+    """
+    Memory budget for ILP-based SAC (selective activation checkpointing).
+    Only used when "apply_ilp_sac" is in compile.joint_passes. Controls
+    the fraction of total activation memory that can be saved (0.0-1.0).
+    0.0 = recompute everything, 1.0 = save everything.
+    """
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -582,7 +582,14 @@ def get_joint_custom_passes_from_config(
         if pass_name == "inductor_decomposition":
             continue
 
-        joint_custom_passes.append(AVAILABLE_JOINT_PASSES[pass_name])
+        pass_fn = AVAILABLE_JOINT_PASSES[pass_name]
+
+        # Bind per-pass config parameters via functools.partial
+        if pass_name == "apply_ilp_sac":
+            memory_budget = getattr(compile_config, "memory_budget", 0.5)
+            pass_fn = functools.partial(pass_fn, memory_budget=memory_budget)
+
+        joint_custom_passes.append(pass_fn)
 
     if joint_pass_names:
         logger.info(f"Using joint passes from config: {joint_pass_names}")

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -724,6 +724,110 @@ def apply_sac_pass(
     return gm
 
 
+def apply_ilp_sac_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    memory_budget: float = 0.5,
+) -> torch.fx.GraphModule:
+    """Apply ILP-based selective activation checkpointing on the joint graph.
+
+    Uses an Integer Linear Program to decide which activations to save vs
+    recompute, minimizing recomputation time subject to a memory budget.
+
+    After ILP tagging, the same boundary pass as ``apply_sac_pass`` forces
+    ``MUST_SAVE`` on recomputable nodes whose output crosses a layer boundary.
+
+    ``getitem`` / ``wait_tensor`` nodes inherit the parent's policy.
+
+    Requires PuLP (``pip install pulp``).
+
+    Args:
+        gm: The joint forward-backward graph module.
+        memory_budget: Fraction of total activation memory to allow (0.0-1.0).
+            0.0 = recompute everything, 1.0 = save everything.
+
+    Returns:
+        The annotated graph module.
+    """
+    from torchtitan.experiments.graph_trainer.sac_ilp import solve_ilp_policy
+
+    logger.info(f"Solving ILP for SAC policy with memory_budget={memory_budget:.2f}")
+    ilp_policies = solve_ilp_policy(gm, memory_budget)
+
+    layer_stats: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"save": 0, "recompute": 0}
+    )
+
+    # Pass 1: Tag each forward node with the ILP-computed policy.
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+
+        if _is_backward_node(node):
+            continue
+
+        if node.target in (
+            operator.getitem,
+            torch.ops._c10d_functional.wait_tensor.default,
+        ):
+            # Propagate from parent
+            parent = node.args[0]
+            if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
+                node.meta["recompute"] = parent.meta["recompute"]
+            continue
+
+        layer_id = _get_layer_id(node)
+
+        if node.name in ilp_policies:
+            policy = ilp_policies[node.name]
+        else:
+            # Nodes not in ILP (e.g. no backward consumers) default to recompute
+            policy = CheckpointPolicy.PREFER_RECOMPUTE
+
+        node.meta["recompute"] = policy
+        if policy == CheckpointPolicy.MUST_SAVE:
+            layer_stats[layer_id]["save"] += 1
+        else:
+            layer_stats[layer_id]["recompute"] += 1
+
+    # Pass 2: Force MUST_SAVE at layer boundaries (same as apply_sac_pass).
+    def _is_recomputable(n: torch.fx.Node) -> bool:
+        return n.meta.get("recompute") in (
+            CheckpointPolicy.PREFER_RECOMPUTE,
+            CheckpointPolicy.MUST_RECOMPUTE,
+        )
+
+    boundary_saves = 0
+    for node in gm.graph.nodes:
+        if _is_backward_node(node) or not _is_recomputable(node):
+            continue
+        node_layer_id = _get_layer_id(node)
+        for user in node.users:
+            if (
+                not _is_backward_node(user)
+                and _is_recomputable(user)
+                and _get_layer_id(user) > node_layer_id
+            ):
+                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+                boundary_saves += 1
+                break
+
+    gm.recompile()
+    logger.info(f"Applied ILP-based SAC pass (memory_budget={memory_budget:.2f}).")
+    if boundary_saves:
+        logger.info(f"  Forced {boundary_saves} nodes to MUST_SAVE at layer boundaries")
+    for layer_id in sorted(layer_stats):
+        stats = layer_stats[layer_id]
+        label = "non-layer" if layer_id == _NOT_IN_LAYERS else str(layer_id)
+        logger.info(
+            f"  Layer {label}: "
+            f"{stats['save']} MUST_SAVE, "
+            f"{stats['recompute']} PREFER_RECOMPUTE"
+        )
+    return gm
+
+
 def selective_activation_remat_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple | None = None
 ) -> torch.fx.GraphModule:
@@ -975,5 +1079,6 @@ AVAILABLE_JOINT_PASSES = {
     "inductor_decomposition": inductor_decomposition_pass,
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
     "apply_sac": apply_sac_pass,
+    "apply_ilp_sac": apply_ilp_sac_pass,
     "cpu_offload": cpu_offload_pass,
 }

--- a/torchtitan/experiments/graph_trainer/sac_ilp.py
+++ b/torchtitan/experiments/graph_trainer/sac_ilp.py
@@ -1,0 +1,393 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ILP-based selective activation checkpointing (SAC) policy.
+
+Formulates save-vs-recompute decisions as an Integer Linear Program (ILP):
+minimize total recomputation time subject to a memory budget. The solver
+runs once at compile time and produces a mapping from FX node name to
+``CheckpointPolicy``.
+
+Requires PuLP (``pip install pulp``) as an optional dependency.
+
+Design:
+    1. Scan the forward graph for activation nodes that have backward consumers.
+    2. Classify each node: view-like (always recompute), comm ops (always save),
+       random ops (always save), and general ops (candidates for ILP).
+    3. For candidate nodes, estimate memory cost and recomputation time from
+       shape metadata.
+    4. Solve per-layer ILP: minimize recomputation time subject to activation
+       memory <= budget.
+    5. Return a closure ``node_name -> CheckpointPolicy``.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections import defaultdict
+
+import torch
+import torch.fx
+from torch._functorch.partitioners import get_default_op_list
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
+    _is_backward_node,
+    _NOT_IN_LAYERS,
+)
+from torchtitan.tools.logging import logger
+
+# Op classification from upstream partitioner
+_OP_LIST = get_default_op_list()
+
+_VIEW_OPS = frozenset(_OP_LIST.view_ops)
+_RANDOM_OPS = frozenset(_OP_LIST.random_ops)
+_COMPUTE_INTENSIVE_OPS = frozenset(_OP_LIST.compute_intensive_ops)
+
+# Communication ops that should always be saved to avoid re-communication.
+_COMM_NAMESPACES = frozenset({"_c10d_functional"})
+
+
+def _get_overload_packet(target: object) -> object:
+    """Return the overloadpacket for overload-agnostic matching."""
+    if hasattr(target, "overloadpacket"):
+        return target.overloadpacket
+    return target
+
+
+def _is_view_op(node: torch.fx.Node) -> bool:
+    return _get_overload_packet(node.target) in _VIEW_OPS
+
+
+def _is_random_op(node: torch.fx.Node) -> bool:
+    return _get_overload_packet(node.target) in _RANDOM_OPS
+
+
+def _is_comm_op(node: torch.fx.Node) -> bool:
+    ns = getattr(node.target, "namespace", None)
+    return ns in _COMM_NAMESPACES
+
+
+def _is_compute_intensive_op(node: torch.fx.Node) -> bool:
+    return _get_overload_packet(node.target) in _COMPUTE_INTENSIVE_OPS
+
+
+def _tensor_bytes(val: torch.Tensor) -> int:
+    """Get tensor size in bytes, handling symbolic shapes gracefully."""
+    try:
+        return int(val.nelement() * val.element_size())
+    except Exception:
+        # Symbolic shapes (e.g. DSv3 MoE) may fail int() conversion
+        return 0
+
+
+def _estimate_recompute_cost(node: torch.fx.Node) -> float:
+    """Estimate relative recomputation cost for a node.
+
+    Uses a simple heuristic based on op type and output size:
+    - Compute-intensive ops (mm, bmm, sdpa, etc.): cost proportional to output
+      element count, scaled by a large multiplier reflecting their high FLOP cost.
+    - Elementwise / reduction ops: cost proportional to output element count.
+    - View-like ops: zero cost (they are free to recompute).
+    """
+    if _is_view_op(node):
+        return 0.0
+
+    val = node.meta.get("val")
+    if not isinstance(val, torch.Tensor):
+        return 0.0
+
+    try:
+        numel = int(val.nelement())
+    except Exception:
+        numel = 0
+
+    if numel == 0:
+        return 0.0
+
+    if _is_compute_intensive_op(node):
+        # mm/bmm/sdpa are ~100x more expensive per element than pointwise
+        return float(numel) * 100.0
+
+    # General elementwise / reduction ops
+    return float(numel)
+
+
+def _has_backward_consumer(node: torch.fx.Node) -> bool:
+    """Check if any user of this node is a backward node."""
+    return any(_is_backward_node(u) for u in node.users)
+
+
+# ============================================================
+# Node stats collection
+# ============================================================
+
+
+class _NodeStats:
+    """Per-node metadata for ILP formulation."""
+
+    __slots__ = ("name", "memory_bytes", "recompute_cost", "forced_policy")
+
+    def __init__(
+        self,
+        name: str,
+        memory_bytes: int,
+        recompute_cost: float,
+        forced_policy: CheckpointPolicy | None,
+    ):
+        self.name = name
+        self.memory_bytes = memory_bytes
+        self.recompute_cost = recompute_cost
+        self.forced_policy = forced_policy
+
+
+def _collect_node_stats(
+    gm: torch.fx.GraphModule,
+) -> dict[int, list[_NodeStats]]:
+    """Collect per-node stats grouped by layer ID.
+
+    Returns a dict mapping layer_id -> list of _NodeStats for nodes that
+    are forward call_function nodes with backward consumers (i.e., activations
+    that would be saved for backward).
+
+    Nodes with forced policies (views, comms, random ops) have
+    ``forced_policy`` set and are excluded from ILP optimization.
+    """
+    layer_stats: dict[int, list[_NodeStats]] = defaultdict(list)
+
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if _is_backward_node(node):
+            continue
+
+        # Skip getitem and wait_tensor -- they inherit parent's policy
+        if node.target in (
+            operator.getitem,
+            torch.ops._c10d_functional.wait_tensor.default,
+        ):
+            continue
+
+        # Only consider nodes whose outputs are consumed by backward
+        if not _has_backward_consumer(node):
+            continue
+
+        layer_id = _get_layer_id(node)
+        val = node.meta.get("val")
+
+        memory_bytes = 0
+        if isinstance(val, torch.Tensor):
+            memory_bytes = _tensor_bytes(val)
+
+        recompute_cost = _estimate_recompute_cost(node)
+
+        # Determine forced policy
+        forced_policy = None
+        if _is_view_op(node):
+            forced_policy = CheckpointPolicy.PREFER_RECOMPUTE
+        elif _is_comm_op(node):
+            forced_policy = CheckpointPolicy.MUST_SAVE
+        elif _is_random_op(node):
+            # Random ops must be saved to preserve determinism
+            forced_policy = CheckpointPolicy.MUST_SAVE
+
+        layer_stats[layer_id].append(
+            _NodeStats(
+                name=node.name,
+                memory_bytes=memory_bytes,
+                recompute_cost=recompute_cost,
+                forced_policy=forced_policy,
+            )
+        )
+
+    return layer_stats
+
+
+# ============================================================
+# ILP solver
+# ============================================================
+
+
+def _solve_layer_ilp(
+    nodes: list[_NodeStats],
+    memory_budget: float,
+) -> dict[str, CheckpointPolicy]:
+    """Solve the ILP for a single layer's activation nodes.
+
+    Minimizes total recomputation time subject to:
+        sum(memory_i * save_i) <= memory_budget * total_memory
+
+    where save_i is a binary variable (1 = save, 0 = recompute).
+
+    Args:
+        nodes: Per-node stats for this layer.
+        memory_budget: Fraction (0.0 to 1.0) of total activation memory
+            allowed. 0.0 = recompute everything, 1.0 = save everything.
+
+    Returns:
+        Dict mapping node name -> CheckpointPolicy.
+    """
+    try:
+        import pulp
+    except ImportError as e:
+        raise ImportError(
+            "PuLP is required for ILP-based SAC policy. "
+            "Install it with: pip install pulp"
+        ) from e
+
+    result: dict[str, CheckpointPolicy] = {}
+
+    # Separate forced nodes from candidates
+    candidates: list[_NodeStats] = []
+    for node_stat in nodes:
+        if node_stat.forced_policy is not None:
+            result[node_stat.name] = node_stat.forced_policy
+        else:
+            candidates.append(node_stat)
+
+    if not candidates:
+        return result
+
+    # Total memory if all candidates were saved
+    total_candidate_memory = sum(n.memory_bytes for n in candidates)
+
+    if total_candidate_memory == 0:
+        # No memory cost -- save everything
+        for n in candidates:
+            result[n.name] = CheckpointPolicy.MUST_SAVE
+        return result
+
+    # Memory from forced MUST_SAVE nodes counts against the budget
+    forced_save_memory = sum(
+        n.memory_bytes for n in nodes if n.forced_policy == CheckpointPolicy.MUST_SAVE
+    )
+    total_possible_memory = total_candidate_memory + forced_save_memory
+
+    # Available memory budget for candidates (subtract forced saves)
+    budget_bytes = memory_budget * total_possible_memory - forced_save_memory
+    budget_bytes = max(0.0, budget_bytes)
+
+    # If budget allows saving everything, skip the solver
+    if budget_bytes >= total_candidate_memory:
+        for n in candidates:
+            result[n.name] = CheckpointPolicy.MUST_SAVE
+        return result
+
+    # If budget is zero, recompute everything
+    if budget_bytes <= 0:
+        for n in candidates:
+            result[n.name] = CheckpointPolicy.PREFER_RECOMPUTE
+        return result
+
+    # Formulate ILP
+    prob = pulp.LpProblem("SAC_layer", pulp.LpMinimize)
+
+    # Binary variables: save_i = 1 means save, 0 means recompute
+    save_vars = {
+        n.name: pulp.LpVariable(f"save_{n.name}", cat=pulp.constants.LpBinary)
+        for n in candidates
+    }
+
+    # Objective: minimize total recomputation cost
+    # recompute cost of node i = cost_i * (1 - save_i)
+    # = sum(cost_i) - sum(cost_i * save_i)
+    # Since sum(cost_i) is a constant, minimizing recompute cost is
+    # equivalent to maximizing sum(cost_i * save_i).
+    # PuLP minimizes, so we negate: minimize -sum(cost_i * save_i)
+    prob += pulp.lpSum(-n.recompute_cost * save_vars[n.name] for n in candidates)
+
+    # Constraint: total saved memory <= budget
+    prob += (
+        pulp.lpSum(n.memory_bytes * save_vars[n.name] for n in candidates)
+        <= budget_bytes
+    )
+
+    # Solve silently
+    solver = pulp.PULP_CBC_CMD(msg=0)
+    status = prob.solve(solver)
+
+    if status != pulp.constants.LpStatusOptimal:
+        logger.warning(
+            f"ILP solver did not find optimal solution (status={status}). "
+            "Falling back to recompute-all for this layer."
+        )
+        for n in candidates:
+            result[n.name] = CheckpointPolicy.PREFER_RECOMPUTE
+        return result
+
+    # Extract solution
+    for n in candidates:
+        var = save_vars[n.name]
+        if pulp.value(var) is not None and pulp.value(var) > 0.5:
+            result[n.name] = CheckpointPolicy.MUST_SAVE
+        else:
+            result[n.name] = CheckpointPolicy.PREFER_RECOMPUTE
+
+    return result
+
+
+# ============================================================
+# Top-level policy factory
+# ============================================================
+
+
+def solve_ilp_policy(
+    gm: torch.fx.GraphModule,
+    memory_budget: float,
+) -> dict[str, CheckpointPolicy]:
+    """Run ILP solver on the graph and return per-node policy decisions.
+
+    Solves one ILP per layer. Nodes not in any layer are defaulted to
+    PREFER_RECOMPUTE. View-like ops always recompute, comm ops and random ops
+    always save.
+
+    Args:
+        gm: The joint forward-backward graph module.
+        memory_budget: Fraction of total activation memory to allow (0.0-1.0).
+            0.0 = recompute everything, 1.0 = save everything.
+
+    Returns:
+        Dict mapping node name -> CheckpointPolicy for all forward activation
+        nodes with backward consumers.
+    """
+    if not 0.0 <= memory_budget <= 1.0:
+        raise ValueError(
+            f"memory_budget must be between 0.0 and 1.0, got {memory_budget}"
+        )
+
+    layer_stats = _collect_node_stats(gm)
+    all_policies: dict[str, CheckpointPolicy] = {}
+
+    for layer_id, nodes in sorted(layer_stats.items()):
+        layer_policies = _solve_layer_ilp(nodes, memory_budget)
+        all_policies.update(layer_policies)
+
+        # Log per-layer summary
+        num_save = sum(
+            1 for p in layer_policies.values() if p == CheckpointPolicy.MUST_SAVE
+        )
+        num_recompute = sum(
+            1 for p in layer_policies.values() if p != CheckpointPolicy.MUST_SAVE
+        )
+        save_bytes = sum(
+            n.memory_bytes
+            for n in nodes
+            if layer_policies.get(n.name) == CheckpointPolicy.MUST_SAVE
+        )
+        recompute_bytes = sum(
+            n.memory_bytes
+            for n in nodes
+            if layer_policies.get(n.name) != CheckpointPolicy.MUST_SAVE
+        )
+        label = "non-layer" if layer_id == _NOT_IN_LAYERS else str(layer_id)
+        logger.info(
+            f"  ILP layer {label}: "
+            f"{num_save} MUST_SAVE ({save_bytes / 1024:.1f} KB), "
+            f"{num_recompute} PREFER_RECOMPUTE ({recompute_bytes / 1024:.1f} KB)"
+        )
+
+    return all_policies

--- a/torchtitan/experiments/graph_trainer/tests/test_sac_ilp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_sac_ilp.py
@@ -1,0 +1,489 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import TestCase
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+from torchtitan.experiments.graph_trainer.passes import apply_ilp_sac_pass
+
+
+def _has_pulp() -> bool:
+    try:
+        import pulp  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _build_gm_with_layers(ops_per_layer, *, num_layers=2):
+    """Build a GraphModule with forward and backward nodes across layers.
+
+    Each layer gets the ops from ``ops_per_layer`` (a list of op targets).
+    Forward nodes are annotated with module_fqn metadata and fake tensor
+    metadata. A synthetic backward node consumes the last forward node
+    to simulate an activation saved for backward.
+
+    Returns (gm, forward_node_names_per_layer).
+    """
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty(4, 16)
+
+    y = graph.placeholder("y")
+    y.meta["val"] = torch.empty(4, 16)
+
+    forward_names: list[list[str]] = []
+    last = x
+
+    for layer_idx in range(num_layers):
+        layer_names = []
+        for op_target in ops_per_layer:
+            node = graph.call_function(op_target, args=(last, y))
+            node.meta["custom"] = {_MODULE_FQN: f"layers.{layer_idx}.feed_forward"}
+            # Fake tensor metadata for memory estimation
+            node.meta["val"] = torch.empty(4, 16)
+            layer_names.append(node.name)
+            last = node
+        forward_names.append(layer_names)
+
+    # Add a synthetic backward node that consumes the last forward node.
+    # This makes the last forward node have backward consumers.
+    bwd_node = graph.call_function(torch.ops.aten.neg.default, args=(last,))
+    bwd_node.meta["autograd_backward"] = True
+    bwd_node.meta["val"] = torch.empty(4, 16)
+
+    # Also add backward consumers for intermediate nodes to make them
+    # eligible as activations saved for backward.
+    for node in list(graph.nodes):
+        if (
+            node.op == "call_function"
+            and not node.meta.get("autograd_backward", False)
+            and node.target != operator.getitem
+        ):
+            bwd_consumer = graph.call_function(torch.ops.aten.neg.default, args=(node,))
+            bwd_consumer.meta["autograd_backward"] = True
+            bwd_consumer.meta["val"] = torch.empty(4, 16)
+
+    graph.output(last)
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    return gm, forward_names
+
+
+def _build_simple_gm(op_targets, *, layer_fqn="layers.0.feed_forward"):
+    """Build a simple GraphModule with a chain of forward ops and backward consumers."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty(4, 16)
+
+    y = graph.placeholder("y")
+    y.meta["val"] = torch.empty(4, 16)
+
+    last = x
+    for target in op_targets:
+        if target is operator.getitem:
+            node = graph.call_function(target, args=(last, 0))
+        else:
+            node = graph.call_function(target, args=(last, y))
+        node.meta["custom"] = {_MODULE_FQN: layer_fqn}
+        node.meta["val"] = torch.empty(4, 16)
+        last = node
+
+    # Add backward consumers for all forward nodes
+    for node in list(graph.nodes):
+        if (
+            node.op == "call_function"
+            and not node.meta.get("autograd_backward", False)
+            and node.target != operator.getitem
+        ):
+            bwd = graph.call_function(torch.ops.aten.neg.default, args=(node,))
+            bwd.meta["autograd_backward"] = True
+            bwd.meta["val"] = torch.empty(4, 16)
+
+    graph.output(last)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _get_forward_policies(gm):
+    """Extract recompute policies for forward call_function nodes."""
+    policies = {}
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if node.meta.get("autograd_backward", False):
+            continue
+        if "recompute" in node.meta:
+            policies[node.name] = node.meta["recompute"]
+    return policies
+
+
+@unittest.skipUnless(_has_pulp(), "PuLP not installed")
+class TestILPSACPass(TestCase):
+    """Unit tests for the ILP-based SAC pass."""
+
+    def test_budget_1_saves_everything(self):
+        """With memory_budget=1.0, all candidate ops should be MUST_SAVE."""
+        gm = _build_simple_gm(
+            [
+                torch.ops.aten.mm.default,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ]
+        )
+        apply_ilp_sac_pass(gm, memory_budget=1.0)
+        policies = _get_forward_policies(gm)
+
+        for name, policy in policies.items():
+            self.assertEqual(
+                policy,
+                CheckpointPolicy.MUST_SAVE,
+                f"Node {name} should be MUST_SAVE with budget=1.0",
+            )
+
+    def test_budget_0_recomputes_everything(self):
+        """With memory_budget=0.0, all candidate ops should be PREFER_RECOMPUTE."""
+        gm = _build_simple_gm(
+            [
+                torch.ops.aten.mm.default,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ]
+        )
+        apply_ilp_sac_pass(gm, memory_budget=0.0)
+        policies = _get_forward_policies(gm)
+
+        for name, policy in policies.items():
+            self.assertEqual(
+                policy,
+                CheckpointPolicy.PREFER_RECOMPUTE,
+                f"Node {name} should be PREFER_RECOMPUTE with budget=0.0",
+            )
+
+    def test_intermediate_budget_prioritizes_expensive_ops(self):
+        """With a partial budget, the ILP should save expensive ops (mm) over cheap ones."""
+        gm = _build_simple_gm(
+            [
+                torch.ops.aten.mm.default,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ]
+        )
+        # Use a budget that can save roughly 1 of 3 activations
+        apply_ilp_sac_pass(gm, memory_budget=0.33)
+        policies = _get_forward_policies(gm)
+
+        # mm is compute-intensive, so it should be saved before add/relu
+        mm_nodes = [
+            name
+            for name in policies
+            if "mm" in name and policies[name] == CheckpointPolicy.MUST_SAVE
+        ]
+        add_relu_saved = [
+            name
+            for name in policies
+            if ("add" in name or "relu" in name)
+            and policies[name] == CheckpointPolicy.MUST_SAVE
+        ]
+        # With a tight budget, mm should be preferentially saved
+        self.assertGreaterEqual(
+            len(mm_nodes),
+            len(add_relu_saved),
+            "ILP should prioritize saving compute-intensive ops",
+        )
+
+    def test_comm_ops_always_saved(self):
+        """Communication ops should always be MUST_SAVE regardless of budget."""
+        gm = _build_simple_gm(
+            [
+                torch.ops._c10d_functional.reduce_scatter_tensor.default,
+                torch.ops.aten.add.Tensor,
+            ]
+        )
+        apply_ilp_sac_pass(gm, memory_budget=0.0)
+        policies = _get_forward_policies(gm)
+
+        for name, policy in policies.items():
+            node = next(n for n in gm.graph.nodes if n.name == name)
+            if node.target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
+                self.assertEqual(
+                    policy,
+                    CheckpointPolicy.MUST_SAVE,
+                    "Comm ops should always be MUST_SAVE",
+                )
+
+    def test_getitem_inherits_parent_policy(self):
+        """getitem nodes should inherit the parent's recompute tag."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 16)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.empty(4, 16)
+
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, y))
+        mm.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        mm.meta["val"] = torch.empty(4, 16)
+
+        # Wrap in tuple for getitem
+        def _make_tuple(t):
+            return (t, t)
+
+        tup = graph.call_function(_make_tuple, args=(mm,))
+        tup.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        tup.meta["val"] = (torch.empty(4, 16), torch.empty(4, 16))
+
+        gi = graph.call_function(operator.getitem, args=(tup, 0))
+        gi.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        gi.meta["val"] = torch.empty(4, 16)
+
+        # Add backward consumers
+        for node in [mm, tup, gi]:
+            bwd = graph.call_function(torch.ops.aten.neg.default, args=(node,))
+            bwd.meta["autograd_backward"] = True
+            bwd.meta["val"] = torch.empty(4, 16)
+
+        graph.output(gi)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        apply_ilp_sac_pass(gm, memory_budget=1.0)
+
+        gi_node = next(n for n in gm.graph.nodes if n.target is operator.getitem)
+        parent_node = gi_node.args[0]
+        self.assertIn("recompute", gi_node.meta)
+        if "recompute" in parent_node.meta:
+            self.assertEqual(
+                gi_node.meta["recompute"],
+                parent_node.meta["recompute"],
+                "getitem should inherit parent policy",
+            )
+
+    def test_layer_boundary_forces_must_save(self):
+        """Recomputable nodes at layer boundaries should be forced to MUST_SAVE."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 16)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.empty(4, 16)
+
+        # Layer 0 node
+        n0 = graph.call_function(torch.ops.aten.add.Tensor, args=(x, y))
+        n0.meta["custom"] = {_MODULE_FQN: "layers.0.feed_forward"}
+        n0.meta["val"] = torch.empty(4, 16)
+
+        # Layer 1 node (consumes n0)
+        n1 = graph.call_function(torch.ops.aten.add.Tensor, args=(n0, y))
+        n1.meta["custom"] = {_MODULE_FQN: "layers.1.feed_forward"}
+        n1.meta["val"] = torch.empty(4, 16)
+
+        # Add backward consumers
+        for node in [n0, n1]:
+            bwd = graph.call_function(torch.ops.aten.neg.default, args=(node,))
+            bwd.meta["autograd_backward"] = True
+            bwd.meta["val"] = torch.empty(4, 16)
+
+        graph.output(n1)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        # budget=0 would normally recompute everything, but boundary constraint
+        # forces n0 to MUST_SAVE since it feeds a higher layer.
+        apply_ilp_sac_pass(gm, memory_budget=0.0)
+
+        n0_node = next(
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and not n.meta.get("autograd_backward", False)
+            and n.meta.get("custom", {}).get(_MODULE_FQN) == "layers.0.feed_forward"
+        )
+        self.assertEqual(
+            n0_node.meta["recompute"],
+            CheckpointPolicy.MUST_SAVE,
+            "Boundary node should be forced to MUST_SAVE",
+        )
+
+    def test_backward_nodes_not_tagged(self):
+        """Backward nodes should not receive recompute tags."""
+        gm = _build_simple_gm([torch.ops.aten.add.Tensor])
+        apply_ilp_sac_pass(gm, memory_budget=0.5)
+
+        for node in gm.graph.nodes:
+            if node.meta.get("autograd_backward", False):
+                self.assertNotIn(
+                    "recompute",
+                    node.meta,
+                    f"Backward node {node.name} should not be tagged",
+                )
+
+    def test_invalid_budget_raises(self):
+        """Memory budget outside [0.0, 1.0] should raise ValueError."""
+        gm = _build_simple_gm([torch.ops.aten.add.Tensor])
+        with self.assertRaises(ValueError):
+            apply_ilp_sac_pass(gm, memory_budget=1.5)
+        with self.assertRaises(ValueError):
+            apply_ilp_sac_pass(gm, memory_budget=-0.1)
+
+    def test_multi_layer_graph(self):
+        """ILP should produce valid policies for a multi-layer graph."""
+        gm, forward_names = _build_gm_with_layers(
+            [torch.ops.aten.mm.default, torch.ops.aten.add.Tensor],
+            num_layers=3,
+        )
+        apply_ilp_sac_pass(gm, memory_budget=0.5)
+        policies = _get_forward_policies(gm)
+
+        # Every forward node should have a policy
+        for layer_names in forward_names:
+            for name in layer_names:
+                self.assertIn(name, policies, f"Node {name} should have a policy")
+                self.assertIn(
+                    policies[name],
+                    (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_RECOMPUTE),
+                    f"Node {name} has unexpected policy {policies[name]}",
+                )
+
+    def test_empty_graph(self):
+        """An empty graph (no forward ops) should not crash."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        # Should not raise
+        apply_ilp_sac_pass(gm, memory_budget=0.5)
+
+
+class TestILPSACPassWithoutPuLP(TestCase):
+    """Test ILP SAC behavior when PuLP is not installed."""
+
+    def test_import_error_message(self):
+        """When PuLP is not available, a clear error message should be raised."""
+        import unittest.mock
+
+        gm = _build_simple_gm([torch.ops.aten.mm.default])
+
+        # Mock the import to fail
+        with unittest.mock.patch.dict("sys.modules", {"pulp": None}):
+            with self.assertRaises(ImportError) as ctx:
+                apply_ilp_sac_pass(gm, memory_budget=0.5)
+            self.assertIn("PuLP", str(ctx.exception))
+
+
+class TestNodeStatsCollection(TestCase):
+    """Unit tests for node stats collection used by ILP."""
+
+    def test_view_ops_get_forced_recompute(self):
+        """View-like ops should have forced_policy = PREFER_RECOMPUTE."""
+        from torchtitan.experiments.graph_trainer.sac_ilp import _collect_node_stats
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 16)
+
+        view = graph.call_function(torch.ops.aten.view.default, args=(x, [4, 16]))
+        view.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        view.meta["val"] = torch.empty(4, 16)
+
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(view,))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["val"] = torch.empty(4, 16)
+
+        graph.output(view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        layer_stats = _collect_node_stats(gm)
+        # The view node should have forced_policy
+        found = False
+        for nodes in layer_stats.values():
+            for ns in nodes:
+                if ns.name == view.name:
+                    self.assertEqual(
+                        ns.forced_policy, CheckpointPolicy.PREFER_RECOMPUTE
+                    )
+                    found = True
+        self.assertTrue(found, "View node should appear in stats")
+
+    def test_comm_ops_get_forced_save(self):
+        """Communication ops should have forced_policy = MUST_SAVE."""
+        from torchtitan.experiments.graph_trainer.sac_ilp import _collect_node_stats
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 16)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.empty(4, 16)
+
+        rs = graph.call_function(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            args=(x, y),
+        )
+        rs.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        rs.meta["val"] = torch.empty(4, 16)
+
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(rs,))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["val"] = torch.empty(4, 16)
+
+        graph.output(rs)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        layer_stats = _collect_node_stats(gm)
+        found = False
+        for nodes in layer_stats.values():
+            for ns in nodes:
+                if ns.name == rs.name:
+                    self.assertEqual(ns.forced_policy, CheckpointPolicy.MUST_SAVE)
+                    found = True
+        self.assertTrue(found, "Comm node should appear in stats")
+
+    def test_compute_intensive_ops_have_high_cost(self):
+        """Compute-intensive ops should have higher recompute cost than elementwise."""
+        from torchtitan.experiments.graph_trainer.sac_ilp import _collect_node_stats
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 16)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.empty(4, 16)
+
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, y))
+        mm.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        mm.meta["val"] = torch.empty(4, 16)
+
+        add = graph.call_function(torch.ops.aten.add.Tensor, args=(mm, y))
+        add.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        add.meta["val"] = torch.empty(4, 16)
+
+        for node in [mm, add]:
+            bwd = graph.call_function(torch.ops.aten.neg.default, args=(node,))
+            bwd.meta["autograd_backward"] = True
+            bwd.meta["val"] = torch.empty(4, 16)
+
+        graph.output(add)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        layer_stats = _collect_node_stats(gm)
+        mm_cost = None
+        add_cost = None
+        for nodes in layer_stats.values():
+            for ns in nodes:
+                if ns.name == mm.name:
+                    mm_cost = ns.recompute_cost
+                elif ns.name == add.name:
+                    add_cost = ns.recompute_cost
+
+        self.assertIsNotNone(mm_cost)
+        self.assertIsNotNone(add_cost)
+        self.assertGreater(mm_cost, add_cost, "mm should cost more than add")
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()


### PR DESCRIPTION
## Summary

- Adds an ILP (Integer Linear Programming) solver (`sac_ilp.py`) that formulates save-vs-recompute decisions as an optimization problem: minimize total recomputation time subject to a memory budget
- Integrates as a new graph pass `apply_ilp_sac_pass` registered as `"apply_ilp_sac"` in `AVAILABLE_JOINT_PASSES`, selectable via `--compile.joint_passes apply_ilp_sac`
- Adds `compile.memory_budget` config field (0.0-1.0) to control the activation memory budget

### Design

The ILP solver runs once at compile time per layer:
1. Scans the forward graph for activations with backward consumers
2. Classifies each node: view-like (always recompute), comm ops (always save), random ops (always save to preserve determinism), general ops (ILP candidates)
3. For candidates, estimates memory cost (tensor bytes) and recompute cost (shape-based heuristic: compute-intensive ops like mm get 100x multiplier)
4. Solves a binary knapsack ILP per layer using PuLP CBC solver
5. Layer boundary constraint (Pass 2 from `apply_sac_pass`) is applied on top of ILP decisions

### Usage

```bash
NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh \
    --compile.mode aot_fx_trace \
    --compile.joint_passes apply_ilp_sac \
    --compile.memory_budget 0.5
```

### Key constraints handled
- Symbolic shapes (DSv3 MoE): `int()` can fail on SymInt, uses try/except
- PuLP is an optional dependency with a clear `ImportError` message
- Solver runs at compile time only, not per training step
- FSDP all-gathers / communication ops always saved to avoid re-communication
- Layer boundary nodes forced to `MUST_SAVE` regardless of ILP decision

## Test plan

- [x] 14 unit tests in `test_sac_ilp.py` covering:
  - Budget extremes (0.0 recomputes all, 1.0 saves all)
  - ILP prioritizes compute-intensive ops (mm) over cheap ops (add/relu)
  - Comm ops always saved regardless of budget
  - getitem/wait_tensor inherit parent policy
  - Layer boundary forces MUST_SAVE
  - Backward nodes not tagged
  - Invalid budget raises ValueError
  - Multi-layer graphs produce valid policies
  - Empty graph handled gracefully
  - Clear error when PuLP not installed
  - Node stats: view ops forced recompute, comm ops forced save, cost ordering
- [x] Existing `TestApplySACPass` tests still pass (no regression)
- [x] `pre-commit run --all-files` passes
- [ ] GPU integration test with debug model (requires GPU cluster)