### PR TITLE
[graph_trainer] Remove apply_graph_ac

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -13,7 +13,6 @@ from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
 
-from torchtitan.config import CompileConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
 
@@ -198,27 +197,3 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     module_to_name = {m: n for n, m in model.named_modules()}
     module_fqns = convert_modules_to_fqns(module_list, module_to_name)
     return module_fqns
-
-
-def apply_graph_ac(
-    compile_config: CompileConfig,
-    ac_config: "ActivationCheckpointConfig",
-) -> None:
-    """Add apply_sac to compile joint passes for graph-based selective AC.
-
-    Must be called only when ac_config.mode != "none". Only "selective" mode
-    is supported; other modes raise ValueError.
-    """
-    if ac_config.mode != "selective":
-        raise ValueError(
-            f"graph_trainer only supports activation_checkpoint.mode 'selective' or "
-            f"'none', got {ac_config.mode!r}. Use 'selective' for graph-based SAC."
-        )
-
-    joint_pass_names = getattr(compile_config, "joint_passes", [])
-    if "apply_sac" not in joint_pass_names:
-        compile_config.joint_passes = list(joint_pass_names) + ["apply_sac"]
-        logger.info(
-            "activation_checkpoint.mode is 'selective', added apply_sac to "
-            "compile.joint_passes"
-        )

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -16,10 +16,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
-from torchtitan.experiments.graph_trainer.common_utils import (
-    annotate_module_fqns,
-    apply_graph_ac,
-)
+from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
@@ -102,9 +99,6 @@ def parallelize_deepseekv3(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             enable_sp=parallelism.enable_sequence_parallel,
         )
-
-    if ac_config.mode != "none":
-        apply_graph_ac(compile_config, ac_config)
 
     mp_policy = MixedPrecisionPolicy(
         param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -13,10 +13,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
-from torchtitan.experiments.graph_trainer.common_utils import (
-    annotate_module_fqns,
-    apply_graph_ac,
-)
+from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
@@ -66,9 +63,6 @@ def parallelize_llama(
         tp_mesh = parallel_dims.get_mesh("tp")
         model.parallelize(tp_mesh)
         maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
-
-    if ac_config.mode != "none":
-        apply_graph_ac(compile_config, ac_config)
 
     # apply data parallel
     if (

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -44,7 +44,6 @@ import torch.distributed as dist
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
-    apply_graph_ac,
     parallelize_inputs,
     register_blockmask_pytree_node,
 )
@@ -158,9 +157,6 @@ def _common_setup(config):
 
     # For aot_fx_trace, apply_compile inside parallelize_fn is a no-op
     # (returns model unchanged), so we pass the real compile_config.
-    # This lets side effects from parallelize_fn (e.g. apply_graph_ac
-    # adding "apply_sac" to joint_passes) be visible to
-    # compute_config_fingerprint later without needing a manual hack.
     # For aot, apply_compile would try to load a non-existent artifact,
     # so we suppress it with a copy that has enable=False. This
     # complexity goes away once we complete the migration to
@@ -226,12 +222,6 @@ def _precompile_aot(
             "serializable output "
             f"({', '.join(sorted(_SERIALIZABLE_PASSES))}) in --compile.passes."
         )
-
-    # Augment compile_config with AC joint passes to match the training
-    # path, which calls apply_graph_ac during parallelization. Without
-    # this the SAC pass won't run and the config fingerprint will differ.
-    if config.activation_checkpoint.mode != "none":
-        apply_graph_ac(compile_config, config.activation_checkpoint)
 
     register_blockmask_pytree_node()
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -16,10 +16,7 @@ from torchtitan.config import (
 )
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
-from torchtitan.experiments.graph_trainer.common_utils import (
-    annotate_module_fqns,
-    apply_graph_ac,
-)
+from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
 
@@ -98,9 +95,6 @@ def parallelize_qwen3(
             ep_etp_mesh=parallel_dims.get_optional_mesh(["ep", "etp"]),
             enable_sp=parallelism.enable_sequence_parallel,
         )
-
-    if ac_config.mode != "none":
-        apply_graph_ac(compile_config, ac_config)
 
     mp_policy = MixedPrecisionPolicy(
         param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],


### PR DESCRIPTION
## Summary
- Remove `apply_graph_ac` which added `"apply_sac"` to `compile.joint_passes` — only used by the deprecated `aot` compile mode
- In the default `aot_fx_trace` path, SAC is handled by `tag_with_memory_policy_pass` in `compile_time_passes`, making `apply_graph_ac` a no-op
- Clean up all callsites: llama3, deepseek_v3, qwen3 parallelize functions and `precompile_main.py`

## Test plan
- [ ] `pre-commit run --all-files` passes
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x`
- [ ] Integration tests with `aot_fx_trace` mode produce identical loss