### PR TITLE
[MoE] Pad token count to a multiple of sp_size in AllToAllTokenDispatcher

### DIFF
--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -7,8 +7,7 @@
 import unittest
 
 import torch
-import torch.distributed as dist
-from torch.distributed.device_mesh import init_device_mesh
+import torch.nn.functional as F
 
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 
@@ -143,75 +142,49 @@ class TestPermute(unittest.TestCase):
         )
 
 
-class TestAllToAllDispatcherOddTokens(unittest.TestCase):
-    """Verify ``AllToAllTokenDispatcher`` handles an odd ``bs * slen`` not
-    divisible by ``sp_size`` via the SP pad/unpad path (see
-    ``docs/moe_sp_padding.md``).
+class TestSPPaddingRoundTrip(unittest.TestCase):
+    """Verify AllToAllTokenDispatcher's SP padding/unpadding recovers the
+    original tokens for an uneven ``bs * slen`` (not divisible by ``sp_size``).
 
-    Drives dispatch + identity-expert + combine on a single-rank EP mesh once
-    per ``sp_rank``; summing the per-rank outputs must recover the original
-    tokens (the pad row at the tail is masked out by combine).
+    See docs/moe_sp_padding.md. Like TestPermute above, this runs on CPU by
+    only exercising the pure-tensor helper ``_split_along_sp`` rather than
+    going through dispatch()/combine() (which need CUDA + a real EP mesh).
     """
 
-    @classmethod
-    def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest(
-                "AllToAllTokenDispatcher.dispatch uses torch.histc on the "
-                "expert indices, which is not implemented for Long on CPU."
-            )
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="nccl",
-                init_method="tcp://localhost:12361",
-                world_size=1,
-                rank=0,
-            )
-
-    @classmethod
-    def tearDownClass(cls):
-        if dist.is_initialized():
-            dist.destroy_process_group()
-
-    def test_dispatch_combine_odd_tokens(self):
+    def test_round_trip_recovers_original(self):
         original_num_tokens = 7  # not divisible by sp_size=4
         sp_size = 4
-        num_experts = 4
-        top_k = 1
         dim = 3
 
-        device = torch.device("cuda")
-        ep_mesh = init_device_mesh("cuda", (1,), mesh_dim_names=("ep",))
-
-        torch.manual_seed(0)
-        x = torch.randn(original_num_tokens, dim, device=device)
-        top_scores = torch.ones(original_num_tokens, top_k, device=device)
-        # Route every token to expert 0 — keeps the per-rank scatter target
-        # deterministic so summing across SP ranks reconstructs x cleanly.
-        selected_experts_indices = torch.zeros(
-            original_num_tokens, top_k, dtype=torch.long, device=device
-        )
-
         cfg = AllToAllTokenDispatcher.Config(
-            num_experts=num_experts, top_k=top_k, score_before_experts=True
+            num_experts=4, top_k=1, score_before_experts=True
         )
+        dispatcher = AllToAllTokenDispatcher(cfg)
+        dispatcher.sp_size = sp_size
 
-        summed = torch.zeros_like(x)
-        for sp_rank in range(sp_size):
-            dispatcher = AllToAllTokenDispatcher(cfg)
-            dispatcher.ep_mesh = ep_mesh
-            dispatcher.sp_size = sp_size
-            dispatcher.sp_rank = sp_rank
+        x = torch.randn(original_num_tokens, dim)
 
-            routed_input, _, metadata = dispatcher.dispatch(
-                x.clone(), top_scores.clone(), selected_experts_indices.clone()
+        # Pad (matches what dispatch() does on entry).
+        pad = (-original_num_tokens) % sp_size
+        x_padded = F.pad(x, (0, 0, 0, pad))
+        self.assertEqual(x_padded.shape, (8, dim))
+
+        # Split per rank, then reassemble (this is what the EP all-to-all
+        # gathers back in real distributed training).
+        local_num_tokens = x_padded.shape[0] // sp_size
+        per_rank_slices = []
+        for rank in range(sp_size):
+            dispatcher.sp_rank = rank
+            (slice_,) = dispatcher._split_along_sp(x_padded)
+            torch.testing.assert_close(
+                slice_,
+                x_padded[rank * local_num_tokens : (rank + 1) * local_num_tokens],
             )
-            # Identity expert.
-            out = dispatcher.combine(routed_input, metadata, x, shared_experts=None)
-            self.assertEqual(out.shape, x.shape)
-            summed = summed + out
+            per_rank_slices.append(slice_)
+        reassembled = torch.cat(per_rank_slices, dim=0)
 
-        torch.testing.assert_close(summed, x)
+        # Unpad to recover original prefix bitwise.
+        torch.testing.assert_close(reassembled[:original_num_tokens], x)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -7,6 +7,8 @@
 import unittest
 
 import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
 
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 
@@ -139,6 +141,77 @@ class TestPermute(unittest.TestCase):
             set(permuted_indices.tolist()),
             set(range(total)),
         )
+
+
+class TestAllToAllDispatcherOddTokens(unittest.TestCase):
+    """Verify ``AllToAllTokenDispatcher`` handles an odd ``bs * slen`` not
+    divisible by ``sp_size`` via the SP pad/unpad path (see
+    ``docs/moe_sp_padding.md``).
+
+    Drives dispatch + identity-expert + combine on a single-rank EP mesh once
+    per ``sp_rank``; summing the per-rank outputs must recover the original
+    tokens (the pad row at the tail is masked out by combine).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "AllToAllTokenDispatcher.dispatch uses torch.histc on the "
+                "expert indices, which is not implemented for Long on CPU."
+            )
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                init_method="tcp://localhost:12361",
+                world_size=1,
+                rank=0,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_dispatch_combine_odd_tokens(self):
+        original_num_tokens = 7  # not divisible by sp_size=4
+        sp_size = 4
+        num_experts = 4
+        top_k = 1
+        dim = 3
+
+        device = torch.device("cuda")
+        ep_mesh = init_device_mesh("cuda", (1,), mesh_dim_names=("ep",))
+
+        torch.manual_seed(0)
+        x = torch.randn(original_num_tokens, dim, device=device)
+        top_scores = torch.ones(original_num_tokens, top_k, device=device)
+        # Route every token to expert 0 — keeps the per-rank scatter target
+        # deterministic so summing across SP ranks reconstructs x cleanly.
+        selected_experts_indices = torch.zeros(
+            original_num_tokens, top_k, dtype=torch.long, device=device
+        )
+
+        cfg = AllToAllTokenDispatcher.Config(
+            num_experts=num_experts, top_k=top_k, score_before_experts=True
+        )
+
+        summed = torch.zeros_like(x)
+        for sp_rank in range(sp_size):
+            dispatcher = AllToAllTokenDispatcher(cfg)
+            dispatcher.ep_mesh = ep_mesh
+            dispatcher.sp_size = sp_size
+            dispatcher.sp_rank = sp_rank
+
+            routed_input, _, metadata = dispatcher.dispatch(
+                x.clone(), top_scores.clone(), selected_experts_indices.clone()
+            )
+            # Identity expert.
+            out = dispatcher.combine(routed_input, metadata, x, shared_experts=None)
+            self.assertEqual(out.shape, x.shape)
+            summed = summed + out
+
+        torch.testing.assert_close(summed, x)
 
 
 if __name__ == "__main__":

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -438,26 +438,9 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
-        # Recover the dispatch-time padded length so scatter_add into
-        # pad-token indices stays in-bounds; pad rows are sliced off below.
-        original_num_tokens = metadata.original_num_tokens
-        if self.sp_size > 1:
-            padded_num_tokens = original_num_tokens + (
-                (-original_num_tokens) % self.sp_size
-            )
-        else:
-            padded_num_tokens = original_num_tokens
-        pad = padded_num_tokens - original_num_tokens
-
         # shared_experts overlaps with the async a2a (NCCL stream).
         # Score application + scatter_add forces the a2a to sync.
