### PR TITLE
[WIP] Enable DP-to-EP for MoE inference

### DIFF
--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -81,6 +81,10 @@ class ParallelDims:
             # Always keep fsdp mesh with real backend so fully_shard()
             # can apply MixedPrecisionPolicy even at degree 1.
             return True
+        if name == "dp_replicate":
+            # Always keep dp_replicate mesh so replicate() / fully_shard()
+            # can use it for data parallel replication even at degree 1.
+            return True
         if name == "efsdp":
             # We always keep the efsdp if EP is larger than 1 because we need
             # FSDP wrapping to help the MoE layers do mixed precision training.

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -277,61 +277,10 @@ class TorchTitanVLLMModelWrapper(Module):
             skip_dp=True,
         )
 
-        # Check which params are DTensor (TP-sharded) vs plain
-        dtensor_params = []
-        plain_params = []
-        for n, p in self.model.named_parameters():
-            if isinstance(p, DTensor):
-                dtensor_params.append(f"{n}:{p.placements}")
-            else:
-                plain_params.append(n)
-        print(
-            f"[INIT] After parallelize: "
-            f"{len(dtensor_params)} DTensor params, {len(plain_params)} plain params",
-            flush=True,
-        )
-        # Show a few MoE-related params
-        moe_params = [
-            (n, p)
-            for n, p in self.model.named_parameters()
-            if "moe" in n or "experts" in n
-        ]
-        for n, p in moe_params[:3]:
-            if isinstance(p, DTensor):
-                print(
-                    f"[INIT]   MoE DTensor: {n} placement={p.placements} local={p._local_tensor.shape}",
-                    flush=True,
-                )
-            else:
-                print(
-                    f"[INIT]   MoE plain: {n} shape={p.shape} device={p.device}",
-                    flush=True,
-                )
-
         # Materialize model on GPU — only allocates local shards (not full
         # model) thanks to EP/TP DTensor sharding applied above.
         device_type = vllm_config.device_config.device.type
         self.model.to_empty(device=device_type)
