### PR TITLE
[graph_trainer] Apply simple_fsdp unconditionally for NGPU=1 parity (#3148)

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -13,7 +13,12 @@ from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
 
+from torchtitan.config import TORCH_DTYPE_MAP, TrainingConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.graph_trainer.simple_fsdp import (
+    data_parallel,
+    MixedPrecisionPolicy,
+)
 from torchtitan.tools.logging import logger
 
 _MODULE_FQN = "module_fqn"
@@ -197,3 +202,71 @@ def get_transformer_block_buckets(model) -> list[list[str] | str]:
     module_to_name = {m: n for n, m in model.named_modules()}
     module_fqns = convert_modules_to_fqns(module_list, module_to_name)
     return module_fqns
+
+
+def apply_simple_fsdp(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+) -> nn.Module:
+    """Wrap the model (and any MoE experts) with graph_trainer's simple_fsdp.
+
+    For MoE-enabled models, ``moe.experts`` submodules are separately wrapped
+    on the EDP mesh when expert parallelism is enabled.
+    """
+    if parallel_dims.dp_replicate_enabled:
+        if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
+            dp_mesh_dim_names = ["dp_replicate", "fsdp"]
+            dp_mode = "hybrid_shard"
+        else:
+            dp_mesh_dim_names = ["dp_replicate"]
+            dp_mode = "replicate"
+    else:
+        dp_mesh_dim_names = ["fsdp"]
+        dp_mode = "fully_shard"
+
+    dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
+    )
+
+    if parallel_dims.ep_enabled and hasattr(model, "layers"):
+        edp_mesh_names = (
+            ["dp_replicate", "efsdp"]
+            if parallel_dims.dp_replicate_enabled
+            else ["efsdp"]
+        )
+        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+        assert edp_mesh is not None
+
+        for _, transformer_block in model.layers.items():
+            if not getattr(transformer_block, "moe_enabled", False):
+                continue
+            assert hasattr(transformer_block, "moe")
+            experts_shard_dim = 0
+            if (
+                edp_mesh["efsdp"].size() * parallel_dims.ep
+                > transformer_block.moe.experts.num_experts
+            ):
+                experts_shard_dim = 1
+
+            transformer_block.moe.experts = data_parallel(
+                transformer_block.moe.experts,
+                edp_mesh,
+                dp_mode,
+                mp_policy=mp_policy,
+                shard_dim=experts_shard_dim,
+            )
+
+    model = data_parallel(
+        model,
+        dp_mesh,
+        dp_mode,
+        mp_policy=mp_policy,
+    )
+    logger.info(
+        "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
+    )
+    return model

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -67,6 +67,10 @@ class GraphTrainerCompileConfig(CompileConfig):
     enable_cudagraph: bool = True
     """When False, skip the cudagraph pass even if the graph is compatible."""
 
+    cpu_offload_prefetch_n_layers: int = 1
+    """Prefetch reloads this many layers ahead in the backward graph
+    to overlap H2D transfers with compute."""
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/cpu_offload.py
@@ -13,8 +13,8 @@ them around saved activations to reduce GPU memory.
 
 Offload pattern (forward):
     cpu = ao.offload(gpu_tensor)
-    ... forward consumers use gpu_tensor ...
-    cpu = ao.wait_tensor(cpu, keepalive=gpu_tensor)
+    ... forward consumers read gpu_tensor ...
+    cpu = ao.wait_tensor(cpu, keepalive=gpu_tensor)  # frees gpu_tensor storage
 
 Reload pattern (backward):
     gpu = ao.reload(cpu, device)
