### PR TITLE
fix: proper cp global_max_loss accounting

### DIFF
--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -445,6 +445,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # These attributes must be initialized before checkpoint loading.
         self.step = 0
         self.ntokens_seen = 0
+        self._rank_local_valid_tokens_per_step = 0
 
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
@@ -637,9 +638,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.config.parallelism.context_parallel_load_balancer,
             )
 
-        # Accumulate after CP sharding so labels.numel() reflects the actual
-        # unique tokens this rank processes (not the full pre-split sequence).
+        # Accumulate after CP sharding so counts reflect the actual unique
+        # tokens this rank processes (not the full pre-split sequence).
         self.ntokens_seen += labels.numel()
+        self._rank_local_valid_tokens_per_step += int(
+            (labels != IGNORE_INDEX).sum()
+        )
 
         return inputs, labels, extra_inputs, extra_kwargs
 
@@ -739,6 +743,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             global_valid_tokens = local_valid_tokens.float()
 
         # Process each microbatch: move to GPU, forward/backward, then free
+        self._rank_local_valid_tokens_per_step = 0
         accumulated_losses = []
         for input_dict, labels in microbatches:
             # Move tensors to GPU
@@ -782,11 +787,23 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # global_avg_loss = sum(local_loss_sum) / global_valid_tokens
             #                 = sum(loss)
             #
-            # For global_max_loss, we want the max of local average losses across ranks:
-            # local_avg_loss = local_loss_sum / local_valid_tokens
-            #                = (loss * global_valid_tokens) / local_valid_tokens
+            # For global_max_loss, we want the max of all the rank-local average losses.
+            # local_valid_tokens is the pre-CP-sharding count, identical on all ranks in a CP group,
+            # whereas max-loss requires the post-CP-sharding count. This is provided by
+            # _rank_local_valid_tokens_per_step, which is accumulated after CP sharding in
+            # post_dataloading_process:
+            # local_avg_loss = local_loss_sum / rank_local_valid_tokens
+            #                = (loss * global_valid_tokens) / rank_local_valid_tokens
             # global_max_loss = max(local_avg_loss)
-            local_avg_loss = loss * global_valid_tokens / local_valid_tokens
+            rank_local_valid_tokens = torch.tensor(
+                self._rank_local_valid_tokens_per_step,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            # clamp avoids 0/0 when, e.g.,  a CP shard contains only masked tokens (loss=0)
+            local_avg_loss = (
+                loss * global_valid_tokens / rank_local_valid_tokens.clamp(min=1)
+            )
             global_avg_loss, global_max_loss, global_ntokens_seen = (
                 dist_utils.dist_sum(loss, loss_mesh),
                 dist_utils.dist_max(local_avg_loss, loss_mesh),


### PR DESCRIPTION

The current `global_max_loss` computation is inaccurate for context-parallelism because it relies on
`local_valid_tokens`, which is computed prior to CP-sharding.  

Relates to https://github.com/pytorch/torchtitan/pull/2314. CC @wwwjn @Shagun-G @tianyu-l

## Problem

Current computation:
```
local_avg_loss  = local_loss_sum / local_valid_tokens
global_max_loss = max(local_avg_loss)   # all-reduce max over ranks
```

With context parallelism (CP), the sequence is sharded across CP ranks *after* `local_valid_tokens` is computed. That means every rank in a CP group has the same `local_valid_tokens` value, even though each rank only processes approx `local_valid_tokens / cp_degree` tokens. This results in `global_max_loss` being too-small by a factor of  `~cp_degree`. See before/after screenshots below.

See the screenshots of the max and
mean losses from wandb and the CLI printout of the loss scale.

## Fix

Track `_rank_local_valid_tokens_per_step` by accumulating `(labels != IGNORE_INDEX).sum()` inside `post_dataloading_process`, *after* CP sharding has been applied. This gives the true count of valid tokens on each rank's CP shard. Use this rank-local count as the denominator for `local_avg_loss`.

A `clamp(min=1)` guard is also added to handle the degenerate case where a CP shard contains only
masked tokens (all `IGNORE_INDEX`), which would otherwise produce a 0/0.

## Screenshots

#### Before Fix

<img width="1382" height="301" alt="Scherm­afbeelding 2026-04-27 om 9 38 54 AM" src="https://github.com/user-attachments/assets/999bead5-cd15-438e-90c2-be49fd607001" />
<img width="1231" height="361" alt="Scherm­afbeelding 2026-04-27 om 9 40 36 AM" src="https://github.com/user-attachments/assets/459ca1f1-c325-4fd9-8edc-38cfd9d37e15" />


#### After Fix

<img width="1399" height="350" alt="Scherm­afbeelding 2026-04-27 om 10 24 11 AM" src="https://github.com/user-attachments/assets/748080f6-e9e7-4583-9db1-d7b9c0b70e9d" />
<img width="1231" height="361" alt="Scherm­afbeelding 2026-04-27 om 10 23 39 AM" src="https://github.com/user-attachments/assets/00bb45e2-5038-4db2-8a6e-de4ac828a54f" />
