### PR TITLE
[GraphTrainer] Remove SAC peak-memory test from H100 CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -69,8 +69,7 @@ jobs:
         # Run precompile integration tests (DSv3 with EP; Llama3 runs in default workflow)
         NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile --ngpu 8 --test_name aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
 
-        # Run bitwise deterministic and SAC peak-memory guardrail tests
+        # Run bitwise deterministic
         pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v
-        pytest torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py -v
 
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint


### PR DESCRIPTION
## Summary
- Remove `test_sac_peak_memory.py` from the H100 graph_trainer integration test workflow since the test file doesn't need H100. The test is already run in A100.  

## Test plan
- [x] Verify H100 CI workflow passes without the removed test