### PR TITLE
[GraphTrainer] Annotate loss region with module_fqn

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -273,7 +273,7 @@ def apply_graph_passes(
             and before/after graphs to tlparse for each pass.
     """
     debug = compile_config is not None and compile_config.debug_graph_passes
-    tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced")
+    tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
     for pass_fn in passes:
         pass_name = (
             pass_fn.func.__name__
@@ -281,7 +281,7 @@ def apply_graph_passes(
             else pass_fn.__name__
         )
         if debug:
-            tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}")
+            tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}", debug=debug)
             before_snapshot = snapshot_graph(gm)
             start = time.perf_counter()
         gm = pass_fn(gm, example_inputs)
@@ -291,7 +291,7 @@ def apply_graph_passes(
         if debug:
             elapsed = time.perf_counter() - start
             logger.info(f"Pass {pass_name} took {elapsed:.3f}s")
-            tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}")
+            tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}", debug=debug)
             after_snapshot = snapshot_graph(gm)
             log_graph_diff(before_snapshot, after_snapshot, pass_name)
     return gm
@@ -975,6 +975,7 @@ def tlparse_log_graph_pass(
     example_inputs: tuple | None = None,
     *,
     graph_name: str,
+    debug: bool = False,
 ) -> torch.fx.GraphModule:
     """Log the transformed graph to tlparse via trace_structured.
 
@@ -986,10 +987,15 @@ def tlparse_log_graph_pass(
         example_inputs: The example inputs (unused, required by protocol).
         graph_name: The name for this graph artifact
             (e.g. "aot_forward_graph_transformed").
+        debug: When True, include additional metadata in the printed nodes.
 
     Returns:
         The graph module unchanged.
     """
+    additional_meta = ["autograd_backward"]
+    if debug:
+        additional_meta.append("seq_nr")
+
     trace_structured(
         "artifact",
         metadata_fn=lambda: {
@@ -1001,7 +1007,7 @@ def tlparse_log_graph_pass(
             include_stride=True,
             include_device=True,
             expanded_def=True,
-            additional_meta=["autograd_backward"],
+            additional_meta=additional_meta,
         ),
         expect_trace_id=False,
     )

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -9,8 +9,10 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+from torch.fx.traceback import annotate_fn
 
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
@@ -33,11 +35,19 @@ def make_fwd_bwd_step(loss_fn):
     ``loss_fn`` is captured in the closure so it is not a graph input.
     """
 
+    # The loss function is not a submodule of the model, so
+    # annotate_module_fqns won't tag it. Annotate it here so that
+    # downstream passes (bucketing, SAC, kernel annotations) can
+    # attribute loss nodes in the traced graph.
+    @annotate_fn({_MODULE_FQN: "loss"})
+    def compute_loss(pred, labels, global_valid_tokens):
+        return loss_fn(pred, labels) / global_valid_tokens
+
     def fwd_bwd_step(
         model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
     ):
         pred = model(inputs, **extra_inputs, **extra_kwargs)
-        loss = loss_fn(pred, labels) / global_valid_tokens
+        loss = compute_loss(pred, labels, global_valid_tokens)
         params = [
             p
             for _, p in model.named_parameters(remove_duplicate=False)


### PR DESCRIPTION
## Summary
- Annotate the loss computation with `@annotate_fn({_MODULE_FQN: "loss"})` so that loss-region FX nodes carry `module_fqn` in `node.meta["custom"]`, enabling downstream passes (bucketing, SAC, kernel annotations) to attribute them correctly.
- Include `seq_nr` in tlparse graph dumps when `--compile.debug_graph_passes` is enabled, helping correlate forward and backward nodes during debugging.

## Test plan
- [x] Run `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x` to verify numerics are unchanged
- [x] Run with `--compile.debug_graph_passes` and `TORCH_TRACE` to verify loss nodes now show `module_fqn: 'loss'` and `seq_nr` appears in debug dumps

Tlp 
Before
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpkriFhI/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

after: 
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpDKei0I/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000