### PR TITLE
fix(dist_reduce): run mesh all_reduce when DTensor mesh is orthogonal

### DIFF
--- a/tests/unit_tests/test_dist_reduce_dtensor.py
+++ b/tests/unit_tests/test_dist_reduce_dtensor.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for _dist_reduce on DTensor inputs.
+
+Covers two cases:
+
+1. DTensor whose mesh equals the requested reduction mesh:
+   ``full_tensor()`` already reduces over that mesh, so the explicit
+   all_reduce must be skipped to avoid double-counting.
+
+2. DTensor whose mesh is *orthogonal* to the requested reduction mesh
+   (e.g. a TP-Replicated loss tensor reduced across the batch mesh):
+   ``full_tensor()`` is a no-op for Replicate placements, so the
+   explicit all_reduce must still run on the requested mesh.
+
+Before the fix, the second case was silently dropped — the function
+returned ``float(x.full_tensor().item())`` for every DTensor input,
+so reductions on orthogonal meshes never ran.
+"""
+
+import torch
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Partial, Replicate
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.distributed import utils as dist_utils
+
+
+class TestDistReduceDTensor(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @with_comms
+    def test_dtensor_orthogonal_mesh_reduces(self):
+        """A Replicated-on-TP loss tensor reduced across batch_mesh.
+
+        With world=4, build a 2D mesh ('batch', 'tp') of shape (2, 2).
+        Place a tensor with the per-rank value `1.0 + batch_rank` on the
+        TP mesh as Replicate (so all 4 ranks see their batch_rank's value
+        replicated across TP). Reduce-sum across batch_mesh: expected
+        sum = 1.0 + 2.0 = 3.0 (each batch_rank contributes once).
+        """
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, 2), mesh_dim_names=("batch", "tp")
+        )
+        batch_mesh = mesh_2d["batch"]
+        tp_mesh = mesh_2d["tp"]
+
+        # Each rank's local value depends on its batch position.
+        batch_rank = batch_mesh.get_local_rank()
+        local = torch.tensor(
+            [1.0 + float(batch_rank)], device=self.device_type
+        )
+
+        # Build a Replicated DTensor on the TP mesh (no reduction across TP).
+        replicated_on_tp = distribute_tensor(
+            local, tp_mesh, placements=[Replicate()]
+        )
+
+        # Reduce across batch_mesh. This is the failure case.
+        result = dist_utils.dist_sum(replicated_on_tp, batch_mesh)
+
+        # Expected: 1.0 (batch=0) + 2.0 (batch=1) = 3.0 on every rank.
+        self.assertEqual(result, 3.0)
+
+    @with_comms
+    def test_dtensor_same_mesh_no_double_count(self):
+        """A Partial-on-batch DTensor reduced across batch_mesh.
+
+        When the DTensor's mesh equals the reduction mesh, ``full_tensor()``
+        does the reduction — the explicit all_reduce must be skipped.
+        Build a Partial-on-batch DTensor where each batch rank holds
+        ``1.0`` locally; reduce on batch_mesh gives ``world_batch = 2``.
+        With double-counting, we'd see 4.
+        """
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, 2), mesh_dim_names=("batch", "tp")
+        )
+        batch_mesh = mesh_2d["batch"]
+
+        local = torch.tensor([1.0], device=self.device_type)
+        partial_on_batch = distribute_tensor(
+            local, batch_mesh, placements=[Partial()]
+        )
+        result = dist_utils.dist_sum(partial_on_batch, batch_mesh)
+        self.assertEqual(result, 2.0)
+
+    @with_comms
+    def test_plain_tensor_unchanged(self):
+        """Plain-tensor path still works as before."""
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, 2), mesh_dim_names=("batch", "tp")
+        )
+        batch_mesh = mesh_2d["batch"]
+
+        local = torch.tensor([1.0], device=self.device_type)
+        result = dist_utils.dist_sum(local, batch_mesh)
+        self.assertEqual(result, 2.0)
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -45,23 +45,37 @@ def _dist_reduce(
             process group, and then the result will be all_reduced for the mesh.
     """
     if isinstance(x, DTensor):
