### PR TITLE
Use `current_accelerator` for device in AutoParallel calls to enable XPU

### DIFF
--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -24,6 +24,7 @@ from torchtitan.experiments.autoparallel.configs import AutoParallelCompileConfi
 from torchtitan.models.common.moe import _run_experts_grouped_mm
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import device_type
 
 
 def create_functional_router_forward(
@@ -306,7 +307,7 @@ def parallelize_deepseekv3(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.accelerator.current_accelerator(),
+                device=torch.device(device_type),
             ),
         )
 

--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -306,7 +306,7 @@ def parallelize_deepseekv3(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.device("cuda"),
+                device=torch.accelerator.current_accelerator(),
             ),
         )
 

--- a/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
+++ b/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
@@ -71,7 +71,7 @@ def parallelize_llama(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.device("cuda"),
+                device=torch.accelerator.current_accelerator(),
             ),
         )
 

--- a/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
+++ b/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
@@ -21,6 +21,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.autoparallel.configs import AutoParallelCompileConfig
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import device_type
 
 
 def parallelize_llama(
@@ -71,7 +72,7 @@ def parallelize_llama(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.accelerator.current_accelerator(),
+                device=torch.device(device_type),
             ),
         )
 

--- a/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
@@ -89,7 +89,7 @@ def parallelize_deepseekv3(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.device("cuda"),
+                device=torch.accelerator.current_accelerator(),
             ),
         )
 

--- a/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
@@ -21,6 +21,7 @@ from torchtitan.experiments.autoparallel.configs import AutoParallelCompileConfi
 from torchtitan.protocols.model_converter import ModelConvertersContainer
 
 from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import device_type
 
 
 # TODO: Autoparallel should transparently wrap the original nn.Module
@@ -89,7 +90,7 @@ def parallelize_deepseekv3(
                 0,
                 model.config.vocab_size,
                 (global_batch_size, training.seq_len),
-                device=torch.accelerator.current_accelerator(),
+                device=torch.device(device_type),
             ),
         )
 


### PR DESCRIPTION
In order to enable AutoParallel for XPU, this changes the `torch.device("cuda")` device to `torch.accelerator.current_accelerator()`.