### PR TITLE
[graph_trainer] Apply simple_fsdp unconditionally for NGPU=1 parity

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -13,7 +13,12 @@ from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
 
+from torchtitan.config import TORCH_DTYPE_MAP, TrainingConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.graph_trainer.simple_fsdp import (
+    data_parallel,
+    MixedPrecisionPolicy,
+)
 from torchtitan.tools.logging import logger
 
 _MODULE_FQN = "module_fqn"
@@ -197,3 +202,71 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     module_to_name = {m: n for n, m in model.named_modules()}
     module_fqns = convert_modules_to_fqns(module_list, module_to_name)
     return module_fqns
+
+
+def apply_simple_fsdp(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+) -> nn.Module:
+    """Wrap the model (and any MoE experts) with graph_trainer's simple_fsdp.
+
+    For MoE-enabled models, ``moe.experts`` submodules are separately wrapped
+    on the EDP mesh when expert parallelism is enabled.
+    """
+    if parallel_dims.dp_replicate_enabled:
+        if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
+            dp_mesh_dim_names = ["dp_replicate", "fsdp"]
+            dp_mode = "hybrid_shard"
+        else:
+            dp_mesh_dim_names = ["dp_replicate"]
+            dp_mode = "replicate"
+    else:
+        dp_mesh_dim_names = ["fsdp"]
+        dp_mode = "fully_shard"
+
+    dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
+    )
+
+    if parallel_dims.ep_enabled and hasattr(model, "layers"):
+        edp_mesh_names = (
+            ["dp_replicate", "efsdp"]
+            if parallel_dims.dp_replicate_enabled
+            else ["efsdp"]
+        )
+        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+        assert edp_mesh is not None
+
+        for _, transformer_block in model.layers.items():
+            if not getattr(transformer_block, "moe_enabled", False):
+                continue
+            assert hasattr(transformer_block, "moe")
+            experts_shard_dim = 0
+            if (
+                edp_mesh["efsdp"].size() * parallel_dims.ep
+                > transformer_block.moe.experts.num_experts
+            ):
+                experts_shard_dim = 1
+
+            transformer_block.moe.experts = data_parallel(
+                transformer_block.moe.experts,
+                edp_mesh,
+                dp_mode,
+                mp_policy=mp_policy,
+                shard_dim=experts_shard_dim,
+            )
+
+    model = data_parallel(
+        model,
+        dp_mesh,
+        dp_mode,
+        mp_policy=mp_policy,
+    )
+    logger.info(
+        "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
+    )
+    return model

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -4,28 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
 from torchtitan.models.deepseek_v3.parallelize import apply_moe_ep_tp
-from torchtitan.tools.logging import logger
 
 
 def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
@@ -98,68 +94,10 @@ def parallelize_deepseekv3(
             enable_sp=parallelism.enable_sequence_parallel,
         )
 
