### PR TITLE
[mxfp8] Fix MXFP8GroupedExpertsConverter to actually swap GroupedExperts params

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -162,7 +162,15 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                         instance = base_cls.build(self, **kwargs)
                         recipe = MXFP8TrainingRecipe(recipe_name)
                         mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-                        quantize_(instance, config=mxfp8_op_config)
+                        # torchao's quantize_ defaults filter_fn to _is_linear,
+                        # which skips GroupedExperts. Pass a filter that matches
+                        # the built GroupedExperts instance so its nn.Parameters
+                        # (w1/w2/w3) get swapped to MXFP8 wrapper subclasses.
+                        quantize_(
+                            instance,
+                            config=mxfp8_op_config,
+                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+                        )
                         return instance
 
                 _converted_config_cache[base_cls] = MXFP8GroupedExpertsConfig


### PR DESCRIPTION
Stacked PRs:
 * #3198
 * #3197
 * __->__#3199


--- --- ---

### [mxfp8] Fix MXFP8GroupedExpertsConverter to actually swap GroupedExperts params


torchao's quantize_ defaults filter_fn to _is_linear, which only matches
nn.Linear modules. GroupedExperts is not an nn.Linear, so the quantize_
call inside MXFP8GroupedExpertsConfig.build() was a silent no-op — w1/w2/w3
stayed as plain tensors and torch._grouped_mm never saw an MXFP8 wrapper,
so the captured FX graph showed plain aten._grouped_mm instead of the
quantized scaled_grouped_mm path.

Pass a custom filter_fn that matches the built GroupedExperts instance so
its nn.Parameters get swapped to MXFP8 wrapper subclasses. Now the
__torch_function__ override on _grouped_mm fires correctly and routes to
_to_mxfp8_then_scaled_grouped_mm during forward.

Co-Authored with Claude
