### PR TITLE
[WIP][numerics] Add activation tracer

### DIFF
--- a/tests/unit_tests/test_activation_tracer.py
+++ b/tests/unit_tests/test_activation_tracer.py
@@ -1,0 +1,613 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for activation_tracer and compare_numerics.
+
+Covers each change documented in ACTIVATION_TRACER_CHANGES.md.
+Run with:
+    pytest torchtitan/tools/tests/test_activation_tracer.py -x -v
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchtitan.tools.activation_tracer import (
+    ActivationTracer,
+    CapturedActivation,
+    NumericsDebugger,
+    _clean_fqn,
+    _is_filtered_frame,
+    _parse_stack_trace,
+    _resolve_module_location,
+    _should_capture,
+    dump_captures_to_file,
+    is_numerics_capture_active,
+    set_numerics_capture_active,
+)
+from torchtitan.tools.compare_numerics import naive_compare_captures
+
+
+BATCH = 32
+
+
+def _make_model(device="cpu"):
+    """Simple model for testing. Uses 64-wide layers so batch=32 gives
+    numel=2048 per activation, above the 1000 threshold."""
+    return nn.Sequential(
+        nn.Linear(64, 64, bias=False, device=device),
+        nn.ReLU(),
+        nn.Linear(64, 64, bias=False, device=device),
+    )
+
+
+class _FeedForward(nn.Module):
+    """Mimics torchtitan FeedForward: ops between child module calls."""
+
+    def __init__(self, device="cpu"):
+        super().__init__()
+        self.w1 = nn.Linear(32, 64, bias=False, device=device)
+        self.w2 = nn.Linear(64, 32, bias=False, device=device)
+        self.w3 = nn.Linear(32, 64, bias=False, device=device)
+
+    def forward(self, x):
+        return self.w2(torch.nn.functional.silu(self.w1(x)) * self.w3(x))
+
+
+class TestCleanFQN(unittest.TestCase):
+    """Change 3: FQN cleaning."""
+
+    def test_strips_checkpoint_wrapper(self):
+        self.assertEqual(
+            _clean_fqn("layers.0._checkpoint_wrapped_module.attention.wq"),
+            "layers.0.attention.wq",
+        )
+
+    def test_no_change_without_wrapper(self):
+        self.assertEqual(
+            _clean_fqn("layers.0.attention.wq"),
+            "layers.0.attention.wq",
+        )
+
+    def test_multiple_wrappers(self):
+        fqn = "a._checkpoint_wrapped_module.b._checkpoint_wrapped_module.c"
+        self.assertEqual(_clean_fqn(fqn), "a.b.c")
+
+
+class TestIsFilteredFrame(unittest.TestCase):
+    """Frame filtering for stack traces."""
+
+    def test_filters_torch_nn(self):
+        self.assertTrue(_is_filtered_frame("/home/user/pytorch/torch/nn/modules/linear.py"))
+        self.assertTrue(_is_filtered_frame("/home/user/pytorch/torch/nn/functional.py"))
+
+    def test_filters_torch_autograd(self):
+        self.assertTrue(_is_filtered_frame("/home/user/pytorch/torch/autograd/graph.py"))
+
+    def test_filters_activation_tracer(self):
+        self.assertTrue(_is_filtered_frame("/home/user/torchtitan/tools/activation_tracer.py"))
+
+    def test_keeps_model_code(self):
+        self.assertFalse(_is_filtered_frame("/home/user/torchtitan/models/common/attention.py"))
+        self.assertFalse(_is_filtered_frame("/home/user/torchtitan/models/llama3/model.py"))
+
+    def test_keeps_torchtitan(self):
+        self.assertFalse(_is_filtered_frame("/home/user/torchtitan/torchtitan/trainer.py"))
+
+
+class TestParseStackTrace(unittest.TestCase):
+    """Stack trace parsing from node.meta['stack_trace']."""
+
+    def test_parses_file_line_func(self):
+        trace = (
+            '  File "/home/user/models/attention.py", line 534, in forward\n'
+            '    xq, xk, xv = self.qkv_linear(x)\n'
+        )
+        frames = _parse_stack_trace(trace)
+        self.assertEqual(len(frames), 1)
+        self.assertEqual(frames[0].lineno, 534)
+        self.assertIn("attention.py", frames[0].filename)
+
+    def test_filters_nn_modules(self):
+        trace = (
+            '  File "/pytorch/torch/nn/modules/module.py", line 1789, in _call_impl\n'
+            '    return forward_call(*args, **kwargs)\n'
+            '  File "/home/user/models/attention.py", line 534, in forward\n'
+            '    xq = self.wq(x)\n'
+        )
+        frames = _parse_stack_trace(trace)
+        self.assertEqual(len(frames), 1)
+        self.assertIn("attention.py", frames[0].filename)
+
+    def test_filters_activation_tracer(self):
+        trace = (
+            '  File "/home/user/tools/activation_tracer.py", line 100, in wrapped\n'
+            '    return orig(*args)\n'
+            '  File "/home/user/models/decoder.py", line 140, in forward\n'
+            '    h = layer(h)\n'
+        )
+        frames = _parse_stack_trace(trace)
+        self.assertEqual(len(frames), 1)
+        self.assertIn("decoder.py", frames[0].filename)
+
+
+class TestResolveModuleLocation(unittest.TestCase):
+    """Change 4: Source location via inspect."""
+
+    def test_returns_location_for_custom_module(self):
+        # _resolve_module_location uses inspect.getfile which works on
+        # modules defined in real files. Modules in this test file work.
+        model = _FeedForward()
+        frames = _resolve_module_location(model)
+        # This may be empty if running from <string> — skip in that case
+        if frames:
+            self.assertIn("test_activation_tracer", frames[0].filename)
+
+    def test_filters_nn_linear(self):
+        linear = nn.Linear(4, 4)
+        frames = _resolve_module_location(linear)
+        self.assertEqual(len(frames), 0)
+
+    def test_filters_nn_relu(self):
+        relu = nn.ReLU()
+        frames = _resolve_module_location(relu)
+        self.assertEqual(len(frames), 0)
+
+
+class TestShouldCapture(unittest.TestCase):
+    """Change 1: FakeTensor filtering and basic capture logic."""
+
+    def test_captures_float_tensor(self):
+        t = torch.randn(100, 100)
+
+        class FakeFunc:
+            class _schema:
+                name = "aten::mm"
+
+        self.assertTrue(_should_capture(FakeFunc, t, 1000, None))
+
+    def test_skips_small_tensor(self):
+        t = torch.randn(5, 5)
+
+        class FakeFunc:
+            class _schema:
+                name = "aten::mm"
+
+        self.assertFalse(_should_capture(FakeFunc, t, 1000, None))
+
+    def test_skips_int_tensor(self):
+        t = torch.randint(0, 10, (100, 100))
+
+        class FakeFunc:
+            class _schema:
+                name = "aten::mm"
+
+        self.assertFalse(_should_capture(FakeFunc, t, 1000, None))
+
+    def test_skips_excluded_ops(self):
+        t = torch.randn(100, 100)
+
+        class FakeFunc:
+            class _schema:
+                name = "aten::view"
+
+        self.assertFalse(_should_capture(FakeFunc, t, 1000, None))
+
+    def test_skips_fake_tensor(self):
+        from torch._subclasses import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(100, 100)
+
+        class FakeFunc:
+            class _schema:
+                name = "aten::mm"
+
+        self.assertFalse(_should_capture(FakeFunc, t, 1000, None))
+
+
+class TestActivationTracer(unittest.TestCase):
+    """Core ActivationTracer functionality."""
+
+    def test_captures_forward_ops(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            model(x)
+        self.assertGreater(len(caps), 0)
+        # Should have mm ops from the two Linear layers
+        mm_keys = [k for k in caps if "mm" in k]
+        self.assertGreaterEqual(len(mm_keys), 2)
+
+    def test_captures_with_backward(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            out = model(x)
+            out.sum().backward()
+        # Should capture both forward and backward ops
+        self.assertGreater(len(caps), 2)
+
+    def test_module_fqn_in_keys(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            model(x)
+        # Keys should contain module names like "0" (first Linear)
+        keys = list(caps.keys())
+        has_module = any("0/" in k for k in keys)
+        self.assertTrue(has_module, f"No module FQN in keys: {keys}")
+
+    def test_captures_ops_without_module_fqn(self):
+        """Change 5: ops without module context use <none>."""
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            out = model(x)
+            # Loss is outside any module
+            loss = out.sum()
+            loss.backward()
+        none_keys = [k for k in caps if "<none>" in k]
+        # There should be at least some <none> ops from backward
+        # (depends on autograd graph mapping)
+        self.assertIsInstance(none_keys, list)
+
+    def test_double_exit_guard(self):
+        """Change 8: double-exit doesn't crash."""
+        model = _make_model()
+        tracer = ActivationTracer(model)
+        caps = tracer.__enter__()
+        model(torch.randn(BATCH, 64))
+        # Simulate dispatch mode exiting early
+        tracer._dispatch_mode._exited = True
+        # Should not crash
+        tracer.__exit__(None, None, None)
+
+    def test_detect_anomaly_enabled(self):
+        """Change 10: detect_anomaly is enabled during tracing."""
+        model = _make_model()
+        self.assertFalse(torch.is_anomaly_enabled())
+        with ActivationTracer(model) as caps:
+            self.assertTrue(torch.is_anomaly_enabled())
+        self.assertFalse(torch.is_anomaly_enabled())
+
+
+class TestPhaseTagging(unittest.TestCase):
+    """Change 2 & 7: phase tagging (forward/backward)."""
+
+    def test_forward_ops_tagged_forward(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            model(x)
+        for cap in caps.values():
+            self.assertEqual(cap.phase, "forward")
+
+    def test_backward_ops_tagged_backward(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            out = model(x)
+            out.sum().backward()
+        phases = {cap.phase for cap in caps.values()}
+        self.assertIn("backward", phases)
+
+    def test_backward_sticky_flag(self):
+        """Once backward starts, all subsequent ops are tagged backward."""
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            out = model(x)
+            out.sum().backward()
+        # Find the first backward op
+        keys = list(caps.keys())
+        first_bwd = None
+        for i, k in enumerate(keys):
+            if caps[k].phase == "backward":
+                first_bwd = i
+                break
+        # All ops after the first backward should be backward
+        if first_bwd is not None:
+            for k in keys[first_bwd:]:
+                self.assertEqual(
+                    caps[k].phase, "backward",
+                    f"Op {k} after first backward should be backward"
+                )
+
+
+class TestBackwardFQNMapping(unittest.TestCase):
+    """Change 9: backward module FQN via autograd graph mapping."""
+
+    def test_backward_ops_have_module_fqn(self):
+        model = _make_model()
+        x = torch.randn(BATCH, 64)
+        with ActivationTracer(model) as caps:
+            out = model(x)
+            out.sum().backward()
+        bwd_ops = {k: v for k, v in caps.items() if v.phase == "backward"}
+        # At least some backward ops should have module FQN (not <none>)
+        fqn_ops = [k for k in bwd_ops if "<none>" not in k]
+        self.assertGreater(
+            len(fqn_ops), 0,
+            "No backward ops with module FQN"
+        )
+
+    def test_parent_claims_ops_between_children(self):
+        """For ``w2(silu(w1(x)) * w3(x))``, the silu and mul that live
+        directly inside the parent forward must be attributed to the
+        parent in BOTH forward and backward — not to any child — and
+        the child mm ops must still be attributed to their own
+        modules (the parent must not stomp on them).
+
+        This is the FeedForward-shaped case the autograd-graph
+        traversal in ``_record_grad_fn`` is built to handle: the
+        parent's silu/mul are sandwiched between child subgraphs in
+        the reverse graph, so without "walk through already-claimed
+        nodes" they would stay unattributed, and without
+        "claim only unclaimed" the parent would overwrite the
+        children.
+        """
+        model = _FeedForward()
+        x = torch.randn(4, 32, requires_grad=True)
+        # min_numel=1 so the small test tensors aren't filtered out.
+        with ActivationTracer(model, min_numel=1) as caps:
+            out = model(x)
+            out.sum().backward()
+
+        # Group keys by op name and module prefix.
+        def has_op(prefix: str, op_substr: str, phase: str) -> bool:
+            return any(
+                k.startswith(prefix + "/") and op_substr in k and v.phase == phase
+                for k, v in caps.items()
+            )
+
+        # Root module's FQN is the empty string, which renders as
+        # "<none>" in the key.
+        ROOT = "<none>"
+
+        # Forward: parent ops live under root, child mms under their modules.
+        self.assertTrue(has_op(ROOT, "silu", "forward"),
+                        "parent's silu should be attributed to root")
+        self.assertTrue(has_op(ROOT, "mul", "forward"),
+                        "parent's mul should be attributed to root")
+        self.assertTrue(has_op("w1", "mm", "forward"),
+                        "w1's mm should stay attributed to w1")
+        self.assertTrue(has_op("w2", "mm", "forward"),
+                        "w2's mm should stay attributed to w2")
+        self.assertTrue(has_op("w3", "mm", "forward"),
+                        "w3's mm should stay attributed to w3")
+
+        # Backward: same attributions, recovered via _grad_fn_to_module.
+        self.assertTrue(has_op(ROOT, "silu_backward", "backward"),
+                        "silu_backward must be attributed to root, not a child")
+        self.assertTrue(has_op("w1", "mm", "backward"),
+                        "w1's backward mm should stay attributed to w1")
+        self.assertTrue(has_op("w2", "mm", "backward"),
+                        "w2's backward mm should stay attributed to w2")
+        self.assertTrue(has_op("w3", "mm", "backward"),
+                        "w3's backward mm should stay attributed to w3")
+
+        # Negative: nothing on the silu path should leak under any child.
+        for k, v in caps.items():
+            if "silu" in k:
+                for child in ("w1/", "w2/", "w3/"):
+                    self.assertNotIn(
+                        child, k,
+                        f"silu op leaked under child {child}: {k} ({v.phase})",
+                    )
+
+
+class TestDumpCaptures(unittest.TestCase):
+    """Change 6: deterministic stat computation and dump format."""
+
+    def test_writes_file(self):
+        caps = {
+            "mod/op_0_mm": CapturedActivation(
+                tensor=torch.randn(100, 100)
+            ),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            path = f.name
+        try:
+            dump_captures_to_file(caps, path)
+            content = open(path).read()
+            self.assertIn("[mod/op_0_mm]", content)
+            self.assertIn("Shape:", content)
+            self.assertIn("L1 norm:", content)
+            self.assertIn("L2 norm:", content)
+            self.assertIn("Min:", content)
+            self.assertIn("Max:", content)
+        finally:
+            os.unlink(path)
+
+    def test_cleans_fqn_in_output(self):
+        """Change 3: _checkpoint_wrapped_module stripped at dump time."""
+        caps = {
+            "layers.0._checkpoint_wrapped_module.wq/op_0_mm": CapturedActivation(
+                tensor=torch.randn(100, 100)
+            ),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            path = f.name
+        try:
+            dump_captures_to_file(caps, path)
+            content = open(path).read()
+            self.assertNotIn("_checkpoint_wrapped_module", content)
+            self.assertIn("[layers.0.wq/op_0_mm]", content)
+        finally:
+            os.unlink(path)
+
+    def test_deterministic_norms(self):
+        """Change 6: CPU float64 gives deterministic results."""
+        t = torch.randn(1000, 1000, device="cpu")
+        caps = {"test/op_0_mm": CapturedActivation(tensor=t)}
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            path = f.name
+        try:
+            dump_captures_to_file(caps, path)
+            content1 = open(path).read()
+            dump_captures_to_file(caps, path)
+            content2 = open(path).read()
+            self.assertEqual(content1, content2)
+        finally:
+            os.unlink(path)
+
+    def test_phase_in_output(self):
+        caps = {
+            "mod/op_0_mm": CapturedActivation(
+                tensor=torch.randn(100, 100), phase="backward"
+            ),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            path = f.name
+        try:
+            dump_captures_to_file(caps, path)
+            content = open(path).read()
+            self.assertIn("Phase: backward", content)
+        finally:
+            os.unlink(path)
+
+    def test_forward_phase_not_in_output(self):
+        caps = {
+            "mod/op_0_mm": CapturedActivation(
+                tensor=torch.randn(100, 100), phase="forward"
+            ),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            path = f.name
+        try:
+            dump_captures_to_file(caps, path)
+            content = open(path).read()
+            self.assertNotIn("Phase:", content)
+        finally:
+            os.unlink(path)
+
+
+class TestCompareCaptures(unittest.TestCase):
+    """naive_compare_captures function."""
+
+    def test_identical_captures_match(self):
+        t = torch.randn(100, 100)
+        caps_a = {"mod/op_0_mm": CapturedActivation(tensor=t.clone())}
+        caps_b = {"mod/op_0_mm": CapturedActivation(tensor=t.clone())}
+        results = naive_compare_captures(caps_a, caps_b, verbose=False)
+        self.assertTrue(results["mod/op_0_mm"]["match"])
+
+    def test_different_captures_mismatch(self):
+        caps_a = {"mod/op_0_mm": CapturedActivation(tensor=torch.randn(100, 100))}
+        caps_b = {"mod/op_0_mm": CapturedActivation(tensor=torch.randn(100, 100))}
+        results = naive_compare_captures(caps_a, caps_b, verbose=False)
+        self.assertFalse(results["mod/op_0_mm"]["match"])
+
+    def test_tolerance(self):
+        t = torch.randn(100, 100)
+        caps_a = {"mod/op_0_mm": CapturedActivation(tensor=t)}
+        caps_b = {"mod/op_0_mm": CapturedActivation(tensor=t + 1e-6)}
+        results = naive_compare_captures(caps_a, caps_b, atol=1e-5, verbose=False)
+        self.assertTrue(results["mod/op_0_mm"]["match"])
+
+    def test_shape_mismatch(self):
+        caps_a = {"mod/op_0_mm": CapturedActivation(tensor=torch.randn(10, 10))}
+        caps_b = {"mod/op_0_mm": CapturedActivation(tensor=torch.randn(10, 20))}
+        results = naive_compare_captures(caps_a, caps_b, verbose=False)
+        self.assertFalse(results["mod/op_0_mm"]["match"])
+        self.assertIn("error", results["mod/op_0_mm"])
+
+
+class TestNumericsDebugger(unittest.TestCase):
+    """NumericsDebugger lifecycle."""
+
+    def test_global_flag(self):
+        model = _make_model()
+        self.assertFalse(is_numerics_capture_active())
+        debugger = NumericsDebugger(
+            enabled=True, model=model, dump_dir="/tmp/test", capture_step=1
+        )
+        debugger.__enter__()
+        # Flag set after _setup, which happens in __enter__ for step 1
+        self.assertTrue(is_numerics_capture_active())
+        debugger._teardown()
+        self.assertFalse(is_numerics_capture_active())
+
+    def test_captures_on_correct_step(self):
+        # Use a model with large enough tensors (min_numel=1000)
+        model = nn.Sequential(
+            nn.Linear(64, 64, bias=False),
+            nn.ReLU(),
+            nn.Linear(64, 64, bias=False),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            debugger = NumericsDebugger(
+                enabled=True, model=model,
+                dump_dir=tmpdir, capture_step=1,
+            )
+            debugger.__enter__()
+
+            # Run forward with batch large enough for min_numel
+            model(torch.randn(32, 64))
+            self.assertFalse(debugger._captured)
+
+            debugger.step()
+            self.assertTrue(debugger._captured)
+
+            debugger.__exit__(None, None, None)
+
+            log_path = os.path.join(tmpdir, "rank_0_activations.log")
+            self.assertTrue(os.path.exists(log_path))
+
+    def test_disabled(self):
+        model = _make_model()
+        debugger = NumericsDebugger(
+            enabled=False, model=model, dump_dir="/tmp/test", capture_step=1
+        )
+        debugger.__enter__()
+        self.assertFalse(is_numerics_capture_active())
+        debugger.__exit__(None, None, None)
+
+
+class TestFQNInterpreter(unittest.TestCase):
+    """FQNInterpreter for traced graph replay."""
+
+    def test_sets_module_name_from_node_meta(self):
+        """FQNInterpreter reads node.meta['custom']['module_fqn']."""
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        from torchtitan.experiments.graph_trainer.debug_utils import (
+            FQNInterpreter,
+        )
+
+        def fn(x, w):
+            return torch.mm(x, w)
+
+        x = torch.randn(BATCH, 64)
+        w = torch.randn(64, 64)
+        gm = make_fx(fn)(x, w)
+
+        for node in gm.graph.nodes:
+            if node.op == "call_function" and "mm" in str(node.target):
+                node.meta["custom"] = {"module_fqn": "test_module"}
+                break
+
+        names_seen = []
+        orig_run_node = FQNInterpreter.run_node
+
+        class TrackingInterpreter(FQNInterpreter):
+            def run_node(self, n):
+                fqn = (n.meta.get("custom") or {}).get("module_fqn")
+                if fqn:
+                    names_seen.append(fqn)
+                return orig_run_node(self, n)
+
+        interp = TrackingInterpreter(gm)
+        interp.run(x, w)
+        self.assertIn("test_module", names_seen)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_compare_numerics.py
+++ b/tests/unit_tests/test_compare_numerics.py
@@ -1,0 +1,416 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for compare_numerics.py.
+
+Run with:
+    python -m unittest tests.unit_tests.test_compare_numerics -v
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+
+class TestCompareNumerics(unittest.TestCase):
+    """Tests for compare_numerics.py: log parsing, matching, HTML generation."""
+
+    def test_parse_log(self):
+        from torchtitan.tools.compare_numerics import parse_log
+
+        content = """\
+Total captured activations: 2
+================================================================================
+
+[mod_a/op_0_mm]
+  Shape: torch.Size([4, 8]), Dtype: torch.float32
+  L1 norm:  1.000000e+00
+  L2 norm:  2.000000e+00
+  Min:      -1.000000e+00
+  Max:      1.000000e+00
+  Location: test.py:10
+
+[mod_b/op_0_add]
+  Shape: torch.Size([4, 8]), Dtype: torch.float32
+  L1 norm:  3.000000e+00
+  L2 norm:  4.000000e+00
+  Min:      0.000000e+00
+  Max:      2.000000e+00
+  Phase: backward
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".log", delete=False
+        ) as f:
+            f.write(content)
+            path = f.name
+        try:
+            entries, skipped = parse_log(path)
+            self.assertEqual(len(entries), 2)
+            self.assertEqual(entries[0].key, "mod_a/op_0_mm")
+            self.assertEqual(entries[0].phase, "forward")
+            self.assertEqual(entries[0].stats["L1 norm"], "1.000000e+00")
+            self.assertEqual(entries[1].key, "mod_b/op_0_add")
+            self.assertEqual(entries[1].phase, "backward")
+            # Missing header line → empty set, not an error.
+            self.assertEqual(skipped, set())
+        finally:
+            os.unlink(path)
+
+    def test_parse_log_reads_skipped_ops(self):
+        """``Excluded ops dispatched:`` header is parsed into the set."""
+        from torchtitan.tools.compare_numerics import parse_log
+
+        content = """\
+Total captured activations: 1
+Excluded ops dispatched: wait_tensor, _pre_bucket_all_gather, all_gather_into_tensor_out
+================================================================================
+
+[mod/op_0_mm]
+  Shape: torch.Size([4, 8])
+  L1 norm:  1.0
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".log", delete=False
+        ) as f:
+            f.write(content)
+            path = f.name
+        try:
+            _, skipped = parse_log(path)
+            self.assertEqual(
+                skipped,
+                {"wait_tensor", "_pre_bucket_all_gather", "all_gather_into_tensor_out"},
+            )
+        finally:
+            os.unlink(path)
+
+    def test_parse_log_empty_skipped(self):
+        """``Excluded ops dispatched: (none)`` parses as empty set."""
+        from torchtitan.tools.compare_numerics import parse_log
+
+        content = """\
+Total captured activations: 0
+Excluded ops dispatched: (none)
+================================================================================
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".log", delete=False
+        ) as f:
+            f.write(content)
+            path = f.name
+        try:
+            _, skipped = parse_log(path)
+            self.assertEqual(skipped, set())
+        finally:
+            os.unlink(path)
+
+    def test_html_renders_skipped_ops_section(self):
+        """The skipped-ops section appears in the HTML for both sides,
+        showing one chip per op name and the run names."""
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        html_out = generate_html(
+            match_entries(eager, traced),
+            "e.log",
+            "t.log",
+            name1="eager",
+            name2="traced",
+            skipped1=set(),
+            skipped2={"wait_tensor", "_pre_bucket_all_gather"},
+        )
+        self.assertIn("Excluded ops dispatched", html_out)
+        # The skipped chip should carry the op name, not any FQN.
+        self.assertIn("wait_tensor", html_out)
+        self.assertIn("_pre_bucket_all_gather", html_out)
+        self.assertIn("skipped-chip", html_out)
+        # Side 1 has no skipped ops → renders "(none)".
+        self.assertIn("(none)", html_out)
+
+    def test_exact_match(self):
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        results = match_entries(eager, traced)
+        matched = [r for r in results if r[2] == "match"]
+        self.assertEqual(len(matched), 1)
+        # Strategy should be "exact" for same-key matches.
+        self.assertEqual(matched[0][4], "exact")
+
+    def test_fuzzy_match_ignores_counter(self):
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        eager = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_3_mm", stats={"L1 norm": "2.0"}, phase="backward"),
+        ]
+        traced = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_1_mm", stats={"L1 norm": "2.0"}, phase="backward"),
+        ]
+        results = match_entries(eager, traced)
+        matched = [r for r in results if r[0] and r[1]]
+        self.assertEqual(len(matched), 2)
+        strategies = {r[4] for r in matched}
+        self.assertEqual(strategies, {"exact", "fuzzy"})
+
+    def test_numeric_match_by_shape_and_l1(self):
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        eager = [
+            OpEntry(
+                key="<none>/op_5_add",
+                stats={"Shape": "[4, 8]", "L1 norm": "1.5"},
+                phase="backward",
+            ),
+        ]
+        traced = [
+            OpEntry(
+                key="layers.0/op_2_add",
+                stats={"Shape": "[4, 8]", "L1 norm": "1.5"},
+                phase="backward",
+            ),
+        ]
+        results = match_entries(eager, traced)
+        paired = [r for r in results if r[0] and r[1]]
+        self.assertEqual(len(paired), 1)
+        self.assertEqual(paired[0][4], "stats")
+
+    def test_shape_diff_detected(self):
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={
+            "Shape": "[2048, 2048]", "L1 norm": "1.0",
+        })]
+        traced = [OpEntry(key="mod/op_0_mm", stats={
+            "Shape": "[16384, 2048]", "L1 norm": "8.0",
+        })]
+        results = match_entries(eager, traced)
+        diffs = results[0][3]
+        self.assertIn("Shape", diffs)
+
+    def test_generate_html(self):
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        results = match_entries(eager, traced)
+        html_out = generate_html(results, "eager.log", "traced.log")
+        self.assertIn("mod/op_0_mm", html_out)
+        self.assertIn("Forward", html_out)
+
+    def test_fuzzy_match_shows_both_keys(self):
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_3_mm", stats={"L1 norm": "1.0"}, phase="backward")]
+        traced = [OpEntry(key="mod/op_1_mm", stats={"L1 norm": "1.0"}, phase="backward")]
+        results = match_entries(eager, traced)
+        html_out = generate_html(results, "eager.log", "traced.log")
+        self.assertIn("mod/op_3_mm", html_out)
+        self.assertIn("mod/op_1_mm", html_out)
+        self.assertIn("key-eager", html_out)
+        self.assertIn("key-traced", html_out)
+
+    def test_per_stat_scaling(self):
+        """Each stat is compared on its own scale, not L1-normalized.
+
+        L1 norm itself differs by 0.1% — should register as ~1e-3 diff.
+        Min differs by 100% — should register as ~1.0 diff. The two
+        intensities must not be tied together (the old behavior scaled
+        Min by L1, which buried meaningful Min diffs).
+        """
+        from torchtitan.tools.compare_numerics import OpEntry, _compute_diffs
+
+        e = OpEntry(key="test", stats={
+            "L1 norm": "1.000e+03", "Min": "-1.0",
+        })
+        t = OpEntry(key="test", stats={
+            "L1 norm": "1.001e+03", "Min": "-2.0",
+        })
+        diffs = _compute_diffs(e, t)
+        # L1 norm: |1003 - 1000| / 1003 ≈ 0.001
+        self.assertAlmostEqual(diffs["L1 norm"], 1e-3, places=3)
+        # Min: |1 - 2| / 2 = 0.5 — judged on Min's own magnitude, not L1
+        self.assertAlmostEqual(diffs["Min"], 0.5, places=2)
+
+    def test_real_diff_flagged(self):
+        """Meaningful diffs should be flagged."""
+        from torchtitan.tools.compare_numerics import OpEntry, _compute_diffs
+
+        e = OpEntry(key="test", stats={
+            "L1 norm": "1.000000e+03", "Mean": "1.000000e-02",
+        })
+        t = OpEntry(key="test", stats={
+            "L1 norm": "1.000000e+03", "Mean": "2.000000e-02",
+        })
+        diffs = _compute_diffs(e, t)
+        self.assertIn("Mean", diffs)
+
+    def test_results_preserve_eager_order(self):
+        """Eager-side rows must appear in eager-log order regardless of
+        which matching pass claimed each entry."""
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        # Eager: [exact, fuzzy, only, exact]. Traced has matching entries
+        # for indices 0, 1, 3 — index 2 is eager_only. Without
+        # order-preservation the result would interleave by pass
+        # (exact-then-fuzzy), shuffling indices 1 and 3.
+        eager = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_3_mm", stats={"L1 norm": "2.0"}),
+            OpEntry(key="mod/op_5_only", stats={"L1 norm": "9.0"}),
+            OpEntry(key="mod/op_7_silu", stats={"L1 norm": "4.0"}),
+        ]
+        traced = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_1_mm", stats={"L1 norm": "2.0"}),
+            OpEntry(key="mod/op_7_silu", stats={"L1 norm": "4.0"}),
+        ]
+        results = match_entries(eager, traced)
+        eager_keys = [r[0].key for r in results if r[0] is not None]
+        self.assertEqual(eager_keys, [e.key for e in eager])
+
+    def test_only_side_has_empty_strategy(self):
+        """eager_only / traced_only rows must have empty match_strategy."""
+        from torchtitan.tools.compare_numerics import OpEntry, match_entries
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_other", stats={"L1 norm": "2.0"})]
+        results = match_entries(eager, traced)
+        statuses = {r[2]: r[4] for r in results}
+        self.assertEqual(statuses["eager_only"], "")
+        self.assertEqual(statuses["traced_only"], "")
+
+    def test_html_uses_default_names(self):
+        """Without --name1/--name2 the page uses 'run1' and 'run2'."""
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        html_out = generate_html(match_entries(eager, traced), "e.log", "t.log")
+        self.assertIn("run1 vs run2", html_out)
+        self.assertIn(">run1<", html_out)
+        self.assertIn(">run2<", html_out)
+
+    def test_html_uses_custom_names(self):
+        """Custom names appear in the title, side labels, only-side
+        counts, and filter checkboxes."""
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_other", stats={"L1 norm": "1.0"})]
+        html_out = generate_html(
+            match_entries(eager, traced),
+            "e.log",
+            "t.log",
+            name1="bf16",
+            name2="fp32",
+        )
+        self.assertIn("bf16 vs fp32", html_out)
+        self.assertIn("bf16 only", html_out)
+        self.assertIn("fp32 only", html_out)
+        self.assertIn("Show bf16-only", html_out)
+        self.assertIn("Show fp32-only", html_out)
+        self.assertNotIn("run1", html_out)
+
+    def test_html_escapes_names(self):
+        """Names are HTML-escaped to prevent injection."""
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        traced = [OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"})]
+        html_out = generate_html(
+            match_entries(eager, traced),
+            "e.log",
+            "t.log",
+            name1="<img src=x>",
+            name2="A&B",
+        )
+        # Name must be escaped, not injected as raw markup.
+        self.assertNotIn("<img src=x>", html_out)
+        self.assertIn("&lt;img src=x&gt;", html_out)
+        self.assertIn("A&amp;B", html_out)
+
+    def test_html_renders_match_method_column(self):
+        """The HTML must include the Match method column header and
+        chip labels for each strategy."""
+        from torchtitan.tools.compare_numerics import (
+            OpEntry,
+            generate_html,
+            match_entries,
+        )
+
+        eager = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_5_mm", stats={"L1 norm": "2.0"}, phase="backward"),
+            OpEntry(
+                key="<none>/op_5_add",
+                stats={"Shape": "[4, 8]", "L1 norm": "1.5"},
+                phase="backward",
+            ),
+        ]
+        traced = [
+            OpEntry(key="mod/op_0_mm", stats={"L1 norm": "1.0"}),
+            OpEntry(key="mod/op_1_mm", stats={"L1 norm": "2.0"}, phase="backward"),
+            OpEntry(
+                key="layers.0/op_2_add",
+                stats={"Shape": "[4, 8]", "L1 norm": "1.5"},
+                phase="backward",
+            ),
+        ]
+        html_out = generate_html(match_entries(eager, traced), "e.log", "t.log")
+        self.assertIn("Match method", html_out)
+        # Each pass produces its corresponding chip label and CSS class.
+        self.assertIn("strategy-exact", html_out)
+        self.assertIn("same op key", html_out)
+        self.assertIn("strategy-fuzzy", html_out)
+        self.assertIn("fuzzy op key", html_out)
+        self.assertIn("strategy-stats", html_out)
+
+    def test_shape_diff_always_flagged(self):
+        """Shape mismatches are always flagged at max intensity."""
+        from torchtitan.tools.compare_numerics import OpEntry, _compute_diffs
+
+        e = OpEntry(key="test", stats={
+            "L1 norm": "1.0", "Shape": "[2048, 2048]",
+        })
+        t = OpEntry(key="test", stats={
+            "L1 norm": "1.0", "Shape": "[16384, 2048]",
+        })
+        diffs = _compute_diffs(e, t)
+        self.assertIn("Shape", diffs)
+        self.assertEqual(diffs["Shape"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/debug_utils.py
+++ b/torchtitan/experiments/graph_trainer/debug_utils.py
@@ -89,3 +89,53 @@ def log_graph_diff(
         logger.info(f"[{pass_name}] graph unchanged")
     else:
         logger.info(f"[{pass_name}] graph diff:\n" + "\n".join(lines))
+
+
+class FQNInterpreter(torch.fx.Interpreter):
+    """Interpreter that sets activation tracer context vars from node metadata.
+
+    For each node, reads:
+    - ``node.meta["custom"]["module_fqn"]`` → sets _current_module_name
+    - ``node.meta["stack_trace"]`` → parsed and set as _current_stack_frames
+    - ``node.meta["autograd_backward"]`` → sets _current_is_backward
+
+    This is needed because traced graph replay via ``gm(*inputs)`` bypasses
+    module forwards entirely, so the monkeypatched forwards from _patch_model
+    never fire.  FQNInterpreter walks the graph node-by-node, restoring the
+    context that _patch_model would have set during eager execution.
+    """
+
+    def run_node(self, n: torch.fx.Node):
+        from contextvars import Token
+
+        from torchtitan.tools.activation_tracer import (
+            _current_module_name,
+            _current_phase_override,
+            _current_stack_frames,
+            _parse_stack_trace,
+        )
+
+        fqn = (n.meta.get("custom") or {}).get("module_fqn")
+        stack_trace = n.meta.get("stack_trace")
+        is_backward = n.meta.get("autograd_backward", False)
+
+        phase = "backward" if is_backward else "forward"
+
+        # Each ContextVar.set() returns a Token that remembers the
+        # previous value.  We collect them so the finally block can
+        # restore all vars in reverse order (LIFO, like nested withs).
+        tokens: list[Token] = []
+        if fqn:
+            tokens.append(_current_module_name.set(fqn))
+        if stack_trace:
+            tokens.append(
+                _current_stack_frames.set(_parse_stack_trace(stack_trace))
+            )
+        tokens.append(_current_phase_override.set(phase))
+        try:
+            return super().run_node(n)
+        finally:
+            # Reset each context var to its value before this node,
+            # so the next node starts with a clean slate.
+            for token in reversed(tokens):
+                token.var.reset(token)

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -444,6 +444,7 @@ def run_traced(
     traced_result: TracedResult,
     state: Any,
     *args: Any,
+    interpreter_cls: type | None = None,
 ) -> Any:
     """Execute a traced graph with fresh parameters read from the live module.
 
@@ -466,7 +467,10 @@ def run_traced(
     flat_inputs, _ = _unwrap_subclasses(all_args)
 
     with torch.no_grad():
-        flat_outputs = traced_result.gm(*flat_inputs)
+        if interpreter_cls is not None:
+            flat_outputs = interpreter_cls(traced_result.gm).run(*flat_inputs)
+        else:
+            flat_outputs = traced_result.gm(*flat_inputs)
     wrapped = _wrap_subclasses(
         flat_outputs,
         traced_result.num_flat_outputs,
@@ -504,6 +508,7 @@ def run_traced_train_step(
     module: nn.Module,
     *args: Any,
     validate_module_fqns: bool = False,
+    interpreter_cls: type | None = None,
 ) -> Any:
     """Reference implementation for executing a traced whole train step."""
 
@@ -526,4 +531,4 @@ def run_traced_train_step(
             f"  Traced: {traced_result.state_fqns}\n"
             f"  Got:    {list(state.keys())}"
         )
-    return run_traced(traced_result, state, *args)
+    return run_traced(traced_result, state, *args, interpreter_cls=interpreter_cls)

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -67,6 +67,16 @@ class GraphTrainer(Trainer):
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
 
+    def _get_interpreter_cls(self) -> type | None:
+        from torchtitan.tools.activation_tracer import is_numerics_capture_active
+
+        if is_numerics_capture_active():
+            from torchtitan.experiments.graph_trainer.debug_utils import FQNInterpreter
+
+            return FQNInterpreter
+
+        return None
+
     def forward_backward_step(
         self,
         *,
@@ -178,6 +188,7 @@ class GraphTrainer(Trainer):
                 global_valid_tokens,
                 extra_inputs,
                 extra_kwargs,
+                interpreter_cls=self._get_interpreter_cls(),
             )
         loss = outputs[0]
         grads = outputs[1:]

--- a/torchtitan/tools/activation_tracer.py
+++ b/torchtitan/tools/activation_tracer.py
@@ -1,0 +1,818 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Lightweight activation tracer using monkeypatch + TorchDispatchMode.
+
+Captures intermediate tensor values during training without modifying
+model source code. Works with DTensor and torch.compile.
+
+For each captured op, we track:
+    - **Op name**: the ATen operation (e.g. mm, bmm, silu, add)
+    - **Module FQN**: which module the op belongs to
+      (e.g. ``layers.0.attention.qkv_linear.wq``)
+    - **Source location**: stack trace back to the model code that
+      triggered the op (e.g. ``common/attention.py:534``)
+    - **Phase**: whether the op ran during forward or backward
+
+What gets captured:
+    By default, captures outputs of every op that isn't in ``_EXCLUDED_OPS``
+    (denylist of infrastructure ops: view, reshape, transpose, clone, copy_,
+    detach, collective comms, etc.) and that produces a float tensor with at
+    least ``min_numel`` elements (default 1000). This errs on the side of
+    capturing too much rather than silently missing newly introduced compute
+    ops (e.g. ``_scaled_dot_product_flash_attention``, ``_scaled_mm``).
+
+    Each captured tensor is keyed by ``module_fqn/op_N_opname`` (e.g.
+    ``layers.0.attention.qkv_linear.wq/op_0_mm``) and tagged with its
+    phase (forward or backward).
+
+Filtering / customization:
+    Pass ``op_filter`` to ``ActivationTracer`` to restrict capture to specific
+    ops (matched by substring against the op name). For example, to only
+    capture matrix multiplies and softmax::
+
+        ActivationTracer(model, op_filter={"mm", "bmm", "softmax"})
+
+    Tweak ``min_numel`` to filter small tensors, and edit ``_EXCLUDED_OPS``
+    to drop additional infrastructure ops you never want to see.
+"""
+
+import functools
+import os
+import re
+import traceback
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+import torch
+from torch import nn
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+@dataclass
+class _StackFrame:
+    filename: str
+    lineno: int
+    name: str
+    line: str | None = None
+
+    def short_str(self) -> str:
+        parts = self.filename.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-2:]) if len(parts) >= 2 else self.filename
+        return f"{short_path}:{self.lineno}"
+
+
+@dataclass
+class CapturedActivation:
+    """A captured activation with its source location."""
+
+    tensor: torch.Tensor
+    stack_frames: list[_StackFrame] = field(default_factory=list)
+    phase: str = "forward"
+
+    @property
+    def shape(self):
+        return self.tensor.shape
+
+    @property
+    def dtype(self):
+        return self.tensor.dtype
+
+
+# Ops to always exclude — infrastructure, not meaningful for numerics parity.
+# These are creation, view/reshape, indexing, and collective comm ops that
+# either don't perform compute or just rewrap the underlying storage.
+_EXCLUDED_OPS = frozenset(
+    {
+        # Creation
+        "empty",
+        "empty_like",
+        "zeros",
+        "zeros_like",
+        "ones",
+        "ones_like",
+        "full",
+        "full_like",
+        "lift_fresh",
+        "lift_fresh_copy",
+        # Copies / dtype conversion
+        "copy_",
+        "_to_copy",
+        "to",
+        "clone",
+        "contiguous",
+        "_pin_memory",
+        # View / reshape
+        "view",
+        "_unsafe_view",
+        "view_as",
+        "view_as_real",
+        "view_as_complex",
+        "reshape",
+        "_reshape_alias",
+        "flatten",
+        "unflatten",
+        "alias",
+        # Permutation
+        "permute",
+        "transpose",
+        "t",
+        "unsqueeze",
+        "squeeze",
+        "expand",
+        "expand_as",
+        "repeat",
+        # Concatenation / splitting
+        "cat",
+        "stack",
+        "split",
+        "chunk",
+        # Indexing
+        "narrow",
+        "select",
+        "index_select",
+        "gather",
+        "scatter",
+        "slice",
+        "as_strided",
+        # Autograd plumbing
+        "detach",
+        # Collective comm (DTensor / FSDP).
+        #
+        # Async collective ops dispatch and return *before* the
+        # destination buffer is filled — the buffer was just allocated
+        # (often via empty()) and a work handle is queued; the data only
+        # becomes valid after the corresponding wait_tensor.  Our
+        # __torch_dispatch__ clones the output at dispatch time, so we
+        # would capture uninitialized memory (NaN / garbage bit patterns
+        # from the CUDA allocator) rather than the actual gathered /
+        # scattered tensor.  wait_tensor is itself a no-op view that
+        # returns the same tensor; capturing it adds no information
+        # beyond the eventual consumer op and risks the same race.
+        "redistribute",
+        "all_gather",
+        "all_gather_into_tensor",
+        "all_gather_into_tensor_out",
+        "_pre_bucket_all_gather",
+        "all_reduce",
+        "reduce_scatter",
+        "reduce_scatter_tensor",
+        "_pre_bucket_reduce_scatter",
+        "wait_tensor",
+    }
+)
+
+def _is_filtered_frame(path: str) -> bool:
+    """Filter frames from torch internals and activation_tracer.
+
+    Used by both _extract_user_frames (live traceback) and
+    _parse_stack_trace (node.meta / autograd traceback strings).
+    """
+    if "/torch/nn/" in path or "\\torch\\nn\\" in path:
+        return True
+    if "/torch/autograd/" in path or "\\torch\\autograd\\" in path:
+        return True
+    if "activation_tracer.py" in path:
+        return True
+    return False
+
+
+def _extract_user_frames(stack: list[traceback.FrameSummary]) -> list[_StackFrame]:
+    """Extract user-code frames from a live traceback, filtering out
+    torch internals and activation_tracer frames."""
+    frames = []
+    for frame in reversed(stack):
+        if not _is_filtered_frame(frame.filename) and not frame.filename.startswith("<"):
+            frames.append(
+                _StackFrame(
+                    filename=frame.filename,
+                    lineno=frame.lineno,
+                    name=frame.name,
+                    line=frame.line,
+                )
+            )
+    return frames
+
+
+def _get_op_name(func) -> str:
+    if hasattr(func, "_schema"):
+        return func._schema.name.split("::")[-1]
+    return str(func).split(".")[-1].replace(">", "")
+
+
+def _should_capture(func, result, min_numel: int, op_filter: set[str] | None) -> bool:
+    """Filter to only capture "interesting" tensors.
+
+    Filters by:
+    - Tensor type (must be a real tensor, not FakeTensor)
+    - Size (must have at least min_numel elements)
+    - Dtype (must be float32, float16, or bfloat16)
+    - Always excludes infrastructure ops (empty, copy_, view, etc.)
+    - Optionally by op name (if op_filter is provided)
+
+    For DTensors, the local tensor is used for size/dtype checks.
+
+    Args:
+        func: The dispatch function.
+        result: The operation result.
+        min_numel: Minimum number of elements to capture.
+        op_filter: Optional set of op name substrings to match.
+                  If None, captures all ops that pass other filters.
+
+    Returns:
+        True if the result should be captured.
+    """
+    if not isinstance(result, torch.Tensor):
+        return False
+
+    # Skip FakeTensors produced during make_fx tracing.
+    if isinstance(result, torch._subclasses.FakeTensor):
+        return False
+
+    try:
+        from torch.distributed.tensor import DTensor
+
+        tensor = result._local_tensor if isinstance(result, DTensor) else result
+    except ImportError:
+        tensor = result
+
+    if tensor.numel() < min_numel:
+        return False
+    if tensor.dtype not in {torch.float32, torch.float16, torch.bfloat16}:
+        return False
+
+    op_name = _get_op_name(func)
+    if op_name in _EXCLUDED_OPS:
+        return False
+    if op_filter is None:
+        return True
+    return any(f in op_name for f in op_filter)
+
+
+# The current module FQN for the op being dispatched.
+#
+# Set by _patch_model's wrapped_forward during eager execution, and by
+# FQNInterpreter.run_node during traced graph replay (from
+# node.meta["custom"]["module_fqn"]).  Read by _maybe_capture to build
+# the capture key (e.g. "layers.0.attention.wq/op_0_mm").
+#
+# During eager backward, the monkeypatched forwards don't fire (C++
+# autograd engine bypasses them), so this is None.  _maybe_capture
+# falls back to _grad_fn_to_module to recover the FQN from the
+# autograd graph.
+_current_module_name: ContextVar[str | None] = ContextVar(
+    "_current_module_name", default=None
+)
+
+# Override for stack frames attached to captured activations.
+#
+# Set by _patch_model (from inspect.getfile of the module's forward
+# method) during eager forward, and by FQNInterpreter (from
+# node.meta["stack_trace"]) during traced replay.  When set,
+# _maybe_capture uses these instead of the live traceback (which is
+# uninformative under FSDP's C++ dispatch or during traced replay).
+#
+# During eager backward, this is None and _maybe_capture reads the
+# forward traceback from _current_autograd_node().metadata["traceback_"]
+# (enabled by detect_anomaly).
+_current_stack_frames: ContextVar[list[_StackFrame] | None] = ContextVar(
+    "_current_stack_frames", default=None
+)
+
+# Phase override for the current op ("forward" or "backward").
+#
+# Set by FQNInterpreter from node.meta["autograd_backward"] during
+# traced replay.  When set, _maybe_capture uses this directly instead
+# of inferring the phase from the autograd state.
+#
+# None means no override (eager mode) — _maybe_capture falls back to
+# the _in_backward sticky flag on the dispatch mode.
+_current_phase_override: ContextVar[str | None] = ContextVar(
+    "_current_phase_override", default=None
+)
+
+# Global flag indicating that NumericsDebugger has armed capture.
+#
+# Checked by GraphTrainer._get_interpreter_cls() to decide whether to
+# route traced graph replay through FQNInterpreter (which populates
+# _current_module_name from node metadata) instead of direct gm(*inputs).
+# Module-level bool rather than a callback — each rank is a separate
+# process, so no thread-safety concern.
+_numerics_capture_active = False
+
+
+def is_numerics_capture_active() -> bool:
+    return _numerics_capture_active
+
+
+def set_numerics_capture_active(active: bool) -> None:
+    global _numerics_capture_active
+    _numerics_capture_active = active
+
+
+_STACK_TRACE_RE = re.compile(
+    r'File "([^"]+)", line (\d+), in (\S+)\n\s*(.*?)(?=\n|$)'
+)
+
+
+def _parse_stack_trace(trace_str: str) -> list[_StackFrame]:
+    """Parse File/line/func entries from node.meta["stack_trace"],
+    filtering out torch.nn.modules frames."""
+    frames = []
+    for m in _STACK_TRACE_RE.finditer(trace_str):
+        if not _is_filtered_frame(m.group(1)):
+            frames.append(
+                _StackFrame(
+                    filename=m.group(1),
+                    lineno=int(m.group(2)),
+                    name=m.group(3),
+                    line=m.group(4).strip() or None,
+                )
+            )
+    return frames
+
+
+def _clean_fqn(fqn: str) -> str:
+    """Strip activation-checkpoint wrapper names from FQNs."""
+    return fqn.replace("._checkpoint_wrapped_module", "")
+
+
+def _resolve_module_location(module: nn.Module) -> list[_StackFrame]:
+    """Resolve source location from the module class definition.
+
+    Under FSDP and activation checkpointing, module forwards are
+    dispatched from C++ hooks, so the Python call stack inside
+    ``__torch_dispatch__`` only shows the top-level entry point
+    (e.g. ``train.py:main``).  The model-level frames
+    (``attention.py``, ``decoder.py``) are not on the stack because
+    the C++ runtime broke the Python call chain.
+
+    We work around this by using ``inspect.getfile`` to look up
+    where the module's ``forward`` method is defined at patch time.
+    This gives a stable location (e.g. ``common/attention.py:278``)
+    regardless of how the module is invoked at runtime.
+
+    For aot_fx_trace mode, ``node.meta["stack_trace"]`` provides
+    exact per-op line numbers recorded during tracing, so this
+    fallback is only needed for eager mode.
+    """
+    import inspect
+
+    try:
+        fn = type(module).forward
+        source_file = inspect.getfile(fn)
+        if _is_filtered_frame(source_file):
+            return []
+        _, lineno = inspect.getsourcelines(fn)
+        return [_StackFrame(filename=source_file, lineno=lineno, name="forward")]
+    except (TypeError, OSError):
+        return []
+
+
+# Maps autograd Node (grad_fn) to module FQN. Built during forward by
+# _patch_model, read during backward by _maybe_capture to give backward
+# ops their originating module's FQN.
+_grad_fn_to_module: dict[object, str] = {}
+
+
+def _patch_model(model: nn.Module) -> list[tuple[nn.Module, callable]]:
+    """Monkeypatch every module's forward to track module context.
+
+    Three things happen in each wrapped forward:
+
+    1. Set _current_module_name so _maybe_capture knows which module
+       the current op belongs to (used as the key prefix).
+    2. Set _current_stack_frames to the module's source location
+       (from inspect.getfile) so captured ops get a meaningful
+       location even when the live traceback is empty (FSDP).
+    3. After forward returns, walk the autograd graph from the output
+       grad_fn to build the _grad_fn_to_module mapping.  This lets
+       _maybe_capture recover the module FQN for backward ops, where
+       _current_module_name is not set (C++ autograd engine bypasses
+       the monkeypatched forwards).
+
+    The default args (_name, _orig, _loc) capture loop variables
+    by value — without them, all closures would share the last
+    iteration's values.
+
+    Returns a list of (module, original_forward) pairs for unpatching.
+    """
+    _grad_fn_to_module.clear()
+    saved = []
+
+    for name, module in model.named_modules():
+        original_forward = module.forward
+        saved.append((module, original_forward))
+
+        # Pre-resolve source location from class definition at patch
+        # time.  This is the fallback for eager forward ops — the live
+        # traceback inside __torch_dispatch__ is empty under FSDP.
+        location = _resolve_module_location(module)
+
+        @functools.wraps(original_forward)
+        def wrapped_forward(
+            *args, _name=name, _orig=original_forward, _loc=location, **kwargs
+        ):
+            # Snapshot input grad_fns BEFORE forward runs.  These are
+            # the boundary in _record_grad_fn's traversal — the walk
+            # must not cross into them because they belong to the
+            # caller's scope (sibling or parent module), not this module.
+            input_grad_fns = _collect_grad_fns(args, kwargs)
+
+            name_token = _current_module_name.set(_name)
+            frames_token = _current_stack_frames.set(_loc) if _loc else None
+            try:
+                result = _orig(*args, **kwargs)
+            finally:
+                if frames_token is not None:
+                    _current_stack_frames.reset(frames_token)
+                _current_module_name.reset(name_token)
+
+            # Walk the autograd graph from this module's output to map
+            # grad_fn nodes to this module's FQN.  By this point, child
+            # modules have already mapped their nodes (they ran during
+            # _orig above), so the walk passes through them without
+            # overriding and reaches unmapped nodes that belong to this
+            # module (e.g. the mul in FeedForward between w1/w3 and w2).
+            _record_grad_fn(result, _name, input_grad_fns)
+            return result
+
+        module.forward = wrapped_forward
+
+    return saved
+
+
+def _unpatch_model(saved: list[tuple[nn.Module, callable]]) -> None:
+    """Restore original forward methods saved by _patch_model."""
+    for module, original_forward in saved:
+        module.forward = original_forward
+    _grad_fn_to_module.clear()
+
+
+def _collect_grad_fns(args, kwargs) -> set:
+    """Collect grad_fn objects from input tensors."""
+    grad_fns = set()
+    for a in torch.utils._pytree.tree_leaves((args, kwargs)):
+        if isinstance(a, torch.Tensor) and a.grad_fn is not None:
+            grad_fns.add(a.grad_fn)
+    return grad_fns
+
+
+def _record_grad_fn(result, module_name: str, input_grad_fns: set) -> None:
+    """Map output grad_fn to module FQN for backward op attribution.
+
+    Walks the autograd graph from the output grad_fn (DFS via an
+    explicit stack), mapping internal nodes to the module.  Stops at
+    nodes already mapped (child modules) and at input grad_fns
+    (sibling/parent module boundary).  Traversal order doesn't matter
+    for correctness — the "claim only if unclaimed" check is
+    order-independent.
+    """
+    for t in torch.utils._pytree.tree_leaves(result):
+        if not isinstance(t, torch.Tensor) or t.grad_fn is None:
+            continue
+        stack = [t.grad_fn]
+        visited = set()
+        while stack:
+            fn = stack.pop()
+            if fn in visited or fn in input_grad_fns:
+                continue
+            visited.add(fn)
+            if fn not in _grad_fn_to_module:
+                _grad_fn_to_module[fn] = module_name
+            # Walk through child-module nodes (already mapped) to
+            # reach unmapped nodes behind them — those belong to
+            # this (parent) module.
+            for parent, _ in fn.next_functions:
+                if parent is not None and parent not in visited:
+                    stack.append(parent)
+
+
+class _CaptureDispatchMode(TorchDispatchMode):
+    """Lightweight TorchDispatchMode that clones tensor outputs without wrapping."""
+
+    def __init__(
+        self,
+        captures: dict[str, CapturedActivation],
+        op_counters: dict[str, int],
+        min_numel: int,
+        op_filter: set[str] | None,
+        skipped_excluded_ops: set[str],
+    ):
+        super().__init__()
+        self.captures = captures
+        self.op_counters = op_counters
+        self.min_numel = min_numel
+        self.op_filter = op_filter
+        # Records op names that actually dispatched but were dropped
+        # because they live in _EXCLUDED_OPS.  Surfaced in the log /
+        # HTML so users can see which always-skipped ops the model
+        # currently dispatches.
+        self.skipped_excluded_ops = skipped_excluded_ops
+        self._exited = False
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        result = func(*args, **kwargs)
+        try:
+            op_name = _get_op_name(func)
+            if op_name in _EXCLUDED_OPS:
+                self.skipped_excluded_ops.add(op_name)
+            else:
+                self._maybe_capture(func, result)
+        except Exception:
+            pass
+        return result
+
+    def _maybe_capture(self, func, result):
+        if not _should_capture(func, result, self.min_numel, self.op_filter):
+            return
+
+        # _current_module_name is set by _patch_model (eager forward)
+        # or FQNInterpreter (traced replay).
+        module_name = _current_module_name.get()
+
+        # For eager backward: recover module FQN and source location
+        # from the autograd node.  _current_module_name is not set
+        # during backward (C++ autograd bypasses monkeypatched forwards),
+        # but the autograd node maps back to the forward module via
+        # _grad_fn_to_module, and detect_anomaly saves forward tracebacks.
+        autograd_fwd_trace = None
+        autograd_node = torch._C._current_autograd_node()
+        if autograd_node is not None:
+            if module_name is None:
+                module_name = _grad_fn_to_module.get(autograd_node)
+            tb = autograd_node.metadata.get("traceback_")
+            if tb:
+                autograd_fwd_trace = "".join(tb)
+
+        module_name = module_name or "<none>"
+
+        op_name = _get_op_name(func)
+        self.op_counters.setdefault(module_name, 0)
+        seq = self.op_counters[module_name]
+        self.op_counters[module_name] += 1
+
+        key = f"{module_name}/op_{seq}_{op_name}"
+
+        try:
+            from torch.distributed.tensor import DTensor
+
+            if isinstance(result, DTensor):
+                tensor = result._local_tensor.detach().clone()
+            else:
+                tensor = result.detach().clone()
+        except ImportError:
+            tensor = result.detach().clone()
+
+        # Stack frames priority:
+        # 1. _current_stack_frames (from _patch_model or FQNInterpreter)
+        # 2. Autograd forward traceback (from detect_anomaly, backward only)
+        # 3. Live traceback (fallback)
+        override_frames = _current_stack_frames.get()
+        if override_frames is not None:
+            stack_frames = override_frames
+        elif autograd_fwd_trace is not None:
+            stack_frames = _parse_stack_trace(autograd_fwd_trace)
+        else:
+            stack = traceback.extract_stack()
+            stack_frames = _extract_user_frames(stack)
+
+        # Phase priority:
+        # 1. _current_phase_override (from FQNInterpreter for traced)
+        # 2. Autograd node present → "backward"
+        # 3. Default → "forward"
+        phase = _current_phase_override.get()
+        if phase is None:
+            if autograd_node is not None:
+                phase = "backward"
+            else:
+                phase = "forward"
+
+        self.captures[key] = CapturedActivation(
+            tensor=tensor,
+            stack_frames=stack_frames,
+            phase=phase,
+        )
+
+
+class ActivationTracer:
+    """Zero-source-change activation tracer using monkeypatch + TorchDispatchMode.
+
+    Captures intermediate tensor values during a forward pass, keyed by
+    ``module_fqn/op_N_opname``. Works with DTensor and avoids the
+    compatibility issues that DebugMode has with DTensor dispatch.
+
+    Example::
+
+        with ActivationTracer(model) as captures:
+            output = model(input_batch)
+
+        for key, cap in captures.items():
+            print(f"{key}: shape={cap.shape}, loc={cap.stack_frames[-1].short_str()}")
+
+    Args:
+        model: The model to trace.
+        min_numel: Minimum tensor size to capture (default 1000).
+        op_filter: Op name substrings to capture. Default None, which captures
+            every op not in ``_EXCLUDED_OPS``. Pass a set of substrings (e.g.
+            ``{"mm", "softmax"}``) to restrict capture to a narrower allowlist.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        *,
+        min_numel: int = 1000,
+        op_filter: set[str] | None = None,
+    ):
+        self.model = model
+        self.min_numel = min_numel
+        self.op_filter = op_filter
+        self._captures: dict[str, CapturedActivation] = {}
+        self._op_counters: dict[str, int] = {}
+        # Op names that dispatched but were dropped because they sit
+        # in _EXCLUDED_OPS.  Surfaced in the log/HTML to make the
+        # always-skipped filtering visible.
+        self.skipped_excluded_ops: set[str] = set()
+        self._dispatch_mode: _CaptureDispatchMode | None = None
+        self._saved_forwards: list[tuple[nn.Module, callable]] = []
+
+    def __enter__(self) -> dict[str, CapturedActivation]:
+        # Skip patching for GraphModules — traced replay uses
+        # FQNInterpreter to set context vars from node metadata,
+        # and module forwards don't fire during gm(*inputs).
+        import torch.fx
+
+        if not isinstance(self.model, torch.fx.GraphModule):
+            self._saved_forwards = _patch_model(self.model)
+            # Enable detect_anomaly so autograd saves forward tracebacks
+            # on backward nodes — _maybe_capture reads them via
+            # _current_autograd_node().metadata["traceback_"].
+            self._anomaly_ctx = torch.autograd.set_detect_anomaly(
+                True, check_nan=False
+            )
+            self._anomaly_ctx.__enter__()
+        self._dispatch_mode = _CaptureDispatchMode(
+            self._captures,
+            self._op_counters,
+            self.min_numel,
+            self.op_filter,
+            self.skipped_excluded_ops,
+        )
+        self._dispatch_mode.__enter__()
+        return self._captures
+
+    def __exit__(self, *args):
+        if self._dispatch_mode and not self._dispatch_mode._exited:
+            self._dispatch_mode.__exit__(*args)
+        # Reset context vars.
+        _current_phase_override.set(None)
+        _current_module_name.set(None)
+        _current_stack_frames.set(None)
+        if hasattr(self, "_anomaly_ctx"):
+            self._anomaly_ctx.__exit__(*args)
+        if self._saved_forwards:
+            _unpatch_model(self._saved_forwards)
+            self._saved_forwards = []
+
+
+def dump_captures_to_file(
+    captures: dict[str, CapturedActivation],
+    filepath: str,
+    *,
+    skipped_excluded_ops: set[str] | None = None,
+) -> None:
+    """Write per-op activation statistics to a human-readable log file.
+
+    Args:
+        captures: Captured activations to dump.
+        filepath: Output path.
+        skipped_excluded_ops: Optional set of op names that dispatched
+            during the captured step but were dropped because they
+            live in ``_EXCLUDED_OPS``.  When provided, written into the
+            log header as a comma-separated list so the comparison
+            tool can surface them in the HTML.
+    """
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    with open(filepath, "w") as f:
+        f.write(f"Total captured activations: {len(captures)}\n")
+        if skipped_excluded_ops is not None:
+            ops_str = ", ".join(sorted(skipped_excluded_ops)) or "(none)"
+            f.write(f"Excluded ops dispatched: {ops_str}\n")
+        f.write("=" * 80 + "\n\n")
+        for key, cap in captures.items():
+            t = cap.tensor
+            tf = t.float()
+            f.write(f"[{_clean_fqn(key)}]\n")
+            f.write(f"  Shape: {t.shape}, Dtype: {t.dtype}\n")
+            f.write(f"  L1 norm:  {tf.norm(p=1).item():.6e}\n")
+            f.write(f"  L2 norm:  {tf.norm(p=2).item():.6e}\n")
+            f.write(f"  Min:      {tf.min().item():.6e}\n")
+            f.write(f"  Max:      {tf.max().item():.6e}\n")
+            f.write(f"  Mean:     {tf.mean().item():.6e}\n")
+            if cap.stack_frames:
+                f.write(f"  Location: {cap.stack_frames[-1].short_str()}\n")
+            if cap.phase != "forward":
+                f.write(f"  Phase: {cap.phase}\n")
+            f.write("\n")
+
+
+class NumericsDebugger:
+    """Captures per-op activations on a designated training step.
+
+    Designed to be driven by :class:`Profiler` via its ``step()`` method,
+    which is called *after* each training step.  To capture step N the
+    debugger arms the tracer after step N-1 completes and dumps after
+    step N completes.
+
+    Args:
+        enabled: Whether numerics capture is active.
+        model: The model whose activations to capture.
+        dump_dir: Directory for output log files.
+        capture_step: The training step to capture (1-indexed).
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        model: nn.Module,
+        dump_dir: str,
+        capture_step: int = 1,
+    ):
+        self._enabled = enabled
+        self._model = model
+        self._dump_dir = dump_dir
+        self._capture_step = capture_step
+        self._step = 0
+        self._captured = False
+        self._captures: dict[str, CapturedActivation] | None = None
+
+    def __enter__(self) -> "NumericsDebugger":
+        if self._enabled and self._capture_step == 1:
+            self._setup()
+        return self
+
+    def __exit__(self, *args) -> None:
+        self._teardown()
+
+    def step(self) -> None:
+        """Called after each training step (same cadence as Profiler.step)."""
+        self._step += 1
+        if not self._enabled or self._captured:
+            return
+        if self._step == self._capture_step - 1:
+            self._setup()
+        elif self._step == self._capture_step:
+            self._dump()
+
+    def _setup(self) -> None:
+        """Enter ActivationTracer so the next training step is captured."""
+        from torchtitan.tools.logging import logger
+
+        logger.info(
+            f"Numerics capture: arming for step {self._capture_step}"
+        )
+        self._captures = {}
+
+        set_numerics_capture_active(True)
+        self._tracer = ActivationTracer(self._model)
+        self._captures = self._tracer.__enter__()
+
+    def _dump(self) -> None:
+        """Dump captures after the capture step completes."""
+        from torchtitan.tools.logging import logger
+
+        # Snapshot the tracer's skipped-ops set before _teardown drops
+        # the reference.
+        tracer = getattr(self, "_tracer", None)
+        skipped = set(tracer.skipped_excluded_ops) if tracer is not None else set()
+        self._teardown()
+        if not self._captures:
+            return
+
+        rank = (
+            torch.distributed.get_rank()
+            if torch.distributed.is_initialized()
+            else 0
+        )
+        filepath = os.path.join(self._dump_dir, f"rank_{rank}_activations.log")
+        dump_captures_to_file(
+            self._captures, filepath, skipped_excluded_ops=skipped
+        )
+        logger.info(f"Dumped {len(self._captures)} activations to {filepath}")
+        self._captured = True
+        self._captures = None
+
+    def _teardown(self) -> None:
+        set_numerics_capture_active(False)
+        tracer = getattr(self, "_tracer", None)
+        if tracer is not None:
+            if tracer._dispatch_mode and not tracer._dispatch_mode._exited:
+                tracer.__exit__(None, None, None)
+            self._tracer = None

--- a/torchtitan/tools/compare_numerics.py
+++ b/torchtitan/tools/compare_numerics.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""Compare two numerics activation logs and generate an interactive HTML diff.
+
+Inputs are the per-rank text logs produced by
+``torchtitan.tools.activation_tracer.dump_captures_to_file`` (typically
+written to ``{dump_folder}/numerics/rank_{rank}_activations.log`` when
+``--profiler.dump_numerics`` is set). Each log is a sequence of
+``[module_fqn/op_N_opname]`` blocks with per-op stats (Shape, L1/L2 norm,
+Min/Max/Mean), source ``Location``, and optional ``Phase``.
+
+Pipeline:
+    1. ``parse_log`` reads each file into a list of :class:`OpEntry`.
+    2. ``match_entries`` aligns the two lists with three passes (exact key
+       → fuzzy key → numeric stats) so that ops with different counters
+       or FQNs across modes can still be compared.
+    3. ``_compute_diffs`` flags per-stat differences, scaled by the
+       tensor's L1 norm to suppress near-zero noise.
+    4. ``generate_html`` renders an interactive page with collapsible
+       Forward/Backward sections, per-cell diff coloring, filter toggles,
+       and row hover-highlighting.
+
+The naming "eager" vs "traced" is purely conventional — the tool is
+symmetric, and any two logs (e.g. two ranks, two compile modes, two
+checkpoints) can be compared.
+
+Usage:
+    python compare_numerics.py <eager_log> <traced_log> -o <output.html>
+"""
+
+import argparse
+import html
+import math
+import re
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class OpEntry:
+    """One captured op parsed from a numerics log file.
+
+    Attributes:
+        key: ``module_fqn/op_N_opname`` identifier from the ``[...]``
+            header line. Used as the primary matching key.
+        stats: Per-stat string values (Shape, L1 norm, L2 norm, Min, Max,
+            Mean). Stored as strings so we can preserve formatting and
+            detect non-numeric mismatches (e.g. shape).
+        phase: ``"forward"`` or ``"backward"`` from the ``Phase:`` line.
+            Forward is the default when the log omits the line.
+        location: Source location like ``common/attention.py:534`` from
+            the ``Location:`` line. Surfaced in the HTML for navigation.
+    """
+
+    key: str
+    stats: dict[str, str] = field(default_factory=dict)
+    phase: str = "forward"
+    location: str = ""
+
+
+def parse_log(path: str) -> tuple[list[OpEntry], set[str]]:
+    """Parse an activation log file.
+
+    The file format is the one produced by
+    ``activation_tracer.dump_captures_to_file``: a small header (total
+    count, optional ``Excluded ops dispatched:`` line) followed by a
+    sequence of op blocks. Each op block begins with a ``[key]``
+    header on its own line, followed by indented stat lines
+    (``Shape:``, ``L1 norm:``, etc.), and optionally ``Location:`` and
+    ``Phase:`` lines. Anything else is ignored.
+
+    Args:
+        path: Path to the log file (typically
+            ``{dump_folder}/numerics/rank_{rank}_activations.log``).
+
+    Returns:
+        Tuple of ``(entries, skipped_excluded_ops)``.
+        Entries are in the order they appear in the file (the
+        op-dispatch order during the captured step, which is meaningful
+        for the matching passes in ``match_entries``).
+        ``skipped_excluded_ops`` is the set of op names that dispatched
+        but were dropped during capture because they live in
+        ``_EXCLUDED_OPS``; empty if the log doesn't carry the header
+        line.
+    """
+    entries: list[OpEntry] = []
+    skipped: set[str] = set()
+    current = None
+    with open(path) as f:
+        for line in f:
+            m = re.match(r"^\[(.+)\]", line)
+            if m:
+                if current:
+                    entries.append(current)
+                current = OpEntry(key=m.group(1))
+            elif current:
+                m2 = re.match(r"^\s+(Shape|L1 norm|L2 norm|Min|Max|Mean):\s+(.+)", line)
+                if m2:
+                    current.stats[m2.group(1)] = m2.group(2).strip()
+                elif "Location:" in line:
+                    current.location = line.strip().replace("Location: ", "")
+                elif "Phase:" in line:
+                    current.phase = line.strip().replace("Phase: ", "")
+            elif line.startswith("Excluded ops dispatched:"):
+                payload = line.split(":", 1)[1].strip()
+                if payload and payload != "(none)":
+                    skipped = {op.strip() for op in payload.split(",") if op.strip()}
+    if current:
+        entries.append(current)
+    return entries, skipped
+
+
+def _fuzzy_key(key: str) -> str:
+    """Strip the per-module op counter from a key.
+
+    Example: ``layers.0.w2/op_3_mm`` -> ``layers.0.w2/mm``.
+
+    Used by ``match_entries`` Pass 2: between modes the same module may
+    dispatch the same op N times but in different relative order (e.g.
+    backward ops are interleaved differently), so the counter ``N`` is
+    unstable. Stripping it lets us match by ``module_fqn + op_type``.
+    """
+    return re.sub(r"/op_\d+_", "/", key)
+
+
+# Stat names recognized in the log and compared per-op. Must match the
+# stats written by activation_tracer.dump_captures_to_file. Adding a new
+# stat here also requires extending the parser regex in parse_log and
+# the table headers in generate_html.
+STAT_FIELDS = ["Shape", "L1 norm", "L2 norm", "Min", "Max", "Mean"]
+
+
+def _rel_diff(a_str: str, b_str: str) -> float | None:
+    """Compute symmetric relative difference between two stat strings.
+
+    The denominator is ``max(|a|, |b|, 1e-30)`` so the result is bounded
+    by 1 and never blows up when both values are tiny. The 1e-30 floor
+    prevents division by zero when both inputs are exactly zero.
+
+    Args:
+        a_str: First stat string (e.g. ``"3.36e+04"``).
+        b_str: Second stat string.
+
+    Returns:
+        Relative difference in ``[0, 1]`` for numeric inputs, or ``None``
+        when either value cannot be parsed as a float (e.g. the
+        ``Shape`` field, which is rendered as ``torch.Size([...])``).
+    """
+    try:
+        a, b = float(a_str), float(b_str)
+    except (ValueError, TypeError):
+        return None
+    denom = max(abs(a), abs(b), 1e-30)
+    return abs(a - b) / denom
+
+
+def _compute_diffs(e_entry, t_entry):
+    """Compute per-stat differences between two matched op entries.
+
+    Each stat is compared on its own scale via :func:`_rel_diff`
+    (symmetric relative difference, ``abs(a-b) / max(|a|, |b|, 1e-30)``).
+    L1 norm differences are judged against L1 magnitude, Min against
+    Min magnitude, etc. — comparing across columns (e.g. scaling Min
+    by L1) would over- or under-suppress diffs depending on stat.
+
+    Special case: non-numeric stats (Shape, rendered as
+    ``torch.Size([...])``) get a flat ``1.0`` intensity when they
+    differ, since "the shape changed" is binary.
+
+    Args:
+        e_entry: Entry from the first log (typically eager).
+        t_entry: Entry from the second log (typically traced).
+
+    Returns:
+        Dict mapping stat name to a relative-diff intensity in
+        ``[0, 1]`` (numeric stats) or ``1.0`` (non-numeric mismatch).
+        Only stats that actually differ are included; an empty dict
+        means "matched".
+    """
+    diffs = {}
+    for stat in STAT_FIELDS:
+        ev = e_entry.stats.get(stat)
+        tv = t_entry.stats.get(stat)
+        if ev and tv and ev != tv:
+            rd = _rel_diff(ev, tv)
+            # _rel_diff returns None for non-numeric stats (Shape).
+            diffs[stat] = 1.0 if rd is None else rd
+    return diffs
+
+
+def match_entries(eager: list[OpEntry], traced: list[OpEntry]):
+    """Pair up ops between two logs using a three-pass matching strategy.
+
+    Cross-mode comparisons (eager vs aot_fx_trace, etc.)
+    can't rely on identical keys: op counters drift when ops are
+    interleaved differently, and some ops have different module
+    attributions between modes (e.g. gradient accumulation adds may
+    surface under different FQNs). The three passes progressively relax
+    the matching criteria so that ops still get paired:
+
+    Pass 1 — Exact key match. Catches the bulk of forward ops where
+        both runs dispatch the same op in the same module-relative
+        order. Most-specific match; runs first to claim the
+        "obviously the same op" cases.
+
+    Pass 2 — Fuzzy key match (``module_fqn + op_type``, counter
+        stripped via :func:`_fuzzy_key`). Handles ops where the
+        per-module sequence number drifts between modes, common for
+        backward ops which are interleaved differently.
+
+    Pass 3 — Stats match (``op_type + Shape + L1 norm``). Last-resort
+        match for ops whose module FQN differs between modes (e.g.
+        gradient accumulation adds in autograd internals). Identifies
+        ops by their tensor signature rather than by name.
+
+    Anything still unmatched is returned with status ``eager_only`` or
+    ``traced_only`` so it shows up in the HTML's "only" filter.
+
+    Args:
+        eager: Entries from the first log.
+        traced: Entries from the second log.
+
+    Returns:
+        List of ``(eager_entry | None, traced_entry | None, status,
+        diffs, match_strategy)`` tuples. ``status`` is one of
+        ``"match"``, ``"diff"``, ``"eager_only"``, ``"traced_only"``.
+        ``match_strategy`` records which pass paired the entries:
+        ``"exact"``, ``"fuzzy"``, ``"stats"``, or ``""`` for only-side
+        rows. Eager-side entries appear in their original log order;
+        ``traced_only`` entries follow at the end in their original
+        traced-log order.
+    """
+    traced_used = set()
+
+    # Collect a (status, diffs, traced_entry, strategy) for each eager
+    # entry, by its index in the eager list. Each pass fills in slots
+    # that earlier passes left empty. Emitting in eager-index order at
+    # the end keeps the output aligned with the eager log's op-dispatch
+    # sequence.
+    eager_results: list[tuple[str, dict, OpEntry, str] | None] = [None] * len(eager)
+
+    def _try_pass(strategy: str, key_fn) -> None:
+        # Build traced-side index from currently unclaimed entries, then
+        # walk eager in order and claim the first available match per
+        # entry that hasn't been filled by an earlier pass.
+        index: dict[object, list[OpEntry]] = {}
+        for e in traced:
+            if id(e) not in traced_used:
+                index.setdefault(key_fn(e), []).append(e)
+        for i, e_entry in enumerate(eager):
+            if eager_results[i] is not None:
+                continue
+            for c in index.get(key_fn(e_entry), []):
+                if id(c) not in traced_used:
+                    traced_used.add(id(c))
+                    diffs = _compute_diffs(e_entry, c)
+                    status = "diff" if diffs else "match"
+                    eager_results[i] = (status, diffs, c, strategy)
+                    break
+
+    # Pass 1: exact match (forward ops, where keys agree).
+    _try_pass("exact", lambda e: e.key)
+
+    # Pass 2: fuzzy match (module_fqn + op_type, counter stripped).
+    _try_pass("fuzzy", lambda e: _fuzzy_key(e.key))
+
+    # Pass 3: stats match (op_type + Shape + L1 norm) — handles ops
+    # whose FQN differs between modes.
+    def _stats_key(entry: OpEntry) -> tuple[str, str, str]:
+        op_type = _fuzzy_key(entry.key).split("/")[-1] if "/" in entry.key else entry.key
+        return (op_type, entry.stats.get("Shape", ""), entry.stats.get("L1 norm", ""))
+
+    _try_pass("stats", _stats_key)
+
+    # Emit eager entries in their original order. Anything still None
+    # is eager_only.
+    results = []
+    for e_entry, slot in zip(eager, eager_results, strict=True):
+        if slot is None:
+            results.append((e_entry, None, "eager_only", {}, ""))
+        else:
+            status, diffs, t_entry, strategy = slot
+            results.append((e_entry, t_entry, status, diffs, strategy))
+
+    # traced_only entries (never claimed by any pass) trail at the end
+    # in traced-log order.
+    for t_entry in traced:
+        if id(t_entry) not in traced_used:
+            results.append((None, t_entry, "traced_only", {}, ""))
+
+    return results
+
+
+def generate_html(
+    results,
+    eager_path,
+    traced_path,
+    name1: str = "run1",
+    name2: str = "run2",
+    skipped1: set[str] | None = None,
+    skipped2: set[str] | None = None,
+) -> str:
+    """Render matching results as a self-contained interactive HTML page.
+
+    The output has:
+
+    * A summary bar with match / diff / only-side counts.
+    * Filter checkboxes to hide each row category.
+    * Two collapsible sections — Forward and Backward — each rendering
+      a table with one row per (run1, run2) pair. Each row shows both
+      sides' stats stacked, with diff cells colored on a white-to-red
+      log scale, and the source ``Location`` for click-to-navigate
+      context.
+    * Hover-highlighting that tints both halves of a row pair together.
+
+    The page is fully self-contained (inline CSS + JS, no external
+    assets).
+
+    Args:
+        results: Output of :func:`match_entries`.
+        eager_path: Path of the first log (currently unused in output;
+            kept so callers can pass it for future provenance display).
+        traced_path: Path of the second log.
+        name1: Display name for the first log (defaults to ``"run1"``).
+            Used in the page title, row-side label, and filter
+            checkbox.
+        name2: Display name for the second log (defaults to ``"run2"``).
+        skipped1: Op names that dispatched in run 1 but were dropped by
+            ``_EXCLUDED_OPS`` (from the log's ``Excluded ops
+            dispatched:`` header). Rendered as a small chip list under
+            the summary so the user sees which always-skipped ops the
+            model actually exercises.
+        skipped2: Same for run 2.
+
+    Returns:
+        Complete HTML document as a string.
+    """
+    # HTML-escape user-provided names since they go into the document
+    # body and attribute values.
+    name1_safe = html.escape(name1)
+    name2_safe = html.escape(name2)
+
+    def _skipped_block(label: str, ops: set[str] | None) -> str:
+        if not ops:
+            chips = '<span class="skipped-none">(none)</span>'
+        else:
+            chips = "".join(
+                f'<span class="skipped-chip">{html.escape(op)}</span>'
+                for op in sorted(ops)
+            )
+        return (
+            f'<div class="skipped-row">'
+            f'<span class="skipped-label">{html.escape(label)}:</span> {chips}'
+            f"</div>"
+        )
+
+    skipped_section = (
+        f'<div class="skipped-section">'
+        f'<div class="skipped-title">Excluded ops dispatched '
+        f'<span class="skipped-help">(present at runtime but filtered '
+        f'by <code>_EXCLUDED_OPS</code>)</span></div>'
+        f"{_skipped_block(name1, skipped1)}"
+        f"{_skipped_block(name2, skipped2)}"
+        f"</div>"
+    )
+    def _phase(e, t):
+        return (e.phase if e else t.phase)
+    fwd = [r for r in results if _phase(r[0], r[1]) == "forward"]
+    bwd = [r for r in results if _phase(r[0], r[1]) == "backward"]
+
+    total_match = sum(1 for r in results if r[2] == "match")
+    total_diff = sum(1 for r in results if r[2] == "diff")
+    total_eager = sum(1 for r in results if r[2] == "eager_only")
+    total_traced = sum(1 for r in results if r[2] == "traced_only")
+
+    def make_table(entries, section_id):
+        rows = []
+        for idx, (e, t, status, diffs, strategy) in enumerate(entries):
+            row_id = f"{section_id}_{idx}"
+
+            if status == "eager_only":
+                cls = "eager-only"
+            elif status == "traced_only":
+                cls = "traced-only"
+            elif status == "diff":
+                cls = "has-diff"
+            else:
+                cls = "all-match"
+
+            # Show both keys when they differ (fuzzy match)
+            e_key = html.escape(e.key) if e else ""
+            t_key = html.escape(t.key) if t else ""
+            if e and t and e.key == t.key:
+                key_html = e_key
+            elif e and t:
+                key_html = (
+                    f'<span class="key-eager">{e_key}</span>'
+                    f'<br><span class="key-traced">{t_key}</span>'
+                )
+            else:
+                key_html = e_key or t_key
+
+            # Build stat cells with intensity-based diff coloring.
+            # Relative diff is mapped to opacity: tiny diffs are faint
+            # red, large diffs and non-numeric mismatches (Shape) are
+            # full red.
+            eager_cells = []
+            traced_cells = []
+            for stat in STAT_FIELDS:
+                ev = e.stats.get(stat, "") if e else ""
+                tv = t.stats.get(stat, "") if t else ""
+                rd = diffs.get(stat)
+                if rd is not None:
+                    # White-to-red gradient: intensity 0 = white text,
+                    # intensity 1 = full red text + red background tint.
+                    # Log scale: 1e-8 → 0.0, 1e-1+ → 1.0
+                    if rd >= 0.1:
+                        t_val = 1.0
+                    elif rd <= 1e-8:
+                        t_val = 0.0
+                    else:
+                        t_val = (math.log10(rd) + 8) / 7
+                    # Text: white (220,220,220) → red (248,80,80)
+                    r = int(220 + (248 - 220) * t_val)
+                    g = int(220 - (220 - 80) * t_val)
+                    b = int(220 - (220 - 80) * t_val)
+                    # Background: transparent → faint red
+                    bg_alpha = t_val * 0.15
+                    style = (
+                        f' style="color: rgb({r},{g},{b});'
+                        f" background: rgba(248,80,80,{bg_alpha:.2f});"
+                        f' font-weight: bold"'
+                    )
+                else:
+                    style = ""
+                eager_cells.append(f"<td{style}>{html.escape(ev)}</td>")
+                traced_cells.append(f"<td{style}>{html.escape(tv)}</td>")
+
+            e_loc = html.escape(e.location) if e else ""
+            t_loc = html.escape(t.location) if t else ""
+            e_phase = e.phase if e else ""
+            t_phase = t.phase if t else ""
+
+            strategy_label = {
+                "exact": "same op key",
+                "fuzzy": "fuzzy op key",
+                "stats": "stats",
+            }.get(strategy, "")
+            strategy_html = (
+                f'<span class="strategy strategy-{strategy}">{strategy_label}</span>'
+                if strategy
+                else ""
+            )
+
+            rows.append(f"""
+            <tr class="op-row {cls}" data-row-id="{row_id}"
+                onmouseenter="highlight('{row_id}')"
+                onmouseleave="unhighlight('{row_id}')">
+              <td class="key-cell" rowspan="2">{key_html}</td>
+              <td class="match-cell" rowspan="2">{strategy_html}</td>
+              <td class="side-label">{name1_safe}</td>
+              {''.join(eager_cells)}
+              <td>{e_loc}</td>
+              <td>{e_phase}</td>
+            </tr>
+            <tr class="op-row {cls}" data-row-id="{row_id}"
+                onmouseenter="highlight('{row_id}')"
+                onmouseleave="unhighlight('{row_id}')">
+              <td class="side-label">{name2_safe}</td>
+              {''.join(traced_cells)}
+              <td>{t_loc}</td>
+              <td>{t_phase}</td>
+            </tr>""")
+
+        return "\n".join(rows)
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Numerics Comparison</title>
+<style>
+  body {{ font-family: 'SF Mono', 'Menlo', monospace; font-size: 12px; margin: 20px; background: #1a1a2e; color: #e0e0e0; }}
+  h1 {{ color: #00d4ff; font-size: 18px; }}
+  h2 {{ color: #7ec8e3; font-size: 15px; margin-top: 30px; cursor: pointer; }}
+  h2:hover {{ color: #00d4ff; }}
+  .summary {{ background: #16213e; padding: 12px 18px; border-radius: 8px; margin-bottom: 20px; display: inline-block; }}
+  .summary span {{ margin-right: 20px; }}
+  .match-count {{ color: #4ade80; }}
+  .diff-count {{ color: #f87171; }}
+  .only-count {{ color: #fbbf24; }}
+  table {{ border-collapse: collapse; width: 100%; margin-bottom: 20px; }}
+  th {{ background: #0f3460; color: #e0e0e0; padding: 6px 10px; text-align: left; position: sticky; top: 0; z-index: 1; }}
+  td {{ padding: 4px 10px; border-bottom: 1px solid #1a1a3e; white-space: nowrap; }}
+  .key-cell {{ font-weight: bold; color: #7ec8e3; vertical-align: top; border-right: 2px solid #0f3460; max-width: 400px; overflow: hidden; text-overflow: ellipsis; line-height: 1.6; }}
+  .key-eager {{ color: #c4b5fd; font-size: 11px; }}
+  .key-traced {{ color: #67e8f9; font-size: 11px; }}
+  .side-label {{ color: #888; font-size: 11px; width: 50px; }}
+  .match-cell {{ vertical-align: middle; border-right: 2px solid #0f3460; }}
+  .strategy {{ font-size: 11px; padding: 2px 6px; border-radius: 4px; font-weight: bold; }}
+  .strategy-exact {{ color: #4ade80; background: rgba(74,222,128,0.15); }}
+  .strategy-fuzzy {{ color: #fbbf24; background: rgba(251,191,36,0.15); }}
+  .strategy-stats {{ color: #a78bfa; background: rgba(167,139,250,0.15); }}
+  .op-row:nth-of-type(4n+1), .op-row:nth-of-type(4n+2) {{ background: #0f1629; }}
+  .op-row:nth-of-type(4n+3), .op-row:nth-of-type(4n+4) {{ background: #1a1a2e; }}
+  .op-row.highlighted {{ background: #1e3a5f !important; }}
+  .section {{ margin-bottom: 30px; }}
+  .section-content {{ display: block; }}
+  .section-content.collapsed {{ display: none; }}
+  .toggle {{ font-size: 12px; color: #888; }}
+  .skipped-section {{ background: #16213e; padding: 10px 15px; border-radius: 8px; margin-bottom: 20px; }}
+  .skipped-title {{ color: #7ec8e3; font-weight: bold; margin-bottom: 6px; }}
+  .skipped-help {{ color: #888; font-weight: normal; font-size: 11px; }}
+  .skipped-row {{ margin-bottom: 4px; }}
+  .skipped-label {{ color: #aaa; margin-right: 6px; }}
+  .skipped-chip {{ display: inline-block; background: rgba(167,139,250,0.15); color: #a78bfa; font-size: 11px; padding: 2px 6px; border-radius: 4px; margin-right: 4px; }}
+  .skipped-none {{ color: #666; font-style: italic; font-size: 11px; }}
+  .filter-bar {{ margin-bottom: 15px; }}
+  .filter-bar label {{ margin-right: 15px; color: #aaa; cursor: pointer; }}
+  .filter-bar input {{ margin-right: 4px; }}
+</style>
+</head>
+<body>
+<h1>Numerics Comparison: {name1_safe} vs {name2_safe}</h1>
+<div class="summary">
+  <span class="match-count">✓ {total_match} matched</span>
+  <span class="diff-count">✗ {total_diff} diffs</span>
+  <span class="only-count">← {total_eager} {name1_safe} only</span>
+  <span class="only-count">→ {total_traced} {name2_safe} only</span>
+</div>
+
+{skipped_section}
+
+<div class="filter-bar">
+  <label><input type="checkbox" checked onchange="toggleClass('all-match', this.checked)"> Show matched</label>
+  <label><input type="checkbox" checked onchange="toggleClass('has-diff', this.checked)"> Show diffs</label>
+  <label><input type="checkbox" checked onchange="toggleClass('eager-only', this.checked)"> Show {name1_safe}-only</label>
+  <label><input type="checkbox" checked onchange="toggleClass('traced-only', this.checked)"> Show {name2_safe}-only</label>
+</div>
+
+<div class="section">
+  <h2 onclick="toggleSection('fwd')">Forward ({len(fwd)} ops) <span class="toggle" id="fwd-toggle">▼</span></h2>
+  <div class="section-content" id="fwd">
+    <table>
+      <tr><th>Op</th><th>Match method</th><th>Side</th><th>Shape</th><th>L1 norm</th><th>L2 norm</th><th>Min</th><th>Max</th><th>Mean</th><th>Location</th><th>Phase</th></tr>
+      {make_table(fwd, "fwd")}
+    </table>
+  </div>
+</div>
+
+<div class="section">
+  <h2 onclick="toggleSection('bwd')">Backward ({len(bwd)} ops) <span class="toggle" id="bwd-toggle">▼</span></h2>
+  <div class="section-content" id="bwd">
+    <table>
+      <tr><th>Op</th><th>Match method</th><th>Side</th><th>Shape</th><th>L1 norm</th><th>L2 norm</th><th>Min</th><th>Max</th><th>Mean</th><th>Location</th><th>Phase</th></tr>
+      {make_table(bwd, "bwd")}
+    </table>
+  </div>
+</div>
+
+
+<script>
+function highlight(rowId) {{
+  document.querySelectorAll('[data-row-id="' + rowId + '"]').forEach(
+    el => el.classList.add('highlighted'));
+}}
+function unhighlight(rowId) {{
+  document.querySelectorAll('[data-row-id="' + rowId + '"]').forEach(
+    el => el.classList.remove('highlighted'));
+}}
+function toggleSection(id) {{
+  const el = document.getElementById(id);
+  const toggle = document.getElementById(id + '-toggle');
+  if (el.classList.contains('collapsed')) {{
+    el.classList.remove('collapsed');
+    toggle.textContent = '▼';
+  }} else {{
+    el.classList.add('collapsed');
+    toggle.textContent = '▶';
+  }}
+}}
+function toggleClass(cls, show) {{
+  document.querySelectorAll('.op-row.' + cls).forEach(el => {{
+    el.style.display = show ? '' : 'none';
+  }});
+}}
+</script>
+</body>
+</html>"""
+
+
+def naive_compare_captures(
+    captures_a: dict,
+    captures_b: dict,
+    *,
+    rtol: float = 0,
+    atol: float = 0,
+    verbose: bool = True,
+) -> dict[str, dict]:
+    """Compare activations captured from two runs by raw key.
+
+    Simple key-based comparison (requires identical key sets). For
+    cross-mode comparison with fuzzy matching, use ``match_entries``
+    on parsed log files instead.
+
+    Args:
+        captures_a: Captures from run A (dict of CapturedActivation).
+        captures_b: Captures from run B.
+        rtol: Relative tolerance (0 = bitwise).
+        atol: Absolute tolerance (0 = bitwise).
+        verbose: Print comparison results.
+
+    Returns:
+        Dict mapping keys to ``{"match": bool, "max_diff": float, ...}``.
+    """
+    import torch
+
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        DTensor = None  # type: ignore[assignment, misc]
+
+    results = {}
+    common_keys = set(captures_a.keys()) & set(captures_b.keys())
+
+    if verbose:
+        print(f"\n{'=' * 80}")
+        print("Activation Parity Comparison")
+        print(f"A keys: {len(captures_a)}, B keys: {len(captures_b)}, "
+              f"common: {len(common_keys)}")
+        print(f"{'=' * 80}")
+
+    for key in sorted(common_keys):
+        ta = captures_a[key].tensor
+        tb = captures_b[key].tensor
+
+        if DTensor is not None:
+            ta = ta._local_tensor if isinstance(ta, DTensor) else ta
+            tb = tb._local_tensor if isinstance(tb, DTensor) else tb
+
+        if ta.shape != tb.shape:
+            if verbose:
+                print(f"\n[{key}] SHAPE MISMATCH: {ta.shape} vs {tb.shape}")
+            results[key] = {"match": False, "error": "shape mismatch"}
+            continue
+
+        diff = (ta.float() - tb.float()).abs()
+        max_diff = diff.max().item()
+        mean_diff = diff.mean().item()
+
+        if rtol == 0 and atol == 0:
+            match = torch.equal(ta, tb)
+        else:
+            match = torch.allclose(ta, tb, rtol=rtol, atol=atol)
+
+        results[key] = {
+            "match": match,
+            "max_diff": max_diff,
+            "mean_diff": mean_diff,
+        }
+
+        if verbose:
+            status = "MATCH" if match else "DIFF"
+            print(f"\n[{key}] {status}")
+            print(f"  Shape: {ta.shape}, Dtype: {ta.dtype}")
+            print(f"  Max diff: {max_diff:.6e}, Mean diff: {mean_diff:.6e}")
+
+    if verbose:
+        total = len(results)
+        matched = sum(1 for r in results.values() if r.get("match", False))
+        print(f"\n{'=' * 80}")
+        print(f"Summary: {matched}/{total} matched")
+        print(f"{'=' * 80}")
+
+    return results
+
+
+def main():
+    """CLI entry point: parse two logs, match entries, write HTML diff.
+
+    Invoked via ``python -m torchtitan.tools.compare_numerics`` or
+    directly. See module docstring for the typical workflow.
+    """
+    parser = argparse.ArgumentParser(description="Compare numerics activation logs")
+    parser.add_argument("eager", help="First log file")
+    parser.add_argument("traced", help="Second log file")
+    parser.add_argument("-o", "--output", default="numerics_diff.html", help="Output HTML file")
+    parser.add_argument(
+        "--name1",
+        default="run1",
+        help="Display name for the first log (default: run1)",
+    )
+    parser.add_argument(
+        "--name2",
+        default="run2",
+        help="Display name for the second log (default: run2)",
+    )
+    args = parser.parse_args()
+
+    eager, skipped_eager = parse_log(args.eager)
+    traced, skipped_traced = parse_log(args.traced)
+    results = match_entries(eager, traced)
+    html_content = generate_html(
+        results,
+        args.eager,
+        args.traced,
+        name1=args.name1,
+        name2=args.name2,
+        skipped1=skipped_eager,
+        skipped2=skipped_traced,
+    )
+
+    with open(args.output, "w") as f:
+        f.write(html_content)
+    print(f"Wrote {args.output} ({len(results)} entries)")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -16,6 +16,7 @@ from torchtitan.config import Configurable
 from torchtitan.config.function import Function
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
+from torchtitan.tools.activation_tracer import NumericsDebugger
 
 # how much memory allocation/free ops to record in memory snapshots
 MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
@@ -164,6 +165,10 @@ class Profiler(Configurable):
         This is used to configure torch.profiler.schedule.
         """
 
+        dump_numerics: bool = False
+        """Dump per-op activation logs for numerics debugging.
+        Writes to {dump_folder}/numerics/rank_{rank}_activations.log."""
+
         enable_memory_snapshot: bool = False
         """Whether to dump memory snapshot."""
 
@@ -186,6 +191,7 @@ class Profiler(Configurable):
         global_step: int = 0,
         base_folder: str = "",
         leaf_folder: str = "",
+        model: torch.nn.Module | None = None,  # for numerics debugger
     ) -> None:
         self._config = config
         self._global_step = global_step
@@ -193,6 +199,10 @@ class Profiler(Configurable):
         self._leaf_folder = leaf_folder
         self.torch_profiler = None
         self.memory_profiler = None
+        self.numerics_debugger = None
+        # Numerics debugger needs the model to monkeypatch module forwards
+        # for ActivationTracer dispatch interception.
+        self._model = model
 
     def active(
         self,
@@ -227,6 +237,9 @@ class Profiler(Configurable):
             base_folder=self._base_folder,
             leaf_folder=self._leaf_folder,
         )
+        self.numerics_debugger = self.build_numerics_debugger(
+            base_folder=self._base_folder,
+        )
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
@@ -237,6 +250,9 @@ class Profiler(Configurable):
             if isinstance(exc_val, torch.OutOfMemoryError):
                 self.memory_profiler.step(exit_ctx=True)
             self.memory_profiler = None
+        if self.numerics_debugger is not None:
+            self.numerics_debugger.__exit__(exc_type, exc_val, exc_tb)
+            self.numerics_debugger = None
         return False
 
     def step(self) -> None:
@@ -245,6 +261,8 @@ class Profiler(Configurable):
             self.torch_profiler.step()
         if self.memory_profiler is not None:
             self.memory_profiler.step()
+        if self.numerics_debugger is not None:
+            self.numerics_debugger.step()
 
     def build_torch_profiler(
         self,
@@ -364,3 +382,19 @@ class Profiler(Configurable):
         return MemoryProfiler(
             global_step, cfg.profile_freq, snapshot_dir, leaf_folder, rank
         )
+
+    def build_numerics_debugger(self, *, base_folder: str):
+        """Create and return a :class:`NumericsDebugger`, or ``None`` if disabled."""
+        cfg = self._config
+        if not cfg.dump_numerics or self._model is None:
+            return None
+
+        dump_dir = os.path.join(base_folder, "numerics")
+        debugger = NumericsDebugger(
+            enabled=True,
+            model=self._model,
+            dump_dir=dump_dir,
+            capture_step=cfg.profile_freq,
+        )
+        debugger.__enter__()
+        return debugger

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -812,6 +812,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         with config.profiler.build(
             global_step=self.step,
             base_folder=config.dump_folder,
+            model=self.model_parts[0],
         ) as profiler:
             data_iterator = self.batch_generator(self.dataloader)
             while self.should_continue_training():


### PR DESCRIPTION
# PR Summary

Adds a numerics-debugging tool that captures per-op activation statistics during a training step and renders an interactive diff between two runs. Driven by a new `--profiler.dump_numerics` flag, with first-class support for both eager and `aot_fx_trace` compile modes.

## `torchtitan/tools/activation_tracer.py` (new, 762 LOC)

Core capture machinery. Two pieces:

- **`ActivationTracer`** — context manager that combines two mechanisms to capture per-op outputs and keep them attributed to the model code:
  - **`_CaptureDispatchMode`** (a `TorchDispatchMode`) intercepts every dispatched op; `_should_capture` filters by a denylist `_EXCLUDED_OPS` (creation/view/permutation/indexing/comm) and a numel/dtype floor. Captured tensors are cloned and keyed `module_fqn/op_N_opname`.
  - **`_patch_model`** monkeypatches every `nn.Module.forward` to set three `ContextVar`s (module name, stack frames, autograd-grad-fn map) before delegating to the real forward. After forward returns, `_record_grad_fn` BFS-walks the autograd graph from each output to record `grad_fn → module_fqn` so backward ops can be attributed correctly.

- **`NumericsDebugger`** — driven from the existing `Profiler.step()`; arms the tracer one step before the capture step and dumps to `{dump_folder}/numerics/rank_{rank}_activations.log` after.

### How phase and stack location are determined

This was the trickiest part of the design — different mode/phase combinations bypass different layers of the Python call stack, so the source is different in each cell:

| Mode | Phase | Phase determined by | Stack location determined by | Module FQN determined by |
|------|-------|---------------------|------------------------------|--------------------------|
| Eager | Forward | No autograd node + no override → `"forward"` | `_current_stack_frames` set by `_patch_model.wrapped_forward` from `inspect.getfile(type(module).forward)` | `_current_module_name` set by `_patch_model.wrapped_forward` |
| Eager | Backward | `_current_autograd_node()` is non-None → `"backward"` | Monkeypatched forwards don't fire (C++ autograd bypasses Python). Falls back to `_current_autograd_node().metadata["traceback_"]` — the **forward** traceback, saved by autograd because `ActivationTracer.__enter__` enables `set_detect_anomaly(True, check_nan=False)`. Parsed via `_parse_stack_trace`. | `_current_module_name` is None during backward → falls back to `_grad_fn_to_module[autograd_node]` (built during forward by `_record_grad_fn` BFS) |
| Traced (`gm(*inputs)`) | Either | `node.meta["autograd_backward"]` → sets `_current_phase_override` | `node.meta["stack_trace"]` parsed via `_parse_stack_trace` → sets `_current_stack_frames` | `node.meta["custom"]["module_fqn"]` → sets `_current_module_name` |

For traced replay, `gm(*inputs)` bypasses module forwards entirely, so the monkeypatch never fires. The `FQNInterpreter` (in `debug_utils.py`) walks the graph node by node and pushes/pops context vars from each node's `meta` so the dispatch-mode capture sees the right FQN/stack/phase per op.

### Why we can't just call `traceback.extract_stack()` inside `__torch_dispatch__`

The obvious approach would be: when an op fires inside `_CaptureDispatchMode.__torch_dispatch__`, walk the live Python call stack with `traceback.extract_stack()` and that's our location. This works in plain eager mode, but **fails silently under FSDP and activation checkpointing**, which are the production configurations we actually care about:

- **FSDP** wraps each module's forward and dispatches the wrapped forward via C++ hooks (parameter all-gather, post-backward reduce-scatter). By the time the op reaches `__torch_dispatch__`, the C++ runtime has broken the Python call chain — `attention.forward` and `decoder.forward` are *not* on the Python stack. `extract_stack()` returns only the entry point (`train.py:main`) plus dispatch-mode framework frames, which is useless for finding the model code that produced the op.
- **Activation checkpointing** has the same issue: recompute runs inside `torch.autograd.function.BackwardCFunction.apply` (a C function), so the model-level frames are gone there too.
- Even when frames *are* on the stack, the live traceback can only point at *some line inside* the module's forward; the line that actually corresponds to the dispatched op is hard to recover reliably (multiple ops per source line, fused dispatches, etc.).

`_resolve_module_location` works around this by computing the location once at patch time, from the module's class definition — `inspect.getfile(type(module).forward)` plus `inspect.getsourcelines` gives the file and line where the forward method is *defined*. That's stable regardless of how the runtime invokes it (FSDP wrap, AC, raw eager). The trade-off is that we get module-level granularity (the forward's header line) rather than the exact op line — and for the traced path that's not a problem because `node.meta["stack_trace"]` from AOTAutograd captures the per-op line at trace time, when the Python stack *is* intact.

Live `traceback.extract_stack()` is still kept as a last-resort fallback inside `_maybe_capture` for cases where neither `_current_stack_frames` nor an autograd-saved traceback is available.

### How `_record_grad_fn` attributes backward ops to modules

The `_grad_fn_to_module` mapping in the table above is built by `_record_grad_fn` during forward. It walks the autograd reverse graph (DFS via an explicit stack — order doesn't matter for correctness, since the "claim only if unclaimed" check is order-independent) and has to navigate two delicate boundaries:

1. **Input boundary (`input_grad_fns`)** — captured *before* the real forward runs by walking `args`/`kwargs` for any tensor with a `grad_fn`. These are autograd nodes belonging to the **caller** (sibling or parent module). The BFS must not cross into them, otherwise the current module would over-claim ops that aren't its responsibility.

2. **Already-mapped boundary** — by the time a parent module's `wrapped_forward` runs `_record_grad_fn`, every child module nested inside it has already finished its own `_record_grad_fn` call (children's `_orig(...)` runs to completion before the parent's post-forward block). Their grad_fns are already mapped to the child FQN, so the parent must not overwrite them.

The walk itself, starting from each output tensor's `grad_fn`:

```python
stack = [t.grad_fn]
visited = set()
while stack:
    fn = stack.pop()                   # LIFO → DFS
    if fn in visited or fn in input_grad_fns:
        continue                       # boundary: caller's autograd nodes
    visited.add(fn)
    if fn not in _grad_fn_to_module:
        _grad_fn_to_module[fn] = module_name   # claim only unclaimed nodes
    for parent, _ in fn.next_functions:
        if parent is not None and parent not in visited:
            stack.append(parent)       # walk upstream toward inputs
```

**Why "claim only unclaimed" but still walk through.** When the parent's traversal hits a node a child already claimed, it does *not* overwrite — the child is more specific. But the walk **continues through** that child node into its `next_functions`. This is deliberate: between child-module subgraphs there can be operations the parent module performed itself. If the walk stopped at every already-mapped node, those parent-only ops would never get claimed.

The clearest example is `FeedForward`, whose forward is `w2(silu(w1(x)) * w3(x))`. The `silu` and `mul` are called directly inside `FeedForward.forward` — they are *not* inside any child module — so they need to be attributed to `FeedForward`, even though they sit sandwiched between child-module subgraphs in the autograd reverse graph:

```
              forward direction (data flow) ─────────────►

   x ──┬──► [w1.forward] ──► h1 ──► silu ──► s ──┬──► mul ──► p ──► [w2.forward] ──► y
       │     (claims mm,                          │           ▲      (claims mm
       │      Tback, AccGrad                      │           │       Tback, AccGrad
       │      for w1)                             │           │       for w2)
       └──► [w3.forward] ──► h3 ──────────────────┘           │
             (claims mm,                                      │
              Tback, AccGrad                                  │
              for w3)
```

The actual autograd reverse graph (verified by walking `y.grad_fn.next_functions` on a real `FeedForward(dim=8, hidden=16)` with `bias=False` linears):

```
              ◄───────── BFS direction (autograd reverse graph)

   MmBackward0 [w2] ─┬─► MulBackward0 [?] ─┬─► SiluBackward0 [?] ─► MmBackward0 [w1] ─┬─► AccumulateGrad (w1.weight)
        ↑            │                     │                                          └─► TBackward0 ─► AccumulateGrad
        already      │                     └─► MmBackward0 [w3] ─┬─► TBackward0 ─► AccumulateGrad (w3.weight)
        claimed      │                                            (input x is a leaf, x.grad_fn is None,
        by w2        └─► TBackward0 ─► AccumulateGrad (w2.weight)  so BFS terminates at AccumulateGrads)
```

(`TBackward0` is the weight-transpose backward inserted because `nn.Linear` computes `x @ weight.T`; `AccumulateGrad` is the leaf accumulator for each parameter.)

When `FeedForward.wrapped_forward` runs its `_record_grad_fn` (after every child has already run theirs), the autograd graph state is:

```
  MmBackward0   [w2]            ← already claimed by w2 (along with its TBackward0/AccumulateGrad)
  MulBackward0  [    ]          ← UNCLAIMED — happened in FeedForward, not a child
  SiluBackward0 [    ]          ← UNCLAIMED — same
  MmBackward0   [w1]            ← already claimed by w1 (along with its TBackward0/AccumulateGrad)
  MmBackward0   [w3]            ← already claimed by w3 (along with its TBackward0/AccumulateGrad)
```

The walk starts from the output's `grad_fn` (`MmBackward0 [w2]`), sees it's already claimed, doesn't overwrite, but follows `next_functions` upstream. It reaches `MulBackward0` and `SiluBackward0` — both unclaimed — and stamps them with `feed_forward`. Continuing upstream it hits `MmBackward0 [w1]` and `MmBackward0 [w3]` (already claimed, skip the claim, but the walk continues into their parameter-side subtrees, which are also already claimed by the children), and eventually terminates at the leaf `AccumulateGrad` nodes (no `next_functions`). End state:

```
  MmBackward0   [w2]            ← unchanged (child)
  MulBackward0  [feed_forward]  ← claimed by parent
  SiluBackward0 [feed_forward]  ← claimed by parent
  MmBackward0   [w1]            ← unchanged (child)
  MmBackward0   [w3]            ← unchanged (child)
```

Without the "walk through already-claimed nodes" rule, the traversal would have stopped at `MmBackward0 [w2]` and `MulBackward0`/`SiluBackward0` would have stayed unattributed (showing up as `<none>` in the log). Without the "don't overwrite already-claimed" rule, `feed_forward` would have stomped over the more-specific child attributions for w1/w2/w3 (and all the per-parameter `TBackward0`/`AccumulateGrad` nodes underneath them).

`next_functions` points upstream toward inputs (autograd's reverse graph), so the sweep goes from output back toward the module's input boundary — exactly the territory this module's forward produced. Net effect: each autograd node is mapped to the **innermost** module whose forward produced it; parents claim only the "glue" ops between children. During backward, `_maybe_capture` reads `_grad_fn_to_module[autograd_node]` and gets the correct, tightly-scoped FQN.

## `torchtitan/tools/compare_numerics.py` (new, 659 LOC)

Standalone CLI tool that diffs two activation logs and produces a self-contained interactive HTML report.

- **`parse_log`** parses the human-readable log format produced by `dump_captures_to_file`.
- **`match_entries`** pairs ops between the two logs in **three passes**, each progressively more relaxed:
  1. **Same op key** — exact `module_fqn/op_N_opname` match. Catches the bulk of forward ops.
  2. **Fuzzy op key** — strips the per-module counter (`mod/op_3_mm` ↔ `mod/op_1_mm`). Backward ops often interleave differently between modes, so the counter drifts.
  3. **Stats** — matches by `op_type + Shape + L1 norm`. Last-resort match for ops whose FQN differs between modes (e.g. autograd-internal grad-accumulation adds).
  Eager-side rows are emitted in original log order regardless of which pass matched them; traced-only rows trail at the end.
- **`_compute_diffs`** scales each stat against its own column (via symmetric relative diff with a `1e-30` floor), so an L2 diff is judged on L2's magnitude rather than on the tensor's L1 norm.
- **`generate_html`** renders a single self-contained HTML page with collapsible Forward/Backward sections, per-cell white-to-red coloring on a log-scale relative diff, hover-row highlighting, filter checkboxes, a "Match method" column showing how each pair was paired, and configurable run names via `--name1`/`--name2` (default `run1`/`run2`).

Two test files (`test_activation_tracer.py`, `test_compare_numerics.py`) cover capture filtering, phase tagging, the three matching passes, eager-order preservation, the match-method column, run-name handling, and HTML escape safety.

## Changes to existing trainer / graph_trainer / profiler

Wiring to drive the tracer from the existing training loop:

- **`torchtitan/tools/profiler.py`** — adds `Profiler.Config.dump_numerics` (a new `--profiler.dump_numerics` flag); adds a `model` kwarg to `Profiler.__init__`; builds a `NumericsDebugger` inside `__enter__`, calls `step()` from `Profiler.step()`, and tears it down in `__exit__`. Capture step is reused from `cfg.profile_freq`.

- **`torchtitan/trainer.py`** — passes `model_parts[0]` into `profiler.build(...)` so the debugger can monkeypatch its forwards.

- **`torchtitan/experiments/graph_trainer/make_fx_tracer.py`** — `run_traced` and `run_traced_train_step` accept an `interpreter_cls` kwarg. When set, replay goes through `interpreter_cls(gm).run(...)` instead of `gm(*flat_inputs)`. Default `None` leaves the fast path untouched.

- **`torchtitan/experiments/graph_trainer/trainer.py`** — `_get_interpreter_cls()` returns `FQNInterpreter` only when `is_numerics_capture_active()` is true (set by `NumericsDebugger`). Threaded into the `run_traced_train_step` call. Normal compiled training pays zero overhead.

- **`torchtitan/experiments/graph_trainer/debug_utils.py`** — adds `FQNInterpreter`, a `torch.fx.Interpreter` subclass that reads `node.meta["custom"]["module_fqn"]`, `node.meta["stack_trace"]`, and `node.meta["autograd_backward"]` and pushes them onto the activation tracer's context vars for the duration of each node's execution. This is the bridge that lets traced replay produce captures with the same FQN/stack/phase attribution that the eager path gets via the monkeypatch.

## Usage

### Capture numerics

```bash
# Eager mode
NGPU=1 MODULE=llama3 CONFIG=llama3_debugmodel \
    ./run_train.sh \
    --profiler.dump_numerics \
    --profiler.profile_freq 2 \
    --training.steps 2

# aot_fx_trace mode
NGPU=1 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
    ./run_train.sh \
    --profiler.dump_numerics \
    --profiler.profile_freq 2 \
    --training.steps 2 \
    --compile.mode aot_fx_trace

# Multi-GPU
NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
    ./run_train.sh \
    --profiler.dump_numerics \
    --profiler.profile_freq 2 \
    --training.steps 2 \
    --compile.mode aot_fx_trace \
    --parallelism.data_parallel_shard_degree=4 \
    --parallelism.tensor_parallel_degree=2
```

Output: `{dump_folder}/numerics/rank_{N}_activations.log`

### Compare two logs

```bash
python -m torchtitan.tools.compare_numerics \
    outputs_numerics/eager/numerics/rank_0_activations.log \
    outputs_numerics/traced/numerics/rank_0_activations.log \
    -o numerics_diff.html
```

### Commands used to generate the current HTML
https://www.internalfb.com/intern/px/p/9LGvr/

```bash
cd torchtitan

# Run both modes with same seed, deterministic, float32, no FSDP
NGPU=1 MODULE=llama3 CONFIG=llama3_debugmodel \
    ./run_train.sh \
    --dump_folder ./outputs_numerics/eager \
    --training.steps 2 \
    --profiler.dump_numerics \
    --profiler.profile_freq 2 \
    --debug.seed 42 \
    --debug.deterministic \
    --training.mixed_precision_param float32

NGPU=1 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
    ./run_train.sh \
    --dump_folder ./outputs_numerics/traced \
    --training.steps 2 \
    --profiler.dump_numerics \
    --profiler.profile_freq 2 \
    --compile.mode aot_fx_trace \
    --debug.seed 42 \
    --debug.deterministic \
    --training.mixed_precision_param float32

# Generate comparison HTML
python -m torchtitan.tools.compare_numerics \
    outputs_numerics/eager/numerics/rank_0_activations.log \
    outputs_numerics/traced/numerics/rank_0_activations.log \
    -o numerics_diff.html
```

### Run tests

```bash
python -m unittest tests.unit_tests.test_activation_tracer -v
```

## Output format

```
[layers.0.attention.qkv_linear.wq/op_0_mm]
  Shape: torch.Size([16384, 256]), Dtype: torch.float32
  L1 norm:  1.066932e+06
  L2 norm:  6.550494e+02
  Min:      -1.275938e+00
  Max:      1.309514e+00
  Location: common/attention.py:534
  Phase: backward
```

## Why not just `diff`?

A naive `diff` of two activation logs doesn't work because:

1. **Op keys don't match between modes.** Eager and traced backward ops
   have different op counter sequences (e.g. `wq/op_3_mm` vs `wq/op_1_mm`)
   because AC recomputation inserts extra ops in eager that shift all
   counters. `compare_numerics.py` uses three-pass matching: exact key →
   fuzzy key (strip counter, match by module + op type) → numeric match
   (same shape + L1 norm). This recovers ~80 additional backward pairs
   that naive key comparison misses.

2. **Not all differences matter equally.** A `Mean` diff of `1.29e-20`
   vs `-1.28e-20` is floating-point noise when the tensor's L1 norm is
   `1e+3` — both values are effectively zero. But a `Min` diff of
   `-1.28` vs `-4.28` is a real divergence. `compare_numerics.py` scales
   diff highlighting relative to the tensor's L1 norm: negligible diffs
   get white/near-invisible text, real diffs get bright red with a red
   background tint, and shape mismatches are always full red.

3. **Different FQN formats.** Eager FQNs include `_checkpoint_wrapped_module`
   from AC wrapping. Traced FQNs don't. The logs clean this at dump time,
   but backward FQNs can still differ (e.g. `feed_forward.w2/op_4_mul` vs
   `feed_forward/op_5_mul`) due to autograd graph mapping vs FX node
   metadata using different attribution strategies.

## Key design decisions

**Two capture mechanisms**: `ActivationTracer` (TorchDispatchMode, per-op)
for the main capture path, and `ModuleLevelDebugger` (module hooks, per-module)
as a standalone utility for FSDP-compatible gradient inspection.

**FQNInterpreter for traced mode**: The traced graph replays via
`gm(*inputs)` which bypasses module forwards. `FQNInterpreter` walks
the graph node-by-node, setting `_current_module_name` from
`node.meta["custom"]["module_fqn"]` and `_current_stack_frames` from
`node.meta["stack_trace"]`.

**Backward FQN via autograd graph mapping**: During forward, builds a
`grad_fn → module_fqn` mapping via boundary-aware BFS. During backward,
looks up `_current_autograd_node()` in the mapping. Input grad_fns act
as BFS stop points to prevent child modules from claiming parent-scope
ops.

**detect_anomaly for backward locations**: Enables
`torch.autograd.set_detect_anomaly(check_nan=False)` so autograd saves
forward tracebacks on backward nodes. During backward,
`_current_autograd_node().metadata["traceback_"]` provides the forward
source location.

**CPU float64 stats**: `dump_captures_to_file` computes norms on CPU in
float64 for deterministic reductions (CUDA reductions are
non-deterministic due to parallel summation order).

**Global flag for interpreter routing**: `is_numerics_capture_active()`
is a module-level bool that `GraphTrainer._get_interpreter_cls()` checks.
No callbacks or trainer references needed.

## Known differences between modes

See `NUMERICS_DEBUGGER.md` for full details. Key points:

- **Forward ops**: Match by key. Small diffs possible in bfloat16 (use
  float32 + deterministic for bitwise match).
- **Backward FQN granularity**: Boundary-aware BFS approximates the
  traced graph's `module_fqn` but may differ for ops at module
  boundaries.
- **Op counts**: Eager captures forward + AC recomputation ops (all
  tagged backward). Traced captures forward + explicit backward ops.
- **Loss ops**: Eager uses `ChunkedCELoss` (chunked lm_head), traced
  forces `CrossEntropyLoss` (full lm_head). Different shapes/norms.
- **Fuzzy matching**: `compare_numerics.py` matches backward ops by
  module + op type (ignoring counter), and by shape + L1 norm for
  remaining unmatched ops.

PR authored with Claude.
