### PR TITLE
Enable SFT for HF Transformer backed trainer

### DIFF
--- a/torchtitan/experiments/transformers_modeling_backend/__init__.py
+++ b/torchtitan/experiments/transformers_modeling_backend/__init__.py
@@ -59,8 +59,24 @@ flavors = {
             n_kv_heads=16,
         ),
     ),
+    "sft_debugmodel": HFTransformerModel.Config(
+        titan_dense_config=TitanDenseModelConfig(
+            dim=256,
+            n_layers=2,
+            n_heads=16,
+            n_kv_heads=16,
+            attn_mask_type="block_causal",
+        ),
+        attn_implementation="flex_torchtitan",
+    ),
     "full": HFTransformerModel.Config(
         titan_dense_config=TitanDenseModelConfig(),
+    ),
+    "sft_full": HFTransformerModel.Config(
+        titan_dense_config=TitanDenseModelConfig(
+            attn_mask_type="block_causal",
+        ),
+        attn_implementation="flex_torchtitan",
     ),
 }
 

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -99,7 +99,7 @@ def transformers_modeling_backend_sft_full() -> TransformersBackendConfig:
         hf_model="Qwen/Qwen3-0.6B",
         model_spec=model_registry("sft_full"),
         tokenizer=HFBackendTokenizer.Config(),
-        optimizer=OptimizersContainer.Config(lr=2e-5),
+        optimizer=default_adamw(lr=2e-5),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -127,9 +127,7 @@ def transformers_modeling_backend_sft_full() -> TransformersBackendConfig:
             interval=10,
             last_save_model_only=False,
         ),
-        activation_checkpoint=ActivationCheckpointConfig(
-            mode="selective",
-        ),
+        activation_checkpoint=SelectiveAC.Config(),
     )
 
 
@@ -148,7 +146,7 @@ def transformers_modeling_backend_sft_debugmodel() -> TransformersBackendConfig:
         hf_model="Qwen/Qwen3-4B-Instruct-2507",
         model_spec=model_registry("sft_debugmodel"),
         tokenizer=HFBackendTokenizer.Config(),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -173,7 +171,5 @@ def transformers_modeling_backend_sft_debugmodel() -> TransformersBackendConfig:
             interval=10,
             last_save_model_only=False,
         ),
-        activation_checkpoint=ActivationCheckpointConfig(
-            mode="selective",
-        ),
+        activation_checkpoint=SelectiveAC.Config(),
     )

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -14,7 +14,10 @@ from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.experiments.transformers_modeling_backend.configs import (
     TransformersBackendConfig,
 )
-from torchtitan.hf_datasets.text_datasets import ChatDataLoader, HuggingFaceTextDataLoader
+from torchtitan.hf_datasets.text_datasets import (
+    ChatDataLoader,
+    HuggingFaceTextDataLoader,
+)
 from torchtitan.tools.profiler import Profiler
 
 from . import model_registry

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -14,10 +14,11 @@ from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.experiments.transformers_modeling_backend.configs import (
     TransformersBackendConfig,
 )
-from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.hf_datasets.text_datasets import ChatDataLoader, HuggingFaceTextDataLoader
 from torchtitan.tools.profiler import Profiler
 
 from . import model_registry
+from .tokenizer import HFBackendTokenizer
 
 
 def transformers_modeling_backend_debugmodel() -> TransformersBackendConfig:
@@ -80,4 +81,99 @@ def transformers_modeling_backend_full() -> TransformersBackendConfig:
             last_save_model_only=False,
         ),
         activation_checkpoint=SelectiveAC.Config(),