-        if shared_experts is not None:
-            shared_out = shared_experts(x)
-            out = F.pad(shared_out, (0, 0, 0, pad)) if pad > 0 else shared_out
-        elif pad > 0:
-            out = x.new_zeros(padded_num_tokens, x.shape[-1])
-        else:
-            out = torch.zeros_like(x)
+        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -468,11 +451,22 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # When sequence_parallel is active, dispatch splits tokens to a local
         # shard, so token_indices_experts_sorted are 0-based local indices.
         # Offset them to global positions so scatter_add into full x is correct.
+        original_num_tokens = metadata.original_num_tokens
         if self.sp_size > 1:
+            padded_num_tokens = original_num_tokens + (
+                (-original_num_tokens) % self.sp_size
+            )
             local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
                 metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
             )
+            # Drop pad-row entries: their global indices fall in
+            # [original_num_tokens, padded_num_tokens), out of `out`'s range.
+            # scatter_add itself is not padded; `out` matches x's shape.
+            if padded_num_tokens != original_num_tokens:
+                mask = token_indices_experts_sorted < original_num_tokens
+                token_indices_experts_sorted = token_indices_experts_sorted[mask]
+                routed_output = routed_output[mask]
         else:
             token_indices_experts_sorted = metadata.token_indices_experts_sorted
 
@@ -482,8 +476,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
             routed_output,
         )
-        if pad > 0:
-            out = out[:original_num_tokens]
         return out
 
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -7,6 +7,7 @@
 from dataclasses import dataclass
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
@@ -34,6 +35,9 @@ class AllToAllDispatchMetadata(LocalDispatchMetadata):
     permuted_indices: torch.Tensor  # for _unpermute
     input_splits: list[int]
     output_splits: list[int]
