### PR TITLE
[GraphTrainer] Overhaul README for accuracy and clarity

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -3,22 +3,24 @@
 [![integration and numerics tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml?query=branch%3Amain) [![GraphTrainer H100 8 GPU Integration Tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer_h100.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer_h100.yaml?query=branch%3Amain)
 
 
-This experiment demonstrates graph-based distributed training in torchtitan through toolkit-style usage of PyTorch's compiler technologies. The goal is to give users explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training.
+This experiment demonstrates graph-based distributed training in torchtitan through toolkit-style usage of PyTorch's compiler technologies. The goal is to give users explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training. See the [Manifesto](MANIFESTO.md) for the motivation and design philosophy behind GraphTrainer.
 
 **Key features:**
-- **Full train step graph capture** — `make_fx`-based `minimal_fx_tracer` traces forward + loss + backward into a single FX graph, without AOTAutograd partitioning, giving full visibility and control over the entire computation.
+- **Full train step graph capture** — `make_fx`-based `minimal_fx_tracer` traces forward + loss + backward (and optionally `optimizer.step`) into a single FX graph, without AOTAutograd partitioning, giving full visibility and control over the entire computation.
 - **[SimpleFSDP](https://arxiv.org/abs/2411.00284)** — A compiler-based FSDP that represents sharding as parameterized collectives within the computation graph, making it fully tracer-friendly while achieving memory and throughput improvements over eager FSDP2.
-- **Tensor-granularity memory policy** — Each activation can independently be saved, recomputed, or CPU-offloaded, unlike module-level eager SAC. Different strategies mix freely within a single layer.
+- **Tensor-granularity memory policy** — Each activation can independently be saved, recomputed, or offloaded to the CPU, unlike module-level eager SAC. Different strategies mix freely within a single layer.
 - **Graph pass pipeline** — Structured into default (numerics-preserving) and opt-in performance passes: bucketing for comm/compute overlap, async TP, regional/full Inductor compilation, CUDA graphs, CPU offload, and selective activation remat.
 - **Pre-compile (Compile-on-One-Rank)** — Compile on a single GPU, serialize the artifact, and load on all ranks at training time — skipping compilation entirely. Config fingerprinting detects stale artifacts.
 - **Composable parallelism** — FSDP + TP + EP in the graph, with async tensor parallel (micro-pipeline TP via symmetric memory) as an opt-in graph pass.
 - **Debug tooling** — tlparse integration for browser-based graph inspection, and CUDA graph kernel annotations in profiler traces.
 
-Three compilation modes are currently supported:
-- **AOT FX trace mode** (`--compile.mode aot_fx_trace`): Non-strict tracing of the full forward + loss + backward via `make_fx`, producing a single end-to-end graph without AOTAutograd partitioning.
+<details>
+<summary>Legacy compilation modes (deprecated)</summary>
+
+In addition to the default `aot_fx_trace` mode, two legacy modes exist but are deprecated and will be removed:
 - **AOT mode** (`--compile.mode aot`): Explicit joint graph export with a custom graph pass pipeline.
 - **JIT mode** (`--compile.mode jit`): Standard `torch.compile()` with graph passes registered to custom backends.
-> **Deprecation notice:** The `aot` and `jit` compile modes are deprecated and will be removed in the future. Please migrate to `aot_fx_trace`.
+</details>
 
 ### Prerequisites
 
@@ -39,6 +41,12 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
 
 ```bash
 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./run_train.sh
+```
+
+#### Training Qwen3-14B
+
+```bash
+MODULE=graph_trainer.qwen3 CONFIG=graph_trainer_qwen3_14b ./run_train.sh
 ```
 
 ### Configuring Parallelism
@@ -67,7 +75,7 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 # CPU activation offloading
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.memory_policy cpu_offload_all
 
-# Disable CUDA graphs
+# Disable CUDA graphs (for debugging)
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.no-enable_cudagraph
 
 # Disable all graph passes (for debugging)
@@ -131,13 +139,16 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmo
     --parallelism.expert_tensor_parallel_degree 1
 ```
 
-**`--virtual-local-rank`:** This torchrun flag makes every worker process see
-`LOCAL_RANK=0` and target `cuda:0`. torchrun isolates each worker's GPU via
-`CUDA_VISIBLE_DEVICES`, so `cuda:0` maps to a different physical GPU per
-worker. This is required for CooR because the precompiled artifact was
-compiled on a single process targeting `cuda:0`, and CooR handles
-rank-specific computation dynamically at runtime via
-`_runtime_compute_coordinate_on_dim`.
+<details>
+<summary><code>--virtual-local-rank</code> explained</summary>
+
+This torchrun flag makes every worker process see `LOCAL_RANK=0` and target
+`cuda:0`. torchrun isolates each worker's GPU via `CUDA_VISIBLE_DEVICES`, so
+`cuda:0` maps to a different physical GPU per worker. This is required for
+CooR because the precompiled artifact was compiled on a single process
+targeting `cuda:0`, and CooR handles rank-specific computation dynamically
+at runtime via `_runtime_compute_coordinate_on_dim`.
+</details>
 
 Pre-compile works with any compiler pass that produces serializable output,
 including `full_inductor_compilation` and `regional_inductor`. Use a shared
@@ -145,7 +156,7 @@ filesystem path for the artifact directory in multi-node setups.
 
 ### Composability Support
 
-Some of the features require the updates from PyTorch, with which we are working on providing composability support for the following features:
+Composability status for `aot_fx_trace` mode:
 
 | Feature | Support |
 | :--------: | :--------: |
@@ -157,7 +168,7 @@ Some of the features require the updates from PyTorch, with which we are working
 |Context Parallelism| ✅ |
 |Distributed Checkpointing| ✅ |
 |CUDA Graphs| ✅ |
-|Float8 Training| 🚧 |
+|Float8/MXFP8 Training| 🚧 |
 |Expert Parallelism| ✅ |
 |Expert Parallelism + Activation Checkpointing| 🚧 |
 |Expert Parallelism + Pipeline Parallelism| 🚧 |

--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -1,15 +1,20 @@
 ## GraphTrainer
 
-[![integration and numerics tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml?query=branch%3Amain)
-[![arXiv](https://img.shields.io/badge/arXiv-2411.00284-b31b1b.svg)](https://arxiv.org/abs/2411.00284)
+[![integration and numerics tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer.yaml?query=branch%3Amain) [![GraphTrainer H100 8 GPU Integration Tests](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer_h100.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_graph_trainer_h100.yaml?query=branch%3Amain)
 
-This experiment demonstrates graph-based distributed training in torchtitan through toolkit-style usage of PyTorch's compiler technologies, including:
-- [SimpleFSDP](https://arxiv.org/abs/2411.00284) as a compiler-friendly fully sharded data parallel implementation
-- Dynamo and AOTAutograd as the joint graph capture frontend
-- Provenance-tracking infrastructure as the user annotation backbone
-- Graph optimization via FX graph passes
 
-The goal is to give users more explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training. Three compilation modes are currently supported:
+This experiment demonstrates graph-based distributed training in torchtitan through toolkit-style usage of PyTorch's compiler technologies. The goal is to give users explicit control over the compiler stack in terms of performance, numerics, and debuggability during large-scale distributed training.
+
+**Key features:**
+- **Full train step graph capture** — `make_fx`-based `minimal_fx_tracer` traces forward + loss + backward into a single FX graph, without AOTAutograd partitioning, giving full visibility and control over the entire computation.
+- **[SimpleFSDP](https://arxiv.org/abs/2411.00284)** — A compiler-based FSDP that represents sharding as parameterized collectives within the computation graph, making it fully tracer-friendly while achieving memory and throughput improvements over eager FSDP2.
+- **Tensor-granularity memory policy** — Each activation can independently be saved, recomputed, or CPU-offloaded, unlike module-level eager SAC. Different strategies mix freely within a single layer.
+- **Graph pass pipeline** — Structured into default (numerics-preserving) and opt-in performance passes: bucketing for comm/compute overlap, async TP, regional/full Inductor compilation, CUDA graphs, CPU offload, and selective activation remat.
+- **Pre-compile (Compile-on-One-Rank)** — Compile on a single GPU, serialize the artifact, and load on all ranks at training time — skipping compilation entirely. Config fingerprinting detects stale artifacts.
+- **Composable parallelism** — FSDP + TP + EP in the graph, with async tensor parallel (micro-pipeline TP via symmetric memory) as an opt-in graph pass.
+- **Debug tooling** — tlparse integration for browser-based graph inspection, and CUDA graph kernel annotations in profiler traces.
+
+Three compilation modes are currently supported:
 - **AOT FX trace mode** (`--compile.mode aot_fx_trace`): Non-strict tracing of the full forward + loss + backward via `make_fx`, producing a single end-to-end graph without AOTAutograd partitioning.
 - **AOT mode** (`--compile.mode aot`): Explicit joint graph export with a custom graph pass pipeline.
 - **JIT mode** (`--compile.mode jit`): Standard `torch.compile()` with graph passes registered to custom backends.
@@ -21,7 +26,7 @@ GraphTrainer requires the latest PyTorch nightly, which can be installed (e.g., 
 ```bash
 pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu130 --force-reinstall
 ```
-You can replace `cu130` with another version of CUDA or an AMD GPU (e.g. `rocm6.3`).
+You can replace `cu130` with another version of CUDA.
 
 ### Quick Start
 
@@ -50,23 +55,23 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./r
 
 ### Compiler Optimizations
 
-> **Note:** Graph pass support for `aot_fx_trace` mode is a work in progress. The `--compile.passes` and `--compile.joint_passes` flags currently only apply to the deprecated `aot` and `jit` modes.
+The `aot_fx_trace` mode has a built-in pass pipeline controlled by dedicated flags.
 
 ```bash
-# Auto bucketing for comm/compute overlap
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes auto_bucketing
+# Full Inductor compilation (default is regional — compiles only tagged regions)
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.inductor_compilation full
 
-# Transformer-block bucketing for comm/compute overlap
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes transformer_block_bucketing
+# Numerics-changing optimizations (e.g. RMSNorm Inductor fusion)
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.numerics_changing_optim
 
-# CUDAGraph
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.passes cudagraph
+# CPU activation offloading
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.memory_policy cpu_offload_all
 
-# Full Inductor compilation (AOT)
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode aot --compile.joint_passes inductor_decomposition --compile.passes full_inductor_compilation
+# Disable CUDA graphs
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.no-enable_cudagraph
 
-# Full Inductor compilation (JIT)
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.mode jit --compile.backend inductor
+# Disable all graph passes (for debugging)
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.no-enable_passes
 ```
 
 ### Pre-compile (Compile-on-One-Rank)
@@ -90,8 +95,6 @@ precompile when upgrading PyTorch or changing the model/parallelism setup.
 python -m torchtitan.experiments.graph_trainer.precompile_main \
     --module graph_trainer.llama3 \
     --config graph_trainer_llama3_debugmodel \
-    --compile.passes full_inductor_compilation \
-    --compile.joint_passes inductor_decomposition \
     --compile.precompile_artifact_dir /tmp/precompile_artifacts \
     --parallelism.data_parallel_shard_degree 4 \
     --parallelism.tensor_parallel_degree 2
@@ -100,8 +103,6 @@ python -m torchtitan.experiments.graph_trainer.precompile_main \
 # Uses run_train_precompile.sh which passes --virtual-local-rank to torchrun.
 NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
     ./torchtitan/experiments/graph_trainer/run_train_precompile.sh \
-    --compile.passes full_inductor_compilation \
-    --compile.joint_passes inductor_decomposition \
     --compile.precompile_artifact_dir /tmp/precompile_artifacts \
     --parallelism.data_parallel_shard_degree 4 \
     --parallelism.tensor_parallel_degree 2
@@ -114,8 +115,6 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
 python -m torchtitan.experiments.graph_trainer.precompile_main \
     --module graph_trainer.deepseek_v3 \
     --config graph_trainer_deepseek_v3_debugmodel \
-    --compile.passes full_inductor_compilation \
-    --compile.joint_passes inductor_decomposition \
     --compile.precompile_artifact_dir /tmp/dsv3_precompile_artifacts \
     --parallelism.data_parallel_shard_degree 4 \
     --parallelism.tensor_parallel_degree 2 \
@@ -125,8 +124,6 @@ python -m torchtitan.experiments.graph_trainer.precompile_main \
 # Step 2: load and train with torchrun (uses all GPUs)
 NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel \
     ./torchtitan/experiments/graph_trainer/run_train_precompile.sh \
-    --compile.passes full_inductor_compilation \
-    --compile.joint_passes inductor_decomposition \
     --compile.precompile_artifact_dir /tmp/dsv3_precompile_artifacts \
     --parallelism.data_parallel_shard_degree 4 \
     --parallelism.tensor_parallel_degree 2 \
@@ -158,10 +155,9 @@ Some of the features require the updates from PyTorch, with which we are working
 |Mixed Precision Training| ✅ |
 |Tensor Parallelism| ✅ |
 |Context Parallelism| ✅ |
-|Pipeline Parallelism| ✅ |
 |Distributed Checkpointing| ✅ |
 |CUDA Graphs| ✅ |
-|Float8 Training| ✅ |
+|Float8 Training| 🚧 |
 |Expert Parallelism| ✅ |
 |Expert Parallelism + Activation Checkpointing| 🚧 |
 |Expert Parallelism + Pipeline Parallelism| 🚧 |


### PR DESCRIPTION
## Summary
- Add structured **Key features** section highlighting: full train step graph capture, SimpleFSDP, tensor-granularity memory policy, graph pass pipeline, pre-compile (CooR), composable parallelism, and debug tooling
- Link to MANIFESTO.md for motivation and design philosophy
- Replace all deprecated `--compile.passes`/`--compile.joint_passes` examples with correct `aot_fx_trace` flags (`--compile.inductor_compilation`, `--compile.memory_policy`, `--compile.numerics_changing_optim`, etc.)
- Fix pre-compile examples that were silently using wrong flags for the default `aot_fx_trace` mode
- Collapse deprecated aot/jit modes and `--virtual-local-rank` explanation into `<details>` blocks
- Add Qwen3-14B to Quick Start
- Tighten composability table: update intro text, downgrade Float8 and Pipeline Parallelism to reflect actual `aot_fx_trace` support
- Remove ROCm mention from prerequisites

## Test plan
- [x] Docs-only change, no code modified
- [ ] Verified all referenced config names exist in config_registry.py files
- [ ] Verified all `--compile.*` flags match GraphTrainerCompileConfig fields