### PR TITLE
[Checkpoint] BaseModel state dict pipeline and pure I/O CheckpointManager

### DIFF
--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -125,8 +125,8 @@ class CheckpointManager(Configurable):
         config (Checkpoint): The config used to configure the checkpointing.
         base_folder (str): The base folder to save the checkpoint. Will be concatenated
             with config.folder
-        sd_adapter (Optional[type[BaseStateDictAdapter]]): The adapter used to convert model state
-            dicts between native format and other formats.
+        sd_adapter (Optional[BaseStateDictAdapter]): HF I/O config (storage reader/writer,
+            fqn mapping, assets path). Key transforms are on the model.
 
     """
 
@@ -335,11 +335,15 @@ class CheckpointManager(Configurable):
         self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
         self.last_save_model_only = config.last_save_model_only
         self.last_save_in_hf = config.last_save_in_hf
+
+        # HF I/O config extracted from sd_adapter. CheckpointManager only
+        # needs these for HF storage reader/writer — key transforms are on
+        # the model via model.set_sd_transforms().
+        self.hf_io = sd_adapter
         if self.last_save_in_hf:
             assert (
-                sd_adapter is not None
+                self.hf_io is not None
             ), "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
-        self.sd_adapter = sd_adapter
         self.additional_load_path = config.additional_load_path
         self.additional_load_in_hf = config.additional_load_in_hf
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
@@ -412,15 +416,17 @@ class CheckpointManager(Configurable):
         checkpoint_id: str,
         async_mode: AsyncMode,
         enable_garbage_collection: bool = False,
-        to_hf: bool = False,
+        hf_storage: bool = False,
     ) -> Future | AsyncSaveResponse | None:
         """Save the checkpoint with dcp.
         Args:
-            state_dict (dict): The state dict to save.
+            state_dict (dict): The state dict to save (key transforms already applied).
             checkpoint_id (str): The checkpoint id to save.
             async_mode (AsyncMode): Whether the checkpoint is async.
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
-            to_hf (bool): Whether to save in HF model definition and safetensors format.
+            hf_storage (bool): Whether to use HF safetensors storage writer.
+                Key transforms must be applied by the caller via
+                model.get_sd(external=True) before calling this method.
 
         Returns:
             Future: The future object if the checkpoint is async, otherwise None.
@@ -431,14 +437,19 @@ class CheckpointManager(Configurable):
         storage_writer: HuggingFaceStorageWriter | None = None
         checkpoint_save_id: str | None = None
         fqn_to_index_mapping: dict[Any, int] | None = None
-        if to_hf:
+        keys_match_mapping = False
+        if hf_storage:
             assert (
-                self.sd_adapter is not None
-            ), "trying to save checkpoint in HF safetensors format, but sd_adapter is not provided."
-            state_dict = self.sd_adapter.to_hf(state_dict)
-
-            fqn_to_index_mapping = self.sd_adapter.fqn_to_index_mapping
-            if fqn_to_index_mapping:
+                self.hf_io is not None
+            ), "trying to save in HF safetensors format, but sd_adapter is not provided."
+            fqn_to_index_mapping = self.hf_io.fqn_to_index_mapping
+            # Only use sharded mapping when saved keys match the mapping
+            # (e.g. base model HF save). For adapter-only saves (PEFT),
+            # keys won't be in the base mapping — fall through to consolidation.
+            keys_match_mapping = fqn_to_index_mapping and any(
+                k in fqn_to_index_mapping for k in state_dict
+            )
+            if keys_match_mapping:
                 storage_writer = HuggingFaceStorageWriter(
                     path=os.path.join(checkpoint_id, "sharded"),
                     save_distributed=True,
@@ -482,7 +493,7 @@ class CheckpointManager(Configurable):
                 checkpoint_id=checkpoint_save_id,
             )
 
