### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add FSDP collective splitting

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -48,10 +48,74 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
     _MODULE_FQN,
 )
+from torchtitan.experiments.graph_trainer.fsdp_patterns import find_fsdp_unshard_outputs
 from torchtitan.tools.logging import logger
 
 
 _FSDP_BUCKET_META = "fsdp_bucket"
+
+
+def _chain_nodes_to_placeholder(
+    output: fx.Node,
+    placeholder: fx.Node,
+) -> set[fx.Node]:
+    """Return graph nodes in one FSDP unshard chain, excluding the placeholder."""
+    chain_nodes: set[fx.Node] = set()
+    queue = [output]
+    while queue:
+        node = queue.pop()
+        if node is placeholder or node in chain_nodes:
+            continue
+        chain_nodes.add(node)
+        queue.extend(node.all_input_nodes)
+    return chain_nodes
+
+
+def deduplicate_fsdp_unshard_chains_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Canonicalize duplicate SimpleFSDP unshard chains per flat parameter.
+
+    A traced parametrized module can read the same FSDP parameter more than
+    once. Each read materializes an equivalent all-gather/wait reconstruction
+    chain from the same flat parameter placeholder. Downstream FSDP passes
+    assume one unsharded value per flat parameter, so this pass rewrites all
+    duplicate chains to the first chain and removes the now-dead duplicate
+    collective infrastructure.
+    """
+    del example_inputs
+
+    removable_nodes: set[fx.Node] = set()
+    num_duplicate_chains = 0
+    for placeholder in gm.graph.find_nodes(op="placeholder"):
+        unshard_outputs = find_fsdp_unshard_outputs(placeholder)
+        if len(unshard_outputs) <= 1:
+            continue
+        canonical_output = unshard_outputs[0]
+        for duplicate_output in unshard_outputs[1:]:
+            removable_nodes.update(
+                _chain_nodes_to_placeholder(duplicate_output, placeholder)
+            )
+            duplicate_output.replace_all_uses_with(canonical_output)
+            num_duplicate_chains += 1
+
+    if num_duplicate_chains == 0:
+        return gm
+
+    def _is_impure_for_fsdp_dedup(node: fx.Node) -> bool:
+        if node in removable_nodes:
+            return False
+        return node.is_impure()
+
+    gm.graph.eliminate_dead_code(is_impure_node=_is_impure_for_fsdp_dedup)
+    gm.graph.lint()
+    gm.recompile()
+    logger.info(
+        "Canonicalized %d duplicate FSDP unshard chain(s)",
+        num_duplicate_chains,
+    )
+    return gm
 
 
 def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:

--- a/torchtitan/experiments/graph_trainer/fsdp_patterns.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_patterns.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Pattern helpers for GraphPP's current simple-FSDP collective traces.
+
+The matchers intentionally follow c10d functional traces produced by FSDP2:
+
+    param_shard -> all_gather -> wait -> view*/split-cat -> compute
+    local_grad -> cast/view* -> reduce_scatter -> wait -> param_grad
+    local_grad -> cast/view* -> all_reduce -> wait -> param_grad
+
+They are structural helpers for today's trace shape. A future upstream FSDP or
+torch.pipelining annotation should replace this with explicit collective-region
+metadata instead of broader pattern matching.
+"""
+
+import operator
+from typing import Any
+
+import torch
+import torch.fx as fx
+
+
+def is_wait_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.wait_tensor.default
+    )
+
+
+def is_all_gather_into_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.all_gather_into_tensor.default
+    )
+
+
+def is_reduce_scatter_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+    )
+
+
+def is_all_reduce(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is torch.ops._c10d_functional.all_reduce.default
+    )
+
+
+def is_reduce_grad_collective(node: fx.Node) -> bool:
+    return is_reduce_scatter_tensor(node) or is_all_reduce(node)
+
+
+def _find_last_all_gather_in_chain(start_node: fx.Node) -> fx.Node | None:
+    """Find the final all-gather in a linear FSDP unshard launch chain."""
+    node = start_node
+    last_all_gather = None
+    while True:
+        if is_all_gather_into_tensor(node):
+            last_all_gather = node
+        if len(node.users) != 1:
+            break
+        user = next(iter(node.users))
+        if len(user.all_input_nodes) > 1:
+            break
+        node = user
+    return last_all_gather
+
+
+def _find_last_user_in_wait_chain(wait_node: fx.Node) -> fx.Node:
+    """Find the last FSDP unshard node before the value enters real compute.
+
+    The traced FSDP unshard has a mostly linear shape:
+
+        flat_param -> ... -> all_gather -> wait -> view* -> compute
+
+    Some models reshape the gathered flat buffer through a split/cat fanout:
+
+        wait -> split -> getitem_0 --+
+                      -> getitem_1 --+-> cat -> view* -> compute
+
+    In both cases the FSDP region ends before the first consumer with multiple
+    FX inputs. The split/getitem/cat fanout is still part of reconstructing the
+    unsharded parameter value, so it is included in the chain.
+    """
+    node = wait_node
+    while True:
+        if len(node.users) != 1:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.aten.split.Tensor
+                and all(
+                    user.op == "call_function"
+                    and user.target == operator.getitem
+                    and len(user.users) == 1
+                    for user in node.users
+                )
+            ):
+                getitem_users = [next(iter(user.users)) for user in node.users]
+                potential_cat = getitem_users[0]
+                if all(user == potential_cat for user in getitem_users) and (
+                    potential_cat.op == "call_function"
+                    and potential_cat.target == torch.ops.aten.cat.default
+                ):
+                    node = potential_cat
+                    continue
+            break
+
+        user = next(iter(node.users))
+        if len(user.all_input_nodes) > 1:
+            break
+        node = user
+    return node
+
+
+def _find_last_non_view_node_in_chain(node: fx.Node) -> fx.Node:
+    """Return the value GraphPP should pass across the unshard boundary."""
+    result = node
+    while hasattr(result.target, "is_view") and result.target.is_view:
+        if len(result.all_input_nodes) != 1:
+            raise ValueError(f"View node {result.name} should have exactly one input")
+        result = result.all_input_nodes[0]
+    return result
+
+
+def _unshard_output_from_all_gather(last_all_gather: fx.Node) -> fx.Node:
+    if len(last_all_gather.users) != 1:
+        raise ValueError(
+            f"Expected one wait_tensor user for all_gather node {last_all_gather.name}, "
+            f"got {len(last_all_gather.users)}"
+        )
+    wait_node = next(iter(last_all_gather.users))
+    if not is_wait_tensor(wait_node):
+        raise ValueError(
+            f"Expected wait_tensor after all_gather node {last_all_gather.name}, "
+            f"got {wait_node.name}"
+        )
+
+    wait_chain_user = _find_last_user_in_wait_chain(wait_node)
+    return _find_last_non_view_node_in_chain(wait_chain_user)
+
+
+def find_fsdp_unshard_outputs(param_placeholder: fx.Node) -> tuple[fx.Node, ...]:
+    """Return all FSDP unshard outputs launched from one flat parameter input.
+
+    Most parameters have one linear all-gather chain. Some real traces read the
+    same parametrized value more than once, which produces multiple equivalent
+    all-gather/wait chains from the same placeholder.
+    ``deduplicate_fsdp_unshard_chains_pass`` canonicalizes those duplicate
+    chains before downstream FSDP passes rely on a single unsharded value.
+    """
+    last_all_gather = _find_last_all_gather_in_chain(param_placeholder)
+    if last_all_gather is not None:
+        return (_unshard_output_from_all_gather(last_all_gather),)
+
+    outputs: list[fx.Node] = []
+    seen: set[fx.Node] = set()
+    for user in param_placeholder.users:
+        if len(user.all_input_nodes) > 1:
+            continue
+        last_all_gather = _find_last_all_gather_in_chain(user)
+        if last_all_gather is None:
+            continue
+        output = _unshard_output_from_all_gather(last_all_gather)
+        if output not in seen:
+            seen.add(output)
+            outputs.append(output)
+    return tuple(outputs)
+
+
+def find_fsdp_unshard_output(param_placeholder: fx.Node) -> fx.Node | None:
+    """Return the extracted unshard output for one flat parameter input.
+
+    GraphPP and the SAC force-save policy must agree on this node. It is the
+    same value AutoParallel saves for ``reshard_after_forward=False``: the last
+    non-view node in the FSDP all-gather/wait reconstruction chain. Parameters
+    without an all-gather are replicated or otherwise already local, so callers
+    should keep the original placeholder as that parameter's unsharded value.
+
+    TODO(sanketpurandare): requires upstream change: FSDP trace/passes should
+    annotate unshard collective regions for downstream graph extraction.
+    """
+    outputs = find_fsdp_unshard_outputs(param_placeholder)
+    if not outputs:
+        return None
+    return outputs[0]
+
+
+def find_fsdp_unshard_save_node(param_placeholder: fx.Node) -> fx.Node | None:
+    return find_fsdp_unshard_output(param_placeholder)
+
+
+def find_fsdp_unshard_save_nodes(param_placeholder: fx.Node) -> tuple[fx.Node, ...]:
+    """Return all FSDP unshard values that SAC must save for one parameter."""
+    return find_fsdp_unshard_outputs(param_placeholder)
+
+
+def find_fsdp_reduce_grad_input(param_grad_output: Any) -> fx.Node | None:
+    """Return the split point before an FSDP reduce-grad epilogue.
+
+    The backward FSDP/DDP/HSDP tail is traced as a unary chain ending in the
+    synced grad output:
+
+        local_grad -> cast/view* -> reduce_scatter -> wait -> sharded_grad
+        local_grad -> cast/view* -> all_reduce -> wait -> replicated_grad
+        local_grad -> cast/view* -> all_reduce -> wait -> reduce_scatter
+          -> wait -> grad
+
+    GraphPP splits at the input to the earliest grad-sync collective in that
+    suffix. The cast remains in ``bw_no_fsdp`` so microbatch accumulation
+    happens in FSDP's reduce dtype, and ``reduce_grad`` contains only the
+    scheduled collective epilogue. Values that are not FX nodes, such as
+    ``None`` parameter-grad slots, are not collective outputs and are preserved
+    by the caller.
+
+    TODO(sanketpurandare): requires upstream change: FSDP trace/passes should
+    annotate reduce-grad collective regions for downstream graph extraction.
+    """
+    if not isinstance(param_grad_output, fx.Node):
+        return None
+
+    node = param_grad_output
+    reduce_grad_input = None
+    while isinstance(node, fx.Node) and len(node.all_input_nodes) == 1:
+        input_node = node.all_input_nodes[0]
+        if len(input_node.users) > 1:
+            break
+        previous_node = node
+        node = input_node
+        if is_reduce_grad_collective(previous_node):
+            reduce_grad_input = node
+    return reduce_grad_input

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -12,10 +12,20 @@ from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
     GraphPPDiDwSplit,
     split_di_dw_graph,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.split_fsdp_collectives import (
+    GraphPPFSDPBackwardSplit,
+    GraphPPFSDPForwardSplit,
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
 
 __all__ = [
     "GraphPPDiDwSplit",
+    "GraphPPFSDPBackwardSplit",
+    "GraphPPFSDPForwardSplit",
     "GraphMeta",
     "partition_joint_graph",
+    "split_backward_fsdp_collectives",
     "split_di_dw_graph",
+    "split_forward_fsdp_collectives",
 ]

--- a/torchtitan/experiments/graph_trainer/graph_pp/split_fsdp_collectives.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/split_fsdp_collectives.py
@@ -1,0 +1,361 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import dataclasses
+from copy import deepcopy
+
+import torch
+import torch.fx as fx
+import torch.utils._pytree as pytree
+from torch._functorch.partitioners import _extract_graph_with_inputs_outputs
+from torch.fx._lazy_graph_module import _make_graph_module
+
+from torchtitan.experiments.graph_trainer.fsdp_patterns import (
+    find_fsdp_reduce_grad_input,
+    find_fsdp_unshard_outputs,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    allow_fx_graph_extraction_of_side_effectful_ops,
+    graph_outputs,
+    output_names,
+    placeholder_names,
+    trace_graph_pp_graph,
+    unique_in_order,
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GraphPPFSDPForwardSplit:
+    """Forward graph split around FSDP unshard collectives.
+
+    Attributes:
+        unshard_module (fx.GraphModule | None): Graph that turns flat
+            parameter inputs into unsharded parameter values, or ``None`` when
+            the forward graph has no FSDP unshard collective.
+        fw_no_fsdp_module (fx.GraphModule): Forward graph with FSDP unshard
+            collectives removed.
+        unshard_flat_param_indices (tuple[int, ...]): Flat parameter indices
+            consumed by ``unshard_module``.
+        unshard_output_names (tuple[str, ...]): ``unshard_module`` output
+            names.
+        fw_no_fsdp_input_names (tuple[str, ...]): ``fw_no_fsdp_module``
+            placeholder names.
+        fw_no_fsdp_flat_input_indices (tuple[int, ...]): Flat traced input
+            indices for non-parameter inputs still consumed by
+            ``fw_no_fsdp_module``.
+        num_fw_unsharded_param_inputs (int): Number of leading
+            ``fw_no_fsdp_module`` inputs supplied by ``unshard_module``.
+        fw_no_fsdp_output_names (tuple[str, ...]): ``fw_no_fsdp_module`` output
+            names.
+    """
+
+    unshard_module: fx.GraphModule | None
+    fw_no_fsdp_module: fx.GraphModule
+    unshard_flat_param_indices: tuple[int, ...]
+    unshard_output_names: tuple[str, ...]
+    fw_no_fsdp_input_names: tuple[str, ...]
+    fw_no_fsdp_flat_input_indices: tuple[int, ...]
+    num_fw_unsharded_param_inputs: int
+    fw_no_fsdp_output_names: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GraphPPFSDPBackwardSplit:
+    """Backward graph split around FSDP/DDP/HSDP reduce-grad collectives.
+
+    Attributes:
+        bw_no_fsdp_module (fx.GraphModule): Backward graph with reduce-grad
+            epilogues removed from parameter-gradient outputs.
+        reduce_grad_module (fx.GraphModule | None): Graph that performs
+            reduce-scatter/all-reduce epilogues for parameter gradients, or
+            ``None`` when no reduce-grad collective exists.
+        bw_no_fsdp_output_names (tuple[str, ...]): ``bw_no_fsdp_module`` output
+            names.
+        reduce_grad_input_names (tuple[str, ...]): ``reduce_grad_module``
+            placeholder names, or empty when ``reduce_grad_module`` is
+            ``None``.
+    """
+
+    bw_no_fsdp_module: fx.GraphModule
+    reduce_grad_module: fx.GraphModule | None
+    bw_no_fsdp_output_names: tuple[str, ...]
+    reduce_grad_input_names: tuple[str, ...]
+
+
+def split_forward_fsdp_collectives(
+    fw_module: fx.GraphModule,
+    *,
+    num_params: int,
+    fwd_input_names: tuple[str, ...],
+    fwd_flat_input_indices: tuple[int, ...],
+) -> GraphPPFSDPForwardSplit:
+    """Split forward FSDP all-gather chains from a forward graph.
+
+    Contract:
+      unshard(param_shards_and_replicated_params)
+        -> unsharded_param_values
+
+      fw_no_fsdp(unsharded_param_values, remaining_forward_inputs)
+        -> original_forward_outputs
+
+    Flat traced inputs are ordered as params, buffers, then user inputs. Any
+    forward placeholder whose flat input index is less than ``num_params`` is a
+    parameter input. Inputs with an all-gather/wait/view chain become
+    unsharded values. Replicated or otherwise non-sharded params pass through
+    the unshard graph so ``fw_no_fsdp`` still receives one value per original
+    parameter input. If no all-gather chain exists, the split is a no-op.
+
+    Args:
+        fw_module (fx.GraphModule): Forward graph produced by GraphPP
+            partitioning.
+        num_params (int): Number of flat traced inputs that are parameters.
+        fwd_input_names (tuple[str, ...]): Forward graph placeholder names from
+            partition metadata.
+        fwd_flat_input_indices (tuple[int, ...]): Flat traced input index for
+            each forward graph placeholder.
+
+    Returns:
+        GraphPPFSDPForwardSplit: Forward split modules and calling-convention
+        metadata.
+
+    Raises:
+        ValueError: If the provided forward input metadata does not match the
+            graph placeholders.
+    """
+    if num_params < 0:
+        raise ValueError(f"num_params must be non-negative, got {num_params}")
+
+    graph = deepcopy(fw_module.graph)
+    placeholders = graph.find_nodes(op="placeholder")
+    if len(fwd_input_names) != len(placeholders):
+        raise ValueError(
+            "Forward input names must match placeholder count: "
+            f"{len(fwd_input_names)} != {len(placeholders)}"
+        )
+    if len(fwd_flat_input_indices) != len(placeholders):
+        raise ValueError(
+            "Forward flat input indices must match placeholder count: "
+            f"{len(fwd_flat_input_indices)} != {len(placeholders)}"
+        )
+    if tuple(node.name for node in placeholders) != fwd_input_names:
+        raise ValueError(
+            "Forward input names must match graph placeholders: "
+            f"expected {tuple(node.name for node in placeholders)}, "
+            f"got {fwd_input_names}"
+        )
+    invalid_indices = sorted(index for index in fwd_flat_input_indices if index < 0)
+    if invalid_indices:
+        raise ValueError(
+            "Forward flat input indices must be non-negative: " f"{invalid_indices}"
+        )
+
+    param_inputs: list[fx.Node] = []
+    param_flat_indices: list[int] = []
+    remaining_inputs: list[fx.Node] = []
+    remaining_flat_input_indices: list[int] = []
+    for node, flat_index in zip(placeholders, fwd_flat_input_indices, strict=True):
+        if flat_index < num_params:
+            param_inputs.append(node)
+            param_flat_indices.append(flat_index)
+        else:
+            remaining_inputs.append(node)
+            remaining_flat_input_indices.append(flat_index)
+
+    unshard_outputs: list[object] = []
+    found_collective = False
+
+    for param_input in param_inputs:
+        param_unshard_outputs = find_fsdp_unshard_outputs(param_input)
+        if not param_unshard_outputs:
+            unshard_outputs.append(param_input)
+            continue
+        if len(param_unshard_outputs) != 1:
+            raise ValueError(
+                "GraphPP FSDP split expects one unshard chain per flat "
+                f"parameter placeholder after deduplication, but "
+                f"{param_input.name} has {len(param_unshard_outputs)}. "
+                "Run deduplicate_fsdp_unshard_chains_pass before splitting."
+            )
+        found_collective = True
+        unshard_output = param_unshard_outputs[0]
+        unshard_outputs.append(unshard_output)
+
+    if not found_collective:
+        trace_graph_pp_graph("graph_pp_fsdp_forward_no_fsdp", fw_module)
+        return GraphPPFSDPForwardSplit(
+            unshard_module=None,
+            fw_no_fsdp_module=fw_module,
+            unshard_flat_param_indices=(),
+            unshard_output_names=(),
+            fw_no_fsdp_input_names=fwd_input_names,
+            fw_no_fsdp_flat_input_indices=fwd_flat_input_indices,
+            num_fw_unsharded_param_inputs=0,
+            fw_no_fsdp_output_names=output_names(fw_module),
+        )
+
+    all_outputs = graph_outputs(graph)
+    output_node = graph.find_nodes(op="output")[0]
+    graph_output_descs = pytree.arg_tree_leaves(
+        output_node.meta.get("desc", [None] * len(all_outputs))
+    )
+    unshard_output_descs = [None] * len(unshard_outputs)
+
+    with allow_fx_graph_extraction_of_side_effectful_ops(
+        {
+            torch.ops._c10d_functional.wait_tensor,
+            torch.ops._c10d_functional.wait_tensor.default,
+        }
+    ):
+        unshard_graph = _extract_graph_with_inputs_outputs(
+            graph,
+            param_inputs,
+            unshard_outputs,
+            unshard_output_descs,
+            "unshard",
+            ignore_must_be_in_fw_bw=True,
+        )
+        fw_no_fsdp_graph = _extract_graph_with_inputs_outputs(
+            graph,
+            unshard_outputs + remaining_inputs,
+            list(all_outputs),
+            graph_output_descs,
+            "fw_no_fsdp",
+            ignore_must_be_in_fw_bw=True,
+        )
+
+    unshard_module = _make_graph_module(fw_module, unshard_graph)
+    fw_no_fsdp_module = _make_graph_module(fw_module, fw_no_fsdp_graph)
+    trace_graph_pp_graph("graph_pp_fsdp_unshard", unshard_module)
+    trace_graph_pp_graph("graph_pp_fsdp_forward_no_fsdp", fw_no_fsdp_module)
+    unshard_output_names = output_names(unshard_module)
+    return GraphPPFSDPForwardSplit(
+        unshard_module=unshard_module,
+        fw_no_fsdp_module=fw_no_fsdp_module,
+        unshard_flat_param_indices=tuple(param_flat_indices),
+        unshard_output_names=unshard_output_names,
+        fw_no_fsdp_input_names=placeholder_names(fw_no_fsdp_module),
+        fw_no_fsdp_flat_input_indices=tuple(remaining_flat_input_indices),
+        num_fw_unsharded_param_inputs=len(unshard_output_names),
+        fw_no_fsdp_output_names=output_names(fw_no_fsdp_module),
+    )
+
+
+def split_backward_fsdp_collectives(
+    bw_module: fx.GraphModule,
+    *,
+    num_param_grads: int,
+) -> GraphPPFSDPBackwardSplit:
+    """Split backward FSDP/DDP/HSDP reduce-grad epilogues.
+
+    Contract:
+      bw_no_fsdp(original_backward_inputs)
+        -> reduce_grad_inputs, remaining_backward_outputs
+
+      reduce_grad(unique_reduce_grad_inputs)
+        -> original_param_grad_outputs
+
+    Backward outputs are ordered as parameter-grad leaves followed by input
+    grads. Parameter-grad slots that do not end in a reduce-scatter/all-reduce
+    chain, including ``None`` slots for unused or non-differentiable params,
+    are kept in place to preserve the one-output-per-param-grad calling
+    convention.
+
+    NOTE: The pre-reduce dtype cast remains in ``bw_no_fsdp``. This matches
+    eager FSDP accumulation with gradient sync disabled, where local grads are
+    accumulated in the reduce dtype and reduced once later.
+
+    Args:
+        bw_module (fx.GraphModule): Backward graph produced by GraphPP
+            partitioning.
+        num_param_grads (int): Number of leading backward outputs that are
+            parameter-gradient slots.
+
+    Returns:
+        GraphPPFSDPBackwardSplit: Backward split modules and
+        calling-convention metadata.
+
+    Raises:
+        ValueError: If ``num_param_grads`` is invalid for the backward graph
+            outputs.
+    """
+    if num_param_grads < 0:
+        raise ValueError(f"num_param_grads must be non-negative, got {num_param_grads}")
+
+    graph = deepcopy(bw_module.graph)
+    placeholders = graph.find_nodes(op="placeholder")
+    all_outputs = graph_outputs(graph)
+    if num_param_grads > len(all_outputs):
+        raise ValueError(
+            "num_param_grads cannot exceed backward output count: "
+            f"{num_param_grads} > {len(all_outputs)}"
+        )
+    grad_outputs = all_outputs[:num_param_grads]
+    remaining_outputs = all_outputs[num_param_grads:]
+    output_node = graph.find_nodes(op="output")[0]
+    output_descs = pytree.arg_tree_leaves(
+        output_node.meta.get("desc", [None] * len(all_outputs))
+    )
+    grad_output_descs = output_descs[:num_param_grads]
+    remaining_output_descs = output_descs[num_param_grads:]
+
+    reduce_grad_inputs = []
+    found_collective = False
+    for grad_output in grad_outputs:
+        reduce_grad_input = find_fsdp_reduce_grad_input(grad_output)
+        if reduce_grad_input is not None:
+            found_collective = True
+            reduce_grad_inputs.append(reduce_grad_input)
+        else:
+            reduce_grad_inputs.append(grad_output)
+
+    if not found_collective:
+        trace_graph_pp_graph("graph_pp_fsdp_backward_no_fsdp", bw_module)
+        return GraphPPFSDPBackwardSplit(
+            bw_no_fsdp_module=bw_module,
+            reduce_grad_module=None,
+            bw_no_fsdp_output_names=output_names(bw_module),
+            reduce_grad_input_names=(),
+        )
+
+    unique_reduce_grad_inputs = unique_in_order(
+        input_node
+        for input_node in reduce_grad_inputs
+        if isinstance(input_node, fx.Node)
+    )
+    bw_no_fsdp_output_descs = [None] * len(reduce_grad_inputs)
+    with allow_fx_graph_extraction_of_side_effectful_ops(
+        {
+            torch.ops._c10d_functional.wait_tensor,
+            torch.ops._c10d_functional.wait_tensor.default,
+        }
+    ):
+        bw_no_fsdp_graph = _extract_graph_with_inputs_outputs(
+            graph,
+            placeholders,
+            reduce_grad_inputs + list(remaining_outputs),
+            bw_no_fsdp_output_descs + remaining_output_descs,
+            "bw_no_fsdp",
+            ignore_must_be_in_fw_bw=True,
+        )
+        reduce_grad_graph = _extract_graph_with_inputs_outputs(
+            graph,
+            unique_reduce_grad_inputs,
+            list(grad_outputs),
+            grad_output_descs,
+            "reduce_grad",
+            ignore_must_be_in_fw_bw=True,
+        )
+
+    bw_no_fsdp_module = _make_graph_module(bw_module, bw_no_fsdp_graph)
+    reduce_grad_module = _make_graph_module(bw_module, reduce_grad_graph)
+    trace_graph_pp_graph("graph_pp_fsdp_backward_no_fsdp", bw_no_fsdp_module)
+    trace_graph_pp_graph("graph_pp_fsdp_reduce_grad", reduce_grad_module)
+    return GraphPPFSDPBackwardSplit(
+        bw_no_fsdp_module=bw_no_fsdp_module,
+        reduce_grad_module=reduce_grad_module,
+        bw_no_fsdp_output_names=output_names(bw_no_fsdp_module),
+        reduce_grad_input_names=placeholder_names(reduce_grad_module),
+    )

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -33,6 +33,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.cpu_offload import (
     tag_all_offloadable_activations,
 )
+from torchtitan.experiments.graph_trainer.fsdp_patterns import (
+    find_fsdp_unshard_save_nodes,
+)
 from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
     log_activation_memory_policy,
 )
@@ -43,16 +46,10 @@ from torchtitan.experiments.graph_trainer.registry import (
 from torchtitan.tools.logging import logger
 
 
-def _make_default_memory_policy(
-    save_ops: set | None = None,
-    *,
-    fsdp_reshard_after_forward: bool = True,
-) -> Callable:
+def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
     """Create a SAC policy function from a set of op targets to save."""
     if save_ops is None:
         save_ops = _get_default_save_ops()
-        if not fsdp_reshard_after_forward:
-            save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         if node.target in save_ops:
@@ -60,6 +57,13 @@ def _make_default_memory_policy(
         return CheckpointPolicy.PREFER_RECOMPUTE
 
     return policy_fn
+
+
+def _find_fsdp_unshard_save_nodes(gm: torch.fx.GraphModule) -> set[torch.fx.Node]:
+    save_nodes: set[torch.fx.Node] = set()
+    for node in gm.graph.find_nodes(op="placeholder"):
+        save_nodes.update(find_fsdp_unshard_save_nodes(node))
+    return save_nodes
 
 
 def _make_full_memory_policy() -> Callable:
@@ -126,6 +130,7 @@ def tag_sac_policy(
     example_inputs: tuple | None = None,
     *,
     policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
+    force_save_nodes: set[torch.fx.Node] | None = None,
 ) -> torch.fx.GraphModule:
     """Apply selective activation checkpointing on the joint graph.
 
@@ -144,12 +149,17 @@ def tag_sac_policy(
         gm: The joint forward-backward graph module.
         policy_fn: Callable that takes a node and returns a CheckpointPolicy.
             Defaults to ``_make_default_memory_policy()`` if None.
+        force_save_nodes: Nodes that must be saved independent of ``policy_fn``.
+            Used for graph-structure constraints such as FSDP unshards with
+            ``reshard_after_forward=False``.
 
     Returns:
         The annotated graph module
     """
     if policy_fn is None:
         policy_fn = _make_default_memory_policy()
+    if force_save_nodes is None:
+        force_save_nodes = set()
 
     # Pass 1: Tag each forward node with a recompute policy.
     for node in gm.graph.nodes:
@@ -166,6 +176,10 @@ def tag_sac_policy(
         # remat pass only supports one region with must_recompute deps.
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
         if fqn.startswith(("lm_head", "loss")):
+            continue
+
+        if node in force_save_nodes:
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
             continue
 
         if node.target in (
@@ -260,15 +274,19 @@ def _default_memory_policy_pass(
     *,
     config: "GraphTrainer.Config",
 ) -> torch.fx.GraphModule:
-    """SAC policy that saves all compute-intensive ops and FSDP all_gathers."""
+    """SAC policy that saves compute-intensive ops and required FSDP unshards."""
     fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         config.parallelism.fsdp_reshard_after_forward,
         pp_enabled=config.parallelism.pipeline_parallel_degree > 1,
     )
-    policy_fn = _make_default_memory_policy(
-        fsdp_reshard_after_forward=fsdp_reshard_after_forward,
+    force_save_nodes = (
+        _find_fsdp_unshard_save_nodes(gm) if not fsdp_reshard_after_forward else None
     )
-    tag_sac_policy(gm, policy_fn=policy_fn)
+    tag_sac_policy(
+        gm,
+        policy_fn=_make_default_memory_policy(),
+        force_save_nodes=force_save_nodes,
+    )
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -63,6 +63,7 @@ from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    deduplicate_fsdp_unshard_chains_pass,
     get_fsdp_param_module_order,
     get_transformer_block_bucket_counts,
     joint_transformer_block_bucketing_reordering_pass,
@@ -190,6 +191,7 @@ def compile_time_passes(
     passes: list[Callable] = [
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
+        deduplicate_fsdp_unshard_chains_pass,
     ]
     ep_overlap_chunk_passes: list[Callable] = []
     ep_overlap_module_fqn: str | None = None

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
+import operator
 import unittest
 import warnings
 from dataclasses import dataclass
@@ -25,9 +26,19 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.deepseek_v3 import (
     model_registry as dsv3_model_registry,
 )
+from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    deduplicate_fsdp_unshard_chains_pass,
+)
+from torchtitan.experiments.graph_trainer.fsdp_patterns import (
+    find_fsdp_unshard_output,
+    find_fsdp_unshard_save_node,
+    find_fsdp_unshard_save_nodes,
+)
 from torchtitan.experiments.graph_trainer.graph_pp import (
     partition_joint_graph,
+    split_backward_fsdp_collectives,
     split_di_dw_graph,
+    split_forward_fsdp_collectives,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.partition import GraphMeta
 from torchtitan.experiments.graph_trainer.graph_pp.utils import flatten_graph_values
@@ -509,6 +520,336 @@ class GraphPPSplitDiDwTest(unittest.TestCase):
         )
 
         self.assertIsNone(split)
+
+
+_FAKE_PG = "graph_pp_test_pg"
+
+
+def _call_targets(gm: fx.GraphModule) -> set[object]:
+    return {node.target for node in gm.graph.nodes if node.op == "call_function"}
+
+
+def _placeholder_names(gm: fx.GraphModule) -> tuple[str, ...]:
+    return tuple(node.name for node in gm.graph.find_nodes(op="placeholder"))
+
+
+def _make_graph_module(graph: fx.Graph) -> fx.GraphModule:
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_forward_graph_with_unshard_and_replicated_param() -> fx.GraphModule:
+    graph = fx.Graph()
+    sharded_param = graph.placeholder("sharded_param")
+    replicated_param = graph.placeholder("replicated_param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(sharded_param, 1, _FAKE_PG),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(all_gather,),
+    )
+    split = graph.call_function(torch.ops.aten.split.Tensor, args=(wait, 2, 0))
+    left = graph.call_function(operator.getitem, args=(split, 0))
+    right = graph.call_function(operator.getitem, args=(split, 1))
+    unsharded_param = graph.call_function(
+        torch.ops.aten.cat.default,
+        args=([left, right], 0),
+    )
+    duplicate_all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(sharded_param, 1, _FAKE_PG),
+    )
+    duplicate_wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(duplicate_all_gather,),
+    )
+    duplicate_split = graph.call_function(
+        torch.ops.aten.split.Tensor,
+        args=(duplicate_wait, 2, 0),
+    )
+    duplicate_left = graph.call_function(operator.getitem, args=(duplicate_split, 0))
+    duplicate_right = graph.call_function(operator.getitem, args=(duplicate_split, 1))
+    duplicate_unsharded_param = graph.call_function(
+        torch.ops.aten.cat.default,
+        args=([duplicate_left, duplicate_right], 0),
+    )
+    sharded_param_uses = graph.call_function(
+        torch.ops.aten.add.Tensor,
+        args=(unsharded_param, duplicate_unsharded_param),
+    )
+    params = graph.call_function(
+        torch.ops.aten.add.Tensor,
+        args=(sharded_param_uses, replicated_param),
+    )
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(params, x))
+    graph.output((out,))
+    return _make_graph_module(graph)
+
+
+def _make_forward_graph_without_fsdp() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(param, x))
+    graph.output((out,))
+    return _make_graph_module(graph)
+
+
+def _make_forward_graph_without_wait() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(param, 1, _FAKE_PG),
+    )
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(all_gather, x))
+    graph.output((out,))
+    return _make_graph_module(graph)
+
+
+def _make_backward_graph_with_reduce_grad_epilogues() -> fx.GraphModule:
+    graph = fx.Graph()
+    fsdp_grad = graph.placeholder("fsdp_grad")
+    ddp_grad = graph.placeholder("ddp_grad")
+    input_grad = graph.placeholder("input_grad")
+    cast = graph.call_function(
+        torch.ops.aten._to_copy.default,
+        args=(fsdp_grad,),
+        kwargs={"dtype": torch.float32},
+    )
+    reduce_scatter = graph.call_function(
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        args=(cast, "sum", 1, _FAKE_PG),
+    )
+    reduce_scatter_wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(reduce_scatter,),
+    )
+    all_reduce = graph.call_function(
+        torch.ops._c10d_functional.all_reduce.default,
+        args=(ddp_grad, "sum", _FAKE_PG),
+    )
+    all_reduce_wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(all_reduce,),
+    )
+    graph.output((reduce_scatter_wait, all_reduce_wait, None, input_grad))
+    return _make_graph_module(graph)
+
+
+def _make_backward_graph_without_fsdp() -> fx.GraphModule:
+    graph = fx.Graph()
+    grad = graph.placeholder("grad")
+    out = graph.call_function(torch.ops.aten.neg.default, args=(grad,))
+    graph.output((out,))
+    return _make_graph_module(graph)
+
+
+class GraphPPFSDPCollectiveSplitTest(unittest.TestCase):
+    def test_forward_pattern_matches_reshard_force_save_pattern(self) -> None:
+        gm = _make_forward_graph_with_unshard_and_replicated_param()
+        deduplicate_fsdp_unshard_chains_pass(gm)
+        sharded_param = gm.graph.find_nodes(op="placeholder")[0]
+        save_nodes = find_fsdp_unshard_save_nodes(sharded_param)
+
+        self.assertEqual(len(save_nodes), 1)
+        self.assertIs(find_fsdp_unshard_output(sharded_param), save_nodes[0])
+        self.assertIs(find_fsdp_unshard_save_node(sharded_param), save_nodes[0])
+
+    def test_forward_split_extracts_unshard_and_replicated_params(self) -> None:
+        gm = _make_forward_graph_with_unshard_and_replicated_param()
+        deduplicate_fsdp_unshard_chains_pass(gm)
+
+        split = split_forward_fsdp_collectives(
+            gm,
+            num_params=2,
+            fwd_input_names=("sharded_param", "replicated_param", "x"),
+            fwd_flat_input_indices=(0, 1, 2),
+        )
+
+        self.assertIsNotNone(split.unshard_module)
+        if split.unshard_module is None:
+            self.fail("Expected forward FSDP split to extract an unshard graph")
+        self.assertEqual(
+            _placeholder_names(split.unshard_module),
+            ("sharded_param", "replicated_param"),
+        )
+        self.assertEqual(split.unshard_flat_param_indices, (0, 1))
+        self.assertEqual(split.num_fw_unsharded_param_inputs, 2)
+        self.assertEqual(split.fw_no_fsdp_flat_input_indices, (2,))
+        self.assertIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _call_targets(split.unshard_module),
+        )
+        self.assertIn(torch.ops.aten.cat.default, _call_targets(split.unshard_module))
+        self.assertNotIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _call_targets(split.fw_no_fsdp_module),
+        )
+
+    def test_forward_split_no_fsdp_is_noop(self) -> None:
+        gm = _make_forward_graph_without_fsdp()
+        split = split_forward_fsdp_collectives(
+            gm,
+            num_params=1,
+            fwd_input_names=("param", "x"),
+            fwd_flat_input_indices=(0, 1),
+        )
+
+        self.assertIsNone(split.unshard_module)
+        self.assertIs(split.fw_no_fsdp_module, gm)
+        self.assertEqual(split.fw_no_fsdp_input_names, ("param", "x"))
+        self.assertEqual(split.fw_no_fsdp_flat_input_indices, (0, 1))
+
+    def test_forward_split_requires_wait_after_all_gather(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Expected wait_tensor"):
+            split_forward_fsdp_collectives(
+                _make_forward_graph_without_wait(),
+                num_params=1,
+                fwd_input_names=("param", "x"),
+                fwd_flat_input_indices=(0, 1),
+            )
+
+    def test_backward_split_extracts_reduce_grad_epilogues(self) -> None:
+        split = split_backward_fsdp_collectives(
+            _make_backward_graph_with_reduce_grad_epilogues(),
+            num_param_grads=3,
+        )
+
+        self.assertIsNotNone(split.reduce_grad_module)
+        if split.reduce_grad_module is None:
+            self.fail("Expected backward FSDP split to extract reduce-grad graph")
+        bw_no_fsdp_targets = _call_targets(split.bw_no_fsdp_module)
+        reduce_grad_targets = _call_targets(split.reduce_grad_module)
+        self.assertIn(torch.ops.aten._to_copy.default, bw_no_fsdp_targets)
+        self.assertNotIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            bw_no_fsdp_targets,
+        )
+        self.assertNotIn(
+            torch.ops._c10d_functional.all_reduce.default,
+            bw_no_fsdp_targets,
+        )
+        self.assertNotIn(torch.ops.aten._to_copy.default, reduce_grad_targets)
+        self.assertIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            reduce_grad_targets,
+        )
+        self.assertIn(
+            torch.ops._c10d_functional.all_reduce.default,
+            reduce_grad_targets,
+        )
+        self.assertEqual(
+            split.reduce_grad_input_names,
+            split.bw_no_fsdp_output_names[:2],
+        )
+        self.assertEqual(len(split.bw_no_fsdp_output_names), 4)
+        self.assertEqual(split.bw_no_fsdp_output_names[-1], "input_grad")
+
+    def test_backward_split_no_fsdp_is_noop_and_validates_grad_count(self) -> None:
+        gm = _make_backward_graph_without_fsdp()
+        split = split_backward_fsdp_collectives(gm, num_param_grads=1)
+
+        self.assertIsNone(split.reduce_grad_module)
+        self.assertIs(split.bw_no_fsdp_module, gm)
+
+        with self.assertRaisesRegex(ValueError, "num_param_grads cannot exceed"):
+            split_backward_fsdp_collectives(gm, num_param_grads=2)
+
+
+class GraphPPFSDPCollectiveSplitDsv3Test(_GraphPPDsv3FSDPTest):
+    def test_real_dsv3_moe_block_fsdp_split_reconstructs_graphs(self) -> None:
+        if torch.cuda.device_count() < 2:
+            raise unittest.SkipTest("real FSDP collective trace requires 2 GPUs")
+
+        self._setup()
+        fsdp_mesh = self.parallel_dims.get_mesh("fsdp")
+        traced_block = _trace_dsv3_moe_block_stage(fsdp_mesh=fsdp_mesh)
+        deduplicate_fsdp_unshard_chains_pass(
+            traced_block.traced.gm,
+            traced_block.traced.example_inputs,
+        )
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced_block.traced,
+            num_fwd_outputs=1,
+            backward_only_input_indices=(len(traced_block.traced.example_inputs) - 1,),
+        )
+        fw_split = split_forward_fsdp_collectives(
+            fw_module,
+            num_params=traced_block.num_flat_param_values,
+            fwd_input_names=meta.fwd_input_names,
+            fwd_flat_input_indices=meta.fwd_flat_input_indices,
+        )
+        bw_split = split_backward_fsdp_collectives(
+            bw_module,
+            num_param_grads=traced_block.num_param_grad_values,
+        )
+
+        self.assertIsNotNone(fw_split.unshard_module)
+        self.assertIsNotNone(bw_split.reduce_grad_module)
+        if fw_split.unshard_module is None or bw_split.reduce_grad_module is None:
+            self.fail("Expected real DSV3 FSDP trace to contain split collectives")
+        self.assertNotIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _call_targets(fw_split.fw_no_fsdp_module),
+        )
+        self.assertNotIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            _call_targets(bw_split.bw_no_fsdp_module),
+        )
+
+        fw_args = [
+            traced_block.flat_inputs[index] for index in meta.fwd_flat_input_indices
+        ]
+        fw_outputs = _boxed_run(fw_module, list(fw_args))
+        unshard_args = [
+            traced_block.flat_inputs[index]
+            for index in fw_split.unshard_flat_param_indices
+        ]
+        unsharded_params = _boxed_run(fw_split.unshard_module, unshard_args)
+        fw_no_fsdp_args = [
+            *unsharded_params,
+            *(
+                traced_block.flat_inputs[index]
+                for index in fw_split.fw_no_fsdp_flat_input_indices
+            ),
+        ]
+        split_fw_outputs = _boxed_run(
+            fw_split.fw_no_fsdp_module,
+            list(fw_no_fsdp_args),
+        )
+        _assert_tensor_sequence_equal(self, split_fw_outputs, fw_outputs)
+
+        bw_args = _backward_args_from_partition(
+            meta,
+            fw_outputs,
+            (traced_block.output_grad,),
+        )
+        bw_outputs = _boxed_run(bw_module, list(bw_args))
+        bw_no_fsdp_outputs = _boxed_run(bw_split.bw_no_fsdp_module, list(bw_args))
+        grad_values_by_name = dict(
+            zip(
+                bw_split.bw_no_fsdp_output_names[: traced_block.num_param_grad_values],
+                bw_no_fsdp_outputs[: traced_block.num_param_grad_values],
+                strict=True,
+            )
+        )
+        reduce_grad_args = [
+            grad_values_by_name[name] for name in bw_split.reduce_grad_input_names
+        ]
+        reduced_grads = _boxed_run(bw_split.reduce_grad_module, reduce_grad_args)
+        split_bw_outputs = (
+            *reduced_grads,
+            *bw_no_fsdp_outputs[traced_block.num_param_grad_values :],
+        )
+        _assert_tensor_sequence_equal(self, split_bw_outputs, bw_outputs)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -77,6 +77,7 @@ from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     _FSDP_BUCKET_META,
+    deduplicate_fsdp_unshard_chains_pass,
     get_transformer_block_bucket_counts,
     reassign_collective_pgs_pass,
     schedule_fsdp_comms_to_dense_regions_pass,
