### PR TITLE
[Checkpoint] BaseModel state dict pipeline and pure I/O CheckpointManager

### DIFF
--- a/scripts/checkpoint_conversion/convert_from_hf.py
+++ b/scripts/checkpoint_conversion/convert_from_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageReader
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 
 
 @torch.inference_mode()
@@ -23,14 +23,12 @@ def convert_from_hf(input_dir, output_dir, model_name, model_flavor):
 
     with torch.device("cpu"):
         model = model_config.build()
-    model = ModelWrapper(model)
-
     sd_adapter = model_spec.state_dict_adapter(model_config, None)
     assert (
         sd_adapter is not None
     ), "trying to convert checkpoint from HF to DCP safetensors format, but sd_adapter is not provided."
     # get state dict in tt format with allocated memory
-    state_dict = model._get_state_dict()
+    state_dict = get_model_state_dict(model)
     # convert empty state dict to hf format so that hf weights can be loaded into it
     hf_state_dict = sd_adapter.to_hf(state_dict)
     dcp.load(

--- a/scripts/checkpoint_conversion/convert_to_hf.py
+++ b/scripts/checkpoint_conversion/convert_to_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageWriter
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.config import TORCH_DTYPE_MAP
 
 
@@ -31,15 +31,13 @@ def convert_to_hf(
 
     with torch.device("cpu"):
         model = model_config.build()
-    model = ModelWrapper(model)
-
     sd_adapter = model_spec.state_dict_adapter(model_config, hf_assets_path)
     assert (
         sd_adapter is not None
     ), "trying to convert checkpoint from DCP to HF safetensors format, but sd_adapter is not provided."
 
     # allocate state dict memory with empty weights to load checkpoint
-    state_dict = model._get_state_dict()
+    state_dict = get_model_state_dict(model)
     dcp.load(
         state_dict,
         checkpoint_id=input_dir,

--- a/scripts/checkpoint_conversion/numerical_tests_example.py
+++ b/scripts/checkpoint_conversion/numerical_tests_example.py
@@ -8,7 +8,7 @@ import torch
 
 import torch.distributed.checkpoint as dcp
 import torch.nn.functional as F
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.config import ConfigManager
 from torchtitan.tools.logging import logger
 
@@ -77,8 +77,7 @@ def forward_tt(model_name, config_name, checkpoint_path, test_set):
     model.init_weights(buffer_device=device)
     model.eval()
 
-    modelWrapper = ModelWrapper(model)
-    state_dict = modelWrapper._get_state_dict()
+    state_dict = get_model_state_dict(model)
 
     # Checkpoint Loading
     logger.info(f"Loading checkpoint at: {checkpoint_path}")

--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
@@ -33,7 +33,7 @@ import torch.nn.functional as F
 
 torch._dynamo.config.disable = True
 
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.models.qwen3_vl import model_registry
 from transformers import AutoProcessor
 
@@ -251,7 +251,7 @@ def run_tt(model_flavor, checkpoint_path, tt_inputs, device):
     model.init_weights(buffer_device=torch.device("cpu"))
     model.half()
 
-    state_dict = ModelWrapper(model)._get_state_dict()
+    state_dict = get_model_state_dict(model)
     print(f"  Loading checkpoint: {checkpoint_path}")
     dcp.load(state_dict, checkpoint_id=checkpoint_path)
     model.to(device)

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -194,7 +194,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -227,7 +226,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -268,7 +266,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -291,7 +288,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         self.assertFalse(manager.load(step=-1))
@@ -315,7 +311,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         res = manager.load(step=-1)
@@ -345,7 +340,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -379,7 +373,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager1.save(curr_step=1, last_step=True)
@@ -399,7 +392,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         r1 = manager2.load(step=1)
@@ -454,7 +446,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=checkpoint_config,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -495,7 +486,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=states,
             config=checkpoint_config,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -532,7 +522,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -558,7 +547,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -612,7 +600,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -650,7 +637,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -677,7 +663,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -718,7 +703,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -19,20 +19,23 @@ from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import CheckpointManager
 
 
-class FakeBaseModel(nn.Module):
-    """A fake BaseModel for checkpoint tests."""
+class FakeBaseModel(nn.Linear):
+    """A fake BaseModel for checkpoint tests.
 
-    def __init__(self, module: nn.Module):
-        super().__init__()
-        self.module = module
+    Inherits nn.Linear so get_model_state_dict works directly, and
+    provides the BaseModel transform methods that CheckpointManager expects.
+    """
 
-    def get_sd(self, mode=None, *, external=False, dtype=None):
-        return dict(self.module.state_dict())
+    def __init__(self, in_features: int = 2, out_features: int = 2):
+        super().__init__(in_features, out_features)
 
-    def load_sd(self, sd):
-        self.module.load_state_dict(sd, strict=False)
+    def to_hf(self, sd):
+        return sd
 
-    def from_external(self, sd, mode=None):
+    def from_hf(self, sd):
+        return sd
+
+    def adapter_to_hf(self, sd):
         return sd
 
 
@@ -123,8 +126,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.test_folder = os.path.join(self.base_temp_dir, self._testMethodName)
         os.makedirs(self.test_folder, exist_ok=True)
 
-        self.model_part = nn.Linear(2, 2)
-        self.model = FakeBaseModel(self.model_part)
+        self.model = FakeBaseModel(2, 2)
         self.states = {"trainer": torch.tensor([1.2347])}
         # TODO: Use a real OptimizerContainer here so that we can actually verify
         # some optimizer.state_dict() behavior (e.g., the key being the parameter name.)
@@ -187,7 +189,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_load.side_effect = self.fake_load
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -196,18 +198,18 @@ class TestCheckpointManager(unittest.TestCase):
             base_folder=self.trainer_config.dump_folder,
         )
 
-        w0 = self.model_part.weight.clone()
-        b0 = self.model_part.bias.clone()
+        w0 = self.model.weight.clone()
+        b0 = self.model.bias.clone()
         p0 = self.optimizers._fake_param.clone()
         manager.save(curr_step=1)
         with torch.no_grad():
-            self.model_part.weight.zero_()
-            self.model_part.bias.zero_()
+            self.model.weight.zero_()
+            self.model.bias.zero_()
         self.optimizers._fake_param = torch.tensor([42.0], dtype=torch.float32)
         manager.load(step=1)
 
-        self.assertTrue(torch.equal(self.model_part.weight, w0))
-        self.assertTrue(torch.equal(self.model_part.bias, b0))
+        self.assertTrue(torch.equal(self.model.weight, w0))
+        self.assertTrue(torch.equal(self.model.bias, b0))
         self.assertTrue(torch.equal(self.optimizers._fake_param, p0))
         manager.close()
 
@@ -220,7 +222,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -261,7 +263,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -284,7 +286,7 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "nonexistent"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -308,7 +310,7 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "checkpoints"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -338,7 +340,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -372,7 +374,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.last_save_model_only = True
         manager1 = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -392,7 +394,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.dump_folder = self.test_folder
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -447,7 +449,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -488,7 +490,7 @@ class TestCheckpointManager(unittest.TestCase):
         states = {"trainer": torch.tensor([0])}
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=states,
@@ -525,7 +527,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -551,7 +553,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -585,9 +587,17 @@ class TestCheckpointManager(unittest.TestCase):
                 super().__init__()
                 self.weight = nn.Parameter(torch.randn(2, 2))
                 self.bias = nn.Parameter(torch.randn(2))
-                # Register freqs_cis as a buffer (common pattern in transformer models)
                 self.register_buffer("freqs_cis", torch.randn(10, 5), persistent=False)
                 self.other_param = nn.Parameter(torch.randn(3, 3))
+
+            def to_hf(self, sd):
+                return sd
+
+            def from_hf(self, sd):
+                return sd
+
+            def adapter_to_hf(self, sd):
+                return sd
 
         fake_model = FakeModelWithFreqsCis()
         mock_save.side_effect = self.fake_save
@@ -597,7 +607,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=FakeBaseModel(fake_model),
+            model_parts=[fake_model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -635,7 +645,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -662,7 +672,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -703,7 +713,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.initial_load_model_only = False
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model=self.model,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -19,6 +19,23 @@ from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import CheckpointManager
 
 
+class FakeBaseModel(nn.Module):
+    """A fake BaseModel for checkpoint tests."""
+
+    def __init__(self, module: nn.Module):
+        super().__init__()
+        self.module = module
+
+    def get_sd(self, mode=None, *, external=False, dtype=None):
+        return dict(self.module.state_dict())
+
+    def load_sd(self, sd):
+        self.module.load_state_dict(sd, strict=False)
+
+    def from_external(self, sd, mode=None):
+        return sd
+
+
 class FakeOptimizersContainer:
     """A fake OptimizersContainer that returns fake state dicts."""
 
@@ -107,7 +124,7 @@ class TestCheckpointManager(unittest.TestCase):
         os.makedirs(self.test_folder, exist_ok=True)
 
         self.model_part = nn.Linear(2, 2)
-        self.model_parts = [self.model_part]
+        self.model = FakeBaseModel(self.model_part)
         self.states = {"trainer": torch.tensor([1.2347])}
         # TODO: Use a real OptimizerContainer here so that we can actually verify
         # some optimizer.state_dict() behavior (e.g., the key being the parameter name.)
@@ -170,7 +187,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_load.side_effect = self.fake_load
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -203,7 +220,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -244,7 +261,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -267,7 +284,7 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "nonexistent"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -291,7 +308,7 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "checkpoints"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -321,7 +338,7 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -355,7 +372,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.last_save_model_only = True
         manager1 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -375,7 +392,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.dump_folder = self.test_folder
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -430,7 +447,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -471,7 +488,7 @@ class TestCheckpointManager(unittest.TestCase):
         states = {"trainer": torch.tensor([0])}
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=states,
@@ -508,7 +525,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -534,7 +551,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -580,7 +597,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=[fake_model],
+            model=FakeBaseModel(fake_model),
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -618,7 +635,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -645,7 +662,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
@@ -686,7 +703,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.initial_load_model_only = False
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model=self.model,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -335,6 +335,7 @@ class CheckpointManager(Configurable):
         self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
         self.last_save_model_only = config.last_save_model_only
         self.last_save_in_hf = config.last_save_in_hf
+        self.create_seed_checkpoint = config.create_seed_checkpoint
 
         # HF I/O config extracted from sd_adapter. CheckpointManager only
         # needs these for HF storage reader/writer — key transforms are on
@@ -816,9 +817,12 @@ class CheckpointManager(Configurable):
         )
 
     def _save_last_step(self, curr_step: int) -> None:
-        # Seed checkpoint (step 0) saves ALL params so it can be loaded
-        # under any parallelism. Training last-step saves only trainable.
-        save_mode = StateDictMode.FULL if curr_step == 0 else StateDictMode.TRAINABLE
+        # Seed checkpoints save ALL params so they can be loaded under any
+        # parallelism. Training last-step saves only trainable.
+        if self.create_seed_checkpoint:
+            save_mode = StateDictMode.FULL
+        else:
+            save_mode = StateDictMode.TRAINABLE
         if self.last_save_model_only:
             export_dtype = (
                 self.export_dtype

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import enum
-import functools
 import os
 import queue
 import re
@@ -21,32 +20,26 @@ from typing import Any, cast, Literal
 import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
-import torch.nn as nn
 from torch.distributed.checkpoint import HuggingFaceStorageWriter
 from torch.distributed.checkpoint._consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
-from torch.distributed.checkpoint.state_dict import (
-    get_model_state_dict,
-    set_model_state_dict,
-    StateDictOptions,
-)
 from torch.distributed.checkpoint.state_dict_saver import (
     AsyncCheckpointerType,
     AsyncSaveResponse,
 )
-from torch.distributed.checkpoint.stateful import Stateful
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
+from torchtitan.protocols.model import BaseModel, StateDictMode
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
 
-MODEL = "model"
+MODEL = "model"  # Kept for backward compat with experiment code
 OPTIMIZER = "optimizer"
 LR_SCHEDULER = "lr_scheduler"
 DATALOADER = "dataloader"
@@ -57,32 +50,6 @@ class AsyncMode(str, enum.Enum):
     DISABLED = "disabled"
     ASYNC = "async"
     ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
-
-
-class ModelWrapper(Stateful):
-    def __init__(self, model: nn.Module | list[nn.Module]) -> None:
-        self.model = [model] if isinstance(model, nn.Module) else model
-        self.cache_state_dict = self._get_state_dict()
-
-    def _get_state_dict(self) -> dict[str, Any]:
-        state_dict = {
-            k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()
-        }
-        return state_dict
-
-    def state_dict(self) -> dict[str, Any]:
-        return self.cache_state_dict
-
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        func = functools.partial(
-            set_model_state_dict,
-            model_state_dict=state_dict,
-            options=StateDictOptions(strict=False),
-        )
-        list(map(func, self.model))
-        # `set_model_state_dict()` does change the keys of the input state_dict,
-        # we will need to reinitialize the cache_state_dict.
-        self.cache_state_dict = self._get_state_dict()
 
 
 class Terminate:
@@ -150,7 +117,7 @@ class CheckpointManager(Configurable):
 
     Args:
         dataloader (DataLoader): The dataloader used to load the data.
-        model_parts (List[nn.Module]): List of model parts to be optimized.
+        model (nn.Module): The model (with _pp_parts set by trainer if PP is used).
         optimizers (OptimizersContainer): The optimizers used to optimize the model.
         lr_schedulers (LRSchedulersContainer): The lr schedulers used to optimize the model.
         states (Dict[str, Any]): The states that need to be saved, other than the
@@ -158,8 +125,8 @@ class CheckpointManager(Configurable):
         config (Checkpoint): The config used to configure the checkpointing.
         base_folder (str): The base folder to save the checkpoint. Will be concatenated
             with config.folder
-        sd_adapter (Optional[type[BaseStateDictAdapter]]): The adapter used to convert model state
-            dicts between native format and other formats.
+        sd_adapter (Optional[BaseStateDictAdapter]): HF I/O config (storage reader/writer,
+            fqn mapping, assets path). Key transforms are on the model.
 
     """
 
@@ -281,6 +248,21 @@ class CheckpointManager(Configurable):
         This will load the model only, excluding the specified keys.
         """
 
+        additional_load_path: str | None = None
+        """
+        Additional checkpoint path for 2-phase loading. When set, ``initial_load_path``
+        always loads base weights (even on resume), and this path provides the adapter
+        or overlay weights. On resume, the checkpoint folder takes priority over this path
+        for adapter + training state.
+        """
+
+        additional_load_in_hf: bool = False
+        """
+        Whether the additional_load_path is in HF/PEFT format (safetensors).
+        When True, loads safetensors and converts via ``model.from_external()``.
+        When False (default), loads via DCP.
+        """
+
         enable_first_step_checkpoint: bool = False
         """
         Enable the checkpoint save at first step. This will save a checkpoint immediately
@@ -309,7 +291,7 @@ class CheckpointManager(Configurable):
         config: Config,
         *,
         dataloader: BaseDataLoader | None,
-        model_parts: list[nn.Module],
+        model: BaseModel,
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
@@ -319,10 +301,10 @@ class CheckpointManager(Configurable):
         self.enable = config.enable
         self.load_only = config.load_only
 
+        self.model = model
         self.states = states
         self.states.update(
             {
-                MODEL: ModelWrapper(model_parts),
                 OPTIMIZER: optimizers,
                 DATALOADER: dataloader,
                 LR_SCHEDULER: lr_schedulers,
@@ -353,11 +335,17 @@ class CheckpointManager(Configurable):
         self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
         self.last_save_model_only = config.last_save_model_only
         self.last_save_in_hf = config.last_save_in_hf
+
+        # HF I/O config extracted from sd_adapter. CheckpointManager only
+        # needs these for HF storage reader/writer — key transforms are on
+        # the model via model.set_sd_transforms().
+        self.hf_io = sd_adapter
         if self.last_save_in_hf:
             assert (
-                sd_adapter is not None
+                self.hf_io is not None
             ), "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
-        self.sd_adapter = sd_adapter
+        self.additional_load_path = config.additional_load_path
+        self.additional_load_in_hf = config.additional_load_in_hf
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
         self.exclude_from_loading = config.exclude_from_loading
         self.interval = config.interval
@@ -428,15 +416,17 @@ class CheckpointManager(Configurable):
         checkpoint_id: str,
         async_mode: AsyncMode,
         enable_garbage_collection: bool = False,
-        to_hf: bool = False,
+        hf_storage: bool = False,
     ) -> Future | AsyncSaveResponse | None:
         """Save the checkpoint with dcp.
         Args:
-            state_dict (dict): The state dict to save.
+            state_dict (dict): The state dict to save (key transforms already applied).
             checkpoint_id (str): The checkpoint id to save.
             async_mode (AsyncMode): Whether the checkpoint is async.
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
-            to_hf (bool): Whether to save in HF model definition and safetensors format.
+            hf_storage (bool): Whether to use HF safetensors storage writer.
+                Key transforms must be applied by the caller via
+                model.get_sd(external=True) before calling this method.
 
         Returns:
             Future: The future object if the checkpoint is async, otherwise None.
@@ -447,14 +437,19 @@ class CheckpointManager(Configurable):
         storage_writer: HuggingFaceStorageWriter | None = None
         checkpoint_save_id: str | None = None
         fqn_to_index_mapping: dict[Any, int] | None = None
-        if to_hf:
+        keys_match_mapping = False
+        if hf_storage:
             assert (
-                self.sd_adapter is not None
-            ), "trying to save checkpoint in HF safetensors format, but sd_adapter is not provided."
-            state_dict = self.sd_adapter.to_hf(state_dict)
-
-            fqn_to_index_mapping = self.sd_adapter.fqn_to_index_mapping
-            if fqn_to_index_mapping:
+                self.hf_io is not None
+            ), "trying to save in HF safetensors format, but sd_adapter is not provided."
+            fqn_to_index_mapping = self.hf_io.fqn_to_index_mapping
+            # Only use sharded mapping when saved keys match the mapping
+            # (e.g. base model HF save). For adapter-only saves (PEFT),
+            # keys won't be in the base mapping — fall through to consolidation.
+            keys_match_mapping = fqn_to_index_mapping and any(
+                k in fqn_to_index_mapping for k in state_dict
+            )
+            if keys_match_mapping:
                 storage_writer = HuggingFaceStorageWriter(
                     path=os.path.join(checkpoint_id, "sharded"),
                     save_distributed=True,
@@ -498,7 +493,7 @@ class CheckpointManager(Configurable):
                 checkpoint_id=checkpoint_save_id,
             )
 
-        if to_hf and fqn_to_index_mapping:
+        if hf_storage and keys_match_mapping:
             consolidate_safetensors_files_on_every_rank(
                 input_dir=os.path.join(checkpoint_id, "sharded"),
                 output_dir=checkpoint_id,
@@ -511,44 +506,36 @@ class CheckpointManager(Configurable):
 
         return ret
 
-    def dcp_load(
+    def _load_from_hf(
         self,
         state_dict: dict[str, Any],
         checkpoint_id: str,
-        from_hf: bool,
-        from_quantized: bool,
+        from_quantized: bool = False,
     ) -> None:
-        """Load the checkpoint with dcp.
-        Args:
-            state_dict (dict): The state dict to load.
-            checkpoint_id (str): The checkpoint id to load.
-            from_hf (bool): Whether to load from HuggingFace checkpoint with
-                its own model definition and safetensors format.
+        """Load weights from a HuggingFace checkpoint into ``state_dict``.
+
+        Pure I/O — the caller provides the container (via
+        ``model.get_sd(mode, external=True)``) and handles conversion
+        afterward.
         """
+        assert (
+            self.hf_io is not None
+        ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
+        hf_storage_reader = self.hf_io.get_hf_storage_reader(
+            checkpoint_id, from_quantized
+        )
+        dcp.load(state_dict, storage_reader=hf_storage_reader)
 
-        if from_hf:
-            assert (
-                self.sd_adapter is not None
-            ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
-            hf_state_dict = self.sd_adapter.to_hf(state_dict)
-            hf_storage_reader = self.sd_adapter.get_hf_storage_reader(
-                checkpoint_id, from_quantized
-            )
+    def _load_from_dcp(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+    ) -> None:
+        """Load weights from a DCP checkpoint into ``state_dict``.
 
-            dcp.load(
-                hf_state_dict,
-                storage_reader=hf_storage_reader,
-            )
-
-            state_dict = self.sd_adapter.from_hf(hf_state_dict)
-            self.states[MODEL].load_state_dict(state_dict)
-        else:
-            dcp.load(state_dict, checkpoint_id=checkpoint_id)
-
-            # TODO: Since we flatten the model states in state_dict, we need to
-            # manually call load_state_dict() for the model. Need to fix this.
-            if MODEL in self.states:
-                self.states[MODEL].load_state_dict(state_dict)
+        Pure I/O — the caller provides the container.
+        """
+        dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
     @torch.no_grad()
     def save(self, curr_step: int, last_step: bool = False) -> None:
@@ -580,7 +567,7 @@ class CheckpointManager(Configurable):
             self._save_last_step(curr_step)
             return
 
-        states = self._flattened_model_states_sd()
+        states = self._flattened_model_states_sd(model_mode=StateDictMode.TRAINABLE)
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             GarbageCollection.collect("GC collection invoked by checkpointer.")
             if self.stager is None:
@@ -631,86 +618,120 @@ class CheckpointManager(Configurable):
         if not self.enable:
             return False
 
-        model_only = False
-        from_hf = False
-        from_quantized = False
-        if not os.path.exists(self.folder):
-            model_only = self.initial_load_model_only
-            from_hf = self.initial_load_in_hf
-            from_quantized = self.initial_load_in_hf_quantized
-            if from_hf:
-                assert (
-                    model_only
-                ), "Only model can be loaded when loading from HF's safetensors checkpoint."
+        begin = time.monotonic()
+        has_additional_load = self.additional_load_path is not None
 
-            if from_quantized:
-                assert (
-                    from_hf
-                ), "Quantized checkpoint can only be loaded from HuggingFace format."
+        # Initial load: base weights from initial_load_path.
+        # With additional_load, always runs (even on resume) to load base first.
+        # Without additional_load, only runs when checkpoint folder doesn't exist.
+        if has_additional_load or not os.path.exists(self.folder):
+            loaded_initial = self._load_initial()
+            if (
+                not loaded_initial
+                and not has_additional_load
+                and not os.path.exists(self.folder)
+            ):
+                return False
 
+        # Resume from checkpoint folder, or load from additional_load_path.
+        resumed = False
+        if os.path.exists(self.folder):
+            step = self._find_load_step() if step == -1 else step
+            if step != -1:
+                checkpoint_id = self._create_checkpoint_id(step)
+                if not os.path.isdir(checkpoint_id):
+                    raise FileNotFoundError(
+                        f"--checkpoint.load_step={step} but "
+                        f"checkpoint {checkpoint_id} is not found."
+                    )
+                model_only = step == 0
+                logger.info(f"Loading checkpoint from {checkpoint_id}.")
+                states = self._states_to_load(model_only)
+                self._load_from_dcp(states, checkpoint_id)
+                self.model.load_sd(states)
+                resumed = True
+        if not resumed and has_additional_load:
+            path = cast(str, self.additional_load_path)
+            if not os.path.isdir(path):
+                raise ValueError(
+                    f"checkpoint.additional_load_path is not a valid directory: {path}"
+                )
+            logger.info(f"Loading additional weights from {path}.")
+            if self.additional_load_in_hf:
+                hf_sd = self.model.get_sd(StateDictMode.TRAINABLE, external=True)
+                self._load_from_hf(hf_sd, path)
+                native_sd = self.model.from_external(hf_sd, StateDictMode.TRAINABLE)
+                self.model.load_sd(native_sd)
+            else:
+                sd = self.model.get_sd(StateDictMode.TRAINABLE)
+                self._load_from_dcp(sd, path)
+                self.model.load_sd(sd)
+
+        GarbageCollection.collect("GC collection for checkpoint loading.")
+        logger.info(
+            f"Finished loading the checkpoint in "
+            f"{time.monotonic() - begin:.2f} seconds."
+        )
+        return True
+
+    def _load_initial(self) -> bool:
+        """Load base weights from initial_load_path or hf_assets_path.
+
+        Returns:
+            True if initial weights were loaded.
+        """
+        from_hf = self.initial_load_in_hf
+        from_quantized = self.initial_load_in_hf_quantized
+
+        if from_hf:
             if self.initial_load_path:
                 checkpoint_id = self.initial_load_path
                 if not os.path.isdir(checkpoint_id):
                     raise ValueError(
-                        "checkpoint.initial_load_path is specified but the path is not valid."
-                    )
-                if from_hf:
-                    logger.info(
-                        f"loading from HF safetensors from --checkpoint.initial_load_path: {self.initial_load_path}"
-                    )
-            elif from_hf:
-                assert (
-                    self.sd_adapter is not None
-                    and self.sd_adapter.hf_assets_path is not None
-                ), "from_hf is True but sd_adapter or hf_assets_path is not provided."
-                hf_assets_path = self.sd_adapter.hf_assets_path
-                checkpoint_id = hf_assets_path
-                if not os.path.isdir(checkpoint_id):
-                    raise ValueError(
-                        "model.hf_assets_path is being used to load HF weights but the path is not valid. \
-                        Either make sure hf_assets_path is correct or provide a valid checkpoint.initial_load_path"
+                        "checkpoint.initial_load_path is specified "
+                        "but the path is not valid."
                     )
                 logger.info(
-                    f"loading HF safetensors from --model.hf_assets_path: {hf_assets_path}"
+                    "Loading HF safetensors from "
+                    f"--checkpoint.initial_load_path: {checkpoint_id}"
+                )
+            elif self.hf_io is not None and self.hf_io.hf_assets_path is not None:
+                checkpoint_id = self.hf_io.hf_assets_path
+                if not os.path.isdir(checkpoint_id):
+                    raise ValueError(
+                        "model.hf_assets_path is being used to load HF weights "
+                        "but the path is not valid."
+                    )
+                logger.info(
+                    "Loading HF safetensors from "
+                    f"--model.hf_assets_path: {checkpoint_id}"
                 )
             else:
                 return False
-        else:
-            if self.initial_load_path:
-                logger.warning(
-                    "checkpoint.initial_load_path is provided but the checkpoint.folder exists. "
-                    f"Checkpointer will use the checkpoints from the checkpoint.folder {self.folder}."
-                )
-            if self.initial_load_in_hf:
-                logger.warning(
-                    "checkpoint.initial_load_in_hf is True but the checkpoint.folder exists. "
-                    "Checkpointer will not load from HF safetensors"
-                )
-            step = self._find_load_step() if step == -1 else step
-            if step == -1:
-                return False
-            model_only = step == 0
-            checkpoint_id = self._create_checkpoint_id(step)
 
+            hf_sd = self.model.get_sd(StateDictMode.BASE, external=True)
+            self._load_from_hf(hf_sd, checkpoint_id, from_quantized)
+            native_sd = self.model.from_external(hf_sd, StateDictMode.BASE)
+            self.model.load_sd(native_sd)
+            return True
+
+        if self.initial_load_path:
+            checkpoint_id = self.initial_load_path
             if not os.path.isdir(checkpoint_id):
-                raise FileNotFoundError(
-                    f"--checkpoint.load_step={step} but checkpoint {checkpoint_id} is not found."
+                raise ValueError(
+                    "checkpoint.initial_load_path is specified "
+                    "but the path is not valid."
                 )
+            logger.info(f"Loading DCP checkpoint from {checkpoint_id}.")
+            if self.initial_load_model_only:
+                sd = self.model.get_sd(StateDictMode.BASE)
+            else:
+                sd = self._flattened_model_states_sd(model_mode=StateDictMode.BASE)
+            self._load_from_dcp(sd, checkpoint_id)
+            self.model.load_sd(sd)
+            return True
 
-        logger.info(f"Loading the checkpoint from {checkpoint_id}.")
-        begin = time.monotonic()
-        states = self._states_to_load(model_only)
-        self.dcp_load(
-            states,
-            checkpoint_id=checkpoint_id,
-            from_hf=from_hf,
-            from_quantized=from_quantized,
-        )
-        GarbageCollection.collect("GC collection for checkpoint loading.")
-        logger.info(
-            f"Finished loading the checkpoint in {time.monotonic() - begin:.2f} seconds."
-        )
-        return True
+        return False
 
     def maybe_wait_for_staging(self) -> None:
         """Wait for the staging to finish if it is enabled.
@@ -759,33 +780,27 @@ class CheckpointManager(Configurable):
         return os.path.join(folder, f"step-{step}")
 
     def _flattened_model_states_sd(
-        self, state_dict: dict[str, Any] | None = None
+        self,
+        state_dict: dict[str, Any] | None = None,
+        *,
+        model_mode: StateDictMode = StateDictMode.FULL,
     ) -> dict[str, Any]:
-        """Flatten the model states into a single dictionary.
-
-        Note that other states, such as optimizer states, are not flattened.
-        """
+        """Flatten model keys alongside training states."""
         states = state_dict if state_dict is not None else self.states
-        sd = {k: v for k, v in states.items() if k != MODEL}
-        if MODEL in states:
-            sd.update(states[MODEL].state_dict())
+        sd = dict(states)
+        sd.update(self.model.get_sd(model_mode))
         return sd
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         """Determines which states to load for the given step.
 
-        This API is used to determine which states to load based on the
-        configurations.
-
-        Args:
-            model_only (bool): Whether to load the model only.
-
-        Returns:
-            Dict[str, Any]: The states to load for the given step.
+        Uses TRAINABLE mode for model keys. When no params are frozen,
+        TRAINABLE == FULL so every key is included. With adapters (e.g.
+        LoRA), TRAINABLE returns only adapter keys — base weights come
+        from the initial load.
         """
-        # For the first step, we will only load the model.
         if model_only:
-            return self.states[MODEL].state_dict()
+            return self.model.get_sd(StateDictMode.FULL)
 
         for exclude_key in self.exclude_from_loading:
             if exclude_key not in self.states:
@@ -795,40 +810,46 @@ class CheckpointManager(Configurable):
             k: v for k, v in self.states.items() if k not in self.exclude_from_loading
         }
 
-        states_to_load = self._flattened_model_states_sd(states_to_load)
-
-        return states_to_load
+        return self._flattened_model_states_sd(
+            states_to_load, model_mode=StateDictMode.TRAINABLE
+        )
 
     def _save_last_step(self, curr_step: int) -> None:
-        # We only consider saving model only at the end of the training. So this
-        # won't affect preemption and training resume. We also only allow dtype
-        # conversion when we are checkpointing model only and the current dtype
-        # is not the same as the export dtype at the end of the training.
-
+        # Seed checkpoint (step 0) saves ALL params so it can be loaded
+        # under any parallelism. Training last-step saves only trainable.
+        save_mode = StateDictMode.FULL if curr_step == 0 else StateDictMode.TRAINABLE
         if self.last_save_model_only:
-            states = self.states[MODEL].state_dict()
-
-            if self.export_dtype != torch.float32:
-                states = {k: v.to(self.export_dtype) for k, v in states.items()}
+            export_dtype = (
+                self.export_dtype
+                if self.export_dtype != TORCH_DTYPE_MAP["float32"]
+                else None
+            )
+            states = self.model.get_sd(
+                save_mode,
+                external=self.last_save_in_hf,
+                dtype=export_dtype,
+            )
             logger.info(
                 f"Saving a model only checkpoint in {self.export_dtype} "
                 f"at last step, step {curr_step}."
             )
         else:
             logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
-            states = self._flattened_model_states_sd()
+            states = self._flattened_model_states_sd(model_mode=save_mode)
 
         if self.last_save_in_hf:
             assert (
                 self.last_save_model_only
             ), "Only model can be saved when saving in HF safetensors format."
 
+        checkpoint_id = self._create_checkpoint_id(curr_step)
+
         self.dcp_save(
             states,
-            checkpoint_id=self._create_checkpoint_id(curr_step),
+            checkpoint_id=checkpoint_id,
             async_mode=AsyncMode.DISABLED,
             enable_garbage_collection=True,
-            to_hf=self.last_save_in_hf,
+            hf_storage=self.last_save_in_hf,
         )
 
     def _should_save(self, curr_step: int, last_step: bool = False) -> bool:

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -42,7 +42,6 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
 from torchtitan.protocols.model import BaseModel, StateDictMode
-from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
@@ -186,8 +185,8 @@ class CheckpointManager(Configurable):
         config (Checkpoint): The config used to configure the checkpointing.
         base_folder (str): The base folder to save the checkpoint. Will be concatenated
             with config.folder
-        sd_adapter (Optional[BaseStateDictAdapter]): HF I/O config (storage reader/writer,
-            fqn mapping, assets path). Key transforms are on the model.
+        The model's ``sd_adapter`` attribute provides HF I/O config (storage
+            reader/writer, fqn mapping, assets path) and key transforms.
 
     """
 
@@ -356,7 +355,6 @@ class CheckpointManager(Configurable):
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
-        sd_adapter: BaseStateDictAdapter | None,
         base_folder: str = "",
     ) -> None:
         self.enable = config.enable
@@ -400,14 +398,10 @@ class CheckpointManager(Configurable):
         self.last_save_in_hf = config.last_save_in_hf
         self.create_seed_checkpoint = config.create_seed_checkpoint
 
-        # HF I/O config extracted from sd_adapter. CheckpointManager only
-        # needs these for HF storage reader/writer — key transforms are on
-        # the model via model.set_sd_transforms().
-        self.hf_io = sd_adapter
         if self.last_save_in_hf:
             assert (
-                self.hf_io is not None
-            ), "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
+                self.model.sd_adapter is not None
+            ), "checkpoint.last_save_in_hf is True, but model has no sd_adapter."
         self.initial_load_frozen = config.initial_load_frozen
         self.last_save_trainable_only = config.last_save_trainable_only
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
@@ -522,9 +516,9 @@ class CheckpointManager(Configurable):
         keys_match_mapping = False
         if hf_storage:
             assert (
-                self.hf_io is not None
-            ), "trying to save in HF safetensors format, but sd_adapter is not provided."
-            fqn_to_index_mapping = self.hf_io.fqn_to_index_mapping
+                self.model.sd_adapter is not None
+            ), "trying to save in HF safetensors format, but model has no sd_adapter."
+            fqn_to_index_mapping = self.model.sd_adapter.fqn_to_index_mapping
             # Only use sharded mapping when saved keys match the mapping
             # (e.g. base model HF save). For adapter-only saves (PEFT),
             # keys won't be in the base mapping — fall through to consolidation.
@@ -602,9 +596,9 @@ class CheckpointManager(Configurable):
         handles conversion back via ``model.from_hf()`` afterward.
         """
         assert (
-            self.hf_io is not None
-        ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
-        hf_storage_reader = self.hf_io.get_hf_storage_reader(
+            self.model.sd_adapter is not None
+        ), "trying to load checkpoint in HF safetensors format, but model has no sd_adapter."
+        hf_storage_reader = self.model.sd_adapter.get_hf_storage_reader(
             checkpoint_id, from_quantized
         )
         dcp.load(state_dict, storage_reader=hf_storage_reader)
@@ -773,8 +767,11 @@ class CheckpointManager(Configurable):
                     "Loading HF safetensors from "
                     f"--checkpoint.initial_load_path: {checkpoint_id}"
                 )
-            elif self.hf_io is not None and self.hf_io.hf_assets_path is not None:
-                checkpoint_id = self.hf_io.hf_assets_path
+            elif (
+                self.model.sd_adapter is not None
+                and self.model.sd_adapter.hf_assets_path is not None
+            ):
+                checkpoint_id = self.model.sd_adapter.hf_assets_path
                 if not os.path.isdir(checkpoint_id):
                     raise ValueError(
                         "model.hf_assets_path is being used to load HF weights "

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -494,6 +494,7 @@ class CheckpointManager(Configurable):
             )
 
         if hf_storage and keys_match_mapping:
+            assert fqn_to_index_mapping is not None
             consolidate_safetensors_files_on_every_rank(
                 input_dir=os.path.join(checkpoint_id, "sharded"),
                 output_dir=checkpoint_id,

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -20,15 +20,23 @@ from typing import Any, cast, Literal
 import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
+import torch.nn as nn
 from torch.distributed.checkpoint import HuggingFaceStorageWriter
 from torch.distributed.checkpoint._consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    set_model_state_dict,
+    StateDictOptions,
+)
 from torch.distributed.checkpoint.state_dict_saver import (
     AsyncCheckpointerType,
     AsyncSaveResponse,
 )
+from torch.distributed.checkpoint.stateful import Stateful
+
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -39,11 +47,64 @@ from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
 
-MODEL = "model"  # Kept for backward compat with experiment code
+MODEL = "model"
 OPTIMIZER = "optimizer"
 LR_SCHEDULER = "lr_scheduler"
 DATALOADER = "dataloader"
 TRAIN_STATE = "train_state"
+
+
+class ModelWrapper(Stateful):
+    """Stateful wrapper that merges state dicts across PP stages.
+
+    Handles pipeline-parallel iteration and mode-based filtering.
+    Set ``mode`` before each save/load to control which parameters
+    are included in ``state_dict()``.
+    """
+
+    def __init__(self, model_parts: list[nn.Module]) -> None:
+        self.model_parts = model_parts
+        self.mode = StateDictMode.FULL
+
+    def _full_sd(self) -> dict[str, Any]:
+        sd: dict[str, Any] = {}
+        for part in self.model_parts:
+            sd.update(get_model_state_dict(part))
+        return sd
+
+    def state_dict(self) -> dict[str, Any]:
+        if self.mode == StateDictMode.TRAINABLE:
+            sd: dict[str, Any] = {}
+            for part in self.model_parts:
+                sd.update(
+                    get_model_state_dict(
+                        part,
+                        options=StateDictOptions(ignore_frozen_params=True),
+                    )
+                )
+            return sd
+        if self.mode == StateDictMode.BASE:
+            full_sd = self._full_sd()
+            trainable_sd: dict[str, Any] = {}
+            for part in self.model_parts:
+                trainable_sd.update(
+                    get_model_state_dict(
+                        part,
+                        options=StateDictOptions(ignore_frozen_params=True),
+                    )
+                )
+            if len(trainable_sd) == len(full_sd):
+                return full_sd
+            return {k: v for k, v in full_sd.items() if k not in trainable_sd}
+        return self._full_sd()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        for part in self.model_parts:
+            set_model_state_dict(
+                part,
+                model_state_dict=state_dict,
+                options=StateDictOptions(strict=False),
+            )
 
 
 class AsyncMode(str, enum.Enum):
@@ -117,7 +178,7 @@ class CheckpointManager(Configurable):
 
     Args:
         dataloader (DataLoader): The dataloader used to load the data.
-        model (nn.Module): The model (with _pp_parts set by trainer if PP is used).
+        model_parts (list[nn.Module]): Model parts (one per PP stage, or single-element list).
         optimizers (OptimizersContainer): The optimizers used to optimize the model.
         lr_schedulers (LRSchedulersContainer): The lr schedulers used to optimize the model.
         states (Dict[str, Any]): The states that need to be saved, other than the
@@ -248,19 +309,19 @@ class CheckpointManager(Configurable):
         This will load the model only, excluding the specified keys.
         """
 
-        additional_load_path: str | None = None
+        initial_load_frozen: bool = False
         """
-        Additional checkpoint path for 2-phase loading. When set, ``initial_load_path``
-        always loads base weights (even on resume), and this path provides the adapter
-        or overlay weights. On resume, the checkpoint folder takes priority over this path
-        for adapter + training state.
+        When True, initial load only loads frozen/base params (adapter training).
+        Adapters are freshly initialized at build time by the converter (e.g.
+        LoRAConverter). On resume, the full model (base + adapters) is loaded
+        from the checkpoint folder.
         """
 
-        additional_load_in_hf: bool = False
+        last_save_trainable_only: bool = False
         """
-        Whether the additional_load_path is in HF/PEFT format (safetensors).
-        When True, loads safetensors and converts via ``model.from_external()``.
-        When False (default), loads via DCP.
+        When True, last step save only saves trainable params (e.g. LoRA
+        adapters). Combine with ``last_save_in_hf=True`` to export adapters
+        in PEFT safetensors format.
         """
 
         enable_first_step_checkpoint: bool = False
@@ -291,7 +352,7 @@ class CheckpointManager(Configurable):
         config: Config,
         *,
         dataloader: BaseDataLoader | None,
-        model: BaseModel,
+        model_parts: list[nn.Module],
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
@@ -301,10 +362,12 @@ class CheckpointManager(Configurable):
         self.enable = config.enable
         self.load_only = config.load_only
 
-        self.model = model
+        self.model = cast(BaseModel, model_parts[0])
+        self.model_wrapper = ModelWrapper(model_parts)
         self.states = states
         self.states.update(
             {
+                MODEL: self.model_wrapper,
                 OPTIMIZER: optimizers,
                 DATALOADER: dataloader,
                 LR_SCHEDULER: lr_schedulers,
@@ -345,12 +408,30 @@ class CheckpointManager(Configurable):
             assert (
                 self.hf_io is not None
             ), "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
-        self.additional_load_path = config.additional_load_path
-        self.additional_load_in_hf = config.additional_load_in_hf
+        self.initial_load_frozen = config.initial_load_frozen
+        self.last_save_trainable_only = config.last_save_trainable_only
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
         self.exclude_from_loading = config.exclude_from_loading
         self.interval = config.interval
         self.enable_first_step_checkpoint = config.enable_first_step_checkpoint
+
+        if self.initial_load_in_hf and not self.initial_load_model_only:
+            raise ValueError(
+                "checkpoint.initial_load_in_hf requires "
+                "checkpoint.initial_load_model_only=True because "
+                "safetensors only contains model weights."
+            )
+        if self.initial_load_in_hf_quantized and not self.initial_load_in_hf:
+            raise ValueError(
+                "checkpoint.initial_load_in_hf_quantized requires "
+                "checkpoint.initial_load_in_hf=True."
+            )
+        if self.last_save_in_hf and not self.last_save_model_only:
+            raise ValueError(
+                "checkpoint.last_save_in_hf requires "
+                "checkpoint.last_save_model_only=True because "
+                "safetensors only contains model weights."
+            )
 
         # Async checkpoint related fields.
         async_mode = config.async_mode.lower()
@@ -427,7 +508,7 @@ class CheckpointManager(Configurable):
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
             hf_storage (bool): Whether to use HF safetensors storage writer.
                 Key transforms must be applied by the caller via
-                model.get_sd(external=True) before calling this method.
+                model.to_hf() or model.adapter_to_hf() before calling this method.
 
         Returns:
             Future: The future object if the checkpoint is async, otherwise None.
@@ -517,8 +598,8 @@ class CheckpointManager(Configurable):
         """Load weights from a HuggingFace checkpoint into ``state_dict``.
 
         Pure I/O — the caller provides the container (via
-        ``model.get_sd(mode, external=True)``) and handles conversion
-        afterward.
+        ``model_wrapper.state_dict()`` then ``model.to_hf()``) and
+        handles conversion back via ``model.from_hf()`` afterward.
         """
         assert (
             self.hf_io is not None
@@ -569,7 +650,8 @@ class CheckpointManager(Configurable):
             self._save_last_step(curr_step)
             return
 
-        states = self._flattened_model_states_sd(model_mode=StateDictMode.TRAINABLE)
+        self.model_wrapper.mode = StateDictMode.FULL
+        states = self._flattened_model_states_sd()
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             GarbageCollection.collect("GC collection invoked by checkpointer.")
             if self.stager is None:
@@ -621,53 +703,40 @@ class CheckpointManager(Configurable):
             return False
 
         begin = time.monotonic()
-        has_additional_load = self.additional_load_path is not None
 
-        # Initial load: base weights from initial_load_path.
-        # With additional_load, always runs (even on resume) to load base first.
-        # Without additional_load, only runs when checkpoint folder doesn't exist.
-        if has_additional_load or not os.path.exists(self.folder):
-            loaded_initial = self._load_initial()
-            if (
-                not loaded_initial
-                and not has_additional_load
-                and not os.path.exists(self.folder)
-            ):
+        if not os.path.exists(self.folder):
+            # No checkpoint folder — try initial load
+            if not self._load_initial():
                 return False
-
-        # Resume from checkpoint folder, or load from additional_load_path.
-        resumed = False
-        if os.path.exists(self.folder):
-            step = self._find_load_step() if step == -1 else step
-            if step != -1:
-                checkpoint_id = self._create_checkpoint_id(step)
-                if not os.path.isdir(checkpoint_id):
-                    raise FileNotFoundError(
-                        f"--checkpoint.load_step={step} but "
-                        f"checkpoint {checkpoint_id} is not found."
-                    )
-                model_only = step == 0
-                logger.info(f"Loading checkpoint from {checkpoint_id}.")
-                states = self._states_to_load(model_only)
-                self._load_from_dcp(states, checkpoint_id)
-                self.model.load_sd(states)
-                resumed = True
-        if not resumed and has_additional_load:
-            path = cast(str, self.additional_load_path)
-            if not os.path.isdir(path):
-                raise ValueError(
-                    f"checkpoint.additional_load_path is not a valid directory: {path}"
+        else:
+            # Resume from checkpoint folder
+            if self.initial_load_path:
+                logger.warning(
+                    "checkpoint.initial_load_path is provided but the "
+                    "checkpoint.folder exists. Checkpointer will use the "
+                    f"checkpoints from the checkpoint.folder {self.folder}."
                 )
-            logger.info(f"Loading additional weights from {path}.")
-            if self.additional_load_in_hf:
-                hf_sd = self.model.get_sd(StateDictMode.TRAINABLE, external=True)
-                self._load_from_hf(hf_sd, path)
-                native_sd = self.model.from_external(hf_sd, StateDictMode.TRAINABLE)
-                self.model.load_sd(native_sd)
-            else:
-                sd = self.model.get_sd(StateDictMode.TRAINABLE)
-                self._load_from_dcp(sd, path)
-                self.model.load_sd(sd)
+            if self.initial_load_in_hf:
+                logger.warning(
+                    "checkpoint.initial_load_in_hf is True but the "
+                    "checkpoint.folder exists. Checkpointer will not load "
+                    "from HF safetensors."
+                )
+            step = self._find_load_step() if step == -1 else step
+            if step == -1:
+                return False
+            checkpoint_id = self._create_checkpoint_id(step)
+            if not os.path.isdir(checkpoint_id):
+                raise FileNotFoundError(
+                    f"--checkpoint.load_step={step} but "
+                    f"checkpoint {checkpoint_id} is not found."
+                )
+            model_only = step == 0
+            logger.info(f"Loading checkpoint from {checkpoint_id}.")
+            self.model_wrapper.mode = StateDictMode.FULL
+            states = self._states_to_load(model_only)
+            self._load_from_dcp(states, checkpoint_id)
+            self.model_wrapper.load_state_dict(states)
 
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
@@ -677,11 +746,18 @@ class CheckpointManager(Configurable):
         return True
 
     def _load_initial(self) -> bool:
-        """Load base weights from initial_load_path or hf_assets_path.
+        """Load initial weights from initial_load_path or hf_assets_path.
+
+        When ``initial_load_frozen`` is True (adapter training), only BASE
+        (frozen) params are loaded; adapters are freshly initialized.
+        Otherwise, FULL model is loaded.
 
         Returns:
             True if initial weights were loaded.
         """
+        load_mode = (
+            StateDictMode.BASE if self.initial_load_frozen else StateDictMode.FULL
+        )
         from_hf = self.initial_load_in_hf
         from_quantized = self.initial_load_in_hf_quantized
 
@@ -711,10 +787,12 @@ class CheckpointManager(Configurable):
             else:
                 return False
 
-            hf_sd = self.model.get_sd(StateDictMode.BASE, external=True)
+            self.model_wrapper.mode = load_mode
+            sd = self.model_wrapper.state_dict()
+            hf_sd = self.model.to_hf(sd)
             self._load_from_hf(hf_sd, checkpoint_id, from_quantized)
-            native_sd = self.model.from_external(hf_sd, StateDictMode.BASE)
-            self.model.load_sd(native_sd)
+            native_sd = self.model.from_hf(hf_sd)
+            self.model_wrapper.load_state_dict(native_sd)
             return True
 
         if self.initial_load_path:
@@ -725,12 +803,13 @@ class CheckpointManager(Configurable):
                     "but the path is not valid."
                 )
             logger.info(f"Loading DCP checkpoint from {checkpoint_id}.")