-        if to_hf and fqn_to_index_mapping:
+        if hf_storage and keys_match_mapping:
             consolidate_safetensors_files_on_every_rank(
                 input_dir=os.path.join(checkpoint_id, "sharded"),
                 output_dir=checkpoint_id,
@@ -495,46 +506,36 @@ class CheckpointManager(Configurable):
 
         return ret
 
-    def _load_from_hf(self, checkpoint_id: str, from_quantized: bool) -> None:
-        """Load base model weights from a HuggingFace checkpoint."""
+    def _load_from_hf(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+        from_quantized: bool = False,
+    ) -> None:
+        """Load weights from a HuggingFace checkpoint into ``state_dict``.
+
+        Pure I/O — the caller provides the container (via
+        ``model.get_sd(mode, external=True)``) and handles conversion
+        afterward.
+        """
         assert (
-            self.sd_adapter is not None
+            self.hf_io is not None
         ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
-        hf_state_dict = self.sd_adapter.to_hf(self.model.get_sd(StateDictMode.BASE))
-        hf_storage_reader = self.sd_adapter.get_hf_storage_reader(
+        hf_storage_reader = self.hf_io.get_hf_storage_reader(
             checkpoint_id, from_quantized
         )
-        dcp.load(
-            hf_state_dict,
-            storage_reader=hf_storage_reader,
-        )
-        converted_sd = self.sd_adapter.from_hf(hf_state_dict)
-        self.model.load_sd(converted_sd)
+        dcp.load(state_dict, storage_reader=hf_storage_reader)
 
-    def _load_from_dcp(self, state_dict: dict[str, Any], checkpoint_id: str) -> None:
-        """Load from a DCP checkpoint."""
-        dcp.load(state_dict, checkpoint_id=checkpoint_id)
-        self.model.load_sd(state_dict)
+    def _load_from_dcp(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+    ) -> None:
+        """Load weights from a DCP checkpoint into ``state_dict``.
 
-    def _load_additional(self, path: str) -> None:
-        """Load adapter/overlay weights from additional_load_path.
-
-        Supports DCP (default) or HF/PEFT format (via model.from_external).
+        Pure I/O — the caller provides the container.
         """
-        if not os.path.isdir(path):
-            raise ValueError(
-                f"checkpoint.additional_load_path is not a valid directory: {path}"
-            )
-        logger.info(f"Loading additional weights from {path}.")
-        if self.additional_load_in_hf:
-            from safetensors.torch import load_file
-
-            external_sd = load_file(os.path.join(path, "adapter_model.safetensors"))
-            native_sd = self.model.from_external(external_sd)
-            self.model.load_sd(native_sd)
-        else:
-            adapter_sd = self.model.get_sd(StateDictMode.TRAINABLE)
-            self._load_from_dcp(adapter_sd, path)
+        dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
     @torch.no_grad()
     def save(self, curr_step: int, last_step: bool = False) -> None:
@@ -618,17 +619,22 @@ class CheckpointManager(Configurable):
             return False
 
         begin = time.monotonic()
-        two_phase = self.additional_load_path is not None
+        has_additional_load = self.additional_load_path is not None
 
-        # Phase 1: load base weights from initial_load_path.
-        # Always runs when two_phase is True (even on resume).
-        # Without two_phase, only runs when checkpoint folder doesn't exist.
-        if two_phase or not os.path.exists(self.folder):
+        # Initial load: base weights from initial_load_path.
+        # With additional_load, always runs (even on resume) to load base first.
+        # Without additional_load, only runs when checkpoint folder doesn't exist.
+        if has_additional_load or not os.path.exists(self.folder):
             loaded_initial = self._load_initial()
-            if not loaded_initial and not os.path.exists(self.folder):
+            if (
+                not loaded_initial
+                and not has_additional_load
+                and not os.path.exists(self.folder)
+            ):
                 return False
 
-        # Phase 2: load from checkpoint folder (resume) or additional_load_path.
+        # Resume from checkpoint folder, or load from additional_load_path.
+        resumed = False
         if os.path.exists(self.folder):
             step = self._find_load_step() if step == -1 else step
             if step != -1:
@@ -642,8 +648,24 @@ class CheckpointManager(Configurable):
                 logger.info(f"Loading checkpoint from {checkpoint_id}.")
                 states = self._states_to_load(model_only)
                 self._load_from_dcp(states, checkpoint_id)
-        elif two_phase and self.additional_load_path:
-            self._load_additional(self.additional_load_path)
+                self.model.load_sd(states)
+                resumed = True
+        if not resumed and has_additional_load:
+            path = cast(str, self.additional_load_path)
+            if not os.path.isdir(path):
+                raise ValueError(
+                    f"checkpoint.additional_load_path is not a valid directory: {path}"
+                )
+            logger.info(f"Loading additional weights from {path}.")
+            if self.additional_load_in_hf:
+                hf_sd = self.model.get_sd(StateDictMode.TRAINABLE, external=True)
+                self._load_from_hf(hf_sd, path)
+                native_sd = self.model.from_external(hf_sd, StateDictMode.TRAINABLE)
+                self.model.load_sd(native_sd)
+            else:
+                sd = self.model.get_sd(StateDictMode.TRAINABLE)
+                self._load_from_dcp(sd, path)
+                self.model.load_sd(sd)
 
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
@@ -653,7 +675,7 @@ class CheckpointManager(Configurable):
         return True
 
     def _load_initial(self) -> bool:
-        """Phase 1: load base weights from initial_load_path or hf_assets_path.
+        """Load base weights from initial_load_path or hf_assets_path.
 
         Returns:
             True if initial weights were loaded.
@@ -673,11 +695,8 @@ class CheckpointManager(Configurable):
                     "Loading HF safetensors from "
                     f"--checkpoint.initial_load_path: {checkpoint_id}"
                 )
-            elif (
-                self.sd_adapter is not None
-                and self.sd_adapter.hf_assets_path is not None
-            ):
-                checkpoint_id = self.sd_adapter.hf_assets_path
+            elif self.hf_io is not None and self.hf_io.hf_assets_path is not None:
+                checkpoint_id = self.hf_io.hf_assets_path
                 if not os.path.isdir(checkpoint_id):
                     raise ValueError(
                         "model.hf_assets_path is being used to load HF weights "
@@ -690,7 +709,10 @@ class CheckpointManager(Configurable):
             else:
                 return False
 
-            self._load_from_hf(checkpoint_id, from_quantized)
+            hf_sd = self.model.get_sd(StateDictMode.BASE, external=True)
+            self._load_from_hf(hf_sd, checkpoint_id, from_quantized)
+            native_sd = self.model.from_external(hf_sd, StateDictMode.BASE)
+            self.model.load_sd(native_sd)
             return True
 
         if self.initial_load_path:
@@ -701,9 +723,12 @@ class CheckpointManager(Configurable):
                     "but the path is not valid."
                 )
             logger.info(f"Loading DCP checkpoint from {checkpoint_id}.")
-            model_only = self.initial_load_model_only
-            states = self._states_to_load(model_only)
-            self._load_from_dcp(states, checkpoint_id)
+            if self.initial_load_model_only:
+                sd = self.model.get_sd(StateDictMode.BASE)
+            else:
+                sd = self._flattened_model_states_sd(model_mode=StateDictMode.BASE)
+            self._load_from_dcp(sd, checkpoint_id)
+            self.model.load_sd(sd)
             return True
 
         return False
@@ -767,7 +792,13 @@ class CheckpointManager(Configurable):
         return sd
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
-        """Determines which states to load for the given step."""
+        """Determines which states to load for the given step.
+
+        Uses TRAINABLE mode for model keys. When no params are frozen,
+        TRAINABLE == FULL so every key is included. With adapters (e.g.
+        LoRA), TRAINABLE returns only adapter keys — base weights come
+        from the initial load.
+        """
         if model_only:
             return self.model.get_sd(StateDictMode.FULL)
 
@@ -788,10 +819,16 @@ class CheckpointManager(Configurable):
         # under any parallelism. Training last-step saves only trainable.
         save_mode = StateDictMode.FULL if curr_step == 0 else StateDictMode.TRAINABLE
         if self.last_save_model_only:
-            states = self.model.get_sd(save_mode)
-
-            if self.export_dtype != torch.float32:
-                states = {k: v.to(self.export_dtype) for k, v in states.items()}
+            export_dtype = (
+                self.export_dtype
+                if self.export_dtype != TORCH_DTYPE_MAP["float32"]
+                else None
+            )
+            states = self.model.get_sd(
+                save_mode,
+                external=self.last_save_in_hf,
+                dtype=export_dtype,
+            )
             logger.info(
                 f"Saving a model only checkpoint in {self.export_dtype} "
                 f"at last step, step {curr_step}."
@@ -805,12 +842,14 @@ class CheckpointManager(Configurable):
                 self.last_save_model_only
             ), "Only model can be saved when saving in HF safetensors format."
 
+        checkpoint_id = self._create_checkpoint_id(curr_step)
+
         self.dcp_save(
             states,
-            checkpoint_id=self._create_checkpoint_id(curr_step),
+            checkpoint_id=checkpoint_id,
             async_mode=AsyncMode.DISABLED,
             enable_garbage_collection=True,
-            to_hf=self.last_save_in_hf,
+            hf_storage=self.last_save_in_hf,
         )
 
     def _should_save(self, curr_step: int, last_step: bool = False) -> bool:

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -6,10 +6,10 @@
 
 import enum
 from abc import abstractmethod
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+import torch
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
@@ -60,20 +60,31 @@ class BaseModel(Module):
             sd.update(get_model_state_dict(part))
         return sd
 
-    def get_sd(self, mode: StateDictMode = StateDictMode.FULL) -> dict[str, Any]:
+    def get_sd(
+        self,
+        mode: StateDictMode = StateDictMode.FULL,
+        *,
+        external: bool = False,
+        dtype: "torch.dtype | None" = None,
+    ) -> dict[str, Any]:
         """Get state dict for checkpointing.
 
         Args:
-            mode: FULL returns all keys. TRAINABLE returns only requires_grad=True
-                keys (uses DCP's ignore_frozen_params for correct FQN handling
-                with torch.compile / DDP wrappers). BASE returns only
-                requires_grad=False keys (or all if nothing is frozen).
+            mode: Which params to include.
+                FULL: all keys.
+                TRAINABLE: only requires_grad=True keys (uses DCP's
+                    ignore_frozen_params). When no params are frozen,
+                    TRAINABLE == FULL.
+                BASE: only requires_grad=False keys (or all if nothing frozen).
+            external: If True, remap keys to external format via
+                ``to_external`` (sd_adapter HF remapping, then converter
+                transforms in order).
+            dtype: Optional dtype cast for export (e.g. bfloat16).
         """
         if mode == StateDictMode.FULL:
-            return self._raw_sd()
-
-        if mode == StateDictMode.TRAINABLE:
-            sd: dict[str, Any] = {}
+            sd = self._raw_sd()
+        elif mode == StateDictMode.TRAINABLE:
+            sd = {}
             for part in self._get_parts():
                 sd.update(
                     get_model_state_dict(
@@ -81,14 +92,25 @@ class BaseModel(Module):
                         options=StateDictOptions(ignore_frozen_params=True),
                     )
                 )
-            return sd
+        else:
+            # BASE: full minus trainable
+            full_sd = self._raw_sd()
+            trainable_sd = self.get_sd(StateDictMode.TRAINABLE)
+            if len(trainable_sd) == len(full_sd):
+                sd = full_sd
+            else:
+                sd = {k: v for k, v in full_sd.items() if k not in trainable_sd}
 
-        # BASE: full minus trainable
-        full_sd = self._raw_sd()
-        trainable_sd = self.get_sd(StateDictMode.TRAINABLE)
-        if len(trainable_sd) == len(full_sd):
-            return full_sd
-        return {k: v for k, v in full_sd.items() if k not in trainable_sd}
+        if external:
+            sd = self.to_external(sd, mode)
+
+        if dtype is not None:
+            sd = {
+                k: v.to(dtype) if isinstance(v, torch.Tensor) else v
+                for k, v in sd.items()
+            }
+
+        return sd
 
     def load_sd(self, sd: dict[str, Any]) -> None:
         """Load state dict with strict=False (partial loads OK)."""
@@ -99,27 +121,45 @@ class BaseModel(Module):
                 options=StateDictOptions(strict=False),
             )
 
-    _to_external: Callable[[dict[str, Any]], dict[str, Any]] | None = None
-    _from_external: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    # State dict transforms, set once by set_sd_transforms().
+    _to_hf = None
+    _from_hf = None
 
-    def to_external(self, adapter_sd: dict[str, Any]) -> dict[str, Any]:
-        """Convert native adapter SD to external format (e.g. PEFT).
+    def set_sd_transforms(self, sd_adapter=None) -> None:
+        """Wire state dict transforms onto this model.
 
-        Set ``_to_external`` callable via trainer wiring (e.g. from
-        ``LoRAStateDictAdapter.to_hf``).
+        Extracts HF key remapping from sd_adapter (``to_hf``, ``from_hf``).
+        I/O concerns (storage reader/writer, fqn mapping) stay on
+        CheckpointManager.
+
+        Called once by the trainer after model build.
         """
-        if self._to_external is not None:
-            return self._to_external(adapter_sd)
-        return adapter_sd
+        if sd_adapter is not None:
+            self._to_hf = sd_adapter.to_hf
+            self._from_hf = sd_adapter.from_hf
 
-    def from_external(self, external_sd: dict[str, Any]) -> dict[str, Any]:
-        """Convert external format (e.g. PEFT) to native adapter SD.
+    def to_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
+        """Convert native state dict keys to external format.
 
-        Set ``_from_external`` callable via trainer wiring.
+        The mode determines which transforms to apply:
+        - BASE: HF remapping only (base model keys)
+        - TRAINABLE: no-op (reserved for converter transforms)
+        - FULL: HF remapping (same as BASE for now)
         """
-        if self._from_external is not None:
-            return self._from_external(external_sd)
-        return external_sd
+        if mode in (StateDictMode.FULL, StateDictMode.BASE):
+            if self._to_hf is not None:
+                sd = self._to_hf(sd)
+        return sd
+
+    def from_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
+        """Convert external format state dict keys to native format.
+
+        Reverse of ``to_external``, filtered by mode.
+        """
+        if mode in (StateDictMode.FULL, StateDictMode.BASE):
+            if self._from_hf is not None:
+                sd = self._from_hf(sd)
+        return sd
 
     def init_weights(self, **kwargs) -> None:
         """Backward-compatible alias for ``init_states``.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -49,30 +49,6 @@ from torchtitan.tools.logging import logger
 from torchtitan.tools.profiler import Profiler
 
 
-def _collect_adapter_key_patterns(config) -> set[str]:
-    """Collect key patterns from adapter configs in the model config tree.
-
-    Adapter configs declare ``_is_adapter = True`` and ``_key_pattern`` (e.g.
-    ``"lora_"``).  Returns the set of key patterns found, or empty if no
-    adapters are configured.
-    """
-    patterns: set[str] = set()
-    if not dataclasses.is_dataclass(config):
-        return patterns
-    cls = type(config)
-    if getattr(cls, "_is_adapter", False):
-        patterns.add(cls._key_pattern)
-    for f in dataclasses.fields(config):
-        val = getattr(config, f.name)
-        if dataclasses.is_dataclass(val):
-            patterns.update(_collect_adapter_key_patterns(val))
-        elif isinstance(val, list):
-            for item in val:
-                if dataclasses.is_dataclass(item):
-                    patterns.update(_collect_adapter_key_patterns(item))
-    return patterns
-
-
 class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
@@ -220,7 +196,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
-        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
@@ -412,23 +387,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             self.model_parts = [model]
 
-        # Freeze non-adapter parameters when adapters (e.g. LoRA) are present
-        adapter_key_patterns = _collect_adapter_key_patterns(model_config)
-        if adapter_key_patterns:
-            frozen_count = 0
-            adapter_count = 0
-            for model_part in self.model_parts:
-                for name, param in model_part.named_parameters():
-                    if any(pattern in name for pattern in adapter_key_patterns):
-                        adapter_count += 1
-                    else:
-                        param.requires_grad_(False)
-                        frozen_count += 1
-            logger.info(
-                f"Adapter training: froze {frozen_count} base parameters, "
-                f"kept {adapter_count} adapter parameters trainable."
-            )
-
         # Set lm_head reference for ChunkedCELoss after model construction.
         # Non-PP: single model part always has lm_head.
         # PP: only the last stage has lm_head; non-last stages skip this.
@@ -488,17 +446,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         if parallel_dims.pp_enabled:
             model_ref._pp_parts = self.model_parts
 
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if model_spec.state_dict_adapter
+            else None
+        )
+
+        model_ref.set_sd_transforms(sd_adapter)
+
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
             model=model_ref,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
+            sd_adapter=sd_adapter,
             base_folder=config.dump_folder,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3187
* __->__ #3186
* #3185

BaseModel owns the full state dict pipeline: filter (by requires_grad
mode) → transform (HF key remapping) → cast (dtype).

- get_sd(mode, external, dtype): single entry point. FULL/TRAINABLE/BASE
  modes filter by requires_grad via DCP ignore_frozen_params.
- to_external(sd, mode) / from_external(sd, mode): mode-based transform
  routing. BASE applies HF remapping, TRAINABLE reserved for converters.
- set_sd_transforms(sd_adapter): extracts to_hf/from_hf from sd_adapter.
  I/O concerns (storage reader/writer) stay on CheckpointManager.
- load_sd: strict=False for partial loads.

CheckpointManager becomes pure I/O:
- _load_from_hf(container, path) and _load_from_dcp(container, path)
  take a container dict and fill it. Caller builds container, converts,
  and applies — uniform pattern for all load paths.
- hf_io (renamed from sd_adapter) for HF storage reader/writer only.
- keys_match_mapping for adapter-only HF saves (consolidation mode).
- Initial load always uses BASE mode (== FULL when nothing frozen).

Trainer simplified:
- Removed _collect_adapter_key_patterns and freeze logic.
- One-line wiring: model_ref.set_sd_transforms(sd_adapter).