### PR TITLE
[GraphTrainer][AutoDev] Add synthetic dataloader for precompile workflows

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -10,6 +10,9 @@ from typing import Literal
 
 from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.config.configs import CompileConfig
+from torchtitan.experiments.graph_trainer.synthetic_dataloader import (
+    SyntheticDataLoader,
+)
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
 
@@ -61,6 +64,28 @@ class GraphTrainerCompileConfig(CompileConfig):
     here to skip compilation. For multi-node setups use a shared filesystem
     path.
     """
+
+
+def use_synthetic_dataloader(config: "GraphTrainer.Config") -> "GraphTrainer.Config":
+    """Replace the dataloader config with a synthetic one for precompilation.
+
+    Reads vocab_size from the model config so callers don't need to specify it
+    manually. This avoids initializing a real dataset (e.g. downloading from
+    HuggingFace) when only input shapes matter for graph tracing.
+
+    Args:
+        config: A GraphTrainer.Config with model_spec already set.
+
+    Returns:
+        The same config object with dataloader replaced (mutated in place
+        and returned for chaining convenience).
+    """
+    assert (
+        config.model_spec is not None
+    ), "model_spec must be set before calling use_synthetic_dataloader"
+    vocab_size = config.model_spec.model.vocab_size
+    config.dataloader = SyntheticDataLoader.Config(vocab_size=vocab_size)
+    return config
 
 
 def to_graph_trainer_config(

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -195,7 +195,25 @@ def _common_setup(config):
 
     logger.info("Model parallelized and materialized")
 
-    tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
+    # Build tokenizer only when needed (flex/varlen attention masks).
+    # Skipping it avoids requiring HF tokenizer assets on disk when
+    # precompiling with standard causal attention.
+    tokenizer = None
+    if isinstance(model_config, Decoder.Config) and model_config.layers:
+        inner_attention = getattr(
+            model_config.layers[0].attention, "inner_attention", None
+        )
+        if inner_attention is not None:
+            from torchtitan.models.common.attention import (
+                FlexAttention,
+                VarlenAttention,
+            )
+
+            if isinstance(
+                inner_attention,
+                (FlexAttention.Config, VarlenAttention.Config),
+            ):
+                tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
 
     return (
         model,

--- a/torchtitan/experiments/graph_trainer/synthetic_dataloader.py
+++ b/torchtitan/experiments/graph_trainer/synthetic_dataloader.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Synthetic dataloader for precompilation and benchmarking.
+
+Generates random token IDs with the correct shapes and dtypes, avoiding
+the cost of initializing a real dataset (e.g. downloading from HuggingFace
+or loading sixlib). Only input shapes matter for tracing/compilation, so
+real data is unnecessary for precompile workflows.
+
+Usage:
+    --dataloader synthetic --dataloader.vocab_size 128256
+
+For precompile, vocab_size is read from the model config automatically
+when using the graph_trainer config_registry functions.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch.distributed.checkpoint.stateful import Stateful
+from torch.utils.data import IterableDataset
+
+from torchtitan.components.dataloader import ParallelAwareDataloader
+
+
+class SyntheticDataset(IterableDataset, Stateful):
+    """Infinite dataset of random token ID sequences.
+
+    Each sample is a pair of (input_dict, labels) matching the format
+    produced by HuggingFaceTextDataset: input_dict contains an "input"
+    tensor of shape (seq_len,) and labels is a tensor of shape (seq_len,).
+    Token IDs are sampled uniformly from [0, vocab_size).
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        seq_len: int,
+    ) -> None:
+        if vocab_size <= 0:
+            raise ValueError(
+                f"vocab_size must be positive, got {vocab_size}. "
+                "Set --dataloader.vocab_size or use a config that sets it."
+            )
+        self.vocab_size = vocab_size
+        self.seq_len = seq_len
+        self._step = 0
+
+    def __iter__(self):
+        while True:
+            # Use a different seed per step for variety, but this is
+            # synthetic data so exact reproducibility is not critical.
+            input_ids = torch.randint(0, self.vocab_size, (self.seq_len,))
+            labels = torch.randint(0, self.vocab_size, (self.seq_len,))
+            self._step += 1
+            yield {"input": input_ids}, labels
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"step": self._step}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self._step = state_dict.get("step", 0)
+
+
+class SyntheticDataLoader(ParallelAwareDataloader):
+    """Dataloader that generates synthetic random token sequences.
+
+    Designed for precompilation and benchmarking where real data is
+    unnecessary -- only input shapes matter for graph tracing.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ParallelAwareDataloader.Config):
+        dataset: str = "synthetic"
+        """Dataset name (always 'synthetic' for this dataloader)."""
+
+        vocab_size: int = 0
+        """Vocabulary size for random token generation. Set to 0 to require
+        explicit configuration (typically auto-set from the model config)."""
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        dp_world_size: int,
+        dp_rank: int,
+        seq_len: int,
+        local_batch_size: int,
+        **kwargs,
+    ):
+        vocab_size = config.vocab_size
+        if vocab_size <= 0:
+            raise ValueError(
+                "SyntheticDataLoader requires vocab_size > 0. "
+                "Set --dataloader.vocab_size explicitly or use a config "
+                "function that sets it from the model config."
+            )
+
+        ds = SyntheticDataset(
+            vocab_size=vocab_size,
+            seq_len=seq_len,
+        )
+
+        super().__init__(
+            ds,
+            dp_rank=dp_rank,
+            dp_world_size=dp_world_size,
+            batch_size=local_batch_size,
+        )

--- a/torchtitan/experiments/graph_trainer/tests/test_synthetic_dataloader.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_synthetic_dataloader.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchtitan.experiments.graph_trainer.synthetic_dataloader import (
+    SyntheticDataLoader,
+    SyntheticDataset,
+)
+
+
+class TestSyntheticDataset(unittest.TestCase):
+    def test_yields_correct_shapes(self):
+        ds = SyntheticDataset(vocab_size=100, seq_len=32)
+        it = iter(ds)
+        input_dict, labels = next(it)
+
+        self.assertIn("input", input_dict)
+        self.assertEqual(input_dict["input"].shape, (32,))
+        self.assertEqual(labels.shape, (32,))
+
+    def test_token_ids_in_range(self):
+        vocab_size = 50
+        ds = SyntheticDataset(vocab_size=vocab_size, seq_len=64)
+        it = iter(ds)
+
+        for _ in range(10):
+            input_dict, labels = next(it)
+            self.assertTrue((input_dict["input"] >= 0).all())
+            self.assertTrue((input_dict["input"] < vocab_size).all())
+            self.assertTrue((labels >= 0).all())
+            self.assertTrue((labels < vocab_size).all())
+
+    def test_dtype_is_long(self):
+        ds = SyntheticDataset(vocab_size=100, seq_len=16)
+        it = iter(ds)
+        input_dict, labels = next(it)
+
+        self.assertEqual(input_dict["input"].dtype, torch.int64)
+        self.assertEqual(labels.dtype, torch.int64)
+
+    def test_invalid_vocab_size_raises(self):
+        with self.assertRaises(ValueError):
+            SyntheticDataset(vocab_size=0, seq_len=16)
+
+        with self.assertRaises(ValueError):
+            SyntheticDataset(vocab_size=-1, seq_len=16)
+
+    def test_state_dict_roundtrip(self):
+        ds = SyntheticDataset(vocab_size=100, seq_len=16)
+        it = iter(ds)
+        for _ in range(5):
+            next(it)
+
+        state = ds.state_dict()
+        self.assertEqual(state["step"], 5)
+
+        ds2 = SyntheticDataset(vocab_size=100, seq_len=16)
+        ds2.load_state_dict(state)
+        self.assertEqual(ds2._step, 5)
+
+    def test_infinite_iteration(self):
+        """Verify the dataset yields indefinitely."""
+        ds = SyntheticDataset(vocab_size=100, seq_len=8)
+        it = iter(ds)
+        for _ in range(1000):
+            input_dict, labels = next(it)
+            self.assertEqual(input_dict["input"].shape, (8,))
+
+
+class TestSyntheticDataLoader(unittest.TestCase):
+    def test_config_defaults(self):
+        config = SyntheticDataLoader.Config()
+        self.assertEqual(config.dataset, "synthetic")
+        self.assertEqual(config.vocab_size, 0)
+
+    def test_zero_vocab_size_raises(self):
+        config = SyntheticDataLoader.Config(vocab_size=0)
+        with self.assertRaises(ValueError):
+            SyntheticDataLoader(
+                config,
+                dp_world_size=1,
+                dp_rank=0,
+                seq_len=32,
+                local_batch_size=2,
+            )
+
+    def test_dataloader_yields_batches(self):
+        config = SyntheticDataLoader.Config(vocab_size=100)
+        dl = SyntheticDataLoader(
+            config,
+            dp_world_size=1,
+            dp_rank=0,
+            seq_len=32,
+            local_batch_size=4,
+        )
+
+        it = iter(dl)
+        batch = next(it)
+        input_dict, labels = batch
+
+        self.assertIn("input", input_dict)
+        # Batched shape: (batch_size, seq_len)
+        self.assertEqual(input_dict["input"].shape, (4, 32))
+        self.assertEqual(labels.shape, (4, 32))
+
+
+class TestUseSyntheticDataloader(unittest.TestCase):
+    def test_replaces_dataloader_config(self):
+        from types import SimpleNamespace
+
+        from torchtitan.experiments.graph_trainer.configs import (
+            use_synthetic_dataloader,
+        )
+
+        # Create a minimal config-like object with model_spec
+        config = SimpleNamespace(
+            model_spec=SimpleNamespace(
+                model=SimpleNamespace(vocab_size=32000),
+            ),
+            dataloader=SimpleNamespace(dataset="c4_test"),
+        )
+
+        use_synthetic_dataloader(config)
+
+        self.assertIsInstance(config.dataloader, SyntheticDataLoader.Config)
+        self.assertEqual(config.dataloader.vocab_size, 32000)
+        self.assertEqual(config.dataloader.dataset, "synthetic")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `SyntheticDataLoader` to graph_trainer that generates random token IDs with correct shapes/dtypes, avoiding the cost of initializing a real dataset (e.g. HuggingFace downloads, sixlib) when only input shapes matter for compilation
- Add `use_synthetic_dataloader()` config helper that reads vocab_size from the model config automatically
- Make tokenizer building in `precompile_main.py` conditional -- only built when flex/varlen attention requires it, so standard causal attention precompile no longer requires HF tokenizer assets on disk

**Board item**: `PVTI_lADOAUB9vs4BT6Cuzgq7q0s` (pytorch project #161)

## Motivation

Graph trainer currently requires a real dataset even during precompilation and benchmarking workflows. Initializing real dataloaders can be expensive (e.g. in sixlib) and is unnecessary for tracing -- only input shapes/sizes matter. This change formalizes the pattern already used in unit tests (random inputs) into a proper Configurable dataloader.

## Usage

**In config functions** (recommended for precompile configs):
```python
from torchtitan.experiments.graph_trainer.configs import use_synthetic_dataloader

def my_precompile_config() -> GraphTrainer.Config:
    config = to_graph_trainer_config(base_config(), model_registry)
    use_synthetic_dataloader(config)  # auto-reads vocab_size from model
    return config
```

**Via CLI** (for ad-hoc usage):
```bash
python -m torchtitan.experiments.graph_trainer.precompile_main \
    --module graph_trainer.llama3 \
    --config graph_trainer_llama3_debugmodel \
    --compile.mode aot_fx_trace \
    --compile.precompile_artifact_dir /tmp/artifacts
```
Note: `precompile_main.py` already creates synthetic inputs internally and never uses the dataloader. The `SyntheticDataLoader` is primarily useful for the **training step** after precompile (`run_train_precompile.sh`) when real data quality doesn't matter.

## Test plan

- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_synthetic_dataloader.py -x` -- 10 tests covering shapes, dtypes, token ranges, state_dict roundtrip, config integration, error handling
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -x` -- all 30 existing tests pass
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x -k eager_self_deterministic` -- bitwise determinism guardrail passes
- [x] `pre-commit run --all-files` -- flake8, ufmt, pydoclint, codespell all pass (pyrefly failure is pre-existing environment issue)