### PR TITLE
[GraphTrainer] Register BlockMask pytree node in aot_fx_trace precompile path

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -380,6 +380,12 @@ def _precompile_aot_fx_trace(
         else contextlib.nullcontext()
     )
 
+    from torchtitan.experiments.graph_trainer.common_utils import (
+        maybe_register_blockmask_pytree_node,
+    )
+
+    maybe_register_blockmask_pytree_node()
+
     logger.info("Tracing fwd+loss+bwd via make_fx...")
     with loss_parallel_ctx:
         traced_result = trace_train_step(fwd_bwd_fn)(

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -152,12 +152,12 @@ class GraphTrainer(Trainer):
         extra_inputs: dict[str, torch.Tensor],
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:
+        maybe_register_blockmask_pytree_node()
         if self._traced_step is None:
             if self.config.compile.precompile_artifact_dir:
                 self._load_precompiled_fx_trace(model)
             else:
                 fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
-                maybe_register_blockmask_pytree_node()
                 with self.train_context():
                     self._traced_step = trace_train_step(fwd_bwd_fn)(
                         model,


### PR DESCRIPTION
The aot_fx_trace precompile path in precompile_main.py was missing the `maybe_register_blockmask_pytree_node()` call before tracing. This caused precompilation to fail for models using FlexAttention (e.g. DeepSeek-v3) with:

```
ValueError: minimal_fx_tracer requires all pytree leaves in state/args
to be tensors or primitives (int/float/bool/str), got BlockMask.
```

The `aot` precompile path already had `register_blockmask_pytree_node()` and the training path had `maybe_register_blockmask_pytree_node()`, but the `aot_fx_trace` precompile path was missing it.

## Test Plan

Tested on MAST with DeepSeek-v3 16B (DP=4, TP=2, EP=4) on GB300 — precompile now succeeds where it previously failed with the BlockMask ValueError.

The existing `test_precompile_vs_trace` tests in `test_bitwise_deterministic.py` already cover this code path for FlexAttention models (TestDSv3FlexAttnBitwiseDeterministic, TestLlama3FlexAttnBitwiseDeterministic).