### PR TITLE
[GraphTrainer] Fix compatibility with ChunkedCELoss

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, fields, replace
 from typing import Literal
 
+from torchtitan.components.loss import ChunkedCELoss, CrossEntropyLoss
 from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.protocols.model_spec import ModelSpec
@@ -100,6 +101,13 @@ def to_graph_trainer_config(
     ac = d.get("activation_checkpoint")
     if ac is not None and ac.mode != "none":
         d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
+
+    # TODO: Support ChunkedCELoss in graph_trainer. Currently it sets
+    # _skip_lm_head=True which makes lm_head.weight unused in the forward
+    # pass, breaking torch.autograd.grad in make_fx tracing.
+    loss = d.get("loss")
+    if loss is not None and isinstance(loss, ChunkedCELoss.Config):
+        d["loss"] = CrossEntropyLoss.Config()
 
     # Merge CUDA graph kernel annotations into profiler traces when profiling
     # is active.  No-op otherwise (and no-op when requirements aren't met).

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import torch
 import torch.nn as nn
 
-from torchtitan.components.loss import cross_entropy_loss
+from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.distributed.utils import get_train_context
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
@@ -30,7 +30,7 @@ def build_minimal_trainer(
     """Build the minimal Trainer/GraphTrainer needed for single-GPU test steps."""
     trainer = object.__new__(trainer_cls)
     trainer.model_parts = [model]
-    trainer.loss_fn = cross_entropy_loss
+    trainer.loss_fn = CrossEntropyLoss(CrossEntropyLoss.Config())
     trainer.parallel_dims = SimpleNamespace(pp_enabled=False, cp_enabled=False)
     trainer.train_context = get_train_context(False)
     trainer.model_config = model_config


### PR DESCRIPTION
## Summary
- ChunkedCELoss (#2937) sets `_skip_lm_head=True` on the model, making `lm_head.weight` unused in the forward pass and breaking `torch.autograd.grad` in `make_fx` tracing. Fall back to `CrossEntropyLoss` in `to_graph_trainer_config` when `ChunkedCELoss` is configured.
- Update `_trainer_test_utils` to use `CrossEntropyLoss` instance instead of the raw `cross_entropy_loss` function, matching the new `BaseLoss.__call__(pred, labels, global_valid_tokens)` signature.

## Test plan
- [x] 8-GPU aot_fx_trace FSDP+TP run completes successfully
- [x] All bitwise deterministic tests pass (Llama3, DSv3, FlexAttn, precompile)