### PR TITLE
Disable all experimental workflows for ROCm for all conditions

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -31,6 +31,8 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
+    with:
+      is-experimental: 1
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      is-experimental: 1
+      is-experimental: true
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_autoparallel.yaml
+++ b/.github/workflows/integration_test_8gpu_autoparallel.yaml
@@ -31,6 +31,8 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
+    with:
+      is-experimental: 1
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_autoparallel.yaml
+++ b/.github/workflows/integration_test_8gpu_autoparallel.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      is-experimental: 1
+      is-experimental: true
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -32,6 +32,8 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
+    with:
+      is-experimental: 1
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -33,7 +33,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      is-experimental: 1
+      is-experimental: true
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -31,6 +31,8 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
+    with:
+      is-experimental: 1
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      is-experimental: 1
+      is-experimental: true
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_vlm.yaml
+++ b/.github/workflows/integration_test_8gpu_vlm.yaml
@@ -31,6 +31,8 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
+    with:
+      is-experimental: 1
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/integration_test_8gpu_vlm.yaml
+++ b/.github/workflows/integration_test_8gpu_vlm.yaml
@@ -32,7 +32,7 @@ jobs:
   set-matrix:
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      is-experimental: 1
+      is-experimental: true
 
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -1,4 +1,4 @@
-name: Set Matrix
+game: Set Matrix
 
 on:
   workflow_call:
@@ -11,6 +11,10 @@ on:
         description: 'Override default (linux.g5.48xlarge.nvidia.gpu) CUDA runner label'
         required: false
         type: string
+      is-experimental:
+        description: 'Check if the workflow is experimental'
+        required: false
+        type: int
     outputs:
       matrix:
         description: dynamically set matrix
@@ -46,19 +50,22 @@ jobs:
           ROCM_RUNNER="${ROCM_RUNNER_INPUT:-$DEFAULT_ROCM_RUNNER}"
           CUDA_RUNNER="${CUDA_RUNNER_INPUT:-$DEFAULT_CUDA_RUNNER}"
 
-          # Define ROCm matrix
-          ROCM_MATRIX=$(cat <<EOF
-          {
-            "name": "rocm",
-            "runner": "${ROCM_RUNNER}",
-            "gpu-arch-type": "rocm",
-            "gpu-arch-version": "7.1",
-            "docker-image": "torchtitan-rocm-ubuntu-22.04-clang12",
-            "index-url": "https://download.pytorch.org/whl/nightly/rocm7.1",
-            "torch-version": ""
-          }
-          EOF
-          )
+          # Define ROCm matrix (empty for experimental workflows)
+          if [[ "${{ inputs.is-experimental }}" == "1" ]]; then
+            ROCM_MATRIX=""
+          else
+            ROCM_MATRIX=$(cat <<EOF
+            {
+              "name": "rocm",
+              "runner": "${ROCM_RUNNER}",
+              "gpu-arch-type": "rocm",
+              "gpu-arch-version": "7.1",
+              "docker-image": "torchtitan-rocm-ubuntu-22.04-clang12",
+              "index-url": "https://download.pytorch.org/whl/nightly/rocm7.1",
+              "torch-version": ""
+            }
+            EOF
+            )
 
           # Define CUDA matrix
           CUDA_MATRIX=$(cat <<EOF

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -15,6 +15,7 @@ on:
         description: 'Check if the workflow is experimental'
         required: false
         type: int
+        default: 0
     outputs:
       matrix:
         description: dynamically set matrix

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -14,8 +14,8 @@ on:
       is-experimental:
         description: 'Check if the workflow is experimental'
         required: false
-        type: int
-        default: 0
+        type: boolean
+        default: false
     outputs:
       matrix:
         description: dynamically set matrix
@@ -52,7 +52,7 @@ jobs:
           CUDA_RUNNER="${CUDA_RUNNER_INPUT:-$DEFAULT_CUDA_RUNNER}"
 
           # Define ROCm matrix (empty for experimental workflows)
-          if [[ "${{ inputs.is-experimental }}" == "1" ]]; then
+          if [[ "${{ inputs.is-experimental }}" == "true" ]]; then
             ROCM_MATRIX=""
           else
             ROCM_MATRIX=$(cat <<EOF

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -53,7 +53,7 @@ jobs:
 
           # Define ROCm matrix (empty for experimental workflows)
           if [[ "${{ inputs.is-experimental }}" == "true" ]]; then
-            ROCM_MATRIX=""
+            ROCM_MATRIX="[]"
           else
             ROCM_MATRIX=$(cat <<EOF
             {

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -53,7 +53,7 @@ jobs:
 
           # Define ROCm matrix (empty for experimental workflows)
           if [[ "${{ inputs.is-experimental }}" == "true" ]]; then
-            ROCM_MATRIX="[]"
+            ROCM_MATRIX=""
           else
             ROCM_MATRIX=$(cat <<EOF
             {

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -67,6 +67,7 @@ jobs:
             }
             EOF
             )
+          fi
 
           # Define CUDA matrix
           CUDA_MATRIX=$(cat <<EOF


### PR DESCRIPTION
 It was found that for cron and push to main the experimental workflows were still running. Hence, this PR disables all experimental workflows for ROCm.