+            self.model_wrapper.mode = load_mode
             if self.initial_load_model_only:
-                sd = self.model.get_sd(StateDictMode.BASE)
+                sd = self.model_wrapper.state_dict()
             else:
-                sd = self._flattened_model_states_sd(model_mode=StateDictMode.BASE)
+                sd = self._flattened_model_states_sd()
             self._load_from_dcp(sd, checkpoint_id)
-            self.model.load_sd(sd)
+            self.model_wrapper.load_state_dict(sd)
             return True
 
         return False
@@ -782,27 +861,26 @@ class CheckpointManager(Configurable):
         return os.path.join(folder, f"step-{step}")
 
     def _flattened_model_states_sd(
-        self,
-        state_dict: dict[str, Any] | None = None,
-        *,
-        model_mode: StateDictMode = StateDictMode.FULL,
+        self, state_dict: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Flatten model keys alongside training states."""
+        """Flatten model keys alongside training states.
+
+        The caller must set ``self.model_wrapper.mode`` before calling.
+        """
         states = state_dict if state_dict is not None else self.states
-        sd = dict(states)
-        sd.update(self.model.get_sd(model_mode))
+        sd = {k: v for k, v in states.items() if k != MODEL}
+        if MODEL in states:
+            sd.update(states[MODEL].state_dict())
         return sd
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         """Determines which states to load for the given step.
 
-        Uses TRAINABLE mode for model keys. When no params are frozen,
-        TRAINABLE == FULL so every key is included. With adapters (e.g.
-        LoRA), TRAINABLE returns only adapter keys — base weights come
-        from the initial load.
+        Resume always loads FULL model (base + adapters if present).
+        The caller sets ``self.model_wrapper.mode`` to FULL before calling.
         """
         if model_only:
-            return self.model.get_sd(StateDictMode.FULL)
+            return self.states[MODEL].state_dict()
 
         for exclude_key in self.exclude_from_loading:
             if exclude_key not in self.states:
@@ -812,40 +890,40 @@ class CheckpointManager(Configurable):
             k: v for k, v in self.states.items() if k not in self.exclude_from_loading
         }
 
-        return self._flattened_model_states_sd(
-            states_to_load, model_mode=StateDictMode.TRAINABLE
-        )
+        return self._flattened_model_states_sd(states_to_load)
 
     def _save_last_step(self, curr_step: int) -> None:
-        # Seed checkpoints save ALL params so they can be loaded under any
-        # parallelism. Training last-step saves only trainable.
-        if self.create_seed_checkpoint:
-            save_mode = StateDictMode.FULL
-        else:
+        if self.last_save_trainable_only:
             save_mode = StateDictMode.TRAINABLE
+        else:
+            save_mode = StateDictMode.FULL
+
         if self.last_save_model_only:
             export_dtype = (
                 self.export_dtype
                 if self.export_dtype != TORCH_DTYPE_MAP["float32"]
                 else None
             )
-            states = self.model.get_sd(
-                save_mode,
-                external=self.last_save_in_hf,
-                dtype=export_dtype,
-            )
+            self.model_wrapper.mode = save_mode
+            states = self.model_wrapper.state_dict()
+            if self.last_save_in_hf:
+                if self.last_save_trainable_only:
+                    states = self.model.adapter_to_hf(states)
+                else:
+                    states = self.model.to_hf(states)
+            if export_dtype is not None:
+                states = {
+                    k: v.to(export_dtype) if isinstance(v, torch.Tensor) else v
+                    for k, v in states.items()
+                }
             logger.info(
                 f"Saving a model only checkpoint in {self.export_dtype} "
                 f"at last step, step {curr_step}."
             )
         else:
             logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
-            states = self._flattened_model_states_sd(model_mode=save_mode)
-
-        if self.last_save_in_hf:
-            assert (
-                self.last_save_model_only
-            ), "Only model can be saved when saving in HF safetensors format."
+            self.model_wrapper.mode = save_mode
+            states = self._flattened_model_states_sd()
 
         checkpoint_id = self._create_checkpoint_id(curr_step)
 

--- a/torchtitan/experiments/autoparallel/llama3/__init__.py
+++ b/torchtitan/experiments/autoparallel/llama3/__init__.py
@@ -16,7 +16,7 @@ from .parallelize_llama import parallelize_llama
 
 
 def model_registry(flavor: str) -> ModelSpec:
-    config = llama3_configs[flavor]()
+    config = llama3_configs[flavor](attn_backend="sdpa")
     return ModelSpec(
         name="autoparallel/llama3",
         flavor=flavor,

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -7,7 +7,7 @@
 import os
 from collections.abc import Generator
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record
@@ -255,17 +255,20 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             training_steps=config.training.steps,
         )
 
+        model_ref = cast(BaseModel, self.model_parts[0])
+        sd_adapter = (
+            self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if self.train_spec.state_dict_adapter
+            else None
+        )
+        model_ref.set_sd_adapter(sd_adapter)
+
         self.checkpointer = config.checkpoint.build(
             dataloader=None,
             model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if self.train_spec.state_dict_adapter
-                else None
-            ),
             base_folder=config.dump_folder,
         )
 

--- a/torchtitan/experiments/ft/checkpoint.py
+++ b/torchtitan/experiments/ft/checkpoint.py
@@ -213,12 +213,7 @@ class FTCheckpointManager(CheckpointManager):
         begin = time.monotonic()
         logger.info(f"Loading the FT checkpoint at step {step}.")
         checkpoint_id = self._create_checkpoint_id(step, folder=self._ft_folder())
-        self.dcp_load(
-            self.ft_states,
-            checkpoint_id=checkpoint_id,
-            from_hf=False,
-            from_quantized=False,
-        )
+        self._load_from_dcp(self.ft_states, checkpoint_id)
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
             f"Finished loading the ft checkpoint in "

--- a/torchtitan/experiments/ft/checkpoint.py
+++ b/torchtitan/experiments/ft/checkpoint.py
@@ -36,7 +36,6 @@ from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.experiments.ft.manager import FTManager
-from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
@@ -78,7 +77,6 @@ class FTCheckpointManager(CheckpointManager):
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
-        sd_adapter: BaseStateDictAdapter | None,
         base_folder: str = "",
         ft_manager: FTManager | None = None,
     ) -> None:
@@ -90,7 +88,6 @@ class FTCheckpointManager(CheckpointManager):
             optimizers=optimizers,
             lr_schedulers=lr_schedulers,
             states=states,
-            sd_adapter=sd_adapter,
             base_folder=base_folder,
         )
 

--- a/torchtitan/experiments/ft/llama3/__init__.py
+++ b/torchtitan/experiments/ft/llama3/__init__.py
@@ -15,7 +15,7 @@ from torchtitan.models.llama3 import (
 
 
 def model_registry(flavor: str) -> FaultTolerantModelSpec:
-    config = llama3_configs[flavor]()
+    config = llama3_configs[flavor](attn_backend="sdpa")
     return FaultTolerantModelSpec(
         name="ft/llama3",
         flavor=flavor,

--- a/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
+++ b/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
@@ -154,7 +154,6 @@ class TestFTCheckpointManager(unittest.TestCase):
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
-            sd_adapter=None,
             base_folder=self.test_folder,
             ft_manager=self.ft_manager,
         )

--- a/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
+++ b/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
@@ -18,6 +18,26 @@ from torch.utils.data import DataLoader
 from torchtitan.experiments.ft.checkpoint import FTCheckpointManager
 
 
+class FakeBaseModel(nn.Linear):
+    """A fake BaseModel for FT checkpoint tests.
+
+    Inherits nn.Linear so get_model_state_dict works directly, and
+    provides the BaseModel transform methods that CheckpointManager expects.
+    """
+
+    def __init__(self, in_features: int = 2, out_features: int = 2):
+        super().__init__(in_features, out_features)
+
+    def to_hf(self, sd):
+        return sd
+
+    def from_hf(self, sd):
+        return sd
+
+    def adapter_to_hf(self, sd):
+        return sd
+
+
 class FakeOptimizersContainer:
     def __init__(self):
         self._fake_param = torch.tensor([1.0], dtype=torch.float32)
@@ -83,7 +103,8 @@ class TestFTCheckpointManager(unittest.TestCase):
         self.base_temp_dir = tempfile.mkdtemp()
         self.test_folder = os.path.join(self.base_temp_dir, self._testMethodName)
         os.makedirs(self.test_folder, exist_ok=True)
-        self.model_parts = [nn.Linear(2, 2)]
+        self.model = FakeBaseModel(2, 2)
+        self.model_parts = [self.model]
         self.states = {"trainer": torch.tensor([1.2347])}
         self.optimizers = FakeOptimizersContainer()
         self.lr_schedulers = FakeLRSchedulersContainer()

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -278,6 +278,14 @@ class FaultTolerantTrainer(Trainer):
         self.step = 0
         self.ntokens_seen = 0
 
+        model_ref = cast(BaseModel, self.model_parts[0])
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if model_spec.state_dict_adapter
+            else None
+        )
+        model_ref.set_sd_adapter(sd_adapter)
+
         # FT addition: pass ft_manager to CheckpointManager
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
@@ -285,11 +293,6 @@ class FaultTolerantTrainer(Trainer):
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
             base_folder=config.dump_folder,
             ft_manager=self.ft_manager,
         )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -122,18 +122,18 @@ class PolicyTrainer(Actor, Configurable):
             distinct_seed_mesh_dims=["pp"],
         )
 
-        # Initialize state dict adapter for HF checkpoint loading
-        if model_spec.state_dict_adapter is not None:
-            self.sd_adapter = model_spec.state_dict_adapter(
-                model_spec.model, hf_assets_path
-            )
-        else:
-            self.sd_adapter = None
-
         # Create training policy model
         model = self._build_model(model_spec, config, device_type, hf_assets_path)
         model.train()
         self.model = model
+
+        # Store state dict adapter on the model for HF checkpoint loading
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_spec.model, hf_assets_path)
+            if model_spec.state_dict_adapter is not None
+            else None
+        )
+        model.set_sd_adapter(sd_adapter)
         self.model_parts = [model]
 
         # Build optimizer and LR scheduler
@@ -167,7 +167,7 @@ class PolicyTrainer(Actor, Configurable):
             model: The model to load weights into.
             checkpoint_path: Path to HF checkpoint directory.
         """
-        if self.sd_adapter is None:
+        if model.sd_adapter is None:
             logger.warning(
                 "No state_dict_adapter available, skipping initial weight load"
             )
@@ -179,10 +179,10 @@ class PolicyTrainer(Actor, Configurable):
                 "Please provide a valid path to a HuggingFace checkpoint directory."
             )
 
