### PR TITLE
RL: observability spans across trainer/generator/controller (#3234)

### DIFF
--- a/tests/unit_tests/observability/test_structured_logging.py
+++ b/tests/unit_tests/observability/test_structured_logging.py
@@ -252,7 +252,7 @@ class TestRelativeStep:
         """When set_step is called without relative_step, it defaults to step.
 
         Prevents a stale _RELATIVE_STEP_GLOBAL from leaking across calls
-        (e.g. sync_step broadcasts that omit the kwarg). Correct for
+        (e.g. sync_log_step broadcasts that omit the kwarg). Correct for
         non-resumed runs; resumed trainers must pass relative_step
         explicitly.
         """
@@ -662,7 +662,7 @@ class TestNoOpFlag:
             set_step(1)
             with log_trace_span("step"):
                 pass
-            log_trace_instant("binary_start")
+            log_trace_instant("structured_logger_started")
 
         trace_dir = tmp_path / "structured_logs"
         lines = []
@@ -688,7 +688,7 @@ class TestNoOpFlag:
             set_step(1)
             with log_trace_span("step"):
                 pass
-            log_trace_instant("binary_start")
+            log_trace_instant("structured_logger_started")
             log_trace_scalar({"x": 1.0})
         finally:
             sl_mod._disabled = False
@@ -760,7 +760,7 @@ class TestLogTraceScalar:
 class TestLogTraceInstant:
     def test_writes_instant_marker(self, tmp_path, structured_logger_fixture):
         init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
-        log_trace_instant("binary_start")
+        log_trace_instant("structured_logger_started")
 
         trace_dir = os.path.join(str(tmp_path), "structured_logs")
         jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
@@ -768,7 +768,7 @@ class TestLogTraceInstant:
             lines = [json.loads(line) for line in f if line.strip()]
 
         assert len(lines) == 1
-        assert lines[0]["log_type_name"] == "binary_start"
+        assert lines[0]["log_type_name"] == "structured_logger_started"
         assert lines[0]["log_type"] == "instant"
         assert lines[0]["event_name"] is None
 
@@ -1091,11 +1091,11 @@ class TestGenerateGanttTrace:
         """Records with ``log_type == "instant"`` render as instants even when
         their ``log_type_name`` ends in ``_start``. Confirms the classifier
         branches on emission intent, not name suffix — so future instants
-        like ``binary_start`` / ``training_start`` work without an allowlist.
+        like ``structured_logger_started`` / ``training_start`` work without an allowlist.
         """
         records = [
             {
-                "log_type_name": "binary_start",
+                "log_type_name": "structured_logger_started",
                 "log_type": "instant",
                 "time_us": 1000,
                 "rank": 0,
@@ -1118,7 +1118,7 @@ class TestGenerateGanttTrace:
         instant_names = [
             e.get("name") for e in trace["traceEvents"] if e.get("ph") == "i"
         ]
-        assert "binary_start" in instant_names
+        assert "structured_logger_started" in instant_names
         assert "training_start" in instant_names
         # No span-pair events were created from these records.
         assert not any(e.get("ph") == "X" for e in trace["traceEvents"])

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass, field
 
 import torch
 import torchstore as ts
-from monarch.actor import Actor, endpoint
+from monarch.actor import Actor, current_rank, endpoint
+
 from torchtitan.config import (
     CompileConfig,
     Configurable,
@@ -24,7 +25,9 @@ from torchtitan.experiments.rl.models.vllm_registry import (
     TORCHTITAN_CONFIG_FORMAT,
 )
 from torchtitan.experiments.rl.types import Completion
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.tools.logging import init_logger
 from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig, CompilationConfig
@@ -186,7 +189,17 @@ class VLLMGenerator(Actor, Configurable):
         model_path: str,
         compile_config: CompileConfig,
         max_num_seqs: int,
+        output_dir: str,
     ):
+        init_logger()
+        sl.init_structured_logger(
+            source="rl_generator",
+            output_dir=output_dir,
+            rank=current_rank().rank,
+            enable=config.debug.enable_structured_logging,
+        )
+        sl.log_trace_instant("structured_logger_started")
+
         self.config = config
         self.model_spec = model_spec
 
@@ -252,9 +265,10 @@ class VLLMGenerator(Actor, Configurable):
             engine_kwargs["seed"] = config.debug.seed
         engine_args = EngineArgs(**engine_kwargs)
 
-        logger.info("Initializing LLMEngine from EngineArgs...")
-        self._engine = LLMEngine.from_engine_args(engine_args)
-        logger.info("vLLM rollout engine initialized")
+        with sl.log_trace_span("vllm_init"):
+            logger.info("Initializing LLMEngine from EngineArgs...")
+            self._engine = LLMEngine.from_engine_args(engine_args)
+            logger.info("vLLM rollout engine initialized")
 
         self.policy_version = 0
 
@@ -285,6 +299,12 @@ class VLLMGenerator(Actor, Configurable):
         return self._engine.model_executor.driver_worker.get_model()
 
     @endpoint
+    async def sync_log_step(self, step: int, relative_step: int | None = None) -> None:
+        """Sync the structured-logger step counter from the controller."""
+        sl.set_step(step, relative_step=relative_step)
+
+    @endpoint
+    @sl.log_trace_span("generate")
     async def generate(
         self,
         prompts: list[str],
@@ -326,8 +346,9 @@ class VLLMGenerator(Actor, Configurable):
                 self._engine.add_request(str(i), prompt, sampling_params)
 
             all_outputs = []
-            while self._engine.has_unfinished_requests():
-                all_outputs.extend(self._engine.step())
+            with sl.log_trace_span("engine_steps"):
+                while self._engine.has_unfinished_requests():
+                    all_outputs.extend(self._engine.step())
 
             # vLLM may return requests out of order; sort by the integer
             # request_id we assigned so prompt_idx lines up with the input.
@@ -359,6 +380,7 @@ class VLLMGenerator(Actor, Configurable):
         return completions
 
     @endpoint
+    @sl.log_trace_span("pull_model_state_dict")
     async def pull_model_state_dict(self, version: int) -> None:
         """Pull latest weights from TorchStore.
 

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -12,12 +12,13 @@ from typing import Any
 import torch
 import torch.distributed.checkpoint as dcp
 import torchstore as ts
-from monarch.actor import Actor, endpoint
+from monarch.actor import Actor, current_rank, endpoint
 from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
     set_model_state_dict,
     StateDictOptions,
 )
+
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import (
@@ -39,6 +40,7 @@ from torchtitan.experiments.rl.actors.utils import (
 )
 from torchtitan.experiments.rl.types import TrainBatch
 from torchtitan.models.common.attention import create_varlen_metadata_for_document
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger
@@ -90,9 +92,16 @@ class PolicyTrainer(Actor, Configurable):
         compile_config: CompileConfig,
         hf_assets_path: str = "",
         generator_dtype: str = "",
+        output_dir: str,
     ):
-
         init_logger()
+        sl.init_structured_logger(
+            source="rl_trainer",
+            output_dir=output_dir,
+            rank=current_rank().rank,
+            enable=config.debug.enable_structured_logging,
+        )
+        sl.log_trace_instant("structured_logger_started")
 
         self.config = config
         self.compile_config = compile_config
@@ -112,7 +121,8 @@ class PolicyTrainer(Actor, Configurable):
         # Enable batch-invariant mode BEFORE init_distributed
         set_batch_invariance(config.debug.batch_invariant)
 
-        world_size = dist_utils.init_distributed(config.comm)
+        with sl.log_trace_span("torch_distributed_init"):
+            world_size = dist_utils.init_distributed(config.comm)
 
         self.parallel_dims = ParallelDims.from_config(config.parallelism, world_size)
 
@@ -202,6 +212,7 @@ class PolicyTrainer(Actor, Configurable):
             f"({len(torchtitan_state_dict)} parameters)"
         )
 
+    @sl.log_trace_span("build_model")
     def _build_model(
         self,
         model_spec: ModelSpec,
@@ -257,6 +268,12 @@ class PolicyTrainer(Actor, Configurable):
         return model
 
     @endpoint
+    async def sync_log_step(self, step: int, relative_step: int | None = None) -> None:
+        """Sync the structured-logger step counter from the controller."""
+        sl.set_step(step, relative_step=relative_step)
+
+    @endpoint
+    @sl.log_trace_span("forward_backward")
     async def forward_backward(self, train_data: list[TrainBatch]) -> dict:
         """Run forward pass, compute loss, and call backward.
 
@@ -294,18 +311,20 @@ class PolicyTrainer(Actor, Configurable):
         ).unsqueeze(0)
         attention_masks = create_varlen_metadata_for_document(positions)
 
-        logits = self.model(
-            token_ids, attention_masks=attention_masks, positions=positions
-        )
+        with sl.log_trace_span("model_forward"):
+            logits = self.model(
+                token_ids, attention_masks=attention_masks, positions=positions
+            )
         all_policy_logprobs = compute_logprobs(logits, token_ids)
         policy_logprobs = extract_response_logprobs(
             all_policy_logprobs, seq_lens, prompt_lens, response_lens
         )
 
-        loss, loss_metrics = self.loss_fn(
-            policy_logprobs=policy_logprobs,
-            advantages=advantages,
-        )
+        with sl.log_trace_span("loss_fn"):
+            loss, loss_metrics = self.loss_fn(
+                policy_logprobs=policy_logprobs,
+                advantages=advantages,
+            )
 
         verification_result = verify_logprob_identity(
             local_batch.token_logprobs,
@@ -322,7 +341,8 @@ class PolicyTrainer(Actor, Configurable):
 
         # Backward pass
         self.optimizers.zero_grad()
-        loss.backward()
+        with sl.log_trace_span("model_backward"):
+            loss.backward()
 
         return {
             "loss": loss.item(),
@@ -338,6 +358,7 @@ class PolicyTrainer(Actor, Configurable):
         }
 
     @endpoint
+    @sl.log_trace_span("optim_step")
     async def optim_step(self) -> dict:
         """Clip gradients, step optimizer and LR scheduler.
 
@@ -347,15 +368,17 @@ class PolicyTrainer(Actor, Configurable):
         # TODO: Accept optional optimizer params (e.g. learning rate)
         # to allow controller-owned schedules (see Tinker API).
 
-        grad_norm = dist_utils.clip_grad_norm_(
-            [p for m in self.model_parts for p in m.parameters()],
-            self.config.training.max_norm,
-            foreach=True,
-            pp_mesh=self.parallel_dims.get_optional_mesh("pp"),
-        )
+        with sl.log_trace_span("grad_clip"):
+            grad_norm = dist_utils.clip_grad_norm_(
+                [p for m in self.model_parts for p in m.parameters()],
+                self.config.training.max_norm,
+                foreach=True,
+                pp_mesh=self.parallel_dims.get_optional_mesh("pp"),
+            )
 
-        self.optimizers.step()
-        self.lr_schedulers.step()
+        with sl.log_trace_span("optim"):
+            self.optimizers.step()
+            self.lr_schedulers.step()
 
         self.policy_version += 1
 
@@ -370,6 +393,7 @@ class PolicyTrainer(Actor, Configurable):
         }
 
     @endpoint
+    @sl.log_trace_span("save_checkpoint")
     async def save_checkpoint(self, path: str) -> None:
         """Save model state dict to disk via DCP.
 
@@ -383,6 +407,7 @@ class PolicyTrainer(Actor, Configurable):
         logger.info(f"Saved checkpoint to {path}")
 
     @endpoint
+    @sl.log_trace_span("push_model_state_dict")
     async def push_model_state_dict(self) -> None:
         """Publish model weights for generator consumption via TorchStore.
 

--- a/torchtitan/experiments/rl/actors/utils.py
+++ b/torchtitan/experiments/rl/actors/utils.py
@@ -7,7 +7,10 @@
 import torch
 import torch.nn.functional as F
 
+from torchtitan.observability import structured_logger as sl
 
+
+@sl.log_trace_span("compute_logprobs")
 def compute_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
     """Compute per-token logprobs from logits.
 
@@ -27,6 +30,7 @@ def compute_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Ten
     return logprobs.gather(2, shift_targets.unsqueeze(-1)).squeeze(-1)
 
 
+@sl.log_trace_span("extract_response_logprobs")
 def extract_response_logprobs(
     packed_logprobs: torch.Tensor,
     seq_lens: list[int],
@@ -47,6 +51,7 @@ def extract_response_logprobs(
     return result
 
 
+@sl.log_trace_span("verify_logprob_identity")
 def verify_logprob_identity(
     vllm_token_log_probs: list[list[float]],
     batch_token_log_probs: list[torch.Tensor],

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -52,6 +52,7 @@ from torchtitan.experiments.rl.types import (
     TrainBatch,
     Trajectory,
 )
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
 
 logger = logging.getLogger(__name__)
@@ -299,6 +300,7 @@ class RLTrainer(Configurable):
         ]
 
     @staticmethod
+    @sl.log_trace_span("_collate_episodes")
     def _collate_episodes(episodes: list[Episode]) -> TrainBatch:
         """Pack episodes into a single varlen-packed TrainBatch."""
         all_ids: list[int] = []
@@ -322,6 +324,7 @@ class RLTrainer(Configurable):
             token_logprobs=[ep.token_logprobs for ep in episodes],
         )
 
+    @sl.log_trace_span("setup")
     async def setup(
         self,
         *,
@@ -368,93 +371,99 @@ class RLTrainer(Configurable):
 
         self._multi_node = host_mesh is not None
 
-        if host_mesh is not None:
-            # Multi-node mode: dedicate whole nodes to trainer vs generator
-            if (
-                trainer_nodes is None
-                or generator_nodes is None
-                or gpus_per_node is None
-            ):
-                raise ValueError(
-                    "trainer_nodes, generator_nodes, and gpus_per_node are "
-                    "required when host_mesh is provided"
+        # TODO(observability): the mesh_spawn span wraps ~80 LoC of branching
+        # provisioner logic. Pull a Provisioner.spawn_meshes(...) helper and
+        # shrink this span to a single call.
+        with sl.log_trace_span("mesh_spawn"):
+            if host_mesh is not None:
+                # Multi-node mode: dedicate whole nodes to trainer vs generator
+                if (
+                    trainer_nodes is None
+                    or generator_nodes is None
+                    or gpus_per_node is None
+                ):
+                    raise ValueError(
+                        "trainer_nodes, generator_nodes, and gpus_per_node are "
+                        "required when host_mesh is provided"
+                    )
+                # Validate that world sizes are evenly divisible by node counts
+                assert self.trainer_world_size % trainer_nodes == 0, (
+                    f"trainer_world_size ({self.trainer_world_size}) must be "
+                    f"evenly divisible by trainer_nodes ({trainer_nodes})"
                 )
-            # Validate that world sizes are evenly divisible by node counts
-            assert self.trainer_world_size % trainer_nodes == 0, (
-                f"trainer_world_size ({self.trainer_world_size}) must be "
-                f"evenly divisible by trainer_nodes ({trainer_nodes})"
+                assert self.generator_world_size % generator_nodes == 0, (
+                    f"generator_world_size ({self.generator_world_size}) must be "
+                    f"evenly divisible by generator_nodes ({generator_nodes})"
+                )
+
+                # Compute GPUs per node for each role based on the config's
+                # world size and number of nodes allocated to that role
+                trainer_gpus_per_node = self.trainer_world_size // trainer_nodes
+                generator_gpus_per_node = self.generator_world_size // generator_nodes
+
+                trainer_host_mesh = host_mesh.slice(hosts=slice(0, trainer_nodes))
+                generator_host_mesh = host_mesh.slice(
+                    hosts=slice(trainer_nodes, trainer_nodes + generator_nodes)
+                )
+
+                # Use Provisioner to set CUDA_VISIBLE_DEVICES so each role
+                # only sees its own GPUs and doesn't conflict with other
+                # processes on the node
+                trainer_provisioner = Provisioner(total_gpus=gpus_per_node)
+                generator_provisioner = Provisioner(total_gpus=gpus_per_node)
+
+                trainer_mesh = trainer_host_mesh.spawn_procs(
+                    per_host={"gpus": trainer_gpus_per_node},
+                    bootstrap=trainer_provisioner.allocate(trainer_gpus_per_node),
+                )
+                generator_mesh = generator_host_mesh.spawn_procs(
+                    per_host={"gpus": generator_gpus_per_node},
+                    bootstrap=generator_provisioner.allocate(generator_gpus_per_node),
+                )
+            else:
+                # Single-node mode: partition GPUs on this_host() via
+                # CUDA_VISIBLE_DEVICES
+                provisioner = Provisioner(total_gpus=total_gpus)
+                trainer_mesh = this_host().spawn_procs(
+                    per_host={"gpus": self.trainer_world_size},
+                    bootstrap=provisioner.allocate(self.trainer_world_size),
+                )
+                generator_mesh = this_host().spawn_procs(
+                    per_host={"gpus": self.generator_world_size},
+                    bootstrap=provisioner.allocate(self.generator_world_size),
+                )
+
+            # Store proc meshes for cleanup
+            self._proc_meshes = [trainer_mesh, generator_mesh]
+
+            await setup_torch_elastic_env_async(trainer_mesh)
+            await setup_torch_elastic_env_async(generator_mesh)
+
+            # Spawn actors on their respective meshes
+            self.trainer = trainer_mesh.spawn(
+                "trainer",
+                PolicyTrainer,
+                config.trainer,
+                model_spec=config.model_spec,
+                hf_assets_path=config.hf_assets_path,
+                generator_dtype=config.generator.model_dtype,
+                compile_config=config.compile,
+                output_dir=config.dump_folder,
             )
-            assert self.generator_world_size % generator_nodes == 0, (
-                f"generator_world_size ({self.generator_world_size}) must be "
-                f"evenly divisible by generator_nodes ({generator_nodes})"
+
+            self.generator = generator_mesh.spawn(
+                "generator",
+                VLLMGenerator,
+                config.generator,
+                model_spec=config.model_spec,
+                model_path=config.hf_assets_path,
+                compile_config=config.compile,
+                max_num_seqs=max(
+                    config.num_prompts_per_step * config.generator.sampling.n,
+                    config.num_validation_samples,
+                ),
+                output_dir=config.dump_folder,
             )
-
-            # Compute GPUs per node for each role based on the config's
-            # world size and number of nodes allocated to that role
-            trainer_gpus_per_node = self.trainer_world_size // trainer_nodes
-            generator_gpus_per_node = self.generator_world_size // generator_nodes
-
-            trainer_host_mesh = host_mesh.slice(hosts=slice(0, trainer_nodes))
-            generator_host_mesh = host_mesh.slice(
-                hosts=slice(trainer_nodes, trainer_nodes + generator_nodes)
-            )
-
-            # Use Provisioner to set CUDA_VISIBLE_DEVICES so each role
-            # only sees its own GPUs and doesn't conflict with other
-            # processes on the node
-            trainer_provisioner = Provisioner(total_gpus=gpus_per_node)
-            generator_provisioner = Provisioner(total_gpus=gpus_per_node)
-
-            trainer_mesh = trainer_host_mesh.spawn_procs(
-                per_host={"gpus": trainer_gpus_per_node},
-                bootstrap=trainer_provisioner.allocate(trainer_gpus_per_node),
-            )
-            generator_mesh = generator_host_mesh.spawn_procs(
-                per_host={"gpus": generator_gpus_per_node},
-                bootstrap=generator_provisioner.allocate(generator_gpus_per_node),
-            )
-        else:
-            # Single-node mode: partition GPUs on this_host() via
-            # CUDA_VISIBLE_DEVICES
-            provisioner = Provisioner(total_gpus=total_gpus)
-            trainer_mesh = this_host().spawn_procs(
-                per_host={"gpus": self.trainer_world_size},
-                bootstrap=provisioner.allocate(self.trainer_world_size),
-            )
-            generator_mesh = this_host().spawn_procs(
-                per_host={"gpus": self.generator_world_size},
-                bootstrap=provisioner.allocate(self.generator_world_size),
-            )
-
-        # Store proc meshes for cleanup
-        self._proc_meshes = [trainer_mesh, generator_mesh]
-
-        await setup_torch_elastic_env_async(trainer_mesh)
-        await setup_torch_elastic_env_async(generator_mesh)
-
-        # Spawn actors on their respective meshes
-        self.trainer = trainer_mesh.spawn(
-            "trainer",
-            PolicyTrainer,
-            config.trainer,
-            model_spec=config.model_spec,
-            hf_assets_path=config.hf_assets_path,
-            generator_dtype=config.generator.model_dtype,
-            compile_config=config.compile,
-        )
-
-        self.generator = generator_mesh.spawn(
-            "generator",
-            VLLMGenerator,
-            config.generator,
-            model_spec=config.model_spec,
-            model_path=config.hf_assets_path,
-            compile_config=config.compile,
-            max_num_seqs=max(
-                config.num_prompts_per_step * config.generator.sampling.n,
-                config.num_validation_samples,
-            ),
-        )
 
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
@@ -462,13 +471,16 @@ class RLTrainer(Configurable):
         # LocalRankStrategy: routes each process to a storage volume based on
         #   LOCAL_RANK, so colocated processes share the same volume.
         # https://github.com/meta-pytorch/torchstore
-        await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
+        with sl.log_trace_span("torchstore_init"):
+            await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
 
-        # push weights from trainer
-        self.trainer.push_model_state_dict.call().get()
-        # pull weights for policy version 0 (initial weights)
-        self.generator.pull_model_state_dict.call(0).get()
+        # Initial weight sync from trainer to generator
+        with sl.log_trace_span("trainer_push_model_state_dict"):
+            self.trainer.push_model_state_dict.call().get()
+        with sl.log_trace_span("generator_pull_model_state_dict"):
+            self.generator.pull_model_state_dict.call(0).get()
 
+    @sl.log_trace_span("_collect_rollouts")
     def _collect_rollouts(self, num_groups: int, step: int) -> list[Trajectory]:
         """Collect group rollouts: one single-use env per group, scored and returned."""
         envs = [
@@ -478,14 +490,16 @@ class RLTrainer(Configurable):
             self.generator.generate.call([env.prompt for env in envs]).get()
         )
         trajectories: list[Trajectory] = []
-        for c in completions:
-            step_result = envs[c.prompt_idx].step(c.text)
-            trajectories.append(
-                Trajectory(sample_idx=c.prompt_idx, transitions=[(c, step_result)])
-            )
+        with sl.log_trace_span("score"):
+            for c in completions:
+                step_result = envs[c.prompt_idx].step(c.text)
+                trajectories.append(
+                    Trajectory(sample_idx=c.prompt_idx, transitions=[(c, step_result)])
+                )
         return trajectories
 
     @staticmethod
+    @sl.log_trace_span("_build_episodes")
     def _build_episodes(trajectories: list[Trajectory]) -> list[Episode]:
         """Group trajectories by sample, apply mean-baseline advantage, flatten to Episodes."""
         groups: dict[int, list[Trajectory]] = {}
@@ -513,6 +527,7 @@ class RLTrainer(Configurable):
                 )
         return episodes
 
+    @sl.log_trace_span("validate")
     async def validate(self) -> dict:
         """Run validation on held-out prompts using greedy sampling.
         TODO: investigate using pass@k."""
@@ -552,7 +567,13 @@ class RLTrainer(Configurable):
         pre_validation = await self.validate()
         logger.info(f"Pre:  {_format_validation(pre_validation)}")
 
-        for step in range(num_steps):
+        sl.log_trace_instant("training_start")
+
+        for step in range(1, num_steps + 1):
+            sl.set_step(step)
+            # Propagate the step counter to actors for structured logging.
+            self.trainer.sync_log_step.call(step)
+            self.generator.sync_log_step.call(step)
             # Cancellation point for Ctrl-C (KeyboardInterrupt) handling.
             # This yields to the event loop to check for cancellation, which
             # doesn't happen with `.get` calls.
@@ -563,6 +584,7 @@ class RLTrainer(Configurable):
 
             # --- Collect data and create episodes --- #
             trajectories = self._collect_rollouts(num_groups, step=step)
+
             episodes = self._build_episodes(trajectories)
 
             if self.config.log_samples:
@@ -573,18 +595,27 @@ class RLTrainer(Configurable):
                 self._collate_episodes(per_rank_episodes)
                 for per_rank_episodes in self._shard_episodes(episodes)
             ]
-            fwd_bwd_metrics = self._get_rank_0_value(
-                self.trainer.forward_backward.call(batches).get()
-            )
-            optim_metrics = self._get_rank_0_value(self.trainer.optim_step.call().get())
+            with sl.log_trace_span("trainer_forward_backward_call"):
+                fwd_bwd_metrics = self._get_rank_0_value(
+                    self.trainer.forward_backward.call(batches).get()
+                )
+
+            with sl.log_trace_span("trainer_optim_step_call"):
+                optim_metrics = self._get_rank_0_value(
+                    self.trainer.optim_step.call().get()
+                )
             metrics = {**fwd_bwd_metrics, **optim_metrics}
 
             # --- Weight sync --- #
-            t0 = time.perf_counter()
-            self.trainer.push_model_state_dict.call().get()
-            t_push = time.perf_counter() - t0
-            self.generator.pull_model_state_dict.call(metrics["policy_version"]).get()
-            t_sync = time.perf_counter() - t0
+            with sl.log_trace_span("trainer_push_model_state_dict"):
+                t0 = time.perf_counter()
+                self.trainer.push_model_state_dict.call().get()
+                t_push = time.perf_counter() - t0
+            with sl.log_trace_span("generator_pull_model_state_dict"):
+                self.generator.pull_model_state_dict.call(
+                    metrics["policy_version"]
+                ).get()
+                t_sync = time.perf_counter() - t0
             logger.info(f"Weight sync: push={t_push:.3f}s, total={t_sync:.3f}s")
 
             # --- Logging --- #
@@ -614,6 +645,15 @@ class RLTrainer(Configurable):
 
 async def main():
     config = ConfigManager().parse_args()
+    sl.init_structured_logger(
+        source="rl_controller",
+        output_dir=config.dump_folder,
+        rank=0,
+        # pyrefly: ignore [missing-attribute]
+        enable=config.trainer.debug.enable_structured_logging,
+    )
+    sl.log_trace_instant("structured_logger_started")
+
     rl_trainer = RLTrainer(config)
     try:
         await rl_trainer.setup()

--- a/torchtitan/observability/structured_logger/__init__.py
+++ b/torchtitan/observability/structured_logger/__init__.py
@@ -11,7 +11,7 @@ Typical use::
     from torchtitan.observability import structured_logger as sl
 
     sl.init_structured_logger(source="training", output_dir="./outputs")
-    sl.log_trace_instant("binary_start")
+    sl.log_trace_instant("structured_logger_started")
     with sl.log_trace_span("fwd_bwd"):
         ...
 """

--- a/torchtitan/observability/structured_logger/gantt_generator.py
+++ b/torchtitan/observability/structured_logger/gantt_generator.py
@@ -300,7 +300,7 @@ def _collect_paired_and_instants(
 
         # Point-in-time records (log_trace_instant, log_trace_scalar) carry
         # log_type=instant. Branch on intent before suffix matching so that
-        # instants whose names happen to end in "_start" (binary_start,
+        # instants whose names happen to end in "_start" (structured_logger_started,
         # training_start) don't get wrongly routed to the span-pair stack.
         if log_type == str(LogType.INSTANT):
             if event_type == "metric_value":

--- a/torchtitan/observability/structured_logger/step_state.py
+++ b/torchtitan/observability/structured_logger/step_state.py
@@ -59,7 +59,7 @@ Example::
 Note: inside a task, global tags are NOT visible (``get_step_tags`` returns
 the task's CV when non-empty). Actor contexts are intentionally isolated;
 if a tag needs to reach actors, set it per-task (e.g. via the controller's
-sync_step broadcast).
+sync_log_step broadcast).
 """
 
 import asyncio

--- a/torchtitan/observability/structured_logger/structured_logging.py
+++ b/torchtitan/observability/structured_logger/structured_logging.py
@@ -155,6 +155,11 @@ class TraceEventsOnlyFilter(logging.Filter):
         return False
 
 
+# TODO(observability): rename `rank` -> `mesh_rank`. The value is the rank within
+# the actor's proc mesh (`current_rank().rank`), not globally unique across
+# multiple RL meshes (e.g. trainer + generator each start at 0).
+# TODO(observability): handle duplicate `source` across actor meshes -- today
+# (source, rank) collides if two meshes share a name (e.g. two generators).
 def init_structured_logger(
     source: str, output_dir: str, rank: int | None = None, enable: bool = True
 ) -> None:
@@ -176,7 +181,7 @@ def init_structured_logger(
     Example::
 
         init_structured_logger(source="trainer", output_dir="./outputs")
-        log_trace_instant("binary_start")
+        log_trace_instant("structured_logger_started")
     """
     global _is_initialized, _disabled
 

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -36,7 +36,7 @@ def main() -> None:
         # pyrefly: ignore [missing-attribute]
         enable=config.debug.enable_structured_logging,
     )
-    sl.log_trace_instant("binary_start")
+    sl.log_trace_instant("structured_logger_started")
 
     trainer: Trainer | None = None
 


### PR DESCRIPTION
Summary:

TLDR: Adds to the RL experiment the structured-logging APIs. 

Time spans, scalars and events can be logged, per rank, with metadata, to a jsonl or database, using python standard logger. This can then be converted into a gantt chart. It is cheap, runs on every step, and useful to find stragglers, high level bottlenecks, how asynchronous an RL run is, debug timeouts, weird behavior on some rank on some step, etc.

For details of the APIs, please read the added readme in torchtitan/observability/structured_loggger/README.md.

Examples:
 {F1989343083} 

## Is it safe?

The workhorse here is logger.info. So the same way you treat logger.info, you should treat the structured logger.

It can be disabled with a config flag

If the user forgets to setup init_structured_logger, we still call logger.info, but nothing is saved anywhere.

It detects is_compiling and skips if true.

Tested with async coroutines and monarch as well.

Differential Revision: D101225148


