### PR TITLE
[torchtitan] Fix deepseek_v3_16b config to use deepep comm backend

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -83,7 +83,7 @@ def deepseek_v3_16b() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/deepseek-moe-16b-base",
         model_spec=model_registry(
-            "16B", attn_backend="flex", moe_comm_backend="standard"
+            "16B", attn_backend="flex", moe_comm_backend="deepep"
         ),
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",


### PR DESCRIPTION
**Summary:** [D101435913](https://www.internalfb.com/diff/D101435913) introduced a token dispatcher hierarchy that requires moe_comm_backend (model construction) to match parallelism.expert_parallel_comm_backend (parallelization). The deepseek_v3_16b config used moe_comm_backend="standard" but the gb200 conveyor test passes expert_parallel_comm_backend="deepep",  causing an AssertionError in apply_moe_ep_tp. This has broken
sandcastle-test-titan-gb200-package since release 195 (April 18).


**Test Case**
Run MAST job with deepseek_v3_16b on GB200 and verify training starts without assertion failure. https://msl-runs.internalmeta.com/mast/graph_trainer_llama3_70b_fsdp_tp_daily_grandteton_test-512--hjvx2dgl%253APRODUCTION%253A0/summary. mast jobs fails at the same point as h100 equivalent due to a separate issue.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3137