+    )
+
+
+def transformers_modeling_backend_sft_full() -> TransformersBackendConfig:
+    """SFT config with real HF pretrained weights loaded via initial_load_in_hf."""
+
+    def process_sample(sample):
+        return [
+            {"role": "user", "content": sample["question"]},
+            {"role": "assistant", "content": sample["answer"]},
+        ]
+
+    return TransformersBackendConfig(
+        loss=CrossEntropyLoss.Config(),
+        hf_assets_path="./tests/assets/qwen3_0.6b",
+        hf_model="Qwen/Qwen3-0.6B",
+        model_spec=model_registry("sft_full"),
+        tokenizer=HFBackendTokenizer.Config(),
+        optimizer=OptimizersContainer.Config(lr=2e-5),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=2,
+            decay_ratio=0.8,
+            decay_type="linear",
+            min_lr_factor=0.0,
+        ),
+        training=TrainingConfig(
+            local_batch_size=2,
+            seq_len=2048,
+            steps=10,
+        ),
+        dataloader=ChatDataLoader.Config(
+            dataset_path="json",
+            load_dataset_kwargs={
+                "data_files": "tests/assets/sft_test/data.json",
+                "split": "train",
+            },
+            sample_processor=process_sample,
+        ),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        checkpoint=CheckpointManager.Config(
+            enable=True,
+            initial_load_in_hf=True,
+            initial_load_model_only=True,
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=ActivationCheckpointConfig(
+            mode="selective",
+        ),
+    )
+
+
+def transformers_modeling_backend_sft_debugmodel() -> TransformersBackendConfig:
+    """SFT debug config for the transformers backend using ChatDataLoader."""
+
+    def process_sample(sample):
+        return [
+            {"role": "user", "content": sample["question"]},
+            {"role": "assistant", "content": sample["answer"]},
+        ]
+
+    return TransformersBackendConfig(
+        loss=CrossEntropyLoss.Config(),
+        hf_assets_path="./tests/assets/tokenizer",
+        hf_model="Qwen/Qwen3-4B-Instruct-2507",
+        model_spec=model_registry("sft_debugmodel"),
+        tokenizer=HFBackendTokenizer.Config(),
+        optimizer=OptimizersContainer.Config(lr=8e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=2,
+            decay_ratio=0.8,
+            decay_type="linear",
+            min_lr_factor=0.0,
+        ),
+        training=TrainingConfig(
+            local_batch_size=8,
+            seq_len=2048,
+            steps=10,
+        ),
+        dataloader=ChatDataLoader.Config(
+            dataset_path="json",
+            load_dataset_kwargs={
+                "data_files": "tests/assets/sft_test/data.json",
+                "split": "train",
+            },
+            sample_processor=process_sample,
+        ),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        checkpoint=CheckpointManager.Config(
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=ActivationCheckpointConfig(
+            mode="selective",
+        ),
     )

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -157,8 +157,12 @@ def transformers_modeling_backend_sft_debugmodel() -> TransformersBackendConfig:
             min_lr_factor=0.0,
         ),
         training=TrainingConfig(
-            local_batch_size=8,
-            seq_len=2048,
+            # Keep this small: this debug model uses the full Qwen3 vocab
+            # (~152k), so cross-entropy materializes a
+            # local_batch_size * seq_len * vocab logits tensor. batch=8,
+            # seq=2048 is ~9GB in fp32 and OOMs the 22GB CI GPUs.
+            local_batch_size=1,
+            seq_len=1024,
             steps=10,
         ),
         dataloader=ChatDataLoader.Config(

--- a/torchtitan/experiments/transformers_modeling_backend/configs.py
+++ b/torchtitan/experiments/transformers_modeling_backend/configs.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, replace
 
 from torchtitan.trainer import Trainer
 
@@ -13,3 +13,20 @@ from torchtitan.trainer import Trainer
 class TransformersBackendConfig(Trainer.Config):
     hf_model: str = ""
     """HuggingFace model ID (e.g., 'Qwen/Qwen2.5-7B')"""
+
+    def build(self, **kwargs):
+        from torchtitan.experiments.transformers_modeling_backend.trainer import (
+            SFTTrainer,
+        )
+
+        if not kwargs:
+            return SFTTrainer(config=replace(self))
+
+        config_fields = {f.name for f in fields(self)}
+        overlap = config_fields & kwargs.keys()
+        if overlap:
+            raise ValueError(
+                f"build() kwargs {overlap} overlap with config fields. "
+                "Put these values in the Config, not in build() kwargs."
+            )
+        return SFTTrainer(config=replace(self), **kwargs)

--- a/torchtitan/experiments/transformers_modeling_backend/configs.py
+++ b/torchtitan/experiments/transformers_modeling_backend/configs.py
@@ -4,29 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, fields, replace
+from torchtitan.experiments.transformers_modeling_backend.trainer import SFTTrainer
 
-from torchtitan.trainer import Trainer
-
-
-@dataclass(kw_only=True, slots=True)
-class TransformersBackendConfig(Trainer.Config):
-    hf_model: str = ""
-    """HuggingFace model ID (e.g., 'Qwen/Qwen2.5-7B')"""
-
-    def build(self, **kwargs):
-        from torchtitan.experiments.transformers_modeling_backend.trainer import (
-            SFTTrainer,
-        )
-
-        if not kwargs:
-            return SFTTrainer(config=replace(self))
-
-        config_fields = {f.name for f in fields(self)}
-        overlap = config_fields & kwargs.keys()
-        if overlap:
-            raise ValueError(
-                f"build() kwargs {overlap} overlap with config fields. "
-                "Put these values in the Config, not in build() kwargs."
-            )
-        return SFTTrainer(config=replace(self), **kwargs)
+# The HF-backend config is just SFTTrainer's own Config. SFTTrainer defines a
+# nested Config, so Configurable.__init_subclass__ auto-wires _owner=SFTTrainer;
+# the inherited Config.build() then constructs an SFTTrainer (and keeps the
+# config-field vs build()-kwarg overlap check) -- no reimplementation needed.
+TransformersBackendConfig = SFTTrainer.Config

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -267,6 +267,10 @@ class HFTransformerModel(BaseModel):
                     attn_implementation
                 ] = _flex_torchtitan_attention_forward
             elif attn_implementation not in AttentionInterface._global_mapping:
+                logger.info(
+                    f"'{attn_implementation}' not in HF AttentionInterface registry, "
+                    "defaulting to sdpa_attention_forward"
+                )
                 AttentionInterface._global_mapping[
                     attn_implementation
                 ] = sdpa_attention_forward
@@ -352,8 +356,13 @@ class HFTransformerModel(BaseModel):
             self.mlp_bias = False
             self.use_cache = False
             self.initializer_range = 1.0  # use as std for normal init in embedding