@@ -87,6 +88,7 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     run_traced,
 )
 from torchtitan.experiments.graph_trainer.memory_policy import (
+    _default_memory_policy_pass,
     _make_default_memory_policy,
     _make_full_memory_policy,
     tag_sac_policy,
@@ -150,6 +152,67 @@ class TestDefaultTransformerBlockBuckets(TestCase):
             ],
             [False, True],
         )
+
+
+class TestFSDPUnshardDedupPass(TestCase):
+    def _duplicate_unshard_graph(self) -> torch.fx.GraphModule:
+        graph = torch.fx.Graph()
+        sharded_param = graph.placeholder("sharded_param")
+        x = graph.placeholder("x")
+
+        all_gather_0 = graph.call_function(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            args=(sharded_param, 1, "fsdp_pg"),
+        )
+        wait_0 = graph.call_function(
+            torch.ops._c10d_functional.wait_tensor.default,
+            args=(all_gather_0,),
+        )
+        unsharded_0 = graph.call_function(
+            torch.ops.aten.view.default,
+            args=(wait_0, [4]),
+        )
+
+        all_gather_1 = graph.call_function(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            args=(sharded_param, 1, "fsdp_pg"),
+        )
+        wait_1 = graph.call_function(
+            torch.ops._c10d_functional.wait_tensor.default,
+            args=(all_gather_1,),
+        )
+        unsharded_1 = graph.call_function(
+            torch.ops.aten.view.default,
+            args=(wait_1, [4]),
+        )
+
+        params = graph.call_function(
+            torch.ops.aten.add.Tensor,
+            args=(unsharded_0, unsharded_1),
+        )
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(params, x))
+        graph.output(out)
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        gm.graph.lint()
+        gm.recompile()
+        return gm
+
+    def test_duplicate_fsdp_unshard_chains_are_canonicalized(self) -> None:
+        gm = self._duplicate_unshard_graph()
+
+        self.assertEqual(
+            sum(1 for node in gm.graph.nodes if is_all_gather(node)),
+            2,
+        )
+
+        deduplicate_fsdp_unshard_chains_pass(gm)
+
+        self.assertEqual(
+            sum(1 for node in gm.graph.nodes if is_all_gather(node)),
+            1,
+        )
+        gm.graph.lint()
 
 
 class ToyModel(Module):
