### PR TITLE
fix(hf_datasets): shuffle ChatDataset before splitting across nodes

### DIFF
--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -77,9 +77,8 @@ class TestChatDatasetShiftedTokens(unittest.TestCase):
 
     def test_shifted_by_one(self):
         tokenizer = _load_tokenizer()
-        ds = _load_dataset()
         chat_ds = ChatDataset(
-            dataset=ds,
+            dataset=_load_dataset(),
             tokenizer=tokenizer,
             sample_processor=_process_sample,
             seq_len=2048,
@@ -90,8 +89,9 @@ class TestChatDatasetShiftedTokens(unittest.TestCase):
         input_ids = batch["input"]
         label_ids = labels
 
-        # Tokenize the first sample directly to get ground truth tokens
-        sample = ds[0]
+        # Tokenize the first sample directly to get ground truth tokens. ChatDataset shuffles the
+        # dataset internally at init, and ChatDataset._original_data is the post-shuffle dataset.
+        sample = chat_ds._original_data[0]
         messages = _process_sample(sample)
         full_text = tokenizer.apply_chat_template(messages)
         # Chat templates already include end tokens, so no add_eos

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -311,7 +311,7 @@ class ChatDataset(IterableDataset, Stateful):
         # datasets, split_dataset_by_node assigns contiguous data chunks to consecutive nodes, which
         # can lead to token imbalances, causing some nodes' epoch_idx to run ahead of others.
         self._original_data = split_dataset_by_node(
-            dataset.shuffle(seed=42), dp_rank, dp_world_size
+            cast(Dataset, dataset.shuffle(seed=42)), dp_rank, dp_world_size
         )
         self._data = self._original_data
         self._tokenizer = tokenizer

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -300,7 +300,6 @@ class ChatDataset(IterableDataset, Stateful):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         infinite: bool = False,
-        seed: int = 42,
     ) -> None:
         if tokenizer.eos_id is None:
             raise ValueError(
@@ -312,14 +311,13 @@ class ChatDataset(IterableDataset, Stateful):
         # datasets, split_dataset_by_node assigns contiguous data chunks to consecutive nodes, which
         # can lead to token imbalances, causing some nodes' epoch_idx to run ahead of others.
         self._original_data = split_dataset_by_node(
-            dataset.shuffle(seed=seed), dp_rank, dp_world_size
+            dataset.shuffle(seed=42), dp_rank, dp_world_size
         )
         self._data = self._original_data
         self._tokenizer = tokenizer
         self._eos_id = tokenizer.eos_id
         self.seq_len = seq_len
         self.infinite = infinite
-        self.seed = seed
         self._sample_processor = sample_processor
 
         self._dataset_id = f"{dataset.info.dataset_name}/{dataset.split}"
@@ -488,7 +486,7 @@ class ChatDataset(IterableDataset, Stateful):
                 if isinstance(self._data, Dataset):
                     self._data = cast(
                         Dataset,
-                        self._original_data.shuffle(seed=self.seed + self._epoch),
+                        self._original_data.shuffle(seed=42 + self._epoch),
                     )
                 elif hasattr(self._data, "set_epoch"):
                     self._data.set_epoch(self._epoch)

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -300,6 +300,7 @@ class ChatDataset(IterableDataset, Stateful):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         infinite: bool = False,
+        seed: int = 42,
     ) -> None:
         if tokenizer.eos_id is None:
             raise ValueError(
@@ -307,12 +308,18 @@ class ChatDataset(IterableDataset, Stateful):
                 "ChatDataset requires a tokenizer with a valid EOS token."
             )
 
-        self._original_data = split_dataset_by_node(dataset, dp_rank, dp_world_size)
+        # Shuffle the initial data to promote an even distribution across nodes. For map-style
+        # datasets, split_dataset_by_node assigns contiguous data chunks to consecutive nodes, which
+        # can lead to token imbalances, causing some nodes' epoch_idx to run ahead of others.
+        self._original_data = split_dataset_by_node(
+            dataset.shuffle(seed=seed), dp_rank, dp_world_size
+        )
         self._data = self._original_data
         self._tokenizer = tokenizer
         self._eos_id = tokenizer.eos_id
         self.seq_len = seq_len
         self.infinite = infinite
+        self.seed = seed
         self._sample_processor = sample_processor
 
         self._dataset_id = f"{dataset.info.dataset_name}/{dataset.split}"
@@ -480,7 +487,8 @@ class ChatDataset(IterableDataset, Stateful):
                 self._epoch += 1
                 if isinstance(self._data, Dataset):
                     self._data = cast(
-                        Dataset, self._original_data.shuffle(seed=42 + self._epoch)
+                        Dataset,
+                        self._original_data.shuffle(seed=self.seed + self._epoch),
                     )
                 elif hasattr(self._data, "set_epoch"):
                     self._data.set_epoch(self._epoch)


### PR DESCRIPTION
Adds an initial shuffle to `ChatDataset` (mirroring the end-of-epoch shuffles the class already does) to promote even token distribution across nodes.

Without this, I was finding that `split_dataset_by_node` can give highly-imbalanced examples to different nodes, due to the default behavior where it splits map-style datasets sequentially.  This is problematic when the dataset has some non-trivial ordering bias, e.g. if shorter examples tend to be early in the dataset. Can lead to node-0, say, getting way fewer tokens than other nodes and completing its initial epoch early, an offset that persists for the remainder of training.