### PR TITLE
[rl] Set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True for monarch RDMA

### DIFF
--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -29,6 +29,9 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+# must run before torch import
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
 import torch
 import torchstore as ts
 from monarch.actor import this_host


### PR DESCRIPTION
Monarch's RDMA path emits this warning during weight sync:

> UserWarning: CUDA caching allocator is not using expandable segments.
> This is required to maximize RDMA performance with CUDA tensors.

Setting the env var before the first \`import torch\` in \`grpo.py\`
suppresses it. \`setdefault\` preserves any user override.

**Test:** warning count goes from **6 → 0** on a full \`rl_grpo_qwen3_0_6b\` run; no other behavior change.