### PR TITLE
refactor get_attention_masks to use positions instead of eos_id

### DIFF
--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -15,6 +15,7 @@ from datasets import Dataset
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
 from torchtitan.hf_datasets.text_datasets import ChatDataLoader, ChatDataset
+from torchtitan.models.common.attention import get_document_mask_mod
 
 # Path to the test tokenizer and fixture data
 _ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "assets")
@@ -437,6 +438,52 @@ class TestChatDatasetInfiniteLooping(unittest.TestCase):
         batches = [next(it) for _ in range(20)]
         self.assertEqual(len(batches), 20)
         self.assertGreaterEqual(chat_ds._epoch, 1)
+
+
+class TestDocumentMaskBlocksCrossDocAttention(unittest.TestCase):
+    """Verify that position-based document masks block cross-document attention."""
+
+    def test_packed_samples_block_cross_document_attention(self):
+        tokenizer = _load_tokenizer()
+        ds = _load_dataset()
+        chat_ds = ChatDataset(
+            dataset=ds,
+            tokenizer=tokenizer,
+            sample_processor=_process_sample,
+            seq_len=2048,
+            infinite=False,
+        )
+
+        r0 = chat_ds._tokenize_sample(ds[0])
+        r1 = chat_ds._tokenize_sample(ds[1])
+        self.assertIsNotNone(r0)
+        self.assertIsNotNone(r1)
+        input_ids_0, _ = r0
+        input_ids_1, _ = r1
+
+        packed = input_ids_0 + input_ids_1
+        boundary = len(input_ids_0)
+        positions = torch.tensor(
+            [list(range(len(input_ids_0))) + list(range(len(input_ids_1)))]
+        )
+
+        mask_mod = get_document_mask_mod(positions)
+        b, h = torch.tensor(0), torch.tensor(0)
+
+        self.assertFalse(
+            mask_mod(b, h, torch.tensor(boundary), torch.tensor(boundary - 1)).item(),
+        )
+        self.assertFalse(
+            mask_mod(b, h, torch.tensor(len(packed) - 1), torch.tensor(0)).item(),
+        )
+        self.assertTrue(
+            mask_mod(b, h, torch.tensor(boundary - 1), torch.tensor(0)).item(),
+        )
+        self.assertTrue(
+            mask_mod(
+                b, h, torch.tensor(len(packed) - 1), torch.tensor(boundary)
+            ).item(),
+        )
 
 
 if __name__ == "__main__":

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -201,9 +201,7 @@ class Validator(BaseValidator):
             extra_kwargs["attention_masks"] = cast(
                 BaseModel, model_parts[0]
             ).get_attention_masks(
-                input_batch=inputs,
-                tokenizer=self.tokenizer,
-                extra_inputs=extra_inputs,
+                positions=extra_kwargs.get("positions"),
             )
         except TypeError:
             pass

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -174,12 +174,12 @@ class Trainer(ForgeEngine):
         # extra_kwargs are.
         extra_kwargs: dict[str, Any] = {}
 
