### PR TITLE
Revert precompile PRs (#3107, #3178) to fix CI

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -418,6 +418,19 @@ def _precompile_aot_fx_trace(
 
     passes = compile_time_passes(traced_result, config)
 
+    # TODO: Remove this filter once upstream manual_overlap_bucketing
+    # supports make_fx-traced graphs where collective group_name args
+    # are FX Node references instead of string literals. The bucketing
+    # and comm_analysis code crashes with
+    # "AttributeError: 'Node' object has no attribute 'size'" or
+    # "assert isinstance(group_name, str)".
+    passes = [
+        p
+        for p in passes
+        if getattr(p, "func", p)
+        is not joint_transformer_block_bucketing_reordering_pass
+    ]
+
     traced_result.gm = apply_graph_passes(
         traced_result.gm, traced_result.example_inputs, passes
     )

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -27,9 +27,6 @@ from torch.nn.attention.flex_attention import flex_attention
 
 from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
-from torchtitan.experiments.graph_trainer.common_utils import (
-    maybe_register_blockmask_pytree_node,
-)
 from torchtitan.experiments.graph_trainer.deepseek_v3 import (
     model_registry as dsv3_model_registry,
 )
@@ -118,27 +115,6 @@ class BitwiseDeterministicBase(unittest.TestCase):
         FlexAttention.inductor_configs = self._orig_inductor_configs
         FlexAttention._compiled_flex_attn = self._orig_compiled_flex_attn
 
-    def _get_extra_kwargs(self, model: nn.Module) -> dict[str, object]:
-        """Build extra_kwargs matching what post_dataloading_process produces.
-
-        For FlexAttention models, this generates the BlockMask attention
-        masks. For SDPA models, returns an empty dict.
-        """
-        from torchtitan.models.common.attention import FlexAttention as FlexAttnModule
-        from torchtitan.models.common.decoder import Decoder
-
-        if not isinstance(self.model_config, Decoder.Config):
-            return {}
-        layer = self.model_config.layers[0]
-        inner_attention = getattr(layer.attention, "inner_attention", None)
-        if not isinstance(inner_attention, FlexAttnModule.Config):
-            return {}
-        tokenizer = HuggingFaceTokenizer(tokenizer_path=_TOKENIZER_PATH)
-        attention_masks = model.get_attention_masks(
-            input_batch=self.inputs, tokenizer=tokenizer,
-        )
-        return {"attention_masks": attention_masks}
-
     def _run_steps(
         self,
         model: nn.Module,
@@ -209,8 +185,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
             BATCH_SIZE * SEQ_LEN, dtype=torch.float, device="cuda"
         )
         extra_inputs: dict[str, torch.Tensor] = {}
-        extra_kwargs: dict[str, object] = self._get_extra_kwargs(model)
-        maybe_register_blockmask_pytree_node()
+        extra_kwargs: dict[str, torch.Tensor] = {}
 
         # Step 1: Trace the graph
         traced_result = trace_train_step(fwd_bwd_fn)(
@@ -469,6 +444,8 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
+    # TODO: numerics mismatch between precompile and trace with FlexAttention
+    @unittest.skip("FlexAttention precompile numerics mismatch — under investigation")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
@@ -536,6 +513,8 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
+    # TODO: numerics mismatch between precompile and trace with FlexAttention
+    @unittest.skip("FlexAttention precompile numerics mismatch — under investigation")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
@@ -660,6 +639,8 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
+    # TODO: numerics mismatch between precompile and trace with FlexAttention
+    @unittest.skip("FlexAttention precompile numerics mismatch — under investigation")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)


### PR DESCRIPTION
## Summary
- Reverts #3107 ("Enable bucketing pass in precompile path") — the upstream PyTorch fix (pytorch/pytorch#181529) hasn't landed on `viable/strict` yet, so the nightly doesn't have it and the bucketing pass crashes with `AttributeError: 'Node' object has no attribute 'size'`.
- Reverts #3178 ("Fix FlexAttention precompile bitwise deterministic tests") — the unskipped `test_precompile_vs_trace` tests hit a separate PyTorch nightly regression in `_higher_order_ops/utils.py` (`Proxy` passed where `Tensor` expected).

Both will be re-landed once the upstream fixes reach `viable/strict` and flow into nightlies.

## Test plan
- CI should pass with both reverts applied