-            # FlexAttention does not support dropout
-            if hasattr(self, "attention_dropout"):
+            # FlexAttention does not support dropout (not part of PyTorch's
+            # flex_attention API). Override to 0 if the model sets it.
+            if hasattr(self, "attention_dropout") and self.attention_dropout > 0:
+                logger.warning(
+                    f"attention_dropout={self.attention_dropout} is not supported "
+                    "with FlexAttention, setting to 0.0"
+                )
                 self.attention_dropout = 0.0
 
             # When dim is explicitly overridden (e.g. debugmodel), derive the

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -87,30 +87,20 @@ def _flex_torchtitan_attention_forward(
     scaling = kwargs.get("scaling")
     block_mask = attention_mask if isinstance(attention_mask, BlockMask) else None
 
-    flex_module = getattr(module, "_flex_kernel", None)
-    if flex_module is not None:
-        # HF layout (B, N, L, H) -> native layout (B, L, N, H)
-        q_BLNH = query_BNLH.transpose(1, 2)
-        k_BLNH = key_BNLH.transpose(1, 2)
-        v_BLNH = value_BNLH.transpose(1, 2)
-        out_BLNH = flex_module(
-            q_BLNH, k_BLNH, v_BLNH, attention_masks=block_mask, scale=scaling
-        )
-        # Native layout (B, L, N, H) -> HF layout (B, N, L, H)
-        return out_BLNH.transpose(1, 2), None
+    # This forward is only registered as the "flex_torchtitan" attention impl,
+    # and HFTransformerModel attaches a _flex_kernel to every self_attn when that
+    # impl is selected, so the kernel module is always present here.
+    flex_module = module._flex_kernel
 
-    # Fallback: call flex_attention directly (no CP support)
-    from torch.nn.attention.flex_attention import flex_attention
-
-    out_BNLH = flex_attention(
-        query_BNLH,
-        key_BNLH,
-        value_BNLH,
-        block_mask=block_mask,
-        scale=scaling,
-        enable_gqa=True,
+    # HF layout (B, N, L, H) -> native layout (B, L, N, H)
+    q_BLNH = query_BNLH.transpose(1, 2)
+    k_BLNH = key_BNLH.transpose(1, 2)
+    v_BLNH = value_BNLH.transpose(1, 2)
+    out_BLNH = flex_module(
+        q_BLNH, k_BLNH, v_BLNH, attention_masks=block_mask, scale=scaling
     )
-    return out_BNLH, None
+    # Native layout (B, L, N, H) -> HF layout (B, N, L, H)
+    return out_BLNH.transpose(1, 2), None
 
 
 class SliceableModuleDict(ModuleDict):

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -261,11 +261,6 @@ class HFTransformerModel(BaseModel):
             self._titan_injected_model_args["attn_implementation"] = attn_implementation
             self.attn_implementation = attn_implementation
             if attn_implementation == "flex_torchtitan":
-                # HF model code has more dynamo guards than native TorchTitan,
-                # causing extra recompilations during TP warmup.
-                import torch._dynamo.config
-
-                torch._dynamo.config.cache_size_limit = 64
                 AttentionInterface._global_mapping[
                     attn_implementation
                 ] = _flex_torchtitan_attention_forward

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -99,8 +99,10 @@ def _flex_torchtitan_attention_forward(
     out_BLNH = flex_module(
         q_BLNH, k_BLNH, v_BLNH, attention_masks=block_mask, scale=scaling
     )
-    # Native layout (B, L, N, H) -> HF layout (B, N, L, H)
-    return out_BLNH.transpose(1, 2), None
+    # HF attention interface expects output as (B, L, N, H) (batch, seq, heads,
+    # head_dim) -- same layout sdpa_attention_forward returns. out_BLNH is
+    # already in that layout, so return it directly (no transpose).
+    return out_BLNH, None
 
 
 class SliceableModuleDict(ModuleDict):

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -27,10 +27,13 @@ from torchtitan.protocols.module import ModuleDict
 from torchtitan.tools.logging import logger
 
 
+# Shape suffix legend (matches torchtitan/models/common/attention.py):
+#   B = batch, L = sequence length, N = num heads, H = head dimension.
+# HF attention layout is (B, N, L, H); native TorchTitan layout is (B, L, N, H).
 class HFFlexAttention(FlexAttention):
     """FlexAttention kernel for HF models.
 
-    Accepts Q/K/V in native TorchTitan layout (batch, seq, heads, dim) so that
+    Accepts Q/K/V in native TorchTitan layout (B, L, N, H) so that
     apply_cp_to_forward's K/V all-gather (dim=1, the seq dim) works correctly.
     The caller (_flex_torchtitan_attention_forward) transposes from HF layout
     before calling this module, and transposes back after.
@@ -41,9 +44,9 @@ class HFFlexAttention(FlexAttention):
 
     def forward(
         self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        q_BLNH: torch.Tensor,
+        k_BLNH: torch.Tensor,
+        v_BLNH: torch.Tensor,
         *,
         attention_masks: BlockMask | None = None,
         scale: float | None = None,
@@ -52,22 +55,24 @@ class HFFlexAttention(FlexAttention):
     ) -> torch.Tensor:
         from torch.nn.attention.flex_attention import flex_attention
 
-        # Transpose to (batch, heads, seq, dim) for flex_attention kernel
-        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
-        out = flex_attention(
-            q,
-            k,
-            v,
+        # Transpose to (B, N, L, H) for the flex_attention kernel
+        q_BNLH = q_BLNH.transpose(1, 2)
+        k_BNLH = k_BLNH.transpose(1, 2)
+        v_BNLH = v_BLNH.transpose(1, 2)
+        out_BNLH = flex_attention(
+            q_BNLH,
+            k_BNLH,
+            v_BNLH,
             block_mask=attention_masks,
             scale=scale,
             enable_gqa=enable_gqa,
         )
-        # Transpose back to (batch, seq, heads, dim)
-        return out.transpose(1, 2)
+        # Transpose back to (B, L, N, H)
+        return out_BNLH.transpose(1, 2)
 
 
 def _flex_torchtitan_attention_forward(
-    module, query, key, value, attention_mask, **kwargs
+    module, query_BNLH, key_BNLH, value_BNLH, attention_mask, **kwargs
 ):
     """FlexAttention forward registered via AttentionInterface.
 
@@ -75,32 +80,37 @@ def _flex_torchtitan_attention_forward(
     each HF attention layer, so apply_cp_to_forward's K/V all-gather wrapping
     applies automatically.
 
-    Transposes Q/K/V from HF layout (batch, heads, seq, dim) to native
-    TorchTitan layout (batch, seq, heads, dim) before calling the module,
-    so CP's dim=1 all-gather targets the sequence dimension correctly.
+    Transposes Q/K/V from HF layout (B, N, L, H) to native TorchTitan layout
+    (B, L, N, H) before calling the module, so CP's dim=1 all-gather targets
+    the sequence dimension correctly.
     """
     scaling = kwargs.get("scaling")
     block_mask = attention_mask if isinstance(attention_mask, BlockMask) else None
 
     flex_module = getattr(module, "_flex_kernel", None)
     if flex_module is not None:
-        # HF layout → native layout: (batch, heads, seq, dim) → (batch, seq, heads, dim)
-        q = query.transpose(1, 2)
-        k = key.transpose(1, 2)
-        v = value.transpose(1, 2)
-        out = flex_module(
-            q, k, v, attention_masks=block_mask, scale=scaling
+        # HF layout (B, N, L, H) -> native layout (B, L, N, H)
+        q_BLNH = query_BNLH.transpose(1, 2)
+        k_BLNH = key_BNLH.transpose(1, 2)
+        v_BLNH = value_BNLH.transpose(1, 2)
+        out_BLNH = flex_module(
+            q_BLNH, k_BLNH, v_BLNH, attention_masks=block_mask, scale=scaling
         )
-        # Native layout → HF layout
-        return out.transpose(1, 2), None
+        # Native layout (B, L, N, H) -> HF layout (B, N, L, H)
+        return out_BLNH.transpose(1, 2), None
 
     # Fallback: call flex_attention directly (no CP support)
     from torch.nn.attention.flex_attention import flex_attention
 
-    out = flex_attention(
-        query, key, value, block_mask=block_mask, scale=scaling, enable_gqa=True
+    out_BNLH = flex_attention(
+        query_BNLH,
+        key_BNLH,
+        value_BNLH,
+        block_mask=block_mask,
+        scale=scaling,
+        enable_gqa=True,
     )
-    return out, None
+    return out_BNLH, None
 
 
 class SliceableModuleDict(ModuleDict):

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -10,13 +10,9 @@ import math
 from dataclasses import dataclass, fields
 
 import torch
-import torch._dynamo.config
 from torch import nn
 from torch.nn import init
 
-# TP async collectives produce varying tensor types that trigger dynamo
-# recompilation. Increase the limit so guards stabilize after initial steps.
-torch._dynamo.config.cache_size_limit = 64
 from transformers import AutoConfig
 from transformers.configuration_utils import PretrainedConfig
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
@@ -263,6 +259,10 @@ class HFTransformerModel(BaseModel):
             self._titan_injected_model_args["attn_implementation"] = attn_implementation
             self.attn_implementation = attn_implementation
             if attn_implementation == "flex_torchtitan":
+                # HF model code has more dynamo guards than native TorchTitan,
+                # causing extra recompilations during TP warmup.
+                import torch._dynamo.config
+                torch._dynamo.config.cache_size_limit = 64
                 AttentionInterface._global_mapping[
                     attn_implementation
                 ] = _flex_torchtitan_attention_forward

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -10,17 +10,101 @@ import math
 from dataclasses import dataclass, fields
 
 import torch
+import torch._dynamo.config
 from torch import nn
 from torch.nn import init
+
+# TP async collectives produce varying tensor types that trigger dynamo
+# recompilation. Increase the limit so guards stabilize after initial steps.
+torch._dynamo.config.cache_size_limit = 64
 from transformers import AutoConfig
 from transformers.configuration_utils import PretrainedConfig
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
 from transformers.modeling_utils import AttentionInterface, PreTrainedModel
 
+from torch.nn.attention.flex_attention import BlockMask
+
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import ModuleDict
 from torchtitan.tools.logging import logger
+
+
+class HFFlexAttention(FlexAttention):
+    """FlexAttention kernel for HF models.
+
+    Accepts Q/K/V in native TorchTitan layout (batch, seq, heads, dim) so that
+    apply_cp_to_forward's K/V all-gather (dim=1, the seq dim) works correctly.
+    The caller (_flex_torchtitan_attention_forward) transposes from HF layout
+    before calling this module, and transposes back after.
+
+    This subclass passes the isinstance(FlexAttention) check in
+    apply_cp_to_forward, so CP wrapping works naturally.
+    """
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        attention_masks: BlockMask | None = None,
+        scale: float | None = None,
+        enable_gqa: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        from torch.nn.attention.flex_attention import flex_attention
+
+        # Transpose to (batch, heads, seq, dim) for flex_attention kernel
+        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+        out = flex_attention(
+            q,
+            k,
+            v,
+            block_mask=attention_masks,
+            scale=scale,
+            enable_gqa=enable_gqa,
+        )
+        # Transpose back to (batch, seq, heads, dim)
+        return out.transpose(1, 2)
+
+
+def _flex_torchtitan_attention_forward(
+    module, query, key, value, attention_mask, **kwargs
+):
+    """FlexAttention forward registered via AttentionInterface.
+
+    Routes the kernel call through the HFFlexAttention module attached to
+    each HF attention layer, so apply_cp_to_forward's K/V all-gather wrapping
+    applies automatically.
+
+    Transposes Q/K/V from HF layout (batch, heads, seq, dim) to native
+    TorchTitan layout (batch, seq, heads, dim) before calling the module,
+    so CP's dim=1 all-gather targets the sequence dimension correctly.
+    """
+    scaling = kwargs.get("scaling")
+    block_mask = attention_mask if isinstance(attention_mask, BlockMask) else None
+
+    flex_module = getattr(module, "_flex_kernel", None)
+    if flex_module is not None:
+        # HF layout → native layout: (batch, heads, seq, dim) → (batch, seq, heads, dim)
+        q = query.transpose(1, 2)
+        k = key.transpose(1, 2)
+        v = value.transpose(1, 2)
+        out = flex_module(
+            q, k, v, attention_masks=block_mask, scale=scaling
+        )
+        # Native layout → HF layout
+        return out.transpose(1, 2), None
+
+    # Fallback: call flex_attention directly (no CP support)
+    from torch.nn.attention.flex_attention import flex_attention
+
+    out = flex_attention(
+        query, key, value, block_mask=block_mask, scale=scaling, enable_gqa=True
+    )
+    return out, None
 
 
 class SliceableModuleDict(ModuleDict):
@@ -178,10 +262,14 @@ class HFTransformerModel(BaseModel):
             """Configure HuggingFace attention settings."""
             self._titan_injected_model_args["attn_implementation"] = attn_implementation
             self.attn_implementation = attn_implementation
-            # NOTE:(3outeille):This will force create_causal_mask to return None
-            AttentionInterface._global_mapping[
-                attn_implementation
-            ] = sdpa_attention_forward
+            if attn_implementation == "flex_torchtitan":
+                AttentionInterface._global_mapping[
+                    attn_implementation
+                ] = _flex_torchtitan_attention_forward
+            elif attn_implementation not in AttentionInterface._global_mapping:
+                AttentionInterface._global_mapping[
+                    attn_implementation
+                ] = sdpa_attention_forward
 
         def _create_getter_setter_dynamically(self, has_moe: bool):
             """
@@ -264,6 +352,9 @@ class HFTransformerModel(BaseModel):
             self.mlp_bias = False
             self.use_cache = False
             self.initializer_range = 1.0  # use as std for normal init in embedding
+            # FlexAttention does not support dropout
+            if hasattr(self, "attention_dropout"):
+                self.attention_dropout = 0.0
 
             # When dim is explicitly overridden (e.g. debugmodel), derive the
             # dependent sizes from it. Otherwise keep what AutoConfig loaded from
@@ -363,6 +454,12 @@ class HFTransformerModel(BaseModel):
 
         for layer in self.model.model.layers.values():
             layer.moe_enabled = False
+            # Attach FlexAttention kernel module to each attention layer
+            # so apply_cp_to_forward can find and wrap it for CP.
+            if hasattr(layer, "self_attn") and config.attn_implementation == "flex_torchtitan":
+                layer.self_attn.register_module(
+                    "_flex_kernel", HFFlexAttention(config=HFFlexAttention.Config())
+                )
 
     def set_cp_mesh(self, mesh):
         self.cp_mesh = mesh
@@ -656,16 +753,24 @@ class HFTransformerModel(BaseModel):
                 "Could not find rotary_emb in the model. Please check the model structure."
             )
 
-    def forward(self, *args, **kwargs):
+    def forward(self, *args, positions=None, attention_masks=None, **kwargs):
         local_seq_len = self.max_seq_len
         local_seq_len //= (
             self.cp_mesh.size()
             if self.cp_mesh is not None and self.cp_mesh.size() > 1
             else 1
         )
-        kwargs["position_ids"] = torch.arange(
-            local_seq_len, device=args[0].device
-        ).unsqueeze(0)
+
+        if positions is not None:
+            kwargs["position_ids"] = positions.to(args[0].device)
+        else:
+            kwargs["position_ids"] = torch.arange(
+                local_seq_len, device=args[0].device
+            ).unsqueeze(0)
+
+        if attention_masks is not None:
+            kwargs["attention_mask"] = attention_masks
+
         output = self.model.model(*args, **kwargs)
         if self._skip_lm_head:
             return output.last_hidden_state

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -13,12 +13,12 @@ import torch
 from torch import nn
 from torch.nn import init
 
+from torch.nn.attention.flex_attention import BlockMask
+
 from transformers import AutoConfig
 from transformers.configuration_utils import PretrainedConfig
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
 from transformers.modeling_utils import AttentionInterface, PreTrainedModel
-
-from torch.nn.attention.flex_attention import BlockMask
 
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
@@ -262,6 +262,7 @@ class HFTransformerModel(BaseModel):
                 # HF model code has more dynamo guards than native TorchTitan,
                 # causing extra recompilations during TP warmup.
                 import torch._dynamo.config
+
                 torch._dynamo.config.cache_size_limit = 64
                 AttentionInterface._global_mapping[
                     attn_implementation
@@ -465,7 +466,10 @@ class HFTransformerModel(BaseModel):
             layer.moe_enabled = False
             # Attach FlexAttention kernel module to each attention layer
             # so apply_cp_to_forward can find and wrap it for CP.
-            if hasattr(layer, "self_attn") and config.attn_implementation == "flex_torchtitan":
+            if (
+                hasattr(layer, "self_attn")
+                and config.attn_implementation == "flex_torchtitan"
+            ):
                 layer.self_attn.register_module(
                     "_flex_kernel", HFFlexAttention(config=HFFlexAttention.Config())
                 )

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -101,6 +101,14 @@ def parallelize_hf_transformers(
 
     if parallel_dims.cp_enabled:
         model.set_cp_mesh(parallel_dims.get_mesh("cp"))
+        # Collect HFFlexAttention kernel modules for CP wrapping
+        flex_modules = []
+        for layer in model.layers.values():
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "_flex_kernel"):
+                flex_modules.append(layer.self_attn._flex_kernel)
+        if flex_modules:
+            from torchtitan.distributed.context_parallel import apply_cp_to_forward
+            apply_cp_to_forward(flex_modules, parallel_dims.get_mesh("cp"))
         logger.info("Applied Context Parallel to the model")
 
     return model

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -108,6 +108,7 @@ def parallelize_hf_transformers(
                 flex_modules.append(layer.self_attn._flex_kernel)
         if flex_modules:
             from torchtitan.distributed.context_parallel import apply_cp_to_forward
+
             apply_cp_to_forward(flex_modules, parallel_dims.get_mesh("cp"))
         logger.info("Applied Context Parallel to the model")
 

--- a/torchtitan/experiments/transformers_modeling_backend/tests/integration_tests.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/integration_tests.py
@@ -34,6 +34,17 @@ def build_transformers_modeling_backend_test_list() -> list[OverrideDefinitions]
             "transformers_modeling_backend_fsdp+tp+pp",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module transformers_modeling_backend",
+                    "--config transformers_modeling_backend_sft_debugmodel",
+                ],
+            ],
+            "Transformers Backend SFT ChatDataset",
+            "transformers_modeling_backend_sft",
+            ngpu=2,
+        ),
     ]
     return integration_tests_flavors
 