-
-        # Check materialized model size
-        total_bytes = sum(
-            p._local_tensor.numel() * p._local_tensor.element_size()
-            if isinstance(p, DTensor)
-            else p.numel() * p.element_size()
-            for p in self.model.parameters()
-        )
-        meta_params = [
-            n
-            for n, p in self.model.named_parameters()
-            if p.device.type == "meta"
-            or (isinstance(p, DTensor) and p._local_tensor.device.type == "meta")
-        ]
-        print(
-            f"[INIT] Model materialized: {total_bytes / 1e9:.2f} GB, "
-            f"params={sum(1 for _ in self.model.parameters())}, "
-            f"meta_params={len(meta_params)}: {meta_params[:3]}",
-            flush=True,
-        )
 
         # Pre-extend RoPE cache to cover vLLM's max model length (profiling
         # may use up to 2x max_seq_len, so use max_model_len which already

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -108,19 +108,24 @@ def create_torchtitan_config_from_vllm_config(
     world_size = dist.get_world_size()
     parallel_config = vllm_config.parallel_config
 
-    # When EP is enabled, all TP ranks are repurposed for expert parallelism
-    # (each rank holds a shard of experts): ep_size = tp_size, etp_size = 1.
     tp_size = parallel_config.tensor_parallel_size
+    dp_size = parallel_config.data_parallel_size
+
     if parallel_config.enable_expert_parallel:
-        ep_size = tp_size
+        # EP spans all ranks within a DP*TP group.
+        ep_size = dp_size * tp_size
         etp_size = 1
     else:
         ep_size = 1
         etp_size = 1
 
+    # Map vLLM DP to dp_shard so the mesh math works:
+    # world_size = dp_shard * tp * pp, and efsdp = dp_shard * tp / (ep * etp).
+    # FSDP is skipped for inference (skip_dp=True in parallelize), so
+    # dp_shard is just a mesh dimension placeholder, not actual sharding.
     parallel_dims = ParallelDims(
-        dp_replicate=parallel_config.data_parallel_size,
-        dp_shard=1,
+        dp_replicate=1,
+        dp_shard=dp_size,
         cp=1,
         tp=tp_size,
         pp=parallel_config.pipeline_parallel_size,
@@ -130,8 +135,8 @@ def create_torchtitan_config_from_vllm_config(
     )
 
     parallelism = ParallelismConfig(
-        data_parallel_replicate_degree=parallel_config.data_parallel_size,
-        data_parallel_shard_degree=1,
+        data_parallel_replicate_degree=1,
+        data_parallel_shard_degree=dp_size,
         context_parallel_degree=1,
         tensor_parallel_degree=tp_size,
         pipeline_parallel_degree=parallel_config.pipeline_parallel_size,
@@ -141,13 +146,11 @@ def create_torchtitan_config_from_vllm_config(
         enable_sequence_parallel=False,
     )
 
-    # Build the full device mesh so all dimensions (tp, ep, etp, efsdp, etc.)
-    # are available to the core parallelize function.
     parallel_dims.build_mesh()
 
     logger.info(
         f"Created TorchTitan config from vLLM: "
-        f"DP={parallel_dims.dp_replicate}, TP={parallel_dims.tp}, "
+        f"DP={dp_size}, TP={parallel_dims.tp}, "
         f"CP={parallel_dims.cp}, PP={parallel_dims.pp}, "
         f"EP={parallel_dims.ep}, ETP={parallel_dims.etp}"
     )
@@ -541,7 +544,7 @@ class TorchTitanVLLMModelWrapper(Module):
                 torchtitan_state_dict[name] = DTensor.from_local(
                     tensor.to(device_mesh.device_type),
                     device_mesh=device_mesh,
-                    placements=[Replicate()],
+                    placements=[Replicate()] * device_mesh.ndim,
                 )
 
         return self.load_weights_from_state_dict(torchtitan_state_dict)

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -289,8 +289,12 @@ def apply_fsdp(
                 )
 
                 assert edp_mesh is not None
-                edp_mesh_info = FSDPMeshInfo(mesh=edp_mesh, shard_mesh_dim=0)
-                dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)
+                edp_mesh_info = FSDPMeshInfo(
+                    mesh=edp_mesh, shard_mesh_dim=0
+                )  # edp mesh is also 2D, [replicated, efsdp]
+                dp_mesh_info = FSDPMeshInfo(
+                    mesh=dp_mesh, shard_mesh_dim=0
+                )  # dp mesh is 2D, [replicate, shard]
 
                 def _shard_placement_fn(
                     param: nn.Parameter,
@@ -303,7 +307,7 @@ def apply_fsdp(
                         return ShardPlacementResult(
                             placement=_expert_placement, mesh_info=_edp_mesh_info
                         )
-                    else:
+                    else:  # moe.router / moe.shared_experts, apply dense dp shard
                         return ShardPlacementResult(
                             placement=Shard(0), mesh_info=_dp_mesh_info
                         )

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -386,8 +386,6 @@ def apply_moe_ep_tp(
     ep_etp_mesh: DeviceMesh | None,
     comm_backend: str = "standard",
     enable_sp: bool = True,
-    pad_multiple: int | None = None,
-    inference: bool = False,
 ):
     """
     Apply MoE expert/tensor parallelism plans to MoE-enabled transformer blocks.
@@ -400,7 +398,6 @@ def apply_moe_ep_tp(
         ep_etp_mesh: Combined EP/ETP mesh.
         comm_backend: MoE communication backend.
         enable_sp: Whether sequence parallelism is enabled.
-        pad_multiple: Optional token padding multiple for compatible expert kernels.
     """
     assert ep_mesh is not None or tp_mesh is not None
 
@@ -471,16 +468,9 @@ def apply_moe_ep_tp(
         experts_mesh, experts_plan = None, None
         if ep_mesh is None:
             assert ep_etp_mesh is None
-            if inference:
-                # For inference without EP, skip expert parallelization.
-                # Expert weights stay full (not TP-sharded) — the MoE
-                # uses grouped_mm which needs full weights per expert.
-                experts_mesh = None
-                experts_plan = None
-            else:
-                experts_mesh = tp_mesh
-                # input Replicate, output Partial
-                experts_plan = TensorParallel()
+            experts_mesh = tp_mesh
+            # input Replicate, output Partial
+            experts_plan = TensorParallel()
         elif tp_mesh is None or etp_mesh is None:
             assert ep_etp_mesh is None
             experts_mesh = ep_mesh

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -82,25 +82,43 @@ def parallelize_qwen3(
     if model_compile_enabled:
         apply_compile(model, compile_config)
 
-    # Skip FSDP wrapper for inference. FSDP's forward hooks
-    # are incompatible with torch.inference_mode() used by vLLM.
-    # AC and compile are disabled via config (mode="none", enable=False).
-    if skip_dp:
-        return model
+    if skip_dp:  # Inference path
+        # there's only one kind of DP which is DDP during inferece, but we use "fsdp" to represent dp_degree
+        # Trick: apply number of fsdp_degree of DDP, instead of FSDP on dense module
+        assert not parallel_dims.dp_replicate_enabled
+        dp_mesh_names = [
+            "fsdp",
+            "dp_replicate",
+        ]  # we need to use 2D mesh to apply DDP on first mesh
+        dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
 
-    dp_mesh_names = (
-        ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    )
-    dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+        # Assumption: DP is only applied when EP degree is greater than dense module's TP degree
+        # So EP >= (DP * TP) for inference. Otherwise we will just spin more vllm instances
+        # efsdp degree must = 1
+        edp_mesh = None
+        if parallel_dims.ep_enabled:
+            edp_mesh_names = [
+                "efsdp",
+                "dp_replicate",
+            ]  # we need to use 2D mesh to apply DDP on first mesh
+            edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+            if edp_mesh is not None:
+                assert edp_mesh.size() == 2
 
-    edp_mesh = None
-    if parallel_dims.ep_enabled:
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
+    else:  # pre-training path
+        dp_mesh_names = (
+            ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
         )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+        dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+
+        edp_mesh = None
+        if parallel_dims.ep_enabled:
+            edp_mesh_names = (
+                ["dp_replicate", "efsdp"]
+                if parallel_dims.dp_replicate_enabled
+                else ["efsdp"]
+            )
+            edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
 
     apply_fsdp(
         model,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3143
* #3142

In development. Currently it doesn't work with weight loading

Map vLLM's data_parallel_size to dp_shard in TorchTitan's mesh math, enabling EP to span both DP and TP ranks (ep = dp * tp). For inference, the skip_dp path computes 2D meshes (fsdp + dp_replicate) then calls apply_fsdp which uses shard_placement_fn to route expert params to efsdp mesh and dense params to fsdp mesh.

Changes:
- parallel_dims: dp_replicate mesh always exists (needed for 2D mesh)
- vllm_wrapper: ep_size = dp_size * tp_size, dp_shard = dp_size
- qwen3/parallelize: inference path computes 2D meshes for apply_fsdp
- llama4/parallelize: clarify shard_placement_fn comments