@@ -27,6 +27,7 @@ This module works with the make_fx traced joint fwd+bwd graph, using
 """
 
 import operator
+import os
 
 import torch
 
@@ -59,6 +60,7 @@ _VIEW_OPS = frozenset(
         aten.t,
         aten.transpose,
         aten.view,
+        aten._unsafe_view,
         aten.reshape,
         aten.unsqueeze,
         aten.squeeze,
@@ -69,6 +71,9 @@ _VIEW_OPS = frozenset(
         aten.as_strided,
         aten.alias,
         aten.split,
+        aten.narrow,
+        aten.unfold,
+        aten.detach,
     }
 )
 
@@ -86,6 +91,59 @@ def _get_aten_target(node: Node) -> object:
 def _is_view(node: Node) -> bool:
     """Check if a node produces a view (aliased memory, not a new allocation)."""
     return _get_aten_target(node) in _VIEW_OPS
+
+
+def _get_storage_chain(node: Node) -> tuple[set[Node], bool]:
+    """Walk the view chain to find all nodes sharing this tensor's storage.
+
+    Views alias the base tensor's storage, so any node reachable through view
+    edges (and its non-view consumers) depends on the storage being alive.
+
+    Returns:
+        (chain_nodes, has_bwd) where chain_nodes is every forward
+        ``call_function`` node reachable through the view chain (including
+        non-view endpoints) and has_bwd is True if any node in the chain
+        has un-redirected backward consumers.
+    """
+    chain_nodes: set[Node] = set()
+    has_bwd = False
+
+    def _walk(n: Node) -> None:
+        nonlocal has_bwd
+        for user in n.users:
+            if user.op != "call_function":
+                continue
+            if _is_backward_node(user):
+                has_bwd = True
+                continue
+            chain_nodes.add(user)
+            if _is_view(user):
+                _walk(user)
+
+    _walk(node)
+    return chain_nodes, has_bwd
+
+
+def _collect_view_tree(node: Node) -> list[Node]:
+    """BFS collecting all forward view descendants in topological order.
+
+    Views share storage with the base tensor, so they must be replayed from
+    a reloaded tensor to allow deallocating the original GPU storage.
+    """
+    result: list[Node] = []
+    queue = [node]
+    visited = {node}
+    while queue:
+        current = queue.pop(0)
+        for user in current.users:
+            if user in visited or user.op != "call_function":
+                continue
+            if _is_backward_node(user) or not _is_view(user):
+                continue
+            visited.add(user)
+            result.append(user)
+            queue.append(user)
+    return result
 
 
 def _is_collective_or_wait(node: Node) -> bool:
@@ -148,6 +206,22 @@ def _can_offload_node(node: Node) -> bool:
     return _has_offloadable_tensor(node)
 
 
+def _has_recompute_consumer(node: Node) -> bool:
+    """Check if any forward user (or transitive view user) is tagged for recomputation."""
+    for user in node.users:
+        if user.op != "call_function" or _is_backward_node(user):
+            continue
+        policy = user.meta.get("recompute")
+        if policy in (
+            CheckpointPolicy.MUST_RECOMPUTE,
+            CheckpointPolicy.PREFER_RECOMPUTE,
+        ):
+            return True
+        if _is_view(user) and _has_recompute_consumer(user):
+            return True
+    return False
+
+
 # ============================================================
 # Forward/backward node classification for make_fx traced graphs
 # ============================================================
@@ -183,27 +257,34 @@ def _classify_forward_backward(
 # ============================================================
 
 
+def _detect_sac_active(gm: torch.fx.GraphModule) -> bool:
+    """Check if SAC has already tagged nodes in the graph."""
+    for node in gm.graph.nodes:
+        if node.op != "call_function" or _is_backward_node(node):
+            continue
+        policy = node.meta.get("recompute")
+        if policy in (
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.PREFER_RECOMPUTE,
+            CheckpointPolicy.MUST_RECOMPUTE,
+        ):
+            return True
+    return False
+
+
 def tag_all_offloadable_activations(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
     """Tag all saved activations eligible for CPU offloading.
 
-    This is a reference implementation that offloads all offloadable
-    activations. In practice, users should tag activations via annotations
-    or graph passes for more fine-grained control over which activations
-    are offloaded.
-
     Sets ``node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD`` on
-    eligible nodes. Eligibility requires:
-      1. Node is a forward node (not ``autograd_backward``)
-      2. Node has a layer index derivable from ``meta["custom"]["module_fqn"]``
-      3. Passes ``_can_offload_node`` (not a view, not tiny, etc.)
-      4. Has at least one backward consumer
+    eligible forward nodes. When SAC is active, only MUST_SAVE nodes are
+    tagged (the surviving activations after recomputation decisions).
+    Without SAC, any forward node with backward consumers is eligible.
 
-    The last layer is skipped when multiple layers exist, since its activations
-    are consumed immediately in backward (offloading adds overhead with no
-    benefit).
+    The last layer is skipped (its activations are consumed immediately
+    in backward).
 
     Args:
         gm: The GraphModule containing the full fwd+bwd graph.