--- a/torchtitan/experiments/transformers_modeling_backend/tokenizer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tokenizer.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+from torchtitan.components.tokenizer import HuggingFaceTokenizer
+
+
+class HFBackendTokenizer(HuggingFaceTokenizer):
+    """Tokenizer that passes special tokens to chat templates.
+
+    Some HF models' chat templates reference bos_token, eos_token, etc.
+    The base tokenizer only passes messages. This subclass auto-injects
+    special tokens so all HF chat templates work.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(HuggingFaceTokenizer.Config):
+        pass
+
+    def __init__(self, config=None, *, tokenizer_path):
+        super().__init__(config=config, tokenizer_path=tokenizer_path)
+        # Fix: when bos_token and eos_token are the same string, the base
+        # tokenizer's elif logic only sets bos_token. Ensure eos is set too.
+        if self.eos_id is None and self._hf_config:
+            eos_str = self._get_token_from_config(self._hf_config, "eos_token")
+            if eos_str is not None:
+                self.eos_token = eos_str
+                self.eos_id = self.tokenizer.token_to_id(eos_str)
+
+    def apply_chat_template(self, messages, **kwargs):
+        kwargs.setdefault("bos_token", self.bos_token or "")
+        kwargs.setdefault("eos_token", self.eos_token or "")
+        kwargs.setdefault("add_generation_prompt", True)
+        return super().apply_chat_template(messages, **kwargs)

--- a/torchtitan/experiments/transformers_modeling_backend/trainer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/trainer.py
@@ -28,12 +28,16 @@ class SFTTrainer(Trainer):
     @sl.log_trace_span("post_dataloading_process")
     def post_dataloading_process(
         self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], dict[str, Any]]:
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
         inputs = input_dict["input"]
-        extra_inputs = {k: v for k, v in input_dict.items() if k != "input"}
-        extra_kwargs: dict[str, Any] = {}
+        # Everything else becomes a model-forward kwarg, forwarded to all PP
+        # stages (matches the base Trainer contract). positions is read here so
+        # we can build the block-causal mask.
+        extra_kwargs: dict[str, Any] = {
+            k: v for k, v in input_dict.items() if k != "input"
+        }
 
-        positions = extra_inputs.pop("positions", None)
+        positions = extra_kwargs.get("positions", None)
 
         attn_mask_type = getattr(self.model_config, "attn_mask_type", "causal")
 
@@ -48,8 +52,6 @@ class SFTTrainer(Trainer):
             extra_kwargs["attention_masks"] = create_attention_mask(
                 mask_mod, B, None, seq_len, seq_len
             )
-
-        extra_kwargs["positions"] = positions
 
         if self.parallel_dims.cp_enabled:
             from torchtitan.distributed.context_parallel import (
@@ -70,4 +72,4 @@ class SFTTrainer(Trainer):
 
         self.ntokens_seen += labels.numel()
 
-        return inputs, labels, extra_inputs, extra_kwargs
+        return inputs, labels, extra_kwargs

--- a/torchtitan/experiments/transformers_modeling_backend/trainer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/trainer.py
@@ -1,0 +1,73 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import torch
+from torch.nn.attention.flex_attention import and_masks
+
+from torchtitan.models.common.attention import (
+    create_attention_mask,
+    get_causal_mask_mod,
+    get_document_mask_mod,
+)
+from torchtitan.observability import structured_logger as sl
+from torchtitan.trainer import Trainer
+
+
+class SFTTrainer(Trainer):
+    """Trainer subclass that builds a BlockMask for HF models in SFT.
+
+    Builds the BlockMask in post_dataloading_process (before any parallelism
+    sharding) so it works correctly with TP + sequence parallel.
+    """
+
+    @sl.log_trace_span("post_dataloading_process")
+    def post_dataloading_process(
+        self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], dict[str, Any]]:
+        inputs = input_dict["input"]
+        extra_inputs = {k: v for k, v in input_dict.items() if k != "input"}
+        extra_kwargs: dict[str, Any] = {}
+
+        positions = extra_inputs.pop("positions", None)
+
+        attn_mask_type = getattr(self.model_config, "attn_mask_type", "causal")
+
+        if attn_mask_type == "block_causal":
+            assert (
+                positions is not None
+            ), "block_causal mask requires per-document positions from the dataloader"
+            mask_mod = and_masks(
+                get_causal_mask_mod(), get_document_mask_mod(positions)
+            )
+            B, seq_len = positions.shape
+            extra_kwargs["attention_masks"] = create_attention_mask(
+                mask_mod, B, None, seq_len, seq_len
+            )
+
+        extra_kwargs["positions"] = positions
+
+        if self.parallel_dims.cp_enabled:
+            from torchtitan.distributed.context_parallel import (
+                prepare_context_parallel_input,
+            )
+
+            load_balancer = self.config.parallelism.context_parallel_load_balancer
+            if attn_mask_type == "block_causal":
+                load_balancer = "ptrr"
+            inputs, labels, extra_kwargs = prepare_context_parallel_input(
+                inputs,
+                labels,
+                extra_kwargs,
+                self.parallel_dims.get_mesh("cp"),
+                self.device,
+                load_balancer,
+            )
+
+        self.ntokens_seen += labels.numel()
+
+        return inputs, labels, extra_inputs, extra_kwargs

--- a/torchtitan/experiments/transformers_modeling_backend/trainer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/trainer.py
@@ -16,6 +16,7 @@ from torchtitan.models.common.attention import (
     get_document_mask_mod,
 )
 from torchtitan.observability import structured_logger as sl
+from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
 
 
@@ -65,7 +66,15 @@ class SFTTrainer(Trainer):
             )
 
             load_balancer = self.config.parallelism.context_parallel_load_balancer
-            if attn_mask_type == "block_causal":
+            if attn_mask_type == "block_causal" and load_balancer == "headtail":
+                # "headtail" is the SDPA default and cannot shard a FlexAttention
+                # BlockMask; switch to the flex-compatible "ptrr". An explicit
+                # None (disable balancing) or "ptrr" is respected.
+                logger.warning(
+                    "context_parallel_load_balancer='headtail' is SDPA-only and "
+                    "cannot shard a block_causal BlockMask; using 'ptrr'. Set it "
+                    "explicitly (ptrr or None) to silence this."
+                )
                 load_balancer = "ptrr"
             inputs, labels, extra_kwargs = prepare_context_parallel_input(
                 inputs,

--- a/torchtitan/experiments/transformers_modeling_backend/trainer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/trainer.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -24,6 +25,11 @@ class SFTTrainer(Trainer):
     Builds the BlockMask in post_dataloading_process (before any parallelism
     sharding) so it works correctly with TP + sequence parallel.
     """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Trainer.Config):
