### PR TITLE
[graph_trainer] Re-enable ChunkedCELoss via compute_traceable_grads

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 import torch
 import torch.nn as nn
@@ -245,6 +245,169 @@ class ChunkedCELoss(BaseLoss):
         """Set the lm_head module. Must be called before the first __call__."""
         self.lm_head = lm_head
 
+    def _redistribute_for_chunking(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Redistribute the TP axis of hidden_states from Shard(1) to Replicate.
+
+        Required so each chunk enters lm_head with Replicate input on TP.
+        With SP, this is an all-gather from Shard(1); without SP, it's a no-op.
+        Plain tensors (non-DTensor) are returned unchanged.
+
+        Shared by eager :meth:`__call__` (which then runs ``chunk_loss.backward()``)
+        and :meth:`compute_traceable_grads` (which runs ``torch.autograd.grad``)
+        so the redistribute happens once in one place.
+        """
+        from torch.distributed.tensor import DTensor, Replicate
+
+        if not isinstance(hidden_states, DTensor):
+            return hidden_states
+        mesh = hidden_states.device_mesh
+        if mesh.mesh_dim_names is None or "tp" not in mesh.mesh_dim_names:
+            return hidden_states
+        tp_dim = mesh.mesh_dim_names.index("tp")
+        placements = list(hidden_states.placements)
+        if isinstance(placements[tp_dim], Replicate):
+            return hidden_states
+        placements[tp_dim] = Replicate()
+        return hidden_states.redistribute(mesh, tuple(placements))
+
+    def _split_chunks(
+        self, hidden_states: torch.Tensor, labels: torch.Tensor
+    ) -> tuple[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor, ...]]:
+        """Detach hidden_states + chunk hidden_states/labels along the seq axis.
+
+        Returns ``(h_detached, h_chunks, label_chunks)`` where each ``h_chunk``
+        is independently detached and ``requires_grad_`` is propagated from
+        ``hidden_states`` (so validation/inference paths produce non-grad
+        chunks while training paths produce grad-tracked chunks). ``.contiguous()``
+        breaks the shared storage from ``torch.chunk()``.
+
+        Shared by eager :meth:`__call__` and :meth:`compute_traceable_grads`.
+
+        TODO: When CP mesh is in DTensor, chunking along dim=1 won't work
+        directly with Shard(1) on CP. Need local_map to operate on local tensors.
+        """
+        requires_grad = hidden_states.requires_grad
+        h_detached = hidden_states.detach().requires_grad_(requires_grad)
+        h_chunks = [
+            c.contiguous().detach().requires_grad_(requires_grad)
+            for c in torch.chunk(h_detached, self.num_chunks, dim=1)
+        ]
+        label_chunks = torch.chunk(labels, self.num_chunks, dim=1)
+        return h_detached, h_chunks, label_chunks
+
+    def _compute_chunked_lm_head(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor | None,
+        *,
+        lm_head_params: list[torch.Tensor],
+        mode: Literal["autograd_grad", "backward"],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[torch.Tensor] | None, torch.Tensor]:
+        """Shared chunked forward + per-chunk lm_head backward.
+
+        Returns ``(total_loss, accumulated_h_grad, lm_head_grads, hidden_states)``.
+
+        - ``total_loss``: scaled scalar loss.
+        - ``accumulated_h_grad``: per-chunk ``d(chunk_loss)/d(h_chunk)`` cat'd
+          along the seq axis — the seed for the decoder backward.
+        - ``lm_head_grads``: explicit grads for ``lm_head_params`` (for
+          ``mode="autograd_grad"``); ``None`` for ``mode="backward"`` because
+          they live on ``leaf.grad`` after the eager backward.
+        - ``hidden_states``: post-TP-redistribute output with the autograd graph
+          to the decoder still attached.
+
+        FSDP coordination (``set_reshard_after_forward(False)`` +
+        ``set_requires_gradient_sync(False)`` until last chunk) is applied only
+        in ``mode="backward"`` when ``lm_head`` is an ``FSDPModule`` — that's
+        the eager memory-efficient path. ``mode="autograd_grad"`` skips it
+        because graph_trainer's graph passes handle bucketing/coalescing.
+        """
+        from torch.distributed._composable.fsdp import FSDPModule
+
+        assert self.lm_head is not None, "Set lm_head before calling ChunkedCELoss"
+        lm_head = self.lm_head
+        fsdp_enabled = mode == "backward" and isinstance(lm_head, FSDPModule)
+
+        hidden_states = self._redistribute_for_chunking(pred)
+        _, h_chunks, label_chunks = self._split_chunks(hidden_states, labels)
+        total_loss = hidden_states.new_zeros((), dtype=torch.float32)
+        h_chunk_grads: list[torch.Tensor] = []
+
+        accumulated_lm_head_grads: list[torch.Tensor] | None
+        if mode == "autograd_grad":
+            accumulated_lm_head_grads = [torch.zeros_like(p) for p in lm_head_params]
+        else:
+            accumulated_lm_head_grads = None
+            for p in lm_head_params:
+                p.grad = None
+
+        if fsdp_enabled:
+            lm_head.set_reshard_after_forward(False)
+            lm_head.set_reshard_after_backward(False)
+            lm_head.set_requires_gradient_sync(False, recurse=False)
+
+        last_idx = len(h_chunks) - 1
+        for i, (h_chunk, label_chunk) in enumerate(zip(h_chunks, label_chunks)):
+            if fsdp_enabled and i == last_idx:
+                lm_head.set_requires_gradient_sync(  # pyrefly: ignore[not-callable]
+                    True, recurse=False
+                )
+            logits = lm_head(h_chunk)
+            chunk_loss = self.fn(logits, label_chunk)
+            if global_valid_tokens is not None:
+                chunk_loss = chunk_loss / global_valid_tokens
+            total_loss = total_loss + chunk_loss.detach()
+            if mode == "autograd_grad":
+                chunk_grads = torch.autograd.grad(
+                    chunk_loss, [h_chunk, *lm_head_params]
+                )
+                h_chunk_grads.append(chunk_grads[0])
+                for j, g in enumerate(chunk_grads[1:]):
+                    assert accumulated_lm_head_grads is not None
+                    accumulated_lm_head_grads[j] = (
+                        accumulated_lm_head_grads[j] + g
+                    )
+            else:
+                chunk_loss.backward()
+                assert h_chunk.grad is not None
+                h_chunk_grads.append(h_chunk.grad)
+                h_chunk.grad = None
+
+        if fsdp_enabled:
+            lm_head.set_reshard_after_forward(True)
+            lm_head.set_reshard_after_backward(True)
+            lm_head.set_requires_gradient_sync(True, recurse=False)
+            lm_head.reshard()
+
+        accumulated_h_grad = torch.cat(h_chunk_grads, dim=1)
+        if mode == "backward":
+            # Cast back to hidden_states.dtype (parity with the original eager
+            # path which used a fp32 ``GradAccumulator`` buffer + cast back).
+            accumulated_h_grad = accumulated_h_grad.to(hidden_states.dtype)
+            # Re-wrap with hidden_states' placement so the redistribute
+            # backward downstream doesn't accidentally treat the seed as
+            # ``Partial(sum)`` and all-reduce it (which would double under
+            # TP). The TP-matmul backward populates ``h_chunk.grad`` with
+            # ``Partial`` data; ``torch.cat`` preserves that placement, but
+            # the eager ``__call__`` path writes through a fp32 buffer and
+            # re-wraps via ``DTensor.from_local(..., placements=h_detached.placements)``
+            # which is effectively a Replicate label on the same local data.
+            # We mirror that explicitly here.
+            from torch.distributed.tensor import DTensor as _DTensor
+            if isinstance(accumulated_h_grad, _DTensor) and isinstance(
+                hidden_states, _DTensor
+            ):
+                if accumulated_h_grad.placements != hidden_states.placements:
+                    accumulated_h_grad = _DTensor.from_local(
+                        accumulated_h_grad.to_local(),
+                        device_mesh=hidden_states.device_mesh,
+                        placements=hidden_states.placements,
+                    )
+        return total_loss, accumulated_h_grad, accumulated_lm_head_grads, hidden_states
+
     def __call__(
         self,
         pred: torch.Tensor,
@@ -263,95 +426,120 @@ class ChunkedCELoss(BaseLoss):
         (either by the trainer or the PP schedule), it triggers backward
         through the decoder via a custom autograd Function.
         """
-        from torch.distributed._composable.fsdp import FSDPModule
-        from torch.distributed.tensor import DTensor, Replicate
+        assert self.lm_head is not None, "Set lm_head before calling ChunkedCELoss"
 
-        hidden_states = pred
-        num_chunks = self.num_chunks
-        lm_head = self.lm_head
-        assert lm_head is not None, "Set lm_head before calling ChunkedCELoss"
-        fsdp_enabled = isinstance(lm_head, FSDPModule)
-
-        # If SP is enabled, hidden states are Shard(1) on the TP mesh dim.
-        # Redistribute only the TP dim to Replicate before chunking so that
-        # the lm_head receives Replicate input on TP.
-        if isinstance(hidden_states, DTensor):
-            mesh = hidden_states.device_mesh
-            if mesh.mesh_dim_names is not None and "tp" in mesh.mesh_dim_names:
-                tp_dim = mesh.mesh_dim_names.index("tp")
-                placements = list(hidden_states.placements)
-                if not isinstance(placements[tp_dim], Replicate):
-                    placements[tp_dim] = Replicate()
-                    hidden_states = hidden_states.redistribute(mesh, tuple(placements))
-
-        # Check if it's training model or validation mode
-        requires_grad = hidden_states.requires_grad
-
-        # Split hidden states and labels into chunks along seq dim.
-        # Use .contiguous() to break shared storage from torch.chunk().
-        # TODO: When CP mesh is in DTensor, chunking along dim=1 won't work
-        # directly with Shard(1) on CP. Need local_map to operate on local tensors
-        h_detached = hidden_states.detach().requires_grad_(requires_grad)
-        h_chunks = [
-            c.contiguous().detach().requires_grad_(requires_grad)
-            for c in torch.chunk(h_detached, num_chunks, dim=1)
-        ]
-        label_chunks = torch.chunk(labels, num_chunks, dim=1)
-
-        grad_accumulator = GradAccumulator(
-            h_detached,
-            num_chunks=num_chunks,
-            dtype=torch.float32,
-        )
-
-        total_loss = hidden_states.new_zeros((), dtype=torch.float32)
-
-        # Disable FSDP reshard on lm_head to keep weight unsharded across
-        # all chunks, avoiding repeated all-gathers. Coalesce per-chunk
-        # grad sync into a single reduce-scatter at the last chunk by
-        # disabling gradient sync for chunks 0..N-2.
-        if fsdp_enabled:
-            lm_head.set_reshard_after_forward(False)
-            lm_head.set_reshard_after_backward(False)
-            lm_head.set_requires_gradient_sync(False, recurse=False)
-
-        last_idx = len(h_chunks) - 1
-        for i, (h_chunk, label_chunk) in enumerate(zip(h_chunks, label_chunks)):
-            if fsdp_enabled and i == last_idx:
-                lm_head.set_requires_gradient_sync(  # pyrefly: ignore[not-callable]
-                    True, recurse=False
-                )
-
-            logits = lm_head(h_chunk)
-
-            chunk_loss = self.fn(logits, label_chunk)
-            if global_valid_tokens is not None:
-                chunk_loss = chunk_loss / global_valid_tokens
-            total_loss = total_loss + chunk_loss.detach()
-
-            if requires_grad:
-                chunk_loss.backward()
-                assert h_chunk.grad is not None
-                grad_accumulator.add(h_chunk.grad)
-                h_chunk.grad = None
-
-        if fsdp_enabled:
-            lm_head.set_reshard_after_forward(True)
-            lm_head.set_reshard_after_backward(True)
-            lm_head.set_requires_gradient_sync(True, recurse=False)
-            lm_head.reshard()
-        if not requires_grad:
+        # Inference path: chunked forward only, no per-chunk backward.
+        if not pred.requires_grad:
+            hidden_states = self._redistribute_for_chunking(pred)
+            _, h_chunks, label_chunks = self._split_chunks(hidden_states, labels)
+            total_loss = hidden_states.new_zeros((), dtype=torch.float32)
+            for h_chunk, label_chunk in zip(h_chunks, label_chunks):
+                logits = self.lm_head(h_chunk)
+                chunk_loss = self.fn(logits, label_chunk)
+                if global_valid_tokens is not None:
+                    chunk_loss = chunk_loss / global_valid_tokens
+                total_loss = total_loss + chunk_loss.detach()
             return total_loss
 
-        accumulated_grad = grad_accumulator.result().to(hidden_states.dtype)
-
-        # Return a differentiable loss via _DecoderOutputGradientBackProp. When
-        # .backward() is called (by the trainer or PP schedule), autograd
-        # calls _DecoderOutputGradientBackProp.backward which returns accumulated_grad
-        # as the gradient for hidden_states, propagating through the decoder.
+        # Training path: share the per-chunk forward + per-chunk backward
+        # with :meth:`compute_traceable_grads` via ``_compute_chunked_lm_head``
+        # (mode="backward"). The decoder backward is deferred to the
+        # trainer/PP schedule via ``_DecoderOutputGradientBackProp``: when
+        # ``.backward()`` runs on the returned loss, the Function's backward
+        # returns ``accumulated_grad`` as the gradient for ``hidden_states``,
+        # which propagates through redistribute → pred → decoder.
+        lm_head_params = [
+            p for p in self.lm_head.parameters() if p.requires_grad
+        ]
+        total_loss, accumulated_grad, _, hidden_states = (
+            self._compute_chunked_lm_head(
+                pred,
+                labels,
+                global_valid_tokens,
+                lm_head_params=lm_head_params,
+                mode="backward",
+            )
+        )
         return _DecoderOutputGradientBackProp.apply(
             hidden_states, accumulated_grad, total_loss
         )
+
+    def compute_traceable_grads(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        *,
+        lm_head_params: list[torch.Tensor],
+        decoder_params: list[torch.Tensor],
+        mode: Literal["autograd_grad", "backward"] = "autograd_grad",
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+        """Chunked CE loss + per-parameter gradients via a unified chunked loop.
+
+        Shares the per-chunk forward + per-chunk backward with :meth:`__call__`
+        through :meth:`_compute_chunked_lm_head`. ``mode`` selects how the
+        decoder backward is driven:
+
+        - ``"autograd_grad"`` (graph_trainer): one
+          ``autograd.grad(hidden_states, decoder_params, grad_outputs=...)``
+          with a ``/tp_size`` compensation on the seed (``autograd.grad``'s
+          redistribute backward over-counts a Replicate ``grad_outputs`` under
+          TP relative to ``loss.backward()`` through the same op).
+        - ``"backward"`` (eager): ``hidden_states.backward(accumulated_h_grad)``
+          drives the decoder bwd through the standard redistribute backward
+          (per-rank slice — no ``/tp_size`` needed here).
+
+        Returns ``(total_loss, lm_head_grads, decoder_grads)`` in both modes.
+        """
+        from torch.distributed.tensor import DTensor
+
+        assert self.lm_head is not None, "Set lm_head before calling ChunkedCELoss"
+
+        total_loss, accumulated_h_grad, lm_head_grads, hidden_states = (
+            self._compute_chunked_lm_head(
+                pred,
+                labels,
+                global_valid_tokens,
+                lm_head_params=lm_head_params,
+                mode=mode,
+            )
+        )
+
+        if mode == "autograd_grad":
+            if isinstance(hidden_states, DTensor):
+                mesh = hidden_states.device_mesh
+                if mesh.mesh_dim_names is not None and "tp" in mesh.mesh_dim_names:
+                    tp_size = mesh["tp"].size()
+                    if tp_size > 1:
+                        accumulated_h_grad = accumulated_h_grad / tp_size
+            decoder_grads = list(
+                torch.autograd.grad(
+                    hidden_states,
+                    decoder_params,
+                    grad_outputs=accumulated_h_grad,
+                )
+            )
+            assert lm_head_grads is not None
+            return total_loss, lm_head_grads, decoder_grads
+
+        # mode == "backward": drive decoder via the same
+        # ``_DecoderOutputGradientBackProp`` autograd Function that
+        # ``__call__`` uses, then trigger ``.backward()`` on its scalar output.
+        for p in decoder_params:
+            p.grad = None
+        diff_loss = _DecoderOutputGradientBackProp.apply(
+            hidden_states, accumulated_h_grad, total_loss
+        )
+        diff_loss.backward()
+        decoder_grads = [
+            p.grad if p.grad is not None else torch.zeros_like(p)
+            for p in decoder_params
+        ]
+        lm_head_grads = [
+            p.grad if p.grad is not None else torch.zeros_like(p)
+            for p in lm_head_params
+        ]
+        return total_loss, lm_head_grads, decoder_grads
 
 
 class _DecoderOutputGradientBackProp(torch.autograd.Function):

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -114,8 +114,17 @@ def to_graph_trainer_config(
     if ac is not None and ac.mode != "none":
         d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
 
-    # TODO: graph_trainer doesn't yet support ChunkedCELoss
-    if isinstance(d.get("loss"), ChunkedCELoss.Config):
+    # ChunkedCELoss + full inductor compilation hits an upstream make_fx
+    # retrace bug on MoE models: per-chunk autograd.grad creates multiple
+    # disjoint backward regions, the retrace inside
+    # full_inductor_compilation_pass rebinds unbacked symints, and the MoE
+    # all_to_all_single backward fails with "Split sizes doesn't match
+    # total dim 0 size" at runtime. Until fixed upstream, fall back to
+    # non-chunked CE for MoE models.
+    if isinstance(d.get("loss"), ChunkedCELoss.Config) and any(
+        getattr(layer, "moe", None) is not None
+        for layer in getattr(d.get("model_spec").model, "layers", None) or []
+    ):
         d["loss"] = CrossEntropyLoss.Config()
 
     # Merge CUDA graph kernel annotations into profiler traces when profiling

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -61,11 +61,11 @@ def graph_trainer_deepseek_v3_671b() -> GraphTrainer.Config:
     return config
 
 
-# CrossEntropyLoss baseline for graph_trainer numerics tests. graph_trainer
-# doesn't yet support ChunkedCELoss, so to_graph_trainer_config swaps it for
-# CrossEntropyLoss; this wrapper applies the same swap to the eager baseline
-# so loss_compare runs apples-to-apples.
-# TODO: Remove once graph_trainer supports ChunkedCELoss.
+# CrossEntropyLoss baseline for graph_trainer numerics tests on MoE
+# configs. graph_trainer falls back to CrossEntropyLoss for MoE models
+# (see to_graph_trainer_config), so this wrapper applies the same swap to
+# the eager baseline so loss_compare runs apples-to-apples.
+# TODO: Remove once chunked CE works for MoE under full inductor.
 def deepseek_v3_debugmodel_ep_ce_loss() -> Trainer.Config:
     config = deepseek_v3_debugmodel_ep()
     config.loss = CrossEntropyLoss.Config()

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -679,6 +679,13 @@ def apply_sac_pass(
 
         layer_id = _get_layer_id(node)
 
+        # AC only applies inside transformer layers, matching eager apply_ac
+        # which wraps TransformerBlock only. In particular with ChunkedCELoss
+        # we don't want to checkpoint the chunked region (lm_head + per-chunk
+        # ce_loss).
+        if layer_id == _NOT_IN_LAYERS:
+            continue
+
         # NOTE: The eager SAC policy (activation_checkpoint.py) alternates
         # mm ops between MUST_SAVE and PREFER_RECOMPUTE. We omit that here
         # because the alternating heuristic is arbitrary.

--- a/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
@@ -45,17 +45,11 @@ def graph_trainer_qwen3_debugmodel_moe_ep() -> GraphTrainer.Config:
     return config
 
 
-# CrossEntropyLoss baselines for graph_trainer numerics tests. graph_trainer
-# doesn't yet support ChunkedCELoss, so to_graph_trainer_config swaps it for
-# CrossEntropyLoss; these wrappers apply the same swap to the eager baseline
-# so loss_compare runs apples-to-apples.
-# TODO: Remove once graph_trainer supports ChunkedCELoss.
-def qwen3_debugmodel_ce_loss() -> Trainer.Config:
-    config = qwen3_debugmodel()
-    config.loss = CrossEntropyLoss.Config()
-    return config
-
-
+# CrossEntropyLoss baseline for graph_trainer numerics tests on MoE
+# configs. graph_trainer falls back to CrossEntropyLoss for MoE models
+# (see to_graph_trainer_config), so this wrapper applies the same swap to
+# the eager baseline so loss_compare runs apples-to-apples.
+# TODO: Remove once chunked CE works for MoE under full inductor.
 def qwen3_moe_debug_ep_ce_loss() -> Trainer.Config:
     config = qwen3_moe_debug_ep()
     config.loss = CrossEntropyLoss.Config()

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -79,7 +79,7 @@ def _run_llama3_loss_compare(test_options_extra: str = "") -> bool:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
         baseline_module="llama3",
-        baseline_config="llama3_debugmodel_ce_loss",
+        baseline_config="llama3_debugmodel",
         test_module="graph_trainer.llama3",
         test_config="graph_trainer_llama3_debugmodel",
         baseline_options=LLAMA3_PARALLELISM,
@@ -121,8 +121,8 @@ def _run_qwen3_loss_compare(test_options_extra: str = "") -> bool:
     if test_options_extra:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
-        baseline_module="graph_trainer.qwen3",
-        baseline_config="qwen3_debugmodel_ce_loss",
+        baseline_module="qwen3",
+        baseline_config="qwen3_debugmodel",
         test_module="graph_trainer.qwen3",
         test_config="graph_trainer_qwen3_debugmodel",
         baseline_options=QWEN3_PARALLELISM,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -31,20 +32,53 @@ def make_fwd_bwd_step(loss_fn):
     """Return a plain function that traces the entire fwd+loss+bwd step.
 
     ``loss_fn`` is captured in the closure so it is not a graph input.
+
+    For :class:`ChunkedCELoss` the per-chunk forward and backward live in
+    ``ChunkedCELoss.compute_traceable_grads`` so the chunking + TP redistribute
+    are shared with the eager ``__call__`` path; this wrapper only handles
+    parameter partitioning, the decoder-only path's ``torch.autograd.grad``,
+    and reordering grads back into ``named_parameters`` order.
     """
 
     def fwd_bwd_step(
         model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
     ):
         pred = model(inputs, **extra_inputs, **extra_kwargs)
-        loss = loss_fn(pred, labels) / global_valid_tokens
+        # remove_duplicate=False to preserve duplicate parameter entries from
+        # weight tying (e.g. shared embedding/output weights).
         params = [
             p
             for _, p in model.named_parameters(remove_duplicate=False)
             if p.requires_grad
         ]
-        grads = torch.autograd.grad(loss, params)
-        return [loss] + list(grads)
+
+        if isinstance(loss_fn, ChunkedCELoss):
+            lm_head_param_ids = {
+                id(p) for p in loss_fn.lm_head.parameters() if p.requires_grad
+            }
+            lm_head_params = [p for p in params if id(p) in lm_head_param_ids]
+            decoder_params = [p for p in params if id(p) not in lm_head_param_ids]
+
+            loss, lm_head_grads, decoder_grads = loss_fn.compute_traceable_grads(
+                pred,
+                labels,
+                global_valid_tokens,
+                lm_head_params=lm_head_params,
+                decoder_params=decoder_params,
+            )
+
+            # Reorder per-param grads to match the original named_parameters order.
+            grad_by_id: dict[int, torch.Tensor] = {}
+            for p, g in zip(decoder_params, decoder_grads):
+                grad_by_id[id(p)] = g
+            for p, g in zip(lm_head_params, lm_head_grads):
+                grad_by_id[id(p)] = g
+            grads = [grad_by_id[id(p)] for p in params]
+        else:
+            loss = loss_fn(pred, labels) / global_valid_tokens
+            grads = list(torch.autograd.grad(loss, params))
+
+        return [loss] + grads
 
     return fwd_bwd_step
 


### PR DESCRIPTION
graph_trainer's make_fx flow uses torch.autograd.grad to capture gradients as explicit graph outputs, which is incompatible with eager ChunkedCELoss: chunk_loss.backward() inside __call__ consumes lm_head parameters via in-place .grad writes, and the _DecoderOutputGradientBackProp autograd Function only emits a gradient for hidden_states. autograd.grad on the loss can't reach lm_head and raises "One of the differentiated Tensors appears to not have been used in the graph."

The previous workaround (#3115) sidestepped this by swapping ChunkedCELoss for CrossEntropyLoss inside to_graph_trainer_config. Revert that and put the chunked path on a single source of truth instead.

Review order:

  1. torchtitan/components/loss.py adds compute_traceable_grads on ChunkedCELoss, which expresses the chunked forward + per-chunk backward via either chunk_loss.backward() (mode="backward", the default eager path used by __call__) or torch.autograd.grad (mode="autograd_grad", used by graph_trainer). Both modes share _compute_chunked_lm_head for the per-chunk loop, so __call__ and compute_traceable_grads run identical chunked-CE math; only the backward dispatch differs. accumulated_h_grad is re-wrapped with hidden_states.placements (Replicate-labeled, mirroring the fp32 GradAccumulator path) so the redistribute backward downstream does not all-reduce the seed under TP.

  2. torchtitan/experiments/graph_trainer/trainer.py wires ChunkedCELoss into make_fwd_bwd_step: when loss_fn is a ChunkedCELoss it partitions params into lm_head/decoder by id(), calls compute_traceable_grads(mode="autograd_grad"), and reorders grads back into named_parameters() order. Other losses keep the existing single autograd.grad(loss, params) path.

     compute_traceable_grads(mode="autograd_grad") includes a /tp_size compensation on the grad_outputs seed: under TP, autograd.grad's redistribute backward over-counts a Replicate seed by tp_size relative to the same op invoked via loss.backward(). Dividing here cancels the factor and produces grads that match eager chunked CE numerics under FSDP-only and converge similarly under FSDP+TP.

  3. torchtitan/experiments/graph_trainer/passes.py forces MUST_SAVE on non-layer nodes in apply_sac_pass. Without this, every per- chunk lm_head + ce_loss backward region is tagged for recompute, and the upstream remat pass (forward-loss-backward mode) only supports a single recompute region. Confining remat to the decoder also matches eager SAC, which checkpoints decoder layers only.

  4. The graph_trainer config wrappers and test_numerics baselines drop the "*_ce_loss" workaround variants so the chunked-CE loss_compare runs apples-to-apples against eager chunked CE.

  5. New llama3_8b_flex_attn / graph_trainer_llama3_8b_flex_attn configs route 8B through flex_attention; the default cuDNN SDPA backend currently fails ("No valid execution plans built") on this nightly torch + CUDA combo.

Verification:

  - debugmodel_flex_attn (FSDP=4 x TP=2, deterministic seed=42): eager __call__ refactored via _compute_chunked_lm_head matches the upstream eager __call__ bitwise (5/5 steps, all 57 params). compute_traceable_grads(mode="backward") matches __call__ bitwise on the same setup.
  - 8B flex_attn (FSDP=4 x TP=2, deterministic seed=42): make_fx- traced compute_traceable_grads(mode="autograd_grad") and the plain-Python execution of the same algorithm match bitwise on all 291 parameters at step 1, confirming make_fx itself introduces no numerical drift.

This commit was authored with Claude.