-        # DTensor path: ``full_tensor()`` already performs the mesh reduction
-        # for Partial placements and is a no-op for Replicate. Skipping the
-        # subsequent mesh all-reduce is required to avoid double-counting.
+        # DTensor path. ``full_tensor()`` reduces across the DTensor's own
+        # mesh (Partial → reduced; Replicate → no-op) and returns a plain
+        # tensor with the full value on every rank.
+        #
         # Shard placements are not supported — semantics are undefined since
         # the reduction target is ambiguous.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
         )
-        if extra_pg is not None:
-            raise ValueError(
-                "_dist_reduce does not support DTensor input combined with "
-                "extra_pg: ``full_tensor()`` already reduces over the DTensor's "
-                "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
-                "to that mesh. Pass a plain tensor when using extra_pg."
-            )
-        return float(x.full_tensor().item())
+
+        # If the requested reduction mesh is the same mesh the DTensor
+        # already lives on, ``full_tensor()`` has done the reduction and
+        # we must skip the subsequent all_reduce to avoid double-counting.
+        # Otherwise (the requested mesh is orthogonal to the DTensor's mesh,
+        # e.g. reducing a TP-Replicated loss across batch_mesh), we still
+        # need to reduce on the requested mesh — fall through to the
+        # plain-tensor path with the materialized full tensor.
+        x_mesh = x.device_mesh
+        x = x.full_tensor()
+        if mesh is None or _meshes_share_axes(x_mesh, mesh):
+            if extra_pg is not None:
+                raise ValueError(
+                    "_dist_reduce does not support DTensor input combined "
+                    "with extra_pg when the DTensor's mesh covers the "
+                    "requested reduction mesh: ``full_tensor()`` already "
+                    "reduces over that mesh and extra_pg is orthogonal. "
+                    "Pass a plain tensor when using extra_pg."
+                )
+            return float(x.item())
+        # Fall through to plain-tensor path to do the cross-mesh reduction.
 
     # Plain tensor path.
     if extra_pg is not None:
@@ -70,6 +84,18 @@ def _dist_reduce(
         return float(x.item())
     assert x.numel() == 1  # required by `.item()`
     return float(funcol.all_reduce(x, reduceOp=reduceOp, group=mesh).item())
+
+
+def _meshes_share_axes(a: DeviceMesh, b: DeviceMesh) -> bool:
+    """True if meshes ``a`` and ``b`` cover any of the same root-mesh axes.
+
+    ``DeviceMesh.mesh_dim_names`` is an unambiguous identifier for an axis
+    within a root mesh, so a non-empty intersection of dim-name sets means
+    the two meshes overlap on at least one axis.
+    """
+    a_names = set(a.mesh_dim_names or ())
+    b_names = set(b.mesh_dim_names or ())
+    return bool(a_names & b_names)
 
 
 # TODO: rename this to maybe_dist_max


### PR DESCRIPTION
Since #2963, `_dist_reduce` short-circuits all DTensor inputs with `return float(x.full_tensor().item())`, skipping the requested mesh all_reduce entirely. The justification in the comment ("avoid double-counting") only holds when the DTensor's own mesh covers the requested reduction mesh; when they are orthogonal — as in the trainer's loss reduction where the loss is a Replicated DTensor on the TP mesh and the requested mesh is `loss_mesh = batch x cp` — the cross-batch sum is silently dropped.

Symptom: every TP > 1 run reports `loss = true_loss / dp_world_size`. For a 2B run at TP=2 with 24 ranks, step-1 loss is 1.08 instead of the ~12.95 ln(vocab) baseline observed at TP=1. Gradients and optimizer steps are unaffected because backward goes through `loss.backward()` not `_dist_reduce` — only the printed/logged loss is wrong.

Fix: detect mesh axis overlap via `mesh_dim_names`. If the DTensor's mesh shares any axis with the requested mesh, `full_tensor()` already covers that axis and we skip the explicit all_reduce as before. If the meshes are disjoint, we materialize via `full_tensor()` and fall through to the plain-tensor path so the requested-mesh all_reduce runs.

Adds a unit test covering both the orthogonal case (was broken) and the same-mesh case (must not double-count).