### PR TITLE
[CI] Move lychee link checker to nightly workflow

### DIFF
--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -1,0 +1,56 @@
+name: Link Check
+
+on:
+  schedule:
+    # Run nightly at 07:00 UTC
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install Lychee (Latest Release)
+        run: |
+          # Query GitHub API for the latest release tag
+          LATEST_TAG=$(curl -s https://api.github.com/repos/lycheeverse/lychee/releases/latest | jq -r .tag_name)
+          echo "Installing Lychee version: $LATEST_TAG"
+
+          URL="https://github.com/lycheeverse/lychee/releases/download/${LATEST_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+
+          # Load the archive, extract into temp folder, move the binary, delete the rest
+          mkdir -p lychee_install
+          curl -sLO "$URL"
+          tar -xzf "lychee-x86_64-unknown-linux-gnu.tar.gz" -C lychee_install --strip-components=1
+          sudo mv lychee_install/lychee /usr/local/bin/
+          rm -rf lychee_install "lychee-x86_64-unknown-linux-gnu.tar.gz"
+
+          # Verify installation
+          lychee --version
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install -r requirements-dev.txt
+          pre-commit install-hooks
+
+      - name: Check links with Lychee
+        run: |
+          pre-commit run lychee-link-checker --all-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -67,6 +67,7 @@ jobs:
         run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Check in-repo links with Lychee (offline)
+        shell: bash -eo pipefail {0}
         env:
           ALL_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,24 +29,6 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
 
-      - name: Install Lychee (Latest Release)
-        run: |
-          # Query GitHub API for the latest release tag
-          LATEST_TAG=$(curl -s https://api.github.com/repos/lycheeverse/lychee/releases/latest | jq -r .tag_name)
-          echo "Installing Lychee version: $LATEST_TAG"
-
-          URL="https://github.com/lycheeverse/lychee/releases/download/${LATEST_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz"
-
-          # Load the archive, extract into temp folder, move the binary, delete the rest
-          mkdir -p lychee_install
-          curl -sLO "$URL"
-          tar -xzf "lychee-x86_64-unknown-linux-gnu.tar.gz" -C lychee_install --strip-components=1
-          sudo mv lychee_install/lychee /usr/local/bin/
-          rm -rf lychee_install "lychee-x86_64-unknown-linux-gnu.tar.gz"
-
-          # Verify installation
-          lychee --version
-
       - name: Install dependencies and lint utilities
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
@@ -59,7 +41,3 @@ jobs:
 
       - name: Lint modified files
         run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
-
-      - name: Check links with Lychee
-        run: |
-          pre-commit run lychee-link-checker --all-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,24 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
 
+      - name: Install Lychee (Latest Release)
+        run: |
+          # Query GitHub API for the latest release tag
+          LATEST_TAG=$(curl -s https://api.github.com/repos/lycheeverse/lychee/releases/latest | jq -r .tag_name)
+          echo "Installing Lychee version: $LATEST_TAG"
+
+          URL="https://github.com/lycheeverse/lychee/releases/download/${LATEST_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+
+          # Load the archive, extract into temp folder, move the binary, delete the rest
+          mkdir -p lychee_install
+          curl -sLO "$URL"
+          tar -xzf "lychee-x86_64-unknown-linux-gnu.tar.gz" -C lychee_install --strip-components=1
+          sudo mv lychee_install/lychee /usr/local/bin/
+          rm -rf lychee_install "lychee-x86_64-unknown-linux-gnu.tar.gz"
+
+          # Verify installation
+          lychee --version
+
       - name: Install dependencies and lint utilities
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
@@ -40,4 +58,20 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v45.0.6
 
       - name: Lint modified files
+        env:
+          # External-link checking via lychee is flaky on transient network
+          # failures and runs in the nightly Link Check workflow. We still run
+          # lychee on PRs in the next step, but in --offline mode for in-repo
+          # link validation only.
+          SKIP: lychee-link-checker
         run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Check in-repo links with Lychee (offline)
+        run: |
+          FILES=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" \
+            | tr ' ' '\n' | grep -E '\.(md|py)$' || true)
+          if [ -z "$FILES" ]; then
+            echo "No modified markdown/python files; skipping lychee."
+            exit 0
+          fi
+          lychee --offline --no-progress --root-dir=. $FILES

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -67,11 +67,20 @@ jobs:
         run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Check in-repo links with Lychee (offline)
+        env:
+          ALL_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          FILES=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" \
-            | tr ' ' '\n' | grep -E '\.(md|py)$' || true)
+          FILES=""
+          for f in $ALL_FILES; do
+            case "$f" in
+              *.md|*.py) FILES="$FILES $f" ;;
+            esac
+          done
           if [ -z "$FILES" ]; then
             echo "No modified markdown/python files; skipping lychee."
             exit 0
           fi
+          # --offline checks only filesystem links; no network requests, so
+          # no external flakiness. The nightly Link Check workflow covers
+          # external links.
           lychee --offline --no-progress --root-dir=. $FILES


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3158

The lychee link checker is flaky due to transient external network failures, causing spurious PR CI failures. Move it out of per-PR lint into a dedicated nightly workflow so flakes no longer block PRs but broken links still get surfaced.