+        hf_model: str = ""
+        """HuggingFace model ID (e.g. 'Qwen/Qwen2.5-7B')."""
 
     @sl.log_trace_span("post_dataloading_process")
     def post_dataloading_process(


### PR DESCRIPTION
## Summary


  Enables supervised fine-tuning (SFT) for any HuggingFace model in the
  transformers_modeling_backend experiment, building on the native SFT infrastructure from #2556.

  - Uses FlexAttention with BlockMask for packed sequences. Builds the BlockMask in
    `post_dataloading_process` (before parallelism sharding) using TorchTitan's existing
    `get_causal_mask_mod` + `get_document_mask_mod` — same mask infrastructure as native TorchTitan SFT.
  - `HFFlexAttention` subclasses TorchTitan's `FlexAttention` kernel module, handling HF's tensor
    layout via transposes. Registered as a submodule on each HF attention layer so
    `apply_cp_to_forward` works naturally — no globals needed.
  - Registers `flex_torchtitan` as a custom attention implementation that bypasses HF's internal
    mask creation (which builds at the wrong point for TP+SP) and routes through a compile-friendly
    `flex_attention` call.
  - `SFTTrainer` subclass overrides `post_dataloading_process` to build the BlockMask at full
    sequence length before any parallelism touches the data.
  - `HFTransformerStateDictAdapter` enables loading pretrained HF weights (trivial `model.` prefix
    mapping, handles weight tying).
  - `HFBackendTokenizer` passes `bos_token`/`eos_token` to chat templates and fixes an edge case
    where BOS and EOS share the same token string.
  - TitanDenseModelConfig defaults changed to None so HF config values aren't overridden when using
    full-size models.
  - No dynamo `cache_size_limit` workaround needed: relies on the upstream nested-`AsyncCollectiveTensor`
    fix (pytorch#186442), so the flex path stays under the default recompile limit across all parallelisms.
  - All changes within `torchtitan/experiments/transformers_modeling_backend/` — no core modifications.

  ## Files changed

  | File | Description |
  |---|---|
  | trainer.py (new) | `SFTTrainer` builds BlockMask before parallelism sharding, handles CP load balancer |
  | state_dict_adapter.py (new) | `model.` prefix strip/add for HF weight loading, handles weight tying |
  | tokenizer.py (new) | Passes special tokens to chat templates, fixes shared BOS/EOS edge case |
  | model.py | `HFFlexAttention` subclass + `_flex_torchtitan_attention_forward`; `forward()` accepts positions/attention_masks; guard 
  `intermediate_size`/`head_dim` recalculation; disable `attention_dropout` for FlexAttention |
  | configs.py | `build()` override to use `SFTTrainer` |
  | parallelize.py | Collects `HFFlexAttention` modules and calls `apply_cp_to_forward` for CP |
  | __init__.py | `sft_debugmodel`/`sft_full` flavors with `attn_implementation="flex_torchtitan"`; wire `state_dict_adapter`; None defaults for
  TitanDenseModelConfig |
  | config_registry.py | SFT config functions (random init + pretrained weight loading) using `ChatDataLoader` and `HFBackendTokenizer` |
  | tests/integration_tests.py | 2-GPU SFT integration test |

  ## Parallelism support

  | Parallelism | Status |
  |---|---|
  | FSDP | Works |
  | FSDP + TP | Works |
  | FSDP + TP + PP | Works |
  | FSDP + AC (selective/full) | Works |
  | FSDP + compile | Works |
  | FSDP + TP + compile | Works |
  | FSDP + CP | Works |
  | CP + compile | Works |
  | TP + CP | Works |
  | FSDP + TP + CP | Works |
  | FSDP + TP + CP + compile | Works |

  ## Test plan

  - [x] Pretraining regression: `transformers_modeling_backend_debugmodel` identical loss before/after
  - [x] SFT debugmodel (Qwen3 arch): loss 11.0 → 3.3, 2 GPUs
  - [x] SFT debugmodel (Mistral arch): loss 10.9 → 8.3 — architecture-agnostic
  - [x] SFT with pretrained Qwen3-0.6B: loss 13.4 → 6.1
  - [x] SFT with pretrained Qwen2.5-0.5B-Instruct: loss 5.3 → 1.7
  - [x] SFT with pretrained Llama-3.2-1B-Instruct: loss 7.6 → 0.0001
  - [x] SFT with pretrained Seed-Coder-8B-Instruct: loss 6.8 → 2.1
  - [x] SFT with pretrained Granite-3.1-2B-Instruct: loss 50.2 → 12.2
  - [x] FSDP + TP (4 GPU): works
  - [x] FSDP + TP + PP (8 GPU): works
  - [x] FSDP + compile (2 GPU): works
  - [x] FSDP + TP + compile (4 GPU): works
  - [x] FSDP + CP (2 GPU): works
  - [x] CP + compile (2 GPU): works
  - [x] TP + CP (4 GPU): works
  - [x] FSDP + TP + CP (8 GPU): works
  - [x] FSDP + TP + CP + compile (8 GPU, full 28-layer qwen3_0.6b): works — 0 cache-limit hits at default recompile limit
  - [x] Reproducibility: compare loss curves against native SFT on same model/data
  - [x] SFT loss/KL parity vs native (#2556), qwen3_0.6b, same weights + packed batch: max |loss diff| 3.4e-06, max KL 5.0e-09

  Numeric verification results:

  ### Native TorchTitan vs HuggingFace — logit parity (qwen3_0.6b, same weights + input, fp32, 161 positions)

  | metric | value |
  |---|---|
  | top1 match | 100.0000% |
  | top5 overlap | 100.0000% |
  | KL(HF ‖ native) | 1.60e-06 |
  | KL(native ‖ HF) | 6.78e-07 |
  | max \|logit diff\| | 9.06e-05 |
  | mean \|logit diff\| | 5.14e-06 |
  | cosine similarity | 1.000000 |