### PR TITLE
Revert "[Attention] Remove MATH from ScaledDotProductAttention default backends (#3080)"

### DIFF
--- a/scripts/generate/_generation.py
+++ b/scripts/generate/_generation.py
@@ -5,9 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torch.nn.attention import SDPBackend
-
-from torchtitan.models.common.attention import ScaledDotProductAttention
 
 
 def multinomial_sample_one(
@@ -66,20 +63,6 @@ def generate(
         rng = torch.Generator(input_ids.device).manual_seed(seed)
 
     generated_tokens = input_ids.clone()
-
-    # Inference can hit shapes that ``FLASH_ATTENTION`` / ``CUDNN_ATTENTION``
-    # refuse (e.g., debug-model ``head_dim=16`` is outside flash's supported
-    # set). The trainer-side ``ScaledDotProductAttention`` defaults
-    # intentionally exclude ``MATH`` so silent slow-path fallback can't hide
-    # mistakes during training. Each module opens its own
-    # ``with sdpa_kernel(self.sdpa_backends, set_priority=True)`` inside
-    # ``forward``, so an outer ``sdpa_kernel`` wrapper is overridden and has
-    # no effect. Instead, append ``MATH`` as a last-resort fallback to each
-    # ``ScaledDotProductAttention`` instance for the generate path.
-    for module in model.modules():
-        if isinstance(module, ScaledDotProductAttention):
-            if SDPBackend.MATH not in module.sdpa_backends:
-                module.sdpa_backends = list(module.sdpa_backends) + [SDPBackend.MATH]
 
     for _ in range(max_new_tokens):
         next_token = generate_next_token(

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -43,7 +43,7 @@ def apply_tp_minus_sp(model: nn.Module, tp_mesh: DeviceMesh):
         tp_mesh,
         {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
-            "lm_head": ColwiseParallel(output_layouts=Replicate()),
+            "output": ColwiseParallel(output_layouts=Replicate()),
         },
     )
 

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -43,7 +43,7 @@ def apply_tp_minus_sp(model: nn.Module, tp_mesh: DeviceMesh):
         tp_mesh,
         {
             "tok_embeddings": RowwiseParallel(input_layouts=Replicate()),
-            "output": ColwiseParallel(output_layouts=Replicate()),
+            "lm_head": ColwiseParallel(output_layouts=Replicate()),
         },
     )
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -271,14 +271,8 @@ class ScaledDotProductAttention(Module):
             self.sdpa_backends = [
                 SDPBackend.CUDNN_ATTENTION,
                 SDPBackend.FLASH_ATTENTION,
+                SDPBackend.MATH,
             ]
-            # ROCm builds typically lack ``CUDNN_ATTENTION`` and have a
-            # narrower ``FLASH_ATTENTION`` shape support, so the strict
-            # CUDA-only set above can fail to dispatch and raise "No
-            # available kernel". Keep ``MATH`` as a fallback on ROCm so
-            # training stays functional; CUDA keeps the strict set.
-            if torch.version.hip is not None:
-                self.sdpa_backends.append(SDPBackend.MATH)
 
     def forward(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3135

This reverts commit 112fd92bf1ac8e3c67e76aaa96fce767a0283d67.

After landing #3080, many CI jobs report "no kernel" errors because
without MATH in the default backend list SDPA cannot dispatch for
several training shapes/configurations. Restoring MATH as a fallback
unblocks CI; we can revisit a narrower fix later.


**Any lint errors are pre-existing. **