### PR TITLE
[DO NOT LAND] graph trainer mxfp8 repro

### DIFF
--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchtitan.components.quantization.mx import MXFP8Converter
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -16,6 +17,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_debugmodel,
     llama3_debugmodel_flex_attn,
 )
+from torchtitan.protocols.model_converter import ModelConvertersContainer
 
 from . import model_registry
 
@@ -32,9 +34,35 @@ def graph_trainer_llama3_debugmodel_flex_attn() -> (GraphTrainer.Config):
     return config
 
 
+def graph_trainer_llama3_debugmodel_mxfp8() -> GraphTrainer.Config:
+    """Llama3 debugmodel with MXFP8 quantization. Requires SM100+ (B200/B100)
+    and torchao."""
+    config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    config.model_converters = ModelConvertersContainer.Config(
+        converters=[
+            MXFP8Converter.Config(fqns=["layers"]),
+        ],
+    )
+    return config
+
+
 def graph_trainer_llama3_8b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_8b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_8b_mxfp8() -> GraphTrainer.Config:
+    """Llama3 8B with MXFP8 quantization. Requires SM100+ (B200/B100)
+    and torchao."""
+    config = to_graph_trainer_config(llama3_8b(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    config.model_converters = ModelConvertersContainer.Config(
+        converters=[
+            MXFP8Converter.Config(fqns=["layers"]),
+        ],
+    )
     return config
 
 


### PR DESCRIPTION
Repro: 
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b_mxfp8 ./run_train.sh --compile.mode aot_fx_trace --profiler.profile_freq 15 --training.steps 20
```

No mxfp8 kernels are generated by looking at the profiling trace. The GEMM kernels are identical as the ones from normal bf16 runs
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot_fx_trace
```