### PR TITLE
[CI] Use replace-imports-with-any to avoid missing packages causing CI failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ testpaths = ["tests"]
 
 [tool.pyrefly]
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
-ignore-missing-imports = ["torchao.*", "torchft"]  # optional dependencies
+replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*"]  # optional dependencies
 search-path = ["../pytorch"]  # local built pytorch

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -9,7 +9,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 from tokenizers import AddedToken, Tokenizer
 from torchtitan.config import Configurable
@@ -72,8 +72,8 @@ class BaseTokenizer(ABC, Configurable):
             lstrip_blocks=True,
             extensions=[jinja2.ext.loopcontrols],
         )
-        env.globals["raise_exception"] = cast(Any, raise_exception)
-        env.globals["strftime_now"] = cast(Any, strftime_now)
+        env.globals["raise_exception"] = raise_exception
+        env.globals["strftime_now"] = strftime_now
         env.filters["tojson"] = tojson
         self._chat_template = env.from_string(template)
 

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -18,10 +18,8 @@ from torch.distributed import ProcessGroup
 from torch.utils._python_dispatch import _disable_current_modes
 
 try:
-    # pyrefly: ignore [missing-import]
     from deep_ep import Buffer
 
-    # pyrefly: ignore [missing-import]
     from deep_ep.utils import EventHandle, EventOverlap
 except ImportError as e:
     raise ImportError(

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -163,9 +163,7 @@ def _dispatch_impl(
         )
 
     num_local_experts = num_experts // _buffer.group_size
-    from deep_ep.hybrid_ep_buffer import (  # pyrefly: ignore [missing-import]
-        indices_to_map,
-    )
+    from deep_ep.hybrid_ep_buffer import indices_to_map
 
     routing_map, probs = indices_to_map(
         topk_idx, topk_weights.float(), x.shape[0], num_experts
@@ -382,7 +380,6 @@ def get_buffer(
         raise AssertionError("HybridEP FP8 dispatch not yet supported")
 
     try:
-        # pyrefly: ignore [missing-import]
         from deep_ep import HybridEPBuffer
     except ImportError as e:
         raise ImportError(

--- a/torchtitan/hf_datasets/multimodal/utils/image.py
+++ b/torchtitan/hf_datasets/multimodal/utils/image.py
@@ -16,10 +16,8 @@ import einops as E
 import requests
 import torch
 
-# pyrefly: ignore [missing-import]
 import torchvision.io
 
-# pyrefly: ignore [missing-import]
 import torchvision.transforms.v2.functional as TVF
 
 from PIL import Image

--- a/torchtitan/hf_datasets/multimodal/utils/video.py
+++ b/torchtitan/hf_datasets/multimodal/utils/video.py
@@ -9,7 +9,6 @@
 import numpy as np
 import torch
 
-# pyrefly: ignore [missing-import]
 import torchvision.transforms.v2.functional as TVF
 
 from torchtitan.tools.logging import logger


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3180

    Hope this fix the pyrefly painpoint caused by missing packages such as deep_ep and torchvision.

    `replace-imports-with-any` vs `ignore-missing-imports`:

    |                       | `ignore-missing-imports`                                              | `replace-imports-with-any`                                       |
    |-----------------------|-----------------------------------------------------------------------|------------------------------------------------------------------|
    | When it kicks in      | Only when the module can't be found on disk                           | Always, whether the module is installed or not                   |
    | What it does          | Suppresses the "missing-import" error and types the imported names as `Any` | Pretends the module is `Any` -- skips loading its real types entirely |
    | If the lib IS installed | Pyrefly type-checks against real types -> may surface errors -> contributors add ignores | Pyrefly still treats it as `Any` -> no errors -> behavior identical to CI |

    `ignore-missing-imports` only papers over the absence of a library. The moment a contributor installs it locally, pyrefly switches modes and starts type-checking it for real -- surfacing errors that contributors then silence with `# pyrefly: ignore [...]`. CI (without the lib) sees those ignores as useless
and tells contributors to remove them. That's the asymmetry.

    `replace-imports-with-any` removes the asymmetry by forcing everyone -- installed or not -- to see the module as `Any`. The module's real types are never consulted, so there are no environment-dependent errors.