### PR TITLE
[codex] Fix weight tying parameter accounting

### DIFF
--- a/tests/unit_tests/test_weight_tying.py
+++ b/tests/unit_tests/test_weight_tying.py
@@ -63,6 +63,17 @@ class TestLlama3WeightTying(unittest.TestCase):
             "tok_embeddings.weight and output.weight must remain tied after init_states",
         )
 
+    def test_tied_parameter_count_matches_unique_parameters(self):
+        """Tied embeddings should be counted once, not subtracted away."""
+        config = _make_config(enable_weight_tying=True)
+        model = Llama3Model(config)
+        unique_param_count = sum(
+            p.numel() for p in {id(p): p for p in model.parameters()}.values()
+        )
+        reported_param_count, _ = config.get_nparams_and_flops(model, seq_len=512)
+
+        self.assertEqual(reported_param_count, unique_param_count)
+
     def test_pp_guard_raises_when_weight_tying_and_pp_enabled(self):
         """update_from_config must raise NotImplementedError when PP > 1 and weight tying is on."""
         from unittest.mock import MagicMock

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -407,6 +407,8 @@ def get_dense_model_nparams_and_flops(
             nparams: Total number of model parameters.
             num_flops_per_token: Estimated number of floating point operations per token.
     """
+    # model.parameters() de-duplicates shared parameters, so tied input/output
+    # embeddings are counted once.
     nparams = sum(p.numel() for p in model.parameters())
     nparams_embedding = sum(
         sum(p.numel() for p in m.parameters())
@@ -425,9 +427,9 @@ def get_dense_model_nparams_and_flops(
     # With tied embeddings, PyTorch's parameter iterator already counts the
     # shared input/output parameter once. That parameter still participates in
     # the lm_head matmul, so do not subtract it for either size or FLOPs.
-    nparams_for_flops = nparams if enable_weight_tying else nparams - nparams_embedding
+    nparams_for_matmul = nparams if enable_weight_tying else nparams - nparams_embedding
     num_flops_per_token = (
-        6 * nparams_for_flops + 6 * n_layers * n_heads * head_dims * seq_len
+        6 * nparams_for_matmul + 6 * n_layers * n_heads * head_dims * seq_len
     )
 
     return nparams, num_flops_per_token
@@ -496,26 +498,15 @@ def get_moe_model_nparams_and_flops(
     # With tied embeddings, PyTorch's parameter iterator already counts the
     # shared input/output parameter once. That parameter still participates in
     # the lm_head matmul, so do not subtract it for either size or FLOPs.
-    nparams_embedding_for_flops = (
-        0
-        if (
-            hasattr(model_config, "enable_weight_tying")
-            and model_config.enable_weight_tying
+    if getattr(model_config, "enable_weight_tying", False):
+        nparams_for_matmul = nparams_dense + nparams_sparse_active
+    else:
+        nparams_for_matmul = (
+            nparams_dense - nparams_embedding + nparams_sparse_active
         )
-        else nparams_embedding
-    )
     num_flops_per_token = (
-        6 * (nparams_dense - nparams_embedding_for_flops + nparams_sparse_active)
+        6 * nparams_for_matmul
         + 6 * len(model_config.layers) * n_heads * head_dims * seq_len
     )
-
-    if (
-        hasattr(model_config, "enable_weight_tying")
-        and model_config.enable_weight_tying
-    ):
-        logger.info(
-            "Weight tying enabled; shared input/output embedding parameters "
-            "are counted once."
-        )
 
     return nparams, num_flops_per_token

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -422,13 +422,13 @@ def get_dense_model_nparams_and_flops(
     #    but recomputation should not be counted in calculating MFU           (+0)
     # 3. each matmul performs 1 multiplication and 1 addition                 (*2)
     # 4. we follow the convention and do not account for sparsity in causal attention
+    # With tied embeddings, PyTorch's parameter iterator already counts the
+    # shared input/output parameter once. That parameter still participates in
+    # the lm_head matmul, so do not subtract it for either size or FLOPs.
+    nparams_for_flops = nparams if enable_weight_tying else nparams - nparams_embedding
     num_flops_per_token = (
-        6 * (nparams - nparams_embedding) + 6 * n_layers * n_heads * head_dims * seq_len
+        6 * nparams_for_flops + 6 * n_layers * n_heads * head_dims * seq_len
     )
-
-    # If weight tying is enabled, subtract embedding parameters from total count
-    if enable_weight_tying:
-        nparams = nparams - nparams_embedding
 
     return nparams, num_flops_per_token
 
@@ -493,16 +493,29 @@ def get_moe_model_nparams_and_flops(
         f"sparse {nparams_sparse:,}, active {nparams_dense + nparams_sparse_active:,}"
     )
 
+    # With tied embeddings, PyTorch's parameter iterator already counts the
+    # shared input/output parameter once. That parameter still participates in
+    # the lm_head matmul, so do not subtract it for either size or FLOPs.
+    nparams_embedding_for_flops = (
+        0
+        if (
+            hasattr(model_config, "enable_weight_tying")
+            and model_config.enable_weight_tying
+        )
+        else nparams_embedding
+    )
     num_flops_per_token = (
-        6 * (nparams_dense - nparams_embedding + nparams_sparse_active)
+        6 * (nparams_dense - nparams_embedding_for_flops + nparams_sparse_active)
         + 6 * len(model_config.layers) * n_heads * head_dims * seq_len
     )
 
-    # If weight tying is enabled, subtract embedding parameters from total count
     if (
         hasattr(model_config, "enable_weight_tying")
         and model_config.enable_weight_tying
     ):
-        nparams = nparams - nparams_embedding
+        logger.info(
+            "Weight tying enabled; shared input/output embedding parameters "
+            "are counted once."
+        )
 
     return nparams, num_flops_per_token

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -501,9 +501,7 @@ def get_moe_model_nparams_and_flops(
     if getattr(model_config, "enable_weight_tying", False):
         nparams_for_matmul = nparams_dense + nparams_sparse_active
     else:
-        nparams_for_matmul = (
-            nparams_dense - nparams_embedding + nparams_sparse_active
-        )
+        nparams_for_matmul = nparams_dense - nparams_embedding + nparams_sparse_active
     num_flops_per_token = (
         6 * nparams_for_matmul
         + 6 * len(model_config.layers) * n_heads * head_dims * seq_len


### PR DESCRIPTION
## Summary
- Keep tied input/output embeddings counted once in model parameter totals.
- Keep tied lm_head weights included in FLOPs accounting because the output projection still runs.
- Add a regression test that tied model parameter reporting matches unique PyTorch parameters.

## Root Cause
model.parameters() already de-duplicates shared parameters when input embeddings and lm_head are tied, but the accounting helper subtracted the embedding parameters again. That under-reported tied model size and also removed the output projection from the FLOPs estimate.

## Validation
- /data/app/modded-nanogpt/.venv/bin/python -m pytest -q tests/unit_tests/test_weight_tying.py