### PR TITLE
Use CrossEntropyLoss for torchcomms 3D compile tests

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -586,7 +586,6 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module llama3 --config llama3_debugmodel_ce_loss",
                     "--comm.mode torchcomms",
                     "--parallelism.context_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -586,6 +586,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--module llama3 --config llama3_debugmodel_ce_loss",
                     "--comm.mode torchcomms",
                     "--parallelism.context_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -600,6 +601,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--module llama3 --config llama3_debugmodel_ce_loss",
                     "--comm.mode torchcomms",
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",


### PR DESCRIPTION
Use llama3_debugmodel_ce_loss (standard CrossEntropyLoss) for the torchcomms_3d_dp+tp+pp+compile test to work around a PyTorch bug with ChunkedCELoss + torchcomms + compile.

With CrossEntropyLoss, lm_head runs as part of the model forward and is compiled together with the model. The loss-parallel all-reduce (inside F.cross_entropy) is captured in the same compiled graph as the model's TP collectives, so it uses the same correctly-registered process group.

With ChunkedCELoss, lm_head is extracted from the model (_skip_lm_head=True) and runs in eager mode inside the loss. cross_entropy_loss is then compiled separately. This separate compilation captures a process group name that cannot be resolved at runtime when torchcomms is enabled — torchcomms uses split_group (hash-based PG names) for real backends but falls back to new_group (sequential integer names) for fake-backend mesh dimensions, and the compiled loss picks up one of these unresolvable integer names.