### PR TITLE
[rl] Remove VLLMGenerator.__del__ cleanup method

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -366,4 +366,5 @@ class VLLMGenerator(Actor, Configurable):
         """Cleanup vLLM engine."""
         if hasattr(self, "_engine"):
             del self._engine
-            torch.cuda.empty_cache()
+            if torch is not None:
+                torch.cuda.empty_cache()

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -361,10 +361,3 @@ class VLLMGenerator(Actor, Configurable):
         logger.debug(
             f"{os.getpid()=} Generator pulled model state dict for policy v{version}"
         )
-
-    def __del__(self):
-        """Cleanup vLLM engine."""
-        if hasattr(self, "_engine"):
-            del self._engine
-            if torch is not None:
-                torch.cuda.empty_cache()


### PR DESCRIPTION
The `__del__` method is unnecessary and fragile — Python's GC naturally cleans up self._engine, and module globals like torch may be None during interpreter shutdown. Removing it eliminates the shutdown error `AttributeError: 'NoneType' object has no attribute 'cuda'` that some are experiencing.
