### PR TITLE
[graph_trainer] Add MXFP8 and Float8 debugmodel configs

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -54,6 +54,7 @@ jobs:
 
         python -m pip install --force-reinstall --pre \
           torch --index-url https://download.pytorch.org/whl/nightly/cu130
+        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu130
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -5,11 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.components.loss import CrossEntropyLoss
+from torchtitan.components.quantization import (
+    Float8GroupedExpertsConverter,
+    Float8LinearConverter,
+    MXFP8GroupedExpertsConverter,
+    MXFP8LinearConverter,
+)
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+from torchtitan.models.deepseek_v3 import model_registry as dsv3_model_registry
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
     deepseek_v3_671b,
@@ -46,7 +53,52 @@ def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
     return config
 
 
-def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> (GraphTrainer.Config):
+def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
+    base = deepseek_v3_debugmodel()
+    base.model_spec = dsv3_model_registry(
+        "debugmodel",
+        moe_comm_backend="standard",
+        quantization=[
+            MXFP8LinearConverter.Config(
+                model_compile_enabled=True,
+                # Include-list of FQN substrings. Skips wkv_a/wkv_b (K/V
+                # projections), router.gate, and lm_head.
+                fqns=[
+                    "attention.wq",
+                    "attention.wo",
+                    "feed_forward",
+                    "shared_experts",
+                ],
+            ),
+            MXFP8GroupedExpertsConverter.Config(model_compile_enabled=True),
+        ],
+    )
+    config = to_graph_trainer_config(base, model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_float8_ep() -> GraphTrainer.Config:
+    base = deepseek_v3_debugmodel_ep()
+    model_compile_enabled = base.compile.enable and "model" in base.compile.components
+    base.model_spec = dsv3_model_registry(
+        "debugmodel",
+        quantization=[
+            Float8LinearConverter.Config(
+                filter_fqns=["output", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+            Float8GroupedExpertsConverter.Config(
+                model_compile_enabled=model_compile_enabled
+            ),
+        ],
+    )
+    config = to_graph_trainer_config(base, model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel_flex_attn(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -4,17 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+from torchtitan.models.llama3 import model_registry as llama3_model_registry
 from torchtitan.models.llama3.config_registry import (
     llama3_405b,
     llama3_70b,
     llama3_8b,
     llama3_debugmodel,
     llama3_debugmodel_flex_attn,
+    llama3_debugmodel_float8,
 )
 
 from . import model_registry
@@ -26,8 +29,31 @@ def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
     return config
 
 
-def graph_trainer_llama3_debugmodel_flex_attn() -> (GraphTrainer.Config):
+def graph_trainer_llama3_debugmodel_mxfp8() -> GraphTrainer.Config:
+    base = llama3_debugmodel()
+    base.model_spec = llama3_model_registry(
+        "debugmodel",
+        quantization=[
+            MXFP8LinearConverter.Config(
+                model_compile_enabled=True,
+                # Include-list of FQN substrings. Skips wk, wv, lm_head.
+                fqns=["attention.wq", "attention.wo", "feed_forward"],
+            ),
+        ],
+    )
+    config = to_graph_trainer_config(base, model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_flex_attn() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_debugmodel_flex_attn(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(llama3_debugmodel_float8(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -553,6 +553,77 @@ def build_graph_trainer_default_test_list() -> list[OverrideDefinitions]:
     return _build_llama3_tests()
 
 
+def _build_float8_tests() -> list[OverrideDefinitions]:
+    """Float8 tests (require H100 or newer)."""
+    return [
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_float8",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+Float8",
+            "aot_fx_trace_llama3_fsdp_tp_float8",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_float8",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+Float8+full_inductor",
+            "aot_fx_trace_llama3_fsdp_tp_float8_full_inductor",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel_float8_ep",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP+Float8",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_float8",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel_float8_ep",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 2",
+                    "--debug.moe_force_load_balance",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP+Float8+full_inductor",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_float8_full_inductor",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+    ]
+
+
 def _build_async_tp_tests() -> list[OverrideDefinitions]:
     """Async TP tests (require NVLink for symmetric memory)."""
     return [
@@ -581,8 +652,13 @@ def _build_async_tp_tests() -> list[OverrideDefinitions]:
 
 
 def build_graph_trainer_h100_test_list() -> list[OverrideDefinitions]:
-    """DeepSeek-v3 + Qwen3 + async_tp tests (for H100 machines)."""
-    return _build_deepseek_v3_tests() + _build_qwen3_tests() + _build_async_tp_tests()
+    """DeepSeek-v3 + Qwen3 + Float8 + async_tp tests (for H100 machines)."""
+    return (
+        _build_deepseek_v3_tests()
+        + _build_qwen3_tests()
+        + _build_float8_tests()
+        + _build_async_tp_tests()
+    )
 
 
 _TEST_SUITES_FUNCTION = {


### PR DESCRIPTION
Stacked PRs:
 * __->__#3198
 * #3197


--- --- ---

### [graph_trainer] Add MXFP8 and Float8 debugmodel configs


Add graph_trainer debug-model configs for MXFP8 on Llama 3 and DeepSeek v3, plus Float8 graph_trainer debug-model configs for Llama 3 and DeepSeek v3 EP.

Keep the DeepSeek v3 Float8 EP config local to graph_trainer: it starts from deepseek_v3_debugmodel_ep(), swaps in Float8 linear and grouped-expert converters, then enables the graph_trainer compile config. Also add 4-GPU H100 graph_trainer Float8 integration cases for AOT FX trace with and without full Inductor, and install torchao nightly in the graph_trainer H100 workflow so those cases can run.

Co-Authored with Claude