+        positions = extra_inputs.pop("positions", None)
+
         try:
             # pyrefly: ignore [not-callable]
             extra_kwargs["attention_masks"] = self.model_parts[0].get_attention_masks(
-                input_batch=inputs,
-                tokenizer=self.tokenizer,
-                extra_inputs=extra_inputs,
+                positions=positions,
             )
         except TypeError:
             pass

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -64,6 +64,7 @@ from torchtitan.experiments.graph_trainer.precompile import (
     _FX_TRACE_ARTIFACT_KEY,
 )
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
@@ -337,34 +338,23 @@ def _precompile_aot_fx_trace(
 
     if isinstance(model_config, Decoder.Config) and model_config.layers:
         attn_config = model_config.layers[0].attention
-        mask_type = getattr(attn_config, "mask_type", "causal")
+        inner_attention = attn_config.inner_attention
 
-        if mask_type == "block_causal" or parallel_dims.cp_enabled:
-            extra_kwargs["positions"] = torch.arange(
+        if attn_config.mask_type == "block_causal":
+            positions = torch.arange(
                 0, dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
             ).expand(dummy_inputs.shape)
+        else:
+            positions = torch.arange(
+                dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
+            ).repeat(dummy_inputs.shape[0], 1)
 
-        inner_attention = getattr(attn_config, "inner_attention", None)
-        if inner_attention is not None:
-            from torchtitan.models.common.attention import (
-                FlexAttention,
-                VarlenAttention,
+        if isinstance(inner_attention, (FlexAttention.Config, VarlenAttention.Config)):
+            extra_kwargs["attention_masks"] = cast(Decoder, model).get_attention_masks(
+                positions=positions,
             )
 
-            if isinstance(
-                inner_attention,
-                (FlexAttention.Config, VarlenAttention.Config),
-            ):
-                assert (
-                    tokenizer is not None
-                ), "tokenizer is required for flex/varlen attention"
-                extra_kwargs["attention_masks"] = cast(
-                    Decoder, model
-                ).get_attention_masks(
-                    input_batch=dummy_inputs,
-                    tokenizer=tokenizer,
-                    extra_inputs=extra_inputs or {},
-                )
+        extra_kwargs["positions"] = positions
 
     # TODO: Add CP support — call prepare_context_parallel_input here
     # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -110,6 +110,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         self.model = model
         self.inputs = torch.randint(0, vocab_size, (BATCH_SIZE, SEQ_LEN), device="cuda")
         self.labels = torch.randint(0, vocab_size, (BATCH_SIZE, SEQ_LEN), device="cuda")
+        self.positions = torch.arange(SEQ_LEN, device="cuda").repeat(BATCH_SIZE, 1)
 
     def tearDown(self):
         FlexAttention.inductor_configs = self._orig_inductor_configs
@@ -143,7 +144,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         for _ in range(NUM_STEPS):
             optimizer.zero_grad()
             loss = trainer.forward_backward_step(
-                input_dict={"input": self.inputs},
+                input_dict={"input": self.inputs, "positions": self.positions},
                 labels=self.labels,
                 global_valid_tokens=global_valid_tokens,
             )
@@ -185,7 +186,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
             BATCH_SIZE * SEQ_LEN, dtype=torch.float, device="cuda"
         )
         extra_inputs: dict[str, torch.Tensor] = {}
-        extra_kwargs: dict[str, torch.Tensor] = {}
+        extra_kwargs: dict[str, torch.Tensor] = {"positions": self.positions}
 
         # Step 1: Trace the graph
         traced_result = trace_train_step(fwd_bwd_fn)(

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -754,11 +754,12 @@ class TestTraceModels(unittest.TestCase):
             model.init_states(buffer_device=torch.device(self.DEVICE))
 
         tokens = torch.randint(0, vocab_size, (1, seq_len), device=self.DEVICE)
-        # Insert EOS tokens to create document boundaries for block_causal mask
-        tokens[:, 15::16] = 1
         labels = torch.randint(0, vocab_size, (1, seq_len), device=self.DEVICE)
+        # Build positions that reset to 0 every 16 tokens (document boundaries)
+        positions = torch.arange(seq_len, device=self.DEVICE) % 16
+        positions = positions.unsqueeze(0)  # [1, seq_len]
         block_mask = create_attention_mask(
-            and_masks(get_causal_mask_mod(), get_document_mask_mod(tokens, eos_id=1)),
+            and_masks(get_causal_mask_mod(), get_document_mask_mod(positions)),
             B=1,
             H=None,
             Q_LEN=seq_len,

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -32,12 +32,11 @@ from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.utils import set_batch_invariance
 from torchtitan.experiments.rl.actors.utils import (
     compute_logprobs,
-    create_positions_from_seq_lens,
-    create_varlen_metadata,
     extract_response_logprobs,
     verify_logprob_identity,
 )
 from torchtitan.experiments.rl.types import TrainBatch
+from torchtitan.models.common.attention import create_varlen_metadata_for_document
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger
@@ -282,8 +281,10 @@ class PolicyTrainer(Actor, Configurable):
                 f"generation max_tokens."
             )
 
-        attention_masks = create_varlen_metadata(seq_lens, device)
-        positions = create_positions_from_seq_lens(seq_lens, device)
+        positions = torch.cat(
+            [torch.arange(l, device=device) for l in seq_lens]
+        ).unsqueeze(0)
+        attention_masks = create_varlen_metadata_for_document(positions)
 
         logits = self.model(
             token_ids, attention_masks=attention_masks, positions=positions

--- a/torchtitan/experiments/rl/actors/utils.py
+++ b/torchtitan/experiments/rl/actors/utils.py
@@ -4,29 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import itertools
-
 import torch
 import torch.nn.functional as F
-
-from torchtitan.models.common.attention import VarlenMetadata
-
-# TODO We should either unify all the mask creation for RL, or move them to a
-#      single file.
-def create_varlen_metadata(seq_lens: list[int], device: torch.device) -> VarlenMetadata:
-    """Build VarlenMetadata from sequence lengths.
-
-    Example:
-        seq_lens = [3, 5, 2]
-        -> cu_seqs = [0, 3, 8, 10], max_len = 5
-    """
-    cu_seqs = torch.tensor(
-        [0] + list(itertools.accumulate(seq_lens)), dtype=torch.int32, device=device
-    )
-    max_len = max(seq_lens)
-    return VarlenMetadata(
-        cu_seq_q=cu_seqs, cu_seq_k=cu_seqs, max_q=max_len, max_k=max_len
-    )
 
 
 def compute_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
@@ -66,18 +45,6 @@ def extract_response_logprobs(
         result.append(packed_logprobs[0, s:e])
         seq_start += seq_lens[i]
     return result
-
-
-def create_positions_from_seq_lens(
-    seq_lens: list[int], device: torch.device
-) -> torch.Tensor:
-    """Build a ``[1, total_tokens]`` positions tensor that resets at each sequence boundary.
-
-    Example:
-        seq_lens = [3, 5, 2]
-        -> positions = [[0, 1, 2, 0, 1, 2, 3, 4, 0, 1]]
-    """
-    return torch.cat([torch.arange(l, device=device) for l in seq_lens]).unsqueeze(0)
 
 
 def verify_logprob_identity(

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -312,27 +312,25 @@ def get_causal_mask_mod() -> _mask_mod_signature:
     return _causal_mask
 
 
-def get_document_mask_mod(batch: torch.Tensor, eos_id: int) -> _mask_mod_signature:
+def get_document_mask_mod(positions: torch.Tensor) -> _mask_mod_signature:
     """Creates a document mask that prevents attention across document boundaries.
 
+    Document boundaries are detected where ``positions`` resets to 0, which
+    marks the start of a new packed document.
+
     Args:
-        batch: Input batch tensor with shape [b, s, h, d]
-        eos_id: End-of-sequence token ID that marks document boundaries
+        positions: Per-token position tensor with shape ``[b, s]``. Positions
+            reset to 0 at each document start.
 
     Returns:
         A mask modifier function that implements document-level masking.
     """
-    # batch is [b, s, h, d] shape
-    eos_mask = batch == eos_id
-    eos_mask[:, -1] = True
-    cumulative_mask = torch.cumsum(torch.where(eos_mask, 1, 0), dim=1)
-    sequence_indices = torch.zeros_like(cumulative_mask, dtype=torch.int32)
-    sequence_indices[:, 1:] = cumulative_mask[:, :-1]
+    doc_ids = torch.cumsum((positions == 0).int(), dim=1) - 1
 
     def document_mask(
         b: torch.Tensor, h: torch.Tensor, q_idx: torch.Tensor, kv_idx: torch.Tensor
     ) -> torch.Tensor:
-        return sequence_indices[b, q_idx] == sequence_indices[b, kv_idx]
+        return doc_ids[b, q_idx] == doc_ids[b, kv_idx]
 
     return document_mask
 
@@ -403,35 +401,30 @@ def create_attention_mask(*args, **kwargs):
 
 
 def create_varlen_metadata_for_document(
-    input_batch: torch.Tensor, eos_id: int
+    positions: torch.Tensor,
 ) -> VarlenMetadata:
-    """
-    Creates cumulative sequence length indices needed for variable length attention
+    """Creates cumulative sequence length indices needed for variable length attention.
+
+    Document boundaries are detected where ``positions`` resets to 0 (same
+    convention as :func:`get_document_mask_mod`).
 
     Args:
-        input_batch
-        eos_id: the EOS id marker
+        positions: Per-token position tensor with shape ``[b, s]``. Positions
+            reset to 0 at each document start.
 
     Returns:
         VarlenMetadata containing cumulative sequence length indices for q, k, and max_seq_len
     """
-    batch_size, seq_len = input_batch.shape
-    device = input_batch.device
+    batch_size, seq_len = positions.shape
+    device = positions.device
     cu_seqlens_list, all_seq_lengths = [], []
     offset = 0
-    max_seqlen = 0
 
     for b in range(batch_size):
-        tokens = input_batch[b]
-        eos_positions = (tokens == eos_id).nonzero(as_tuple=True)[0].to(torch.int32)
+        doc_starts = (positions[b] == 0).nonzero(as_tuple=True)[0].to(torch.int32)
         sample_cu_seqlens = torch.cat(
-            [
-                torch.tensor([0], dtype=torch.int32, device=device),
-                eos_positions + 1,
-                torch.tensor([seq_len], dtype=torch.int32, device=device),
-            ]
+            [doc_starts, torch.tensor([seq_len], dtype=torch.int32, device=device)]
         )
-        sample_cu_seqlens = torch.unique_consecutive(sample_cu_seqlens)
 
         seq_lengths = torch.diff(sample_cu_seqlens)
         all_seq_lengths.append(seq_lengths)

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 import torch
 from torch.nn.attention.flex_attention import and_masks
 
-from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
@@ -151,8 +150,7 @@ class Decoder(BaseModel):
 
     def _get_flex_attention_masks(
         self,
-        input_batch: torch.Tensor,
-        tokenizer: BaseTokenizer,
+        positions: torch.Tensor,
         attn_config: BaseAttention.Config,
     ) -> AttentionMasksType:
         mask_mods = [get_causal_mask_mod()]
@@ -161,42 +159,39 @@ class Decoder(BaseModel):
             case "causal":
                 B = 1
             case "block_causal":
-                B = input_batch.shape[0]
-                assert tokenizer.eos_id is not None
-                mask_mods.append(get_document_mask_mod(input_batch, tokenizer.eos_id))
+                B = positions.shape[0]
+                mask_mods.append(get_document_mask_mod(positions))
             case _:
                 raise ValueError(
                     f"Unknown attention mask type: {attn_config.mask_type}"
                 )
 
+        seq_len = positions.shape[1]
         assert isinstance(attn_config.inner_attention, FlexAttention.Config)
         return create_attention_mask(
             and_masks(*mask_mods),
             B,
             None,
-            input_batch.shape[1],
-            input_batch.shape[1],
+            seq_len,
+            seq_len,
             BLOCK_SIZE=attn_config.inner_attention.block_size,
         )
 
     def get_attention_masks(
         self,
-        input_batch: torch.Tensor,
-        tokenizer: BaseTokenizer,
-        extra_inputs: dict[str, torch.Tensor] | None = None,
+        positions: torch.Tensor,
     ) -> AttentionMasksType:
         attn_config = self.config.layers[0].attention
         inner_attn = attn_config.inner_attention
         if isinstance(inner_attn, FlexAttention.Config):
-            return self._get_flex_attention_masks(input_batch, tokenizer, attn_config)
+            return self._get_flex_attention_masks(positions, attn_config)
         elif isinstance(inner_attn, VarlenAttention.Config):
             if attn_config.mask_type != "block_causal":
                 raise ValueError(
                     f"varlen attention is only supported with block_causal "
                     f"attention mask type, got {attn_config.mask_type}"
                 )
-            assert tokenizer.eos_id is not None
-            return create_varlen_metadata_for_document(input_batch, tokenizer.eos_id)
+            return create_varlen_metadata_for_document(positions)
         else:
             raise TypeError(
                 f"Only VarlenAttention and FlexAttention support attention masks, "

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -12,7 +12,6 @@ import torch
 from torch import nn
 from torch.nn.attention.flex_attention import and_masks, BlockMask
 
-from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
@@ -252,9 +251,7 @@ class GptOssModel(Decoder):
 
     def get_attention_masks(
         self,
-        input_batch: torch.Tensor,
-        tokenizer: BaseTokenizer,
-        extra_inputs: dict[str, torch.Tensor] | None = None,
+        positions: torch.Tensor,
     ) -> AttentionMasksType:
         basic_mask_mods = []
         attn_cfg = self.config.layers[0].attention
@@ -262,16 +259,14 @@ class GptOssModel(Decoder):
         sliding_window_mask_mods = [
             get_sliding_window_mask_mod(attn_cfg.sliding_window_size)
         ]
+        seq_len = positions.shape[1]
         match attn_cfg.mask_type:
             case "causal":
                 B = 1
                 basic_mask_mods.append(get_causal_mask_mod())
             case "block_causal":
-                B = input_batch.shape[0]
-                assert tokenizer.eos_id is not None
-                basic_mask_mods.append(
-                    get_document_mask_mod(input_batch, tokenizer.eos_id)
-                )
+                B = positions.shape[0]
+                basic_mask_mods.append(get_document_mask_mod(positions))
             case _:
                 raise ValueError(f"Unknown attention mask type: {attn_cfg.mask_type}")
 
@@ -280,8 +275,8 @@ class GptOssModel(Decoder):
             and_masks(*basic_mask_mods),
             B,
             None,
-            input_batch.shape[1],
-            input_batch.shape[1],
+            seq_len,
+            seq_len,
         )
 
         # create sliding window mask, has to be created on top of basic attention mask
@@ -289,8 +284,8 @@ class GptOssModel(Decoder):
             and_masks(*basic_mask_mods, *sliding_window_mask_mods),
             B,
             None,
-            input_batch.shape[1],
-            input_batch.shape[1],
+            seq_len,
+            seq_len,
         )
 
         return {"basic_mask": basic_mask, "sliding_window_mask": sliding_window_mask}

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -11,7 +11,6 @@ import torch
 from torch import nn
 from torch.nn.attention.flex_attention import and_masks
 
-from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     create_attention_mask,
@@ -204,9 +203,7 @@ class Llama4Model(Decoder):
 
     def get_attention_masks(
         self,
-        input_batch: torch.Tensor,
-        tokenizer: BaseTokenizer,
-        extra_inputs: dict[str, torch.Tensor] | None = None,
+        positions: torch.Tensor,
     ) -> AttentionMasksType:
         mask_mods = [get_causal_mask_mod()]
         attn_config = self.config.layers[0].attention
@@ -214,9 +211,8 @@ class Llama4Model(Decoder):
             case "causal":
                 B = 1
             case "block_causal":
-                assert tokenizer.eos_id is not None
-                mask_mods.append(get_document_mask_mod(input_batch, tokenizer.eos_id))
-                B = input_batch.shape[0]
+                mask_mods.append(get_document_mask_mod(positions))
+                B = positions.shape[0]
             case _:
                 raise ValueError(
                     f"Unknown attention mask type: {attn_config.mask_type}"
@@ -230,7 +226,7 @@ class Llama4Model(Decoder):
         )
         nope_mask_mod = and_masks(*mask_mods)
 
-        seqlen = input_batch.shape[1]
+        seqlen = positions.shape[1]
         return {
             "rope": create_attention_mask(rope_mask_mod, B, None, seqlen, seqlen),
             "nope": create_attention_mask(nope_mask_mod, B, None, seqlen, seqlen),

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -41,6 +41,8 @@ from torchtitan.config.configs import (
 )
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
+
+from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
@@ -583,45 +585,30 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # every stage can apply RoPE correctly.
         extra_kwargs: dict[str, Any] = {}
 
-        # Resolve positions once: per-document positions for block_causal,
-        # sequential positions when CP needs them for shard indexing,
-        # or None (model uses sequential RoPE slice by default).
-        if isinstance(self.model_config, Decoder.Config):
-            layer = self.model_config.layers[0]
-            attn_config = layer.attention
-        else:
-            attn_config = None
-        mask_type = getattr(attn_config, "mask_type", "causal")
-
         positions = extra_inputs.pop("positions", None)
-        if mask_type == "block_causal":
-            # Per-document positions from the dataloader
-            extra_kwargs["positions"] = positions
-        elif self.parallel_dims.cp_enabled:
-            # Sequential positions needed for correct RoPE after CP sharding
-            extra_kwargs["positions"] = torch.arange(
-                0, inputs.shape[1], dtype=torch.int32, device=self.device
-            ).expand(inputs.shape)
 
-        inner_attention = getattr(attn_config, "inner_attention", None)
-        if inner_attention is not None:
-            from torchtitan.models.common.attention import (
-                FlexAttention,
-                VarlenAttention,
-            )
+        if isinstance(self.model_config, Decoder.Config):
+            attn_config = self.model_config.layers[0].attention
+            inner_attention = attn_config.inner_attention
+
+            if attn_config.mask_type == "block_causal":
+                assert (
+                    positions is not None
+                ), "block_causal mask requires per-document positions from the dataloader"
+            else:
+                positions = torch.arange(
+                    inputs.shape[1], dtype=torch.int32, device=inputs.device
+                ).repeat(inputs.shape[0], 1)
 
             if isinstance(
                 inner_attention, (FlexAttention.Config, VarlenAttention.Config)
             ):
-                assert (
-                    self.tokenizer is not None
-                ), "tokenizer is required for flex/varlen attention"
                 model = cast(Decoder, self.model_parts[0])
                 extra_kwargs["attention_masks"] = model.get_attention_masks(
-                    input_batch=inputs,
-                    tokenizer=self.tokenizer,
-                    extra_inputs=extra_inputs,
+                    positions=positions,
                 )
+
+        extra_kwargs["positions"] = positions
 
         if self.parallel_dims.cp_enabled:
             inputs, labels, extra_kwargs = prepare_context_parallel_input(


### PR DESCRIPTION
1. fixes #3130, use positions instead of eos_id incorrectly to avoid incorrectly stripping it or assuming it correctly determines the end of a sequence
2. fixes #2716, removes tokenizer from get_attention_masks so the rl loop can reuse it and we can have a unified definition

added test to `tests/unit_tests/test_chat_dataset.py`, ran existing `experiments/graph_trainer/tests/test_trace_module.py`

varlen GRPO loop numerics are identical with and without refactor 
<img width="1182" height="260" alt="Screenshot 2026-04-30 at 12 17 24 PM" src="https://github.com/user-attachments/assets/fae1aaf2-29dc-471a-b333-97076d3a6c2b" />

flex llama 3 training run numerics are also identical 
<img width="1275" height="377" alt="Screenshot 2026-04-30 at 1 18 14 PM" src="https://github.com/user-attachments/assets/22b401d2-4e5f-4441-aa84-ee82fb64fcad" />
<img width="1220" height="384" alt="Screenshot 2026-04-30 at 1 17 31 PM" src="https://github.com/user-attachments/assets/c222f54c-2aa7-4cbb-849d-c2c48a216385" />

