### PR TITLE
[HybridEP] Read comm_backend from model config instead of ParallelismConfig

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -43,7 +43,6 @@ def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
         moe_comm_backend="hybridep",
         non_blocking_capacity_factor=1.0,
     )
-    config.parallelism.expert_parallel_comm_backend = "hybridep"
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -22,6 +22,7 @@ from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
 from torchtitan.models.deepseek_v3.parallelize import apply_moe_ep_tp
+from torchtitan.tools.logging import logger
 
 
 def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
@@ -84,7 +85,14 @@ def parallelize_deepseekv3(
         # config in Trainer.Config.__post_init__; Module.parallelize applies it.
         model.parallelize(tp_mesh)
 
-    comm_backend = parallelism.expert_parallel_comm_backend
+    # Read comm_backend from the model's token dispatcher config
+    # (set by moe_comm_backend in model_registry / config factories).
+    moe_config = next((l.moe for l in model.config.layers if l.moe is not None), None)
+    comm_backend = (
+        getattr(moe_config.experts.token_dispatcher, "comm_backend", "standard")
+        if moe_config is not None
+        else "standard"
+    )
     if comm_backend == "hybridep":
         from torchtitan.distributed.deepep import hybridep  # noqa: F401
 
@@ -94,7 +102,6 @@ def parallelize_deepseekv3(
             tp_mesh=parallel_dims.get_optional_mesh("tp"),
             ep_mesh=parallel_dims.get_optional_mesh("ep"),
             enable_sp=parallelism.enable_sequence_parallel,
-            comm_backend=comm_backend,
         )
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -255,7 +255,7 @@ def _build_dsv3_layers(
 def _debugmodel(
     attn_backend: str,
     moe_comm_backend: str,
-    non_blocking_capacity_factor: float | None,
+    non_blocking_capacity_factor: float | None = None,
 ) -> DeepSeekV3Model.Config:
     dim = 256
     n_layers = 6
@@ -320,7 +320,7 @@ def _debugmodel(
 def _16b(
     attn_backend: str,
     moe_comm_backend: str,
-    non_blocking_capacity_factor: float | None,
+    non_blocking_capacity_factor: float | None = None,
 ) -> DeepSeekV3Model.Config:
     dim = 2048
     n_layers = 27
@@ -385,7 +385,7 @@ def _16b(
 def _236b(
     attn_backend: str,
     moe_comm_backend: str,
-    non_blocking_capacity_factor: float | None,
+    non_blocking_capacity_factor: float | None = None,
 ) -> DeepSeekV3Model.Config:
     dim = 5120
     n_layers = 60
@@ -454,7 +454,7 @@ def _236b(
 def _671b(
     attn_backend: str,
     moe_comm_backend: str,
-    non_blocking_capacity_factor: float | None,
+    non_blocking_capacity_factor: float | None = None,
 ) -> DeepSeekV3Model.Config:
     dim = 7168
     n_layers = 61


### PR DESCRIPTION
`expert_parallel_comm_backend` was removed from https://github.com/pytorch/torchtitan/pull/3167. https://github.com/pytorch/torchtitan/pull/3007 didn't take it into account and broke graph trainer CI.

- This PR reads comm backend from the model config to initialize hybridep buffers.
- Also restores non_blocking_capacity_factor default value for the concrete model flavors, since some tests call the concrete flavors directly.

Tested locally:
```
  + NGPU=4                                                                                                                                                                                                                                                 
  + export LOG_RANK=0                                                                                                                                                                                                                                      
  + LOG_RANK=0                                                                                                                                                                                                                                             
  + MODULE=graph_trainer.deepseek_v3                                                                                                                                                                                                                       
  + CONFIG=graph_trainer_deepseek_v3_debugmodel_hybridep                                                                                                                                                                                                   
  + COMM_MODE=                                                                                                                                                                                                                                             
  + TORCHFT_LIGHTHOUSE=http://localhost:29510                                                                                                                                                                                                              
  + '[' -n '' ']'                        
  + PYTORCH_ALLOC_CONF=expandable_segments:True                                                                                                                                                                                                            
  + TORCHFT_LIGHTHOUSE=http://localhost:29510                                                                                                                                                                                                              
  + torchrun --nproc_per_node=4 --rdzv_backend c10d --rdzv_endpoint=localhost:0 --local-ranks-filter 0 --role rank --tee 3 -m torchtitan.train --module graph_trainer.deepseek_v3 --config graph_trainer_deepseek_v3_debugmodel_hybridep --compile.mode
  aot_fx_trace --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2 --training.steps=3                                                                                                 
  [rank0]:[titan] 2026-04-30 09:24:36,606 - root - INFO - torchtitan version: 0.2.2                                                  
  [rank0]:[titan] 2026-04-30 09:24:37,184 - root - INFO - Building device mesh with parallelism: pp=1, dp_replicate=1, dp_shard=2, cp=1, tp=2, ep=2                                                                                                        
  [rank0]:[titan] 2026-04-30 09:24:37,204 - root - INFO - Successfully created meshes with active dimensions: ['batch', 'loss', 'fsdp', 'tp', 'ep', 'efsdp']                                                                                               
  [rank0]:[titan] 2026-04-30 09:24:38,881 - root - INFO - Building graph_trainer/deepseek_v3 debugmodel                                                                                                                                                    
  [rank0]:[titan] 2026-04-30 09:24:38,924 - root - INFO - CUDA capacity: NVIDIA GB200 with 184.00GiB memory                                                                                                                                                
  [rank0]:[titan] 2026-04-30 09:24:38,942 - root - INFO - Total parameter count: dense 23,173,376, sparse 9,840,640, active 28,098,816                                                                                                                     
  [rank0]:[titan] 2026-04-30 09:24:38,942 - root - INFO - Model graph_trainer/deepseek_v3 debugmodel size: 33,014,016 total parameters                                                                                                                     
  [rank0]:[titan] 2026-04-30 09:24:39,022 - root - INFO - Applied Data Parallel (simple_fsdp) (dp mode=fully_shard) to the model                                                                                                                           
  [rank0]:[titan] 2026-04-30 09:24:39,817 - root - INFO - Pre-initialized HybridEP buffer (hidden_dim=256, num_tokens=16384, num_local_experts=4)                                                                                                          
  [rank0]:[titan] 2026-04-30 09:24:39,817 - root - INFO - aot_fx_trace compile mode: graph capture will happen at training time                                                                                                                            
  [rank0]:[titan] 2026-04-30 09:24:40,725 - root - INFO - Peak FLOPS used for computing MFU: 2.500e+15                                                                                                                                                     
  [rank0]:[titan] 2026-04-30 09:24:40,725 - root - INFO - CUDA memory usage for model: 0.04GiB(0.02%)                                                                                                                                                      
  [rank0]:[titan] 2026-04-30 09:24:42,931 - root - INFO - Trainer is initialized with local batch size 8, global batch size 16, gradient accumulation steps 1, sequence length 2048, total steps 3 (warmup 2)                                              
  [rank0]:[titan] 2026-04-30 09:24:42,931 - root - INFO - Training starts at step 1                                                                                                                                                                        
  [rank0]:[titan] 2026-04-30 09:24:47,646 - root - INFO - Removed 62 aten.detach.default node(s) from the graph                                                                                                                                            
  [rank0]:[titan] 2026-04-30 09:24:47,708 - root - INFO - Removed 669 identity view/reshape node(s) from the graph                                                                                                                                         
  [rank0]:[titan] 2026-04-30 09:24:47,709 - root - INFO - Removed 66 identity slice node(s)                                                                                                                                                                
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO - Applied selective activation checkpointing (SAC) graph pass.                                                                                                                                     
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Forced 5 nodes to MUST_SAVE at layer boundaries                                                                                                                                                
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer non-layer: 2 MUST_SAVE, 62 PREFER_RECOMPUTE                                                                                                                                              
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 0: 10 MUST_SAVE, 90 PREFER_RECOMPUTE                                                                                                                                                     
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 1: 13 MUST_SAVE, 120 PREFER_RECOMPUTE                                                                                                                                                    
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 2: 13 MUST_SAVE, 120 PREFER_RECOMPUTE                              
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 3: 13 MUST_SAVE, 120 PREFER_RECOMPUTE                                                                                                                                                    
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 4: 13 MUST_SAVE, 120 PREFER_RECOMPUTE
  [rank0]:[titan] 2026-04-30 09:24:47,880 - root - INFO -   Layer 5: 13 MUST_SAVE, 120 PREFER_RECOMPUTE                                                                                                                                                    
  [rank0]:[titan] 2026-04-30 09:24:50,157 - root - INFO - Applied cudagraph pass.                                                    
  [rank0]:[titan] 2026-04-30 09:25:00,187 - root - INFO - step:  1  loss:  4.03640  grad_norm:  3.3902  memory:  1.93GiB(1.05%)  tps: 386  tflops: 0.21  mfu: 0.01%
  [rank0]:[titan] 2026-04-30 09:25:00,345 - root - INFO - step:  2  loss:  3.05691  grad_norm:  4.5189  memory:  1.93GiB(1.05%)  tps: 52,168  tflops: 28.32  mfu: 1.13%
  [rank0]:[titan] 2026-04-30 09:25:00,389 - root - INFO - step:  3  loss:  2.46308  grad_norm:  2.7644  memory:  1.93GiB(1.05%)  tps: 186,611  tflops: 101.32  mfu: 4.05%
  [rank0]:[titan] 2026-04-30 09:25:02,389 - root - INFO - Training completed                                                                                                                                                                               
  [rank0]:[titan] 2026-04-30 09:25:03,816 - root - INFO - Process group destroyed 
```