### PR TITLE
[AutoParallel] Use autoparallel_backend() for torch.compile

### DIFF
--- a/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/deepseek_v3/parallelize_deepseekv3.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from autoparallel.api import AutoParallel
 from autoparallel.auto_bucketing import configure_inductor_for_autobucketing
+from autoparallel.compile import autoparallel_backend
 from torch.distributed.tensor.placement_types import Replicate, Shard
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -335,7 +336,6 @@ def parallelize_deepseekv3(
         input_fn,
         sparse_mesh,
         mp_policy=mp_policy,
-        compile=compile_config,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 
@@ -375,6 +375,9 @@ def parallelize_deepseekv3(
         t1 = time.time()
         logger.info(f"AutoParallel took {t1 - t0} seconds")
         parallel_mod = autop.apply_placement(sharding_placement)
+
+    if compile_config.enable:
+        parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     set_torchtitan_fields(model, parallel_mod)
 

--- a/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
+++ b/torchtitan/experiments/autoparallel/llama3/parallelize_llama.py
@@ -9,6 +9,7 @@ import time
 import torch
 from autoparallel.api import AutoParallel
 from autoparallel.auto_bucketing import configure_inductor_for_autobucketing
+from autoparallel.compile import autoparallel_backend
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor.placement_types import Replicate, Shard
 from torchtitan.config import (
@@ -107,7 +108,6 @@ def parallelize_llama(
         input_fn,
         dense_mesh,
         mp_policy=mp_policy,
-        compile=compile_config,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 
@@ -146,6 +146,9 @@ def parallelize_llama(
         t1 = time.time()
         logger.info(f"AutoParallel took {t1 - t0} seconds")
         parallel_mod = autop.apply_placement(sharding_placement)
+
+    if compile_config.enable:
+        parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     if loss_parallel_enabled:
 

--- a/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
+++ b/torchtitan/experiments/autoparallel/local_map_deepseek_v3/parallelize_deepseekv3.py
@@ -9,6 +9,7 @@ import time
 import torch
 from autoparallel.api import AutoParallel
 from autoparallel.auto_bucketing import configure_inductor_for_autobucketing
+from autoparallel.compile import autoparallel_backend
 
 from torch.distributed.tensor.placement_types import Shard
 from torchtitan.config import (
@@ -106,7 +107,6 @@ def parallelize_deepseekv3(
         input_fn,
         sparse_mesh,
         mp_policy=mp_policy,
-        compile=should_compile,
         dynamic=True,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
@@ -123,6 +123,9 @@ def parallelize_deepseekv3(
         t1 = time.time()
         logger.info(f"AutoParallel took {t1 - t0} seconds")
         parallel_mod = autop.apply_placement(sharding_placement)
+
+    if should_compile:
+        parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     set_torchtitan_fields(model, parallel_mod)
 


### PR DESCRIPTION
Update autoparallel experiments to match the new API from https://github.com/meta-pytorch/autoparallel/pull/415 which removes the `compile` parameter from AutoParallel and replaces it with an explicit `torch.compile(model, backend=autoparallel_backend())` call.

<!-- ps-id: 6002b76c-ab28-4486-be71-2fceec67c4d8 -->