### PR TITLE
Upgrades torchtitan-ubuntu docker image to 22.04 and CTK 13.0

### DIFF
--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -18,5 +18,5 @@ It also uses the same directory structure as PyTorch.
 ./build.sh "${IMAGE_NAME}" "${DOCKER_BUILD_PARAMETERS}"
 
 # Build a specific image
-./build.sh torchtitan-ubuntu-20.04-clang12 -t myimage:latest
+./build.sh torchtitan-ubuntu-22.04-clang12 -t myimage:latest
 ```

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -18,10 +18,10 @@ PYTHON_VERSION=3.12
 MINICONDA_VERSION=24.3.0-0
 
 case "${IMAGE_NAME}" in
-  torchtitan-ubuntu-20.04-clang12)
-    OS_VERSION=20.04
+  torchtitan-ubuntu-22.04-clang12)
+    OS_VERSION=22.04
     CLANG_VERSION=12
-    BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-runtime-ubuntu${OS_VERSION}
+    BASE_IMAGE=nvidia/cuda:13.0.3-cudnn-devel-ubuntu${OS_VERSION}
     ;;
   torchtitan-rocm-ubuntu-22.04-clang12)
     OS_VERSION=22.04

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -5,6 +5,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Note CUDA uses devel container since comm_backend like DeepEP
+# needs the CUDA toolkit during runtime.
+
 set -exu
 
 IMAGE_NAME="$1"

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - docker-image-name: torchtitan-ubuntu-20.04-clang12
+          - docker-image-name: torchtitan-ubuntu-22.04-clang12
             runner: [self-hosted, linux.2xlarge]
           - docker-image-name: torchtitan-rocm-ubuntu-22.04-clang12
             runner: [linux.2xlarge]

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -35,7 +35,7 @@ jobs:
       runner: linux.g5.48xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
-      docker-image: torchtitan-ubuntu-20.04-clang12
+      docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -35,7 +35,7 @@ jobs:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
-      docker-image: torchtitan-ubuntu-20.04-clang12
+      docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -34,7 +34,7 @@ jobs:
       runner: linux.aws.h100.8
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
-      docker-image: torchtitan-ubuntu-20.04-clang12
+      docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -76,7 +76,7 @@ jobs:
             "runner": "${CUDA_RUNNER}",
             "gpu-arch-type": "cuda",
             "gpu-arch-version": "13.0",
-            "docker-image": "torchtitan-ubuntu-20.04-clang12",
+            "docker-image": "torchtitan-ubuntu-22.04-clang12",
             "index-url": "https://download.pytorch.org/whl/nightly/cu130",
             "torch-version": ""
           }

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -17,7 +17,7 @@ jobs:
   build-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      docker-image: torchtitan-ubuntu-20.04-clang12
+      docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
       script: |
         set -eux

--- a/.github/workflows/unit_test_cpu_torchft.yaml
+++ b/.github/workflows/unit_test_cpu_torchft.yaml
@@ -19,7 +19,7 @@ jobs:
   build-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      docker-image: torchtitan-ubuntu-20.04-clang12
+      docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
       script: |
         set -eux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3184
* __->__ #3183


Upgraded CUDA version of the container to 13.0 to match the pytorch wheel being installed.
Upgraded Ubuntu 20.04 to 22.04 since minimum OS version for CTK 13.0 is 22.04.
Changed runtime container to devel container, since DeepEP requires CTK during compilation and also during runtime.