### PR TITLE
[graph_trainer] Fix test_trace_module by passing attn and comm backends explicitly

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -638,28 +638,30 @@ class TestTraceModels(unittest.TestCase):
     def test_llama3(self):
         from torchtitan.models.llama3 import llama3_configs, Llama3Model
 
-        config = llama3_configs["debugmodel"]()
+        config = llama3_configs["debugmodel"](attn_backend="sdpa")
         self._run_model_test(Llama3Model, config)
 
     def test_qwen3(self):
         from torchtitan.models.qwen3 import qwen3_configs
         from torchtitan.models.qwen3.model import Qwen3Model
 
-        config = qwen3_configs["debugmodel"]()
+        config = qwen3_configs["debugmodel"](attn_backend="sdpa")
         self._run_model_test(Qwen3Model, config)
 
     def test_qwen3_moe(self):
         from torchtitan.models.qwen3 import qwen3_configs
         from torchtitan.models.qwen3.model import Qwen3Model
 
-        config = qwen3_configs["debugmodel_moe"]()
+        config = qwen3_configs["debugmodel_moe"](attn_backend="sdpa")
         self._run_model_test(Qwen3Model, config)
 
     def test_deepseek_v3(self):
         from torchtitan.models.deepseek_v3 import deepseekv3_configs
         from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
 
-        config = deepseekv3_configs["debugmodel"]()
+        config = deepseekv3_configs["debugmodel"](
+            attn_backend="sdpa", moe_comm_backend="standard"
+        )
         self._run_model_test(DeepSeekV3Model, config)
 
     def test_deepseek_v3_flex_attention(self):
@@ -797,7 +799,9 @@ class TestTraceModels(unittest.TestCase):
         from torchtitan.models.llama4 import llama4_configs
         from torchtitan.models.llama4.model import Llama4Model
 
-        config = llama4_configs["debugmodel"]()
+        config = llama4_configs["debugmodel"](
+            attn_backend="flex", moe_comm_backend="standard"
+        )
         self._run_model_test(
             Llama4Model,
             config,
@@ -819,7 +823,7 @@ class TestTraceModels(unittest.TestCase):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"]()
+        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
         vocab_size = config.vocab_size
         model_ref = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
         model_test = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
@@ -868,7 +872,7 @@ class TestTraceModels(unittest.TestCase):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"]()
+        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
         model = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
         annotate_module_fqns(model)
 
@@ -1031,28 +1035,32 @@ class TestTraceFSDP(FSDPTest):
     def test_llama3_fsdp(self):
         from torchtitan.models.llama3 import llama3_configs, Llama3Model
 
-        config = llama3_configs["debugmodel"]()
+        config = llama3_configs["debugmodel"](attn_backend="sdpa")
         self._run_fsdp_model_test(Llama3Model, config)
 
     def test_qwen3_fsdp(self):
         from torchtitan.models.qwen3 import qwen3_configs
         from torchtitan.models.qwen3.model import Qwen3Model
 
-        config = qwen3_configs["debugmodel"]()
+        config = qwen3_configs["debugmodel"](attn_backend="sdpa")
         self._run_fsdp_model_test(Qwen3Model, config)
 
     def test_deepseek_v3_fsdp(self):
         from torchtitan.models.deepseek_v3 import deepseekv3_configs
         from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
 
-        config = deepseekv3_configs["debugmodel"]()
+        config = deepseekv3_configs["debugmodel"](
+            attn_backend="sdpa", moe_comm_backend="standard"
+        )
         self._run_fsdp_model_test(DeepSeekV3Model, config)
 
     def test_llama4_fsdp(self):
         from torchtitan.models.llama4 import llama4_configs
         from torchtitan.models.llama4.model import Llama4Model
 
-        config = llama4_configs["debugmodel"]()
+        config = llama4_configs["debugmodel"](
+            attn_backend="flex", moe_comm_backend="standard"
+        )
         self._run_fsdp_model_test(
             Llama4Model,
             config,
@@ -1073,7 +1081,7 @@ class TestTraceFSDP(FSDPTest):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"]()
+        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
         seq_len = 128
         causal = get_causal_mask_mod()
         sw_size = config.layers[0].attention.sliding_window_size
@@ -1109,7 +1117,7 @@ class TestAutogradGradVsBackwardFSDP(FSDPTest):
         from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
         from torchtitan.models.llama3 import llama3_configs, Llama3Model
 
-        config = llama3_configs["debugmodel"]()
+        config = llama3_configs["debugmodel"](attn_backend="sdpa")
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
         prev_deterministic = torch.are_deterministic_algorithms_enabled()


### PR DESCRIPTION
#3125 dropped the previous defaults from `_debugmodel` (and `_debugmodel_moe`) on llama3, qwen3, deepseek_v3, llama4, and gpt_oss, making both `attn_backend` and `moe_comm_backend` required positional args.                                                       

This PR updates the 13 call sites in `test_trace_module.py` to pass the kwargs explicitly.

```
pytest torchtitan/experiments/graph_trainer/tests/test_trace_module.py -v 
```