### PR TITLE
[draft] Add blockwise FP8 linears

### DIFF
--- a/scripts/fp8_blockwise/compare_deepseek_v3_debugmodel.sh
+++ b/scripts/fp8_blockwise/compare_deepseek_v3_debugmodel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Compare BF16 and experimental blockwise FP8 DeepSeek V3 debug-model runs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+TORCHAO_REPO="${TORCHAO_REPO:-/home/dev/ao}"
+BATCH_SIZES="${BATCH_SIZES:-1 4 8}"
+NGPU="${NGPU:-4}"
+STEPS="${STEPS:-10}"
+SEED="${SEED:-123}"
+DUMP_ROOT="${DUMP_ROOT:-./outputs/fp8_blockwise_compare}"
+LOG_DIR="${LOG_DIR:-${DUMP_ROOT}/logs}"
+
+export PYTHONPATH="${TORCHAO_REPO}:${PYTHONPATH:-}"
+NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+if [[ "${NCCL_SOCKET_IFNAME}" != *,* && "${NCCL_SOCKET_IFNAME}" != ^* && ! -d "/sys/class/net/${NCCL_SOCKET_IFNAME}" ]]; then
+    echo "NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME} is not present on this node; using lo"
+    NCCL_SOCKET_IFNAME="lo"
+fi
+export NCCL_SOCKET_IFNAME
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+
+mkdir -p "${LOG_DIR}"
+
+for batch_size in ${BATCH_SIZES}; do
+    bf16_config="deepseek_v3_debugmodel"
+    fp8_config="deepseek_v3_debugmodel_fp8_blockwise_bs${batch_size}"
+    suffix="chunked"
+
+    bf16_dump="${DUMP_ROOT}/bf16_bs${batch_size}_${suffix}"
+    fp8_dump="${DUMP_ROOT}/fp8_blockwise_bs${batch_size}_${suffix}"
+
+    echo "Running BF16 DeepSeek V3 debugmodel bs=${batch_size} on ${NGPU} GPU(s)"
+    NGPU="${NGPU}" MODULE=deepseek_v3 CONFIG="${bf16_config}" ./run_train.sh \
+        --training.local-batch-size "${batch_size}" \
+        --training.steps "${STEPS}" \
+        --debug.seed "${SEED}" \
+        --dump_folder "${bf16_dump}" "$@" \
+        2>&1 | tee "${LOG_DIR}/bf16_bs${batch_size}_${suffix}.log"
+
+    echo "Running blockwise FP8 DeepSeek V3 debugmodel bs=${batch_size} on ${NGPU} GPU(s)"
+    NGPU="${NGPU}" MODULE=deepseek_v3 CONFIG="${fp8_config}" ./run_train.sh \
+        --training.steps "${STEPS}" \
+        --debug.seed "${SEED}" \
+        --dump_folder "${fp8_dump}" "$@" \
+        2>&1 | tee "${LOG_DIR}/fp8_blockwise_bs${batch_size}_${suffix}.log"
+done

--- a/scripts/fp8_blockwise/run_deepseek_v3_debugmodel.sh
+++ b/scripts/fp8_blockwise/run_deepseek_v3_debugmodel.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run DeepSeek V3 debug model with experimental torchao blockwise FP8 linears.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+TORCHAO_REPO="${TORCHAO_REPO:-/home/dev/ao}"
+BATCH_SIZES="${BATCH_SIZES:-1 4 8}"
+NGPU="${NGPU:-4}"
+DUMP_ROOT="${DUMP_ROOT:-./outputs/fp8_blockwise_deepseek_v3_debugmodel}"
+
+export PYTHONPATH="${TORCHAO_REPO}:${PYTHONPATH:-}"
+NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+if [[ "${NCCL_SOCKET_IFNAME}" != *,* && "${NCCL_SOCKET_IFNAME}" != ^* && ! -d "/sys/class/net/${NCCL_SOCKET_IFNAME}" ]]; then
+    echo "NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME} is not present on this node; using lo"
+    NCCL_SOCKET_IFNAME="lo"
+fi
+export NCCL_SOCKET_IFNAME
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+
+for batch_size in ${BATCH_SIZES}; do
+    CONFIG="deepseek_v3_debugmodel_fp8_blockwise_bs${batch_size}"
+    dump_folder="${DUMP_ROOT}/bs${batch_size}"
+
+    echo "Running ${CONFIG} on ${NGPU} GPU(s); dump_folder=${dump_folder}"
+    NGPU="${NGPU}" MODULE=deepseek_v3 CONFIG="${CONFIG}" ./run_train.sh \
+        --dump_folder "${dump_folder}" \
+        "$@"
+done

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -4,8 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+import torch
 
