### PR TITLE
[GraphTrainer] Add Qwen3 MoE bitwise deterministic tests

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -72,8 +72,8 @@ subclassing.
 ### Local development (debug models, 8 GPUs)
 
 **Run all commands from the repo root.** Use the root `./run_train.sh` with
-`MODULE=graph_trainer.llama3` (or `.deepseek_v3`). The 8B/16B configs use
-`hf_assets_path` relative to the repo root.
+`MODULE=graph_trainer.llama3` (or `.deepseek_v3`, `.qwen3`). The 8B/16B configs
+use `hf_assets_path` relative to the repo root.
 
 For CooR precompile workflows that need `--virtual-local-rank`, use
 `torchtitan/experiments/graph_trainer/run_train_precompile.sh` instead.

--- a/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
@@ -11,6 +11,7 @@ from torchtitan.experiments.graph_trainer.configs import (
 )
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.models.qwen3.config_registry import (
+    qwen3_14b,
     qwen3_debugmodel,
     qwen3_debugmodel_flex,
     qwen3_moe_debug,
@@ -41,6 +42,12 @@ def graph_trainer_qwen3_debugmodel_moe() -> GraphTrainer.Config:
 
 def graph_trainer_qwen3_debugmodel_moe_ep() -> GraphTrainer.Config:
     config = to_graph_trainer_config(qwen3_moe_debug_ep(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_qwen3_14b() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(qwen3_14b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -7,7 +7,7 @@
 """Bitwise deterministic guardrail for graph_trainer.
 
 Tests that Trainer (eager) and GraphTrainer (aot_fx_trace) produce bitwise
-identical losses and gradients on Llama3 and DeepSeek-v3 debug models.
+identical losses and gradients on Llama3, DeepSeek-v3, and Qwen3 debug models.
 
 Requires a CUDA GPU. Run with:
     pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x
@@ -37,6 +37,10 @@ from torchtitan.experiments.graph_trainer.llama3 import (
     model_registry as llama3_model_registry,
 )
 from torchtitan.experiments.graph_trainer.llama3.parallelize import annotate_llama
+from torchtitan.experiments.graph_trainer.qwen3 import (
+    model_registry as qwen3_model_registry,
+)
+from torchtitan.experiments.graph_trainer.qwen3.parallelize import annotate_qwen3
 from torchtitan.experiments.graph_trainer.tests._trainer_test_utils import (
     build_minimal_trainer,
 )
@@ -450,6 +454,98 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "OOMs during flex_attention compilation on A100"
     )
+    def test_aot_fx_trace_vs_eager(self):
+        """aot_fx_trace with passes and eager produce bitwise identical results."""
+        run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)
+        run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
+        self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
+
+    # TODO: numerics mismatch between precompile and trace with FlexAttention
+    @unittest.skip("FlexAttention precompile numerics mismatch — under investigation")
+    def test_precompile_vs_trace(self):
+        """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
+        run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
+        run_precompile = self._run_steps_with_precompile(copy.deepcopy(self.model))
+
+        self._assert_runs_match(run_traced, run_precompile, "trace vs precompile: ")
+
+
+class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
+    """Bitwise determinism tests for Qwen3 MoE debug model."""
+
+    model_registry = staticmethod(qwen3_model_registry)
+    model_flavor = "debugmodel_moe"
+    annotate_model = staticmethod(annotate_qwen3)
+
+    @unittest.skipUnless(
+        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
+    )
+    def test_eager_self_deterministic(self):
+        """Eager mode: results match hardcoded expected values.
+
+        Run `EXPECTTEST_ACCEPT=1 pytest <this_file> ` to update the inline expected values.
+        """
+        loss, model_hash, grad_hash = self._run_steps(
+            copy.deepcopy(self.model), Trainer
+        )
+        assert_expected_inline(str(loss.item()), """7.297995567321777""")
+        assert_expected_inline(
+            model_hash,
+            """81697f98f47d153b64d35719b42f7d2de6d1e7436a1c1c3cf79415aef3b8e2de""",
+        )
+        assert_expected_inline(
+            grad_hash,
+            """bb6d6fb73d9796843ce78d40966ed78a1479fbc8e26dc824e4e1dd77b7cbfaa5""",
+        )
+
+    def test_aot_fx_trace_vs_eager(self):
+        """aot_fx_trace and eager produce bitwise identical losses and grads."""
+        run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)
+        run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
+
+        self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
+
+    def test_precompile_vs_trace(self):
+        """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
+        run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
+        run_precompile = self._run_steps_with_precompile(copy.deepcopy(self.model))
+
+        self._assert_runs_match(run_traced, run_precompile, "trace vs precompile: ")
+
+
+class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
+    """Bitwise determinism tests for Qwen3 MoE with FlexAttention.
+
+    aot_fx_trace compiles FlexAttention HOPs via regional_inductor into fused
+    Triton kernels and produces bitwise identical results to eager.
+    """
+
+    model_registry = staticmethod(qwen3_model_registry)
+    model_flavor = "debugmodel_moe"
+    attn_backend = "flex"
+    annotate_model = staticmethod(annotate_qwen3)
+
+    @unittest.skipUnless(
+        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
+    )
+    def test_eager_self_deterministic(self):
+        """Eager results match hardcoded expected values.
+
+        Run `EXPECTTEST_ACCEPT=1 pytest <this_file>` to update the inline expected values.
+        """
+        loss, model_hash, grad_hash = self._run_steps(
+            copy.deepcopy(self.model), Trainer
+        )
+        assert_expected_inline(str(loss.item()), """7.297987461090088""")
+        assert_expected_inline(
+            model_hash,
+            """4d79b03cf9eaee53df27befad54d3db9177f2127a658e0c8140a02565926ea50""",
+        )
+        assert_expected_inline(
+            grad_hash,
+            """cf4a8c8a0f1ce6ae836fc6a01f608e4d21821abf1f7e4804ec7da3c6f803d1af""",
+        )
+
     def test_aot_fx_trace_vs_eager(self):
         """aot_fx_trace with passes and eager produce bitwise identical results."""
         run_eager = self._run_steps(copy.deepcopy(self.model), Trainer)


### PR DESCRIPTION
## Summary
- Add Qwen3 MoE (SDPA + FlexAttention) to the bitwise deterministic test suite, covering eager-vs-trace, precompile-vs-trace, and hardcoded-hash self-determinism tests.
- Add `graph_trainer_qwen3_14b` config for benchmarking and update CLAUDE.md with Qwen3 examples (local dev, benchmark).

## Test plan
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x -k "Qwen3"` — all 5 pass, 1 skipped (known FlexAttention precompile issue)
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v -k "not eager_self_deterministic"` — all 9 pass (no regressions on Llama3/DSv3)
- [x] Smoke-tested `graph_trainer_qwen3_14b` with 8×H100 FSDP+TP aot_fx_trace (14.8B params, 72GiB memory)