### PR TITLE
Fix ChunkedCELoss final FSDP wrapping

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -16,6 +16,20 @@ from torchtitan.components.loss import (
 )
 
 
+class _LegacyDecoderOutputGradientBackProp(torch.autograd.Function):
+    """Legacy ChunkedCELoss gradient bridge kept for equivalence testing."""
+
+    @staticmethod
+    def forward(ctx, hidden_states, accumulated_grad, loss):
+        ctx.save_for_backward(accumulated_grad)
+        return loss.detach().clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (accumulated_grad,) = ctx.saved_tensors
+        return accumulated_grad, None, None
+
+
 class TestLoss(unittest.TestCase):
     def test_ignore_index_equal_per_token_contribution(self):
         """Test that each valid token contributes equally to the loss.
@@ -310,6 +324,30 @@ class TestChunkedCELoss(unittest.TestCase):
                 places=5,
                 msg=f"Loss with {2**i} chunks should match loss with 1 chunk",
             )
+
+    def test_gradient_bridge_matches_legacy_custom_autograd(self):
+        """The zero-value bridge must match the old custom autograd bridge."""
+        torch.manual_seed(42)
+        hidden_states = torch.randn(2, 8, 32, requires_grad=True)
+        accumulated_grad = torch.randn_like(hidden_states)
+        total_loss = hidden_states.new_tensor(3.25)
+
+        hidden_legacy = hidden_states.detach().clone().requires_grad_(True)
+        hidden_bridge = hidden_states.detach().clone().requires_grad_(True)
+
+        legacy_loss = _LegacyDecoderOutputGradientBackProp.apply(
+            hidden_legacy, accumulated_grad, total_loss
+        )
+        grad_bridge = torch.sum(hidden_bridge * accumulated_grad)
+        bridged_loss = total_loss.detach() + grad_bridge - grad_bridge.detach()
+
+        torch.testing.assert_close(bridged_loss, legacy_loss)
+
+        legacy_loss.backward()
+        bridged_loss.backward()
+
+        torch.testing.assert_close(hidden_bridge.grad, hidden_legacy.grad)
+        torch.testing.assert_close(hidden_bridge.grad, accumulated_grad)
 
 
 if __name__ == "__main__":

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -336,57 +336,17 @@ class ChunkedCELoss(BaseLoss):
                 h_chunk.grad = None
 
         if fsdp_enabled:
-            lm_head.set_reshard_after_forward(True)
             lm_head.set_reshard_after_backward(True)
             lm_head.set_requires_gradient_sync(True, recurse=False)
-            lm_head.reshard()
         if not requires_grad:
             return total_loss
 
         accumulated_grad = grad_accumulator.result().to(hidden_states.dtype)
 
-        # Return a differentiable loss via _DecoderOutputGradientBackProp. When
-        # .backward() is called (by the trainer or PP schedule), autograd
-        # calls _DecoderOutputGradientBackProp.backward which returns accumulated_grad
-        # as the gradient for hidden_states, propagating through the decoder.
-        return _DecoderOutputGradientBackProp.apply(
-            hidden_states, accumulated_grad, total_loss
-        )
-
-
-class _DecoderOutputGradientBackProp(torch.autograd.Function):
-    """Bridges chunked lm_head backward with decoder backward via autograd.
-
-    Forward takes hidden_states (connected to decoder graph), the accumulated
-    gradient from chunked lm_head backward, and the loss value. Returns the
-    loss value as a differentiable tensor.
-
-    Backward returns accumulated_grad as the gradient for hidden_states.
-    Autograd then propagates this through the decoder layers automatically —
-    no explicit hidden_states.backward() needed.
-    """
-
-    @staticmethod
-    # pyrefly: ignore [bad-override]
-    def forward(
-        ctx,
-        hidden_states: torch.Tensor,
-        accumulated_grad: torch.Tensor,
-        loss: torch.Tensor,
-    ) -> torch.Tensor:
-        ctx.save_for_backward(accumulated_grad)
-        # Return a tensor with the correct loss value. We clone to avoid
-        # in-place issues, and the grad_fn comes from this Function.
-        return loss.detach().clone()
-
-    @staticmethod
-    def backward(  # pyrefly: ignore[bad-override]
-        ctx, grad_output: torch.Tensor
-    ) -> tuple[torch.Tensor, None, None]:
-        (accumulated_grad,) = ctx.saved_tensors
-        # Return accumulated_grad as the gradient for hidden_states.
-        # Autograd then propagates this through hidden_states' existing
-        # decoder graph — equivalent to hidden_states.backward(accumulated_grad)
-        # but expressed as a return value so autograd handles the traversal
-        # in a single pass (no "backward through graph twice" error).
-        return accumulated_grad, None, None
+        # Return the correct scalar loss value while attaching the accumulated
+        # chunk gradient to hidden_states for the outer backward pass. This is
+        # equivalent to a custom autograd Function that returns accumulated_grad
+        # as the hidden_states gradient, but avoids saving that gradient inside
+        # a custom Function, which is fragile with FSDP/DTensor tensors.
+        grad_bridge = torch.sum(hidden_states * accumulated_grad)
+        return total_loss.detach() + grad_bridge - grad_bridge.detach()

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -179,6 +179,7 @@ def apply_fsdp(
     reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         reshard_after_forward_policy, pp_enabled
     )
+    use_chunked_ce_loss = getattr(model, "_use_chunked_ce_loss", False)
 
     if getattr(model, "enable_weight_tying", False):
         modules = [
@@ -203,12 +204,29 @@ def apply_fsdp(
         # As an optimization, do not reshard_after_forward the last layers
         # by default since FSDP would prefetch them immediately.
         if model.norm is not None and model.lm_head is not None:
-            # pyrefly: ignore [no-matching-overload]
-            fully_shard(
-                [model.norm, model.lm_head],
-                **fsdp_config,
-                reshard_after_forward=reshard_after_forward_policy == "always",
-            )
+            if use_chunked_ce_loss:
+                # ChunkedCELoss backprops through lm_head before the decoder
+                # backward reaches norm, so these modules must not share one
+                # FSDP unit.
+                # pyrefly: ignore [no-matching-overload]
+                fully_shard(
+                    model.norm,
+                    **fsdp_config,
+                    reshard_after_forward=reshard_after_forward_policy == "always",
+                )
+                # pyrefly: ignore [no-matching-overload]
+                fully_shard(
+                    model.lm_head,
+                    **fsdp_config,
+                    reshard_after_forward=reshard_after_forward_policy == "always",
+                )
+            else:
+                # pyrefly: ignore [no-matching-overload]
+                fully_shard(
+                    [model.norm, model.lm_head],
+                    **fsdp_config,
+                    reshard_after_forward=reshard_after_forward_policy == "always",
+                )
 
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.items():

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -323,6 +323,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
         assert self.gradient_accumulation_steps > 0
 
+        if isinstance(self.loss_fn, ChunkedCELoss):
+            # Some model parallelization paths need to avoid placing the final
+            # norm and lm_head in the same FSDP unit because ChunkedCELoss runs
+            # lm_head backward before the decoder backward.
+            model._use_chunked_ce_loss = True
+
         # apply parallelisms and initialization
         with sl.log_trace_span("model_parallelism_init"):
             if parallel_dims.pp_enabled:


### PR DESCRIPTION
## Summary

- keep final `norm` and `lm_head` in separate FSDP units when `ChunkedCELoss` is active
- avoid forcing an immediate `lm_head` reshard at the end of the chunked loss forward
- replace the custom chunked-loss autograd bridge with an equivalent zero-value gradient bridge
- add unit coverage showing the zero-value bridge returns the same scalar and computes the same hidden-state gradients as the legacy custom autograd bridge

`ChunkedCELoss` runs backward through `lm_head` chunk-by-chunk before the outer decoder backward reaches final `norm`. When `norm` and `lm_head` share one FSDP unit, `lm_head` backward/reshard can affect storage that `norm` still needs later in the same backward pass. On the 8-GPU DeepSeek V3 debug model this fails during the first backward pass with an unallocated tensor error.

Splitting `norm` and `lm_head` only for the chunked-loss path isolates their FSDP storage lifecycle while preserving the existing grouped wrapping for the standard loss path.

The zero-value gradient bridge keeps the same forward value as the old custom autograd Function while attaching the accumulated chunk gradient to `hidden_states` through regular PyTorch ops. The added unit test recreates the legacy bridge locally and verifies both approaches produce identical scalar values and hidden-state gradients.

## Validation

- `PYTHONPATH=/home/dev/ao pytest -q tests/unit_tests/test_loss.py`
- latest `origin/main` fails with `NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh --training.steps 3`
- this branch completes the same 8-GPU DeepSeek V3 debug-model smoke for 3 steps
