### PR TITLE
[GraphTrainer] Add sanketpurandare for graph_trainer codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,3 @@
 /torchtitan/experiments/forge/ @joecummings @felipemello1 @daniellepintz @tianyu-l @wwwjn @fegin
 
 /torchtitan/experiments/graph_trainer/ @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare
-/.github/workflows/*graph_trainer* @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,5 @@
 
 /torchtitan/experiments/forge/ @joecummings @felipemello1 @daniellepintz @tianyu-l @wwwjn @fegin
 
-/torchtitan/experiments/graph_trainer/ @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk
+/torchtitan/experiments/graph_trainer/ @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare
+/.github/workflows/*graph_trainer* @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare


### PR DESCRIPTION
## Summary
- Add @sanketpurandare to graph_trainer codeowners.

## Test plan
- Verified the glob pattern matches both `integration_test_8gpu_graph_trainer.yaml` and `integration_test_8gpu_graph_trainer_h100.yaml`.