### PR TITLE
call correct parallelize function for trainer

### DIFF
--- a/torchtitan/experiments/rl/models/parallelize.py
+++ b/torchtitan/experiments/rl/models/parallelize.py
@@ -40,6 +40,7 @@ def parallelize_qwen3(
     parallelism: ParallelismConfig,
     compile_config: CompileConfig | None = None,
     has_position_id: bool = False,
+    **kwargs,
 ):
     """
     Apply tensor parallelism to the Qwen3 dense model for RL training/inference.

--- a/torchtitan/experiments/rl/simple_grpo_sum_digits.py
+++ b/torchtitan/experiments/rl/simple_grpo_sum_digits.py
@@ -380,19 +380,23 @@ class RLTrainer(Configurable):
         await setup_torch_elastic_env_async(trainer_mesh)
         await setup_torch_elastic_env_async(generator_mesh)
 
+        from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
+
+        trainer_model_spec = replace(
+            config.model_spec, parallelize_fn=parallelize_qwen3
+        )
+
         # Spawn actors on their respective meshes
         self.trainer = trainer_mesh.spawn(
             "trainer",
             PolicyTrainer,
             config.trainer,
-            model_spec=config.model_spec,
+            model_spec=trainer_model_spec,
             hf_assets_path=config.hf_assets_path,
             generator_dtype=config.generator.model_dtype,
         )
 
         # Generator uses RL-specific parallelize (TP-only, no FSDP, vLLM-compatible)
-        from torchtitan.experiments.rl.models.parallelize import parallelize_qwen3
-
         gen_model_spec = replace(config.model_spec, parallelize_fn=parallelize_qwen3)
         self.generator = generator_mesh.spawn(
             "generator",


### PR DESCRIPTION
after https://github.com/pytorch/torchtitan/pull/2969 refactor, the core `parallelize_qwen3` depends on sharding configs being set via `update_from_config()` [here](https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/qwen3/model.py#L125) (which calls `set_qwen3_sharding_config`). The RL trainer never calls update_from_config(), so the trainer gets no TP. but since TP is set for the generator, you get different numerics.