### PR TITLE
[torchtitan] Fix deepseek_v3_16b config to use deepep comm backend

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -83,7 +83,7 @@ def deepseek_v3_16b() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/deepseek-moe-16b-base",
         model_spec=model_registry(
-            "16B", attn_backend="flex", moe_comm_backend="standard"
+            "16B", attn_backend="flex", moe_comm_backend="deepep"
         ),
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -83,6 +83,40 @@ def deepseek_v3_16b() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/deepseek-moe-16b-base",
         model_spec=model_registry(
+            "16B", attn_backend="flex", moe_comm_backend="standard"
+        ),
+        dataloader=HuggingFaceTextDataLoader.Config(
+            dataset="c4",
+        ),
+        optimizer=OptimizersContainer.Config(lr=2.2e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            decay_ratio=0.8,
+            decay_type="cosine",
+            min_lr_factor=0.1,
+        ),
+        training=TrainingConfig(
+            local_batch_size=4,
+            seq_len=4096,
+            steps=1000,
+        ),
+        parallelism=ParallelismConfig(
+            pipeline_parallel_schedule="Interleaved1F1B",
+            expert_parallel_degree=8,
+            expert_tensor_parallel_degree=1,
+        ),
+        checkpoint=CheckpointManager.Config(interval=10),
+        activation_checkpoint=ActivationCheckpointConfig(
+            mode="selective",
+        ),
+        compile=CompileConfig(enable=True, components=["loss"]),
+    )
+
+
+def deepseek_v3_16b_deepep() -> Trainer.Config:
+    return Trainer.Config(
+        loss=ChunkedCELoss.Config(),
+        hf_assets_path="./assets/hf/deepseek-moe-16b-base",
+        model_spec=model_registry(
             "16B", attn_backend="flex", moe_comm_backend="deepep"
         ),
         dataloader=HuggingFaceTextDataLoader.Config(


### PR DESCRIPTION
**Summary:** [D101435913](https://www.internalfb.com/diff/D101435913) introduced a token dispatcher hierarchy that requires moe_comm_backend (model construction) to match parallelism.expert_parallel_comm_backend (parallelization). The deepseek_v3_16b config used moe_comm_backend="standard" but the gb200 conveyor test passes expert_parallel_comm_backend="deepep",  causing an AssertionError in apply_moe_ep_tp. This has broken
sandcastle-test-titan-gb200-package since release 195 (April 18).


**Test Case**
Run MAST job with deepseek_v3_16b on GB200 and verify training starts without assertion failure. mast jobs fails at the same point as h100 equivalent due to a separate issue.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3139

