### PR TITLE
[torchtitan][llama4_parallelize] fixing fsdp_mesh_info bug

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -57,7 +57,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
                 ],
             ],
             "DeepSeek V3 HSDP+EP",
-            "deepseek_v3_hsdp+ep_no_sp",
+            "deepseek_v3_hsdp+ep",
             ngpu=4,
         ),
         OverrideDefinitions(

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -51,12 +51,13 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module deepseek_v3 --config deepseek_v3_debugmodel_ep",
-                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.data_parallel_replicate_degree 2",
+                    "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.expert_parallel_degree 2",
                 ],
             ],
-            "DeepSeek V3 FSDP+EP",
-            "deepseek_v3_fsdp+ep_no_sp",
+            "DeepSeek V3 HSDP+EP",
+            "deepseek_v3_hsdp+ep_no_sp",
             ngpu=4,
         ),
         OverrideDefinitions(
@@ -117,21 +118,6 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "Qwen3 FSDP+TP+CP",
             "qwen3_fsdp+tp+cp",
             ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module qwen3 --config qwen3_moe_debug",
-                    "--parallelism.data_parallel_replicate_degree 2",
-                    "--parallelism.data_parallel_shard_degree 1",
-                    "--parallelism.tensor_parallel_degree 2",
-                    "--parallelism.expert_parallel_degree 2",
-                    "--training.steps 1",
-                ],
-            ],
-            "Qwen3 MoE HSDP+TP+EP",
-            "qwen3_moe_hsdp+tp+ep",
-            ngpu=4,
         ),
         # Integration Test Cases for Llama 4
         # TODO: re-enable compile after fixing

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -118,6 +118,21 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "qwen3_fsdp+tp+cp",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module qwen3 --config qwen3_moe_debug",
+                    "--parallelism.data_parallel_replicate_degree 2",
+                    "--parallelism.data_parallel_shard_degree 1",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 2",
+                    "--training.steps 1",
+                ],
+            ],
+            "Qwen3 MoE HSDP+TP+EP",
+            "qwen3_moe_hsdp+tp+ep",
+            ngpu=4,
+        ),
         # Integration Test Cases for Llama 4
         # TODO: re-enable compile after fixing
         # https://github.com/pytorch/torchtitan/issues/2771

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -71,7 +71,7 @@ def parallelize_llama(
     # runs inside the local_map boundary on local tensors.
     if parallel_dims.cp_enabled:
         apply_cp_to_forward(
-            # pyrefly: ignore [missing-attribute, not-callable]
+            # pyrefly: ignore [missing-attribute]
             [block.attention.inner_attention for block in model.layers.values()],
             parallel_dims.get_mesh("cp"),
         )
@@ -261,12 +261,25 @@ def apply_fsdp(
                 # ep_degree > 1: per-param mesh
                 from torch.distributed.fsdp._fully_shard._fsdp_common import (
                     FSDPMeshInfo,
+                    HSDPMeshInfo,
                     ShardPlacementResult,
                 )
 
                 assert edp_mesh is not None
-                edp_mesh_info = FSDPMeshInfo(mesh=edp_mesh, shard_mesh_dim=0)
-                dp_mesh_info = FSDPMeshInfo(mesh=dp_mesh, shard_mesh_dim=0)
+
+                def _get_fsdp_mesh_info(mesh: DeviceMesh) -> FSDPMeshInfo:
+                    if mesh.ndim == 1:
+                        return FSDPMeshInfo(mesh=mesh, shard_mesh_dim=0)
+                    if mesh.ndim == 2:
+                        return HSDPMeshInfo(
+                            mesh=mesh, replicate_mesh_dim=0, shard_mesh_dim=1
+                        )
+                    raise ValueError(
+                        f"Expected 1D or 2D FSDP mesh, got {mesh.ndim}D mesh."
+                    )
+
+                edp_mesh_info = _get_fsdp_mesh_info(edp_mesh)
+                dp_mesh_info = _get_fsdp_mesh_info(dp_mesh)
 
                 def _shard_placement_fn(
                     param: nn.Parameter,


### PR DESCRIPTION
**Summary:** Fixed the shared Llama4/Qwen3 MoE FSDP path so per-param expert meshes use HSDPMeshInfo when the mesh is 2D HSDP, instead of incorrectly treating (dp_replicate, efsdp/fsdp) as 1D FSDP. This preserves the replicate axis for EP+HSDP expert params and resolves the aten.normal_ DTensor initialization failure exposed by the PyTorch random-op strategy migration. Fixes https://github.com/pytorch/torchtitan/issues/3205

**Test Cases**
1. NGPU=4 MODULE=qwen3 CONFIG=qwen3_moe_debug ./run_train.sh     --parallelism.expert_parallel_degree=2     --parallelism.data_parallel_replicate_degree=2     --parallelism.data_parallel_shard_degree=-1     --parallelism.context_parallel_degree=1     --parallelism.tensor_parallel_degree=1

2. NGPU=4 MODULE=qwen3 CONFIG=qwen3_moe_debug ./run_train.sh     --parallelism.expert_parallel_degree=2     --parallelism.data_parallel_replicate_degree=2     --parallelism.data_parallel_shard_degree=1     --parallelism.context_parallel_degree=1     --parallelism.tensor_parallel_degree=2
3. 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3231

