### PR TITLE
[GraphTrainer] Skip identity-slice rewrite when start/end/step are dynamic Nodes

### DIFF
--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -132,6 +132,16 @@ def remove_identity_slice_pass(
         end = args[3] if len(args) > 3 else sys.maxsize
         step = args[4] if len(args) > 4 else 1
 
+        # Skip if start/end/step are dynamic graph values (FX Nodes) — we
+        # can't prove the slice is identity without concrete/symbolic values
+        # to compare.
+        if (
+            isinstance(start, torch.fx.Node)
+            or isinstance(end, torch.fx.Node)
+            or isinstance(step, torch.fx.Node)
+        ):
+            continue
+
         if start != 0 or step != 1:
             continue
 

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
+import sys
 from unittest.mock import patch
 
 import torch
@@ -1075,6 +1076,55 @@ class TestRemoveIdentitySlicePass(TestCase):
         self.assertEqual(self._count_slice_nodes(gm), 2)
         remove_identity_slice_pass(gm)
         self.assertEqual(self._count_slice_nodes(gm), 0)
+
+    def _build_dynamic_slice_gm(
+        self,
+        *,
+        dynamic_arg: str,
+    ) -> torch.fx.GraphModule:
+        """Build a slice graph where one of start/end/step is a Node."""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        # sym_size is just a convenient way to produce a Node — its concrete
+        # value is irrelevant, what matters is that the arg is an FX Node.
+        sym_node = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        start = sym_node if dynamic_arg == "start" else 0
+        end = sym_node if dynamic_arg == "end" else sys.maxsize
+        step = sym_node if dynamic_arg == "step" else 1
+        sliced = graph.call_function(
+            torch.ops.aten.slice.Tensor, args=(x, 0, start, end, step)
+        )
+        graph.output(sliced)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with FakeTensorMode() as fake_mode:
+            fake_val = fake_mode.from_tensor(torch.empty(8, 16))
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                node.meta["val"] = fake_val
+        return gm
+
+    def test_dynamic_end_skipped(self):
+        """Slices whose ``end`` is an FX Node (dynamic shape at runtime) must
+        be left alone — we can't prove identity at pass time."""
+        gm = self._build_dynamic_slice_gm(dynamic_arg="end")
+        # Must not raise and must not remove the slice (can't prove identity).
+        remove_identity_slice_pass(gm)
+        self.assertEqual(self._count_slice_nodes(gm), 1)
+
+    def test_dynamic_start_skipped(self):
+        """Slices whose ``start`` is an FX Node must be left alone."""
+        gm = self._build_dynamic_slice_gm(dynamic_arg="start")
+        remove_identity_slice_pass(gm)
+        self.assertEqual(self._count_slice_nodes(gm), 1)
+
+    def test_dynamic_step_skipped(self):
+        """Slices whose ``step`` is an FX Node must be left alone."""
+        gm = self._build_dynamic_slice_gm(dynamic_arg="step")
+        remove_identity_slice_pass(gm)
+        self.assertEqual(self._count_slice_nodes(gm), 1)
 
 
 class TestAnnotateModuleFqns(TestCase):


### PR DESCRIPTION
Stacked PRs:
 * #3198
 * #3197
 * #3199
 * __->__#3195


--- --- ---

### [GraphTrainer] Skip identity-slice rewrite when start/end/step are dynamic Nodes


remove_identity_slice_pass compared `end >= dim_size` (and used start/step
as concrete ints) unconditionally. When any of start/end/step is itself an
FX Node (a dynamic value produced by a prior op, e.g. from a symbolic
shape query) this raised
`TypeError: '>=' not supported between instances of 'Node' and 'SymInt'`
or gave a wrong answer when comparing a Node to 0/1.

Skip such nodes: we can't prove a dynamic slice is identity at pass time,
so leave it alone. Adds unit tests that reproduce the failure for each of
start, end, and step being a dynamic Node.

Co-Authored with Claude
