### PR TITLE
Make ChunkedCELoss support torch.autograd.grad

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -8,6 +8,11 @@ import unittest
 
 import torch
 import torch.nn as nn
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    TestCase,
+)
 from torchtitan.components.loss import (
     ChunkedCELoss,
     cross_entropy_loss,
@@ -209,23 +214,49 @@ class _FakeDecoder(nn.Module):
         return self.output(tokens)
 
 
-class TestChunkedCELoss(unittest.TestCase):
-    def _make_model_and_loss(self, dim=32, vocab_size=64, num_chunks=4):
+class TestChunkedCELoss(TestCase):
+    def _make_model_and_loss(
+        self, dim=32, vocab_size=64, num_chunks=4, support_autograd_grad=False
+    ):
         """Create a fake Decoder and ChunkedCELoss for testing."""
         model = _FakeDecoder(dim, vocab_size)
-        chunked_loss = ChunkedCELoss(ChunkedCELoss.Config(num_chunks=num_chunks))
+        chunked_loss = ChunkedCELoss(
+            ChunkedCELoss.Config(
+                num_chunks=num_chunks,
+                support_autograd_grad=support_autograd_grad,
+            )
+        )
         # Bypass isinstance(model, Decoder) check for unit testing
         chunked_loss.lm_head = model.output
         return model, chunked_loss
 
-    def test_numerical_equivalence(self):
+    @staticmethod
+    def _chunked_loss_and_grads(
+        model, chunked_loss, hidden_states, labels, global_valid_tokens
+    ):
+        h = hidden_states.detach().requires_grad_(True)
+        loss = chunked_loss(h, labels, global_valid_tokens)
+        if chunked_loss.support_autograd_grad:
+            h_grad, w_grad = torch.autograd.grad(
+                loss, [h, model.output.weight]
+            )
+        else:
+            loss.backward()
+            h_grad = h.grad
+            w_grad = model.output.weight.grad
+        return loss, h_grad.clone(), w_grad.clone()
+
+    @parametrize("support_autograd_grad", [False, True])
+    def test_numerical_equivalence(self, support_autograd_grad):
         """ChunkedCELoss must produce the same loss and gradients as the standard path."""
         torch.manual_seed(42)
         B, L, D, V = 2, 8, 32, 64
         num_chunks = 4
 
         model_std, _ = self._make_model_and_loss(D, V, num_chunks)
-        model_chunked, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
+        model_chunked, chunked_loss = self._make_model_and_loss(
+            D, V, num_chunks, support_autograd_grad=support_autograd_grad
+        )
 
         # Share the same lm_head weights
         model_chunked.output.load_state_dict(model_std.output.state_dict())
@@ -246,12 +277,15 @@ class TestChunkedCELoss(unittest.TestCase):
         lm_head_grad_std = model_std.output.weight.grad.clone()
 
         # Chunked path
-        hidden_chunked = hidden_states.detach().requires_grad_(True)
-
-        loss_chunked = chunked_loss(hidden_chunked, labels, global_valid_tokens)
-        loss_chunked.backward()
-        grad_chunked = hidden_chunked.grad.clone()
-        lm_head_grad_chunked = model_chunked.output.weight.grad.clone()
+        loss_chunked, grad_chunked, lm_head_grad_chunked = (
+            self._chunked_loss_and_grads(
+                model_chunked,
+                chunked_loss,
+                hidden_states,
+                labels,
+                global_valid_tokens,
+            )
+        )
 
         # Verify loss values match
         torch.testing.assert_close(
@@ -310,6 +344,46 @@ class TestChunkedCELoss(unittest.TestCase):
                 places=5,
                 msg=f"Loss with {2**i} chunks should match loss with 1 chunk",
             )
+
+    def test_support_autograd_grad_bitwise_equal(self):
+        torch.manual_seed(42)
+        B, L, D, V = 2, 8, 32, 64
+        labels = torch.randint(0, V, (B, L))
+        global_valid_tokens = (labels != IGNORE_INDEX).sum().float()
+        hidden_states = torch.randn(B, L, D)
+
+        model_a, loss_a_fn = self._make_model_and_loss(D, V)
+        model_b, loss_b_fn = self._make_model_and_loss(
+            D, V, support_autograd_grad=True
+        )
+        model_b.output.load_state_dict(model_a.output.state_dict())
+
+        loss_a, h_grad_a, w_grad_a = self._chunked_loss_and_grads(
+            model_a, loss_a_fn, hidden_states, labels, global_valid_tokens
+        )
+        loss_b, h_grad_b, w_grad_b = self._chunked_loss_and_grads(
+            model_b, loss_b_fn, hidden_states, labels, global_valid_tokens
+        )
+
+        self.assertEqual(loss_b, loss_a)
+        self.assertEqual(h_grad_b, h_grad_a)
+        self.assertEqual(w_grad_b, w_grad_a)
+
+    def test_support_autograd_grad_does_not_touch_dot_grad(self):
+        torch.manual_seed(0)
+        B, L, D, V = 2, 8, 32, 64
+        model, chunked_loss = self._make_model_and_loss(
+            D, V, support_autograd_grad=True
+        )
+        h = torch.randn(B, L, D, requires_grad=True)
+        labels = torch.randint(0, V, (B, L))
+        loss = chunked_loss(h, labels)
+        torch.autograd.grad(loss, [h, model.output.weight])
+        self.assertIsNone(h.grad)
+        self.assertIsNone(model.output.weight.grad)
+
+
+instantiate_parametrized_tests(TestChunkedCELoss)
 
 
 if __name__ == "__main__":

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -229,6 +229,14 @@ class ChunkedCELoss(BaseLoss):
     class Config(BaseLoss.Config):
         num_chunks: int = 8
         """Number of chunks to split the sequence into."""
+        support_autograd_grad: bool = False
+        """If True, plumb the sharded lm_head param grads (already produced
+        by the chunk loop's reduce-scatter) out as explicit autograd outputs
+        so outer ``torch.autograd.grad(loss, [hidden_states,
+        *lm_head.parameters()])`` returns them directly — no reliance on
+        ``param.grad`` side effects. Required for FX tracing / replay where
+        side-effecting ``.grad`` writes don't survive. Compatible with both
+        outer ``loss.backward()`` and ``torch.autograd.grad`` consumers."""
 
     def __init__(
         self,
@@ -239,6 +247,7 @@ class ChunkedCELoss(BaseLoss):
         self.fn: LossFunction = cross_entropy_loss
         self._maybe_compile(compile_config)
         self.num_chunks = config.num_chunks
+        self.support_autograd_grad = config.support_autograd_grad
         self.lm_head: nn.Module | None = None
 
     def set_lm_head(self, lm_head: nn.Module) -> None:
@@ -345,6 +354,16 @@ class ChunkedCELoss(BaseLoss):
 
         accumulated_grad = grad_accumulator.result().to(hidden_states.dtype)
 
+        if self.support_autograd_grad:
+            return _ChunkedLossWithParamGrads.apply(
+                hidden_states,
+                accumulated_grad,
+                total_loss,
+                lm_head,
+                fsdp_enabled,
+                *lm_head.parameters(),
+            )
+
         # Return a differentiable loss via _DecoderOutputGradientBackProp. When
         # .backward() is called (by the trainer or PP schedule), autograd
         # calls _DecoderOutputGradientBackProp.backward which returns accumulated_grad
@@ -383,10 +402,92 @@ class _DecoderOutputGradientBackProp(torch.autograd.Function):
     def backward(  # pyrefly: ignore[bad-override]
         ctx, grad_output: torch.Tensor
     ) -> tuple[torch.Tensor, None, None]:
+        from torch.distributed.tensor import DTensor
+
         (accumulated_grad,) = ctx.saved_tensors
         # Return accumulated_grad as the gradient for hidden_states.
         # Autograd then propagates this through hidden_states' existing
         # decoder graph — equivalent to hidden_states.backward(accumulated_grad)
         # but expressed as a return value so autograd handles the traversal
         # in a single pass (no "backward through graph twice" error).
-        return accumulated_grad, None, None
+        # Multiply by grad_output so external scaling of the loss (e.g.
+        # ``loss / global_valid_tokens``) chain-rules into the grad. See
+        # _ChunkedLossWithParamGrads.backward for the to_local() rationale.
+        if isinstance(grad_output, DTensor):
+            grad_output = grad_output.to_local()
+        return accumulated_grad * grad_output, None, None
+
+
+class _ChunkedLossWithParamGrads(torch.autograd.Function):
+    """Like ``_DecoderOutputGradientBackProp`` but also plumbs sharded grads
+    for the lm_head parameters out as explicit autograd outputs, so outer
+    ``torch.autograd.grad(loss, [hidden_states, *lm_head.parameters()])``
+    returns correct grads instead of relying on ``param.grad`` side effects.
+
+    Forward is invoked *after* the chunked ``chunk_loss.backward()`` loop has
+    populated each lm_head param's sharded ``.grad`` (via FSDP's last-chunk
+    reduce-scatter). Forward captures those grads, clears ``.grad``, and
+    disables grad sync — so that outer ``loss.backward()`` consumers, whose
+    AccumulateGrad would otherwise (a) double-add onto ``.grad`` and (b)
+    re-fire FSDP's reduce-scatter on already-sharded data, get clean
+    behavior. Backward queues a callback to restore grad sync after the
+    engine drains the rest of the backward graph.
+
+    Outer ``torch.autograd.grad`` consumers bypass AccumulateGrad entirely
+    and just receive the saved sharded grads directly.
+    """
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        accumulated_h_grad: torch.Tensor,
+        total_loss: torch.Tensor,
+        lm_head: nn.Module,
+        fsdp_enabled: bool,
+        *lm_params: torch.Tensor,
+    ) -> torch.Tensor:
+        sharded_param_grads = [p.grad.detach() for p in lm_params]
+        for p in lm_params:
+            p.grad = None
+        if fsdp_enabled:
+            lm_head.set_requires_gradient_sync(False, recurse=False)
+        ctx.save_for_backward(accumulated_h_grad, *sharded_param_grads)
+        ctx.lm_head = lm_head
+        ctx.fsdp_enabled = fsdp_enabled
+        return total_loss.detach().clone()
+
+    @staticmethod
+    def backward(  # pyrefly: ignore[bad-override]
+        ctx, grad_output: torch.Tensor
+    ):
+        from torch.distributed.tensor import DTensor
+
+        saved = ctx.saved_tensors
+        accumulated_h_grad = saved[0]
+        param_grads = saved[1:]
+        if ctx.fsdp_enabled:
+            lm_head = ctx.lm_head
+            torch.autograd.Variable._execution_engine.queue_callback(
+                lambda: lm_head.set_requires_gradient_sync(True, recurse=False)
+            )
+        # Apply chain rule: outer code may have scaled the loss after we
+        # returned (e.g. graph_trainer's compute_loss does
+        # ``loss_fn(...) / global_valid_tokens``); ``grad_output`` carries
+        # that scaling factor into our pre-computed grads.
+        # ``grad_output`` is a scalar replicated DTensor when the outer
+        # graph is distributed, but its mesh may differ from our saved
+        # grads' meshes (e.g. (fsdp, tp) vs (tp)). Extract the local
+        # scalar so the multiply broadcasts cleanly into each grad's
+        # native mesh.
+        if isinstance(grad_output, DTensor):
+            grad_output = grad_output.to_local()
+        return (
+            accumulated_h_grad * grad_output,
+            None,
+            None,
+            None,
+            None,
+            *(g * grad_output for g in param_grads),
+        )

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_fsdp import FSDPTest
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
+from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     extract_module_state,
@@ -167,6 +168,49 @@ class TestTraceModule(unittest.TestCase):
         self.assertTrue(torch.equal(loss_ref, loss_tr))
         for gr, gt in zip(grads_ref, grads_tr, strict=True):
             self.assertTrue(torch.equal(gr, gt))
+
+    def test_chunked_ce_loss_train_step(self):
+        D, V, num_chunks = 32, 257, 4
+        lm_head_ref = nn.Linear(D, V, bias=False).to(
+            device=self.DEVICE, dtype=self.DTYPE
+        )
+        lm_head_test = nn.Linear(D, V, bias=False).to(
+            device=self.DEVICE, dtype=self.DTYPE
+        )
+        lm_head_test.load_state_dict(lm_head_ref.state_dict())
+        hidden_states = torch.randn(
+            self.BATCH_SIZE,
+            self.SEQ_LEN,
+            D,
+            device=self.DEVICE,
+            dtype=self.DTYPE,
+            requires_grad=True,
+        )
+        labels = torch.randint(
+            0, V, (self.BATCH_SIZE, self.SEQ_LEN), device=self.DEVICE
+        )
+
+        def train_step(lm_head, hidden_states, labels):
+            loss_fn = ChunkedCELoss(
+                ChunkedCELoss.Config(
+                    num_chunks=num_chunks, support_autograd_grad=True
+                )
+            )
+            loss_fn.set_lm_head(lm_head)
+            loss = loss_fn(hidden_states, labels)
+            grads = torch.autograd.grad(
+                loss, [hidden_states, *lm_head.parameters()]
+            )
+            return [loss, *grads]
+
+        eager_out = train_step(lm_head_ref, hidden_states, labels)
+        traced = trace_train_step(train_step)(lm_head_test, hidden_states, labels)
+        replay_out = run_traced_train_step(
+            traced, lm_head_test, hidden_states, labels
+        )
+
+        for ref, tr in zip(eager_out, replay_out, strict=True):
+            self.assertTrue(torch.equal(ref, tr))
 
     def test_mlp_multistep_bitwise(self):
         model_ref, tokens, labels, loss_fn = self._make_mlp()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3248
* #3247
* #3246
* __->__ #3245
* #3244

Add a ``support_autograd_grad`` opt-in flag to ``ChunkedCELoss.Config``
that exposes the lm_head parameter gradients as explicit autograd
outputs of the returned loss tensor. Designed for FX-tracing flows
(e.g. graph_trainer's aot_fx_trace) where ``param.grad`` side-effect
writes from ``chunk_loss.backward()`` inside the chunk loop don't
survive into the captured graph and replay therefore produces
all-zero param grads.

Mechanism, when the flag is True:

  - The chunk loop runs unchanged: per-chunk ``chunk_loss.backward()``
    populates ``lm_head.weight.grad`` with the correctly sharded value
    (FSDP last-chunk reduce-scatter still handles the actual reduction).
  - After the loop, the sharded ``param.grad`` is captured via
    ``p.grad.detach()`` and ``p.grad`` is cleared.
  - The captured grads (plus the existing accumulated hidden_states
    grad) are plumbed through a new ``_ChunkedLossWithParamGrads``
    autograd Function as saved tensors. Its backward returns them as
    grads for the corresponding lm_head parameter inputs, so outer
    ``torch.autograd.grad(loss, lm_head.parameters())`` resolves to
    real gradients instead of None / zeros.
  - Under FSDP, ``set_requires_gradient_sync(False)`` is set on lm_head
    and restored after the outer backward via a callback queued on the
    autograd engine. Without this, outer ``loss.backward()`` would
    re-fire the post-accumulate-grad hook on already-sharded grads and
    either error or produce wrong values.

Both ``_DecoderOutputGradientBackProp`` (existing) and the new
``_ChunkedLossWithParamGrads`` multiply the saved grad by
``grad_output`` before returning so external scaling of the loss
(e.g. ``loss / global_valid_tokens``) chain-rules correctly. Saved
grads can live on a different ``DeviceMesh`` than ``grad_output``
(e.g. params on ``(fsdp, tp)`` vs scalar grad on ``(tp)``), so
``grad_output`` is unwrapped via ``to_local()`` when it's a DTensor
to avoid mesh-mismatch errors in the multiply.

Tests:

  - tests/unit_tests/test_loss.py: parametrized ``support_autograd_grad
    in {False, True}`` equivalence check against the unchunked CE
    standard path; bitwise (rtol=0, atol=0) check that True and False
    paths produce identical grads; side-effect contract check that the
    True path doesn't populate ``param.grad``.
  - graph_trainer/tests/test_trace_module.py: end-to-end test that
    traces a small ``lm_head + ChunkedCELoss(support_autograd_grad=
    True)`` train_step via ``trace_train_step`` and verifies
    ``torch.equal`` between eager and replayed loss + h grad + lm_head
    grad on a CUDA model.

The flag defaults to False so existing callers (the eager torchtitan
trainer) are unaffected; consumers that want explicit param grads
opt in. graph_trainer wires this in a separate commit.