-        storage_reader = self.sd_adapter.get_hf_storage_reader(checkpoint_path)
-        hf_state_dict = self.sd_adapter.to_hf(model.state_dict())
+        storage_reader = model.sd_adapter.get_hf_storage_reader(checkpoint_path)
+        hf_state_dict = model.sd_adapter.to_hf(model.state_dict())
         dcp.load(hf_state_dict, storage_reader=storage_reader)
-        torchtitan_state_dict = self.sd_adapter.from_hf(hf_state_dict)
+        torchtitan_state_dict = model.sd_adapter.from_hf(hf_state_dict)
 
         set_model_state_dict(
             model=model,

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -135,10 +135,11 @@ def build_trainer_model(
     # Load HF checkpoint
     if model_spec.state_dict_adapter is not None:
         sd_adapter = model_spec.state_dict_adapter(model_spec.model, hf_assets_path)
-        storage_reader = sd_adapter.get_hf_storage_reader(hf_assets_path)
-        hf_state_dict = sd_adapter.to_hf(model.state_dict())
+        model.set_sd_adapter(sd_adapter)
+        storage_reader = model.sd_adapter.get_hf_storage_reader(hf_assets_path)
+        hf_state_dict = model.to_hf(model.state_dict())
         dcp.load(hf_state_dict, storage_reader=storage_reader)
-        tt_state_dict = sd_adapter.from_hf(hf_state_dict)
+        tt_state_dict = model.from_hf(hf_state_dict)
         set_model_state_dict(
             model=model,
             model_state_dict=tt_state_dict,

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -4,10 +4,34 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import enum
 from abc import abstractmethod
 from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    set_model_state_dict,
+    StateDictOptions,
+)
 
 from .module import Module
+
+
+class StateDictMode(enum.Enum):
+    """Mode for BaseModel.get_sd().
+
+    FULL: all keys. For seed saves, DCP resume.
+    TRAINABLE: only requires_grad=True keys. For interval saves, adapter export.
+    BASE: only requires_grad=False keys (or all if nothing frozen).
+        For HF load containers.
+    """
+
+    FULL = "full"
+    TRAINABLE = "trainable"
+    BASE = "base"
 
 
 class BaseModel(Module):
@@ -20,6 +44,122 @@ class BaseModel(Module):
     ``init_states`` (from Module) auto-recurses; override only for custom
     ordering (e.g., weight tying before init).
     """
+
+    _pp_parts: list[nn.Module] | None = None
+    """Set by the trainer when PP splits the model into multiple parts.
+    When set, get_sd/load_sd operate on all parts.
+    When None (default), they operate on ``self`` only."""
+
+    def _get_parts(self) -> list[nn.Module]:
+        return self._pp_parts if self._pp_parts is not None else [self]
+
+    def _raw_sd(self) -> dict[str, Any]:
+        """Merge state dicts from all PP parts."""
+        sd: dict[str, Any] = {}
+        for part in self._get_parts():
+            sd.update(get_model_state_dict(part))
+        return sd
+
+    def get_sd(
+        self,
+        mode: StateDictMode = StateDictMode.FULL,
+        *,
+        external: bool = False,
+        dtype: "torch.dtype | None" = None,
+    ) -> dict[str, Any]:
+        """Get state dict for checkpointing.
+
+        Args:
+            mode: Which params to include.
+                FULL: all keys.
+                TRAINABLE: only requires_grad=True keys (uses DCP's
+                    ignore_frozen_params). When no params are frozen,
+                    TRAINABLE == FULL.
+                BASE: only requires_grad=False keys (or all if nothing frozen).
+            external: If True, remap keys to external format via
+                ``to_external`` (sd_adapter HF remapping, then converter
+                transforms in order).
+            dtype: Optional dtype cast for export (e.g. bfloat16).
+        """
+        if mode == StateDictMode.FULL:
+            sd = self._raw_sd()
+        elif mode == StateDictMode.TRAINABLE:
+            sd = {}
+            for part in self._get_parts():
+                sd.update(
+                    get_model_state_dict(
+                        part,
+                        options=StateDictOptions(ignore_frozen_params=True),
+                    )
+                )
+        else:
+            # BASE: full minus trainable
+            full_sd = self._raw_sd()
+            trainable_sd = self.get_sd(StateDictMode.TRAINABLE)
+            if len(trainable_sd) == len(full_sd):
+                sd = full_sd
+            else:
+                sd = {k: v for k, v in full_sd.items() if k not in trainable_sd}
+
+        if external:
+            sd = self.to_external(sd, mode)
+
+        if dtype is not None:
+            sd = {
+                k: v.to(dtype) if isinstance(v, torch.Tensor) else v
+                for k, v in sd.items()
+            }
+
+        return sd
+
+    def load_sd(self, sd: dict[str, Any]) -> None:
+        """Load state dict with strict=False (partial loads OK)."""
+        for part in self._get_parts():
+            set_model_state_dict(
+                part,
+                model_state_dict=sd,
+                options=StateDictOptions(strict=False),
+            )
+
+    # State dict transforms, set once by set_sd_transforms().
+    _to_hf = None
+    _from_hf = None
+
+    def set_sd_transforms(self, sd_adapter=None) -> None:
+        """Wire state dict transforms onto this model.
+
+        Extracts HF key remapping from sd_adapter (``to_hf``, ``from_hf``).
+        I/O concerns (storage reader/writer, fqn mapping) stay on
+        CheckpointManager.
+
+        Called once by the trainer after model build.
+        """
+        if sd_adapter is not None:
+            self._to_hf = sd_adapter.to_hf
+            self._from_hf = sd_adapter.from_hf
+
+    def to_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
+        """Convert native state dict keys to external format.
+
+        The mode determines which transforms to apply:
+        - BASE: HF remapping only (base model keys)
+        - TRAINABLE: no-op (reserved for converter transforms)
+        - FULL: HF remapping (same as BASE for now)
+        """
+        if mode in (StateDictMode.FULL, StateDictMode.BASE):
+            if self._to_hf is not None:
+                sd = self._to_hf(sd)
+        return sd
+
+    def from_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
+        """Convert external format state dict keys to native format.
+
+        Reverse of ``to_external``, filtered by mode.
+        """
+        if mode in (StateDictMode.FULL, StateDictMode.BASE):
+            if self._from_hf is not None:
+                sd = self._from_hf(sd)
+        return sd
 
     def init_weights(self, **kwargs) -> None:
         """Backward-compatible alias for ``init_states``.

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -124,6 +124,8 @@ class BaseModel(Module):
     # State dict transforms, set once by set_sd_transforms().
     _to_hf = None
     _from_hf = None
+    _converters_to_external: list | None = None
+    _converters_from_external: list | None = None
 
     def set_sd_transforms(self, sd_adapter=None) -> None:
         """Wire state dict transforms onto this model.
@@ -143,11 +145,19 @@ class BaseModel(Module):
 
         The mode determines which transforms to apply:
         - BASE: HF remapping only (base model keys)
-        - TRAINABLE: no-op (reserved for converter transforms)
-        - FULL: HF remapping (same as BASE for now)
+        - TRAINABLE: converter transforms only (adapter keys).
+            When no converters are registered, trainable keys are base
+            keys, so HF remapping is applied as a fallback.
+        - FULL: both HF remapping and converter transforms
         """
         if mode in (StateDictMode.FULL, StateDictMode.BASE):
             if self._to_hf is not None:
+                sd = self._to_hf(sd)
+        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
+            if self._converters_to_external:
+                for fn in self._converters_to_external:
+                    sd = fn(sd)
+            elif mode == StateDictMode.TRAINABLE and self._to_hf is not None:
                 sd = self._to_hf(sd)
         return sd
 
@@ -156,6 +166,12 @@ class BaseModel(Module):
 
         Reverse of ``to_external``, filtered by mode.
         """
+        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
+            if self._converters_from_external:
+                for fn in reversed(self._converters_from_external):
+                    sd = fn(sd)
+            elif mode == StateDictMode.TRAINABLE and self._from_hf is not None:
+                sd = self._from_hf(sd)
         if mode in (StateDictMode.FULL, StateDictMode.BASE):
             if self._from_hf is not None:
                 sd = self._from_hf(sd)

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -9,24 +9,16 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
-import torch
-import torch.nn as nn
-from torch.distributed.checkpoint.state_dict import (
-    get_model_state_dict,
-    set_model_state_dict,
-    StateDictOptions,
-)
-
 from .module import Module
 
 
 class StateDictMode(enum.Enum):
-    """Mode for BaseModel.get_sd().
+    """Which parameters to include in a state dict operation.
 
     FULL: all keys. For seed saves, DCP resume.
-    TRAINABLE: only requires_grad=True keys. For interval saves, adapter export.
+    TRAINABLE: only requires_grad=True keys. For adapter export.
     BASE: only requires_grad=False keys (or all if nothing frozen).
-        For HF load containers.
+        For initial load in adapter training.
     """
 
     FULL = "full"
@@ -45,136 +37,52 @@ class BaseModel(Module):
     ordering (e.g., weight tying before init).
     """
 
-    _pp_parts: list[nn.Module] | None = None
-    """Set by the trainer when PP splits the model into multiple parts.
-    When set, get_sd/load_sd operate on all parts.
-    When None (default), they operate on ``self`` only."""
-
-    def _get_parts(self) -> list[nn.Module]:
-        return self._pp_parts if self._pp_parts is not None else [self]
-
-    def _raw_sd(self) -> dict[str, Any]:
-        """Merge state dicts from all PP parts."""
-        sd: dict[str, Any] = {}
-        for part in self._get_parts():
-            sd.update(get_model_state_dict(part))
-        return sd
-
-    def get_sd(
-        self,
-        mode: StateDictMode = StateDictMode.FULL,
-        *,
-        external: bool = False,
-        dtype: "torch.dtype | None" = None,
-    ) -> dict[str, Any]:
-        """Get state dict for checkpointing.
-
-        Args:
-            mode: Which params to include.
-                FULL: all keys.
-                TRAINABLE: only requires_grad=True keys (uses DCP's
-                    ignore_frozen_params). When no params are frozen,
-                    TRAINABLE == FULL.
-                BASE: only requires_grad=False keys (or all if nothing frozen).
-            external: If True, remap keys to external format via
-                ``to_external`` (sd_adapter HF remapping, then converter
-                transforms in order).
-            dtype: Optional dtype cast for export (e.g. bfloat16).
-        """
-        if mode == StateDictMode.FULL:
-            sd = self._raw_sd()
-        elif mode == StateDictMode.TRAINABLE:
-            sd = {}
-            for part in self._get_parts():
-                sd.update(
-                    get_model_state_dict(
-                        part,
-                        options=StateDictOptions(ignore_frozen_params=True),
-                    )
-                )
-        else:
-            # BASE: full minus trainable
-            full_sd = self._raw_sd()
-            trainable_sd = self.get_sd(StateDictMode.TRAINABLE)
-            if len(trainable_sd) == len(full_sd):
-                sd = full_sd
-            else:
-                sd = {k: v for k, v in full_sd.items() if k not in trainable_sd}
-
-        if external:
-            sd = self.to_external(sd, mode)
-
-        if dtype is not None:
-            sd = {
-                k: v.to(dtype) if isinstance(v, torch.Tensor) else v
-                for k, v in sd.items()
-            }
-
-        return sd
-
-    def load_sd(self, sd: dict[str, Any]) -> None:
-        """Load state dict with strict=False (partial loads OK)."""
-        for part in self._get_parts():
-            set_model_state_dict(
-                part,
-                model_state_dict=sd,
-                options=StateDictOptions(strict=False),
-            )
-
     # State dict transforms, set once by set_sd_transforms().
     _to_hf = None
     _from_hf = None
-    _converters_to_external: list | None = None
-    _converters_from_external: list | None = None
+    _adapter_to_hf_fns: list | None = None
 
-    def set_sd_transforms(self, sd_adapter=None) -> None:
+    def set_sd_transforms(
+        self, sd_adapter=None, converters: list | None = None
+    ) -> None:
         """Wire state dict transforms onto this model.
 
-        Extracts HF key remapping from sd_adapter (``to_hf``, ``from_hf``).
-        I/O concerns (storage reader/writer, fqn mapping) stay on
-        CheckpointManager.
+        Extracts HF key remapping from sd_adapter. If a converter (e.g.
+        LoRA) provides ``build_external_transforms(sd_adapter)``, collects
+        its ``to_external`` callable for adapter export (e.g. PEFT).
 
         Called once by the trainer after model build.
         """
         if sd_adapter is not None:
             self._to_hf = sd_adapter.to_hf
             self._from_hf = sd_adapter.from_hf
+        self._adapter_to_hf_fns = None
+        for converter in converters or []:
+            build_fn = getattr(converter, "build_external_transforms", None)
+            if build_fn is not None:
+                ct = build_fn(sd_adapter)
+                if ct is not None and "to_external" in ct:
+                    if self._adapter_to_hf_fns is None:
+                        self._adapter_to_hf_fns = []
+                    self._adapter_to_hf_fns.append(ct["to_external"])
 
-    def to_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
-        """Convert native state dict keys to external format.
-
-        The mode determines which transforms to apply:
-        - BASE: HF remapping only (base model keys)
-        - TRAINABLE: converter transforms only (adapter keys).
-            When no converters are registered, trainable keys are base
-            keys, so HF remapping is applied as a fallback.
-        - FULL: both HF remapping and converter transforms
-        """
-        if mode in (StateDictMode.FULL, StateDictMode.BASE):
-            if self._to_hf is not None:
-                sd = self._to_hf(sd)
-        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
-            if self._converters_to_external:
-                for fn in self._converters_to_external:
-                    sd = fn(sd)
-            elif mode == StateDictMode.TRAINABLE and self._to_hf is not None:
-                sd = self._to_hf(sd)
+    def to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert native base model keys to HF format."""
+        if self._to_hf is not None:
+            sd = self._to_hf(sd)
         return sd
 
-    def from_external(self, sd: dict[str, Any], mode: StateDictMode) -> dict[str, Any]:
-        """Convert external format state dict keys to native format.
+    def from_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert HF-format keys back to native format."""
+        if self._from_hf is not None:
+            sd = self._from_hf(sd)
+        return sd
 
-        Reverse of ``to_external``, filtered by mode.
-        """
-        if mode in (StateDictMode.FULL, StateDictMode.TRAINABLE):
-            if self._converters_from_external:
-                for fn in reversed(self._converters_from_external):
-                    sd = fn(sd)
-            elif mode == StateDictMode.TRAINABLE and self._from_hf is not None:
-                sd = self._from_hf(sd)
-        if mode in (StateDictMode.FULL, StateDictMode.BASE):
-            if self._from_hf is not None:
-                sd = self._from_hf(sd)
+    def adapter_to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert native adapter keys to PEFT/HF format."""
+        if self._adapter_to_hf_fns:
+            for fn in self._adapter_to_hf_fns:
+                sd = fn(sd)
         return sd
 
     def init_weights(self, **kwargs) -> None:

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import enum
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from .module import Module
+
+if TYPE_CHECKING:
+    from .state_dict_adapter import BaseStateDictAdapter
 
 
 class StateDictMode(enum.Enum):
@@ -37,25 +42,23 @@ class BaseModel(Module):
     ordering (e.g., weight tying before init).
     """
 
-    # State dict transforms, set once by set_sd_transforms().
-    _to_hf = None
-    _from_hf = None
+    _sd_adapter: BaseStateDictAdapter | None = None
     _adapter_to_hf_fns: list | None = None
 
-    def set_sd_transforms(
-        self, sd_adapter=None, converters: list | None = None
-    ) -> None:
-        """Wire state dict transforms onto this model.
+    @property
+    def sd_adapter(self) -> BaseStateDictAdapter | None:
+        return self._sd_adapter
 
-        Extracts HF key remapping from sd_adapter. If a converter (e.g.
-        LoRA) provides ``build_external_transforms(sd_adapter)``, collects
-        its ``to_external`` callable for adapter export (e.g. PEFT).
+    def set_sd_adapter(
+        self,
+        sd_adapter: BaseStateDictAdapter | None = None,
+        converters: list | None = None,
+    ) -> None:
+        """Store the state dict adapter and build converter transforms.
 
         Called once by the trainer after model build.
         """
-        if sd_adapter is not None:
-            self._to_hf = sd_adapter.to_hf
-            self._from_hf = sd_adapter.from_hf
+        self._sd_adapter = sd_adapter
         self._adapter_to_hf_fns = None
         for converter in converters or []:
             build_fn = getattr(converter, "build_external_transforms", None)
@@ -68,14 +71,14 @@ class BaseModel(Module):
 
     def to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
         """Convert native base model keys to HF format."""
-        if self._to_hf is not None:
-            sd = self._to_hf(sd)
+        if self._sd_adapter is not None:
+            sd = self._sd_adapter.to_hf(sd)
         return sd
 
     def from_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
         """Convert HF-format keys back to native format."""
-        if self._from_hf is not None:
-            sd = self._from_hf(sd)
+        if self._sd_adapter is not None:
+            sd = self._sd_adapter.from_hf(sd)
         return sd
 
     def adapter_to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
-from dataclasses import dataclass
-from typing import TypeAlias
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
 
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
@@ -41,3 +41,4 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+    converters: list[Any] = field(default_factory=list)

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -30,7 +30,6 @@ class BaseStateDictAdapter(ABC):
 
     fqn_to_index_mapping: dict[Any, int] | None
     hf_assets_path: str | None
-    from_hf_map: dict[str, str | None] | None
 
     @abstractmethod
     def __init__(
@@ -89,7 +88,6 @@ class StateDictAdapter(BaseStateDictAdapter):
         hf_assets_path: str | None,
     ):
         self.hf_assets_path = hf_assets_path
-        self.from_hf_map = None
         if hf_assets_path:
             mapping_path = os.path.join(hf_assets_path, "model.safetensors.index.json")
             try:

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -30,6 +30,7 @@ class BaseStateDictAdapter(ABC):
 
     fqn_to_index_mapping: dict[Any, int] | None
     hf_assets_path: str | None
+    from_hf_map: dict[str, str | None] | None
 
     @abstractmethod
     def __init__(
@@ -88,6 +89,7 @@ class StateDictAdapter(BaseStateDictAdapter):
         hf_assets_path: str | None,
     ):
         self.hf_assets_path = hf_assets_path
+        self.from_hf_map = None
         if hf_assets_path:
             mapping_path = os.path.join(hf_assets_path, "model.safetensors.index.json")
             try:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -173,6 +173,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     checkpointer: CheckpointManager
 
     # runtime utilities
+    device: torch.device
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.TrainContext
     gradient_accumulation_steps: int
@@ -195,6 +196,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
+        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -196,7 +196,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
-        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
@@ -442,17 +441,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.step = 0
         self.ntokens_seen = 0
 
+        # Set up BaseModel reference for checkpoint (PP parts handled via _pp_parts)
+        model_ref = cast(BaseModel, self.model_parts[0])
+        if parallel_dims.pp_enabled:
+            model_ref._pp_parts = self.model_parts
+
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if model_spec.state_dict_adapter
+            else None
+        )
+
+        model_ref.set_sd_transforms(sd_adapter)
+
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
-            model_parts=self.model_parts,
+            model=model_ref,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
+            sd_adapter=sd_adapter,
             base_folder=config.dump_folder,
         )
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -195,6 +195,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
+        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -448,7 +448,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else None
         )
 