@@ -1386,6 +1449,64 @@ class TestApplySACPass(TestCase):
         wait_node = nodes[1]
         self.assertEqual(rs_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
         self.assertEqual(wait_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+    def test_default_policy_saves_fsdp_unshard_when_not_resharding(self):
+        """Saves the helper-selected FSDP unshard output only when needed."""
+        cases = (
+            ("never", 1, CheckpointPolicy.MUST_SAVE),
+            # Under PP, the default FSDP policy keeps params unsharded across
+            # forward/backward, so SAC must save the same unshard boundary.
+            ("default", 2, CheckpointPolicy.MUST_SAVE),
+            ("always", 1, CheckpointPolicy.PREFER_RECOMPUTE),
+        )
+
+        for reshard_after_forward, pp_degree, expected_wait_policy in cases:
+            with self.subTest(
+                reshard_after_forward=reshard_after_forward,
+                pp_degree=pp_degree,
+            ):
+                (
+                    gm,
+                    all_gather,
+                    wait,
+                    view,
+                ) = self._fsdp_unshard_test_graph()
+                config = SimpleNamespace(
+                    parallelism=SimpleNamespace(
+                        fsdp_reshard_after_forward=reshard_after_forward,
+                        pipeline_parallel_degree=pp_degree,
+                    )
+                )
+
+                _default_memory_policy_pass(gm, config=config)
+
+                self.assertEqual(
+                    all_gather.meta["recompute"],
+                    CheckpointPolicy.PREFER_RECOMPUTE,
+                )
+                self.assertEqual(wait.meta["recompute"], expected_wait_policy)
+                self.assertEqual(
+                    view.meta["recompute"],
+                    CheckpointPolicy.PREFER_RECOMPUTE,
+                )
+
+    def _fsdp_unshard_test_graph(self):
+        graph = torch.fx.Graph()
+        param = graph.placeholder("param")
+        x = graph.placeholder("x")
+        all_gather = graph.call_function(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            args=(param, 1, "0"),
+        )
+        wait = graph.call_function(
+            torch.ops._c10d_functional.wait_tensor.default,
+            args=(all_gather,),
+        )
+        view = graph.call_function(torch.ops.aten.view.default, args=(wait, [4]))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(view, x))
+        graph.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        return gm, all_gather, wait, view
 
     def test_boundary_nodes_forced_to_must_save(self):
         """Nodes at AC region boundaries should be forced to MUST_SAVE."""
@@ -3308,6 +3429,10 @@ class TestChunkPasses(TestCase):
 
         self.assertLess(
             names.index("canonicalize_graph_pass"),
+            names.index("deduplicate_fsdp_unshard_chains_pass"),
+        )
+        self.assertLess(
+            names.index("deduplicate_fsdp_unshard_chains_pass"),
             names.index("tag_with_memory_policy_pass"),
         )
         self.assertLess(


### PR DESCRIPTION
Stacked PRs:
 * #3585
 * #3090
 * #3089
 * __->__#3088
 * #2727
 * #2726


--- --- ---

### [graph_trainer][aot_fx_trace][graph_pp] Add FSDP collective splitting


Add GraphPP extraction for explicit FSDP UNSHARD and REDUCE_GRAD graphs. The splitters use shared FSDP trace-pattern helpers to identify validated all-gather/wait reconstruction chains and reduce-scatter epilogues, keep the no-FSDP forward/backward graphs on the GraphPP flat calling convention, and leave fused edge graphs out of the runtime contract.

Teach the default SAC policy to force-save the same helper-selected unshard output when FSDP runs with reshard_after_forward=False, matching the AutoParallel force-save behavior instead of saving every all-gather target.

Add FSDP split tests for collective extraction, view and split-cat reconstruction, malformed unshard chains, no-op paths, input-source metadata, reduce-grad input naming, and pre-reduce cast placement.