-from torchtitan.components.quantization import Float8Linear
+from torchtitan.components.quantization import Float8BlockwiseLinear, Float8Linear
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
@@ -13,6 +14,7 @@ from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.gpt_oss.moe import GptOssGroupedExperts
+from torchtitan.tools.utils import has_cuda_capability
 
 
 def test_no_float8_by_default():
@@ -43,6 +45,60 @@ def test_float8_applied_by_model_registry():
         if isinstance(lc, Float8Linear.Config)
     ]
     assert len(converted) > 0
+
+
+@pytest.mark.parametrize(
+    ("config_name", "local_batch_size"),
+    [
+        ("deepseek_v3_debugmodel_fp8_blockwise_bs1", 1),
+        ("deepseek_v3_debugmodel_fp8_blockwise_bs4", 4),
+        ("deepseek_v3_debugmodel_fp8_blockwise_bs8", 8),
+        ("deepseek_v3_671b_fp8_blockwise", 4),
+    ],
+)
+def test_deepseek_v3_blockwise_float8_applied_by_model_registry(
+    config_name,
+    local_batch_size,
+):
+    pytest.importorskip("torchao.prototype.blockwise_fp8_training.linear")
+    if Float8BlockwiseLinear is None:
+        pytest.skip("torchao blockwise FP8 training linear is unavailable")
+    if not has_cuda_capability(9, 0):
+        pytest.skip("blockwise FP8 training requires SM90 or later")
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args(
+        [
+            "--module",
+            "deepseek_v3",
+            "--config",
+            config_name,
+        ]
+    )
+    model_config = config.model_spec.model
+    assert has_quantization(model_config)
+    assert config.training.local_batch_size == local_batch_size
+
+    converted = [
+        lc
+        for _fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
+        if isinstance(lc, Float8BlockwiseLinear.Config)
+    ]
+    assert len(converted) > 0
+    assert all(lc.in_features % 128 == 0 for lc in converted)
+    assert all(lc.out_features % 128 == 0 for lc in converted)
+    assert all(not lc.bias for lc in converted)
+    lm_heads = [
+        lc
+        for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
+        if fqn == "lm_head"
+    ]
+    assert len(lm_heads) == 1
+    assert not isinstance(lm_heads[0], Float8BlockwiseLinear.Config)
+
+    with torch.device("meta"):
+        layer = converted[0].build()
+    assert isinstance(layer, Float8BlockwiseLinear)
 
 
 def test_quantized_grouped_experts():

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -33,6 +33,7 @@ class QuantizationConverter(ModelConfigConverter):
 
 # Re-export all public symbols so callers can import from the package directly.
 from .float8 import (  # noqa: F401, E402
+    Float8BlockwiseLinear,
     Float8GroupedExpertsConverter,
     Float8Linear,
     Float8LinearConverter,
@@ -44,6 +45,7 @@ from .mx import (  # noqa: F401, E402
 )
 
 __all__ = [
+    "Float8BlockwiseLinear",
     "Float8GroupedExpertsConverter",
     "Float8Linear",
     "Float8LinearConverter",

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -21,6 +21,21 @@ from torchtitan.tools.utils import has_cuda_capability
 from .utils import module_filter_fn, swap_token_dispatcher
 
 
+def blockwise_module_filter_fn(
+    config: Linear.Config,
+    fqn: str,
+    filter_fqns: list[str],
+    block_size: int,
+) -> bool:
+    """Filter linears supported by torchao's blockwise FP8 training kernel."""
+    dims_multiples_of_block_size = (
+        config.in_features % block_size == 0 and config.out_features % block_size == 0
+    )
+    is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
+
+    return dims_multiples_of_block_size and not config.bias and not is_filtered_fqn
+
+
 try:
     from torchao.float8.float8_linear import Float8Linear as TorchAOFloat8Linear
 
@@ -50,12 +65,41 @@ except ImportError:
     Float8Linear = None
 
 
+try:
+    from torchao.prototype.blockwise_fp8_training.linear import (
+        Float8BlockwiseLinear as TorchAOFloat8BlockwiseLinear,
+    )
+
+    class Float8BlockwiseLinear(TorchAOFloat8BlockwiseLinear, Module):
+        """TorchTitan wrapper for torchao blockwise FP8 training linear."""
+
+        @dataclass(kw_only=True, slots=True)
+        class Config(Linear.Config):
+            """Drop-in replacement for Linear.Config that builds blockwise FP8 linear."""
+
+            block_size: int = 128
+            use_triton: bool = False
+
+        def __init__(self, config: Config):
+            TorchAOFloat8BlockwiseLinear.__init__(
+                self,
+                config.in_features,
+                config.out_features,
+                bias=config.bias,
+                block_size=config.block_size,
+                use_triton=config.use_triton,
+            )
+
+except ImportError:
+    Float8BlockwiseLinear = None
+
+
 class Float8LinearConverter(QuantizationConverter):
-    """Replace matching Linear.Config with Float8Linear.Config."""
+    """Replace matching Linear.Config with a float8 linear config."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
-        recipe_name: Literal["rowwise", "rowwise_with_gw_hp"] = "rowwise"
+        recipe_name: Literal["rowwise", "rowwise_with_gw_hp", "blockwise"] = "rowwise"
         """Float8 recipe name."""
 
         filter_fqns: list[str] = field(default_factory=list)
@@ -63,6 +107,8 @@ class Float8LinearConverter(QuantizationConverter):
         List of fully qualified names of modules to skip applying float8 training to.
         nn.Linear modules with any dim size not divisible by 16 are always skipped
         due to hardware requirements.
+        For the blockwise recipe, linears must also be bias-free and have in/out
+        features divisible by ``block_size``.
         """
 
         emulate: bool = False
@@ -71,16 +117,54 @@ class Float8LinearConverter(QuantizationConverter):
         This is for test purpose only. Not compatible with torch.compile.
         """
 
+        block_size: int = 128
+        """Block size for the experimental blockwise FP8 training recipe."""
+
+        use_triton: bool = False
+        """
+        Use torchao's explicit Triton GEMM path for blockwise FP8.
+        Keep False for distributed training so DTensor-aware scaled_mm is used.
+        """
+
     def __init__(self, config: Config):
         self.config = config
 
-        if Float8Linear is None:
+        if Float8Linear is None and config.recipe_name != "blockwise":
             raise ImportError(
                 "torchao is not installed. Please install it to use float8 linear layers."
             )
 
         cfg = self.config
         filter_fqns = cfg.filter_fqns
+
+        if cfg.recipe_name == "blockwise":
+            if Float8BlockwiseLinear is None:
+                raise ImportError(
+                    "torchao blockwise FP8 training is not installed. "
+                    "Please install a torchao build with "
+                    "torchao.prototype.blockwise_fp8_training."
+                )
+            if cfg.emulate:
+                raise ValueError("Blockwise FP8 training does not support emulation.")
+            if cfg.block_size != 128:
+                raise ValueError("Blockwise FP8 training currently only supports 128.")
+            if not has_cuda_capability(9, 0):
+                raise ValueError(
+                    "Blockwise FP8 linear training only supported on SM90 or later."
+                )
+
+            clean_fqns = [f for f in filter_fqns if f != "auto_filter_small_kn"]
+            self.filter_fn = partial(
+                blockwise_module_filter_fn,
+                filter_fqns=clean_fqns,
+                block_size=cfg.block_size,
+            )
+            self.enabled = True
+            logger.info(
+                "Float8 blockwise linear training active with block size "
+                f"{cfg.block_size}"
+            )
+            return
 
         if has_cuda_capability(8, 9) or (cfg.emulate and not cfg.model_compile_enabled):
             pass
@@ -147,22 +231,51 @@ class Float8LinearConverter(QuantizationConverter):
         if not self.enabled:
             return
 
-        assert Float8Linear is not None
+        assert Float8Linear is not None or self.config.recipe_name == "blockwise"
+        converted_fqns = []
         for fqn, linear_config, parent, attr in model_config.traverse(Linear.Config):
             if self.filter_fn(linear_config, fqn):
-                new_config = Float8Linear.Config(
-                    in_features=linear_config.in_features,
-                    out_features=linear_config.out_features,
-                    bias=linear_config.bias,
-                    param_init=linear_config.param_init,
-                    _torchao_config=self.torchao_config,
-                )
+                converted_fqns.append(fqn)
+                if self.config.recipe_name == "blockwise":
+                    assert Float8BlockwiseLinear is not None
+                    new_config = Float8BlockwiseLinear.Config(
+                        in_features=linear_config.in_features,
+                        out_features=linear_config.out_features,
+                        bias=linear_config.bias,
+                        param_init=linear_config.param_init,
+                        block_size=self.config.block_size,
+                        use_triton=self.config.use_triton,
+                    )
+                else:
+                    assert Float8Linear is not None
+                    new_config = Float8Linear.Config(
+                        in_features=linear_config.in_features,
+                        out_features=linear_config.out_features,
+                        bias=linear_config.bias,
+                        param_init=linear_config.param_init,
+                        _torchao_config=self.torchao_config,
+                    )
                 if isinstance(parent, list):
                     parent[attr] = new_config
                 else:
                     setattr(parent, attr, new_config)
 
-        logger.info("Swapped to Float8Linear layers")
+        if self.config.recipe_name == "blockwise":
+            sample_fqns = ", ".join(converted_fqns[:8])
+            suffix = ""
+            if len(converted_fqns) > 8:
+                suffix = f", ... (+{len(converted_fqns) - 8} more)"
+            logger.info(
+                "Swapped %d Linear configs to Float8BlockwiseLinear "
+                "(block_size=%d, use_triton=%s). Sample FQNs: %s%s",
+                len(converted_fqns),
+                self.config.block_size,
+                self.config.use_triton,
+                sample_fqns,
+                suffix,
+            )
+        else:
+            logger.info("Swapped to Float8Linear layers")
 
 
 _float8_experts_cache: dict[type, type] = {}

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -72,20 +72,19 @@ def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization.float8 import (
         _float8_experts_cache,
+        Float8BlockwiseLinear,
         Float8Linear,
     )
     from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
 
-    has_quant_linear = (
-        any(
-            isinstance(config, (Float8Linear.Config, MXFP8Linear.Config))
-            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
-        )
-        if Float8Linear is not None
-        else any(
-            isinstance(config, MXFP8Linear.Config)
-            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
-        )
+    quant_linear_types = [MXFP8Linear.Config]
+    if Float8Linear is not None:
+        quant_linear_types.append(Float8Linear.Config)
+    if Float8BlockwiseLinear is not None:
+        quant_linear_types.append(Float8BlockwiseLinear.Config)
+    has_quant_linear = any(
+        isinstance(config, tuple(quant_linear_types))
+        for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
     quant_experts_types = tuple(
         cls.Config  # type: ignore[attr-defined]

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -75,6 +75,41 @@ def deepseek_v3_debugmodel_flex_attn_ep() -> Trainer.Config:
     return config
 
 
+def _deepseek_v3_debugmodel_fp8_blockwise(local_batch_size: int) -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.training.local_batch_size = local_batch_size
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    config.model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            Float8LinearConverter.Config(
+                recipe_name="blockwise",
+                filter_fqns=["lm_head", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+        ],
+    )
+    return config
+
+
+def deepseek_v3_debugmodel_fp8_blockwise() -> Trainer.Config:
+    return _deepseek_v3_debugmodel_fp8_blockwise(local_batch_size=8)
+
+
+def deepseek_v3_debugmodel_fp8_blockwise_bs1() -> Trainer.Config:
+    return _deepseek_v3_debugmodel_fp8_blockwise(local_batch_size=1)
+
+
+def deepseek_v3_debugmodel_fp8_blockwise_bs4() -> Trainer.Config:
+    return _deepseek_v3_debugmodel_fp8_blockwise(local_batch_size=4)
+
+
+def deepseek_v3_debugmodel_fp8_blockwise_bs8() -> Trainer.Config:
+    return _deepseek_v3_debugmodel_fp8_blockwise(local_batch_size=8)
+
+
 def deepseek_v3_16b() -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),
@@ -106,27 +141,46 @@ def deepseek_v3_16b() -> Trainer.Config:
     )
 
 
-def deepseek_v3_671b() -> Trainer.Config:
-    compile_config = CompileConfig(enable=True, components=["loss"])
+def _deepseek_v3_16b_fp8_blockwise(
+    local_batch_size: int | None = None,
+) -> Trainer.Config:
+    config = deepseek_v3_16b()
+    if local_batch_size is not None:
+        config.training.local_batch_size = local_batch_size
     model_compile_enabled = (
-        compile_config.enable and "model" in compile_config.components
+        config.compile.enable and "model" in config.compile.components
     )
+    config.model_spec = model_registry(
+        "16B",
+        attn_backend="flex",
+        converters=[
+            Float8LinearConverter.Config(
+                recipe_name="blockwise",
+                filter_fqns=["lm_head", "output", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+        ],
+    )
+    return config
+
+
+def deepseek_v3_16b_fp8_blockwise() -> Trainer.Config:
+    return _deepseek_v3_16b_fp8_blockwise()
+
+
+def deepseek_v3_16b_fp8_blockwise_bs1() -> Trainer.Config:
+    return _deepseek_v3_16b_fp8_blockwise(local_batch_size=1)
+
+
+def _deepseek_v3_671b_config(
+    *,
+    model_spec,
+    compile_config: CompileConfig,
+) -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/DeepSeek-V3.1-Base",
-        model_spec=model_registry(
-            "671B",
-            attn_backend="flex",
-            converters=[
-                Float8LinearConverter.Config(
-                    filter_fqns=["output", "router.gate"],
-                    model_compile_enabled=model_compile_enabled,
-                ),
-                Float8GroupedExpertsConverter.Config(
-                    model_compile_enabled=model_compile_enabled
-                ),
-            ],
-        ),
+        model_spec=model_spec,
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
@@ -151,4 +205,60 @@ def deepseek_v3_671b() -> Trainer.Config:
             mode="selective",
         ),
         compile=compile_config,
+    )
+
+
+def _deepseek_v3_671b_fp8_blockwise(
+    local_batch_size: int | None = None,
+) -> Trainer.Config:
+    compile_config = CompileConfig(enable=True, components=["loss"])
+    model_compile_enabled = (
+        compile_config.enable and "model" in compile_config.components
+    )
+    config = _deepseek_v3_671b_config(
+        model_spec=model_registry(
+            "671B",
+            attn_backend="flex",
+            converters=[
+                Float8LinearConverter.Config(
+                    recipe_name="blockwise",
+                    filter_fqns=["lm_head", "output", "router.gate"],
+                    model_compile_enabled=model_compile_enabled,
+                ),
+                Float8GroupedExpertsConverter.Config(
+                    model_compile_enabled=model_compile_enabled
+                ),
+            ],
+        ),
+        compile_config=compile_config,
+    )
+    if local_batch_size is not None:
+        config.training.local_batch_size = local_batch_size
+    return config
+
+
+def deepseek_v3_671b_fp8_blockwise() -> Trainer.Config:
+    return _deepseek_v3_671b_fp8_blockwise()
+
+
+def deepseek_v3_671b() -> Trainer.Config:
+    compile_config = CompileConfig(enable=True, components=["loss"])
+    model_compile_enabled = (
+        compile_config.enable and "model" in compile_config.components
+    )
+    return _deepseek_v3_671b_config(
+        model_spec=model_registry(
+            "671B",
+            attn_backend="flex",
+            converters=[
+                Float8LinearConverter.Config(
+                    filter_fqns=["output", "router.gate"],
+                    model_compile_enabled=model_compile_enabled,
+                ),
+                Float8GroupedExpertsConverter.Config(
+                    model_compile_enabled=model_compile_enabled
+                ),
+            ],
+        ),
+        compile_config=compile_config,
     )


### PR DESCRIPTION
## Summary

- add an experimental blockwise FP8 linear recipe backed by the torchao prototype blockwise FP8 training linear
- add DeepSeek V3 debug-model configs for blockwise FP8 batch sizes 1, 4, and 8
- add helper scripts for BF16 versus blockwise FP8 debug-model comparisons using the default chunked-loss path
  - can remove later, this is to do runs locally for now

## Testing

8 GPU, bs=8, 1k steps
<img width="2520" height="1620" alt="image" src="https://github.com/user-attachments/assets/09169191-c227-4aec-acf1-2afe3a74230f" />

<img width="2520" height="1620" alt="image" src="https://github.com/user-attachments/assets/0ce858f8-d63a-4979-8440-1a0c61a09ec9" />
