### PR TITLE
[float8] Quantize GroupedExperts params during conversion

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -214,7 +214,15 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 ):
                     def build(self, **kwargs):
                         instance = base_cls.build(self, **kwargs)
-                        quantize_(instance, config=Float8TrainingOpConfig())
+                        # torchao's quantize_ defaults filter_fn to _is_linear,
+                        # which skips GroupedExperts. Match the built module so
+                        # its nn.Parameters (w1/w2/w3) get wrapped for FP8
+                        # grouped GEMMs.
+                        quantize_(
+                            instance,
+                            config=Float8TrainingOpConfig(),
+                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+                        )
                         return instance
 
                 _converted_config_cache[base_cls] = Float8GroupedExpertsConfig


### PR DESCRIPTION
Stacked PRs:
 * #3198
 * #3197
 * __->__#3233


--- --- ---

### [float8] Quantize GroupedExperts params during conversion


torchao quantize_ defaults to filtering linear modules, which skips GroupedExperts and leaves FP8 MoE weights unwrapped. Pass an explicit GroupedExperts filter so w1/w2/w3 are converted for scaled grouped GEMMs.

This mirrors the MXFP8 grouped-experts path for now. We expect the FP8 and MXFP8 converters to be consolidated into one implementation by https://github.com/pytorch/torchtitan/issues/3219.