### PR TITLE
[graph_trainer] Compose simple_fsdp with torchao FSDP hooks

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -29,6 +30,107 @@ from torchtitan.protocols.module import Module
 _active_parametrization = True
 
 
+@dataclass(frozen=True)
+class _FSDPPostAllGatherState:
+    """Values produced by pre-all-gather and consumed by post-all-gather.
+
+    metadata: Hook-defined auxiliary values needed to reconstruct the tensor
+        subclass after all-gather, e.g. torchao Float8 scale tensors.
+    param_dtype: Logical parameter dtype for the reconstructed wrapper. This
+        is not necessarily the communication tensor dtype.
+    """
+
+    metadata: Any
+    param_dtype: torch.dtype
+
+
+class _PostAllGather(torch.autograd.Function):
+    """Call a tensor subclass's FSDP post-all-gather hook differentiably.
+
+    The hook reconstructs the wrapper subclass around the all-gathered local
+    tensor. When the gathered input is a DTensor, this also restores the DTensor
+    spec around the hook-produced local wrapper.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        gathered: torch.Tensor,
+        wrapper: torch.Tensor,
+        post_all_gather_state: _FSDPPostAllGatherState,
+    ) -> torch.Tensor:
+        gathered_local = (
+            gathered._local_tensor if isinstance(gathered, DTensor) else gathered
+        )
+        # FSDP2 uses the returned inner tensors to manage storage lifetime for
+        # its cached unsharded parameter. SimpleFSDP keeps the returned wrapper
+        # live directly through autograd, so there is no separate storage to free.
+        output, _ = wrapper.fsdp_post_all_gather(
+            (gathered_local,),
+            post_all_gather_state.metadata,
+            post_all_gather_state.param_dtype,
+        )
+        if isinstance(gathered, DTensor):
+            return DTensor(
+                output,
+                gathered._spec,
+                requires_grad=gathered.requires_grad,
+            )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output, None, None
+
+
+class _PreAllGatherDTensor(torch.autograd.Function):
+    """Call a DTensor-local wrapper's FSDP pre-all-gather hook differentiably.
+
+    torchao pre-all-gather hooks return plain tensors to communicate. Taking the
+    original wrapper-containing DTensor as the Function input preserves the
+    autograd edge from the eventual loss back to the wrapped parameter.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        dtensor: DTensor,
+        device_mesh: DeviceMesh,
+        mp_policy: "MixedPrecisionPolicy",
+    ) -> tuple[DTensor, _FSDPPostAllGatherState]:
+        wrapper = dtensor._local_tensor
+        assert mp_policy.param_dtype is not None, (
+            "FSDP hook mixed precision policy should have a concrete param dtype "
+            "before calling fsdp_pre_all_gather"
+        )
+        all_gather_inputs, metadata = wrapper.fsdp_pre_all_gather(
+            device_mesh,
+            dtensor.size(),
+            dtensor.stride(),
+            None,
+            mp_policy,
+        )
+        assert len(all_gather_inputs) == 1, (
+            "simple_fsdp currently supports tensor subclass FSDP hooks with "
+            f"one all-gather input; got {len(all_gather_inputs)}"
+        )
+        return (
+            DTensor(
+                all_gather_inputs[0],
+                dtensor._spec,
+                requires_grad=dtensor.requires_grad,
+            ),
+            _FSDPPostAllGatherState(
+                metadata=metadata,
+                param_dtype=mp_policy.param_dtype,
+            ),
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output, _grad_post_all_gather_state):
+        return grad_output, None, None
+
+
 @contextmanager
 def disable_active_parametrization() -> Generator[None, None, None]:
     global _active_parametrization
@@ -43,6 +145,23 @@ def disable_active_parametrization() -> Generator[None, None, None]:
 class MixedPrecisionPolicy:
     param_dtype: torch.dtype | None = None
     reduce_dtype: torch.dtype | None = None
