### PR TITLE
Fix SAC test compatibility with PyTorch indexed storage

### DIFF
--- a/tests/unit_tests/test_activation_checkpoint.py
+++ b/tests/unit_tests/test_activation_checkpoint.py
@@ -52,10 +52,11 @@ class TestApplyAC(unittest.TestCase):
             out.backward()
 
             x = torch.randn(512, 512, requires_grad=True)
-            out = model_fn(x)
-            with FlopCounterMode(display=False) as mode:
+            with FlopCounterMode(display=False) as fwd_mode:
+                out = model_fn(x)
+            with FlopCounterMode(display=False) as bwd_mode:
                 out.backward()
-            return mode.get_total_flops() / (512**3 * 2)
+            return bwd_mode.get_total_flops() / (512**3 * 2)
 
         # 1. No AC
         model_no_ac = ToyModule()


### PR DESCRIPTION
### Summary                                                                                                    
                                                                  
- Fix test_flops failure caused by PyTorch PR #176455 which switches SAC from re-running the policy function during recompute to indexed storage replay
- Wrap forward with FlopCounterMode so SAC indexes ops under the same dispatch mode stack as backward recompute                                                                                                  
- Backward flops are still measured separately via a dedicated bwd_mode instance — expected values
  unchanged                                                                                                  
                                                                  
### Test plan                                                                                                  
                                                                  
`python -m pytest tests/unit_tests/test_activation_checkpoint.py -xvs`