### PR TITLE
Fix Lychee install in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,7 @@ jobs:
           # Load the archive, extract into temp folder, move the binary, delete the rest
           mkdir -p lychee_install
           curl -sLO "$URL"
-          tar -xzf "lychee-x86_64-unknown-linux-gnu.tar.gz" -C lychee_install
+          tar -xzf "lychee-x86_64-unknown-linux-gnu.tar.gz" -C lychee_install --strip-components=1
           sudo mv lychee_install/lychee /usr/local/bin/
           rm -rf lychee_install "lychee-x86_64-unknown-linux-gnu.tar.gz"
 


### PR DESCRIPTION
Lychee v0.24.1+ ships the release tarball with contents nested under a top-level `lychee-x86_64-unknown-linux-gnu/` directory, so the extracted binary lives at `lychee_install/lychee-x86_64-unknown-linux-gnu/lychee` instead of `lychee_install/lychee`, breaking the install step with "cannot stat 'lychee_install/lychee'".

Pass `--strip-components=1` to tar so the archive root is flattened into `lychee_install/` and the existing `mv` path remains valid.