-    mp_policy = MixedPrecisionPolicy(
-        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-    )
-
-    # apply data parallel
-    dp_mesh: DeviceMesh | None = None
-    if (
-        parallel_dims.fsdp_enabled
-        or parallel_dims.ep_enabled
-        or parallel_dims.dp_replicate_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
-
-        # the mesh dim names of which the MoE params are sharded on via FSDP/HSDP
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
-
-        for _, transformer_block in model.layers.items():
-            if transformer_block.moe_enabled and parallel_dims.ep_enabled:
-                experts_shard_dim = 0
-                assert edp_mesh is not None
-                assert hasattr(transformer_block, "moe")
-                if (
-                    edp_mesh["efsdp"].size() * parallel_dims.ep
-                    > transformer_block.moe.experts.num_experts
-                ):
-                    experts_shard_dim = 1
-
-                transformer_block.moe.experts = data_parallel(
-                    transformer_block.moe.experts,
-                    edp_mesh,
-                    dp_mode,
-                    mp_policy=mp_policy,
-                    shard_dim=experts_shard_dim,
-                )
-
-        model = data_parallel(
-            model,
-            dp_mesh,
-            dp_mode,
-            mp_policy=mp_policy,
-        )
-
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -8,18 +8,15 @@ from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
-from torchtitan.tools.logging import logger
 
 
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
@@ -62,37 +59,10 @@ def parallelize_llama(
         tp_mesh = parallel_dims.get_mesh("tp")
         model.parallelize(tp_mesh)
 
-    # apply data parallel
-    if (
-        parallel_dims.dp_replicate_enabled
-        or parallel_dims.dp_shard_enabled
-        or parallel_dims.cp_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        mp_policy = MixedPrecisionPolicy(
-            param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-            reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-        )
-
-        model = data_parallel(
-            model,
-            parallel_dims.get_mesh(dp_mesh_dim_names),
-            mode=dp_mode,
-            mp_policy=mp_policy,
-        )
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -4,26 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
 from torchtitan.models.llama4.parallelize import apply_moe_ep_tp
-from torchtitan.tools.logging import logger
 
 
 def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
@@ -93,68 +89,10 @@ def parallelize_qwen3(
             enable_sp=parallelism.enable_sequence_parallel,
         )
 
-    mp_policy = MixedPrecisionPolicy(
-        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-    )
-
-    # apply data parallel
-    dp_mesh: DeviceMesh | None = None
-    if (
-        parallel_dims.fsdp_enabled
-        or parallel_dims.ep_enabled
-        or parallel_dims.dp_replicate_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
-
-        # the mesh dim names of which the MoE params are sharded on via FSDP/HSDP
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
-
-        for _, transformer_block in model.layers.items():
-            if transformer_block.moe_enabled and parallel_dims.ep_enabled:
-                experts_shard_dim = 0
-                assert edp_mesh is not None
-                assert hasattr(transformer_block, "moe")
-                if (
-                    edp_mesh["efsdp"].size() * parallel_dims.ep
-                    > transformer_block.moe.experts.num_experts
-                ):
-                    experts_shard_dim = 1
-
-                transformer_block.moe.experts = data_parallel(
-                    transformer_block.moe.experts,
-                    edp_mesh,
-                    dp_mode,
-                    mp_policy=mp_policy,
-                    shard_dim=experts_shard_dim,
-                )
-
-        model = data_parallel(
-            model,
-            dp_mesh,
-            dp_mode,
-            mp_policy=mp_policy,
-        )
-
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from torchtitan.config.configs import TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+
+
+class TestApplySimpleFSDPSingleRank(unittest.TestCase):
+    """Verify simple_fsdp's MixedPrecisionPolicy actually casts params at NGPU=1."""
+
+    def setUp(self):
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method="tcp://localhost:12358",
+                world_size=1,
+                rank=0,
+            )
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
+    def test_param_cast_to_bf16_at_ngpu_1(self):
+        """With ``mixed_precision_param=bfloat16``, the parametrized weight must
+        yield bf16 — and a forward must run in bf16 — even when fsdp /
+        dp_replicate / ep are all disabled. Without the unconditional
+        simple_fsdp wrap, parameters silently stay in fp32 on a single GPU and
+        any downstream bf16-only kernel (e.g. MXFP8) breaks.
+        """
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            etp=1,
+            world_size=1,
+        )
+        training = TrainingConfig(
+            mixed_precision_param="bfloat16",
+            mixed_precision_reduce="float32",
+        )
+
+        model = nn.Linear(8, 8)
+        self.assertEqual(model.weight.dtype, torch.float32)
+
+        model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+
+        # Parametrization replaces ``weight`` access with a bf16 cast via
+        # ``redistribute(forward_dtype=...)``.
+        self.assertEqual(model.weight.dtype, torch.bfloat16)
+
+        # Underlying storage stays in fp32 (the cast is applied per forward),
+        # confirming this is true mixed precision rather than a one-shot
+        # downcast that would lose master-weight precision.
+        self.assertEqual(model._parameters["weight"].dtype, torch.float32)
+
+        # End-to-end: forward against the parametrized weight produces bf16
+        # activations.
+        x = torch.randn(2, 8, dtype=torch.bfloat16)
+        y = model(x)
+        self.assertEqual(y.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The main trainer applies fully_shard unconditionally so MixedPrecisionPolicy's param_dtype cast runs even at degree 1 — the `fsdp` mesh is deliberately kept with a real backend for this (ParallelDims._mesh_exist). graph_trainer's llama3/deepseek_v3/qwen3 parallelize fns instead gated simple_fsdp on fsdp/ep/dp_replicate being enabled, so on a single GPU parameters stayed in fp32 and any bf16-only kernel downstream (e.g. MXFP8) failed.
    
Drop the guard and consolidate the three near-identical data_parallel blocks into apply_simple_fsdp in common_utils. MoE experts handling folds in via ep_enabled + moe_enabled checks (no-op for dense models).
    
Adds tests/test_simple_fsdp.py asserting the bf16 param cast at NGPU=1: the parametrized weight access yields bf16 while the underlying storage stays fp32, and a forward pass produces bf16 activations. Verified the test fails when the gating is reintroduced inside apply_simple_fsdp.