### PR TITLE
add reset_prefix_cache

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -332,6 +332,9 @@ class VLLMGenerator(Actor, Configurable):
             direct_rdma=is_rdma_available(),
         )
         self.policy_version = version
+        # Invalidate the KV prefix cache so stale values computed with the
+        # old weights are never reused for new generations.
+        self._engine.reset_prefix_cache()
         logger.debug(
             f"{os.getpid()=} Generator pulled model state dict for policy v{version}"
         )


### PR DESCRIPTION
need to add self._engine.reset_prefix_cache() so that old KV cache values arent used after weight updates
<img width="1121" height="234" alt="Screenshot 2026-04-24 at 6 41 33 PM" src="https://github.com/user-attachments/assets/89ad1f83-b934-4079-8e7f-0f5b9cffda7d" />