@@ -213,6 +294,7 @@ def tag_all_offloadable_activations(
         The GraphModule with eligible nodes tagged for offload.
     """
     forward_nodes, _ = _classify_forward_backward(gm)
+    sac_active = _detect_sac_active(gm)
 
     # Find all layer IDs to determine the last layer
     all_layer_ids: set[int] = set()
@@ -229,17 +311,29 @@ def tag_all_offloadable_activations(
         if node not in forward_nodes:
             continue
         layer_id = _get_layer_id(node)
-        # Skip the last layer: its activations are consumed immediately in
-        # backward, so offloading adds overhead with no memory benefit.
         if layer_id == _NOT_IN_LAYERS or layer_id == last_layer_id:
             continue
         if not _can_offload_node(node):
             continue
 
-        # Check for backward consumers
-        has_backward_users = any(_is_backward_node(u) for u in node.users)
-        if not has_backward_users:
-            continue
+        existing = node.meta.get("recompute")
+
+        if sac_active:
+            # SAC already resolved recomputation. Only MUST_SAVE nodes are
+            # the surviving activations — safe to offload.
+            if existing != CheckpointPolicy.MUST_SAVE:
+                continue
+        else:
+            if existing in (
+                CheckpointPolicy.MUST_RECOMPUTE,
+                CheckpointPolicy.PREFER_RECOMPUTE,
+            ):
+                continue
+            if _has_recompute_consumer(node):
+                continue
+            _, has_bwd = _get_storage_chain(node)
+            if not has_bwd:
+                continue
 
         node.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD
         tagged += 1
@@ -257,22 +351,54 @@ def tag_all_offloadable_activations(
 # ============================================================
 
 
+def _find_tensor_dep(node: Node, node_positions: dict[Node, int]) -> Node | None:
+    """Find a tensor-valued node suitable for a scheduling dependency.
+
+    If ``node`` itself produces a tensor, return it. Otherwise (e.g. a
+    multi-output op returning a tuple), search its forward ``getitem``
+    users for a tensor-valued one.
+    """
+    if isinstance(node.meta.get("val"), torch.Tensor):
+        return node
+    for user in node.users:
+        if (
+            user.op == "call_function"
+            and user.target is operator.getitem
+            and isinstance(user.meta.get("val"), torch.Tensor)
+            and not _is_backward_node(user)
+        ):
+            return user
+    return None
+
+
 def apply_cpu_offload_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
+    *,
+    prefetch_lookahead: int = 1,
+    cpu_budget_gb: float = 100.0,
 ) -> torch.fx.GraphModule:
     """Insert ao offload/reload/wait_tensor ops for nodes tagged ``MUST_CPU_OFFLOAD``.
 
     Reads ``node.meta["recompute"] is CheckpointPolicy.MUST_CPU_OFFLOAD`` (set by
     ``tag_all_offloadable_activations``) and inserts:
       Forward:  cpu = ao.offload(gpu_tensor)
+                ... forward consumers use gpu_tensor ...
                 cpu = ao.wait_tensor(cpu, keepalive=gpu_tensor)
+                     (placed after last forward consumer; frees GPU storage)
       Backward: gpu = ao.reload(cpu, device)
                 gpu = ao.wait_tensor(gpu)
-    Then redirects backward consumers to use the reloaded tensor.
+                replayed_views = replay view chain from gpu
+    Then redirects backward consumers to use the reloaded/replayed tensors.
 
-    The reload device is inferred from the original tensor's device
-    (from ``node.meta["val"].device``) before offloading.
+    The forward ``ao.wait_tensor`` is placed after the last forward consumer
+    of the GPU tensor. This maximizes compute-transfer overlap (the D2H copy
+    runs on the transfer stream while forward compute continues) and frees
+    GPU storage as early as possible.
+
+    View replay: views share storage with the base tensor. We replay the
+    view ops from the reloaded tensor in backward and redirect backward
+    consumers to the replayed versions.
 
     Args:
         gm: The GraphModule containing the full fwd+bwd graph.
@@ -281,27 +407,54 @@ def apply_cpu_offload_pass(
     Returns:
         The transformed GraphModule with offload/reload ops inserted.
     """
-    # 1. Collect nodes tagged for offload, with their backward consumers
-    offloadable: list[tuple[Node, list[Node]]] = []
+    # 1. Collect nodes tagged for offload with their backward consumers
+    # (direct and through view chain)
+    offloadable: list[tuple[Node, list[Node], list[Node], list[Node]]] = []
     for node in gm.graph.nodes:
         if node.meta.get("recompute") is not CheckpointPolicy.MUST_CPU_OFFLOAD:
             continue
-        bwd_users = [u for u in node.users if _is_backward_node(u)]
-        if not bwd_users:
+        direct_bwd = [u for u in node.users if _is_backward_node(u)]
+        view_tree = _collect_view_tree(node)
+        all_bwd = list(direct_bwd)
+        for vn in view_tree:
+            all_bwd.extend(u for u in vn.users if _is_backward_node(u))
+        if not all_bwd:
             continue
-        offloadable.append((node, bwd_users))
+        offloadable.append((node, direct_bwd, view_tree, all_bwd))
 
     if not offloadable:
         return gm
 
-    # 2. Build position index for ordering queries (only used for pre-existing
-    # nodes; newly inserted nodes never appear in bwd_users).
+    # 2. Apply CPU memory budget: sort by size descending, accept until budget.
+    budget_bytes = cpu_budget_gb * (1024**3)
+    if budget_bytes > 0:
+        offloadable.sort(key=lambda t: _tensor_bytes(t[0].meta["val"]), reverse=True)
+        filtered = []
+        cumulative = 0
+        for entry in offloadable:
+            nbytes = _tensor_bytes(entry[0].meta["val"])
+            if cumulative + nbytes > budget_bytes:
+                continue
+            cumulative += nbytes
+            filtered.append(entry)
+        logger.info(
+            f"CPU offload budget: selected {len(filtered)}/{len(offloadable)} "
+            f"tensors ({cumulative / 1024**3:.2f} / {cpu_budget_gb:.1f} GB)"
+        )
+        offloadable = filtered
+
+    if not offloadable:
+        return gm
+
+    # 3. Build position index for ordering queries (only used for pre-existing
+    # nodes; newly inserted nodes never appear in all_bwd).
     node_to_index: dict[Node, int] = {n: i for i, n in enumerate(gm.graph.nodes)}
 
-    # 3. Insert offload/reload/wait_tensor ops
+    # 4. Insert offload/reload/wait_tensor + view replay
     total_bytes = 0
+    wait_offload_map: dict[Node, Node] = {}
 
-    for node, bwd_users in offloadable:
+    for node, direct_bwd, view_tree, all_bwd in offloadable:
         val = node.meta.get("val")
         assert (
             val is not None
@@ -317,7 +470,6 @@ def apply_cpu_offload_pass(
             )
             offload_node.meta["val"] = val.to(torch.device("cpu"))
 
-        # --- Forward: wait_tensor for D2H completion (initially after offload) ---
         with gm.graph.inserting_after(offload_node):
             wait_offload_node = gm.graph.call_function(
                 torch.ops.ao.wait_tensor.default,
@@ -325,8 +477,10 @@ def apply_cpu_offload_pass(
             )
             wait_offload_node.meta["val"] = offload_node.meta["val"]
 
-        # --- Backward: async CPU->GPU reload + wait before first consumer ---
-        first_consumer = min(bwd_users, key=lambda n: node_to_index[n])
+        wait_offload_map[node] = wait_offload_node
+
+        # --- Backward: async CPU->GPU reload before earliest consumer ---
+        first_consumer = min(all_bwd, key=lambda n: node_to_index[n])
 
         with gm.graph.inserting_before(first_consumer):
             reload_node = gm.graph.call_function(
@@ -335,6 +489,7 @@ def apply_cpu_offload_pass(
             )
             reload_node.meta["val"] = val
             reload_node.meta["autograd_backward"] = True
+            reload_node.meta["partitioner_tag"] = "must_be_in_backward"
 
         with gm.graph.inserting_before(first_consumer):
             wait_node = gm.graph.call_function(
@@ -343,16 +498,80 @@ def apply_cpu_offload_pass(
             )
             wait_node.meta["val"] = val
             wait_node.meta["autograd_backward"] = True
+            wait_node.meta["partitioner_tag"] = "must_be_in_backward"
 
-        # Redirect backward consumers to the reloaded tensor
-        for user in bwd_users:
+        # Redirect direct backward users to the reloaded tensor
+        for user in direct_bwd:
             user.replace_input_with(node, wait_node)
+
+        # Replay view tree in backward and redirect view backward users
+        replay_map: dict[Node, Node] = {node: wait_node}
+        insert_point = wait_node
+
+        for view_node in view_tree:
+            new_args = tuple(
+                replay_map.get(a, a) if isinstance(a, Node) else a
+                for a in view_node.args
+            )
+            with gm.graph.inserting_after(insert_point):
+                replay = gm.graph.call_function(
+                    view_node.target,
+                    args=new_args,
+                    kwargs=view_node.kwargs,
+                )
+                replay.meta["val"] = view_node.meta.get("val")
+                replay.meta["autograd_backward"] = True
+                replay.meta["partitioner_tag"] = "must_be_in_backward"
+
+            replay_map[view_node] = replay
+            insert_point = replay
+
+            view_bwd = [u for u in view_node.users if _is_backward_node(u)]
+            for user in view_bwd:
+                user.replace_input_with(view_node, replay)
 
         logger.debug(
             f"CPU offload: offloading {node.name} "
             f"({_tensor_bytes(val) / 1024:.1f} KB, {val.shape})"
         )
         total_bytes += _tensor_bytes(val)
+
+    # 4b. Move each forward wait to after the last forward consumer of
+    # its GPU tensor. This maximizes D2H/compute overlap and lets
+    # wait_tensor free GPU storage at the optimal point.
+    _AO_OPS = {
+        torch.ops.ao.offload.default,
+        torch.ops.ao.reload.default,
+        torch.ops.ao.wait_tensor.default,
+    }
+    node_positions: dict[Node, int] = {n: i for i, n in enumerate(gm.graph.nodes)}
+    repositioned = 0
+    for node, direct_bwd, view_tree, all_bwd in offloadable:
+        wait_node = wait_offload_map[node]
+        chain_nodes, has_bwd = _get_storage_chain(node)
+        real_consumers = {n for n in chain_nodes if n.target not in _AO_OPS}
+        if has_bwd or not real_consumers:
+            continue
+        last_consumer = max(real_consumers, key=lambda n: node_positions.get(n, 0))
+        # Find a tensor-valued node at or after last_consumer for the dep arg.
+        # Multi-output ops (e.g. attention) return tuples; use a getitem child.
+        dep_node = _find_tensor_dep(last_consumer, node_positions)
+        if dep_node is not None:
+            wait_node.args = (*wait_node.args[:2], dep_node)
+            # Place after dep_node (which may be a getitem child of last_consumer)
+            dep_node.append(wait_node)
+        else:
+            last_consumer.append(wait_node)
+        repositioned += 1
+
+    logger.info(
+        f"CPU offload: repositioned {repositioned} forward waits "
+        f"to after last consumer"
+    )
+
+    # 5. Per-group backward reload prefetch.
+    if prefetch_lookahead > 0:
+        prefetch_offloads(gm, prefetch_lookahead)
 
     gm.graph.lint()
     gm.recompile()
@@ -363,22 +582,113 @@ def apply_cpu_offload_pass(
     return gm
 
 
+def _get_reload_layer(reload_node: Node) -> int:
+    """Get the layer ID of an offloaded activation from the forward op chain.
+
+    Traces: ao.reload(fwd_wait) -> fwd_wait = ao.wait_tensor(offload, orig)
+    -> offload = ao.offload(orig) -> orig has module_fqn.
+    """
+    fwd_wait = reload_node.args[0] if reload_node.args else None
+    if not isinstance(fwd_wait, Node):
+        return _NOT_IN_LAYERS
+    offload = fwd_wait.args[0] if fwd_wait.args else None
+    if not isinstance(offload, Node):
+        return _NOT_IN_LAYERS
+    original = offload.args[0] if offload.args else None
+    if not isinstance(original, Node):
+        return _NOT_IN_LAYERS
+    return _get_layer_id(original)
+
+
+def prefetch_offloads(
+    gm: torch.fx.GraphModule,
+    n_layers: int,
+) -> None:
+    """Move ao.reload nodes N layers earlier in the backward for prefetching.
+
+    For each ao.reload serving layer L's backward, moves it to just before
+    layer (L + n_layers)'s first backward wait node. The corresponding
+    ao.wait_tensor stays in place, so synchronization still happens just
+    before the data is needed. This overlaps the H2D transfer with N layers
+    of backward compute.
+
+    Layer IDs are determined from the forward op chain (ao.reload ->
+    ao.wait_tensor -> ao.offload -> original forward node) rather than
+    backward node metadata, since backward nodes may not carry module_fqn
+    annotations in all tracing modes.
+    """
+    reload_info: list[tuple[Node, Node, int]] = []
+    for node in gm.graph.nodes:
+        if not (
+            node.op == "call_function"
+            and node.target == torch.ops.ao.reload.default
+            and _is_backward_node(node)
+        ):
+            continue
+        wait_node = next(
+            (u for u in node.users if u.target == torch.ops.ao.wait_tensor.default),
+            None,
+        )
+        if wait_node is None:
+            continue
+
+        layer_id = _get_reload_layer(node)
+        if layer_id != _NOT_IN_LAYERS:
+            reload_info.append((node, wait_node, layer_id))
+
+    if not reload_info:
+        return
+
+    node_to_idx: dict[Node, int] = {n: i for i, n in enumerate(gm.graph.nodes)}
+    reload_info.sort(key=lambda x: node_to_idx[x[1]])
+
+    layer_first_wait: dict[int, Node] = {}
+    for _reload, wait, lid in reload_info:
+        if lid not in layer_first_wait:
+            layer_first_wait[lid] = wait
+
+    max_layer = max(layer_first_wait.keys())
+
+    moved = 0
+    for reload_node, _wait_node, layer_id in reload_info:
+        target_layer = min(layer_id + n_layers, max_layer)
+        if target_layer == layer_id or target_layer not in layer_first_wait:
+            continue
+
+        layer_first_wait[target_layer].prepend(reload_node)
+        moved += 1
+
+    if moved > 0:
+        logger.info(
+            f"CPU offload prefetch: moved {moved} reloads " f"{n_layers} layer(s) ahead"
+        )
+
+
 def cpu_offload_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
+    *,
+    prefetch_n_layers: int = 1,
 ) -> torch.fx.GraphModule:
-    """Two-phase CPU offload pass: tag eligible activations, then insert ops.
-
-    This is the top-level entry point conforming to the graph pass signature.
-    It first tags eligible activations with ``tag_all_offloadable_activations``,
-    then inserts offload/reload/wait ops with ``apply_cpu_offload_pass``.
+    """Tag eligible activations and insert ao:: offload/reload/wait ops.
 
     Args:
         gm: The GraphModule containing the full fwd+bwd graph.
         example_inputs: Example inputs (unused, required by pass interface).
+        prefetch_n_layers: Move ao.reload nodes this many layers earlier in
+            the backward graph to overlap H2D with compute.
 
     Returns:
         The transformed GraphModule with offload/reload ops inserted.
     """
     tag_all_offloadable_activations(gm)
-    return apply_cpu_offload_pass(gm, example_inputs)
+
+    cpu_mem_budget = float(os.environ.get("OFFLOAD_CPU_MEMORY_BUDGET_GB", "100"))
+    apply_cpu_offload_pass(
+        gm,
+        example_inputs,
+        prefetch_lookahead=prefetch_n_layers,
+        cpu_budget_gb=cpu_mem_budget,
+    )
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -4,28 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
 from torchtitan.models.deepseek_v3.parallelize import apply_moe_ep_tp
-from torchtitan.tools.logging import logger
 
 
 def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
@@ -98,68 +94,10 @@ def parallelize_deepseekv3(
             enable_sp=parallelism.enable_sequence_parallel,
         )
 
-    mp_policy = MixedPrecisionPolicy(
-        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-    )
-
-    # apply data parallel
-    dp_mesh: DeviceMesh | None = None
-    if (
-        parallel_dims.fsdp_enabled
-        or parallel_dims.ep_enabled
-        or parallel_dims.dp_replicate_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
-
-        # the mesh dim names of which the MoE params are sharded on via FSDP/HSDP
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
-
-        for _, transformer_block in model.layers.items():
-            if transformer_block.moe_enabled and parallel_dims.ep_enabled:
-                experts_shard_dim = 0
-                assert edp_mesh is not None
-                assert hasattr(transformer_block, "moe")
-                if (
-                    edp_mesh["efsdp"].size() * parallel_dims.ep
-                    > transformer_block.moe.experts.num_experts
-                ):
-                    experts_shard_dim = 1
-
-                transformer_block.moe.experts = data_parallel(
-                    transformer_block.moe.experts,
-                    edp_mesh,
-                    dp_mode,
-                    mp_policy=mp_policy,
-                    shard_dim=experts_shard_dim,
-                )
-
-        model = data_parallel(
-            model,
-            dp_mesh,
-            dp_mode,
-            mp_policy=mp_policy,
-        )
-
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -549,7 +549,13 @@ def get_joint_custom_passes_from_config(
                 f"Available joint passes: {list(AVAILABLE_JOINT_PASSES.keys())}"
             )
 
-        joint_custom_passes.append(AVAILABLE_JOINT_PASSES[pass_name])
+        pass_fn = AVAILABLE_JOINT_PASSES[pass_name]
+
+        if pass_name == "cpu_offload":
+            prefetch_n = getattr(compile_config, "cpu_offload_prefetch_n_layers", 1)
+            pass_fn = functools.partial(pass_fn, prefetch_n_layers=prefetch_n)
+
+        joint_custom_passes.append(pass_fn)
 
     if joint_pass_names:
         logger.info(f"Using joint passes from config: {joint_pass_names}")

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -8,18 +8,15 @@ from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.llama3.model import GraphTrainerLlama3Model
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
-from torchtitan.tools.logging import logger
 
 
 def annotate_llama(model: GraphTrainerLlama3Model) -> None:
@@ -62,37 +59,10 @@ def parallelize_llama(
         tp_mesh = parallel_dims.get_mesh("tp")
         model.parallelize(tp_mesh)
 
-    # apply data parallel
-    if (
-        parallel_dims.dp_replicate_enabled
-        or parallel_dims.dp_shard_enabled
-        or parallel_dims.cp_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        mp_policy = MixedPrecisionPolicy(
-            param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-            reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-        )
-
-        model = data_parallel(
-            model,
-            parallel_dims.get_mesh(dp_mesh_dim_names),
-            mode=dp_mode,
-            mp_policy=mp_policy,
-        )
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -146,6 +146,7 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
+    compile_config = config.compile
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
@@ -155,9 +156,12 @@ def compile_time_passes(
             tag_with_memory_policy_pass,
             config=config,
         ),
-        # TODO: currently either SAC or CPU offload is used, not both at the
-        # same time. Composability between these two passes is untested.
-        apply_cpu_offload_pass,
+        # apply_cpu_offload_pass is a no-op unless tag_with_memory_policy_pass
+        # tagged nodes with MUST_CPU_OFFLOAD (via memory_policy="cpu_offload_all").
+        functools.partial(
+            apply_cpu_offload_pass,
+            prefetch_lookahead=compile_config.cpu_offload_prefetch_n_layers,
+        ),
         selective_activation_remat_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
@@ -167,12 +171,8 @@ def compile_time_passes(
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
-    inductor_compilation = config.compile.inductor_compilation
+    inductor_compilation = compile_config.inductor_compilation
     if inductor_compilation == "full":
-        # Compile the entire graph into optimized Triton kernels. Must
-        # be terminal — the FX graph is no longer authoritative after
-        # this pass, so custom_codegen_pass and
-        # insert_kernel_annotations_pass cannot follow.
         passes.append(full_inductor_compilation_pass)
     if inductor_compilation == "regional":
         # FlexAttention HOPs must be compiled (via regional_inductor) to

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -4,26 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
     ParallelismConfig,
-    TORCH_DTYPE_MAP,
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
-from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
 from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
-from torchtitan.experiments.graph_trainer.simple_fsdp import (
-    data_parallel,
-    MixedPrecisionPolicy,
-)
 from torchtitan.models.llama4.parallelize import apply_moe_ep_tp
-from torchtitan.tools.logging import logger
 
 
 def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
@@ -93,68 +89,10 @@ def parallelize_qwen3(
             enable_sp=parallelism.enable_sequence_parallel,
         )
 
-    mp_policy = MixedPrecisionPolicy(
-        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
-        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
-    )
-
-    # apply data parallel
-    dp_mesh: DeviceMesh | None = None
-    if (
-        parallel_dims.fsdp_enabled
-        or parallel_dims.ep_enabled
-        or parallel_dims.dp_replicate_enabled
-    ):
-        if parallel_dims.dp_replicate_enabled:
-            if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-                dp_mesh_dim_names = ["dp_replicate", "fsdp"]
-                dp_mode = "hybrid_shard"
-            else:
-                dp_mesh_dim_names = ["dp_replicate"]
-                dp_mode = "replicate"
-        else:
-            dp_mesh_dim_names = ["fsdp"]
-            dp_mode = "fully_shard"
-
-        dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
-
-        # the mesh dim names of which the MoE params are sharded on via FSDP/HSDP
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
-
-        for _, transformer_block in model.layers.items():
-            if transformer_block.moe_enabled and parallel_dims.ep_enabled:
-                experts_shard_dim = 0
-                assert edp_mesh is not None
-                assert hasattr(transformer_block, "moe")
-                if (
-                    edp_mesh["efsdp"].size() * parallel_dims.ep
-                    > transformer_block.moe.experts.num_experts
-                ):
-                    experts_shard_dim = 1
-
-                transformer_block.moe.experts = data_parallel(
-                    transformer_block.moe.experts,
-                    edp_mesh,
-                    dp_mode,
-                    mp_policy=mp_policy,
-                    shard_dim=experts_shard_dim,
-                )
-
-        model = data_parallel(
-            model,
-            dp_mesh,
-            dp_mode,
-            mp_policy=mp_policy,
-        )
-
-        logger.info(
-            "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode
-        )
+    # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
+    # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
+    # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
@@ -302,6 +302,258 @@ class TestCpuOffloadPass(TestCase):
         ]
         self.assertEqual(len(tagged), 0, "Small tensors should not be tagged")
 
+    def test_prefetch_moves_reloads_earlier(self):
+        """Prefetch should move ao.reload N layers earlier in backward."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            _get_reload_layer,
+            apply_cpu_offload_pass,
+            prefetch_offloads,
+            tag_all_offloadable_activations,
+        )
+
+        gm, fwd_nodes, bwd_nodes = self._build_joint_graph(num_layers=4)
+        tag_all_offloadable_activations(gm)
+        apply_cpu_offload_pass(gm, prefetch_lookahead=0)
+
+        # Record pre-prefetch reload positions
+        nodes_before = list(gm.graph.nodes)
+        reload_positions_before = {
+            n: nodes_before.index(n)
+            for n in nodes_before
+            if n.op == "call_function" and n.target is torch.ops.ao.reload.default
+        }
+        self.assertGreater(len(reload_positions_before), 0)
+
+        prefetch_offloads(gm, n_layers=1)
+
+        nodes = list(gm.graph.nodes)
+        moved_count = 0
+        for node in nodes:
+            if not (
+                node.op == "call_function"
+                and node.target is torch.ops.ao.reload.default
+            ):
+                continue
+            wait_node = next(
+                u for u in node.users if u.target is torch.ops.ao.wait_tensor.default
+            )
+            # Reload must always precede its wait
+            self.assertLess(nodes.index(node), nodes.index(wait_node))
+
+            # Check that moved reloads are now earlier than before
+            layer_id = _get_reload_layer(node)
+            if node in reload_positions_before:
+                new_pos = nodes.index(node)
+                old_pos = reload_positions_before[node]
+                if new_pos < old_pos:
+                    moved_count += 1
+
+        self.assertGreater(moved_count, 0, "Expected at least one reload to be moved")
+
+    def test_prefetch_noop_without_offloads(self):
+        """Prefetch should be a no-op when no offload ops exist."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import prefetch_offloads
+
+        gm, _, _ = self._build_joint_graph(num_layers=3)
+        nodes_before = len(list(gm.graph.nodes))
+        prefetch_offloads(gm, n_layers=1)
+        nodes_after = len(list(gm.graph.nodes))
+        self.assertEqual(nodes_before, nodes_after)
+
+    def test_prefetch_via_cpu_offload_pass(self):
+        """cpu_offload_pass with prefetch_n_layers should insert and move reloads."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import cpu_offload_pass
+
+        def _reload_positions(graph_module):
+            nodes = list(graph_module.graph.nodes)
+            return [
+                nodes.index(n)
+                for n in nodes
+                if n.op == "call_function" and n.target is torch.ops.ao.reload.default
+            ]
+
+        gm_no_prefetch, _, _ = self._build_joint_graph(num_layers=4)
+        gm_no_prefetch = cpu_offload_pass(gm_no_prefetch, prefetch_n_layers=0)
+        pos_no_prefetch = _reload_positions(gm_no_prefetch)
+
+        gm_prefetch, _, _ = self._build_joint_graph(num_layers=4)
+        gm_prefetch = cpu_offload_pass(gm_prefetch, prefetch_n_layers=1)
+        pos_prefetch = _reload_positions(gm_prefetch)
+
+        self.assertGreater(len(pos_prefetch), 0)
+        self.assertEqual(len(pos_no_prefetch), len(pos_prefetch))
+        # With prefetch, reloads should be earlier in the graph
+        earlier_count = sum(1 for a, b in zip(pos_prefetch, pos_no_prefetch) if a < b)
+        self.assertGreater(
+            earlier_count,
+            0,
+            "prefetch_n_layers=1 should move reloads earlier than prefetch_n_layers=0",
+        )
+
+    def test_prefetch_n_layers_2(self):
+        """n_layers=2 should move reloads further than n_layers=1."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import cpu_offload_pass
+
+        def _reload_positions(graph_module):
+            nodes = list(graph_module.graph.nodes)
+            return [
+                nodes.index(n)
+                for n in nodes
+                if n.op == "call_function" and n.target is torch.ops.ao.reload.default
+            ]
+
+        gm1, _, _ = self._build_joint_graph(num_layers=5)
+        gm1 = cpu_offload_pass(gm1, prefetch_n_layers=1)
+        pos_1 = _reload_positions(gm1)
+
+        gm2, _, _ = self._build_joint_graph(num_layers=5)
+        gm2 = cpu_offload_pass(gm2, prefetch_n_layers=2)
+        pos_2 = _reload_positions(gm2)
+
+        self.assertEqual(len(pos_1), len(pos_2))
+        # n_layers=2 should move at least some reloads further than n_layers=1
+        further_count = sum(1 for a, b in zip(pos_2, pos_1) if a < b)
+        self.assertGreater(
+            further_count,
+            0,
+            "prefetch_n_layers=2 should move reloads further than n_layers=1",
+        )
+
+    def test_wait_after_last_forward_consumer(self):
+        """Forward waits should be placed after the last forward consumer."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            _is_backward_node,
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        gm, _, _ = self._build_joint_graph(num_layers=4)
+        tag_all_offloadable_activations(gm)
+        apply_cpu_offload_pass(gm, prefetch_lookahead=0)
+
+        nodes = list(gm.graph.nodes)
+        node_pos = {n: i for i, n in enumerate(nodes)}
+
+        for node in nodes:
+            if not (
+                node.op == "call_function"
+                and node.target is torch.ops.ao.wait_tensor.default
+                and not node.meta.get("autograd_backward")
+            ):
+                continue
+            # Forward wait has keepalive=gpu_tensor as second arg
+            gpu_tensor = node.args[1] if len(node.args) > 1 else None
+            if gpu_tensor is None:
+                continue
+            # All non-ao forward consumers of gpu_tensor should precede wait
+            wait_pos = node_pos[node]
+            ao_ops = {
+                torch.ops.ao.offload.default,
+                torch.ops.ao.reload.default,
+                torch.ops.ao.wait_tensor.default,
+            }
+            for user in gpu_tensor.users:
+                if user.op != "call_function":
+                    continue
+                if _is_backward_node(user) or user.target in ao_ops:
+                    continue
+                self.assertLess(
+                    node_pos[user],
+                    wait_pos,
+                    f"Forward consumer {user.name} at pos {node_pos[user]} "
+                    f"should precede wait at pos {wait_pos}",
+                )
+
+    def test_view_replay_in_backward(self):
+        """View replay: base tensor with view-chain backward users gets offloaded."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        # Forward layer 0: mm -> view -> relu
+        # bwd uses view (not mm directly), so mm only has view-chain backward users
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = self._make_fake_val()
+
+        view = graph.call_function(torch.ops.aten.view.default, args=(mm, [64, 64]))
+        view.meta["autograd_backward"] = False
+        view.meta["custom"] = {"module_fqn": "layers.0.block"}
+        view.meta["val"] = self._make_fake_val()
+
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(view,))
+        relu.meta["autograd_backward"] = False
+        relu.meta["custom"] = {"module_fqn": "layers.0.block"}
+        relu.meta["val"] = self._make_fake_val()
+
+        # Forward layer 1
+        mm2 = graph.call_function(torch.ops.aten.mm.default, args=(relu, relu))
+        mm2.meta["autograd_backward"] = False
+        mm2.meta["custom"] = {"module_fqn": "layers.1.block"}
+        mm2.meta["val"] = self._make_fake_val()
+
+        # Backward: uses view output (NOT mm directly)
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(mm2, view))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
+        bwd.meta["val"] = self._make_fake_val()
+
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+
+        tagged = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("recompute") is CheckpointPolicy.MUST_CPU_OFFLOAD
+        ]
+        self.assertGreater(
+            len(tagged), 0, "mm should be tagged via view chain backward users"
+        )
+
+        gm = apply_cpu_offload_pass(gm)
+
+        offload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.offload.default
+        ]
+        self.assertGreater(len(offload_ops), 0, "Expected offload ops")
+
+        # Verify replayed view exists in backward
+        view_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.aten.view.default
+        ]
+        self.assertEqual(len(view_ops), 2, "Expected original + replayed view op")
+        replayed = [v for v in view_ops if v.meta.get("autograd_backward")]
+        self.assertEqual(len(replayed), 1, "Expected one replayed view in backward")
+
+        # Backward consumer should reference the replayed view, not the original
+        bwd_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.meta.get("autograd_backward") and n.target is torch.ops.aten.mm.default
+        ]
+        for b in bwd_nodes:
+            for arg in b.args:
+                if (
+                    isinstance(arg, torch.fx.Node)
+                    and arg.target is torch.ops.aten.view.default
+                ):
+                    self.assertTrue(
+                        arg.meta.get("autograd_backward"),
+                        "Backward consumer should use replayed view",
+                    )
+
     def test_single_layer_tagged(self):
         """With only one layer, nodes are still tagged (last-layer skip only applies with multiple layers)."""
         from torchtitan.experiments.graph_trainer.cpu_offload import (

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from torchtitan.config.configs import TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+
+
+class TestApplySimpleFSDPSingleRank(unittest.TestCase):
+    """Verify simple_fsdp's MixedPrecisionPolicy actually casts params at NGPU=1."""
+
+    def setUp(self):
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method="tcp://localhost:12358",
+                world_size=1,
+                rank=0,
+            )
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
+    def test_param_cast_to_bf16_at_ngpu_1(self):
+        """With ``mixed_precision_param=bfloat16``, the parametrized weight must
+        yield bf16 — and a forward must run in bf16 — even when fsdp /
+        dp_replicate / ep are all disabled. Without the unconditional
+        simple_fsdp wrap, parameters silently stay in fp32 on a single GPU and
+        any downstream bf16-only kernel (e.g. MXFP8) breaks.
+        """
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            etp=1,
+            world_size=1,
+        )
+        training = TrainingConfig(
+            mixed_precision_param="bfloat16",
+            mixed_precision_reduce="float32",
+        )
+
+        model = nn.Linear(8, 8)
+        self.assertEqual(model.weight.dtype, torch.float32)
+
+        model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+
+        # Parametrization replaces ``weight`` access with a bf16 cast via
+        # ``redistribute(forward_dtype=...)``.
+        self.assertEqual(model.weight.dtype, torch.bfloat16)
+
+        # Underlying storage stays in fp32 (the cast is applied per forward),
+        # confirming this is true mixed precision rather than a one-shot
+        # downcast that would lose master-weight precision.
+        self.assertEqual(model._parameters["weight"].dtype, torch.float32)
+
+        # End-to-end: forward against the parametrized weight produces bf16
+        # activations.
+        x = torch.randn(2, 8, dtype=torch.bfloat16)
+        y = model(x)
+        self.assertEqual(y.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3168

The main trainer applies fully_shard unconditionally so
MixedPrecisionPolicy's param_dtype cast runs even at degree 1 — the
`fsdp` mesh is deliberately kept with a real backend for this
(ParallelDims._mesh_exist). graph_trainer's llama3/deepseek_v3/qwen3
parallelize fns instead gated simple_fsdp on fsdp/ep/dp_replicate being
enabled, so on a single GPU parameters stayed in fp32 and any bf16-only
kernel downstream (e.g. MXFP8) failed.

Drop the guard and consolidate the three near-identical data_parallel
blocks into apply_simple_fsdp in common_utils. MoE experts handling
folds in via ep_enabled + moe_enabled checks (no-op for dense models).

Adds tests/test_simple_fsdp.py asserting the bf16 param cast at NGPU=1:
the parametrized weight access yields bf16 while the underlying storage
stays fp32, and a forward pass produces bf16 activations. Verified the
test fails when the gating is reintroduced inside apply_simple_fsdp.