### PR TITLE
[graph_trainer] Gate overlap_fsdp_ag_rs_pass behind a config flag

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -84,6 +84,12 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Maximum CPU memory budget (in GB per rank) for offloaded activations.
     Tensors are selected largest-first until the budget is exhausted."""
 
+    enable_fsdp_ag_rs_overlap: bool = False
+    """When True, run ``overlap_fsdp_ag_rs_pass``. The pass moves backward
+    FSDP all-gathers onto a separate CUDA stream from reduce-scatters so the
+    two collectives can overlap. It is a no-op when the graph contains no
+    FSDP all-gathers."""
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -361,6 +361,7 @@ def joint_transformer_block_bucketing_reordering_pass(
     module_bucket_plans: list[list[str] | str],
     insert_overlap_deps: bool = False,
     bucket_mode: BucketMode | None = None,
+    enable_fsdp_ag_rs_overlap: bool = False,
 ) -> torch.fx.GraphModule:
     """Run joint-graph manual bucketing and reordering.
 
@@ -379,7 +380,14 @@ def joint_transformer_block_bucketing_reordering_pass(
             ``preserve_node_ordering`` after the topological sort.
         bucket_mode: bucket mode forwarded to the underlying bucketer;
             defaults to ``"custom_ops"`` via the parent class.
+        enable_fsdp_ag_rs_overlap: when ``True``, run ``overlap_fsdp_ag_rs_pass``
+            on ``gm`` before bucketing so that bucketed all-gathers inherit
+            the extra FSDP PG name and run on a separate CUDA stream from
+            reduce-scatters. No-op when the graph contains no FSDP
+            all-gathers.
     """
+    if enable_fsdp_ag_rs_overlap:
+        gm = overlap_fsdp_ag_rs_pass(gm, example_inputs)
 
     def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN)

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -43,7 +43,6 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     joint_transformer_block_bucketing_reordering_pass,
-    overlap_fsdp_ag_rs_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
@@ -138,11 +137,11 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime.
 
-    ``overlap_fsdp_ag_rs_pass`` runs immediately before
-    ``joint_transformer_block_bucketing_reordering_pass`` so that
-    forward+backward all-gathers end up on a separate CUDA stream from
-    reduce-scatters (enabling AG/RS overlap in backward). It is a no-op
-    when the graph contains no FSDP all-gathers.
+    ``joint_transformer_block_bucketing_reordering_pass`` optionally runs
+    ``overlap_fsdp_ag_rs_pass`` first (gated by
+    ``compile.enable_fsdp_ag_rs_overlap``) so that forward+backward
+    all-gathers end up on a separate CUDA stream from reduce-scatters
+    (enabling AG/RS overlap in backward).
     """
     from torchtitan.experiments.graph_trainer.common_utils import (
         get_default_transformer_block_buckets,
@@ -165,10 +164,10 @@ def compile_time_passes(
             defer_n_layers=config.compile.cpu_offload_defer_n_layers,
         ),
         selective_activation_remat_pass,
-        overlap_fsdp_ag_rs_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
+            enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
         ),
     ]
     if config.parallelism.enable_async_tensor_parallel:

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -51,6 +51,7 @@ def build_minimal_trainer(
                 inductor_compilation="regional",
                 numerics_changing_optim=compile_numerics_changing_optim,
                 disable_passes=[],
+                enable_fsdp_ag_rs_overlap=False,
                 debug_graph_passes=False,
                 cpu_offload_prefetch_n_layers=1,
                 cpu_offload_defer_n_layers=1,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -234,6 +234,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
                     cpu_offload_prefetch_n_layers=1,
                     cpu_offload_defer_n_layers=1,
                     cpu_offload_budget_gb=100.0,
+                    enable_fsdp_ag_rs_overlap=False,
                 ),
                 parallelism=SimpleNamespace(
                     pipeline_parallel_degree=1,


### PR DESCRIPTION
- Adds `compile.enable_fsdp_ag_rs_overlap` (default False) to `GraphTrainerConfig`.
- Removes `overlap_fsdp_ag_rs_pass` from the unconditional default pass list. Instead, `joint_transformer_block_bucketing_reordering_pass` now optionally runs the overlap pass first when the new flag is set.                                                                                                                                                                                                          