+    # Pre-pad token count. dispatch() rounds bs*slen up to a multiple of
+    # sp_size when sp_size > 1; combine() slices pad rows off using this.
+    original_num_tokens: int
 
 
 class LocalTokenDispatcher(Configurable):
@@ -223,14 +227,22 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             return super().dispatch(x, top_scores, selected_experts_indices)
 
         ep_size = self.ep_mesh.size()
+        original_num_tokens = x.shape[0]
 
         if self.sp_size > 1:
             assert self.sp_rank >= 0, (
                 "sp_rank must be set before use. "
                 "apply_moe_ep_tp() should set it from tp_mesh._sym_get_coordinate()."
             )
-            # NOTE: If needed, we can pad tokens in case bs*slen is not divisible by TP degree
-            # shape (batch_size * seq_len // ep_size, top_k)
+            # Round bs*slen up to a multiple of sp_size. Pad rows route to
+            # expert 0 with zero scores -> zero contribution to scatter_add.
+            pad = (-original_num_tokens) % self.sp_size
+            if pad > 0:
+                x = F.pad(x, (0, 0, 0, pad))
+                top_scores = F.pad(top_scores, (0, 0, 0, pad))
+                selected_experts_indices = F.pad(
+                    selected_experts_indices, (0, 0, 0, pad)
+                )
             x, top_scores, selected_experts_indices = self._split_along_sp(
                 x, top_scores, selected_experts_indices
             )
@@ -330,6 +342,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
+            original_num_tokens=original_num_tokens,
         )
         return routed_input, num_tokens_per_expert_group, metadata
 
@@ -425,9 +438,26 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
+        # Recover the dispatch-time padded length so scatter_add into
+        # pad-token indices stays in-bounds; pad rows are sliced off below.
+        original_num_tokens = metadata.original_num_tokens
+        if self.sp_size > 1:
+            padded_num_tokens = original_num_tokens + (
+                (-original_num_tokens) % self.sp_size
+            )
+        else:
+            padded_num_tokens = original_num_tokens
+        pad = padded_num_tokens - original_num_tokens
+
         # shared_experts overlaps with the async a2a (NCCL stream).
         # Score application + scatter_add forces the a2a to sync.
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        if shared_experts is not None:
+            shared_out = shared_experts(x)
+            out = F.pad(shared_out, (0, 0, 0, pad)) if pad > 0 else shared_out
+        elif pad > 0:
+            out = x.new_zeros(padded_num_tokens, x.shape[-1])
+        else:
+            out = torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -439,7 +469,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # shard, so token_indices_experts_sorted are 0-based local indices.
         # Offset them to global positions so scatter_add into full x is correct.
         if self.sp_size > 1:
-            local_num_tokens = x.shape[0] // self.sp_size
+            local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
                 metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
             )
@@ -452,6 +482,8 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
             routed_output,
         )
+        if pad > 0:
+            out = out[:original_num_tokens]
         return out
 
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -460,6 +460,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             token_indices_experts_sorted = (
                 metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
             )
+            assert isinstance(token_indices_experts_sorted, torch.Tensor)
             # Drop pad-row entries: their global indices fall in
             # [original_num_tokens, padded_num_tokens), out of `out`'s range.
             # scatter_add itself is not padded; `out` matches x's shape.
@@ -469,8 +470,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
                 routed_output = routed_output[mask]
         else:
             token_indices_experts_sorted = metadata.token_indices_experts_sorted
-
-        assert isinstance(token_indices_experts_sorted, torch.Tensor)
         out = deterministic_scatter_add(
             out,
             token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3172
* #3171
* #3142
* __->__ #3193

Today the dispatcher's _split_along_sp() raises when num_tokens (bs * slen) is not divisible by sp_size (= TP degree). Real workloads with varlen prompts can land on non-divisible totals and crash the MoE forward.

Pad inside dispatch(): round num_tokens up to the next multiple of sp_size, padding x and top_scores with zeros and selected_experts_indices with 0 (so pad rows route deterministically to expert 0 with zero score). combine() reads metadata.original_num_tokens to size the scatter_add buffer at the padded length and slices the pad rows off before returning. When sp_size == 1 or input is already divisible, behavior is bitwise identical to today.

Pad tokens are numerically inert:
- Zero scores -> contribution to scatter_add is exactly zero either before or after expert compute (independent of score_before_experts).
- Pad indices fall in [original, padded), which is sliced off after scatter_add, so they never appear in the returned output.

Trainer/generator can pad by different amounts depending on their batch shapes; the unpadded portions remain bitwise identical.

- TorchAOTokenDispatcher inherits dispatch/combine and gets the fix for free. 
- DeepEPTokenDispatcher uses a separate metadata type and is unaffected.