### PR TITLE
[GraphTrainer][AutoDev] Fuse RoPE kernels via regional Inductor compilation

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -18,6 +18,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
 _MODULE_FQN = "module_fqn"
+_ROPE_REGION = "rope_region"
 _NOT_IN_LAYERS = -1
 
 
@@ -53,6 +54,48 @@ def annotate_module_fqns(model: nn.Module) -> None:
     for fqn, submodule in model.named_modules():
         if fqn:  # skip root module
             submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
+
+
+def annotate_rope_functions() -> None:
+    """Wrap RoPE free functions with ``annotate_fn`` so traced nodes carry a tag.
+
+    RoPE computation is performed by free functions (``apply_rotary_emb_complex``,
+    ``apply_rotary_emb_cos_sin``, ``apply_rotary_emb_single_complex``) called
+    inside attention modules. Unlike ``nn.Module`` submodules, these free
+    functions do not get their own ``module_fqn`` -- all their ops inherit the
+    enclosing attention module's FQN. This makes FQN-based identification
+    impossible.
+
+    This helper monkey-patches the function references in the modules that
+    import them (``attention`` and ``deepseek_v3.model``) so that ``make_fx``
+    tracing propagates a ``rope_region`` tag into ``node.meta["custom"]``.
+    The tag is later consumed by
+    ``annotate_rope_for_regional_inductor_pass``.
+
+    Must be called before tracing, alongside ``annotate_module_fqns``.
+    """
+    import torchtitan.models.common.attention as attn_mod
+    import torchtitan.models.deepseek_v3.model as ds_mod
+
+    rope_annotation = {_ROPE_REGION: True}
+
+    # Patch apply_rotary_emb_complex and apply_rotary_emb_cos_sin in attention.py
+    # (used by GQAttention for Llama3/4, Qwen3, GPT-OSS)
+    for fn_name in ("apply_rotary_emb_complex", "apply_rotary_emb_cos_sin"):
+        original = getattr(attn_mod, fn_name, None)
+        if original is not None and not getattr(original, "_rope_annotated", False):
+            wrapped = annotate_fn(rope_annotation)(original)
+            wrapped._rope_annotated = True
+            setattr(attn_mod, fn_name, wrapped)
+
+    # Patch apply_rotary_emb_single_complex in deepseek_v3/model.py
+    # (used by DeepSeek V3 MLA attention directly)
+    fn_name = "apply_rotary_emb_single_complex"
+    original = getattr(ds_mod, fn_name, None)
+    if original is not None and not getattr(original, "_rope_annotated", False):
+        wrapped = annotate_fn(rope_annotation)(original)
+        wrapped._rope_annotated = True
+        setattr(ds_mod, fn_name, wrapped)
 
 
 def parallelize_inputs(parallel_dims, args, kwargs):

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -18,6 +18,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    annotate_rope_functions,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -35,6 +36,8 @@ from torchtitan.tools.logging import logger
 def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
+    - RoPE annotation: Tags RoPE free functions so their traced ops carry a
+      ``rope_region`` tag for regional Inductor compilation.
     - Expert Parallel (EP) annotations: Tags "dispatch", "combine", and "compute"
       regions in MoE for debugging purposes.
     - Module FQN annotation: Tags each submodule's forward with its
@@ -43,6 +46,8 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
     """
     from torchtitan.models.common.moe import MoE
     from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher
+
+    annotate_rope_functions()
 
     LocalTokenDispatcher.dispatch = annotate_fn({"EP": "dispatch"})(
         LocalTokenDispatcher.dispatch

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -15,6 +15,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    annotate_rope_functions,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -31,8 +32,11 @@ def annotate_llama(model: GraphTrainerLlama3Model) -> None:
 
     Tags each submodule's forward with its fully-qualified name via
     ``torch.fx.traceback.annotate_fn`` for downstream passes (bucketing,
-    SAC region boundaries, etc.).
+    SAC region boundaries, etc.). Also annotates RoPE free functions so
+    their traced ops carry a ``rope_region`` tag for regional Inductor
+    compilation.
     """
+    annotate_rope_functions()
     annotate_module_fqns(model)
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -42,6 +42,7 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
     _MODULE_FQN,
     _NOT_IN_LAYERS,
