### PR TITLE
[experiments/rl] pin torchstore to commit compatible with torchmonarch 0.4.1

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -27,12 +27,24 @@ uv venv --python 3.12 titan-rl
 source titan-rl/bin/activate
 ```
 
-1. Install Monarch and TorchStore from main:
+1. Install Monarch and TorchStore:
 ```bash
 uv pip install torchmonarch==0.4.1
-uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
+uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@8b41ecc52bccff73e762cbe38c6871efdfc5db36"
 uv pip install pygtrie portpicker
 ```
+
+> **NOTE:** torchstore is pinned to `8b41ecc` because the next commit
+> ([`6b2dd81`](https://github.com/meta-pytorch/torchstore/commit/6b2dd81622a159b4a7ff2335a0b9f89c8df4cbdb),
+> "drop SSHJob from SPMD init; use host_mesh_from_store") calls
+> `monarch._src.spmd.host_mesh.host_mesh_from_store`, which is only
+> available in monarch nightlies. With `torchmonarch==0.4.1`,
+> `ts.initialize()` aborts the trainer actor's worker during pickle
+> replay with `ModuleNotFoundError: No module named
+> 'torch._C._distributed_c10d'; 'torch._C' is not a package`.
+> Alternatively, install `torchmonarch==0.3.0` (what the
+> `integration_test_4gpu_rl` workflow uses) to keep torchstore on
+> `main`.
 
 2. Install Flash Attention 3 kernels:
 ```bash


### PR DESCRIPTION
## Summary

`torchstore` `main` (commit [`6b2dd81`](https://github.com/meta-pytorch/torchstore/commit/6b2dd81622a159b4a7ff2335a0b9f89c8df4cbdb), "drop SSHJob from SPMD init; use host_mesh_from_store") calls `monarch._src.spmd.host_mesh.host_mesh_from_store`, which is only available in monarch nightlies. With the released `torchmonarch==0.4.1` (what the README installs), `ts.initialize()` aborts the trainer actor's worker during pickle replay with a misleading error:

```
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```

The CI workflow `integration_test_4gpu_rl.yaml` already dodges this by pinning `torchmonarch==0.3.0`. Following the README verbatim today produces a non-working environment.

This PR pins torchstore to commit [`8b41ecc`](https://github.com/meta-pytorch/torchstore/commit/8b41ecc52bccff73e762cbe38c6871efdfc5db36) (the last commit before the regression) and adds a short note documenting the alternative `torchmonarch==0.3.0` workaround.

## Bisect summary

| torchmonarch | torchstore | result |
|---|---|---|
| 0.4.1 | `8b41ecc` (last good) | pass (3/3) |
| 0.4.1 | `6b2dd81` (first bad) | fail (3/3) |
| 0.4.1 | `main` (`6df7f3ee`) | fail (3/3) |
| 0.3.0 | `main` (`6df7f3ee`) | pass (3/3) |

## Test plan

- [x] Fresh `uv venv --python 3.12 titan_rl_v2`, install per the updated README, run `python torchtitan/experiments/rl/grpo.py --module rl --config rl_grpo_qwen3_0_6b` to completion (10 steps, pre +0.365 → post +0.700 reward).
- [x] Confirm CI `integration_test_4gpu_rl.yaml` is unaffected — it already pins `torchmonarch==0.3.0` and torchstore from `main`, which is also a valid combination.
- [x] Bisect documented in the commit message body.