-        model_ref.set_sd_transforms(sd_adapter, model_spec.converters)
+        model_ref.set_sd_adapter(sd_adapter, model_spec.converters)
 
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
@@ -456,7 +456,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=sd_adapter,
             base_folder=config.dump_folder,
         )
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -173,7 +173,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     checkpointer: CheckpointManager
 
     # runtime utilities
-    device: torch.device
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.TrainContext
     gradient_accumulation_steps: int

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -195,7 +195,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
-        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
@@ -441,10 +440,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.step = 0
         self.ntokens_seen = 0
 
-        # Set up BaseModel reference for checkpoint (PP parts handled via _pp_parts)
         model_ref = cast(BaseModel, self.model_parts[0])
-        if parallel_dims.pp_enabled:
-            model_ref._pp_parts = self.model_parts
 
         sd_adapter = (
             model_spec.state_dict_adapter(model_config, config.hf_assets_path)
@@ -452,11 +448,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else None
         )
 
-        model_ref.set_sd_transforms(sd_adapter)
+        model_ref.set_sd_transforms(sd_adapter, model_spec.converters)
 
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
-            model=model_ref,
+            model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3189
* __->__ #3188

BaseModel owns the full state dict pipeline: filter (by requires_grad mode) → transform (HF key remapping) → cast (dtype, or any other requirements later). ModelWrapper is removed.

- get_sd(mode, external, dtype): single entry point. FULL/TRAINABLE/BASE modes filter by requires_grad via DCP ignore_frozen_params.
- to_external(sd, mode) / from_external(sd, mode): mode-based transform routing. BASE applies HF remapping, TRAINABLE reserved for converters.
- set_sd_transforms(sd_adapter): extracts to_hf/from_hf from sd_adapter. I/O concerns (storage reader/writer) stay on CheckpointManager.
- load_sd: strict=False for partial loads.

CheckpointManager becomes pure I/O:
- _load_from_hf(container, path) and _load_from_dcp(container, path) take a container dict and fill it. Caller builds container, converts, and applies — uniform pattern for all load paths.
- hf_io (renamed from sd_adapter) for HF storage reader/writer only.
- keys_match_mapping for adapter-only HF saves (consolidation mode).
- Initial load always uses BASE mode (== FULL when nothing frozen).

Trainer simplified:
- Removed _collect_adapter_key_patterns and freeze logic.
- One-line wiring: model_ref.set_sd_transforms(sd_adapter).