+    _ROPE_REGION,
 )
 from torchtitan.experiments.graph_trainer.cpu_offload import (
     apply_cpu_offload_pass,
@@ -108,6 +109,13 @@ def compile_time_passes(
         functools.partial(
             annotate_flex_attention_for_regional_inductor_pass,
             flex_compile_config=FlexAttention.inductor_configs,
+        ),
+        # RoPE free functions are annotated at tracing time via
+        # annotate_rope_functions(). This pass tags those nodes for
+        # regional Inductor compilation to fuse RoPE kernels.
+        functools.partial(
+            annotate_rope_for_regional_inductor_pass,
+            rope_compile_config=_ROPE_INDUCTOR_CONFIGS,
         ),
         regional_inductor_pass,
     ]
@@ -627,6 +635,77 @@ def annotate_flex_attention_for_regional_inductor_pass(
                 sub_node.meta.setdefault("custom", {})[
                     "compile_with_inductor"
                 ] = mask_compile_annotation
+    return gm
+
+
+_ROPE_INDUCTOR_CONFIGS: dict[str, bool] = {
+    "wrap_inductor_compiled_regions": True,
+    "max_autotune": True,
+    "coordinate_descent_tuning": True,
+    "triton.cudagraphs": False,
+}
+
+
+def annotate_rope_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    rope_compile_config: dict | None,
+) -> torch.fx.GraphModule:
+    """Tag RoPE nodes with ``compile_with_inductor`` for ``regional_inductor``.
+
+    RoPE free functions (``apply_rotary_emb_complex``,
+    ``apply_rotary_emb_cos_sin``, ``apply_rotary_emb_single_complex``) are
+    annotated at tracing time by ``annotate_rope_functions`` which sets
+    ``node.meta["custom"]["rope_region"] = True``. This pass finds those
+    nodes and tags them so that ``regional_inductor_pass`` compiles them
+    with Inductor.
+
+    Each attention layer's RoPE ops are assigned a separate
+    ``inductor_region`` ID (derived from the enclosing ``module_fqn``) so
+    that Inductor compiles them as independent regions. Forward and backward
+    RoPE ops sharing the same ``module_fqn`` are grouped into the same
+    region.
+
+    Args:
+        gm: The graph module to annotate.
+        example_inputs: Example inputs (unused, required by pass interface).
+        rope_compile_config: Inductor config dict for RoPE nodes.
+            When provided, wrapped as ``{"inductor_configs": rope_compile_config}``.
+            When None, nodes are tagged with an empty annotation.
+    """
+    compile_annotation: dict = (
+        {"inductor_configs": rope_compile_config}
+        if rope_compile_config is not None
+        else {}
+    )
+
+    # Assign a unique inductor_region ID per enclosing module FQN so that
+    # each attention layer's RoPE is compiled as a separate region.
+    fqn_to_region: dict[str, int] = {}
+    next_region = 0
+    num_tagged = 0
+
+    for node in gm.graph.nodes:
+        custom = node.meta.get("custom", {})
+        if not custom.get(_ROPE_REGION):
+            continue
+
+        fqn = custom.get(_MODULE_FQN, "")
+        if fqn not in fqn_to_region:
+            fqn_to_region[fqn] = next_region
+            next_region += 1
+
+        annotation = dict(compile_annotation)
+        annotation["inductor_region"] = fqn_to_region[fqn]
+        node.meta.setdefault("custom", {})["compile_with_inductor"] = annotation
+        num_tagged += 1
+
+    if num_tagged > 0:
+        logger.info(
+            f"Tagged {num_tagged} RoPE node(s) across {len(fqn_to_region)} "
+            f"region(s) for regional Inductor compilation"
+        )
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -18,6 +18,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    annotate_rope_functions,
     apply_graph_ac,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -34,12 +35,16 @@ from torchtitan.tools.logging import logger
 def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
     """Attach annotations to FX graph nodes with ``torch.fx.traceback.annotate_fn``
 
+    - RoPE annotation: Tags RoPE free functions so their traced ops carry a
+      ``rope_region`` tag for regional Inductor compilation.
     - Expert Parallel (EP) annotations: Tags "dispatch", "combine", and "compute"
       regions in MoE for debugging purposes (only if MoE layers exist).
     - Module FQN annotation: Tags each submodule's forward with its
       fully-qualified name for downstream passes (bucketing, SAC region
       boundaries, etc.).
     """
+    annotate_rope_functions()
+
     # Annotate MoE EP regions if any layer has MoE enabled
     if any(layer.moe is not None for layer in model.config.layers):
         from torchtitan.models.common.moe import MoE

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -1263,6 +1263,189 @@ class TestAnnotateModuleFqns(TestCase):
         self.assertEqual(num_before, num_after)
 
 
+class TestAnnotateRopeForRegionalInductor(TestCase):
+    """Unit tests for annotate_rope_for_regional_inductor_pass."""
+
+    def _build_rope_annotated_gm(self, num_layers=2):
+        """Build a GraphModule simulating RoPE ops from multiple attention layers.
+
+        Each layer contributes two RoPE nodes (one for xq, one for xk) with
+        rope_region=True and module_fqn set to layers.<N>.attention.
+        Interspersed non-RoPE nodes simulate the surrounding computation.
+        """
+        from torchtitan.experiments.graph_trainer.common_utils import (
+            _MODULE_FQN,
+            _ROPE_REGION,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        last = x
+
+        for i in range(num_layers):
+            fqn = f"layers.{i}.attention"
+            # Non-RoPE op (e.g. linear projection)
+            proj = graph.call_function(torch.ops.aten.mm.default, args=(last, last))
+            proj.meta["custom"] = {_MODULE_FQN: fqn}
+
+            # RoPE op for xq
+            rope_q = graph.call_function(torch.ops.aten.mul.Tensor, args=(proj, proj))
+            rope_q.meta["custom"] = {_MODULE_FQN: fqn, _ROPE_REGION: True}
+
+            # RoPE op for xk
+            rope_k = graph.call_function(torch.ops.aten.mul.Tensor, args=(rope_q, proj))
+            rope_k.meta["custom"] = {_MODULE_FQN: fqn, _ROPE_REGION: True}
+
+            last = rope_k
+
+        graph.output(last)
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def _count_tagged_nodes(self, gm):
+        """Count nodes tagged with compile_with_inductor."""
+        return sum(
+            1
+            for n in gm.graph.nodes
+            if "compile_with_inductor" in n.meta.get("custom", {})
+        )
+
+    def _get_tagged_regions(self, gm):
+        """Return set of inductor_region IDs from tagged nodes."""
+        regions = set()
+        for n in gm.graph.nodes:
+            annotation = n.meta.get("custom", {}).get("compile_with_inductor")
+            if annotation and "inductor_region" in annotation:
+                regions.add(annotation["inductor_region"])
+        return regions
+
+    def test_rope_nodes_tagged(self):
+        """Nodes with rope_region=True should be tagged with compile_with_inductor."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=2)
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        # 2 layers x 2 RoPE ops = 4 tagged nodes
+        self.assertEqual(self._count_tagged_nodes(gm), 4)
+
+    def test_non_rope_nodes_not_tagged(self):
+        """Nodes without rope_region should not be tagged."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=2)
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        for node in gm.graph.nodes:
+            custom = node.meta.get("custom", {})
+            if not custom.get("rope_region"):
+                self.assertNotIn(
+                    "compile_with_inductor",
+                    custom,
+                    f"Non-RoPE node {node.name} should not be tagged",
+                )
+
+    def test_separate_regions_per_layer(self):
+        """Each attention layer's RoPE ops should get a distinct inductor_region."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=3)
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        regions = self._get_tagged_regions(gm)
+        self.assertEqual(len(regions), 3, "Expected one region per layer")
+
+    def test_same_layer_shares_region(self):
+        """RoPE ops within the same attention layer should share one region ID."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=1)
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        region_ids = []
+        for n in gm.graph.nodes:
+            annotation = n.meta.get("custom", {}).get("compile_with_inductor")
+            if annotation and "inductor_region" in annotation:
+                region_ids.append(annotation["inductor_region"])
+
+        # Both RoPE ops in layer 0 should have the same region ID
+        self.assertEqual(len(region_ids), 2)
+        self.assertEqual(region_ids[0], region_ids[1])
+
+    def test_inductor_configs_propagated(self):
+        """The inductor_configs dict should be present in the annotation."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=1)
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        for n in gm.graph.nodes:
+            annotation = n.meta.get("custom", {}).get("compile_with_inductor")
+            if annotation:
+                self.assertIn("inductor_configs", annotation)
+                self.assertEqual(annotation["inductor_configs"], _ROPE_INDUCTOR_CONFIGS)
+
+    def test_none_config_tags_without_inductor_configs(self):
+        """When rope_compile_config=None, nodes are tagged with empty annotation."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        gm = self._build_rope_annotated_gm(num_layers=1)
+        annotate_rope_for_regional_inductor_pass(gm, rope_compile_config=None)
+
+        tagged = self._count_tagged_nodes(gm)
+        self.assertEqual(tagged, 2)
+        for n in gm.graph.nodes:
+            annotation = n.meta.get("custom", {}).get("compile_with_inductor")
+            if annotation:
+                self.assertNotIn("inductor_configs", annotation)
+
+    def test_noop_without_rope_annotations(self):
+        """When no nodes have rope_region, the pass should be a no-op."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            _ROPE_INDUCTOR_CONFIGS,
+            annotate_rope_for_regional_inductor_pass,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        n1 = graph.call_function(torch.relu, (x,))
+        n1.meta["custom"] = {_MODULE_FQN: "layers.0.attention"}
+        graph.output(n1)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        annotate_rope_for_regional_inductor_pass(
+            gm, rope_compile_config=_ROPE_INDUCTOR_CONFIGS
+        )
+
+        self.assertEqual(self._count_tagged_nodes(gm), 0)
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -10,6 +10,8 @@ from functools import partial
 
 import torch.nn as nn
 
+from torchtitan.components.quantization import QuantizationConverter
+
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -20,7 +22,6 @@ from torchtitan.models.common.config_utils import (
     make_moe_config,
     make_router_config,
 )
-from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.protocols.model_spec import ModelSpec

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -9,6 +9,8 @@ from functools import partial
 
 import torch.nn as nn
 
+from torchtitan.components.quantization import QuantizationConverter
+
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.config_utils import (
@@ -18,7 +20,6 @@ from torchtitan.models.common.config_utils import (
     make_moe_config,
     make_router_config,
 )
-from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.qwen3.model import Qwen3TransformerBlock


### PR DESCRIPTION
## Summary

- Annotate RoPE free functions (`apply_rotary_emb_complex`, `apply_rotary_emb_cos_sin`, `apply_rotary_emb_single_complex`) at tracing time via `annotate_fn` so traced FX nodes carry a `rope_region` tag in `node.meta["custom"]`
- Add `annotate_rope_for_regional_inductor_pass` graph pass that converts `rope_region` tags into `compile_with_inductor` annotations consumed by `regional_inductor_pass`
- Each attention layer's RoPE ops get a separate `inductor_region` ID so Inductor compiles them as independent fused kernels

### Why not FQN-based matching?

Unlike RMSNorm (which is an `nn.Module` with its own FQN), RoPE computation is done by free functions called inside `GQAttention.forward()`. All RoPE ops inherit the attention module's FQN (e.g., `layers.0.attention`), making FQN-based identification impossible. The two-step approach (tracing-time annotation + graph pass) solves this by tagging at the source.

### Backward propagation

`_copy_fwd_metadata_to_bw_nodes` already does `copy.deepcopy(custom)` from forward to backward nodes, so the `rope_region` tag automatically propagates to backward RoPE ops.

### Models covered

- **Llama3/4** (`GQAttention` with `apply_rotary_emb_complex` via `attention.py`)
- **Qwen3, GPT-OSS** (`GQAttention` with `apply_rotary_emb_cos_sin` via `attention.py`)
- **DeepSeek V3** (MLA attention with `apply_rotary_emb_single_complex` via `deepseek_v3/model.py`)

### Numerics note

This could be changing numerics, which is fine per the board item.

## Test plan

- [x] 7 new unit tests in `test_passes.py::TestAnnotateRopeForRegionalInductor`
  - Verifies RoPE nodes tagged, non-RoPE nodes untouched
  - Verifies separate regions per layer, shared region within layer
  - Verifies inductor config propagation
  - Verifies no-op when no rope annotations present
  - Verifies None config produces empty annotations
- [x] All 52 existing non-FSDP tests in `test_passes.py` still pass
- [ ] GPU integration test with Llama3 debug model (FSDP+TP)
- [ ] Benchmark with `c4_test` dataset to measure RoPE kernel fusion speedup