+
+
+def _has_fsdp_all_gather_hooks(tensor: torch.Tensor) -> bool:
+    has_pre_hook = hasattr(tensor, "fsdp_pre_all_gather")
+    has_post_hook = hasattr(tensor, "fsdp_post_all_gather")
+    if has_pre_hook != has_post_hook:
+        raise AssertionError(
+            "simple_fsdp requires tensor subclasses to define both "
+            "fsdp_pre_all_gather and fsdp_post_all_gather"
+        )
+    return has_pre_hook
+
+
+def _uses_fsdp_all_gather_hooks(param: torch.Tensor) -> bool:
+    if isinstance(param, DTensor):
+        return _has_fsdp_all_gather_hooks(param._local_tensor)
+    return _has_fsdp_all_gather_hooks(param)
 
 
 def _distribute_dtensor(
@@ -144,7 +263,7 @@ def _register_parametrization(
     """
     param_name_to_property = {
         param_name: property(
-            lambda self, pn=param_name: parametrization(self._parameters[pn])
+            lambda self, pn=param_name: parametrization(self._parameters[pn], pn)
         )
         for param_name in param_names
     }
@@ -172,6 +291,7 @@ class ReplicateComputation(Module):
         mode: str,
         mp_policy: MixedPrecisionPolicy | None,
         full_dtensor: bool = False,
+        fsdp_hook_param_names: set[str] | None = None,
     ) -> None:
         super().__init__()
         self.device_mesh = device_mesh
@@ -185,8 +305,39 @@ class ReplicateComputation(Module):
         self.param_dtype: torch.dtype | None = mp_policy.param_dtype
         self.reduce_dtype: torch.dtype | None = mp_policy.reduce_dtype
         self.full_dtensor = full_dtensor
+        self.fsdp_hook_param_names = fsdp_hook_param_names or set()
 
-    def replicate_compute(self, x: DTensor) -> torch.Tensor:
+    def _fsdp_pre_all_gather_dtensor(
+        self,
+        dtensor: DTensor,
+    ) -> tuple[DTensor, _FSDPPostAllGatherState]:
+        wrapper = dtensor._local_tensor
+        # Match FSDP2's post-hook dtype contract: use the mixed precision
+        # param dtype when configured, otherwise fall back to the original
+        # wrapper dtype as the logical reconstructed parameter dtype.
+        param_dtype = self.param_dtype or wrapper.dtype
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=param_dtype,
+            reduce_dtype=self.reduce_dtype,
+        )
+        pre_all_gather_dtensor, post_all_gather_state = _PreAllGatherDTensor.apply(
+            dtensor,
+            self.device_mesh,
+            mp_policy,
+        )
+        return pre_all_gather_dtensor, post_all_gather_state
+
+    def replicate_compute(self, x: DTensor, param_name: str = "") -> torch.Tensor:
+        original_dtensor = x
+        post_all_gather_state = None
+        forward_dtype = self.param_dtype
+        use_fsdp_hooks = param_name in self.fsdp_hook_param_names
+        if use_fsdp_hooks:
+            x, post_all_gather_state = self._fsdp_pre_all_gather_dtensor(x)
+            # The pre-all-gather hook applies mp_policy.param_dtype when
+            # producing the communication tensor; avoid a second DTensor cast.
+            forward_dtype = None
+
         # data parallel runtime replicate parameters and do local compute
         # the gradients are partial tensors that needs to perform reduction
         # (i.e. DDP: allreduce, FSDP: reduce_scatter, HSDP: mix of both)
@@ -209,7 +360,7 @@ class ReplicateComputation(Module):
             # DDP's bwd all-reduce on dp_mesh
             replicated_dtensor = sharded_dtensor.redistribute(
                 placements=self.compute_placements,
-                forward_dtype=self.param_dtype,
+                forward_dtype=forward_dtype,
                 backward_dtype=self.reduce_dtype,
             )
 
@@ -231,7 +382,7 @@ class ReplicateComputation(Module):
         elif non_dp_mesh_dims == 0:
             output = x.redistribute(
                 placements=self.compute_placements,
-                forward_dtype=self.param_dtype,
+                forward_dtype=forward_dtype,
                 backward_dtype=self.reduce_dtype,
             )
 
@@ -242,9 +393,17 @@ class ReplicateComputation(Module):
                 f"Unsupported replicate compute on placement {x._spec.placements} for DTensor {x}"
             )
 
-        return output
+        if not use_fsdp_hooks:
+            return output
 
-    def forward(self, x: DTensor) -> torch.Tensor:
+        assert post_all_gather_state is not None
+        return _PostAllGather.apply(
+            output,
+            original_dtensor._local_tensor,
+            post_all_gather_state,
+        )
+
+    def forward(self, x: DTensor, param_name: str = "") -> torch.Tensor:
         global _active_parametrization
         # This should never be set to true during forward, only outside for model
         # inspection / debugging / initialization
@@ -254,8 +413,7 @@ class ReplicateComputation(Module):
         if not _active_parametrization:
             return x
 
-        output = self.replicate_compute(x)
-        return output
+        return self.replicate_compute(x, param_name)
 
 
 def data_parallel(
@@ -289,8 +447,12 @@ def data_parallel(
         if "SimpleFSDP" in mod.__class__.__name__:
             continue
 
+        fsdp_hook_param_names: set[str] = set()
         for p_name, p in params_dict.items():
             if p is not None and p.numel() > 0:
+                if _uses_fsdp_all_gather_hooks(p):
+                    fsdp_hook_param_names.add(p_name)
+
                 distribute_tensor_func = (
                     _distribute_dtensor if isinstance(p, DTensor) else distribute_tensor
                 )
@@ -324,6 +486,7 @@ def data_parallel(
                 mode,
                 mp_policy=mp_policy,
                 full_dtensor=full_dtensor,
+                fsdp_hook_param_names=fsdp_hook_param_names,
             ),
         )
     return model

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
 import unittest
 from unittest.mock import patch
 
@@ -11,9 +12,51 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from torch.distributed._tensor import DTensor, Replicate
+from torch.distributed.device_mesh import DeviceMesh
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
 from torchtitan.config.configs import TrainingConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+from torchtitan.experiments.graph_trainer.make_fx_tracer import trace_train_step
+
+_HAS_TORCHAO = importlib.util.find_spec("torchao") is not None
+
+
+def _single_rank_parallel_dims() -> ParallelDims:
+    return ParallelDims(
+        dp_replicate=1,
+        dp_shard=1,
+        cp=1,
+        tp=1,
+        pp=1,
+        ep=1,
+        world_size=1,
+    )
+
+
+def _bf16_mixed_precision_training() -> TrainingConfig:
+    return TrainingConfig(
+        mixed_precision_param="bfloat16",
+        mixed_precision_reduce="float32",
+    )
+
+
+def _replicated_dtensor(tensor: torch.Tensor, device_type: str) -> DTensor:
+    mesh = DeviceMesh(device_type, [0], mesh_dim_names=("tp",))
+    return DTensor.from_local(tensor, mesh, (Replicate(),))
+
+
+def _count_op(gm: torch.fx.GraphModule, target) -> int:
+    return sum(
+        1
+        for node in gm.graph.nodes
+        if node.op == "call_function" and node.target is target
+    )
 
 
 class TestApplySimpleFSDPSingleRank(unittest.TestCase):
@@ -40,25 +83,14 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         simple_fsdp wrap, parameters silently stay in fp32 on a single GPU and
         any downstream bf16-only kernel (e.g. MXFP8) breaks.
         """
-        parallel_dims = ParallelDims(
-            dp_replicate=1,
-            dp_shard=1,
-            cp=1,
-            tp=1,
-            pp=1,
-            ep=1,
-            etp=1,
-            world_size=1,
-        )
-        training = TrainingConfig(
-            mixed_precision_param="bfloat16",
-            mixed_precision_reduce="float32",
-        )
-
         model = nn.Linear(8, 8)
         self.assertEqual(model.weight.dtype, torch.float32)
 
-        model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+        model = apply_simple_fsdp(
+            model,
+            parallel_dims=_single_rank_parallel_dims(),
+            training=_bf16_mixed_precision_training(),
+        )
 
         # Parametrization replaces ``weight`` access with a bf16 cast via
         # ``redistribute(forward_dtype=...)``.
@@ -75,6 +107,267 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         y = model(x)
         self.assertEqual(y.dtype, torch.bfloat16)
 
+
+class _GroupedMMExperts(nn.Module):
+    def __init__(self, *, num_experts: int, dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(num_experts, hidden_dim, dim))
+        self.w2 = nn.Parameter(torch.randn(num_experts, dim, hidden_dim))
+
+    def forward(
+        self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor
+    ) -> torch.Tensor:
+        w1 = self.w1.to_local() if isinstance(self.w1, DTensor) else self.w1
+        w2 = self.w2.to_local() if isinstance(self.w2, DTensor) else self.w2
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+        h = torch._grouped_mm(
+            x.bfloat16(),
+            w1.bfloat16().transpose(-2, -1),
+            offs=offsets,
+        )
+        return torch._grouped_mm(
+            h,
+            w2.bfloat16().transpose(-2, -1),
+            offs=offsets,
+        ).type_as(x)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+@unittest.skipUnless(_HAS_TORCHAO, "torchao required")
+class TestFSDPHookGraphCaptureSingleRank(unittest.TestCase):
+    """Verify torchao FSDP-hook wrappers survive simple_fsdp graph capture."""
+
+    def setUp(self):
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                init_method="tcp://localhost:12359",
+                world_size=1,
+                rank=0,
+            )
+        torch.manual_seed(0)
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _require_fp8(self, op_name: str) -> None:
+        if torch.cuda.get_device_capability() < (8, 9):
+            self.skipTest(f"FP8 {op_name} requires SM89 or newer")
+
+    def _require_mxfp8_grouped_mm(self) -> None:
+        try:
+            from torchao.prototype.moe_training.mxfp8_grouped_mm import (
+                _SM100_KERNELS_AVAILABLE,
+            )
+        except ImportError:
+            _SM100_KERNELS_AVAILABLE = False
+
+        supported = (
+            torch.cuda.get_device_capability() >= (10, 0) and _SM100_KERNELS_AVAILABLE
+        )
+        if not supported:
+            self.skipTest("MXFP8 grouped GEMM requires SM100 torchao kernels")
+
+    def _require_mxfp8_scaled_mm(self) -> None:
+        if torch.cuda.get_device_capability() < (10, 0):
+            self.skipTest("MXFP8 scaled GEMM requires SM100")
+
+    def _grouped_mm_quantization_config(self, quantization: str):
+        if quantization == "fp8":
+            self._require_fp8("grouped GEMM")
+            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+
+            return Float8TrainingOpConfig()
+
+        if quantization == "mxfp8":
+            self._require_mxfp8_grouped_mm()
+            from torchao.prototype.moe_training.config import (
+                MXFP8TrainingOpConfig,
+                MXFP8TrainingRecipe,
+            )
+
+            return MXFP8TrainingOpConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL)
+
+        raise AssertionError(f"Unknown quantization type: {quantization}")
+
+    def _apply_simple_fsdp_to_quantized_model(
+        self,
+        model: nn.Module,
+        *,
+        storage: str,
+        dtensor_param_names: tuple[str, ...],
+    ) -> nn.Module:
+        if storage == "dtensor":
+            for param_name in dtensor_param_names:
+                param = getattr(model, param_name)
+                setattr(
+                    model,
+                    param_name,
+                    nn.Parameter(
+                        _replicated_dtensor(param, "cuda"),
+                        requires_grad=param.requires_grad,
+                    ),
+                )
+        elif storage != "plain":
+            raise AssertionError(f"Unknown storage type: {storage}")
+
+        return apply_simple_fsdp(
+            model,
+            parallel_dims=_single_rank_parallel_dims(),
+            training=_bf16_mixed_precision_training(),
+        )
+
+    def _build_quantized_scaled_mm_model(
+        self,
+        *,
+        quantization: str,
+        storage: str,
+    ) -> nn.Module:
+        linear_kwargs = dict(in_features=64, out_features=64, bias=False)
+        if quantization == "fp8":
+            self._require_fp8("scaled GEMM")
+
+            from torchao.float8 import Float8LinearConfig as TorchAOFloat8LinearConfig
+
+            from torchtitan.components.quantization import Float8Linear
+
+            assert Float8Linear is not None
+            model = Float8Linear(
+                Float8Linear.Config(
+                    **linear_kwargs,
+                    _torchao_config=TorchAOFloat8LinearConfig.from_recipe_name(
+                        "rowwise"
+                    ),
+                )
+            ).cuda()
+        elif quantization == "mxfp8":
+            self._require_mxfp8_scaled_mm()
+
+            from torchtitan.components.quantization import MXFP8Linear
+
+            model = MXFP8Linear(
+                MXFP8Linear.Config(
+                    **linear_kwargs,
+                    _recipe_name="mxfp8_rceil",
+                )
+            ).cuda()
+        else:
+            raise AssertionError(f"Unknown quantization type: {quantization}")
+
+        return self._apply_simple_fsdp_to_quantized_model(
+            model,
+            storage=storage,
+            dtensor_param_names=("weight",),
+        )
+
+    def _build_quantized_grouped_mm_model(
+        self,
+        *,
+        quantization: str,
+        storage: str,
+    ) -> nn.Module:
+        from torchao.quantization.quant_api import quantize_
+
+        model = _GroupedMMExperts(num_experts=2, dim=64, hidden_dim=64).cuda()
+        quantize_(
+            model,
+            config=self._grouped_mm_quantization_config(quantization),
+            filter_fn=lambda mod, _fqn: isinstance(mod, _GroupedMMExperts),
+        )
+
+        return self._apply_simple_fsdp_to_quantized_model(
+            model,
+            storage=storage,
+            dtensor_param_names=("w1", "w2"),
+        )
+
+    @parametrize("quantization", ("fp8", "mxfp8"))
+    @parametrize("storage", ("plain", "dtensor"))
+    def test_scaled_mm_in_graph(self, quantization: str, storage: str):
+        """Graph capture keeps quantized linear weights on scaled GEMMs."""
+
+        model = self._build_quantized_scaled_mm_model(
+            quantization=quantization,
+            storage=storage,
+        )
+        x = torch.randn(
+            32,
+            64,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        if storage == "dtensor":
+            x = _replicated_dtensor(x, "cuda")
+
+        def forward_fn(model, x):
+            out = model(x)
+            return out.to_local() if isinstance(out, DTensor) else out
+
+        traced = trace_train_step(forward_fn)(model, x)
+
+        num_scaled_mm = _count_op(traced.gm, torch.ops.aten._scaled_mm.default)
+        num_mm = _count_op(traced.gm, torch.ops.aten.mm.default)
+
+        self.assertGreaterEqual(
+            num_scaled_mm,
+            1,
+            "Expected aten._scaled_mm in the captured graph. "
+            "simple_fsdp likely bypassed the quantized linear compute path.",
+        )
+        self.assertEqual(
+            num_mm,
+            0,
+            f"Expected no plain aten.mm in the captured graph. Found {num_mm}.",
+        )
+
+    @parametrize("quantization", ("fp8", "mxfp8"))
+    @parametrize("storage", ("plain", "dtensor"))
+    def test_scaled_grouped_mm_in_graph(self, quantization: str, storage: str):
+        """Graph capture keeps quantized MoE weights on scaled grouped GEMMs."""
+
+        model = self._build_quantized_grouped_mm_model(
+            quantization=quantization,
+            storage=storage,
+        )
+        x = torch.randn(
+            32,
+            64,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        num_tokens_per_expert = torch.tensor(
+            [16, 16],
+            dtype=torch.int64,
+            device="cuda",
+        )
+
+        def forward_fn(model, x, num_tokens_per_expert):
+            return model(x, num_tokens_per_expert)
+
+        traced = trace_train_step(forward_fn)(model, x, num_tokens_per_expert)
+
+        num_scaled_grouped_mm = _count_op(
+            traced.gm, torch.ops.aten._scaled_grouped_mm.default
+        )
+        num_grouped_mm = _count_op(traced.gm, torch.ops.aten._grouped_mm.default)
+
+        self.assertGreaterEqual(
+            num_scaled_grouped_mm,
+            2,
+            "Expected aten._scaled_grouped_mm in the captured graph. "
+            "simple_fsdp likely stripped the torchao training wrapper "
+            "before grouped GEMM.",
+        )
+        self.assertEqual(
+            num_grouped_mm,
+            0,
+            "Expected no plain aten._grouped_mm in the captured graph. "
+            f"Found {num_grouped_mm}.",
+        )
+
+
+instantiate_parametrized_tests(TestFSDPHookGraphCaptureSingleRank)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #3198
 * __->__#3197


--- --- ---

### [graph_trainer] Compose simple_fsdp with torchao FSDP hooks


simple_fsdp distributes parameters into DTensor storage, but torchao tensor
subclasses such as FP8/MXFP8 wrappers need their FSDP pre/post all-gather hooks
to prepare communication tensors and rebuild wrapper tensors after all-gather.
Bypassing those hooks can strip wrapper semantics before the value reaches the
linear or grouped MoE op.

Detect params whose tensor, or DTensor local tensor, defines both
fsdp_pre_all_gather and fsdp_post_all_gather. Preserve the wrapper in DTensor
storage. During ReplicateComputation, run the pre-hook through an autograd
Function before the existing redistribute path, then run the post-hook after
all-gather. The pre-hook bridge keeps the autograd edge from the wrapper param
to the hook-produced plain communication tensor; the post-hook bridge restores
wrapper outputs, including DTensor outputs when TP/EP placements are preserved.

Add SimpleFSDP unit coverage for hook composition with both a plain wrapper
param and a DTensor-local wrapper param, plus the existing MXFP8 graph capture
coverage.
