### PR TITLE
[GraphTrainer] Add ciflow/graph_trainer label to trigger CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,7 @@
   - scripts/**
   - tests/**
   - torchtitan/**
+
+"ciflow/graph_trainer":
+  - torchtitan/experiments/graph_trainer/**
+  - .github/workflows/integration_test_8gpu_graph_trainer.yaml

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,4 +1,5 @@
 ciflow_push_tags:
   - ciflow/8gpu
   - ciflow/h100.8
+  - ciflow/graph_trainer
 labeler_config: labeler.yml

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -7,10 +7,8 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'torchtitan/experiments/graph_trainer/**'
-      - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'
+    types: [labeled, synchronize]
+    branches: [ main ]
   schedule:
     # Runs every 12 hours
     - cron: '0 */12 * * *'
@@ -29,7 +27,7 @@ permissions:
 
 jobs:
   build-test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/graph_trainer')
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.g5.48xlarge.nvidia.gpu


### PR DESCRIPTION
## Summary
- Add `ciflow/graph_trainer` as a ciflow label that gates graph trainer CI on PRs
- Auto-label PRs touching `torchtitan/experiments/graph_trainer/**` via `.github/labeler.yml`
- Register the tag in `pytorch-probot.yml`
- The label can also be manually applied to any PR (e.g. core changes) to trigger graph trainer CI

## Test plan
- [ ] Open a PR touching graph_trainer files → verify `ciflow/graph_trainer` is auto-applied and CI triggers
- [ ] Open a PR not touching graph_trainer files → verify CI does not trigger
- [ ] Manually add `ciflow/graph_trainer` label to a core PR → verify CI triggers