### PR TITLE
[rl] add import torch to provisioner bootstrap to avoid concurrent dlopen …

### DIFF
--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -124,6 +124,8 @@ class Provisioner:
 
         def _bootstrap():
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
+            # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
+            import torch  # noqa: F401
 
         return _bootstrap
 


### PR DESCRIPTION
When Monarch spawns sub-processes and multiple actor threads begin unpickling messages concurrently, they all try to import torch at the same time, causing a race condition in `dlopen` of `torch._C.so`. This results in the misleading error `torch._C is not a package`, even though the import works fine when done sequentially. The fix is to `import torch` in the Provisioner's bootstrap function, which runs once per sub-process before any threading starts, ensuring `torch._C.so` is fully loaded before concurrent unpickling begins. It's unclear whether this is a PyTorch bug (concurrent dlopen should be thread-safe) or a Monarch bug (imports during unpickling should be serialized), so we've added a TODO to remove the workaround once the upstream fix lands. 