### PR TITLE
[LoRA] Converter protocol and PEFT external format support

### DIFF
--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -6,9 +6,8 @@
 
 import math
 import re
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -23,6 +22,7 @@ from torchtitan.models.common.decoder_sharding import (
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.sharding import ShardingConfig
 from torchtitan.tools.logging import logger
+
 
 def _lora_adapter_sharding(
     base_sharding: ShardingConfig | None,
@@ -60,7 +60,6 @@ def _lora_adapter_sharding(
         state_shardings={"weight": base_weight_sharding},
     )
     return replicate_weight, lora_b_sharding
-    return replicate_weight, lora_b_sharding
 
 
 # Cache for dynamically created LoRA classes
@@ -93,18 +92,14 @@ def _get_lora_cls(parent_cls: type) -> type:
                 self.bias.requires_grad_(False)
             self._lora_scaling = _lora_alpha / _lora_rank
 
-            lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(
-                _base_sharding
-            )
+            lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(_base_sharding)
             self.lora_a = Linear.Config(
                 in_features=config.in_features,
                 out_features=_lora_rank,
                 bias=False,
                 sharding_config=lora_a_sharding,
                 param_init={
-                    "weight": lambda w: nn.init.kaiming_uniform_(
-                        w, a=math.sqrt(5)
-                    ),
+                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
                 },
             ).build()
             self.lora_b = Linear.Config(
@@ -139,9 +134,6 @@ class LoRAConfig(Configurable.Config):
     inner config so that sharding and other config-level operations work
     transparently through the wrapper.
     """
-
-    _is_adapter: ClassVar[bool] = True
-    _key_pattern: ClassVar[str] = "lora_"
 
     inner: Linear.Config
     """The original Linear config (preserved for composition with quantization)."""
@@ -273,8 +265,7 @@ class LoRAConverter(Configurable):
         for fqn, cfg, parent, attr in model_config.traverse(Linear.Config):
             last_segment = fqn.rsplit(".", 1)[-1]
             is_target = (
-                self.target_modules is None
-                or last_segment in self.target_modules
+                self.target_modules is None or last_segment in self.target_modules
             )
             if is_target:
                 wrapped = LoRAConfig(
@@ -307,13 +298,20 @@ class LoRAConverter(Configurable):
                 f"Linear.Config in the model config tree."
             )
 
-    @staticmethod
-    def build_to_external(
-        sd_adapter,
-    ) -> Callable[[dict[str, Any]], dict[str, Any]]:
-        """Return a function that converts native adapter keys to external format."""
+    def build_external_transforms(self, sd_adapter) -> dict[str, Any] | None:
+        """Build LoRA external format transforms.
+
+        Returns a dict with ``to_external``/``from_external`` callables
+        for PEFT key remapping, or None if LoRA is not active.
+        """
+        if not _lora_class_cache or sd_adapter is None:
+            return None
         from_hf_map = sd_adapter.from_hf_map
-        return lambda sd: remap_lora_keys_to_hf(sd, from_hf_map)
+
+        return {
+            "to_external": lambda sd: remap_lora_keys_to_hf(sd, from_hf_map),
+            "from_external": lambda sd: remap_lora_keys_from_hf(sd, from_hf_map),
+        }
 
 
 def remap_lora_keys_to_hf(

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -112,6 +112,16 @@ def llama3_debugmodel_lora() -> Trainer.Config:
         LoRAConverter.Config(rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"])
     )
     lora_converter.convert(config.model_spec.model)
+    config.model_spec.converters.append(lora_converter)
+    return config
+
+
+def llama3_debugmodel_lora_checkpoint() -> Trainer.Config:
+    """LoRA training with checkpoint enabled and HF save/load."""
+    config = llama3_debugmodel_lora()
+    config.checkpoint.enable = True
+    config.checkpoint.last_save_model_only = True
+    config.checkpoint.last_save_in_hf = True
     return config
 
 

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -124,38 +124,66 @@ class BaseModel(Module):
     # State dict transforms, set once by set_sd_transforms().
     _to_hf = None
     _from_hf = None
+    _converters_to_external: list | None = None
+    _converters_from_external: list | None = None
 
-    def set_sd_transforms(self, sd_adapter=None) -> None:
+    def set_sd_transforms(
+        self, sd_adapter=None, converters: list | None = None
+    ) -> None:
         """Wire state dict transforms onto this model.
 
-        Extracts HF key remapping from sd_adapter (``to_hf``, ``from_hf``).
-        I/O concerns (storage reader/writer, fqn mapping) stay on
-        CheckpointManager.
+        Extracts HF key remapping from sd_adapter and collects converter
+        transforms. Each converter may implement
+        ``build_external_transforms(sd_adapter)`` returning a dict with
+        ``to_external``/``from_external`` callables.
 
         Called once by the trainer after model build.
         """
         if sd_adapter is not None:
             self._to_hf = sd_adapter.to_hf
             self._from_hf = sd_adapter.from_hf
+        self._converters_to_external = None
+        self._converters_from_external = None
+        for converter in converters or []:
+            build_fn = getattr(converter, "build_external_transforms", None)
+            if build_fn is not None:
+                ct = build_fn(sd_adapter)
+                if ct is not None:
+                    if self._converters_to_external is None:
+                        self._converters_to_external = []
+                        self._converters_from_external = []
+                    if "to_external" in ct:
+                        self._converters_to_external.append(ct["to_external"])
+                    if "from_external" in ct:
+                        self._converters_from_external.append(ct["from_external"])
 
     def to_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
         """Convert native state dict keys to external format.
 
         The mode determines which transforms to apply:
         - BASE: HF remapping only (base model keys)
-        - TRAINABLE: no-op (reserved for converter transforms)
-        - FULL: HF remapping (same as BASE for now)
+        - TRAINABLE: converter transforms only (adapter keys)
+        - FULL: both (base + adapter keys)
         """
         if mode in (StateDictMode.FULL, StateDictMode.BASE):
             if self._to_hf is not None:
                 sd = self._to_hf(sd)
+        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
+            if self._converters_to_external:
+                for fn in self._converters_to_external:
+                    sd = fn(sd)
         return sd
 
     def from_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
         """Convert external format state dict keys to native format.
 
-        Reverse of ``to_external``, filtered by mode.
+        Reverse of ``to_external``: converter transforms (reversed) then
+        HF remapping, filtered by mode.
         """
+        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
+            if self._converters_from_external:
+                for fn in reversed(self._converters_from_external):
+                    sd = fn(sd)
         if mode in (StateDictMode.FULL, StateDictMode.BASE):
             if self._from_hf is not None:
                 sd = self._from_hf(sd)

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
-from dataclasses import dataclass
-from typing import TypeAlias
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
 
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
@@ -41,3 +41,7 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+    converters: list[Any] = field(default_factory=list)
+    """Converters applied to this model (e.g. LoRA, quantization).
+    Each may implement ``build_external_transforms(sd_adapter)``
+    returning a dict with ``to_external``/``from_external`` callables."""

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -452,7 +452,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else None
         )
 
-        model_ref.set_sd_transforms(sd_adapter)
+        model_ref.set_sd_transforms(sd_adapter, model_spec.converters)
 
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3187
* #3186
* #3185

Add converter protocol for external format transforms (e.g. PEFT key
remapping). Converters are stored on ModelSpec.converters and wired
via BaseModel.set_sd_transforms(sd_adapter, converters).

ModelSpec:
- Add converters: list[Any] field. Config registry appends converter
  instances after convert(). Trainer iterates via duck typing.

BaseModel:
- Extend set_sd_transforms to accept converters list. Each converter
  may implement build_external_transforms(sd_adapter) returning
  {to_external, from_external} callables.
- to_external/from_external now route by mode: BASE applies HF
  remapping, TRAINABLE applies converter transforms, FULL applies both.

LoRAConverter:
- Add build_external_transforms instance method returning PEFT key
  remapping (remap_lora_keys_to_hf / remap_lora_keys_from_hf).
- Remove _is_adapter / _key_pattern ClassVars (filtering is by
  requires_grad, not pattern matching).

Config registry:
- llama3_debugmodel_lora: append converter to model_spec.converters.
- llama3_debugmodel_lora_checkpoint: LoRA with HF save enabled.

Tested: DCP resume bit-identical, PEFT safetensors round-trip
bit-identical, Llama 3.1 8B + community PEFT adapter loaded and
finetuned (44% MFU).