### PR TITLE
Observability: structured logging + training instrumentation (#3176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ We look forward to your contributions!
 15. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
 16. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
 17. All options easily configured via [Python config registry](torchtitan/models/llama3/config_registry.py) with `--module` and `--config` CLI flags
-18. [Helper scripts](scripts/) to
+18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
+19. [Helper scripts](scripts/) to
     - download tokenizers from Hugging Face
     - convert original Llama 3 checkpoints into the expected DCP format
     - estimate FSDP/HSDP memory usage without materializing the model

--- a/tests/unit_tests/observability/__init__.py
+++ b/tests/unit_tests/observability/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/unit_tests/observability/test_structured_logging.py
+++ b/tests/unit_tests/observability/test_structured_logging.py
@@ -1,0 +1,1553 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for torchtitan.observability.structured_logger."""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from unittest import mock
+
+import pytest
+from torchtitan.observability.structured_logger import step_state
+from torchtitan.observability.structured_logger.gantt_generator import (
+    generate_gantt_trace,
+)
+from torchtitan.observability.structured_logger.jsonl_handler import (
+    MAX_MESSAGE_SIZE,
+    register_jsonl_handler,
+    TraceJsonlFormatter,
+    TraceJsonlHandler,
+)
+from torchtitan.observability.structured_logger.step_state import (
+    add_step_tag,
+    clear_step_tags,
+    get_relative_step,
+    get_step,
+    get_step_tags,
+    set_step,
+)
+from torchtitan.observability.structured_logger.structured_logging import (
+    _structured_logger,
+    event_extra,
+    ExtraFields,
+    init_structured_logger,
+    log_trace_instant,
+    log_trace_scalar,
+    log_trace_span,
+    LogType,
+    TraceEventsOnlyFilter,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_context():
+    """Reset step state before each test."""
+    step_state._STEP_GLOBAL = None
+    step_state._STEP_CV.set(None)
+    step_state._RELATIVE_STEP_GLOBAL = None
+    step_state._RELATIVE_STEP_CV.set(None)
+    step_state._TAGS_GLOBAL = ()
+    step_state._TAGS_CV.set(())
+    yield
+    step_state._STEP_GLOBAL = None
+    step_state._STEP_CV.set(None)
+    step_state._RELATIVE_STEP_GLOBAL = None
+    step_state._RELATIVE_STEP_CV.set(None)
+    step_state._TAGS_GLOBAL = ()
+    step_state._TAGS_CV.set(())
+
+
+@pytest.fixture
+def structured_logger_fixture():
+    """Provide a clean structured logger for testing."""
+    import torchtitan.observability.structured_logger.structured_logging as sl_mod
+
+    tl = _structured_logger
+    orig = (tl.handlers[:], tl.level, tl.propagate)
+    # Reset the module-level init sentinel so init_structured_logger re-runs
+    # for each test (otherwise the second call short-circuits as "already
+    # initialized").
+    sl_mod._is_initialized = False
+    yield tl
+    tl.handlers, tl.level, tl.propagate = orig
+    sl_mod._is_initialized = False
+
+
+# ---------------------------------------------------------------------------
+# Step context tests (hybrid ContextVar)
+# ---------------------------------------------------------------------------
+
+
+class TestSetStep:
+    def test_set_step_stores_value(self):
+        set_step(42)
+        assert get_step() == 42
+
+    def test_set_step_overwrites(self):
+        set_step(1)
+        set_step(2)
+        assert get_step() == 2
+
+    def test_step_default_is_none(self):
+        assert get_step() is None
+
+    def test_set_step_writes_to_both_global_and_cv(self):
+        set_step(10)
+        assert step_state._STEP_GLOBAL == 10
+        assert step_state._STEP_CV.get() == 10
+
+    def test_get_step_prefers_cv(self):
+        """ContextVar takes priority over global."""
+        step_state._STEP_GLOBAL = 1
+        step_state._STEP_CV.set(2)
+        assert get_step() == 2
+
+    def test_get_step_falls_back_to_global(self):
+        """If CV is None, falls back to global."""
+        step_state._STEP_GLOBAL = 5
+        step_state._STEP_CV.set(None)
+        assert get_step() == 5
+
+
+class TestStepTags:
+    def test_add_step_tag_adds_tag(self):
+        set_step(1)
+        add_step_tag("gc")
+        assert get_step_tags() == ("gc",)
+
+    def test_add_step_tag_deduplicates(self):
+        add_step_tag("gc")
+        add_step_tag("gc")
+        assert get_step_tags() == ("gc",)
+
+    def test_add_step_tag_multiple_tags(self):
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        add_step_tag("checkpoint")
+        assert get_step_tags() == ("gc", "profiling", "checkpoint")
+
+    def test_clear_step_tags_clears_all(self):
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        clear_step_tags()
+        assert get_step_tags() == ()
+
+    def test_step_tags_are_tuples(self):
+        """Step tags are tuples (immutable) to avoid shared-reference issues."""
+        add_step_tag("a")
+        tags = get_step_tags()
+        assert isinstance(tags, tuple)
+
+    def test_set_step_clears_tags(self):
+        add_step_tag("gc")
+        set_step(2)
+        assert get_step_tags() == ()
+
+    def test_add_step_tag_spmd_writes_global_only(self):
+        # SPMD path: no asyncio task context. add_step_tag should write to
+        # _TAGS_GLOBAL; _TAGS_CV stays at default (empty tuple).
+        add_step_tag("gc")
+        add_step_tag("checkpoint")
+        assert step_state._TAGS_GLOBAL == ("gc", "checkpoint")
+        assert step_state._TAGS_CV.get() == ()
+        assert get_step_tags() == ("gc", "checkpoint")  # falls back to global
+
+    def test_get_step_tags_reader_prefers_cv_over_global(self):
+        # Invariant: the reader checks CV first (if non-empty) and falls
+        # back to the global. Pins the contract so changing it would flip
+        # which tag set async-task spans observe.
+        step_state._TAGS_GLOBAL = ("gc",)
+        step_state._TAGS_CV.set(("eval",))
+        assert get_step_tags() == ("eval",)
+
+    def test_add_step_tag_concurrent_async_tasks_are_isolated(self):
+        # Async RL scenario: two actor tasks on the same process add
+        # DIFFERENT tags for the same step. Each task's CV must be scoped;
+        # neither should see the other's tag via the shared global. Also
+        # verifies the exclusive-store semantic: a pre-existing global tag
+        # is NOT visible inside the async tasks (actor contexts are
+        # intentionally isolated; global tags don't bleed in).
+        import asyncio
+
+        # SPMD-side write before any async loop runs → goes to global.
+        add_step_tag("pre_async_global_tag")
+        assert step_state._TAGS_GLOBAL == ("pre_async_global_tag",)
+
+        async def actor_gc():
+            await asyncio.sleep(0.01)
+            add_step_tag("gc")
+            return get_step_tags()
+
+        async def actor_eval():
+            await asyncio.sleep(0.02)  # runs after actor_gc's write
+            add_step_tag("eval")
+            return get_step_tags()
+
+        async def run():
+            return await asyncio.gather(actor_gc(), actor_eval())
+
+        gc_view, eval_view = asyncio.run(run())
+        # Each actor sees ONLY its own tag -- no "gc" leak into actor_eval,
+        # and (importantly) no "pre_async_global_tag" leak from global.
+        assert gc_view == ("gc",), f"actor_gc saw {gc_view!r}, expected ('gc',)"
+        assert eval_view == ("eval",), (
+            f"actor_eval saw {eval_view!r}, expected ('eval',) "
+            f"-- if 'gc' leaked in, add_step_tag is not task-isolated"
+        )
+        # Global is untouched by the tasks' writes.
+        assert step_state._TAGS_GLOBAL == ("pre_async_global_tag",)
+
+    def test_clear_step_tags_resets_both_stores(self):
+        # clear_step_tags is called by set_step, so the SPMD happy path
+        # cycles tags correctly between steps. Verify it also works when
+        # both stores have content.
+        step_state._TAGS_GLOBAL = ("gc",)
+        step_state._TAGS_CV.set(("eval",))
+        step_state.clear_step_tags()
+        assert step_state._TAGS_GLOBAL == ()
+        assert step_state._TAGS_CV.get() == ()
+        assert get_step_tags() == ()
+
+    def test_threading_thread_falls_back_to_global(self):
+        # Plain threading.Thread does NOT inherit ContextVar state (that's
+        # an asyncio-specific copy_context behavior). A reader on such a
+        # thread must fall back to the global for anything to be visible.
+        import threading
+
+        add_step_tag("from_main")  # SPMD: writes global
+        assert step_state._TAGS_GLOBAL == ("from_main",)
+
+        result: list[tuple[str, ...]] = []
+
+        def thread_reader() -> None:
+            result.append(get_step_tags())
+
+        t = threading.Thread(target=thread_reader)
+        t.start()
+        t.join()
+        # Thread sees global via fallback (its CV is at default ()).
+        assert result == [("from_main",)]
+
+
+class TestRelativeStep:
+    def test_relative_step_set_and_get(self):
+        set_step(101, relative_step=1)
+        assert get_relative_step() == 1
+        assert get_step() == 101
+
+    def test_relative_step_default_none(self):
+        assert get_relative_step() is None
+
+    def test_relative_step_defaults_to_step_when_omitted(self):
+        """When set_step is called without relative_step, it defaults to step.
+
+        Prevents a stale _RELATIVE_STEP_GLOBAL from leaking across calls
+        (e.g. sync_step broadcasts that omit the kwarg). Correct for
+        non-resumed runs; resumed trainers must pass relative_step
+        explicitly.
+        """
+        set_step(1, relative_step=1)
+        set_step(2)  # no relative_step -> defaults to step
+        assert get_relative_step() == 2
+
+    def test_relative_step_in_formatter_output(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        set_step(101, relative_step=1)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert parsed["relative_step"] == 1
+
+
+class TestHybridContextVarAsync:
+    def test_asyncio_task_inherits_step(self):
+        """Asyncio tasks inherit the step from the parent context."""
+        results = []
+
+        async def worker():
+            results.append(get_step())
+
+        async def main():
+            set_step(42)
+            task = asyncio.create_task(worker())
+            await task
+
+        asyncio.run(main())
+        assert results == [42]
+
+
+# ---------------------------------------------------------------------------
+# event_extra
+# ---------------------------------------------------------------------------
+
+
+class TestEventExtra:
+    def test_basic_event(self):
+        extra = event_extra("fwd_bwd")
+        assert extra[str(ExtraFields.LOG_TYPE)] == str(LogType.EVENT)
+        assert extra[str(ExtraFields.LOG_TYPE_NAME)] == str("fwd_bwd")
+
+    def test_with_step_and_value(self):
+        extra = event_extra("step", step=10, value=42.0)
+        assert extra[str(ExtraFields.STEP)] == 10
+        assert extra[str(ExtraFields.VALUE)] == 42.0
+
+    def test_with_task_name(self):
+        extra = event_extra("fwd_bwd", task_name="worker-0")
+        assert extra[str(ExtraFields.TASK_NAME)] == "worker-0"
+
+
+# ---------------------------------------------------------------------------
+# TraceJsonlFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestTraceJsonlFormatter:
+    def test_format_produces_flat_json(self):
+        """Output is flat JSON (not 4-column structured format)."""
+        fmt = TraceJsonlFormatter(rank=0, source="trainer")
+        set_step(5)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra(str("fwd_bwd") + "_start", step=5).items():
+            setattr(record, k, v)
+
+        output = fmt.format(record)
+        parsed = json.loads(output)
+        # Flat JSON: fields at top level, no "int"/"normal"/"double" keys
+        assert "int" not in parsed
+        assert "normal" not in parsed
+        assert parsed["rank"] == 0
+        assert parsed["source"] == "trainer"
+        assert parsed["step"] == 5
+
+    def test_rank_and_source_from_self(self):
+        fmt = TraceJsonlFormatter(rank=3, source="generator")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert parsed["rank"] == 3
+        assert parsed["source"] == "generator"
+
+    def test_step_from_global(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        set_step(42)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert parsed["step"] == 42
+
+    def test_task_name_in_output(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step", task_name="worker-0").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert parsed["task_name"] == "worker-0"
+
+    def test_message_truncation(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        long_msg = "x" * (MAX_MESSAGE_SIZE + 100)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg=long_msg,
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert "..." in parsed["message"]
+        assert len(parsed["message"]) < len(long_msg)
+
+    def test_step_tags_in_output(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        set_step(1)
+        add_step_tag("gc")
+        add_step_tag("profiling")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert set(parsed["step_tags"]) == {"gc", "profiling"}
+
+    def test_seq_id_increments(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        seq_ids = []
+        for i in range(3):
+            r = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="test.py",
+                lineno=1,
+                msg=f"msg{i}",
+                args=None,
+                exc_info=None,
+            )
+            for k, v in event_extra("step").items():
+                setattr(r, k, v)
+            parsed = json.loads(fmt.format(r))
+            seq_ids.append(parsed["seq_id"])
+        assert seq_ids == [0, 1, 2]
+
+    def test_global_rank_in_output(self):
+        """global_rank equals rank (needed for per-rank trace track assignment)."""
+        fmt = TraceJsonlFormatter(rank=5, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert parsed["global_rank"] == 5
+        assert parsed["rank"] == 5
+
+    def test_local_rank_in_output(self):
+        """local_rank from LOCAL_RANK env var (default 0)."""
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert "local_rank" in parsed
+        assert isinstance(parsed["local_rank"], int)
+
+    def test_has_time_us(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for k, v in event_extra("step").items():
+            setattr(record, k, v)
+        parsed = json.loads(fmt.format(record))
+        assert "time_us" in parsed
+        assert isinstance(parsed["time_us"], int)
+
+
+# ---------------------------------------------------------------------------
+# TraceEventsOnlyFilter
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEventsOnlyFilter:
+    def test_passes_event_records(self):
+        f = TraceEventsOnlyFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        setattr(record, str(ExtraFields.LOG_TYPE_NAME), str("step"))
+        assert f.filter(record) is True
+
+    def test_blocks_non_event_records(self):
+        f = TraceEventsOnlyFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="just text",
+            args=None,
+            exc_info=None,
+        )
+        assert f.filter(record) is False
+
+
+# ---------------------------------------------------------------------------
+# init_structured_logger
+# ---------------------------------------------------------------------------
+
+
+class TestInitStructuredLogger:
+    def test_creates_trace_jsonl(self, tmp_path, structured_logger_fixture):
+        output_dir = str(tmp_path)
+        init_structured_logger(rank=0, source="trainer", output_dir=output_dir)
+
+        # Logger should have handlers
+        assert any(
+            isinstance(h, TraceJsonlHandler) for h in structured_logger_fixture.handlers
+        )
+
+        # File should exist after we log something
+        set_step(1)
+        structured_logger_fixture.info(
+            "test event",
+            extra=event_extra("step", step=1),
+        )
+
+        structured_logs_dir = os.path.join(output_dir, "structured_logs")
+        assert os.path.exists(structured_logs_dir)
+        jsonl_files = [
+            f for f in os.listdir(structured_logs_dir) if f.endswith(".jsonl")
+        ]
+        assert len(jsonl_files) == 1
+
+        with open(os.path.join(structured_logs_dir, jsonl_files[0])) as f:
+            line = f.readline().strip()
+        parsed = json.loads(line)
+        assert parsed["rank"] == 0
+        assert parsed["source"] == "trainer"
+
+    def test_idempotent(self, tmp_path, structured_logger_fixture):
+        output_dir = str(tmp_path)
+        init_structured_logger(rank=0, source="trainer", output_dir=output_dir)
+        handler_count = len(structured_logger_fixture.handlers)
+        init_structured_logger(rank=0, source="trainer", output_dir=output_dir)
+        assert len(structured_logger_fixture.handlers) == handler_count
+
+    def test_file_naming_pattern(self, tmp_path, structured_logger_fixture):
+        """File name follows: {source}.global_rank_{rank}.{ts}-{rand}.jsonl"""
+        init_structured_logger(rank=3, source="generator", output_dir=str(tmp_path))
+        structured_logs_dir = os.path.join(str(tmp_path), "structured_logs")
+
+        # Force a log event so file is created
+        structured_logger_fixture.info("x", extra=event_extra("step"))
+
+        files = os.listdir(structured_logs_dir)
+        assert len(files) == 1
+        assert files[0].startswith("generator.global_rank_3.")
+        assert files[0].endswith(".jsonl")
+
+    def test_second_call_is_noop(self, tmp_path, structured_logger_fixture):
+        """init_structured_logger is idempotent: second call returns early and
+        does not attach additional handlers."""
+        output_dir = str(tmp_path)
+        init_structured_logger(rank=0, source="trainer", output_dir=output_dir)
+        handler_count = len(structured_logger_fixture.handlers)
+
+        init_structured_logger(rank=0, source="other_actor", output_dir=output_dir)
+
+        assert len(structured_logger_fixture.handlers) == handler_count
+
+
+class TestFactoryMechanism:
+    def test_default_creates_jsonl(self, tmp_path, structured_logger_fixture):
+        """When TITAN_STRUCT_LOGGER_HANDLERS is unset, default JSONL factory runs."""
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TITAN_STRUCT_LOGGER_HANDLERS", None)
+            init_structured_logger(rank=0, source="test", output_dir=str(tmp_path))
+        assert any(
+            isinstance(h, TraceJsonlHandler) for h in structured_logger_fixture.handlers
+        )
+
+    def test_custom_env_replaces_default(self, tmp_path, structured_logger_fixture):
+        """When TITAN_STRUCT_LOGGER_HANDLERS is set, only specified factories run."""
+        called = []
+
+        def fake_factory(*, structured_logger, rank, source, output_dir, **kw):
+            called.append((rank, source))
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "TITAN_STRUCT_LOGGER_HANDLERS": "tests.unit_tests.observability.test_structured_logging.fake_factory"
+            },
+        ):
+            # Patch importlib to load our fake factory
+            with mock.patch("importlib.import_module") as mock_import:
+                mock_mod = mock.MagicMock()
+                mock_mod.fake_factory = fake_factory
+                mock_import.return_value = mock_mod
+                init_structured_logger(rank=0, source="test", output_dir=str(tmp_path))
+
+        assert len(called) == 1
+        assert called[0] == (0, "test")
+        # No TraceJsonlHandler since custom factory replaced default
+        assert not any(
+            isinstance(h, TraceJsonlHandler) for h in structured_logger_fixture.handlers
+        )
+
+
+# ---------------------------------------------------------------------------
+# No-op flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpFlag:
+    def test_structured_logger_disabled_flag(self, tmp_path, structured_logger_fixture):
+        """When the module-level ``_disabled`` flag is set, spans and instants produce no events."""
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        with mock.patch(
+            "torchtitan.observability.structured_logger.structured_logging._disabled",
+            True,
+        ):
+            set_step(1)
+            with log_trace_span("step"):
+                pass
+            log_trace_instant("binary_start")
+
+        trace_dir = tmp_path / "structured_logs"
+        lines = []
+        if trace_dir.exists():
+            for f in trace_dir.iterdir():
+                lines.extend(f.read_text().strip().splitlines())
+        assert (
+            len(lines) == 0
+        ), f"Expected no events when tracing disabled, got {len(lines)}"
+
+    def test_init_with_enable_false_disables_logging(
+        self, tmp_path, structured_logger_fixture
+    ):
+        """``init_structured_logger(enable=False)`` makes all subsequent trace calls no-ops."""
+        import torchtitan.observability.structured_logger.structured_logging as sl_mod
+
+        # Ensure clean state before this test
+        sl_mod._disabled = False
+        try:
+            init_structured_logger(
+                rank=0, source="trainer", output_dir=str(tmp_path), enable=False
+            )
+            set_step(1)
+            with log_trace_span("step"):
+                pass
+            log_trace_instant("binary_start")
+            log_trace_scalar({"x": 1.0})
+        finally:
+            sl_mod._disabled = False
+
+        # No structured_logs directory should be created (no handlers attached)
+        trace_dir = tmp_path / "structured_logs"
+        if trace_dir.exists():
+            for f in trace_dir.iterdir():
+                assert (
+                    f.read_text().strip() == ""
+                ), "Expected no events when init'd with enable=False"
+
+
+# ---------------------------------------------------------------------------
+# log_trace_scalar
+# ---------------------------------------------------------------------------
+
+
+class TestLogTraceScalar:
+    def test_writes_metric_events(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(5)
+        log_trace_scalar({"train.loss": 2.5, "train.tflops": 45.6})
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+        assert lines[0]["log_type_name"] == "metric_value"
+        assert lines[0]["event_name"] == "train.loss"
+        assert lines[0]["value"] == 2.5
+        assert lines[0]["step"] == 5
+        assert lines[1]["event_name"] == "train.tflops"
+        assert lines[1]["value"] == 45.6
+
+    def test_noop_when_disabled(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        with mock.patch(
+            "torchtitan.observability.structured_logger.structured_logging._disabled",
+            True,
+        ):
+            log_trace_scalar({"should.not.appear": 1.0})
+
+        trace_dir = tmp_path / "structured_logs"
+        lines = []
+        if trace_dir.exists():
+            for f in trace_dir.iterdir():
+                lines.extend(f.read_text().strip().splitlines())
+        assert len(lines) == 0
+
+    def test_empty_dict_is_noop(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        log_trace_scalar({})
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 0
+
+
+# ---------------------------------------------------------------------------
+# log_trace_instant
+# ---------------------------------------------------------------------------
+
+
+class TestLogTraceInstant:
+    def test_writes_instant_marker(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        log_trace_instant("binary_start")
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 1
+        assert lines[0]["log_type_name"] == "binary_start"
+        assert lines[0]["log_type"] == "instant"
+        assert lines[0]["event_name"] is None
+
+    def test_noop_when_disabled(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        with mock.patch(
+            "torchtitan.observability.structured_logger.structured_logging._disabled",
+            True,
+        ):
+            log_trace_instant("training_start")
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert len(lines) == 0
+
+
+# ---------------------------------------------------------------------------
+# log_trace_span
+# ---------------------------------------------------------------------------
+
+
+class TestLogTraceSpan:
+    def test_logs_start_and_end(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(5)
+
+        with log_trace_span("fwd_bwd"):
+            time.sleep(0.01)
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+        assert lines[0]["log_type_name"] == str("fwd_bwd") + "_start"
+        assert lines[1]["log_type_name"] == str("fwd_bwd") + "_end"
+        assert lines[1]["value"] > 0
+        assert lines[0]["step"] == 5
+        assert lines[1]["step"] == 5
+        # Span events must NOT have event_name (only in message field)
+        assert lines[0].get("event_name") is None
+        assert lines[1].get("event_name") is None
+
+    def test_event_type_required(self):
+        """event_type is required — cannot be omitted."""
+        with pytest.raises(TypeError):
+            log_trace_span()  # pyrefly: ignore[missing-argument]
+
+    def test_event_type_accepts_plain_string(self, tmp_path, structured_logger_fixture):
+        """Plain strings are accepted as log_type_name."""
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        with log_trace_span("rl_rollout"):
+            pass
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert lines[0]["log_type_name"] == "rl_rollout_start"
+        assert lines[1]["log_type_name"] == "rl_rollout_end"
+
+    def test_two_spans_emit_start_end_pairs(self, tmp_path, structured_logger_fixture):
+        """Sanity check: each `with log_trace_span(...)` writes exactly one
+        start and one end record, identified by their ``log_type_name``."""
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+
+        with log_trace_span("step"):
+            pass
+        with log_trace_span("optim"):
+            pass
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        type_names = [line.get("log_type_name") for line in lines]
+        assert type_names == ["step_start", "step_end", "optim_start", "optim_end"]
+
+    def test_works_as_decorator(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+
+        @log_trace_span("optim")
+        def optimizer_step():
+            pass
+
+        optimizer_step()
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+
+    def test_async_decorator_brackets_coroutine_body(
+        self, tmp_path, structured_logger_fixture
+    ):
+        # ContextDecorator's default __call__ produces a sync wrapper that
+        # exits before `await func(...)` runs, so for an async function the
+        # _end record fires before the body executes. Override __call__ for
+        # coroutine functions so __exit__ runs after the awaitable completes.
+        # Verified by event order in the JSONL stream — no wall-clock timing
+        # needed, so the test is deterministic.
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+
+        @log_trace_span("rl_rollout")
+        async def rollout():
+            log_trace_instant("body_marker")
+
+        asyncio.run(rollout())
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            type_names = [
+                json.loads(line)["log_type_name"] for line in f if line.strip()
+            ]
+
+        assert type_names == ["rl_rollout_start", "body_marker", "rl_rollout_end"]
+
+    def test_exception_recording(self, tmp_path, structured_logger_fixture):
+        """When an exception occurs, an _error event is emitted."""
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        set_step(1)
+
+        with pytest.raises(ValueError):
+            with log_trace_span("step"):
+                raise ValueError("test error")
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        # 3 events: start, error, end
+        assert len(lines) == 3
+        type_names = [line["log_type_name"] for line in lines]
+        assert type_names[0].endswith("_start")
+        assert type_names[1].endswith("_error")
+        assert type_names[2].endswith("_end")
+
+    def test_sync_decorator_caller_points_at_user_site(
+        self, tmp_path, structured_logger_fixture
+    ):
+        """``@log_trace_span`` on a sync function must attribute caller to the
+        user's call site (test method below), not to the internal sync_wrapper
+        in structured_logging.py. Regression guard for the ``stacklevel + 1``
+        adjustment in ``log_trace_span.__call__``.
+        """
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+
+        @log_trace_span("decorated_sync")
+        def my_fn():
+            pass
+
+        my_fn()
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            start = next(
+                json.loads(line)
+                for line in f
+                if line.strip()
+                and json.loads(line)["log_type_name"] == "decorated_sync_start"
+            )
+
+        path, _, funcname = start["caller"].rsplit(":", 2)
+        assert os.path.basename(path) == "test_structured_logging.py", start["caller"]
+        # Without stacklevel+1, funcname would be "sync_wrapper".
+        assert funcname == "test_sync_decorator_caller_points_at_user_site", start[
+            "caller"
+        ]
+
+    def test_nested_async_decorators_emit_in_order(
+        self, tmp_path, structured_logger_fixture
+    ):
+        """Mirrors the RL actor pattern: an outer ``@log_trace_span`` async
+        method awaits an inner ``@log_trace_span`` async method. All four
+        records must emit in nested order (outer_start, inner_start,
+        inner_end, outer_end) — proves ``__exit__`` runs after ``await``
+        completes for both layers, so durations are real and Gantt pairing
+        works.
+        """
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+
+        @log_trace_span("inner_async")
+        async def inner():
+            pass
+
+        @log_trace_span("outer_async")
+        async def outer():
+            await inner()
+
+        asyncio.run(outer())
+
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            type_names = [
+                json.loads(line)["log_type_name"] for line in f if line.strip()
+            ]
+
+        assert type_names == [
+            "outer_async_start",
+            "inner_async_start",
+            "inner_async_end",
+            "outer_async_end",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# generate_gantt_trace (analysis.py)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateGanttTrace:
+    def _write_jsonl(self, path, records):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+
+    def test_pairs_by_span_id(self, tmp_path):
+        """Start/end events are paired by span_id."""
+        records = [
+            {
+                "log_type_name": "fwd_bwd_start",
+                "time_us": 1000,
+                "rank": 0,
+                "step": 1,
+                "span_id": 0,
+                "event_name": "fwd_bwd",
+            },
+            {
+                "log_type_name": "fwd_bwd_end",
+                "time_us": 2000,
+                "rank": 0,
+                "step": 1,
+                "span_id": 0,
+                "value": 1.0,
+                "event_name": "fwd_bwd",
+            },
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        # Filter to only "X" (complete) events
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        assert len(x_events) == 1
+        assert x_events[0]["name"] == "fwd_bwd"
+        assert x_events[0]["ts"] == 1000
+        assert x_events[0]["dur"] == 1000  # 1.0ms * 1000 = 1000us
+
+    def test_empty_dir(self, tmp_path):
+        empty_dir = str(tmp_path / "empty")
+        os.makedirs(empty_dir)
+        trace = generate_gantt_trace(empty_dir, str(tmp_path / "out.json"))
+        assert trace["traceEvents"] == []
+
+    def test_metric_events(self, tmp_path):
+        """metric_value events become instant events."""
+        records = [
+            {
+                "log_type_name": "metric_value",
+                "log_type": "instant",
+                "time_us": 1000,
+                "rank": 0,
+                "step": 1,
+                "event_name": "train.loss",
+                "value": 2.5,
+            },
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        instant_events = [e for e in trace["traceEvents"] if e.get("ph") == "i"]
+        assert len(instant_events) == 1
+        assert "train.loss" in instant_events[0]["name"]
+        assert "2.5" in instant_events[0]["name"]
+
+    def test_error_events(self, tmp_path):
+        """_error events become instant error markers."""
+        records = [
+            {"log_type_name": "fwd_bwd_error", "time_us": 1500, "rank": 0, "step": 1},
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        error_events = [
+            e
+            for e in trace["traceEvents"]
+            if e.get("ph") == "i" and "ERROR" in e.get("name", "")
+        ]
+        assert len(error_events) == 1
+
+    def test_log_type_instant_routes_to_instant_regardless_of_suffix(self, tmp_path):
+        """Records with ``log_type == "instant"`` render as instants even when
+        their ``log_type_name`` ends in ``_start``. Confirms the classifier
+        branches on emission intent, not name suffix — so future instants
+        like ``binary_start`` / ``training_start`` work without an allowlist.
+        """
+        records = [
+            {
+                "log_type_name": "binary_start",
+                "log_type": "instant",
+                "time_us": 1000,
+                "rank": 0,
+            },
+            {
+                "log_type_name": "training_start",
+                "log_type": "instant",
+                "time_us": 2000,
+                "rank": 0,
+            },
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        instant_names = [
+            e.get("name") for e in trace["traceEvents"] if e.get("ph") == "i"
+        ]
+        assert "binary_start" in instant_names
+        assert "training_start" in instant_names
+        # No span-pair events were created from these records.
+        assert not any(e.get("ph") == "X" for e in trace["traceEvents"])
+
+    def test_unknown_event_type_defaults_to_instant(self, tmp_path):
+        """Records whose `log_type_name` doesn't match any branch render as
+        bare instants. Matches Foundry's `ELSE 'instant'` fallthrough so no
+        event is silently dropped.
+        """
+        records = [
+            {"log_type_name": "ad_hoc_marker", "time_us": 1000, "rank": 0, "step": 3},
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        instant_events = [e for e in trace["traceEvents"] if e.get("ph") == "i"]
+        assert len(instant_events) == 1
+        assert instant_events[0]["name"] == "ad_hoc_marker"
+        assert instant_events[0]["args"]["step"] == 3
+
+    def test_null_event_name_uses_type_name(self, tmp_path):
+        """When event_name is null (spans after P0 fix), display_name = type_name."""
+        records = [
+            {
+                "log_type_name": "fwd_bwd_start",
+                "time_us": 1000,
+                "rank": 0,
+                "step": 1,
+                "span_id": 0,
+            },
+            {
+                "log_type_name": "fwd_bwd_end",
+                "time_us": 2000,
+                "rank": 0,
+                "step": 1,
+                "span_id": 0,
+                "value": 1.0,
+            },
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        assert len(x_events) == 1
+        # With null event_name, display_name falls back to type_name
+        assert x_events[0]["name"] == "fwd_bwd"
+
+    def test_fallback_pairing_without_span_id(self, tmp_path):
+        """Falls back to (type_name, pid, rank) when span_id is absent."""
+        records = [
+            {
+                "log_type_name": "step_start",
+                "time_us": 1000,
+                "rank": 0,
+                "step": 1,
+                "event_name": "step",
+            },
+            {
+                "log_type_name": "step_end",
+                "time_us": 2000,
+                "rank": 0,
+                "step": 1,
+                "value": 1.0,
+                "event_name": "step",
+            },
+        ]
+        jsonl_path = os.path.join(str(tmp_path), "structured_logs", "test.jsonl")
+        self._write_jsonl(jsonl_path, records)
+
+        output_path = os.path.join(str(tmp_path), "gantt.json")
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"), output_path
+        )
+
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        assert len(x_events) == 1
+
+    # ------------------------------------------------------------------
+    # Pairing contract (post-span_id-removal): LIFO stack per (source,
+    # task_name). Each test writes records WITHOUT a span_id field and
+    # asserts pairing + tid placement by semantic outcome — which span
+    # ends on which _end, and which tid each span lands on — not by
+    # counting tids.
+    # ------------------------------------------------------------------
+
+    def _start_rec(self, type_name, time_us, task_name, rank=0, event_name=None):
+        return {
+            "log_type_name": f"{type_name}_start",
+            "time_us": time_us,
+            "rank": rank,
+            "task_name": task_name,
+            **({"event_name": event_name} if event_name else {}),
+        }
+
+    def _end_rec(self, type_name, time_us, duration_ms, task_name, rank=0):
+        return {
+            "log_type_name": f"{type_name}_end",
+            "time_us": time_us,
+            "rank": rank,
+            "task_name": task_name,
+            "value": duration_ms,
+        }
+
+    def test_lifo_pairs_nested_spans_single_task(self, tmp_path):
+        """Nested spans within one task pair by LIFO stack on task_name.
+
+        Outer wraps inner; inner ends first, outer ends second.
+        Both spans must carry their original start timestamps and
+        durations after pairing.
+        """
+        records = [
+            self._start_rec("outer", 1000, "Task-1"),
+            self._start_rec("inner", 1200, "Task-1"),
+            self._end_rec("inner", 1400, duration_ms=0.2, task_name="Task-1"),
+            self._end_rec("outer", 2000, duration_ms=1.0, task_name="Task-1"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        by_name = {e["name"]: e for e in trace["traceEvents"] if e.get("ph") == "X"}
+        # Exactly two spans paired, with the right timings.
+        assert "outer" in by_name and "inner" in by_name
+        assert by_name["outer"]["ts"] == 1000
+        assert by_name["outer"]["dur"] == 1000  # 1.0 ms -> 1000 us
+        assert by_name["inner"]["ts"] == 1200
+        assert by_name["inner"]["dur"] == 200
+
+    def test_lifo_pairs_concurrent_non_nested_tasks(self, tmp_path):
+        """Two tasks on the same source whose spans overlap in non-LIFO order.
+
+        A_start, B_start, A_end, B_end — if the pair-by-(source, tid) scheme
+        were used (as msl does), the first _end would pop B (last in stack)
+        and mispair. Keying the stack on task_name isolates the two tasks.
+        """
+        records = [
+            self._start_rec("A", 1000, "Task-1"),
+            self._start_rec("B", 1100, "Task-2"),
+            self._end_rec("A", 1500, duration_ms=0.5, task_name="Task-1"),
+            self._end_rec("B", 2000, duration_ms=0.9, task_name="Task-2"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        by_name = {e["name"]: e for e in trace["traceEvents"] if e.get("ph") == "X"}
+        # A must pair with its own _end (ts=1000, dur=500us), not B's.
+        assert by_name["A"]["ts"] == 1000
+        assert by_name["A"]["dur"] == 500
+        assert by_name["B"]["ts"] == 1100
+        assert by_name["B"]["dur"] == 900
+        # Each task gets its own tid (both auto-named and overlapping).
+        assert by_name["A"]["tid"] != by_name["B"]["tid"]
+
+    def test_spmd_pairing_with_null_task_name(self, tmp_path):
+        """SPMD code has task_name=None on every record; LIFO-per-source pairs
+        nested spans correctly."""
+        records = [
+            self._start_rec("step", 1000, task_name=None),
+            self._start_rec("fwd_bwd", 1100, task_name=None),
+            self._end_rec("fwd_bwd", 1500, duration_ms=0.4, task_name=None),
+            self._end_rec("step", 2000, duration_ms=1.0, task_name=None),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        by_name = {e["name"]: e for e in trace["traceEvents"] if e.get("ph") == "X"}
+        assert by_name["step"]["ts"] == 1000
+        assert by_name["step"]["dur"] == 1000
+        assert by_name["fwd_bwd"]["ts"] == 1100
+        assert by_name["fwd_bwd"]["dur"] == 400
+
+    def test_cross_source_pairing_is_isolated(self, tmp_path):
+        """Two sources with identical task names must pair independently.
+
+        Without source-scoped keys, source_b's records could consume
+        source_a's pending starts (or vice versa) and report wrong
+        durations.
+        """
+        # source_a: A_start at 1000, A_end at 9000 (dur 8 ms)
+        records_a = [
+            self._start_rec("A", 1000, "Task-1"),
+            self._end_rec("A", 9000, duration_ms=8.0, task_name="Task-1"),
+        ]
+        # source_b: reuses "Task-1" but fires earlier and shorter
+        records_b = [
+            self._start_rec("A", 2000, "Task-1"),
+            self._end_rec("A", 3000, duration_ms=1.0, task_name="Task-1"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records_a
+        )
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "b.jsonl"), records_b
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        pid_to_source = {
+            e["pid"]: e["args"]["name"]
+            for e in trace["traceEvents"]
+            if e.get("name") == "process_name"
+        }
+        by_source_and_dur = {
+            (pid_to_source[e["pid"]], e["dur"])
+            for e in trace["traceEvents"]
+            if e.get("ph") == "X"
+        }
+        # Each source's span carries its own duration. If pairing leaked
+        # across sources, one span would take the other's duration.
+        assert ("a", 8000) in by_source_and_dur
+        assert ("b", 1000) in by_source_and_dur
+
+    def test_nested_spans_same_task_share_one_tid(self, tmp_path):
+        """Nested spans within a single task land on ONE tid; Perfetto renders
+        the nesting as a stacked flamegraph on that track, so splitting
+        across multiple tids would produce a confusing "N parallel threads"
+        rendering of what is actually a single thread doing work."""
+        records = [
+            self._start_rec("outer", 1000, "Task-1"),
+            self._start_rec("middle", 1100, "Task-1"),
+            self._start_rec("inner", 1200, "Task-1"),
+            self._end_rec("inner", 1400, duration_ms=0.2, task_name="Task-1"),
+            self._end_rec("middle", 1800, duration_ms=0.7, task_name="Task-1"),
+            self._end_rec("outer", 2000, duration_ms=1.0, task_name="Task-1"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        assert len(x_events) == 3
+        tids = {e["tid"] for e in x_events}
+        assert tids == {0}, (
+            f"Three nested spans in one task should share tid 0, "
+            f"got tids={sorted(tids)}"
+        )
+
+    def test_sequential_tasks_reuse_one_tid(self, tmp_path):
+        """Multiple auto-named tasks that do NOT overlap in wall-clock time
+        should reuse a single tid (like the grader: 5 sequential
+        ``score()`` endpoint calls should appear on one track, not five)."""
+        records = []
+        for i, task in enumerate(["Task-2", "Task-4", "Task-6", "Task-8", "Task-10"]):
+            start = 1000 + i * 10_000
+            end = start + 500
+            records.append(self._start_rec("work", start, task_name=task))
+            records.append(self._end_rec("work", end, duration_ms=0.5, task_name=task))
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        tids = {e["tid"] for e in trace["traceEvents"] if e.get("ph") == "X"}
+        assert tids == {0}
+
+    def test_two_concurrent_tasks_each_with_nested_spans(self, tmp_path):
+        """Two tasks running in parallel, each with a nested inner span.
+
+        Under TASK-RANGE slot-packing: each task's nesting collapses to one
+        slot, the two tasks' ranges overlap -> 2 slots total (one per task).
+        Under SPAN-LEVEL slot-packing (the current bug): all 4 spans are
+        concurrent in wall-clock time -> 4 slots total. The failure mode
+        exactly mirrors the 'grader shows 4 tids' bug the user reported.
+        """
+        records = [
+            # Task-1: outer [1000..3000], inner [1200..1800]
+            self._start_rec("A_outer", 1000, "Task-1"),
+            self._start_rec("A_inner", 1200, "Task-1"),
+            self._end_rec("A_inner", 1800, duration_ms=0.6, task_name="Task-1"),
+            self._end_rec("A_outer", 3000, duration_ms=2.0, task_name="Task-1"),
+            # Task-2: outer [2000..4000] (overlaps Task-1), inner [2200..2800]
+            self._start_rec("B_outer", 2000, "Task-2"),
+            self._start_rec("B_inner", 2200, "Task-2"),
+            self._end_rec("B_inner", 2800, duration_ms=0.6, task_name="Task-2"),
+            self._end_rec("B_outer", 4000, duration_ms=2.0, task_name="Task-2"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        tids = {e["tid"] for e in trace["traceEvents"] if e.get("ph") == "X"}
+        assert len(tids) == 2, (
+            f"Expected 2 tids (one per task), got {len(tids)}: {sorted(tids)}. "
+            f"Span-level slot-packing would give 4 (all spans concurrent in "
+            f"wall-clock); task-range gives 2 (nesting collapses per task)."
+        )
+        # Spans in the same task must share a tid.
+        by_name = {e["name"]: e for e in trace["traceEvents"] if e.get("ph") == "X"}
+        assert by_name["A_outer"]["tid"] == by_name["A_inner"]["tid"]
+        assert by_name["B_outer"]["tid"] == by_name["B_inner"]["tid"]
+        # Different tasks must get different tids.
+        assert by_name["A_outer"]["tid"] != by_name["B_outer"]["tid"]
+
+    def test_concurrent_tasks_get_separate_tids(self, tmp_path):
+        """Two asyncio tasks whose time ranges overlap (e.g., from
+        ``asyncio.gather``) must land on DIFFERENT tids so Perfetto
+        renders them as parallel tracks rather than overlapping bars on
+        one track.
+
+        Under task-range slot-packing: Task-1's range [1000..3000] and
+        Task-2's range [2000..4000] overlap -> slot 0 and slot 1.
+        Under the (wrong) 'just use row.tid' approach, both would default
+        to tid 0 in the fixture and the test would fail.
+        """
+        records = [
+            # Task-1 span: 1000 -> 3000
+            self._start_rec("A", 1000, "Task-1"),
+            self._end_rec("A", 3000, duration_ms=2.0, task_name="Task-1"),
+            # Task-2 span: 2000 -> 4000 (overlaps A in wall-clock)
+            self._start_rec("B", 2000, "Task-2"),
+            self._end_rec("B", 4000, duration_ms=2.0, task_name="Task-2"),
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        by_name = {e["name"]: e for e in trace["traceEvents"] if e.get("ph") == "X"}
+        assert by_name["A"]["tid"] != by_name["B"]["tid"], (
+            f"Concurrent tasks must get different tids; got A.tid="
+            f"{by_name['A']['tid']}, B.tid={by_name['B']['tid']}"
+        )
+
+    def test_instant_uses_task_name_not_span_id_for_tid(self, tmp_path):
+        """Instants (error, metric) with an explicit task_name land on that
+        task's track; without one, they fall back to tid 0."""
+        records = [
+            # Named task "train_loop" has a real span so it gets a tid.
+            self._start_rec("work", 1000, "train_loop"),
+            self._end_rec("work", 2000, duration_ms=1.0, task_name="train_loop"),
+            # Error instant inside the named task should go on its track.
+            {
+                "log_type_name": "work_error",
+                "time_us": 1500,
+                "rank": 0,
+                "task_name": "train_loop",
+            },
+            # Metric with no task -> falls back to tid 0.
+            {
+                "log_type_name": "metric_value",
+                "log_type": "instant",
+                "time_us": 1700,
+                "rank": 0,
+                "event_name": "loss",
+                "value": 2.5,
+                "task_name": None,
+            },
+        ]
+        self._write_jsonl(
+            os.path.join(str(tmp_path), "structured_logs", "a.jsonl"), records
+        )
+        trace = generate_gantt_trace(
+            os.path.join(str(tmp_path), "structured_logs"),
+            os.path.join(str(tmp_path), "gantt.json"),
+        )
+        span = next(e for e in trace["traceEvents"] if e.get("ph") == "X")
+        error = next(
+            e
+            for e in trace["traceEvents"]
+            if e.get("ph") == "i" and "ERROR" in e["name"]
+        )
+        metric = next(
+            e
+            for e in trace["traceEvents"]
+            if e.get("ph") == "i" and "loss" in e["name"]
+        )
+        # Error on explicit task's track, metric on main track.
+        assert error["tid"] == span["tid"]
+        assert metric["tid"] == 0
+
+
+# ---------------------------------------------------------------------------
+# register_jsonl_handler
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterJsonlHandler:
+    def test_creates_handler_with_correct_path(
+        self, tmp_path, structured_logger_fixture
+    ):
+        register_jsonl_handler(
+            structured_logger=structured_logger_fixture,
+            rank=2,
+            source="test_src",
+            output_dir=str(tmp_path),
+        )
+
+        # Should have added a TraceJsonlHandler
+        handlers = [
+            h
+            for h in structured_logger_fixture.handlers
+            if isinstance(h, TraceJsonlHandler)
+        ]
+        assert len(handlers) == 1
+
+        # File path should be in structured_logs/
+        filepath = handlers[0].baseFilename
+        assert "structured_logs" in filepath
+        assert "test_src.global_rank_2" in filepath
+        assert filepath.endswith(".jsonl")

--- a/tests/unit_tests/test_profiler.py
+++ b/tests/unit_tests/test_profiler.py
@@ -14,7 +14,7 @@ class TestProfilerConfig(unittest.TestCase):
     def test_default_field_values(self):
         cfg = Profiler.Config()
         self.assertFalse(cfg.enable_profiling)
-        self.assertEqual(cfg.save_traces_folder, "profile_traces")
+        self.assertEqual(cfg.save_traces_folder, "profiling/traces")
         self.assertEqual(cfg.profile_freq, 10)
         self.assertEqual(cfg.profiler_active, 1)
         self.assertEqual(cfg.profiler_warmup, 3)
@@ -22,7 +22,7 @@ class TestProfilerConfig(unittest.TestCase):
         self.assertIsNone(cfg.profiler_skip_first)
         self.assertIsNone(cfg.profiler_skip_first_wait)
         self.assertFalse(cfg.enable_memory_snapshot)
-        self.assertEqual(cfg.save_memory_snapshot_folder, "memory_snapshot")
+        self.assertEqual(cfg.save_memory_snapshot_folder, "profiling/memory_snapshot")
 
     def test_custom_field_values(self):
         cfg = Profiler.Config(

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -37,14 +37,15 @@ from torch.distributed.checkpoint.state_dict_saver import (
     AsyncSaveResponse,
 )
 from torch.distributed.checkpoint.stateful import Stateful
+
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
-
 
 MODEL = "model"
 OPTIMIZER = "optimizer"
@@ -550,8 +551,9 @@ class CheckpointManager(Configurable):
             if MODEL in self.states:
                 self.states[MODEL].load_state_dict(state_dict)
 
+    @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> None:
+    def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Save the checkpoint for the current step.
 
         This function will save the checkpoint for the current step. If ``last_step`` is
@@ -564,11 +566,13 @@ class CheckpointManager(Configurable):
             last_step (bool, optional): Whether this is the last step of training.
 
         Returns:
-            None
+            bool: True if a checkpoint was written (or staged, for async modes) on
+            this step.
         """
         if not self._should_save(curr_step, last_step):
-            return
+            return False
 
+        sl.add_step_tag("checkpoint_save")
         begin = time.monotonic()
         logger.info("Saving the checkpoint (or staging if async is enabled).")
         checkpoint_id = self._create_checkpoint_id(curr_step)
@@ -578,7 +582,7 @@ class CheckpointManager(Configurable):
         # freed until _async_wait()
         if last_step:
             self._save_last_step(curr_step)
-            return
+            return True
 
         states = self._flattened_model_states_sd()
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
@@ -613,7 +617,9 @@ class CheckpointManager(Configurable):
             "Finished saving the checkpoint (or staging if async is enabled) "
             f"in {time.monotonic() - begin:.2f} seconds."
         )
+        return True
 
+    @sl.log_trace_span("checkpoint_load")
     @torch.no_grad()
     def load(self, step: int = -1) -> bool:
         """Load the checkpoint for the given step.

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -12,6 +12,7 @@ from typing import Any, cast, TypeAlias
 import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
+
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.loss import IGNORE_INDEX, LossFunction
 from torchtitan.components.metrics import MetricsProcessor
@@ -20,6 +21,7 @@ from torchtitan.config import Configurable, ParallelismConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
@@ -220,12 +222,14 @@ class Validator(BaseValidator):
 
         return inputs, labels, extra_inputs, extra_kwargs
 
+    @sl.log_trace_span("eval")
     @torch.no_grad()
     def validate(
         self,
         model_parts: list[nn.Module],
         step: int,
     ) -> None:
+        sl.add_step_tag("eval")
         # Set model to eval mode
         for model in model_parts:
             model.eval()

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -368,3 +368,9 @@ class DebugConfig:
 
     save_config_file: str | None = None
     """Path to save job config into"""
+
+    enable_structured_logging: bool = True
+    """Whether to enable the structured per-rank trace logger (see
+    ``torchtitan.observability.structured_logger``). When False, all
+    ``log_trace_span`` / ``log_trace_instant`` / ``log_trace_scalar`` calls
+    are no-ops. Disable to fully eliminate trace overhead."""

--- a/torchtitan/config/configurable.py
+++ b/torchtitan/config/configurable.py
@@ -10,6 +10,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass, fields, replace
 from typing import ClassVar
 
+from torchtitan.observability import structured_logger as sl
+
 logger = logging.getLogger(__name__)
 
 
@@ -114,17 +116,18 @@ class Configurable:
                     f"{type(self).__name__} has no owner class. "
                     "Define Config inside a Configurable subclass."
                 )
-            if not kwargs:
-                return self._owner(config=replace(self))
+            with sl.log_trace_span(f"{type(self).__qualname__}.build"):
+                if not kwargs:
+                    return self._owner(config=replace(self))
 
-            config_fields = {f.name for f in fields(self)}
-            overlap = config_fields & kwargs.keys()
-            if overlap:
-                raise ValueError(
-                    f"build() kwargs {overlap} overlap with config fields. "
-                    "Put these values in the Config, not in build() kwargs."
-                )
-            return self._owner(config=replace(self), **kwargs)
+                config_fields = {f.name for f in fields(self)}
+                overlap = config_fields & kwargs.keys()
+                if overlap:
+                    raise ValueError(
+                        f"build() kwargs {overlap} overlap with config fields. "
+                        "Put these values in the Config, not in build() kwargs."
+                    )
+                return self._owner(config=replace(self), **kwargs)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/torchtitan/observability/__init__.py
+++ b/torchtitan/observability/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/observability/structured_logger/README.md
+++ b/torchtitan/observability/structured_logger/README.md
@@ -1,0 +1,189 @@
+# TorchTitan Observability
+
+Structured logging for distributed training. Emits per-rank JSONL events for phase timing, diagnostics, and post-hoc analysis.
+
+Design principles:
+- LLM friendly: Emit structured, per-rank data that can be queried during and after a run.
+- Handle both SPMD pretraining (one process group) and RL with multiple independent actors (no shared process group).
+- Stay invisible to users -- no metric dictionaries to pass around.
+- Never block training.
+- Support pluggable backends via handler factories.
+
+## Quickstart
+
+```python
+from torchtitan.tools.logging import init_logger
+from torchtitan.observability import structured_logger as sl
+
+# console logger (stdout, [titan] prefix)
+init_logger()
+
+# Register handlers, i.e. the functions that will take the logs
+# and save to a local jsonl, a database, or something else.
+sl.init_structured_logger(source="training", output_dir="./outputs")
+
+# Use to register a point-in-time marker — training has started.
+sl.log_trace_instant("training_start")
+
+loaded_step = 0
+for step in range(loaded_step + 1, num_steps + 1):
+    # Stamp every subsequent record with `step` and `relative_step`
+    sl.set_step(step, relative_step=step - loaded_step)
+
+    if should_garbage_collect:
+        # Appends "gc" to `step_tags` on every record for this step; tags
+        # reset at the next set_step() call.
+        # Users can filter such steps later, e.g. "ignore if tag X".
+        sl.add_step_tag("gc")
+        with sl.log_trace_span("gc_collect"):
+            run_gc()
+
+    with sl.log_trace_span("fwd_bwd"):
+        output = model(batch)
+        loss.backward()
+
+    with sl.log_trace_span("Optimizer"):
+        optimizer.step()
+
+    # Scalars you may want to register to help debug, for example.
+    sl.log_trace_scalar({
+        "num_trainable_tokens": num_trainable_tokens,
+         "batch_size": bsz
+         })
+```
+
+Call `init_logger()` and `sl.init_structured_logger()` once per process before any trace calls. Rank and source are baked into the formatter at init; every JSONL entry automatically includes `rank`, `source`, `caller` (file:line:function), `time_us`, `step`, `relative_step`, and (when tags are set) `step_tags`.
+
+## API reference
+
+See docstrings for full args:
+
+- `sl.init_structured_logger(source, output_dir, rank=None, enable=True)` -- wire up handlers; call once per process before any trace call. Pass ``enable=False`` (or set ``--debug.enable_structured_logging=False``) to make all trace calls no-ops.
+- `sl.log_trace_span(event_type, description=None, *, stacklevel=2)` -- context manager / decorator; emits `_start` / `_end` / optional `_error` records.
+- `sl.log_trace_instant(event_type, *, stacklevel=2)` -- point-in-time marker (no duration).
+- `sl.log_trace_scalar(scalars, *, stacklevel=2)` -- emit `metric_value` records from a `{name: number}` dict.
+- `sl.set_step(step, *, relative_step=None)` -- stamp subsequent records with a step; clears previous step's tags.
+- `sl.add_step_tag(tag)` / `sl.clear_step_tags()` -- annotate the current step (e.g. `"gc"`, `"eval"`). `clear_step_tags` is called at `set_step`.
+- `TITAN_STRUCT_LOGGER_HANDLERS` -- Define handlers at the env level
+
+## Flow of information
+
+End-to-end, what happens when user code calls one of the `sl.` helpers:
+
+```
+user code
+    │   with sl.log_trace_span("fwd_bwd"):
+    │       ...
+    │
+    │   # On entry, log_trace_span calls:
+    │       _structured_logger.info(
+    │           msg="[step 5] fwd_bwd_start",       ← registers human-readable string
+    │           extra=event_extra(                  ← structured payload
+    │               event_type="fwd_bwd_start",     ← → record.log_type_name
+    │               step=5,                         ← → record.step
+    │               task_name=None,                 ← → record.task_name
+    │           ),
+    │       )
+    │
+    │   # sl.set_step() / sl.add_step_tag() write into a ContextVar and a
+    │   # module global; get_step() / get_step_tags() read them from inside
+    │   # event_extra(...) so every record picks up the current step + tags.
+    ▼
+_structured_logger  (logging.Logger, name="torchtitan.structured_logger",
+                     propagate=False — records stay out of the root logger)
+    │
+    ▼
+TraceEventsOnlyFilter  (drops records that reached the logger WITHOUT a
+                        log_type_name attribute — defensive; shouldn't fire
+                        in practice because only the sl.* helpers write here)
+    │
+    ├── TraceJsonlHandler      ──▶  TraceJsonlFormatter     ──▶  {output_dir}/structured_logs/*.jsonl
+    └── TraceMyDBHandler*     ──▶  TraceMyDBFormatter     ──▶  MyDB # extra handler defined by user
+```
+
+## Custom handlers
+
+`TITAN_STRUCT_LOGGER_HANDLERS` is a comma-separated list of fully-qualified Python function paths. When set, ONLY the listed factories run.
+
+```bash
+export TITAN_STRUCT_LOGGER_HANDLERS="torchtitan.observability.structured_logger.jsonl_handler.register_jsonl_handler,mypackage.my_backend.register_my_db_handler"
+```
+
+A handler factory takes the args `sl.init_structured_logger()` forwards and attaches one handler to `structured_logger`. Example: stream events to a remote database instead of writing to disk, and enrich each record with cluster metadata along the way.
+
+```python
+import logging
+import os
+
+from torchtitan.observability.structured_logger.jsonl_handler import (
+    TraceJsonlFormatter,
+)
+from torchtitan.observability.structured_logger.structured_logging import (
+    TraceEventsOnlyFilter,
+)
+
+
+class MyDBFormatter(TraceJsonlFormatter):
+    """Enrich each record with backend-specific fields before serialization."""
+
+    def _log_dict(self, record):
+        d = super()._log_dict(record)
+        d["cluster"] = os.environ.get("CLUSTER_NAME", "unknown")
+        return d
+
+
+class MyDBHandler(logging.Handler):
+    """Send each trace event to a remote DB as it's emitted."""
+
+    def __init__(self, rank: int, source: str, db_url: str):
+        super().__init__()
+        self.client = MyDBClient(db_url)
+        self.setFormatter(MyDBFormatter(rank=rank, source=source))
+        self.addFilter(TraceEventsOnlyFilter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.client.insert_row(self.format(record))
+        except Exception:
+            self.handleError(record)
+
+
+def register_my_db_handler(
+    *, structured_logger: logging.Logger, rank: int, source: str, **kw
+) -> None:
+    structured_logger.addHandler(
+        MyDBHandler(rank=rank, source=source, db_url="mydb://..."),
+    )
+```
+
+## Analysis
+
+### Gantt trace from JSONL
+
+```python
+from torchtitan.observability.structured_logger.gantt_generator import (
+    generate_gantt_trace,
+)
+
+generate_gantt_trace("outputs/structured_logs/", "outputs/analysis/gantt.json")
+```
+
+Reads every rank's JSONL, pairs `_start` / `_end`, and writes a Chrome Trace JSON. Open in [Perfetto](https://ui.perfetto.dev).
+
+Example dummy ASCII sketch:
+```
+                       step 1                              step 2
+                  ┌──────────────────────────┐       ┌───────────────────────────┐
+trainer rank 0    │ ▓▓ fwd_bwd ▓▓  ▓ optim ▓ │       │ ▓ fwd_bwd ▓▓ ▓▓ optim ▓   │
+trainer rank 1    │  ▓▓ fwd_bwd ▓ ▓ optim ▓  │       │  ▓▓ fwd_bwd ▓▓ ▓ optim ▓  │
+trainer rank 2    │ ▓ fwd_bwd ▓▓ ▓ optim ▓▓  │       │  ▓ fwd_bwd ▓▓▓ ▓ optim ▓▓ │
+trainer rank 3    │  ▓▓ fwd_bwd ▓▓▓ ▓ optim ▓│       │ ▓ fwd_bwd ▓▓ ▓ optim ▓    │
+                  └──────────────────────────┘       └───────────────────────────┘
+controller        ▓▓▓▓▓▓ training_s ▓▓▓▓▓▓▓ ▓ scoring ▓ ▓▓▓▓▓▓ training_s ▓▓▓▓▓▓
+rollouter         ▓▓▓                                     ▓▓▓
+reward                                       ▓▓▓                              ▓▓▓
+                  ├──────────────────────────┼───────────┼──────────────────────┤
+                  0s                         3s          4s                     7s
+```
+
+Each `log_trace_span` becomes a bar. Every source file becomes a separate process row. Auto-named asyncio tasks are slot-packed into a contiguous `0..K-1` range where K is peak concurrency, so the track count stays readable even for long async runs (e.g. RL actors dispatching many concurrent RPCs).

--- a/torchtitan/observability/structured_logger/__init__.py
+++ b/torchtitan/observability/structured_logger/__init__.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Structured logging: per-rank JSONL trace of training phases.
+
+Typical use::
+
+    from torchtitan.observability import structured_logger as sl
+
+    sl.init_structured_logger(source="training", output_dir="./outputs")
+    sl.log_trace_instant("binary_start")
+    with sl.log_trace_span("fwd_bwd"):
+        ...
+"""
+
+from torchtitan.observability.structured_logger.step_state import (
+    add_step_tag,
+    clear_step_tags,
+    get_relative_step,
+    get_step,
+    get_step_tags,
+    set_step,
+)
+from torchtitan.observability.structured_logger.structured_logging import (
+    init_structured_logger,
+    log_trace_instant,
+    log_trace_scalar,
+    log_trace_span,
+)
+
+__all__ = [
+    "init_structured_logger",
+    "set_step",
+    "add_step_tag",
+    "clear_step_tags",
+    "get_step",
+    "get_step_tags",
+    "get_relative_step",
+    "log_trace_scalar",
+    "log_trace_instant",
+    "log_trace_span",
+]

--- a/torchtitan/observability/structured_logger/gantt_generator.py
+++ b/torchtitan/observability/structured_logger/gantt_generator.py
@@ -1,0 +1,484 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Merge per-rank trace JSONL into a Chrome Trace JSON for Perfetto.
+
+TODO: not tuned for thousands of ranks or long runs. If that starts
+to hurt, cap record count with a CLI arg, lower peak memory, or
+assign tids online in the formatter.
+"""
+
+import heapq
+import json
+import os
+from collections import defaultdict
+from glob import glob
+from typing import Any
+
+from torchtitan.observability.structured_logger.structured_logging import LogType
+from torchtitan.tools.logging import logger
+
+
+def generate_gantt_trace(log_dir: str, output_path: str) -> dict:
+    """Merge per-rank JSONL into a Chrome Trace JSON for Perfetto.
+
+    Open the result in https://ui.perfetto.dev or ``chrome://tracing``.
+
+    The problem this solves: every async endpoint call runs in a fresh
+    :class:`asyncio.Task` with an auto-generated name (``Task-1``,
+    ``Task-3``, ...). A naive trace builder would give each task its
+    own Perfetto track, so a 100-step run ends up with hundreds of
+    parallel tracks per actor -- unreadable. This builder groups
+    records by task so all spans that share a task (including nested
+    ones) render on one track. Non-overlapping tasks reuse a track;
+    truly concurrent tasks (e.g. via ``asyncio.gather``) get their own.
+
+    Example::
+
+        # Actor with two nested spans per endpoint call:
+        @endpoint
+        async def generate(self, prompts):
+            with log_trace_span("rl_generate"):
+                with log_trace_span("rl_engine_steps"):
+                    return await self.engine.step(prompts)
+
+        # After 5 sequential calls, the JSONL has 10 paired records
+        # across 5 task names (Task-1, Task-3, ...). Build the trace:
+        generate_gantt_trace("outputs/structured_logs/", "outputs/gantt.json")
+
+        # Perfetto shows the generator as ONE track with 5 stacked
+        # (rl_generate / rl_engine_steps) pairs along its timeline.
+        # If two calls had run via asyncio.gather, they would instead
+        # appear on two parallel tracks.
+
+    Args:
+        log_dir: Directory containing per-rank ``*.jsonl`` trace files.
+        output_path: Path to write the merged Chrome Trace JSON.
+
+    Returns:
+        The Chrome Trace dict (``{"traceEvents": [...]}``). Also
+        written to ``output_path``.
+    """
+    records = load_all_records(log_dir)
+    if not records:
+        logger.info(f"No records found in {log_dir}")
+        return {"traceEvents": []}
+
+    sources = sorted({r["_source_file"] for r in records})
+    source_to_pid = {s: i for i, s in enumerate(sources)}
+
+    paired, instants = _collect_paired_and_instants(records, source_to_pid)
+    tid_by_source_and_task = _assign_tids_per_source(paired)
+    events = _emit_chrome_events(
+        paired=paired,
+        instants=instants,
+        source_to_pid=source_to_pid,
+        tid_by_source_and_task=tid_by_source_and_task,
+    )
+
+    trace = {"traceEvents": events}
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(trace, f, indent=2)
+
+    logger.info(f"Chrome Trace: {output_path}")
+    logger.info(f"  {len(events)} events from {len(sources)} sources")
+    logger.info("  View in: chrome://tracing or https://ui.perfetto.dev")
+    return trace
+
+
+def _assign_tids_per_source(
+    paired: list[dict],
+) -> dict[tuple[str, str | None], int]:
+    """Assign a Perfetto ``tid`` to every paired span (mutates ``s["tid"]``).
+
+    Task-level interval scheduling:
+
+    1. Group spans by ``(source, task_name)``. Each asyncio task has
+       one group; SPMD code groups under ``task_name=None``.
+    2. Compute each group's time range ``[min(start_ts), max(end_ts)]``.
+    3. Slot-pack the task ranges within each source via min-heap
+       interval scheduling. Non-overlapping task ranges reuse a slot.
+    4. Every span inherits its task's slot.
+
+    Nested spans within a task share a tid -- Perfetto renders the
+    nesting as a stacked flamegraph on one track. Concurrent tasks
+    whose ranges overlap get different tids and render as parallel
+    tracks. Sequential tasks reuse a single tid.
+
+    Example (one source, four spans across three tasks)::
+
+        span         start  end    task
+        outer        100    500    Task-1
+        inner        150    200    Task-1   # nested, same task
+        weight_sync  600    800    Task-2   # after Task-1 ends
+        log_shard    650    700    Task-3   # overlaps Task-2
+
+        task ranges:  Task-1 [100, 500]
+                      Task-2 [600, 800]
+                      Task-3 [650, 700]
+
+        slot packing (tasks sorted by start):
+            Task-1 -> slot 0              # first, new slot
+            Task-2 -> slot 0  (reused)    # 500 <= 600, slot 0 free
+            Task-3 -> slot 1              # Task-2 still busy, new slot
+
+        assigned tids:
+            outer       -> 0
+            inner       -> 0   (same task as outer -> Perfetto stacks)
+            weight_sync -> 0
+            log_shard   -> 1
+
+    Args:
+        paired: Paired span dicts from ``_collect_paired_and_instants``.
+            Mutated in place: each span gets a ``"tid"`` key.
+
+    Returns:
+        ``(source, task_name) -> tid`` mapping. Used by
+        ``_resolve_instant_tid`` so instants (which have no paired
+        start) land on their enclosing task's track.
+    """
+    by_source: dict[str, list[dict]] = defaultdict(list)
+    for p in paired:
+        by_source[p["source"]].append(p)
+
+    tid_by_source_and_task: dict[tuple[str, str | None], int] = {}
+
+    for source, spans in by_source.items():
+        # Compute each task's [min_start, max_end] range.
+        task_range: dict[str | None, list[int]] = {}
+        for s in spans:
+            tn = s.get("task_name")
+            ts, end = s["start_ts"], s["end_ts"]
+            r = task_range.get(tn)
+            if r is None:
+                task_range[tn] = [ts, end]
+            else:
+                if ts < r[0]:
+                    r[0] = ts
+                if end > r[1]:
+                    r[1] = end
+
+        # Slot-pack task ranges (min-heap interval scheduling, sorted
+        # by task start time).
+        busy: list[tuple[int, int]] = []
+        next_slot = 0
+        for tn, (start, end) in sorted(task_range.items(), key=lambda x: x[1][0]):
+            if busy and busy[0][0] <= start:
+                _, slot = heapq.heappop(busy)
+            else:
+                slot = next_slot
+                next_slot += 1
+            heapq.heappush(busy, (end, slot))
+            tid_by_source_and_task[(source, tn)] = slot
+
+        # Every span inherits its task's tid.
+        for s in spans:
+            s["tid"] = tid_by_source_and_task[(source, s.get("task_name"))]
+
+    return tid_by_source_and_task
+
+
+def _resolve_instant_tid(
+    *,
+    source: str,
+    task_name: str | None,
+    tid_by_source_and_task: dict[tuple[str, str | None], int],
+) -> int:
+    """Pick the Perfetto tid for an instant event (no paired span).
+
+    An instant lands on the same track as its enclosing task if that
+    task has paired spans. Otherwise it falls back to tid 0 (the
+    per-process main track).
+
+    Args:
+        source: The instant's source (one JSONL file = one source).
+        task_name: The instant's task name, or ``None`` if emitted
+            outside any asyncio task.
+        tid_by_source_and_task: Map produced by ``_assign_tids_per_source``.
+
+    Returns:
+        The Perfetto ``tid`` for the instant.
+    """
+    if (source, task_name) in tid_by_source_and_task:
+        return tid_by_source_and_task[(source, task_name)]
+    return 0
+
+
+def load_all_records(log_dir: str) -> list[dict]:
+    """Load all JSONL records from a ``structured_logs/`` directory.
+
+    Args:
+        log_dir: Directory containing ``*.jsonl`` files (one per rank).
+
+    Returns:
+        All records across all files, each annotated with a
+        ``"_source_file"`` key (the filename minus ``.jsonl``) so the
+        caller can group records by process. Files are loaded in sorted
+        name order; records within a file keep file order.
+    """
+    records = []
+    for path in sorted(glob(os.path.join(log_dir, "*.jsonl"))):
+        source = os.path.basename(path)
+        # Strip the trailing .jsonl extension for a readable source label.
+        source_name = source.rsplit(".", 1)[0] if "." in source else source
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    r = json.loads(line)
+                    r["_source_file"] = source_name
+                    records.append(r)
+    return records
+
+
+def _collect_paired_and_instants(
+    records: list[dict], source_to_pid: dict[str, int]
+) -> tuple[list[dict], list[dict]]:
+    """Pair ``_start`` / ``_end`` via a per-(source, task_name) LIFO stack.
+
+    Each asyncio task name gets its own stack, so nested spans within a
+    task pair correctly regardless of what other tasks on the same
+    process are doing. SPMD code has ``task_name=None`` throughout and
+    pairs on a single stack per source.
+
+    Instants include ``log_trace_instant`` markers, ``log_trace_scalar``
+    metric values, and ``_error`` records.
+
+    Example -- 5 records for one task, one source::
+
+        # input (one JSONL line each, in order)
+        {"log_type_name": "step_start",    "time_us": 100, "task_name": "Task-1"}
+        {"log_type_name": "fwd_bwd_start", "time_us": 110, "task_name": "Task-1"}
+        {"log_type_name": "fwd_bwd_end",   "time_us": 500, "task_name": "Task-1", "value": 0.39}
+        {"log_type_name": "metric_value",  "time_us": 520, "event_name": "loss", "value": 2.5}
+        {"log_type_name": "step_end",      "time_us": 600, "task_name": "Task-1", "value": 0.5}
+
+        # output
+        paired = [
+            {"display_name": "fwd_bwd", "start_ts": 110, "end_ts": 500, ...},
+            {"display_name": "step",    "start_ts": 100, "end_ts": 600, ...},
+        ]
+        instants = [
+            {"name": "loss=2.5000", "time_us": 520, ...},
+        ]
+
+    ``fwd_bwd`` appears first in ``paired`` because LIFO pops the inner
+    span (``fwd_bwd``) when ``fwd_bwd_end`` arrives; ``step`` pops later
+    when ``step_end`` arrives.
+
+    Args:
+        records: All JSONL records across all sources, in the order
+            produced by ``load_all_records``.
+        source_to_pid: Map from ``_source_file`` name to the Perfetto
+            pid assigned to that source.
+
+    Returns:
+        ``(paired, instants)`` -- paired spans in end-order (inner first,
+        outer last) and instant events preserving record order.
+    """
+    paired: list[dict[str, Any]] = []
+    instants: list[dict[str, Any]] = []
+    # LIFO stack per (source, task_name). None task_name maps to one
+    # stack per source (the SPMD path).
+    pending: dict[tuple[str, str | None], list[dict]] = defaultdict(list)
+
+    for r in records:
+        event_type = r.get("log_type_name", "")
+        log_type = r.get("log_type", "")
+        time_us = r.get("time_us") or (r.get("time_ms") or 0) * 1000
+        pid = source_to_pid[r["_source_file"]]
+        rank = r.get("rank", 0)
+        step = r.get("step")
+        task_name = r.get("task_name")
+        source = r["_source_file"]
+        caller = r.get("caller")
+        key = (source, task_name)
+
+        # Point-in-time records (log_trace_instant, log_trace_scalar) carry
+        # log_type=instant. Branch on intent before suffix matching so that
+        # instants whose names happen to end in "_start" (binary_start,
+        # training_start) don't get wrongly routed to the span-pair stack.
+        if log_type == str(LogType.INSTANT):
+            if event_type == "metric_value":
+                event_name = r.get("event_name", "metric")
+                value = r.get("value") or 0
+                display_name = f"{event_name}={value:.4f}"
+            else:
+                display_name = event_type
+            instants.append(
+                {
+                    "name": display_name,
+                    "time_us": time_us,
+                    "pid": pid,
+                    "source": source,
+                    "task_name": task_name,
+                    "step": step,
+                    "caller": caller,
+                }
+            )
+        elif event_type.endswith("_start"):
+            type_name = event_type.removesuffix("_start")
+            display_name = r.get("event_name") or type_name
+            pending[key].append(
+                {
+                    "ts": time_us,
+                    "step": step,
+                    "display_name": display_name,
+                    "pid": pid,
+                    "rank": rank,
+                    "task_name": task_name,
+                    "source": source,
+                    "caller": caller,
+                }
+            )
+
+        elif event_type.endswith("_end"):
+            type_name = event_type.removesuffix("_end")
+            duration_ms = r.get("value", 0)
+            duration_us = (duration_ms or 0) * 1000
+            stack = pending.get(key)
+            start = stack.pop() if stack else None
+            if start is not None:
+                start_ts = start["ts"]
+                end_ts = start_ts + duration_us
+            else:
+                # Orphan _end (e.g. truncated JSONL). Derive start from the
+                # _end's own timestamp and the recorded duration so the span
+                # renders in its real time window instead of after its end.
+                end_ts = time_us
+                start_ts = end_ts - duration_us
+            paired.append(
+                {
+                    "pid": pid,
+                    "rank": (start or {}).get("rank", rank),
+                    "task_name": (start or {}).get("task_name", task_name),
+                    "source": (start or {}).get("source", source),
+                    "start_ts": start_ts,
+                    "end_ts": end_ts,
+                    "display_name": (start or {}).get("display_name", type_name),
+                    "step": step,
+                    "duration_ms": duration_ms,
+                    "caller": (start or {}).get("caller", caller),
+                }
+            )
+
+        elif event_type.endswith("_error"):
+            type_name = event_type.removesuffix("_error")
+            instants.append(
+                {
+                    "name": f"ERROR: {type_name}",
+                    "time_us": time_us,
+                    "pid": pid,
+                    "source": source,
+                    "task_name": task_name,
+                    "step": step,
+                    "caller": caller,
+                }
+            )
+
+        else:
+            # Default: unrecognized record type renders as a bare instant on
+            # the enclosing task's track.
+            instants.append(
+                {
+                    "name": event_type,
+                    "time_us": time_us,
+                    "pid": pid,
+                    "source": source,
+                    "task_name": task_name,
+                    "step": step,
+                    "caller": caller,
+                }
+            )
+
+    return paired, instants
+
+
+def _emit_chrome_events(
+    *,
+    paired: list[dict],
+    instants: list[dict],
+    source_to_pid: dict[str, int],
+    tid_by_source_and_task: dict[tuple[str, str | None], int],
+) -> list[dict]:
+    """Build the Chrome Trace event list (one Perfetto process per source).
+
+    Emits three kinds of events:
+
+    - ``"M"`` (metadata) ``process_name`` -- one per source, labels the
+      process track in Perfetto.
+    - ``"X"`` (complete) -- one per paired span, with ``ts`` / ``dur``
+      for rendering as a bar.
+    - ``"i"`` (instant) -- one per instant event, rendered as a
+      vertical marker on its track.
+
+    Args:
+        paired: Spans from ``_collect_paired_and_instants`` with ``tid``
+            already assigned by ``_assign_tids_per_source``.
+        instants: Instant events from ``_collect_paired_and_instants``.
+        source_to_pid: Map from source name to Perfetto pid.
+        tid_by_source_and_task: Map used to place instants on their
+            enclosing task's track.
+
+    Returns:
+        A flat list of Chrome Trace event dicts ready to serialize.
+    """
+    events: list[dict[str, Any]] = []
+
+    for source, pid in source_to_pid.items():
+        events.append(
+            {
+                "name": "process_name",
+                "ph": "M",
+                "pid": pid,
+                "tid": 0,
+                "args": {"name": source},
+            }
+        )
+
+    for p in paired:
+        duration_ms = p["duration_ms"] or 0
+        args: dict = {
+            **({"step": p["step"]} if p["step"] is not None else {}),
+            "duration_ms": f"{duration_ms:.2f}" if duration_ms else "0.00",
+        }
+        if p.get("caller"):
+            args["caller"] = p["caller"]
+        events.append(
+            {
+                "name": p["display_name"],
+                "ph": "X",
+                "ts": p["start_ts"],
+                "dur": p["end_ts"] - p["start_ts"],
+                "pid": p["pid"],
+                "tid": p.get("tid", 0),
+                "args": args,
+            }
+        )
+
+    for i in instants:
+        tid = _resolve_instant_tid(
+            source=i["source"],
+            task_name=i["task_name"],
+            tid_by_source_and_task=tid_by_source_and_task,
+        )
+        args = {**({"step": i["step"]} if i["step"] is not None else {})}
+        if i.get("caller"):
+            args["caller"] = i["caller"]
+        events.append(
+            {
+                "name": i["name"],
+                "ph": "i",
+                "ts": i["time_us"],
+                "pid": i["pid"],
+                "tid": tid,
+                "s": "t",
+                "args": args,
+            }
+        )
+
+    return events

--- a/torchtitan/observability/structured_logger/jsonl_handler.py
+++ b/torchtitan/observability/structured_logger/jsonl_handler.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Default JSONL backend: formatter, file handler, and factory.
+
+``TraceJsonlFormatter`` is also the base class for backend-specific
+formatters (e.g. the Scuba formatter under ``fb/``).
+"""
+
+import datetime as dt
+import itertools
+import json
+import logging
+import os
+import random
+import socket
+import string
+import threading
+from timeit import default_timer as timer
+from typing import Any
+
+from torchtitan.observability.structured_logger.step_state import (
+    get_relative_step,
+    get_step,
+    get_step_tags,
+)
+from torchtitan.observability.structured_logger.structured_logging import (
+    ExtraFields,
+    LogType,
+    TraceEventsOnlyFilter,
+)
+
+console_logger: logging.Logger = logging.getLogger(__name__)
+
+MAX_MESSAGE_SIZE: int = 1000
+
+
+class TraceJsonlFormatter(logging.Formatter):
+    """Format trace records as one JSON line per record.
+
+    Per-process fields (rank, source, hostname, local_rank) are captured
+    in ``__init__``; per-step fields (step, relative_step, step_tags)
+    are pulled from :mod:`.step_state` at emit time.
+
+    Subclass to enrich records with backend-specific fields.
+
+    Example output (wrapped for readability)::
+
+        {"rank": 0, "source": "training", "step": 5,
+         "log_type_name": "fwd_bwd_end", "value": 12.5, "task_name": "Task-1",
+         "step_tags": ["gc"],
+         "time_us": 1709500000123456, "caller": "trainer.py:796:train_step",
+         "seq_id": 42}
+    """
+
+    def __init__(self, rank: int, source: str):
+        super().__init__()
+        self.rank = rank
+        self.source = source
+        self._local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        self._host_name = socket.gethostname()
+        self._seq_counter = itertools.count()
+        # Per-instance threadlocal: prevents delta_ms leakage when multiple
+        # formatters (e.g. default JSONL + custom backend) are attached to
+        # the same logger in the same process.
+        self._thread_local = threading.local()
+
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps(self._log_dict(record))
+
+    def _log_dict(self, record: logging.LogRecord) -> dict[str, Any]:
+        """Build the flat dict emitted as one JSONL line."""
+        log_dict: dict[str, Any] = {}
+
+        log_dict["delta_ms"] = self._refresh_event_delta()
+        log_dict["tid"] = threading.get_native_id()
+
+        # Rank/source from self (constants, set once in init_structured_logger)
+        log_dict["rank"] = self.rank
+        log_dict["global_rank"] = self.rank
+        log_dict["local_rank"] = self._local_rank
+        log_dict["source"] = self.source
+        log_dict["host_name"] = self._host_name
+        log_dict["pid"] = os.getpid()
+
+        # Step/step_tags/relative_step from hybrid ContextVar/globals
+        step = get_step()
+        if step is not None:
+            log_dict["step"] = step
+        relative_step = get_relative_step()
+        if relative_step is not None:
+            log_dict["relative_step"] = relative_step
+        step_tags = get_step_tags()
+        if step_tags:
+            log_dict["step_tags"] = list(step_tags)
+
+        log_dict["time"] = int(record.created)
+        log_dict["time_ms"] = int(record.created * 1000)
+        log_dict["time_us"] = int(record.created * 1_000_000)
+
+        log_dict["log_type"] = getattr(
+            record, str(ExtraFields.LOG_TYPE), str(LogType.TEXT)
+        )
+        log_type_name = getattr(record, str(ExtraFields.LOG_TYPE_NAME), None)
+        log_dict["log_type_name"] = log_type_name
+
+        # Per-record step/relative_step override (from event_extra)
+        record_step = getattr(record, str(ExtraFields.STEP), None)
+        if record_step is not None:
+            log_dict["step"] = record_step
+        record_relative_step = getattr(record, str(ExtraFields.RELATIVE_STEP), None)
+        if record_relative_step is not None:
+            log_dict["relative_step"] = record_relative_step
+
+        log_dict["event_name"] = getattr(record, str(ExtraFields.EVENT_NAME), None)
+
+        value = getattr(record, str(ExtraFields.VALUE), None)
+        if isinstance(value, (float, int)):
+            log_dict["value"] = float(value)
+
+        # task_name pairs start/end records
+        task_name = getattr(record, str(ExtraFields.TASK_NAME), None)
+        if task_name is not None:
+            log_dict["task_name"] = task_name
+
+        # Caller field for source traceability (file:line:function)
+        log_dict[
+            "caller"
+        ] = f"{os.path.relpath(record.pathname)}:{record.lineno}:{record.funcName}"
+        log_dict["log_file"] = record.filename
+        log_dict["log_function"] = record.funcName
+        log_dict["log_level"] = record.levelname
+        log_dict["logger_name"] = record.name
+        if record.stack_info:
+            log_dict["stack_info"] = record.stack_info
+
+        log_dict["seq_id"] = next(self._seq_counter)
+
+        # Truncate long free-text messages. Event records
+        # (log_trace_span/scalar/instant) pass msg="", so this branch really
+        # only catches plain logger.info() calls routed to the structured
+        # logger -- usually a user mistake.
+        message = record.getMessage()
+        if message is not None:
+            if len(message) <= MAX_MESSAGE_SIZE:
+                log_dict["message"] = message
+            else:
+                half = MAX_MESSAGE_SIZE // 2
+                log_dict["message"] = message[:half] + "..." + message[-half:]
+
+        return log_dict
+
+    def _refresh_event_delta(self) -> float:
+        if not hasattr(self._thread_local, "last_event_time"):
+            self._thread_local.last_event_time = timer()
+        event_delta = (timer() - self._thread_local.last_event_time) * 1000
+        self._thread_local.last_event_time = timer()
+        return event_delta
+
+
+class TraceJsonlHandler(logging.FileHandler):
+    """Per-rank JSONL file handler.
+
+    File path::
+
+        {output_dir}/structured_logs/{source}.global_rank_{rank}.{timestamp}-{random}.jsonl
+    """
+
+    def __init__(self, rank: int, source: str, output_dir: str):
+        timestamp_str = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        random_str = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(6)
+        )
+        filename = f"{source}.global_rank_{rank}.{timestamp_str}-{random_str}.jsonl"
+        filepath = os.path.join(output_dir, "structured_logs", filename)
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        super().__init__(filename=filepath)
+        self.setFormatter(TraceJsonlFormatter(rank=rank, source=source))
+        self.addFilter(TraceEventsOnlyFilter())
+
+
+def register_jsonl_handler(
+    *,
+    structured_logger: logging.Logger,
+    rank: int,
+    source: str,
+    output_dir: str,
+    **kw: Any,
+) -> None:
+    """Default factory: attach a ``TraceJsonlHandler`` to the structured logger."""
+    handler = TraceJsonlHandler(rank=rank, source=source, output_dir=output_dir)
+    structured_logger.addHandler(handler)
+    console_logger.info("Structured logging -> JSONL: %s", handler.baseFilename)

--- a/torchtitan/observability/structured_logger/step_state.py
+++ b/torchtitan/observability/structured_logger/step_state.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Per-step state for structured trace records.
+
+Stores current step, relative step, and step tags. Every trace call
+(``log_trace_span`` / ``log_trace_instant`` / ``log_trace_scalar``)
+stamps records with these values at emit time.
+
+Two runtime models share this state:
+
+- **SPMD trainer.** One process, one thread, no asyncio. Call
+  ``set_step(step)`` once per step; add tags like ``add_step_tag("gc")``
+  when GC ran. A module global suffices.
+- **Async RL.** Multiple actor tasks may run concurrently on the same
+  process (e.g., one actor doing GC while another runs evaluation).
+  Each task may add DIFFERENT tags for the same step, and those views
+  must stay isolated -- actor A's ``"gc"`` must not leak into actor B's
+  view of ``"eval"``.
+
+Design
+------
+Each value is stored in two places:
+
+- **module-level global** -- SPMD path; also the fallback for plain
+  threads (``threading.Thread``), which don't inherit ContextVar state.
+- **ContextVar** -- per-task path; inherited when an asyncio task is
+  spawned, isolated from sibling tasks.
+
+``set_step`` writes both (same value -- steps agree across tasks).
+``add_step_tag`` is task-aware: inside an asyncio task it writes the
+CV (ContextVar) only; outside, the global only. This prevents cross-pollination
+when sibling actor tasks tag independently. Readers check the CV
+first, fall back to the global.
+
+Example::
+
+    # Pre-asyncio SPMD code sets a global tag (e.g. from init logic):
+    add_step_tag("checkpoint_step")                 # writes _TAGS_GLOBAL
+    assert get_step_tags() == ("checkpoint_step",)  # SPMD path reads global
+
+    # Once inside async tasks, tags are task-scoped:
+    set_step(42)
+    async def actor_gc():
+        add_step_tag("gc")                          # writes CV only
+        return get_step_tags()
+    async def actor_eval():
+        add_step_tag("eval")                        # writes CV only
+        return get_step_tags()
+
+    gc_view, eval_view = await asyncio.gather(actor_gc(), actor_eval())
+    assert gc_view == ("gc",)                       # actor A: just its CV
+    assert eval_view == ("eval",)                   # actor B: just its CV
+    assert _TAGS_GLOBAL == ("checkpoint_step",)     # global untouched
+
+Note: inside a task, global tags are NOT visible (``get_step_tags`` returns
+the task's CV when non-empty). Actor contexts are intentionally isolated;
+if a tag needs to reach actors, set it per-task (e.g. via the controller's
+sync_step broadcast).
+"""
+
+import asyncio
+from contextvars import ContextVar
+
+# Module-level globals. Source of truth for SPMD and non-asyncio reads.
+# Tuples (not lists): immutable, so snapshots can't be mutated-through-
+# reference to bypass CV scope-isolation. Concurrent tasks don't overwrite
+# each other -- asyncio copies the context at task spawn, giving each its
+# own CV copy; writes are scope-local.
+_STEP_GLOBAL: int | None = None
+_RELATIVE_STEP_GLOBAL: int | None = None
+_TAGS_GLOBAL: tuple[str, ...] = ()
+
+# Per-task overrides. Async endpoints (e.g. RL actor frameworks) run on fresh
+# asyncio tasks that inherit their parent's Context via asyncio.create_task's
+# implicit copy_context(); writes stay scoped to the writing task.
+_STEP_CV: ContextVar[int | None] = ContextVar("_STEP_CV", default=None)
+_RELATIVE_STEP_CV: ContextVar[int | None] = ContextVar(
+    "_RELATIVE_STEP_CV", default=None
+)
+_TAGS_CV: ContextVar[tuple[str, ...]] = ContextVar("_TAGS_CV", default=())
+
+
+def _is_in_async_task() -> bool:
+    """True iff called from inside a running asyncio task.
+
+    On Python 3.12 ``asyncio.current_task()`` calls
+    ``get_running_loop()`` which raises ``RuntimeError`` when no loop is
+    running. On Python 3.14+ it's expected to return None directly. The
+    try/except handles both.
+    """
+    try:
+        return asyncio.current_task() is not None
+    except RuntimeError:
+        return False
+
+
+def set_step(step: int, *, relative_step: int | None = None) -> None:
+    """Set the current training step. All subsequent trace records will
+    include this step number. Clears step tags from the previous step.
+
+    Args:
+        step: Absolute training step (e.g., 12345 after resuming).
+        relative_step: Steps since process start (1 on first step of each
+            restart). Used by downstream analysis tools to align
+            per-restart event timelines. When None, defaults to ``step``
+            -- correct for runs without checkpoint resume. Resumed
+            trainers must pass it explicitly.
+    Example::
+        self.checkpointer.load(step=config.checkpoint.load_step)
+        loaded_step = self.step
+        for step in range(loaded_step + 1, num_steps + 1):
+            set_step(step, relative_step=step - loaded_step)
+            train_step(...)
+    """
+    global _STEP_GLOBAL, _RELATIVE_STEP_GLOBAL
+    if relative_step is None:
+        relative_step = step
+    _STEP_GLOBAL = step
+    _STEP_CV.set(step)
+    _RELATIVE_STEP_GLOBAL = relative_step
+    _RELATIVE_STEP_CV.set(relative_step)
+    clear_step_tags()
+
+
+def get_step() -> int | None:
+    """Return the current step, or None if not set."""
+    cv = _STEP_CV.get()
+    if cv is not None:
+        return cv
+    return _STEP_GLOBAL
+
+
+def get_relative_step() -> int | None:
+    """Return the relative step (steps since process start), or None."""
+    cv = _RELATIVE_STEP_CV.get()
+    if cv is not None:
+        return cv
+    return _RELATIVE_STEP_GLOBAL
+
+
+def get_step_tags() -> tuple[str, ...]:
+    """Return the current step tags (CV if non-empty, else global)."""
+    cv = _TAGS_CV.get()
+    if cv:
+        return cv
+    return _TAGS_GLOBAL
+
+
+def add_step_tag(tag: str) -> None:
+    """Annotate the current step. Tags appear in trace JSONL for filtering.
+
+    Task-aware write: inside an asyncio task the tag is appended to the
+    CV only (so sibling tasks with different tags don't cross-pollinate
+    via the shared global); outside any task the tag goes to the global
+    only (SPMD path).
+
+    Example::
+
+        if gc_happened:
+            add_step_tag("gc")
+        if is_validation:
+            add_step_tag("eval")
+    """
+    global _TAGS_GLOBAL
+    if _is_in_async_task():
+        current = _TAGS_CV.get()
+        if tag not in current:
+            _TAGS_CV.set(current + (tag,))
+    else:
+        if tag not in _TAGS_GLOBAL:
+            _TAGS_GLOBAL = _TAGS_GLOBAL + (tag,)
+
+
+def clear_step_tags() -> None:
+    """Reset step tags."""
+    global _TAGS_GLOBAL
+    _TAGS_GLOBAL = ()
+    _TAGS_CV.set(())

--- a/torchtitan/observability/structured_logger/structured_logging.py
+++ b/torchtitan/observability/structured_logger/structured_logging.py
@@ -1,0 +1,438 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Structured-logging API: init_structured_logger, log_trace_span, log_trace_instant, log_trace_scalar.
+
+Emits structured JSONL events for phase timing, scalars, and diagnostics.
+Handler factories (JSONL, custom, etc.) are loaded dynamically via
+the ``TITAN_STRUCT_LOGGER_HANDLERS`` env var.
+"""
+
+import asyncio
+import enum
+import functools
+import importlib
+import inspect
+import logging
+import os
+from collections.abc import Callable
+from timeit import default_timer as timer
+from typing import Any, cast, TypeVar
+
+import torch
+
+from torchtitan.observability.structured_logger.step_state import get_step
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Used by this module for regular logging
+console_logger: logging.Logger = logging.getLogger(__name__)
+
+# Dedicated logger for structured events. Uses a name distinct from
+# ``__name__`` so we can set ``propagate = False`` here without also silencing
+# the console logger above.
+_structured_logger: logging.Logger = logging.getLogger("torchtitan.structured_logger")
+_structured_logger.propagate = False
+
+# Used to check if handler has been already initialized. If so, re-initializing
+# is a no-op
+_is_initialized: bool = False
+
+# Set by ``init_structured_logger(enable=False)`` to make all trace calls no-ops.
+_disabled: bool = False
+
+_DEFAULT_HANDLER_FACTORY = (
+    "torchtitan.observability.structured_logger.jsonl_handler.register_jsonl_handler"
+)
+
+
+def _structured_logger_disabled() -> bool:
+    """Whether structured logging is disabled.
+
+    Driven by the ``enable`` flag passed to :func:`init_structured_logger`
+    (sourced from ``DebugConfig.enable_structured_logging``).
+    """
+    return _disabled
+
+
+class StrEnum(enum.Enum):
+    """Stand-in for ``enum.StrEnum`` (added in Python 3.11)
+
+    Mimics it for our use case: ``str(member)`` returns the value (e.g.
+    ``"event"``), not ``"LogType.EVENT"``. Drop in favor of ``enum.StrEnum``
+    once Python 3.10 support is no longer needed.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class LogType(StrEnum):
+    """Record kind in the JSONL stream.
+
+    - ``EVENT``: paired span record (``*_start`` / ``*_end`` from ``log_trace_span``).
+    - ``INSTANT``: point-in-time record (``log_trace_instant``, ``log_trace_scalar``).
+    - ``TEXT``: free-text log record (filtered out by ``TraceEventsOnlyFilter``).
+    """
+
+    EVENT = "event"
+    INSTANT = "instant"
+    TEXT = "text"
+
+
+class ExtraFields(StrEnum):
+    """Keys for the ``extra`` dict passed to logging calls."""
+
+    LOG_TYPE = "log_type"
+    LOG_TYPE_NAME = "log_type_name"
+    EVENT_NAME = "event_name"
+    STEP = "step"
+    VALUE = "value"
+    RELATIVE_STEP = "relative_step"
+    TASK_NAME = "task_name"
+
+
+def event_extra(
+    event_type: str,
+    event_name: str | None = None,
+    step: int | None = None,
+    relative_step: int | None = None,
+    value: float | int | None = None,
+    task_name: str | None = None,
+    log_type: LogType = LogType.EVENT,
+) -> dict[str, Any]:
+    """Build the extra dict for a structured JSONL event record."""
+    return {
+        str(ExtraFields.LOG_TYPE): str(log_type),
+        str(ExtraFields.LOG_TYPE_NAME): str(event_type),
+        str(ExtraFields.EVENT_NAME): event_name,
+        str(ExtraFields.STEP): step,
+        str(ExtraFields.RELATIVE_STEP): relative_step,
+        str(ExtraFields.VALUE): value,
+        str(ExtraFields.TASK_NAME): task_name,
+    }
+
+
+class TraceEventsOnlyFilter(logging.Filter):
+    """Defensive filter: drop any record on the structured logger that did not
+    come through the ``log_trace_*`` API.
+
+    How records get a ``log_type_name`` attribute:
+
+    1. ``log_trace_span`` / ``log_trace_instant`` / ``log_trace_scalar`` all
+       call ``_structured_logger.info(msg, extra=event_extra(...))``.
+    2. ``event_extra`` always sets ``log_type_name`` in the ``extra`` dict.
+    3. Python's logging attaches ``extra`` keys as attributes on the
+       ``LogRecord``, so ``record.log_type_name`` is populated.
+
+    So any record reaching this filter WITHOUT ``log_type_name`` is a plain
+    ``.info("text")`` call made directly on the structured logger — bypassing
+    the API. That should not happen in this codebase (we never call
+    ``_structured_logger`` outside the log_trace_* helpers). The filter exists
+    as a safeguard against future accidents: if someone grabs the logger by
+    name (``logging.getLogger("torchtitan.structured_logger")``) and writes
+    free text, this filter keeps it out of the JSONL stream so the schema
+    stays strict. The first drop emits a one-shot warning to make the trap
+    discoverable.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._warned = False
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if getattr(record, str(ExtraFields.LOG_TYPE_NAME), None) is not None:
+            return True
+        if not self._warned:
+            self._warned = True
+            console_logger.warning(
+                "Plain-text record on the structured logger was dropped. "
+                "Use log_trace_span / log_trace_scalar / log_trace_instant."
+            )
+        return False
+
+
+def init_structured_logger(
+    source: str, output_dir: str, rank: int | None = None, enable: bool = True
+) -> None:
+    """Attach handlers to the structured logger. Call once per process.
+
+    Handler factories come from the ``TITAN_STRUCT_LOGGER_HANDLERS`` env var
+    (comma-separated ``module.path.factory_name``). When unset, a default
+    JSONL handler is registered; when set, ONLY the listed factories run.
+
+    ``rank`` defaults to ``$RANK`` (set by torchrun), so this can run
+    before ``torch.distributed`` init. Idempotent: second and later calls
+    are a no-op.
+
+    When ``enable=False``, all subsequent ``log_trace_*`` calls become
+    no-ops (no handlers are attached).
+
+    Does not configure console output; call ``init_logger()`` for that.
+
+    Example::
+
+        init_structured_logger(source="trainer", output_dir="./outputs")
+        log_trace_instant("binary_start")
+    """
+    global _is_initialized, _disabled
+
+    if not enable:
+        _disabled = True
+        console_logger.info(
+            "Structured logging disabled via DebugConfig.enable_structured_logging=False"
+        )
+        return
+
+    # Avoids re-initializing
+    if _is_initialized:
+        return
+
+    if rank is None:
+        rank = int(os.environ.get("RANK", 0))
+
+    factories_env = os.environ.get("TITAN_STRUCT_LOGGER_HANDLERS", "")
+    if factories_env.strip():
+        factory_paths = [f.strip() for f in factories_env.split(",") if f.strip()]
+    else:
+        factory_paths = [_DEFAULT_HANDLER_FACTORY]
+
+    for factory_path in factory_paths:
+        module_path, func_name = factory_path.rsplit(".", 1)
+        mod = importlib.import_module(module_path)
+        getattr(mod, func_name)(
+            structured_logger=_structured_logger,
+            rank=rank,
+            source=source,
+            output_dir=output_dir,
+        )
+
+    if (
+        _structured_logger.level == logging.NOTSET
+        or _structured_logger.level > logging.INFO
+    ):
+        _structured_logger.setLevel(logging.INFO)
+
+    _is_initialized = True
+
+
+def log_trace_scalar(scalars: dict[str, float | int], *, stacklevel: int = 2) -> None:
+    """Emit a record per (name, value) pair. Useful when adding more context
+    to the trace for debugging, e.g. registering `num_tokens_processed`.
+
+    Step is read from ``set_step()``; non-numeric values are skipped
+    with a warning. Bump ``stacklevel`` when wrapping in a helper so
+    ``caller`` points at the real call site.
+
+    Args:
+        scalars: Mapping of scalar name to numeric value. Non-numeric
+            values are skipped with a warning.
+        stacklevel: Passed through to ``logger.info`` so the ``caller`` field
+            in the emitted record points at the real call site. Increase from
+            the default 2 if you wrap this function in a helper.
+
+    Example::
+
+        log_trace_scalar({"train.loss": 2.5, "train.tflops": 45.6})
+    """
+    if _structured_logger_disabled() or torch.compiler.is_compiling():
+        return
+    step = get_step()
+    bad_keys: list[str] = []
+    for name, value in scalars.items():
+        if not isinstance(value, (float, int)) or isinstance(value, bool):
+            bad_keys.append(name)
+            continue
+        _structured_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {name}={value}",
+            extra=event_extra(
+                "metric_value",
+                event_name=name,
+                value=value,
+                step=step,
+                log_type=LogType.INSTANT,
+            ),
+            stacklevel=stacklevel,
+        )
+    if bad_keys:
+        console_logger.warning(
+            "log_trace_scalar skipped non-numeric values for keys: %s", bad_keys
+        )
+
+
+def log_trace_instant(event_type: str, *, stacklevel: int = 2) -> None:
+    """Emit a zero-duration event or marker (e.g. ``"training_start"``).
+
+    Use ``log_trace_span`` when you want start+end+duration.
+
+    Args:
+        event_type: Free-form string. Becomes ``log_type_name`` in the
+            emitted record.
+        stacklevel: Passed through to ``logger.info`` so the ``caller`` field
+            in the emitted record points at the real call site. Increase from
+            the default 2 if you wrap this function in a helper.
+
+    Example::
+
+        log_trace_instant("training_start")
+    """
+    if torch.compiler.is_compiling() or _structured_logger_disabled():
+        return
+    _structured_logger.info(
+        str(event_type),
+        extra=event_extra(event_type, log_type=LogType.INSTANT),
+        stacklevel=stacklevel,
+    )
+
+
+class log_trace_span:  # noqa: N801
+    """Time a block of work; emits ``_start`` and ``_end`` records.
+
+    Usable as a context manager or decorator. On entry, captures the
+    enclosing :class:`asyncio.Task`'s name via
+    ``asyncio.current_task().get_name()`` (``None`` outside any task)
+    and stamps it on both records. Analysis pairs ``_start`` / ``_end``
+    via a LIFO stack on ``(source, task_name)``, so nested spans in one
+    task pair correctly. The ``_end`` record's ``value`` is the elapsed
+    wall-time in ms.
+
+    On exception, emits an extra ``_error`` record (with exception type
+    and message), then the normal ``_end`` -- so every ``_start`` has a
+    matching close.
+
+    Example::
+
+        # context manager
+        with log_trace_span("fwd_bwd"):
+            loss = model(batch)
+            loss.backward()
+
+        # decorator of sync or async function
+        @log_trace_span("rl_rollout")
+        async def rollout(self, prompts):
+            return await self.engine.generate(prompts)
+
+    Args:
+        event_type: Becomes ``log_type_name`` in the records.
+        description: Human-readable label in the log line; doesn't
+            affect ``log_type_name`` or filtering.
+        stacklevel: Bump when wrapping in a helper so ``caller`` points
+            at the real call site.
+    """
+
+    def __init__(
+        self,
+        event_type: str,
+        description: str | None = None,
+        *,
+        stacklevel: int = 2,
+    ):
+        self.base_name = str(event_type)
+        self.description = description
+        self.stacklevel = stacklevel
+        self.start_time: float = 0.0
+        self._task_name: str | None = None
+        self.start_type_name = self.base_name + "_start"
+        self.end_type_name = self.base_name + "_end"
+
+    def __enter__(self):
+        if torch.compiler.is_compiling() or _structured_logger_disabled():
+            return self
+
+        # Cache the asyncio task name so __exit__ emits the same one as
+        # __enter__; pairing relies on (source, task_name) being stable
+        # across a span. None in SPMD / non-asyncio code.
+        try:
+            task = asyncio.current_task()
+            self._task_name = task.get_name() if task else None
+        except RuntimeError:
+            self._task_name = None
+
+        display_name = self.description or self.base_name
+        self.start_time = timer()
+        step = get_step()
+        _structured_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {display_name} {self.start_type_name}",
+            extra=event_extra(
+                self.start_type_name,
+                step=step,
+                task_name=self._task_name,
+            ),
+            stacklevel=self.stacklevel,
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # On success: emit ``_end``. On exception: emit ``_error`` then
+        # ``_end``. The trailing ``_end`` carries elapsed-until-crash
+        # and keeps pairing simple -- analysis tools don't have to
+        # special-case exceptional spans.
+        if torch.compiler.is_compiling() or _structured_logger_disabled():
+            return None
+
+        end_time = timer()
+        step = get_step()
+        duration_s = end_time - self.start_time
+        delta_ms = duration_s * 1000
+
+        if exc_type is not None:
+            error_type_name = self.base_name + "_error"
+            _structured_logger.info(
+                f"[step {step if step is not None else 'N/A'}] {error_type_name}: {exc_type.__name__}: {exc_val}",
+                extra=event_extra(
+                    error_type_name,
+                    step=step,
+                    task_name=self._task_name,
+                ),
+                stacklevel=self.stacklevel,
+            )
+
+        _structured_logger.info(
+            f"[step {step if step is not None else 'N/A'}] {self.end_type_name} took {delta_ms:.2f} ms",
+            extra=event_extra(
+                self.end_type_name,
+                value=delta_ms,
+                step=step,
+                task_name=self._task_name,
+            ),
+            stacklevel=self.stacklevel,
+        )
+        return None
+
+    def __call__(self, func: F) -> F:
+        # Decorator support. Each invocation of the decorated function builds
+        # a fresh ``log_trace_span`` so concurrent calls don't clobber each
+        # other's ``self.start_time`` / ``self._task_name``.
+        #
+        # The async path wraps so __exit__ runs after ``await func(...)``
+        # completes — a plain sync wrapper would close the context before the
+        # coroutine runs and the recorded duration would be ~0ms.
+        #
+        # TODO: ``caller`` is inaccurate for *async* decorator use — it lands
+        # on async_wrapper / asyncio / threading internals (incl. Monarch
+        # endpoint dispatch). Use as a context manager when this matters.
+        base_name, description, stacklevel = (
+            self.base_name,
+            self.description,
+            self.stacklevel,
+        )
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with log_trace_span(base_name, description, stacklevel=stacklevel):
+                    return await func(*args, **kwargs)
+
+            return cast(F, async_wrapper)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            # stacklevel + 1 skips this wrapper so caller points at the user.
+            with log_trace_span(base_name, description, stacklevel=stacklevel + 1):
+                return func(*args, **kwargs)
+
+        return cast(F, sync_wrapper)

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""Kineto profiler + memory-snapshot lifecycle."""
+
 import os
 import pickle
 import time
@@ -12,10 +14,26 @@ from typing import Annotated
 
 import torch
 import tyro
+
 from torchtitan.config import Configurable
 from torchtitan.config.function import Function
+from torchtitan.observability import structured_logger as sl
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
+
+# Paths expects by meta internal tooling
+PROFILE_DIR = "profiling/traces"  # Profiler.Config.save_traces_folder default
+PROFILE_ITER_DIR = "iteration_{step}"  # PROFILE_DIR/{PROFILE_ITER_DIR}
+PROFILE_FILE = "rank{rank}_trace.json"  # PROFILE_DIR/PROFILE_ITER_DIR/{PROFILE_FILE}
+
+MEMORY_DIR = (
+    "profiling/memory_snapshot"  # Profiler.Config.save_memory_snapshot_folder default
+)
+MEMORY_STEP_DIR = "step_{step:012d}"  # MEMORY_DIR/{MEMORY_STEP_DIR}
+MEMORY_EXIT_DIR = "step_{step:012d}_exit"  # OOM dump variant
+MEMORY_FILE = (
+    "{rank:06d}_step_{step}.pickle"  # MEMORY_DIR/MEMORY_STEP_DIR/{MEMORY_FILE}
+)
 
 # how much memory allocation/free ops to record in memory snapshots
 MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
@@ -53,11 +71,11 @@ class MemoryProfiler:
             return
         if not exit_ctx:
             curr_step = self.step_num
-            dir_name = f"iteration_{curr_step}"
+            dir_name = MEMORY_STEP_DIR.format(step=curr_step)
         else:
-            # dump as iteration_0_exit if OOM at iter 1
+            # dump as step_000000000000_exit if OOM at iter 1
             curr_step = self.step_num - 1
-            dir_name = f"iteration_{curr_step}_exit"
+            dir_name = MEMORY_EXIT_DIR.format(step=curr_step)
         curr_snapshot_dir = os.path.join(
             self._snapshot_dir, dir_name, self._leaf_folder
         )
@@ -66,7 +84,7 @@ class MemoryProfiler:
         logger.info(f"Dumping memory snapshot at step {curr_step}")
         begin = time.monotonic()
         output_file = os.path.join(
-            curr_snapshot_dir, f"rank{self._rank}_memory_snapshot.pickle"
+            curr_snapshot_dir, MEMORY_FILE.format(rank=self._rank, step=curr_step)
         )
         with open(output_file, "wb") as output:
             pickle.dump(device_module.memory._snapshot(), output)
@@ -102,7 +120,7 @@ class Profiler(Configurable):
         enable_profiling: bool = False
         """Whether to enable pytorch profiler."""
 
-        save_traces_folder: str = "profile_traces"
+        save_traces_folder: str = PROFILE_DIR
         """Trace files location."""
 
         profile_freq: int = 10
@@ -167,7 +185,7 @@ class Profiler(Configurable):
         enable_memory_snapshot: bool = False
         """Whether to dump memory snapshot."""
 
-        save_memory_snapshot_folder: str = "memory_snapshot"
+        save_memory_snapshot_folder: str = MEMORY_DIR
         """Memory snapshot files location."""
 
         trace_post_processor: Annotated[
@@ -241,10 +259,13 @@ class Profiler(Configurable):
 
     def step(self) -> None:
         """Advance all active profilers by one training step."""
+
         if self.torch_profiler is not None:
-            self.torch_profiler.step()
+            with sl.log_trace_span("kineto_profiler_step_call"):
+                self.torch_profiler.step()
         if self.memory_profiler is not None:
-            self.memory_profiler.step()
+            with sl.log_trace_span("memory_profiler_step_call"):
+                self.memory_profiler.step()
 
     def build_torch_profiler(
         self,
@@ -285,7 +306,7 @@ class Profiler(Configurable):
         )
 
         def trace_handler(prof):
-            curr_trace_dir_name = "iteration_" + str(prof.step_num)
+            curr_trace_dir_name = PROFILE_ITER_DIR.format(step=prof.step_num)
             curr_trace_dir = os.path.join(trace_dir, curr_trace_dir_name, leaf_folder)
             if not os.path.exists(curr_trace_dir):
                 os.makedirs(curr_trace_dir, exist_ok=True)
@@ -293,7 +314,7 @@ class Profiler(Configurable):
             logger.info(f"Dumping profiler traces at step {prof.step_num}")
             begin = time.monotonic()
 
-            output_file = os.path.join(curr_trace_dir, f"rank{rank}_trace.json")
+            output_file = os.path.join(curr_trace_dir, PROFILE_FILE.format(rank=rank))
             prof.export_chrome_trace(output_file)
 
             if post_processor is not None:

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -14,6 +14,8 @@ from types import ModuleType
 
 import torch
 from torch._utils import _get_available_device_type, _get_device_module
+
+from torchtitan.observability import structured_logger as sl
 from torchtitan.tools.logging import logger
 
 
@@ -55,15 +57,23 @@ class GarbageCollection:
             if torch.distributed.get_rank() == 0:
                 warn_tensor_cycles()
 
-    def run(self, step_count: int):
+    @sl.log_trace_span("gc_collect")
+    def run(self, step_count: int) -> bool:
+        """Run a GC cycle if this step should collect. Returns True when a
+        collection actually ran, False otherwise."""
         if self.debug:
             self.collect(
                 "Force GC to perform collection to obtain debug information",
                 generation=2,
             )
             gc.collect()
-        elif step_count > 1 and step_count % self.gc_freq == 0:
+            sl.add_step_tag("gc")
+            return True
+        if step_count > 1 and step_count % self.gc_freq == 0:
             self.collect("Performing periodic GC collection")
+            sl.add_step_tag("gc")
+            return True
+        return False
 
     @staticmethod
     def collect(reason: str, generation: int = 1):

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -9,6 +9,7 @@ import os
 import torch
 
 from torchtitan.config import ConfigManager
+from torchtitan.observability import structured_logger as sl
 from torchtitan.tools.logging import init_logger, logger
 from torchtitan.trainer import Trainer
 
@@ -26,6 +27,17 @@ def main() -> None:
 
     config_manager = ConfigManager()
     config = config_manager.parse_args()
+
+    # NOTE: internal meta tooling relies on source="training".
+    sl.init_structured_logger(
+        source="training",
+        # pyrefly: ignore [missing-attribute]
+        output_dir=config.dump_folder,
+        # pyrefly: ignore [missing-attribute]
+        enable=config.debug.enable_structured_logging,
+    )
+    sl.log_trace_instant("binary_start")
+
     trainer: Trainer | None = None
 
     try:
@@ -58,7 +70,8 @@ def main() -> None:
     else:
         trainer.close()
         if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+            with sl.log_trace_span("torch_distributed_teardown"):
+                torch.distributed.destroy_process_group()
         logger.info("Process group destroyed")
 
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -42,6 +42,7 @@ from torchtitan.config.configs import (
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools import utils
@@ -321,55 +322,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         assert self.gradient_accumulation_steps > 0
 
         # apply parallelisms and initialization
-        if parallel_dims.pp_enabled:
-            if not model_spec.pipelining_fn:
-                raise RuntimeError(
-                    f"Pipeline Parallel is enabled but {model_spec.name} "
-                    f"does not support pipelining"
-                )
+        with sl.log_trace_span("model_parallelism_init"):
+            if parallel_dims.pp_enabled:
+                if not model_spec.pipelining_fn:
+                    raise RuntimeError(
+                        f"Pipeline Parallel is enabled but {model_spec.name} "
+                        f"does not support pipelining"
+                    )
 
-            # apply both Pipeline Parallel and SPMD-style scaling techniques
-            (
-                self.pp_schedule,
-                self.model_parts,
-                self.pp_has_first_stage,
-                self.pp_has_last_stage,
-            ) = model_spec.pipelining_fn(
-                model,
-                parallel_dims=parallel_dims,
-                training=config.training,
-                parallelism=config.parallelism,
-                compile_config=config.compile,
-                ac_config=config.activation_checkpoint,
-                dump_folder=config.dump_folder,
-                device=self.device,
-                model_config=model_config,
-                parallelize_fn=model_spec.parallelize_fn,
-                loss_fn=self.loss_fn,
-            )
-            # when PP is enabled, `model` obj is no longer used after this point,
-            # model_parts is used instead
-            del model
-
-            for m in self.model_parts:
-                m.to_empty(device=init_device)
-                with torch.no_grad():
-                    # TODO: Change this back to init_weights once
-                    # autoparallel contains the wrap_init_states
-                    cast(BaseModel, m).init_weights(buffer_device=buffer_device)
-                m.train()
-
-            # confirm that user will be able to view loss metrics on the console
-            ensure_pp_loss_visible(
-                parallel_dims=parallel_dims,
-                pp_schedule=config.parallelism.pipeline_parallel_schedule,
-                color=color,
-            )
-        else:
-            if not config.checkpoint.create_seed_checkpoint:
-                # Skip parallelize_fn for seed checkpoints — nothing from
-                # it is needed (AC, compile, nD parallelism, mixed precision, etc.).
-                model = model_spec.parallelize_fn(
+                # apply both Pipeline Parallel and SPMD-style scaling techniques
+                (
+                    self.pp_schedule,
+                    self.model_parts,
+                    self.pp_has_first_stage,
+                    self.pp_has_last_stage,
+                ) = model_spec.pipelining_fn(
                     model,
                     parallel_dims=parallel_dims,
                     training=config.training,
@@ -377,16 +344,51 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     compile_config=config.compile,
                     ac_config=config.activation_checkpoint,
                     dump_folder=config.dump_folder,
+                    device=self.device,
+                    model_config=model_config,
+                    parallelize_fn=model_spec.parallelize_fn,
+                    loss_fn=self.loss_fn,
                 )
+                # when PP is enabled, `model` obj is no longer used after this point,
+                # model_parts is used instead
+                del model
 
-            model.to_empty(device=init_device)
-            with torch.no_grad():
-                # TODO: Change this back to init_weights once
-                # autoparallel contains the wrap_init_states
-                cast(BaseModel, model).init_weights(buffer_device=buffer_device)
-            model.train()
+                for m in self.model_parts:
+                    m.to_empty(device=init_device)
+                    with torch.no_grad():
+                        # TODO: Change this back to init_weights once
+                        # autoparallel contains the wrap_init_states
+                        cast(BaseModel, m).init_weights(buffer_device=buffer_device)
+                    m.train()
 
-            self.model_parts = [model]
+                # confirm that user will be able to view loss metrics on the console
+                ensure_pp_loss_visible(
+                    parallel_dims=parallel_dims,
+                    pp_schedule=config.parallelism.pipeline_parallel_schedule,
+                    color=color,
+                )
+            else:
+                if not config.checkpoint.create_seed_checkpoint:
+                    # Skip parallelize_fn for seed checkpoints — nothing from
+                    # it is needed (AC, compile, nD parallelism, mixed precision, etc.).
+                    model = model_spec.parallelize_fn(
+                        model,
+                        parallel_dims=parallel_dims,
+                        training=config.training,
+                        parallelism=config.parallelism,
+                        compile_config=config.compile,
+                        ac_config=config.activation_checkpoint,
+                        dump_folder=config.dump_folder,
+                    )
+
+                model.to_empty(device=init_device)
+                with torch.no_grad():
+                    # TODO: Change this back to init_weights once
+                    # autoparallel contains the wrap_init_states
+                    cast(BaseModel, model).init_weights(buffer_device=buffer_device)
+                model.train()
+
+                self.model_parts = [model]
 
         # Set lm_head reference for ChunkedCELoss after model construction.
         # Non-PP: single model part always has lm_head.
@@ -499,6 +501,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             f"(warmup {config.lr_scheduler.warmup_steps})"
         )
 
+    @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:
         config = self.config
         world_size = dist_utils.init_distributed(
@@ -538,6 +541,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # Tensors stay on CPU; moved to GPU per-microbatch during training
             yield input_dict, labels
 
+    @sl.log_trace_span("post_dataloading_process")
     def post_dataloading_process(
         self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], dict[str, Any]]:
@@ -639,6 +643,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         return inputs, labels, extra_inputs, extra_kwargs
 
+    @sl.log_trace_span("fwd_bwd")
     def forward_backward_step(
         self,
         *,
@@ -714,9 +719,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         microbatches = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
         for _microbatch in range(self.gradient_accumulation_steps):
-            input_dict, labels = next(data_iterator)
-            local_valid_tokens += (labels != IGNORE_INDEX).sum()
-            microbatches.append((input_dict, labels))
+            with sl.log_trace_span("fetching_batch"):
+                input_dict, labels = next(data_iterator)
+                local_valid_tokens += (labels != IGNORE_INDEX).sum()
+                microbatches.append((input_dict, labels))
+        sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
 
         # All-reduce to get global token count across DP ranks
         # Move to GPU for distributed communication
@@ -744,16 +751,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             )
             accumulated_losses.append(loss.detach())
 
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
-            ep_enabled=parallel_dims.ep_enabled,
-        )
-        self.checkpointer.maybe_wait_for_staging()
-        self.optimizers.step()
-        self.lr_schedulers.step()
+        with sl.log_trace_span("optim"):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=parallel_dims.get_optional_mesh("pp"),
+                ep_enabled=parallel_dims.ep_enabled,
+            )
+            self.checkpointer.maybe_wait_for_staging()
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         # Reduce the data collected over gradient accumulation steps.
         loss = torch.sum(torch.stack(accumulated_losses))
@@ -762,33 +770,37 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         if not self.metrics_processor.should_log(self.step):
             return
 
-        if parallel_dims.dp_cp_enabled:
-            loss = loss.detach()
-            loss_mesh = parallel_dims.get_optional_mesh("loss")
+        with sl.log_trace_span("collect_dist_metrics"):
 
-            # For global_avg_loss, we want the average loss across all ranks:
-            # loss = local_loss_sum / global_valid_tokens
-            # global_avg_loss = sum(local_loss_sum) / global_valid_tokens
-            #                 = sum(loss)
-            #
-            # For global_max_loss, we want the max of local average losses across ranks:
-            # local_avg_loss = local_loss_sum / local_valid_tokens
-            #                = (loss * global_valid_tokens) / local_valid_tokens
-            # global_max_loss = max(local_avg_loss)
-            local_avg_loss = loss * global_valid_tokens / local_valid_tokens
-            global_avg_loss, global_max_loss, global_ntokens_seen = (
-                dist_utils.dist_sum(loss, loss_mesh),
-                dist_utils.dist_max(local_avg_loss, loss_mesh),
-                dist_utils.dist_sum(
-                    torch.tensor(
-                        self.ntokens_seen, dtype=torch.int64, device=self.device
+            sl.log_trace_scalar({"global_valid_tokens": int(global_valid_tokens)})
+
+            if parallel_dims.dp_cp_enabled:
+                loss = loss.detach()
+                loss_mesh = parallel_dims.get_optional_mesh("loss")
+
+                # For global_avg_loss, we want the average loss across all ranks:
+                # loss = local_loss_sum / global_valid_tokens
+                # global_avg_loss = sum(local_loss_sum) / global_valid_tokens
+                #                 = sum(loss)
+                #
+                # For global_max_loss, we want the max of local average losses across ranks:
+                # local_avg_loss = local_loss_sum / local_valid_tokens
+                #                = (loss * global_valid_tokens) / local_valid_tokens
+                # global_max_loss = max(local_avg_loss)
+                local_avg_loss = loss * global_valid_tokens / local_valid_tokens
+                global_avg_loss, global_max_loss, global_ntokens_seen = (
+                    dist_utils.dist_sum(loss, loss_mesh),
+                    dist_utils.dist_max(local_avg_loss, loss_mesh),
+                    dist_utils.dist_sum(
+                        torch.tensor(
+                            self.ntokens_seen, dtype=torch.int64, device=self.device
+                        ),
+                        loss_mesh,
                     ),
-                    loss_mesh,
-                ),
-            )
-        else:
-            global_avg_loss = global_max_loss = float(loss.detach().item())
-            global_ntokens_seen = self.ntokens_seen
+                )
+            else:
+                global_avg_loss = global_max_loss = float(loss.detach().item())
+                global_ntokens_seen = self.ntokens_seen
 
         extra_metrics = {
             "n_tokens_seen": global_ntokens_seen,
@@ -806,7 +818,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def train(self):
         config = self.config
 
+        sl.log_trace_instant("training_start")
+
         self.checkpointer.load(step=config.checkpoint.load_step)
+
+        # Capture loaded step for relative_step calculation.
+        # After checkpoint load: self.step = restored step (e.g. 100), or 0 if fresh.
+        loaded_step = self.step
+
         logger.info(f"Training starts at step {self.step + 1}")
 
         with config.profiler.build(
@@ -816,33 +835,41 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             data_iterator = self.batch_generator(self.dataloader)
             while self.should_continue_training():
                 self.step += 1
-                self.gc_handler.run(self.step)
-                try:
-                    self.train_step(data_iterator)
-                except DataloaderExhaustedError:
-                    logger.warning("Ran out of data; last step was canceled.")
-                    break
+                sl.set_step(self.step, relative_step=self.step - loaded_step)
 
-                self.checkpointer.save(
-                    self.step, last_step=(self.step == config.training.steps)
-                )
+                with sl.log_trace_span("step"):
+                    self.gc_handler.run(self.step)
 
-                # Run validation if validator is available
-                if self.config.validator.enable and self.validator.should_validate(
-                    self.step
-                ):
-                    self.validator.validate(self.model_parts, self.step)
+                    try:
+                        self.train_step(data_iterator)
+                    except DataloaderExhaustedError:
+                        logger.warning("Ran out of data; last step was canceled.")
+                        break
 
-                # signal the profiler that the next profiling step has started
-                profiler.step()
-
-                # reduce timeout after first train step for faster signal
-                # (assuming lazy init and compilation are finished)
-                if self.step == 1:
-                    dist_utils.set_pg_timeouts(
-                        timeout=timedelta(seconds=config.comm.train_timeout_seconds),
-                        parallel_dims=self.parallel_dims,
+                    self.checkpointer.save(
+                        self.step,
+                        last_step=(self.step == config.training.steps),
                     )
+
+                    # Run validation if validator is available
+                    if self.config.validator.enable and self.validator.should_validate(
+                        self.step
+                    ):
+                        self.validator.validate(self.model_parts, self.step)
+
+                    # signal the profiler that the next profiling step has started
+                    profiler.step()
+
+                    # Reduce timeout after the first train step of THIS process
+                    # (assuming lazy init and compilation are finished). Use the
+                    # relative step so this fires on resumed runs too.
+                    if self.step - loaded_step == 1:
+                        dist_utils.set_pg_timeouts(
+                            timeout=timedelta(
+                                seconds=config.comm.train_timeout_seconds
+                            ),
+                            parallel_dims=self.parallel_dims,
+                        )
 
         if torch.distributed.get_rank() == 0:
             logger.info("Sleeping 2 seconds for other ranks to complete")


### PR DESCRIPTION
Summary:

**TLDR**: Enables structured-logging in torchtitan. Time spans, scalars and events can be logged, per rank, with metadata, to a jsonl or database, using python standard logger. This can then be converted into a gantt chart. It is cheap, runs on every step, and useful to find stragglers, high level bottlenecks, how asynchronous an RL run is, debug timeouts, weird behavior on some rank on some step, etc.

**For details of the APIs, please read the added readme in** torchtitan/observability/structured_loggger/README.md.

Examples:
 {F1989149827} 

## Other comments

To minimize the impact of lines changed in the trainer.py code:
- We use decorators where we can, instead of context managers
- We call tags and spans directly inside of some functions, e.g. ckpt, garbage collectors and profiler 
- **initialization**: We add it one time in the build call base class, so everything that calls build is automatically tracked.

## Is it safe?

The workhorse here is logger.info. So the same way you treat logger.info, you should treat the structured logger. 

It can be disabled with a global flag.

If the user forgets to setup `init_structured_logger`, we still call logger.info, but nothing is saved anywhere.

It detects `is_compiling` and skips if true.

## Profiler default paths

To align with expectations set by some internal tooling, we also changed the kineto and memory profilers default path.

Differential Revision: D101049878


