### PR TITLE
[GraphTrainer] Unified framework for activation memory management

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -23,6 +23,32 @@ bound during pass construction in `construct_default_graph_passes` via
 parameters. The apply function is a generic pass runner and must not contain
 pass-specific arguments.
 
+## Memory Policy Framework
+
+`tag_with_memory_policy_pass` is the unified framework for activation memory
+management — selective activation checkpointing (SAC), CPU offload, and
+mixtures of both. It is a two-step process:
+
+1. **Tag nodes.** Each saved forward activation is tagged with one of:
+   - `MUST_SAVE` — keep the activation in GPU memory.
+   - `MUST_RECOMPUTE` — discard and recompute during backward.
+   - `MUST_CPU_OFFLOAD` — offload to CPU, reload before backward.
+
+   Tagging can be done manually (per-node annotations) or with an
+   advanced solver algorithm that optimizes the save/recompute/offload
+   split based on memory budget and compute cost.
+
+2. **Act on tags.** Two passes run unconditionally after tagging (both
+   are no-ops when no nodes carry the relevant tag):
+   - `apply_cpu_offload_pass` — inserts offload/reload/wait ops for
+     `MUST_CPU_OFFLOAD` nodes.
+   - `selective_activation_remat_pass` — duplicates `MUST_RECOMPUTE`
+     ops before backward and DCEs the originals.
+
+The `--compile.memory_policy` config selects the tagging strategy.
+New policies (e.g. budget-aware mixed SAC + offload) should be added
+as new branches in `tag_with_memory_policy_pass`.
+
 ## Don't Modify Core for This Experiment
 
 Do not add `if graph_trainer:` branches to `torchtitan/train.py`

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -44,12 +44,14 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
-    memory_policy: Literal["default", "eager"] = "default"
+    memory_policy: Literal["default", "eager", "cpu_offload_all"] = "default"
     """
     Memory optimization policy for activation management (SAC, offload).
         default: save all compute-intensive ops and FSDP all_gathers.
         eager: alternate mm ops between save/recompute, matching the eager
             AC policy in torchtitan.distributed.activation_checkpoint.
+        cpu_offload_all: offload all eligible activations to CPU.
+            Work in progress — for development and testing only.
     """
 
     enable_cudagraph: bool = True

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -43,7 +43,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
     _NOT_IN_LAYERS,
 )
-from torchtitan.experiments.graph_trainer.cpu_offload import cpu_offload_pass
+from torchtitan.experiments.graph_trainer.cpu_offload import (
+    apply_cpu_offload_pass,
+    tag_all_offloadable_activations,
+)
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
@@ -81,19 +84,19 @@ def compile_time_passes(
     )
     from torchtitan.models.common.attention import FlexAttention
 
-    memory_policy_fn = {
-        "default": _make_default_memory_policy,
-        "eager": _make_eager_memory_policy,
-    }[config.compile.memory_policy]()
-
     n_layers = len(config.model_spec.model.layers)
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
-        # TODO: uncomment after sorting out common tagging API between offload and sac
-        # cpu_offload_pass,
-        functools.partial(selective_activation_remat_pass, policy_fn=memory_policy_fn),
+        functools.partial(
+            tag_with_memory_policy_pass,
+            config=config,
+        ),
+        # TODO: currently either SAC or CPU offload is used, not both at the
+        # same time. Composability between these two passes is untested.
+        apply_cpu_offload_pass,
+        selective_activation_remat_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             fsdp_manual_buckets=get_default_transformer_block_buckets(n_layers),
@@ -783,27 +786,48 @@ def apply_sac_pass(
     return gm
 
 
-def selective_activation_remat_pass(
+def tag_with_memory_policy_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
     *,
-    policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
+    config: "GraphTrainer.Config",
 ) -> torch.fx.GraphModule:
-    """Apply graph-based SAC to a traced fwd+loss+bwd graph.
+    """Tag forward nodes with MUST_SAVE, PREFER_RECOMPUTE, or MUST_CPU_OFFLOAD.
 
-    Tags forward nodes with recompute policy via apply_sac_pass (backward
-    nodes are skipped automatically via ``node.meta["autograd_backward"]``), then
-    applies remat_using_tags_for_fwd_loss_bwd_graph to duplicate
-    PREFER_RECOMPUTE forward ops before backward and DCE originals.
+    The ``config.compile.memory_policy`` selects the tagging strategy:
+        default: SAC with all compute-intensive ops saved.
+        eager: SAC alternating mm ops between save/recompute.
+        cpu_offload_all: tag all eligible activations for CPU offload.
 
-    The model must have been annotated with annotate_module_fqns before
-    tracing so that nodes have custom["module_fqn"] metadata.
+    Other memory policies combining SAC and CPU offload can be added here.
     """
+    memory_policy = config.compile.memory_policy
+    if memory_policy == "default":
+        apply_sac_pass(gm, policy_fn=_make_default_memory_policy())
+    elif memory_policy == "eager":
+        apply_sac_pass(gm, policy_fn=_make_eager_memory_policy())
+    elif memory_policy == "cpu_offload_all":
+        tag_all_offloadable_activations(gm)
+    else:
+        raise ValueError(f"Unknown memory_policy: {memory_policy!r}")
+    return gm
+
+
+def selective_activation_remat_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Duplicate recompute nodes for backward use, then DCE unused forward versions.
+
+    Wraps ``remat_using_tags_for_fwd_loss_bwd_graph`` with the graph pass
+    signature ``(gm, example_inputs)``.
+    """
+    # TODO: remove this wrapper when upstream remat_using_tags_for_fwd_loss_bwd_graph
+    # accepts example_inputs (matching the graph pass signature).
     from torch._functorch._activation_checkpointing.remat_using_tags_for_fwd_loss_bwd_graph_pass import (
         remat_using_tags_for_fwd_loss_bwd_graph,
     )
 
-    apply_sac_pass(gm, policy_fn=policy_fn)
     return remat_using_tags_for_fwd_loss_bwd_graph(gm)
 
 
@@ -1037,5 +1061,4 @@ AVAILABLE_JOINT_PASSES = {
     "inductor_decomposition": inductor_decomposition_pass,
     "fsdp_reshard_after_fwd": fsdp_reshard_after_fwd_pass,
     "apply_sac": apply_sac_pass,
-    "cpu_offload": cpu_offload_pass,
 }

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -335,6 +335,22 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.memory_policy cpu_offload_all",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+cpu_offload_all",
+            "aot_fx_trace_llama3_fsdp_tp_cpu_offload_all",
+            ngpu=8,
+            skip_rocm_test=True,
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- Add `tag_with_memory_policy_pass` that unifies SAC and CPU offload tagging into a single pass, dispatching based on `config.compile.memory_policy`
- Add `cpu_offload_all` memory policy that tags all eligible activations for CPU offload (WIP, for dev/testing)
- Restructure pass pipeline: `apply_cpu_offload_pass` and `selective_activation_remat_pass` always run after tagging (no-ops when no nodes are tagged)

## Test plan
- [x] Pre-commit passes
- [x] CPU offload unit tests pass (`test_cpu_offload.py`)
- [x] Passes unit tests pass (`test_passes.py`)
- [x] Bitwise deterministic tests pass (default policy unchanged)
- [x] Manual 8-GPU run with `--compile.memory_policy cpu_offload_all` completes successfully, logs show 40 activations offloaded (222.81 MB)
- [ ] CI integration test `aot_fx_trace_llama3_fsdp_tp_cpu_offload_all`