### PR TITLE
CP AllGather on the wrong dimension

### DIFF
--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -64,7 +64,7 @@ def apply_cp_to_forward(
                 def cp_forward(q, k, v, **kwargs):
                     k = k.contiguous()
                     v = v.contiguous()
-                    global_k, global_v = flex_cp_allgather(k, v, 2, pg_name)
+                    global_k, global_v = flex_cp_allgather(k, v, 1, pg_name)
                     return orig_fn(q, global_k, global_v, **kwargs)
 
                 return cp_forward


### PR DESCRIPTION


As currently implemented, the all-gather for Flex Attention with Context Parallelism (CP) is expected to occur along the sequence dimension.

From inspecting the code:
[https://github.com/pytorch/torchtitan/blob/627126fe9042072e1e9e122db408047133b8f64d/torchtitan/models/common/attention.py#L225-L242](https://github.com/pytorch/torchtitan/blob/627126fe9042072e1e9e122db408047133b8f64d/torchtitan/models/common/attention.py#L225-L242)

Flex Attention appears to operate on inputs shaped as:
(batch_size, num_heads, seq_len, head_dim)

However, immediately before calling `flex_attention`, there is a transpose that changes the layout to:
(batch_size, seq_len, num_heads, head_dim)

As a result, the current all-gather is applied along an axis that no longer corresponds to the sequence dimension, leading to incorrect behavior under CP.

This PR fixes the issue by explicitly setting the all-gather axis to the sequence dimension (now the second dimension after transpose), ensuring the gather is performed correctly.

