### PR TITLE
[graph_trainer] Generalize minimal_fx_tracer to module + optimizer roots

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import copy
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, nullcontext
@@ -272,16 +273,59 @@ def extract_module_state(mod: nn.Module) -> dict[str, torch.Tensor]:
     }
 
 
-def _check_no_extra_module_in_user_inputs(
-    args: tuple, kwargs: dict, fn_name: str
+def extract_train_state(
+    module: nn.Module | None = None,
+    optimizer: "torch.optim.Optimizer | None" = None,
+) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    """Return ``(model_state, optim_state)`` for ``minimal_fx_tracer``.
+
+    Both are dicts (empty when the corresponding object is ``None``) and are
+    sampled from the live module/optimizer, so callers can reuse this helper
+    to refresh state at runtime.
+    """
+    model_state = extract_module_state(module) if module is not None else {}
+    optim_state = optimizer.state_dict() if optimizer is not None else {}
+    return model_state, optim_state
+
+
+def _check_optimizer_has_module(
+    module: nn.Module | None,
+    optimizer: "torch.optim.Optimizer | None",
 ) -> None:
-    """Reject extra nn.Module instances in user args/kwargs (args[0] is the
-    module-rooted entry point)."""
-    if any(isinstance(v, nn.Module) for v in (*args, *kwargs.values())):
+    """Optimizer parameters align with module.named_parameters() by order, so
+    requiring a module guarantees that alignment."""
+    if optimizer is not None and module is None:
         raise ValueError(
-            f"{fn_name} supports exactly one nn.Module at args[0]. "
-            "Additional nn.Module instances found in args[1:] or kwargs."
+            "minimal_fx_tracer: when 'optimizer' is provided, 'module' must also "
+            "be provided so optimizer parameters align with the module's parameters."
         )
+
+
+@contextlib.contextmanager
+def _reparametrize_train_state(
+    module: nn.Module | None,
+    optimizer: "torch.optim.Optimizer | None",
+    model_state: dict[str, torch.Tensor],
+    optim_state: dict[str, Any],
+):
+    """Reparametrize module and optimizer with explicit tensor state for tracing."""
+    with contextlib.ExitStack() as stack:
+        if module is not None:
+            stack.enter_context(stateless._reparametrize_module(module, model_state))
+        if optimizer is not None:
+            # swap_in_optimizer_params_and_state aligns swapin_parameters values
+            # with optimizer.param_groups by order, so pass only parameters (in
+            # module.named_parameters() order).
+            params_for_optim = {
+                name: model_state[name]
+                for name, _ in module.named_parameters(remove_duplicate=False)
+            }
+            stack.enter_context(
+                torch.optim.swap_in_optimizer_params_and_state(
+                    optimizer, params_for_optim, optim_state
+                )
+            )
+        yield
 
 
 @dataclass
@@ -297,7 +341,7 @@ class TracedResult:
         num_flat_outputs: Number of flat graph outputs before subclass rewrapping.
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
-        state_fqns: Trace-time state keys.
+        state_fqns: Trace-time module parameter/buffer FQNs.
     """
 
     gm: torch.fx.GraphModule
@@ -322,8 +366,13 @@ class TracedResult:
         """Number of leading graph inputs with stable tensor addresses.
 
         Parameters and buffers (the state entries) have fixed addresses across
-        training steps.  Each may expand to multiple plain tensors after
+        training steps. Each may expand to multiple plain tensors after
         subclass unwrapping (e.g. DTensor -> inner tensors).
+
+        TODO: graph_trainer does not trace optimizers yet, so optimizer state
+        tensors are not counted here. When optimizer tracing is enabled, they
+        should be included since their addresses are also stable across steps,
+        avoiding cudagraph re-copying them every step.
         """
         num_state = len(self.state_fqns)
         return sum(
@@ -336,25 +385,36 @@ class TracedResult:
 
 def minimal_fx_tracer(
     fn: Callable,
+    module: nn.Module | None = None,
+    optimizer: "torch.optim.Optimizer | None" = None,
     *,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
-    """Return a tracer for a stateless ``fn`` with explicit ``state`` input.
+    """Return a tracer that captures ``fn`` with implicit module/optimizer state.
 
-    ``fn`` must be a plain callable (not an ``nn.Module``). The returned
-    callable expects ``state`` as the first positional argument, followed by
-    the traced user inputs (positional and keyword)::
+    The returned callable takes the user-facing ``*args`` and ``**kwargs`` for
+    ``fn``; module parameters/buffers and optimizer state are extracted from the
+    live objects and threaded through the graph as static inputs::
 
-        traced_result = minimal_fx_tracer(train_step)(state, tokens, labels=labels)
-        result = run_traced(traced_result, state, tokens, labels=labels)
+        # Stateless function: no module, no optimizer.
+        traced = minimal_fx_tracer(fn)(*args, **kwargs)
 
-    The trace-time ``state``, ``args``, and ``kwargs`` must satisfy these
-    constraints:
-    - ``state`` must be a ``dict[str, Tensor]`` of parameters/buffers
+        # Module-only: parameters/buffers extracted from `module`.
+        traced = minimal_fx_tracer(fn, module=model)(*args, **kwargs)
+
+        # Module + optimizer: optimizer state must already be initialized
+        # before tracing.
+        traced = minimal_fx_tracer(fn, module=model, optimizer=opt)(*args, **kwargs)
+
+    ``fn`` should reference ``module`` and ``optimizer`` from its enclosing
+    closure — passing them explicitly through ``args``/``kwargs`` is invalid
+    because ``nn.Module`` and ``Optimizer`` instances are not pytree-able.
+
+    The trace-time ``args`` and ``kwargs`` must satisfy these constraints:
+
     - all pytree leaves must be tensors or make_fx-safe primitives
       (``int``, ``float``, ``bool``, ``str``, ``None``)
-    - there must be no ``nn.Module`` instances in ``state``, ``args``, or
-      ``kwargs``
+    - there must be no ``nn.Module`` instances in ``args`` or ``kwargs``
 
     Tensor subclasses (for example ``DTensor``) are recursively unwrapped into
     plain tensors for tracing, and the layouts needed to rewrap them are stored
@@ -366,10 +426,16 @@ def minimal_fx_tracer(
     cudagraph capture does not evaluate these nodes, and downstream graph
     passes generally don't need them.
     """
+    _check_optimizer_has_module(module, optimizer)
 
-    def _trace_with_args(state: Any, *args: Any, **kwargs: Any) -> TracedResult:
-        state_fqns = list(state.keys())
-        state_flat = list(state.values())
+    def _trace_with_args(*args: Any, **kwargs: Any) -> TracedResult:
+        model_state, optim_state = extract_train_state(module, optimizer)
+        state_fqns = list(model_state.keys())
+
+        state_tree = {"model": model_state, "optim": optim_state}
+        state_flat, state_spec = pytree.tree_flatten(state_tree)
+        num_state_inputs = len(state_flat)
+
         user_inputs_flat, user_inputs_spec = pytree.tree_flatten((args, kwargs))
 
         # Validate leaves.
@@ -377,8 +443,8 @@ def minimal_fx_tracer(
             if isinstance(leaf, nn.Module):
                 raise ValueError(
                     "minimal_fx_tracer requires explicit tensor state, not nn.Module "
-                    "instances. Use trace_train_step(...) for the reference "
-                    "train-step wrapper."
+                    "instances. Capture nn.Modules in fn's closure or pass them "
+                    "via the 'module' kwarg."
                 )
             if not isinstance(leaf, _ALLOWED_LEAF_TYPES):
                 raise ValueError(
@@ -439,15 +505,20 @@ def minimal_fx_tracer(
             output_layouts = {}
 
             wrapped = _wrap_subclasses(plain_args, num_full_args, input_layouts)
-            state_wrapped = wrapped[: len(state_flat)]
-            user_flat = wrapped[len(state_flat) :]
+            state_wrapped = wrapped[:num_state_inputs]
+            user_flat = wrapped[num_state_inputs:]
 
-            state_for_fn = dict(zip(state_fqns, state_wrapped, strict=True))
+            state_t = pytree.tree_unflatten(list(state_wrapped), state_spec)
+            model_state_t = state_t["model"]
+            optim_state_t = state_t["optim"]
             user_args, user_kwargs = pytree.tree_unflatten(
                 list(user_flat), user_inputs_spec
             )
-            with torch.compiler._patch_engine_backward():
-                result = fn(state_for_fn, *user_args, **user_kwargs)
+
+            with _reparametrize_train_state(
+                module, optimizer, model_state_t, optim_state_t
+            ), torch.compiler._patch_engine_backward():
+                result = fn(*user_args, **user_kwargs)
 
             flat_outs, output_spec = pytree.tree_flatten(result)
             num_flat_outputs = len(flat_outs)
@@ -513,108 +584,73 @@ def minimal_fx_tracer(
 
 def run_traced(
     traced_result: TracedResult,
-    state: Any,
-    *args: Any,
+    *,
+    module: nn.Module | None = None,
+    optimizer: "torch.optim.Optimizer | None" = None,
     _validate_runtime: bool = False,
-    **kwargs: Any,
-) -> Any:
-    """Execute a traced graph with fresh parameters read from the live module.
+) -> Callable[..., Any]:
+    """Return a runner that executes a traced graph against live module/optimizer state.
 
-    This is a reference implementation of traced-graph execution. It keeps the
-    state handling, subclass unwrapping, and output reconstruction logic
-    explicit instead of baking those semantics into ``TracedResult`` itself.
-    Runs under ``torch.no_grad()`` because the graph already contains explicit
-    backward ops (from ``torch.autograd.grad`` traced by make_fx). Without
-    this, PyTorch would build a redundant autograd graph on top, keeping all
-    forward intermediates alive via ``grad_fn`` references.
+    The returned callable takes user-facing args and kwargs::
 
-    With ``_validate_runtime=True``, runtime ``(args, kwargs)`` must flatten
-    to the same pytree spec as trace time; any mismatch raises. Off by
-    default to keep the per-step path overhead-free; the caller must pass
-    kwargs in trace-time order.
+        traced = minimal_fx_tracer(fn, module=model, optimizer=opt)(*args, **kwargs)
+        outputs = run_traced(traced, module=model, optimizer=opt)(*args, **kwargs)
+
+    Mirrors :func:`minimal_fx_tracer`'s state extraction: parameters/buffers
+    are sampled from ``module`` and the optimizer state is sampled from
+    ``optimizer.state_dict()``. Runs under ``torch.no_grad()`` because the
+    graph already contains explicit backward ops (from ``torch.autograd.grad``
+    traced by make_fx). Without this, PyTorch would build a redundant autograd
+    graph on top, keeping all forward intermediates alive via ``grad_fn``
+    references.
+
+    With ``_validate_runtime=True``, runtime module parameter/buffer FQNs must match
+    trace time and runtime ``(args, kwargs)`` must flatten to the same pytree
+    spec as trace time; any mismatch raises. Off by default to keep the
+    per-step path overhead-free; the caller must pass kwargs in trace-time
+    order.
     """
-    state_flat = list(state.values())
-    user_args_flat, runtime_spec = pytree.tree_flatten((args, kwargs))
-    # TODO: pytree's dict flatten preserves insertion order, so kwargs in a
-    # different order than trace produce a different spec even though they
-    # describe the same logical inputs. If pytree sorted dict keys (or
-    # provided a canonicalizing flatten), this check could match valid
-    # reordered calls without needing an explicit reorder step here.
-    if _validate_runtime and runtime_spec != traced_result.user_inputs_spec:
-        raise ValueError(
-            f"input spec mismatch: runtime {runtime_spec} != "
-            f"trace-time {traced_result.user_inputs_spec}"
-        )
-    if any(isinstance(leaf, nn.Module) for leaf in [*state_flat, *user_args_flat]):
-        raise ValueError(
-            "run_traced requires explicit tensor state, not nn.Module instances. "
-            "Use run_traced_train_step(...) for the reference train-step wrapper."
-        )
-    all_args = list(state_flat) + list(user_args_flat)
-    flat_inputs, _ = _unwrap_subclasses(all_args)
+    _check_optimizer_has_module(module, optimizer)
 
-    with torch.no_grad():
-        flat_outputs = traced_result.gm(*flat_inputs)
-    wrapped = _wrap_subclasses(
-        flat_outputs,
-        traced_result.num_flat_outputs,
-        traced_result.output_subclass_layouts,
-    )
-    return pytree.tree_unflatten(wrapped, traced_result.output_spec)
-
-
-def trace_train_step(fn: Callable) -> Callable[..., TracedResult]:
-    """Reference implementation for capturing a whole train step via the core API."""
-
-    def _trace_with_module(
-        module: nn.Module, *args: Any, **kwargs: Any
-    ) -> TracedResult:
-        if not isinstance(module, nn.Module):
+    def _run(*args: Any, **kwargs: Any) -> Any:
+        model_state, optim_state = extract_train_state(module, optimizer)
+        if _validate_runtime and list(model_state.keys()) != traced_result.state_fqns:
             raise ValueError(
-                "trace_train_step requires args[0] to be an nn.Module, "
-                f"got {type(module).__name__}."
+                "module has different parameter/buffer names than during tracing.\n"
+                f"  Traced: {traced_result.state_fqns}\n"
+                f"  Got:    {list(model_state.keys())}"
             )
-        _check_no_extra_module_in_user_inputs(args, kwargs, "trace_train_step")
+        state_tree = {"model": model_state, "optim": optim_state}
+        state_flat, _ = pytree.tree_flatten(state_tree)
 
-        def _stateless_fn(
-            state: dict[str, torch.Tensor], *user_args: Any, **user_kwargs: Any
-        ) -> Any:
-            with stateless._reparametrize_module(module, state):
-                return fn(module, *user_args, **user_kwargs)
+        user_inputs_flat, runtime_spec = pytree.tree_flatten((args, kwargs))
+        # TODO: pytree's dict flatten preserves insertion order, so kwargs in a
+        # different order than trace produce a different spec even though they
+        # describe the same logical inputs. If pytree sorted dict keys (or
+        # provided a canonicalizing flatten), this check could match valid
+        # reordered calls without needing an explicit reorder step here.
+        if _validate_runtime and runtime_spec != traced_result.user_inputs_spec:
+            raise ValueError(
+                f"input spec mismatch: runtime {runtime_spec} != "
+                f"trace-time {traced_result.user_inputs_spec}"
+            )
+        if any(
+            isinstance(leaf, nn.Module) for leaf in [*state_flat, *user_inputs_flat]
+        ):
+            raise ValueError(
+                "run_traced requires explicit tensor state, not nn.Module instances. "
+                "Capture nn.Modules in fn's closure or pass them via the 'module' kwarg."
+            )
+        all_args = list(state_flat) + list(user_inputs_flat)
+        flat_inputs, _ = _unwrap_subclasses(all_args)
 
-        return minimal_fx_tracer(_stateless_fn)(
-            extract_module_state(module), *args, **kwargs
+        with torch.no_grad():
+            flat_outputs = traced_result.gm(*flat_inputs)
+        wrapped = _wrap_subclasses(
+            flat_outputs,
+            traced_result.num_flat_outputs,
+            traced_result.output_subclass_layouts,
         )
+        return pytree.tree_unflatten(wrapped, traced_result.output_spec)
 
-    return _trace_with_module
-
-
-def run_traced_train_step(
-    traced_result: TracedResult,
-    module: nn.Module,
-    *args: Any,
-    validate_module_fqns: bool = False,
-    **kwargs: Any,
-) -> Any:
-    """Reference implementation for executing a traced whole train step.
-
-    ``validate_module_fqns`` is a reserved keyword on this wrapper; user kwargs
-    of that name must be passed via the underlying ``fn``'s positional args.
-    """
-
-    if not isinstance(module, nn.Module):
-        raise ValueError(
-            "run_traced_train_step requires args[0] to be an nn.Module, "
-            f"got {type(module).__name__}."
-        )
-    _check_no_extra_module_in_user_inputs(args, kwargs, "run_traced_train_step")
-
-    # TODO: Consider stronger state validation once the long-term state API settles.
-    state = extract_module_state(module)
-    if validate_module_fqns and list(state.keys()) != traced_result.state_fqns:
-        raise ValueError(
-            "module has different parameter/buffer names than during tracing.\n"
-            f"  Traced: {traced_result.state_fqns}\n"
-            f"  Got:    {list(state.keys())}"
-        )
-    return run_traced(traced_result, state, *args, **kwargs)
+    return _run

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -428,7 +428,7 @@ def precompile_fx_trace_load(
     """Load a precompiled aot_fx_trace artifact.
 
     Returns a TracedResult with the deserialized GraphModule and
-    metadata. The caller uses this with run_traced_train_step to
+    metadata. The caller uses this with run_traced(..., module=model) to
     execute the graph (same path as non-precompiled aot_fx_trace).
 
     DeviceMesh objects are graph inputs (placeholders), not baked-in

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -299,7 +299,7 @@ def _precompile_aot_fx_trace(
     tokenizer,
 ):
     """aot_fx_trace mode precompilation: make_fx tracing + Inductor."""
-    from torchtitan.experiments.graph_trainer.make_fx_tracer import trace_train_step
+    from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
     from torchtitan.experiments.graph_trainer.precompile import (
         compute_config_fingerprint,
         precompile_fx_trace_save,
@@ -308,7 +308,7 @@ def _precompile_aot_fx_trace(
 
     loss_fn = config.loss.build(compile_config=compile_config)
 
-    fwd_bwd_fn = make_fwd_bwd_step(loss_fn)
+    fwd_bwd_fn = make_fwd_bwd_step(model, loss_fn)
 
     seq_len = config.training.seq_len
     local_batch_size = config.training.local_batch_size
@@ -386,8 +386,7 @@ def _precompile_aot_fx_trace(
 
     logger.info("Tracing fwd+loss+bwd via make_fx...")
     with loss_parallel_ctx:
-        traced_result = trace_train_step(fwd_bwd_fn)(
-            model,
+        traced_result = minimal_fx_tracer(fwd_bwd_fn, module=model)(
             dummy_inputs,
             dummy_labels,
             dummy_global_valid_tokens,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -184,8 +184,8 @@ class BitwiseDeterministicBase(unittest.TestCase):
         torchrun training with --compile.precompile_artifact_dir.
         """
         from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-            run_traced_train_step,
-            trace_train_step,
+            minimal_fx_tracer,
+            run_traced,
         )
         from torchtitan.experiments.graph_trainer.passes import (
             apply_graph_passes,
@@ -201,7 +201,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
 
         self.annotate_model(model)
         loss_fn = CrossEntropyLoss.Config().build()
-        fwd_bwd_fn = make_fwd_bwd_step(loss_fn)
+        fwd_bwd_fn = make_fwd_bwd_step(model, loss_fn)
 
         global_valid_tokens = torch.tensor(
             BATCH_SIZE * SEQ_LEN, dtype=torch.float, device="cuda"
@@ -214,8 +214,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         maybe_register_blockmask_pytree_node()
 
         # Step 1: Trace the graph
-        traced_result = trace_train_step(fwd_bwd_fn)(
-            model,
+        traced_result = minimal_fx_tracer(fwd_bwd_fn, module=model)(
             self.inputs,
             self.labels,
             global_valid_tokens,
@@ -277,9 +276,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
         for _ in range(NUM_STEPS):
             optimizer.zero_grad()
-            outputs = run_traced_train_step(
-                loaded_result,
-                model,
+            outputs = run_traced(loaded_result, module=model)(
                 self.inputs,
                 self.labels,
                 global_valid_tokens,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -31,10 +31,7 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import overlap_fsdp_ag_rs_pass
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
-from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-    minimal_fx_tracer,
-    trace_train_step,
-)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
 from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_default_memory_policy,
     apply_sac_pass,
@@ -1101,16 +1098,16 @@ class TestAnnotateModuleFqns(TestCase):
     """Unit tests for annotate_module_fqns and insert_kernel_annotations_pass."""
 
     def _trace_and_get_fqns(self, model, *args):
-        """Trace fwd+bwd with trace_train_step and return module_fqn annotations."""
+        """Trace fwd+bwd via minimal_fx_tracer and return module_fqn annotations."""
 
-        def fwd_step(model, *inputs):
+        def fwd_step(*inputs):
             pred = model(inputs[0])
             loss = pred.sum()
             params = [p for p in model.parameters() if p.requires_grad]
             grads = torch.autograd.grad(loss, params)
             return [loss] + list(grads)
 
-        traced = trace_train_step(fwd_step)(model, *args)
+        traced = minimal_fx_tracer(fwd_step, module=model)(*args)
         fqns = set()
         for node in traced.gm.graph.nodes:
             fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
@@ -1119,7 +1116,7 @@ class TestAnnotateModuleFqns(TestCase):
         return fqns
 
     def test_annotate_transformer_like_model(self):
-        """Module FQNs survive trace_train_step for a transformer-like model
+        """Module FQNs survive minimal_fx_tracer for a transformer-like model
         with distinct submodule classes (norm, attention, ffn)."""
 
         class Norm(torch.nn.Module):
@@ -1187,8 +1184,8 @@ class TestAnnotateModuleFqns(TestCase):
     def test_same_class_instances_get_distinct_fqns(self):
         """Two parameterless instances of the same class get distinct fqns.
 
-        Uses minimal_fx_tracer directly (not trace_train_step) because
-        parameterless models cannot produce gradients via autograd.grad.
+        Calls minimal_fx_tracer without ``module=`` because parameterless
+        models cannot produce gradients via autograd.grad.
         """
 
         class Block(torch.nn.Module):
@@ -1207,10 +1204,10 @@ class TestAnnotateModuleFqns(TestCase):
         model = Model()
         annotate_module_fqns(model)
 
-        def fwd_only(state, x):
+        def fwd_only(x):
             return model(x)
 
-        traced = minimal_fx_tracer(fwd_only)({}, torch.randn(4))
+        traced = minimal_fx_tracer(fwd_only)(torch.randn(4))
         fqns = set()
         for node in traced.gm.graph.nodes:
             fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)

--- a/torchtitan/experiments/graph_trainer/tests/test_profiler.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_profiler.py
@@ -27,8 +27,8 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
     get_cudagraph_annotations,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-    run_traced_train_step,
-    trace_train_step,
+    minimal_fx_tracer,
+    run_traced,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
@@ -42,7 +42,7 @@ class TestKernelAnnotationsE2E(TestCase):
     """E2E test: trace fwd+bwd → insert annotations → cudagraph → profile → check trace."""
 
     def test_profiler_trace_has_module_fqn_annotations(self):
-        """After the full pipeline (trace_train_step → insert_kernel_annotations
+        """After the full pipeline (minimal_fx_tracer → insert_kernel_annotations
         → cudagraph → profile), the profiler trace should contain
         ``module_fqn`` fields on graphed kernel events."""
         if _is_tools_id_unavailable():
@@ -72,15 +72,15 @@ class TestKernelAnnotationsE2E(TestCase):
         x = torch.randn(4, 16, device="cuda")
         labels = torch.randn(4, 16, device="cuda")
 
-        # Trace fwd + loss + bwd via trace_train_step.
-        def fwd_bwd_step(model, inputs, labels):
+        # Trace fwd + loss + bwd via minimal_fx_tracer.
+        def fwd_bwd_step(inputs, labels):
             pred = model(inputs)
             loss = torch.nn.functional.mse_loss(pred, labels)
             params = [p for p in model.parameters() if p.requires_grad]
             grads = torch.autograd.grad(loss, params)
             return [loss] + list(grads)
 
-        traced = trace_train_step(fwd_bwd_step)(model, x, labels)
+        traced = minimal_fx_tracer(fwd_bwd_step, module=model)(x, labels)
 
         # Verify module_fqn metadata survived tracing.
         fqns_in_graph = set()
@@ -96,8 +96,8 @@ class TestKernelAnnotationsE2E(TestCase):
         traced.gm = apply_graph_passes(traced.gm, traced.example_inputs, passes)
 
         # Run: warmup + capture + replay.
-        run_traced_train_step(traced, model, x, labels)  # warmup + capture
-        run_traced_train_step(traced, model, x, labels)  # replay
+        run_traced(traced, module=model)(x, labels)  # warmup + capture
+        run_traced(traced, module=model)(x, labels)  # replay
 
         # Check annotations were captured.
         annotations = get_cudagraph_annotations()
@@ -118,7 +118,7 @@ class TestKernelAnnotationsE2E(TestCase):
                 torch.profiler.ProfilerActivity.CUDA,
             ],
         ) as prof:
-            run_traced_train_step(traced, model, x, labels)
+            run_traced(traced, module=model)(x, labels)
             torch.cuda.synchronize()
 
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
@@ -132,7 +132,7 @@ class TestKernelAnnotationsE2E(TestCase):
         self.assertGreater(count, 0, "annotate_trace matched 0 events")
 
         # Verify module_fqn fields appear on graphed kernel events.
-        # Since trace_train_step traces fwd+bwd into a single graph,
+        # Since minimal_fx_tracer traces fwd+bwd into a single graph,
         # backward kernels (e.g. layer_norm_backward) should also carry
         # annotations from _copy_fwd_metadata_to_bw_nodes.
         fqns_in_trace = set()

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -9,6 +9,7 @@ from collections import Counter
 
 import torch
 import torch.nn as nn
+from torch.optim import swap_in_optimizer_params_and_state
 from torch.testing._internal.common_fsdp import FSDPTest
 
 from torchtitan.experiments.graph_trainer.chunked_loss import (
@@ -23,8 +24,7 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     extract_module_state,
     minimal_fx_tracer,
     run_traced,
-    run_traced_train_step,
-    trace_train_step,
+    TracedResult,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
@@ -39,29 +39,15 @@ def get_loss(logits, labels):
     )
 
 
-def make_train_step(loss_fn):
-    """Return a plain function for module-first tracing. loss_fn is captured in closure."""
+def make_train_step(model, loss_fn):
+    """Return a plain function that closes over ``model`` for module-based tracing."""
 
-    def train_step(model, *args):
+    def train_step(*args):
         *fwd_args, labels = args
         logits = model(*fwd_args)
         loss = loss_fn(logits, labels)
         params = list(model.parameters())
         grads = torch.autograd.grad(loss, params)
-        return [loss] + list(grads)
-
-    return train_step
-
-
-def make_stateless_train_step(model, loss_fn):
-    """Return a state-first function for the minimal_fx_tracer core API."""
-
-    def train_step(state, *args):
-        *fwd_args, labels = args
-        with torch.nn.utils.stateless._reparametrize_module(model, state):
-            logits = model(*fwd_args)
-        loss = loss_fn(logits, labels)
-        grads = torch.autograd.grad(loss, list(state.values()))
         return [loss] + list(grads)
 
     return train_step
@@ -134,27 +120,27 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
     def test_mark_unbacked_mixed_with_static_input_replay(self):
         from torch._dynamo.decorators import mark_unbacked
 
-        def forward(_state, dynamic_x, static_y):
+        def forward(dynamic_x, static_y):
             return dynamic_x.cos() + static_y.sin()
 
         dynamic_x = torch.randn(2, 4)
         static_y = torch.randn(2, 4)
         mark_unbacked(dynamic_x, 0)
 
-        traced = minimal_fx_tracer(forward)({}, dynamic_x, static_y)
+        traced = minimal_fx_tracer(forward)(dynamic_x, static_y)
         dynamic_x_other = torch.randn(3, 4)
         static_y_other = torch.randn(3, 4)
 
         self.assertTrue(
             torch.equal(
-                forward({}, dynamic_x, static_y),
-                run_traced(traced, {}, dynamic_x, static_y),
+                forward(dynamic_x, static_y),
+                run_traced(traced)(dynamic_x, static_y),
             )
         )
         self.assertTrue(
             torch.equal(
-                forward({}, dynamic_x_other, static_y_other),
-                run_traced(traced, {}, dynamic_x_other, static_y_other),
+                forward(dynamic_x_other, static_y_other),
+                run_traced(traced)(dynamic_x_other, static_y_other),
             )
         )
 
@@ -162,7 +148,7 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         from torch._dynamo.decorators import mark_unbacked
         from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
 
-        def forward(_state, x):
+        def forward(x):
             if x.shape[0] > 100:
                 return x.cos()
             return x.sin()
@@ -174,13 +160,13 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
             GuardOnDataDependentSymNode,
             "Could not guard on data-dependent expression",
         ):
-            minimal_fx_tracer(forward)({}, x)
+            minimal_fx_tracer(forward)(x)
 
     def test_mark_unbacked_min_max_preserves_unbacked_placeholder_dim(self):
         from torch._dynamo.decorators import mark_unbacked
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
-        def forward(_state, x):
+        def forward(x):
             if x.size(0) >= 2 and x.size(0) <= 5:
                 return x.sin()
             return x.cos()
@@ -188,7 +174,7 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         x = torch.randn(3, 4)
         mark_unbacked(x, 0, min=2, max=5)
 
-        traced = minimal_fx_tracer(forward)({}, x)
+        traced = minimal_fx_tracer(forward)(x)
         fake_x = next(
             node.meta["val"]
             for node in traced.gm.graph.nodes
@@ -200,20 +186,20 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         self.assertIsInstance(fake_x.size(0), torch.SymInt)
         self.assertTrue(free_unbacked_symbols(fake_x.size(0)))
         self.assertEqual(fake_x.size(1), 4)
-        self.assertTrue(torch.equal(forward({}, x_min), run_traced(traced, {}, x_min)))
-        self.assertTrue(torch.equal(forward({}, x_max), run_traced(traced, {}, x_max)))
+        self.assertTrue(torch.equal(forward(x_min), run_traced(traced)(x_min)))
+        self.assertTrue(torch.equal(forward(x_max), run_traced(traced)(x_max)))
 
     def test_mark_unbacked_preserves_unbacked_placeholder_dim(self):
         from torch._dynamo.decorators import mark_unbacked
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
-        def forward(_state, x):
+        def forward(x):
             return x.sin()
 
         x = torch.randn(2, 4)
         mark_unbacked(x, 0)
 
-        traced = minimal_fx_tracer(forward)({}, x)
+        traced = minimal_fx_tracer(forward)(x)
         fake_x = next(
             node.meta["val"]
             for node in traced.gm.graph.nodes
@@ -224,18 +210,18 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         self.assertIsInstance(fake_x.size(0), torch.SymInt)
         self.assertTrue(free_unbacked_symbols(fake_x.size(0)))
         self.assertEqual(fake_x.size(1), 4)
-        self.assertTrue(torch.equal(forward({}, x), run_traced(traced, {}, x)))
+        self.assertTrue(torch.equal(forward(x), run_traced(traced)(x)))
         self.assertTrue(
             torch.equal(
-                forward({}, x_other),
-                run_traced(traced, {}, x_other),
+                forward(x_other),
+                run_traced(traced)(x_other),
             )
         )
 
     def test_mark_unbacked_multiple_inputs_replay(self):
         from torch._dynamo.decorators import mark_unbacked
 
-        def forward(_state, x, y):
+        def forward(x, y):
             return x.sin() + y.cos()
 
         x = torch.randn(2, 4)
@@ -243,22 +229,22 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         mark_unbacked(x, 0)
         mark_unbacked(y, 0)
 
-        traced = minimal_fx_tracer(forward)({}, x, y)
+        traced = minimal_fx_tracer(forward)(x, y)
         x_other = torch.randn(3, 4)
         y_other = torch.randn(3, 4)
 
-        self.assertTrue(torch.equal(forward({}, x, y), run_traced(traced, {}, x, y)))
+        self.assertTrue(torch.equal(forward(x, y), run_traced(traced)(x, y)))
         self.assertTrue(
             torch.equal(
-                forward({}, x_other, y_other),
-                run_traced(traced, {}, x_other, y_other),
+                forward(x_other, y_other),
+                run_traced(traced)(x_other, y_other),
             )
         )
 
     def test_data_dependent_check_emits_runtime_asserts(self):
         """torch._check on a data-dependent .item() symbol becomes _assert_scalar nodes."""
 
-        def forward(_state, x, n):
+        def forward(x, n):
             v = n.item()
             torch._check(v > 0)
             torch._check(v < 100)
@@ -267,7 +253,7 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         x = torch.randn(8, 4)
         n = torch.tensor([5])
 
-        traced = minimal_fx_tracer(forward, _insert_runtime_asserts=True)({}, x, n)
+        traced = minimal_fx_tracer(forward, _insert_runtime_asserts=True)(x, n)
         assert_count = sum(
             1
             for node in traced.gm.graph.nodes
@@ -281,13 +267,13 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         """Tracing without data-dependent _check produces no _assert_scalar nodes."""
         from torch._dynamo.decorators import mark_unbacked
 
-        def forward(_state, x):
+        def forward(x):
             return x.sin()
 
         x = torch.randn(4, 4)
         mark_unbacked(x, 0)
 
-        traced = minimal_fx_tracer(forward)({}, x)
+        traced = minimal_fx_tracer(forward)(x)
         assert_count = sum(
             1
             for node in traced.gm.graph.nodes
@@ -299,7 +285,7 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
     def test_mark_unbacked_shape_id_multiple_inputs_replay(self):
         from torch._dynamo.decorators import mark_unbacked
 
-        def forward(_state, x, y):
+        def forward(x, y):
             if x.size(0) == y.size(0):
                 return x.sin() + y.cos()
             return x.cos() + y.sin()
@@ -309,14 +295,14 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
         mark_unbacked(x, 0, shape_id="batch")
         mark_unbacked(y, 0, shape_id="batch")
 
-        traced = minimal_fx_tracer(forward)({}, x, y)
+        traced = minimal_fx_tracer(forward)(x, y)
         x_other = torch.randn(3, 4)
         y_other = torch.randn(3, 4)
 
         self.assertTrue(
             torch.equal(
-                forward({}, x_other, y_other),
-                run_traced(traced, {}, x_other, y_other),
+                forward(x_other, y_other),
+                run_traced(traced)(x_other, y_other),
             )
         )
 
@@ -350,12 +336,12 @@ class TestTraceModule(unittest.TestCase):
     def test_mlp_forward(self):
         model, tokens, labels, loss_fn = self._make_mlp()
 
-        def forward(model, tokens):
+        def forward(tokens):
             return model(tokens)
 
-        traced = trace_train_step(forward)(model, tokens)
+        traced = minimal_fx_tracer(forward, module=model)(tokens)
         out_eager = model(tokens)
-        wrapped = run_traced_train_step(traced, model, tokens)
+        wrapped = run_traced(traced, module=model)(tokens)
         self.assertTrue(torch.equal(out_eager, wrapped))
 
     def test_mlp_train_step(self):
@@ -363,15 +349,15 @@ class TestTraceModule(unittest.TestCase):
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step = make_train_step(loss_fn)
-        traced = trace_train_step(train_step)(model_ref, tokens, labels)
+        train_step = make_train_step(model_ref, loss_fn)
+        traced = minimal_fx_tracer(train_step, module=model_ref)(tokens, labels)
 
         logits_ref = model_ref(tokens)
         loss_ref = loss_fn(logits_ref, labels)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        wrapped = run_traced_train_step(traced, model_test, tokens, labels)
+        wrapped = run_traced(traced, module=model_test)(tokens, labels)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -410,8 +396,14 @@ class TestTraceModule(unittest.TestCase):
             return [loss, *grads]
 
         eager_out = train_step(lm_head_ref, hidden_states, labels)
-        traced = trace_train_step(train_step)(lm_head_test, hidden_states, labels)
-        replay_out = run_traced_train_step(traced, lm_head_test, hidden_states, labels)
+
+        def train_step_closure(hidden_states, labels):
+            return train_step(lm_head_test, hidden_states, labels)
+
+        traced = minimal_fx_tracer(train_step_closure, module=lm_head_test)(
+            hidden_states, labels
+        )
+        replay_out = run_traced(traced, module=lm_head_test)(hidden_states, labels)
 
         for ref, tr in zip(eager_out, replay_out, strict=True):
             self.assertTrue(torch.equal(ref, tr))
@@ -421,8 +413,8 @@ class TestTraceModule(unittest.TestCase):
         model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         model_test.load_state_dict(model_ref.state_dict())
 
-        train_step = make_train_step(loss_fn)
-        traced = trace_train_step(train_step)(model_ref, tokens, labels)
+        train_step = make_train_step(model_ref, loss_fn)
+        traced = minimal_fx_tracer(train_step, module=model_ref)(tokens, labels)
 
         opt_ref = torch.optim.Adam(model_ref.parameters(), lr=self.LR)
         opt_copy = torch.optim.Adam(model_test.parameters(), lr=self.LR)
@@ -435,7 +427,7 @@ class TestTraceModule(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            wrapped = run_traced_train_step(traced, model_test, tokens, labels)
+            wrapped = run_traced(traced, module=model_test)(tokens, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -452,23 +444,23 @@ class TestTraceModule(unittest.TestCase):
     def test_non_tensor_leaf_raises(self):
         """Passing a callable leaf in args raises (should be in closure instead)."""
 
-        def fn(model, x, loss_fn):
-            return loss_fn(model(x))
-
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
+        def fn(x, loss_fn):
+            return loss_fn(model(x))
+
         with self.assertRaises(ValueError, msg="all pytree leaves"):
-            trace_train_step(fn)(model, tokens, lambda x: x.sum())
+            minimal_fx_tracer(fn, module=model)(tokens, lambda x: x.sum())
 
     def test_mismatched_module_raises_when_validation_enabled(self):
         """Opt-in module FQN validation catches execution with the wrong module."""
         model, tokens, labels, loss_fn = self._make_mlp()
 
-        def forward(model, tokens):
+        def forward(tokens):
             return model(tokens)
 
-        traced = trace_train_step(forward)(model, tokens)
+        traced = minimal_fx_tracer(forward, module=model)(tokens)
 
         different_model = nn.Sequential(
             nn.Embedding(256, 64),
@@ -476,56 +468,13 @@ class TestTraceModule(unittest.TestCase):
         ).to(device=self.DEVICE, dtype=self.DTYPE)
 
         with self.assertRaises(ValueError, msg="different parameter/buffer names"):
-            run_traced_train_step(
-                traced, different_model, tokens, validate_module_fqns=True
-            )
+            run_traced(traced, module=different_model, _validate_runtime=True)(tokens)
 
-    def test_trace_train_step_requires_module_first_arg(self):
-        def forward(model, tokens):
-            return model(tokens)
-
-        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
-
-        with self.assertRaises(ValueError, msg="args\\[0\\]"):
-            trace_train_step(forward)(tokens)
-
-    def test_core_explicit_state_executes(self):
+    def test_optimizer_passed_without_module_raises(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
-
-        def forward(state, tokens):
-            with torch.nn.utils.stateless._reparametrize_module(model, state):
-                return model(tokens)
-
-        state = extract_module_state(model)
-        traced = minimal_fx_tracer(forward)(state, tokens)
-        out_ref = forward(state, tokens)
-        out_traced = run_traced(traced, state, tokens)
-
-        self.assertTrue(torch.equal(out_ref, out_traced))
-
-    def test_core_explicit_state_train_step(self):
-        model_ref, tokens, labels, loss_fn = self._make_mlp()
-        model_test = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        model_test.load_state_dict(model_ref.state_dict())
-
-        state_ref = extract_module_state(model_ref)
-        state_test = extract_module_state(model_test)
-        train_step = make_stateless_train_step(model_ref, loss_fn)
-        traced = minimal_fx_tracer(train_step)(state_ref, tokens, labels)
-
-        logits_ref = model_ref(tokens)
-        loss_ref = loss_fn(logits_ref, labels)
-        loss_ref.backward()
-        grads_ref = [p.grad.clone() for p in model_ref.parameters()]
-
-        wrapped = run_traced(traced, state_test, tokens, labels)
-        loss_tr = wrapped[0]
-        grads_tr = wrapped[1:]
-
-        self.assertTrue(torch.equal(loss_ref, loss_tr))
-        for gr, gt in zip(grads_ref, grads_tr, strict=True):
-            self.assertTrue(torch.equal(gr, gt))
+        opt = torch.optim.Adam(model.parameters())
+        with self.assertRaises(ValueError, msg="optimizer"):
+            minimal_fx_tracer(lambda: None, optimizer=opt)
 
     def test_kwargs_roundtrip(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
@@ -539,7 +488,7 @@ class TestTraceModule(unittest.TestCase):
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens, scale=scale)
         out_ref = forward(state, tokens, scale=scale)
-        out_traced = run_traced(traced, state, tokens, scale=scale)
+        out_traced = run_traced(traced)(state, tokens, scale=scale)
         self.assertTrue(torch.equal(out_ref, out_traced))
 
     def test_kwargs_runtime_reorder_raises(self):
@@ -557,7 +506,7 @@ class TestTraceModule(unittest.TestCase):
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens, a=a, b=b)
         with self.assertRaisesRegex(ValueError, "input spec mismatch"):
-            run_traced(traced, state, tokens, _validate_runtime=True, b=b, a=a)
+            run_traced(traced, _validate_runtime=True)(state, tokens, b=b, a=a)
 
     def test_kwargs_unknown_kwarg_raises(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
@@ -571,7 +520,7 @@ class TestTraceModule(unittest.TestCase):
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens, scale=scale)
         with self.assertRaisesRegex(ValueError, "input spec mismatch"):
-            run_traced(traced, state, tokens, _validate_runtime=True, factor=scale)
+            run_traced(traced, _validate_runtime=True)(state, tokens, factor=scale)
 
     def test_kwargs_default_omitted_bakes_constant(self):
         """fn with a default kwarg, not passed at trace: default is baked in.
@@ -586,12 +535,12 @@ class TestTraceModule(unittest.TestCase):
 
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens)
-        out_default = run_traced(traced, state, tokens)
+        out_default = run_traced(traced)(state, tokens)
         out_ref = forward(state, tokens)
         self.assertTrue(torch.equal(out_ref, out_default))
 
         with self.assertRaisesRegex(ValueError, "input spec mismatch"):
-            run_traced(traced, state, tokens, _validate_runtime=True, scale=scale)
+            run_traced(traced, _validate_runtime=True)(state, tokens, scale=scale)
 
     def test_kwargs_var_keyword_missing_key_raises(self):
         """fn with **opts: missing a kwarg at runtime changes the kwargs spec."""
@@ -607,11 +556,11 @@ class TestTraceModule(unittest.TestCase):
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens, a=a, b=b)
         out_ref = forward(state, tokens, a=a, b=b)
-        out_traced = run_traced(traced, state, tokens, a=a, b=b)
+        out_traced = run_traced(traced)(state, tokens, a=a, b=b)
         self.assertTrue(torch.equal(out_ref, out_traced))
 
         with self.assertRaisesRegex(ValueError, "input spec mismatch"):
-            run_traced(traced, state, tokens, _validate_runtime=True, a=a)
+            run_traced(traced, _validate_runtime=True)(state, tokens, a=a)
 
     def test_flex_attention_block_mask_mark_unbacked(self):
         from torch._dynamo.decorators import mark_unbacked
@@ -679,7 +628,7 @@ class TestTraceModule(unittest.TestCase):
         mask = make_mask()
         cflex = torch.compile(flex_attention, dynamic=False, fullgraph=True)
 
-        def forward(_state, q, k, v, block_mask):
+        def forward(q, k, v, block_mask):
             out, aux = cflex(
                 q,
                 k,
@@ -689,19 +638,92 @@ class TestTraceModule(unittest.TestCase):
             )
             return out.sum().detach(), aux.max_scores.max().detach()
 
-        minimal_fx_tracer(forward)({}, q, k, v, mask)
+        minimal_fx_tracer(forward)(q, k, v, mask)
 
-    def test_additional_module_arg_raises(self):
-        def forward(model, other_model, tokens):
-            del other_model
-            return model(tokens)
-
+    def test_module_in_args_raises(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         other_model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        with self.assertRaises(ValueError, msg="Additional nn.Module"):
-            trace_train_step(forward)(model, other_model, tokens)
+        def forward(other, tokens):
+            return other(tokens)
+
+        with self.assertRaises(ValueError, msg="nn.Module"):
+            minimal_fx_tracer(forward, module=model)(other_model, tokens)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestReparametrizeOptimizer(unittest.TestCase):
+    """Verify swap_in_optimizer_params_and_state works with a torchtitan OptimizersContainer.
+
+    OptimizersContainer is itself an Optimizer subclass, but it delegates
+    ``step``/``state``/``state_dict`` to inner ``torch.optim.Adam``/``AdamW``
+    instances. ``OptimizersContainer.state_dict()`` returns a DCP-flattened
+    (FQN-keyed) dict, so the reparametrize helper consumes the inner
+    optimizer's raw ``state_dict()`` (packed-int-id format) instead.
+    """
+
+    DEVICE = "cuda"
+    DTYPE = torch.float32
+
+    def test_titan_optimizers_container(self):
+        from torchtitan.components.optimizer import OptimizersContainer
+
+        torch.manual_seed(0)
+        model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
+        container = OptimizersContainer(
+            OptimizersContainer.Config(
+                name="AdamW", lr=1e-3, implementation="for-loop"
+            ),
+            model_parts=[model],
+        )
+        inner = container.optimizers[0]
+
+        # Initialize Adam's lazy per-parameter state.
+        x = torch.randint(0, 256, (2, 16), device=self.DEVICE)
+        loss = model(x).sum()
+        loss.backward()
+        container.step()
+        container.zero_grad(set_to_none=True)
+
+        # Snapshot the originals so we can verify perfect restoration.
+        optim_state_dict = inner.state_dict()
+        original_param_ids = [[id(p) for p in g["params"]] for g in inner.param_groups]
+        original_state_keys = list(inner.state.keys())
+        original_state_id = id(inner.state)
+
+        # Rebind to fake parameter tensors (zeros to make the swap obvious).
+        params_dict = dict(model.named_parameters(remove_duplicate=False))
+        fake_params = {name: torch.zeros_like(p) for name, p in params_dict.items()}
+
+        with swap_in_optimizer_params_and_state(inner, fake_params, optim_state_dict):
+            # The live optimizer now points at the fake tensors.
+            rebound = [p for g in inner.param_groups for p in g["params"]]
+            for fake, rebound_p in zip(fake_params.values(), rebound, strict=True):
+                self.assertIs(fake, rebound_p)
+
+            # Per-param state is keyed by the rebound tensors and shares the
+            # original tensor values (so in-place ops would propagate).
+            for fake in fake_params.values():
+                self.assertIn(fake, inner.state)
+            for name, fake in fake_params.items():
+                # Match against the original state_dict via positional
+                # alignment in the optimizer's first (only) param group.
+                idx = list(fake_params).index(name)
+                packed_id = optim_state_dict["param_groups"][0]["params"][idx]
+                expected_state = optim_state_dict["state"][packed_id]
+                self.assertEqual(
+                    set(inner.state[fake].keys()), set(expected_state.keys())
+                )
+                for k, v in expected_state.items():
+                    if isinstance(v, torch.Tensor):
+                        self.assertIs(inner.state[fake][k], v)
+
+        # After the context the live optimizer is fully restored.
+        self.assertEqual(id(inner.state), original_state_id)
+        self.assertEqual(list(inner.state.keys()), original_state_keys)
+        for orig_ids, group in zip(original_param_ids, inner.param_groups, strict=True):
+            self.assertEqual([id(p) for p in group["params"]], orig_ids)
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
@@ -752,17 +774,17 @@ class TestTraceDTensor(unittest.TestCase):
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
 
-        def forward(model, tokens):
+        def forward(tokens):
             return model(tokens)
 
-        traced = trace_train_step(forward)(model, tokens_dt)
+        traced = minimal_fx_tracer(forward, module=model)(tokens_dt)
         has_subclass = any(
             layout.meta is not None for layout in traced.input_subclass_layouts.values()
         )
         self.assertTrue(has_subclass)
 
         out_eager = model(tokens_dt)
-        wrapped = run_traced_train_step(traced, model, tokens_dt)
+        wrapped = run_traced(traced, module=model)(tokens_dt)
         self.assertTrue(torch.equal(out_eager.full_tensor(), wrapped.full_tensor()))
 
     def test_dtensor_mark_unbacked_rejected(self):
@@ -775,14 +797,14 @@ class TestTraceDTensor(unittest.TestCase):
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
         mark_unbacked(tokens_dt, 0)
 
-        def forward(_state, tokens):
+        def forward(tokens):
             return tokens
 
         with self.assertRaisesRegex(
             ValueError,
             "only supports mark_unbacked\\(\\) on plain tensor inputs",
         ):
-            minimal_fx_tracer(forward)({}, tokens_dt)
+            minimal_fx_tracer(forward)(tokens_dt)
 
     def test_dtensor_train_step(self):
         from torch.distributed._tensor import DTensor, Replicate
@@ -802,15 +824,15 @@ class TestTraceDTensor(unittest.TestCase):
         tokens_dt = DTensor.from_local(tokens, mesh, [Replicate()])
         labels_dt = DTensor.from_local(labels, mesh, [Replicate()])
 
-        train_step = make_train_step(get_loss)
-        traced = trace_train_step(train_step)(model_ref, tokens_dt, labels_dt)
+        train_step = make_train_step(model_ref, get_loss)
+        traced = minimal_fx_tracer(train_step, module=model_ref)(tokens_dt, labels_dt)
 
         logits_ref = model_ref(tokens_dt)
         loss_ref = get_loss(logits_ref, labels_dt)
         loss_ref.backward()
         grads_ref = [p.grad.clone() for p in model_ref.parameters()]
 
-        wrapped = run_traced_train_step(traced, model_test, tokens_dt, labels_dt)
+        wrapped = run_traced(traced, module=model_test)(tokens_dt, labels_dt)
         loss_tr = wrapped[0]
         grads_tr = wrapped[1:]
 
@@ -832,11 +854,11 @@ class TestMetadataPropagation(unittest.TestCase):
     def test_backward_nodes_have_seq_nr(self):
         """Verify that backward FX nodes get seq_nr metadata via patched autograd.grad."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        train_step = make_train_step(get_loss)
+        train_step = make_train_step(model, get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced = trace_train_step(train_step)(model, tokens, labels)
+        traced = minimal_fx_tracer(train_step, module=model)(tokens, labels)
 
         # Collect seq_nr values from all call_function nodes
         seq_nrs = []
@@ -860,11 +882,11 @@ class TestMetadataPropagation(unittest.TestCase):
         """Verify _copy_fwd_metadata_to_bw_nodes copies custom metadata to bwd nodes."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
 
-        train_step = make_train_step(get_loss)
+        train_step = make_train_step(model, get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced = trace_train_step(train_step)(model, tokens, labels)
+        traced = minimal_fx_tracer(train_step, module=model)(tokens, labels)
         gm = traced.gm
 
         # Manually set custom metadata on the first fwd node for each seq_nr
@@ -915,11 +937,11 @@ class TestMetadataPropagation(unittest.TestCase):
     def test_backward_nodes_have_stack_trace(self):
         """Verify that backward nodes get stack_trace from their forward counterpart."""
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
-        train_step = make_train_step(get_loss)
+        train_step = make_train_step(model, get_loss)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         labels = torch.randint(0, 256, (2, 32), device=self.DEVICE)
 
-        traced = trace_train_step(train_step)(model, tokens, labels)
+        traced = minimal_fx_tracer(train_step, module=model)(tokens, labels)
 
         # Find backward nodes: nodes sharing a seq_nr with an earlier (forward) node
         seq_nr_first: dict[int, torch.fx.Node] = {}
@@ -975,11 +997,11 @@ class TestTraceModels(unittest.TestCase):
         num_steps=5,
         lr=1e-3,
     ):
-        train_step = make_train_step(get_loss)
+        train_step = make_train_step(model_ref, get_loss)
 
         maybe_register_blockmask_pytree_node()
-        traced: TracedResult = trace_train_step(train_step)(
-            model_ref, *fwd_args, labels
+        traced: TracedResult = minimal_fx_tracer(train_step, module=model_ref)(
+            *fwd_args, labels
         )
 
         if check_collective_ops:
@@ -1012,7 +1034,7 @@ class TestTraceModels(unittest.TestCase):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            wrapped = run_traced_train_step(traced, model_test, *fwd_args, labels)
+            wrapped = run_traced(traced, module=model_test)(*fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):
@@ -1208,9 +1230,11 @@ class TestTraceModels(unittest.TestCase):
             }
         )(FlexAttention.forward)
         try:
-            train_step = make_train_step(get_loss)
+            train_step = make_train_step(model, get_loss)
             maybe_register_blockmask_pytree_node()
-            traced = trace_train_step(train_step)(model, tokens, block_mask, labels)
+            traced = minimal_fx_tracer(train_step, module=model)(
+                tokens, block_mask, labels
+            )
         finally:
             FlexAttention.forward = orig_forward
 
@@ -1327,10 +1351,10 @@ class TestTraceModels(unittest.TestCase):
         }
         maybe_register_blockmask_pytree_node()
 
-        def forward(model, tokens, attn_masks):
+        def forward(tokens, attn_masks):
             return model(tokens, attn_masks)
 
-        traced = trace_train_step(forward)(model, tokens, attn_masks)
+        traced = minimal_fx_tracer(forward, module=model)(tokens, attn_masks)
 
         flex_nodes = [
             n
@@ -1417,10 +1441,10 @@ class TestTraceFSDP(FSDPTest):
         else:
             fwd_args = (tokens,)
 
-        train_step = make_train_step(get_loss)
+        train_step = make_train_step(model_ref, get_loss)
 
         maybe_register_blockmask_pytree_node()
-        traced = trace_train_step(train_step)(model_ref, *fwd_args, labels)
+        traced = minimal_fx_tracer(train_step, module=model_ref)(*fwd_args, labels)
 
         ag = sum(
             1
@@ -1449,7 +1473,7 @@ class TestTraceFSDP(FSDPTest):
             opt_ref.step()
             opt_ref.zero_grad()
 
-            wrapped = run_traced_train_step(traced, model_test, *fwd_args, labels)
+            wrapped = run_traced(traced, module=model_test)(*fwd_args, labels)
             loss_tr = wrapped[0]
             grads_tr = wrapped[1:]
             for p, g in zip(model_test.parameters(), grads_tr, strict=True):

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -20,8 +20,8 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
-    run_traced_train_step,
-    trace_train_step,
+    minimal_fx_tracer,
+    run_traced,
     TracedResult,
 )
 from torchtitan.experiments.graph_trainer.passes import (
@@ -36,15 +36,15 @@ from torchtitan.experiments.graph_trainer.registry import (
 from torchtitan.trainer import Trainer
 
 
-def make_fwd_bwd_step(loss_fn):
+def make_fwd_bwd_step(model, loss_fn):
     """Return a plain function that traces the entire fwd+loss+bwd step.
 
-    ``loss_fn`` is captured in the closure so it is not a graph input.
+    ``model`` and ``loss_fn`` are captured in the closure so neither shows up
+    as a graph input. Pass ``model`` through ``minimal_fx_tracer(fn, module=model)``
+    to thread its parameters/buffers as static graph inputs.
     """
 
-    def fwd_bwd_step(
-        model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
-    ):
+    def fwd_bwd_step(inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs):
         pred = model(inputs, **extra_inputs, **extra_kwargs)
         # The loss function is not a submodule of the model, so
         # annotate_module_fqns won't tag it. Annotate it here so that
@@ -165,10 +165,9 @@ class GraphTrainer(Trainer):
             if self.config.compile.precompile_artifact_dir:
                 self._load_precompiled_fx_trace(model)
             else:
-                fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
-                with self.train_context(), log_timer("trace_train_step"):
-                    self._traced_step = trace_train_step(fwd_bwd_fn)(
-                        model,
+                fwd_bwd_fn = make_fwd_bwd_step(model, self.loss_fn)
+                with self.train_context(), log_timer("minimal_fx_tracer"):
+                    self._traced_step = minimal_fx_tracer(fwd_bwd_fn, module=model)(
                         inputs,
                         labels,
                         global_valid_tokens,
@@ -190,9 +189,7 @@ class GraphTrainer(Trainer):
                     compile_config=self.config.compile,
                 )
         with self.train_context():
-            outputs = run_traced_train_step(
-                self._traced_step,
-                model,
+            outputs = run_traced(self._traced_step, module=model)(
                 inputs,
                 labels,
                 global_valid_tokens,


### PR DESCRIPTION
Reshapes the public API so a single entry point handles three cases — plain stateless functions, module-rooted train steps, and full module+optimizer train steps:

    minimal_fx_tracer(fn)(*args)
    minimal_fx_tracer(fn, module=m)(*args)
    minimal_fx_tracer(fn, module=m, optimizer=opt)(*args)

`fn` no longer takes an explicit `state` argument; module parameters and `optimizer.state_dict()` are obtained from the live objects and threaded into the graph as inputs, with `stateless._reparametrize_module` and a new `swap_in_optim_state` context wrapping the user fn during tracing. The optimizer must already be initialized before tracing (so its lazy per-parameter state has been populated). `run_traced` mirrors the same arguments as `minimal_fx_tracer`.

`trace_train_step` and `run_traced_train_step` are removed — the new form subsumes both. 


Authored with Claude.