### PR TITLE
[graph_trainer] FSDP AG RS overlap

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -7,7 +7,6 @@
 from collections.abc import Callable
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate_fn
@@ -119,43 +118,6 @@ def end_with_pass(passes: list[Callable], names: list[str]) -> bool:
         and (last_pass_name := getattr(passes[-1], "__name__", None))
         and (last_pass_name in names)
     )
-
-
-# Maps original FSDP group_name -> extra PG group_name
-_EXTRA_FSDP_PG_REGISTRY: dict[str, str] = {}
-
-
-def create_extra_fsdp_pg(parallel_dims: ParallelDims) -> None:
-    """Create an extra process group mirroring the FSDP topology.
-
-    This creates a new NCCL process group with the same ranks as each FSDP
-    sub-group but a different communicator, giving it a separate CUDA stream.
-    """
-    if not parallel_dims.fsdp_enabled:
-        logger.info("FSDP not enabled, skipping extra PG creation")
-        return
-
-    fsdp_mesh = parallel_dims.get_mesh("fsdp")
-    fsdp_pg = fsdp_mesh.get_group()
-    original_name = fsdp_pg.group_name
-
-    if original_name in _EXTRA_FSDP_PG_REGISTRY:
-        logger.info("Extra FSDP PG already created, skipping")
-        return
-
-    ranks = dist.get_process_group_ranks(fsdp_pg)
-    pg = dist.new_group(
-        ranks=ranks, group_desc="fsdp_extra", use_local_synchronization=True
-    )
-    _EXTRA_FSDP_PG_REGISTRY[original_name] = pg.group_name
-    logger.info(
-        f"Created extra FSDP PG " f"(original: {original_name}, extra: {pg.group_name})"
-    )
-
-
-def get_extra_fsdp_pg_name(original_pg_name: str) -> str | None:
-    """Look up the extra PG name for a given original FSDP PG name."""
-    return _EXTRA_FSDP_PG_REGISTRY.get(original_pg_name)
 
 
 def get_default_transformer_block_buckets(

--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -153,9 +153,7 @@ def _apply_aot_compile(
     joint_custom_passes = joint_passes + joint_custom_passes
 
     # Get compiler passes from config
-    compiler_passes = get_compiler_passes_from_config(
-        model, compile_config, parallel_dims
-    )
+    compiler_passes = get_compiler_passes_from_config(model, compile_config)
 
     # Create compilers with specified passes
     fw_compiler, bw_compiler = make_compiler_with_passes(

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -24,11 +24,7 @@ from torch.utils._pytree import TreeSpec
 
 from torchtitan.config import CompileConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import (
-    create_extra_fsdp_pg,
-    end_with_pass,
-    get_extra_fsdp_pg_name,
-)
+from torchtitan.experiments.graph_trainer.common_utils import end_with_pass
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 
@@ -419,15 +415,13 @@ def validate_pass_names(pass_names: list[str], joint_pass_names: list[str]) -> N
 def get_compiler_passes_from_config(
     model: torch.nn.Module,
     compile_config: CompileConfig,
-    parallel_dims: ParallelDims,
 ):
     """
     Extract and validate compiler passes from job config.
 
     Args:
         model: The model being compiled
-        job_config: Job configuration containing compile.passes and compile.joint_passes
-        parallel_dims: Parallelism dimensions (required for separate_ag_pg pass)
+        compile_config: Compile configuration containing compile.passes and compile.joint_passes
 
     Returns:
         List of compiler pass functions
@@ -457,20 +451,11 @@ def get_compiler_passes_from_config(
                 f"Available compiler passes: {list(AVAILABLE_COMPILER_PASSES.keys())}"
             )
         if pass_name == "transformer_block_bucketing":
-            from torchtitan.experiments.graph_trainer.passes import reassign_to_pg_pass
-
-            create_extra_fsdp_pg(parallel_dims)
-            fsdp_mesh = parallel_dims.get_mesh("fsdp")
-            fsdp_pg = fsdp_mesh.get_group()
-            fsdp_pg_name = fsdp_pg.group_name
-            extra_pg_name = get_extra_fsdp_pg_name(fsdp_pg_name)
-            compiler_passes.append(
-                functools.partial(
-                    reassign_to_pg_pass,
-                    source_pg_name=fsdp_pg_name,
-                    target_pg_name=extra_pg_name,
-                )
+            from torchtitan.experiments.graph_trainer.passes import (
+                overlap_fsdp_ag_rs_pass,
             )
+
+            compiler_passes.append(overlap_fsdp_ag_rs_pass)
             compiler_passes.append(
                 functools.partial(
                     AVAILABLE_COMPILER_PASSES[pass_name],

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -64,6 +64,7 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
 )
 from torchtitan.experiments.graph_trainer.reshard_after_forward import (
     annotate_fsdp_all_gather,
+    is_wait_tensor_from_fsdp,
 )
 from torchtitan.tools.logging import logger
 
@@ -141,7 +142,13 @@ def compile_time_passes(
     they run at trace time via ``construct_default_graph_passes``.
 
     cudagraph is excluded because it needs to re-capture the graph into
-    an in-memory CUDA graph at runtime
+    an in-memory CUDA graph at runtime.
+
+    ``overlap_fsdp_ag_rs_pass`` runs immediately before
+    ``joint_transformer_block_bucketing_reordering_pass`` so that
+    forward+backward all-gathers end up on a separate CUDA stream from
+    reduce-scatters (enabling AG/RS overlap in backward). It is a no-op
+    when the graph contains no FSDP all-gathers.
     """
     from torchtitan.experiments.graph_trainer.common_utils import (
         get_default_transformer_block_buckets,
@@ -162,6 +169,7 @@ def compile_time_passes(
         # same time. Composability between these two passes is untested.
         apply_cpu_offload_pass,
         selective_activation_remat_pass,
+        overlap_fsdp_ag_rs_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
@@ -930,37 +938,71 @@ def full_inductor_compilation_pass(
     return gm
 
 
-def reassign_to_pg_pass(
+# Maps an FSDP group_name to an extra group_name created by this pass.
+# Each NCCL PG gets its own CUDA stream, so the extra PG is what enables
+# AG/RS overlap in backward.
+_EXTRA_FSDP_PG_REGISTRY: dict[str, str] = {}
+
+
+def _get_or_create_extra_fsdp_pg(source_pg_name: str) -> str:
+    """Return the extra PG name for ``source_pg_name``, creating it once.
+
+    The extra PG is a new NCCL process group with the same ranks as the source
+    FSDP PG but a different communicator (and therefore a different CUDA stream).
+    """
+    import torch.distributed as dist
+
+    if source_pg_name in _EXTRA_FSDP_PG_REGISTRY:
+        return _EXTRA_FSDP_PG_REGISTRY[source_pg_name]
+
+    source_pg = dist.distributed_c10d._resolve_process_group(source_pg_name)
+    ranks = dist.get_process_group_ranks(source_pg)
+    extra_pg = dist.new_group(
+        ranks=ranks, group_desc="fsdp_extra", use_local_synchronization=True
+    )
+    _EXTRA_FSDP_PG_REGISTRY[source_pg_name] = extra_pg.group_name
+    logger.info(
+        f"Created extra FSDP PG (source: {source_pg_name}, "
+        f"extra: {extra_pg.group_name})"
+    )
+    return extra_pg.group_name
+
+
+def overlap_fsdp_ag_rs_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
-    *,
-    source_pg_name: str,
-    target_pg_name: str,
 ) -> torch.fx.GraphModule:
     """
-    Reassign all-gather nodes from one process group to another.
+    Reassign FSDP all-gather nodes to an extra NCCL process group for
+    AG/RS overlap in backward.
 
-    This pass rewrites all-gather nodes whose PG matches ``source_pg_name`` to use
-    ``target_pg_name`` instead.  Since each NCCL PG gets its own CUDA stream, this
-    can be used to separate AG and RS onto different streams (e.g. for AG/RS
-    overlap in the backward pass).
+    Discovers the FSDP PG by inspecting the graph, creates an extra
+    NCCL PG over the same ranks (giving it a separate CUDA stream),
+    and rewrites every all-gather using that source PG to the extra PG.
+    This separates all-gathers from reduce-scatters onto different streams,
+    enabling AG/RS overlap in backward.
 
-    Must be applied BEFORE bucketing passes so that bucketed all-gathers inherit
-    the new PG name.
-
-    Args:
-        gm: The graph module (forward or backward)
-        example_inputs: Example inputs (unused, required by pass interface)
-        source_pg_name: The group_name of the process group to match
-        target_pg_name: The group_name of the process group to assign
+    No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
+    bucketing passes so bucketed all-gathers inherit the new PG name.
     """
+    source_pg_name: str | None = None
+    for node in gm.graph.nodes:
+        if is_wait_tensor_from_fsdp(node):
+            ag_node = node.args[0]
+            source_pg_name = ag_node.args[2]
+            break
+
+    if source_pg_name is None:
+        return gm
+
+    target_pg_name = _get_or_create_extra_fsdp_pg(source_pg_name)
+
     count = 0
     for node in gm.graph.nodes:
-        if is_all_gather(node):
+        if is_all_gather(node) and node.args[2] == source_pg_name:
             # AG args: (input_tensor, group_size, group_name)
-            if node.args[2] == source_pg_name:
-                node.args = (node.args[0], node.args[1], target_pg_name)
-                count += 1
+            node.args = (node.args[0], node.args[1], target_pg_name)
+            count += 1
     if count > 0:
         logger.info(
             f"Rewrote {count} all-gather node(s) from PG {source_pg_name} "

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -241,9 +241,7 @@ def _precompile_aot(
     joint_custom_passes = get_joint_custom_passes_from_config(
         parallel_dims, compile_config, fsdp_reshard_after_forward
     )
-    compiler_passes = get_compiler_passes_from_config(
-        model, compile_config, parallel_dims
-    )
+    compiler_passes = get_compiler_passes_from_config(model, compile_config)
     fw_compiler, bw_compiler = make_compiler_with_passes(
         compiler_passes, dump_folder=config.dump_folder
     )

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -35,7 +35,7 @@ from torchtitan.experiments.graph_trainer.passes import (
     _make_default_memory_policy,
     apply_sac_pass,
     insert_kernel_annotations_pass,
-    reassign_to_pg_pass,
+    overlap_fsdp_ag_rs_pass,
     remove_detach_pass,
     remove_identity_slice_pass,
     remove_identity_view_pass,
@@ -79,8 +79,8 @@ class ToyModel(Module):
         return x
 
 
-class TestReassignToPgPass(FSDPTest):
-    """Integration tests: toy model + simple_fsdp + export_joint + reassign_to_pg_pass."""
+class TestOverlapFsdpAgRsPass(FSDPTest):
+    """Integration tests: toy model + simple_fsdp + export_joint + overlap_fsdp_ag_rs_pass."""
 
     def _setup(self):
         """Set up ParallelDims and device mesh for FSDP."""
@@ -142,14 +142,15 @@ class TestReassignToPgPass(FSDPTest):
                 count += 1
         return count
 
-    def test_reassign_rewrites_ag_nodes(self):
-        """Apply reassign_to_pg_pass on the real backward graph and verify
-        that all-gather nodes are rewritten to the target PG."""
+    def test_overlap_rewrites_ag_nodes(self):
+        """Apply overlap_fsdp_ag_rs_pass on the real backward graph and verify
+        that FSDP AG nodes are rewritten to the auto-created extra PG."""
+        from torchtitan.experiments.graph_trainer.passes import _EXTRA_FSDP_PG_REGISTRY
+
         self._setup()
         model = self._make_fsdp_model()
         inputs = torch.randn(4, 16).cuda()
         fsdp_pg_name = self._get_fsdp_pg_name()
-        target_pg_name = "test_target_pg"
 
         bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
 
@@ -157,101 +158,44 @@ class TestReassignToPgPass(FSDPTest):
         ag_before = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
         self.assertGreater(ag_before, 0, "Expected AG nodes with FSDP PG name")
 
-        # Apply the pass
-        reassign_to_pg_pass(
-            bw_gm,
-            bw_example_inputs,
-            source_pg_name=fsdp_pg_name,
-            target_pg_name=target_pg_name,
-        )
+        _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
+        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
 
-        # After: AG nodes should use the target PG
+        extra_pg_name = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
         ag_with_old = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
-        ag_with_new = self._count_ag_nodes_with_pg(bw_gm, target_pg_name)
+        ag_with_new = self._count_ag_nodes_with_pg(bw_gm, extra_pg_name)
 
         self.assertEqual(ag_with_old, 0, "No AG nodes should still use the old PG")
         self.assertEqual(
-            ag_with_new, ag_before, "All AG nodes should now use the target PG"
+            ag_with_new,
+            ag_before,
+            "All AG nodes should now use the extra PG",
         )
 
-    def test_reassign_preserves_total_ag_count(self):
+    def test_overlap_preserves_total_ag_count(self):
         """The pass should not add or remove AG nodes, only rewrite PG names."""
         self._setup()
         model = self._make_fsdp_model()
         inputs = torch.randn(4, 16).cuda()
-        fsdp_pg_name = self._get_fsdp_pg_name()
 
         bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
 
         total_before = self._count_all_ag_nodes(bw_gm)
-        reassign_to_pg_pass(
-            bw_gm,
-            bw_example_inputs,
-            source_pg_name=fsdp_pg_name,
-            target_pg_name="new_pg",
-        )
+        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
         total_after = self._count_all_ag_nodes(bw_gm)
 
         self.assertEqual(total_before, total_after)
 
-    def test_reassign_with_non_matching_pg_is_noop(self):
-        """If the source PG name doesn't match any AG node, nothing changes."""
+    def test_overlap_is_noop_when_no_fsdp_ag(self):
+        """If the graph has no FSDP all-gathers, the pass is a no-op."""
         self._setup()
-        model = self._make_fsdp_model()
-        inputs = torch.randn(4, 16).cuda()
-        fsdp_pg_name = self._get_fsdp_pg_name()
-
-        bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
-
-        ag_before = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
-
-        # Use a non-matching source PG name
-        reassign_to_pg_pass(
-            bw_gm,
-            bw_example_inputs,
-            source_pg_name="nonexistent_pg",
-            target_pg_name="target_pg",
-        )
-
-        # FSDP AG nodes should be unchanged
-        ag_after = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
-        self.assertEqual(ag_before, ag_after)
-
-    def test_reassign_with_extra_pg(self):
-        """Test the production-like flow: create an extra FSDP PG and
-        reassign AG nodes to it."""
-        self._setup()
-        model = self._make_fsdp_model()
-        inputs = torch.randn(4, 16).cuda()
-        fsdp_pg_name = self._get_fsdp_pg_name()
-
-        # Create an extra PG mirroring the FSDP topology
-        from torchtitan.experiments.graph_trainer.common_utils import (
-            create_extra_fsdp_pg,
-            get_extra_fsdp_pg_name,
-        )
-
-        create_extra_fsdp_pg(self.parallel_dims)
-        extra_pg_name = get_extra_fsdp_pg_name(fsdp_pg_name)
-
-        bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
-
-        ag_before = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
-        self.assertGreater(ag_before, 0)
-
-        # Reassign to the real extra PG
-        reassign_to_pg_pass(
-            bw_gm,
-            bw_example_inputs,
-            source_pg_name=fsdp_pg_name,
-            target_pg_name=extra_pg_name,
-        )
-
-        ag_old = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
-        ag_new = self._count_ag_nodes_with_pg(bw_gm, extra_pg_name)
-
-        self.assertEqual(ag_old, 0)
-        self.assertEqual(ag_new, ag_before)
+        # Plain (non-FSDP) module: a graph without FSDP all-gathers.
+        gm = torch.fx.symbolic_trace(torch.nn.Linear(4, 4))
+        ag_before = self._count_all_ag_nodes(gm)
+        overlap_fsdp_ag_rs_pass(gm, ())
+        ag_after = self._count_all_ag_nodes(gm)
+        self.assertEqual(ag_before, 0)
+        self.assertEqual(ag_after, 0)
 
 
 class TestApplySACPass(TestCase):


### PR DESCRIPTION
Introduced `overlap_fsdp_ag_rs_pass` to overlap AG and RS in FSDP by creating a separate PG for AG (renaming and refactoring the old `reassign_to_pg_pass`).

The pass:
- Discovers the FSDP PG by walking the graph for FSDP wait_tensor nodes (is_wait_tensor_from_fsdp).
- Lazily creates the extra PG on first use via an internal _EXTRA_FSDP_PG_REGISTRY keyed by source PG name. 
- Rewrites all matching all-gather nodes to the extra PG, putting them on a separate CUDA stream from reduce-scatters so AG/RS overlap in backward. 
- Is a no-op when the graph contains no FSDP all-gathers.

w/o AG RS overlap:
<img width="1545" height="127" alt="Screenshot 2026-04-29 at 1 30 22 PM" src="https://github.com/user-attachments/assets/029c7f48-3e41-4115-ab42-adda8609384c" />

w/ AG RS overlap:
<img width="1830" height="159" alt="Screenshot 2026-04-29 at 1 31 20 PM" src="https://github.com/user-attachments/assets/34347a3c-2397-4027-81fc-f1259a1a1d5e" />
