### PR TITLE
[ft] Forward attn_backend to llama3 config functions

### DIFF
--- a/torchtitan/experiments/ft/llama3/__init__.py
+++ b/torchtitan/experiments/ft/llama3/__init__.py
@@ -14,8 +14,8 @@ from torchtitan.models.llama3 import (
 )
 
 
-def model_registry(flavor: str) -> FaultTolerantModelSpec:
-    config = llama3_configs[flavor]()
+def model_registry(flavor: str, attn_backend: str = "sdpa") -> FaultTolerantModelSpec:
+    config = llama3_configs[flavor](attn_backend=attn_backend)
     return FaultTolerantModelSpec(
         name="ft/llama3",
         flavor=flavor,


### PR DESCRIPTION
## Summary
- The upstream llama3 config functions (e.g. `_debugmodel`) now require an `attn_backend` parameter, but the FT experiment's `model_registry` was calling `llama3_configs[flavor]()` with no arguments
- This caused a `TypeError: _debugmodel() missing 1 required positional argument: 'attn_backend'` in CI ([job link](https://github.com/pytorch/torchtitan/actions/runs/25185478406/job/73841557782))
- Added `attn_backend` parameter to the FT experiment's `model_registry` with default `"sdpa"`, matching the upstream convention

## Test plan
- [ ] CI torchft integration test passes (previously failing with TypeError)