### PR TITLE
varlen window size configurable

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -74,10 +74,21 @@ AttentionMasksType = dict[str, BlockMask] | BlockMask | VarlenMetadata
 class VarlenAttention(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
-        pass
+        window_size: tuple[int, int] = (-1, 0)
+        """ window_size=(left, right) controls the attention window relative to each
+            query position. 'left' is how many tokens before the query to attend to,
+            and 'right' is how many tokens after. A value of -1 means unlimited.
+
+              - (-1, 0): Causal attention - each token attends to all previous tokens
+                         and itself, but no future tokens. Equivalent to is_causal=True.
+              - (-1, -1): Full bidirectional attention (no masking). Equivalent to
+                          is_causal=False.
+              - (W, 0): Sliding window causal - attend to at most W previous tokens.
+        """
 
     def __init__(self, config: Config) -> None:
         super().__init__()
+        self.window_size = config.window_size
 
         from torchtitan.tools.utils import has_cuda_capability
 
@@ -141,17 +152,7 @@ class VarlenAttention(Module):
             max_q,
             max_k,
             scale=scale,
-            # window_size=(left, right) controls the attention window relative to each
-            # query position. 'left' is how many tokens before the query to attend to,
-            # and 'right' is how many tokens after. A value of -1 means unlimited.
-            #
-            # This replaces the is_causal flag:
-            #   - (-1, 0): Causal attention - each token attends to all previous tokens
-            #              and itself, but no future tokens. Equivalent to is_causal=True.
-            #   - (-1, -1): Full bidirectional attention (no masking). Equivalent to
-            #               is_causal=False.
-            #   - (W, 0): Sliding window causal - attend to at most W previous tokens.
-            window_size=(-1, 0),
+            window_size=self.window_size,
             **varlen_kwargs,  # pyrefly: ignore [bad-argument-type]
         )
         assert isinstance(out_packed, torch.Tensor)


### PR DESCRIPTION
Hi everyone!

We’re exploring sliding window attention and noticed that with the varlen backend, window_size is currently fixed to (-1, 0), i.e. full attention https://github.com/pytorch/torchtitan/blob/35c5d52963c47a6cdd1e966412285e0fb87d23c7/torchtitan/models/common/attention.py#L135-L156

My understanding is that this was done to keep a consistent forward interface across backends. That said, it does feel a bit limiting to hardcode this parameter.

This PR introduces an option in the varlen config class so that window_size can be adjusted without modifying the forward interface.

https://github.com/pytorch/torchtitan/blob/35c5d52963c47a6cdd1e966412285e0fb87d23c7/torchtitan/models/common/attention.py#L74-L77

What do you think?