### PR TITLE
[MoE] Pad token count to a multiple of sp_size in AllToAllTokenDispater

### DIFF
--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -7,6 +7,7 @@
 from dataclasses import dataclass
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
@@ -34,6 +35,9 @@ class AllToAllDispatchMetadata(LocalDispatchMetadata):
     permuted_indices: torch.Tensor  # for _unpermute
     input_splits: list[int]
     output_splits: list[int]
+    # Pre-pad token count. dispatch() rounds bs*slen up to a multiple of
+    # sp_size when sp_size > 1; combine() slices pad rows off using this.
+    original_num_tokens: int
 
 
 class LocalTokenDispatcher(Configurable):
@@ -223,14 +227,22 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             return super().dispatch(x, top_scores, selected_experts_indices)
 
         ep_size = self.ep_mesh.size()
+        original_num_tokens = x.shape[0]
 
         if self.sp_size > 1:
             assert self.sp_rank >= 0, (
                 "sp_rank must be set before use. "
                 "apply_moe_ep_tp() should set it from tp_mesh._sym_get_coordinate()."
             )
-            # NOTE: If needed, we can pad tokens in case bs*slen is not divisible by TP degree
-            # shape (batch_size * seq_len // ep_size, top_k)
+            # Round bs*slen up to a multiple of sp_size. Pad rows route to
+            # expert 0 with zero scores -> zero contribution to scatter_add.
+            pad = (-original_num_tokens) % self.sp_size
+            if pad > 0:
+                x = F.pad(x, (0, 0, 0, pad))
+                top_scores = F.pad(top_scores, (0, 0, 0, pad))
+                selected_experts_indices = F.pad(
+                    selected_experts_indices, (0, 0, 0, pad)
+                )
             x, top_scores, selected_experts_indices = self._split_along_sp(
                 x, top_scores, selected_experts_indices
             )
@@ -330,6 +342,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
+            original_num_tokens=original_num_tokens,
         )
         return routed_input, num_tokens_per_expert_group, metadata
 
@@ -425,9 +438,26 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
+        # Recover the dispatch-time padded length so scatter_add into
+        # pad-token indices stays in-bounds; pad rows are sliced off below.
+        original_num_tokens = metadata.original_num_tokens
+        if self.sp_size > 1:
+            padded_num_tokens = original_num_tokens + (
+                (-original_num_tokens) % self.sp_size
+            )
+        else:
+            padded_num_tokens = original_num_tokens
+        pad = padded_num_tokens - original_num_tokens
+
         # shared_experts overlaps with the async a2a (NCCL stream).
         # Score application + scatter_add forces the a2a to sync.
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        if shared_experts is not None:
+            shared_out = shared_experts(x)
+            out = F.pad(shared_out, (0, 0, 0, pad)) if pad > 0 else shared_out
+        elif pad > 0:
+            out = x.new_zeros(padded_num_tokens, x.shape[-1])
+        else:
+            out = torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -439,7 +469,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # shard, so token_indices_experts_sorted are 0-based local indices.
         # Offset them to global positions so scatter_add into full x is correct.
         if self.sp_size > 1:
-            local_num_tokens = x.shape[0] // self.sp_size
+            local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
                 metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
             )
@@ -452,6 +482,8 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
             routed_output,
         )
+        if pad > 0:
+            out = out[:original_num_tokens]
         return out
 
 


### PR DESCRIPTION

Pad inside dispatch(): round num_tokens up to the next multiple of sp_size, padding x and top_scores with zeros and selected_experts_indices with 0 (so pad rows route deterministically to expert 0 with zero score). combine() reads metadata.original_num_tokens to size the scatter_add buffer at the padded length and slices the pad rows off before returning. When sp_size == 1 or input is already divisible, behavior is bitwise identical to today.

Pad tokens are numerically inert:
- Zero scores -> contribution to scatter_add is exactly zero either before or after expert compute (independent of score_before_experts).
- Pad indices fall in [original, padded), which is sliced off after scatter_add, so they never appear in the returned output.

Trainer/generator can pad by different amounts depending on their batch shapes; the unpadded portions remain bitwise identical.

- TorchAOTokenDispatcher inherits dispatch/combine and gets the fix for free. 
- DeepEPTokenDispatcher uses a separate metadata type and is unaffected.