### PR TITLE
[Quantization] Use class factory for MXFP8/Float8 GroupedExperts to fix _owner

### DIFF
--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -5,10 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
-from torchtitan.components.quantization import Float8Linear
+from torchtitan.components.quantization import (
+    Float8GroupedExperts,
+    Float8Linear,
+    MXFP8GroupedExperts,
+)
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.moe import GroupedExperts
 
 
 def test_no_float8_by_default():
@@ -39,3 +44,11 @@ def test_float8_applied_by_model_registry():
         if isinstance(lc, Float8Linear.Config)
     ]
     assert len(converted) > 0
+
+
+def test_quantized_grouped_experts_owner():
+    """Config._owner points at the quantized class, not GroupedExperts."""
+    assert MXFP8GroupedExperts.Config._owner is MXFP8GroupedExperts
+    assert Float8GroupedExperts.Config._owner is Float8GroupedExperts
+    assert issubclass(MXFP8GroupedExperts, GroupedExperts)
+    assert issubclass(Float8GroupedExperts, GroupedExperts)

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -9,6 +9,7 @@ from torchtitan.components.quantization import (
     _QuantizedGroupedExpertsConfig,
     Float8Linear,
 )
+from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
@@ -46,9 +47,13 @@ def test_float8_applied_by_model_registry():
     assert len(converted) > 0
 
 
-def test_mxfp8_grouped_experts_owner():
-    """Dynamic MXFP8 quantized class gets correct _owner, not GroupedExperts."""
+def test_quantized_grouped_experts_owner():
+    """Dynamic quantized classes get correct _owner, not GroupedExperts."""
     mxfp8_cls = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+    float8_cls = _get_float8_grouped_experts_cls(GroupedExperts)
     assert mxfp8_cls.Config._owner is mxfp8_cls
+    assert float8_cls.Config._owner is float8_cls
     assert issubclass(mxfp8_cls, GroupedExperts)
+    assert issubclass(float8_cls, GroupedExperts)
     assert issubclass(mxfp8_cls.Config, _QuantizedGroupedExpertsConfig)
+    assert issubclass(float8_cls.Config, _QuantizedGroupedExpertsConfig)

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -6,8 +6,14 @@
 import pytest
 
 from torchtitan.components.quantization import Float8Linear
-from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
-from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
+from torchtitan.components.quantization.float8 import (
+    _get_float8_grouped_experts_cls,
+    Float8GroupedExperts,
+)
+from torchtitan.components.quantization.mx import (
+    _get_mxfp8_grouped_experts_cls,
+    MXFP8GroupedExperts,
+)
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
@@ -52,5 +58,5 @@ def test_quantized_grouped_experts_owner():
     assert float8_cls.Config._owner is float8_cls
     assert issubclass(mxfp8_cls, GroupedExperts)
     assert issubclass(float8_cls, GroupedExperts)
-    assert issubclass(mxfp8_cls.Config, GroupedExperts.Config)
-    assert issubclass(float8_cls.Config, GroupedExperts.Config)
+    assert issubclass(mxfp8_cls.Config, MXFP8GroupedExperts.Config)
+    assert issubclass(float8_cls.Config, Float8GroupedExperts.Config)

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -6,14 +6,8 @@
 import pytest
 
 from torchtitan.components.quantization import Float8Linear
-from torchtitan.components.quantization.float8 import (
-    _get_float8_grouped_experts_cls,
-    Float8GroupedExpertsConverter,
-)
-from torchtitan.components.quantization.mx import (
-    _get_mxfp8_grouped_experts_cls,
-    MXFP8GroupedExpertsConverter,
-)
+from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
+from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -5,10 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
-from torchtitan.components.quantization import (
-    _QuantizedGroupedExpertsConfig,
-    Float8Linear,
-)
+from torchtitan.components.quantization import Float8Linear
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
@@ -55,5 +52,5 @@ def test_quantized_grouped_experts_owner():
     assert float8_cls.Config._owner is float8_cls
     assert issubclass(mxfp8_cls, GroupedExperts)
     assert issubclass(float8_cls, GroupedExperts)
-    assert issubclass(mxfp8_cls.Config, _QuantizedGroupedExpertsConfig)
-    assert issubclass(float8_cls.Config, _QuantizedGroupedExpertsConfig)
+    assert issubclass(mxfp8_cls.Config, GroupedExperts.Config)
+    assert issubclass(float8_cls.Config, GroupedExperts.Config)

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -7,16 +7,17 @@ import pytest
 
 from torchtitan.components.quantization import Float8Linear
 from torchtitan.components.quantization.float8 import (
-    Float8GroupedExperts,
+    _get_float8_grouped_experts_cls,
     Float8GroupedExpertsConverter,
 )
 from torchtitan.components.quantization.mx import (
-    MXFP8GroupedExperts,
+    _get_mxfp8_grouped_experts_cls,
     MXFP8GroupedExpertsConverter,
 )
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.gpt_oss.moe import GptOssGroupedExperts
 
 
@@ -53,12 +54,15 @@ def test_float8_applied_by_model_registry():
 def test_quantized_grouped_experts():
     """Quantized GroupedExperts: _owner, subclass handling, extra config fields."""
     # Base case
+    MXFP8GroupedExperts = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+    Float8GroupedExperts = _get_float8_grouped_experts_cls(GroupedExperts)
+
     assert MXFP8GroupedExperts.Config._owner is MXFP8GroupedExperts
     assert Float8GroupedExperts.Config._owner is Float8GroupedExperts
 
     # Subclass case (GptOssGroupedExperts has extra swiglu_limit field)
-    mxfp8_cls = MXFP8GroupedExpertsConverter._quantized_cls(GptOssGroupedExperts)
-    float8_cls = Float8GroupedExpertsConverter._quantized_cls(GptOssGroupedExperts)
+    mxfp8_cls = _get_mxfp8_grouped_experts_cls(GptOssGroupedExperts)
+    float8_cls = _get_float8_grouped_experts_cls(GptOssGroupedExperts)
 
     assert mxfp8_cls.Config._owner is mxfp8_cls
     assert float8_cls.Config._owner is float8_cls

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -9,7 +9,6 @@ from torchtitan.components.quantization import (
     _QuantizedGroupedExpertsConfig,
     Float8Linear,
 )
-from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
@@ -47,13 +46,9 @@ def test_float8_applied_by_model_registry():
     assert len(converted) > 0
 
 
-def test_quantized_grouped_experts_owner():
-    """Dynamic quantized classes get correct _owner, not GroupedExperts."""
+def test_mxfp8_grouped_experts_owner():
+    """Dynamic MXFP8 quantized class gets correct _owner, not GroupedExperts."""
     mxfp8_cls = _get_mxfp8_grouped_experts_cls(GroupedExperts)
-    float8_cls = _get_float8_grouped_experts_cls(GroupedExperts)
     assert mxfp8_cls.Config._owner is mxfp8_cls
-    assert float8_cls.Config._owner is float8_cls
     assert issubclass(mxfp8_cls, GroupedExperts)
-    assert issubclass(float8_cls, GroupedExperts)
     assert issubclass(mxfp8_cls.Config, _QuantizedGroupedExpertsConfig)
-    assert issubclass(float8_cls.Config, _QuantizedGroupedExpertsConfig)

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -7,17 +7,17 @@ import pytest
 
 from torchtitan.components.quantization import Float8Linear
 from torchtitan.components.quantization.float8 import (
-    _get_float8_grouped_experts_cls,
     Float8GroupedExperts,
+    Float8GroupedExpertsConverter,
 )
 from torchtitan.components.quantization.mx import (
-    _get_mxfp8_grouped_experts_cls,
     MXFP8GroupedExperts,
+    MXFP8GroupedExpertsConverter,
 )
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
-from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.models.gpt_oss.moe import GptOssGroupedExperts
 
 
 def test_no_float8_by_default():
@@ -50,13 +50,21 @@ def test_float8_applied_by_model_registry():
     assert len(converted) > 0
 
 
-def test_quantized_grouped_experts_owner():
-    """Dynamic quantized classes get correct _owner, not GroupedExperts."""
-    mxfp8_cls = _get_mxfp8_grouped_experts_cls(GroupedExperts)
-    float8_cls = _get_float8_grouped_experts_cls(GroupedExperts)
+def test_quantized_grouped_experts():
+    """Quantized GroupedExperts: _owner, subclass handling, extra config fields."""
+    # Base case
+    assert MXFP8GroupedExperts.Config._owner is MXFP8GroupedExperts
+    assert Float8GroupedExperts.Config._owner is Float8GroupedExperts
+
+    # Subclass case (GptOssGroupedExperts has extra swiglu_limit field)
+    mxfp8_cls = MXFP8GroupedExpertsConverter._quantized_cls(GptOssGroupedExperts)
+    float8_cls = Float8GroupedExpertsConverter._quantized_cls(GptOssGroupedExperts)
+
     assert mxfp8_cls.Config._owner is mxfp8_cls
     assert float8_cls.Config._owner is float8_cls
-    assert issubclass(mxfp8_cls, GroupedExperts)
-    assert issubclass(float8_cls, GroupedExperts)
-    assert issubclass(mxfp8_cls.Config, MXFP8GroupedExperts.Config)
-    assert issubclass(float8_cls.Config, Float8GroupedExperts.Config)
+    assert issubclass(mxfp8_cls, GptOssGroupedExperts)
+    assert issubclass(float8_cls, GptOssGroupedExperts)
+    assert mxfp8_cls._is_quantized_experts
+    assert float8_cls._is_quantized_experts
+    assert hasattr(mxfp8_cls.Config, "swiglu_limit")
+    assert hasattr(float8_cls.Config, "swiglu_limit")

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -62,7 +62,5 @@ def test_quantized_grouped_experts():
     assert float8_cls.Config._owner is float8_cls
     assert issubclass(mxfp8_cls, GptOssGroupedExperts)
     assert issubclass(float8_cls, GptOssGroupedExperts)
-    assert mxfp8_cls._is_quantized_experts
-    assert float8_cls._is_quantized_experts
     assert hasattr(mxfp8_cls.Config, "swiglu_limit")
     assert hasattr(float8_cls.Config, "swiglu_limit")

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -6,10 +6,11 @@
 import pytest
 
 from torchtitan.components.quantization import (
-    Float8GroupedExperts,
+    _QuantizedGroupedExpertsConfig,
     Float8Linear,
-    MXFP8GroupedExperts,
 )
+from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
+from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
@@ -47,8 +48,12 @@ def test_float8_applied_by_model_registry():
 
 
 def test_quantized_grouped_experts_owner():
-    """Config._owner points at the quantized class, not GroupedExperts."""
-    assert MXFP8GroupedExperts.Config._owner is MXFP8GroupedExperts
-    assert Float8GroupedExperts.Config._owner is Float8GroupedExperts
-    assert issubclass(MXFP8GroupedExperts, GroupedExperts)
-    assert issubclass(Float8GroupedExperts, GroupedExperts)
+    """Dynamic quantized classes get correct _owner, not GroupedExperts."""
+    mxfp8_cls = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+    float8_cls = _get_float8_grouped_experts_cls(GroupedExperts)
+    assert mxfp8_cls.Config._owner is mxfp8_cls
+    assert float8_cls.Config._owner is float8_cls
+    assert issubclass(mxfp8_cls, GroupedExperts)
+    assert issubclass(float8_cls, GroupedExperts)
+    assert issubclass(mxfp8_cls.Config, _QuantizedGroupedExpertsConfig)
+    assert issubclass(float8_cls.Config, _QuantizedGroupedExpertsConfig)

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -27,7 +27,7 @@ class QuantizedLinearConfig(Linear.Config):
 
 
 class _QuantizedGroupedExpertsConfig:
-    """Marker base for dynamically created quantized GroupedExperts configs."""
+    """Marker mixin for quantized GroupedExperts configs."""
 
     pass
 
@@ -47,24 +47,20 @@ class QuantizationConverter(ModelConfigConverter):
 
 # Re-export all public symbols so callers can import from the package directly.
 from .float8 import (  # noqa: F401, E402
-    Float8GroupedExperts,
     Float8GroupedExpertsConverter,
     Float8Linear,
     Float8LinearConverter,
 )
 from .mx import (  # noqa: F401, E402
-    MXFP8GroupedExperts,
     MXFP8GroupedExpertsConverter,
     MXFP8Linear,
     MXFP8LinearConverter,
 )
 
 __all__ = [
-    "Float8GroupedExperts",
     "Float8GroupedExpertsConverter",
     "Float8Linear",
     "Float8LinearConverter",
-    "MXFP8GroupedExperts",
     "MXFP8GroupedExpertsConverter",
     "MXFP8Linear",
     "MXFP8LinearConverter",

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -47,20 +47,24 @@ class QuantizationConverter(ModelConfigConverter):
 
 # Re-export all public symbols so callers can import from the package directly.
 from .float8 import (  # noqa: F401, E402
+    Float8GroupedExperts,
     Float8GroupedExpertsConverter,
     Float8Linear,
     Float8LinearConverter,
 )
 from .mx import (  # noqa: F401, E402
+    MXFP8GroupedExperts,
     MXFP8GroupedExpertsConverter,
     MXFP8Linear,
     MXFP8LinearConverter,
 )
 
 __all__ = [
+    "Float8GroupedExperts",
     "Float8GroupedExpertsConverter",
     "Float8Linear",
     "Float8LinearConverter",
+    "MXFP8GroupedExperts",
     "MXFP8GroupedExpertsConverter",
     "MXFP8Linear",
     "MXFP8LinearConverter",

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -26,12 +26,6 @@ class QuantizedLinearConfig(Linear.Config):
     pass
 
 
-class _QuantizedGroupedExpertsConfig:
-    """Marker base for dynamically created quantized GroupedExperts configs."""
-
-    pass
-
-
 class QuantizationConverter(ModelConfigConverter):
     """Base class for quantization converters.
 
@@ -66,5 +60,4 @@ __all__ = [
     "MXFP8LinearConverter",
     "QuantizationConverter",
     "QuantizedLinearConfig",
-    "_QuantizedGroupedExpertsConfig",
 ]

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -15,15 +15,7 @@
 
 from dataclasses import dataclass
 
-from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.model import ModelConfigConverter
-
-
-@dataclass(kw_only=True, slots=True)
-class QuantizedLinearConfig(Linear.Config):
-    """Base config for all quantized Linear variants."""
-
-    pass
 
 
 class QuantizationConverter(ModelConfigConverter):
@@ -59,5 +51,4 @@ __all__ = [
     "MXFP8Linear",
     "MXFP8LinearConverter",
     "QuantizationConverter",
-    "QuantizedLinearConfig",
 ]

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -27,7 +27,7 @@ class QuantizedLinearConfig(Linear.Config):
 
 
 class _QuantizedGroupedExpertsConfig:
-    """Marker mixin for quantized GroupedExperts configs."""
+    """Marker base for dynamically created quantized GroupedExperts configs."""
 
     pass
 

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -169,6 +169,25 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
+class Float8GroupedExperts(GroupedExperts):
+    """GroupedExperts that applies Float8 quantization in its constructor."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config, _QuantizedGroupedExpertsConfig):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+        from torchao.quantization.quant_api import quantize_
+
+        quantize_(
+            self,
+            config=Float8TrainingOpConfig(),
+            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+        )
+
+
 class Float8GroupedExpertsConverter(QuantizationConverter):
     """Apply FP8 quantization to MoE expert grouped GEMMs."""
 
@@ -197,39 +216,10 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             )
 
     def convert(self, model_config) -> None:
-        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-        from torchao.quantization.quant_api import quantize_
-
-        _converted_config_cache: dict[type, type] = {}
-
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-
-            base_cls = type(config)
-            if base_cls not in _converted_config_cache:
-
-                @dataclass(kw_only=True, slots=True)
-                class Float8GroupedExpertsConfig(
-                    base_cls, _QuantizedGroupedExpertsConfig
-                ):
-                    def build(self, **kwargs):
-                        instance = base_cls.build(self, **kwargs)
-                        # torchao's quantize_ defaults filter_fn to _is_linear,
-                        # which skips GroupedExperts. Match the built module so
-                        # its nn.Parameters (w1/w2/w3) get wrapped for FP8
-                        # grouped GEMMs.
-                        quantize_(
-                            instance,
-                            config=Float8TrainingOpConfig(),
-                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-                        )
-                        return instance
-
-                _converted_config_cache[base_cls] = Float8GroupedExpertsConfig
-
-            ConfigCls = _converted_config_cache[base_cls]
-            new_config = ConfigCls(
-                **{f.name: getattr(config, f.name) for f in fields(config)}
+            new_config = Float8GroupedExperts.Config(
+                **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):
                 parent[attr] = new_config

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -180,8 +180,6 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
-        _is_quantized_experts = True
-
         @dataclass(kw_only=True, slots=True)
         class Config(parent_config_cls):  # type: ignore[misc]
             pass

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -169,42 +169,6 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
-_float8_experts_cache: dict[type, type] = {}
-
-
-def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
-    """Get or create a Float8-quantized subclass of *parent_cls*.
-
-    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
-    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
-    """
-    if parent_cls in _float8_experts_cache:
-        return _float8_experts_cache[parent_cls]
-
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
-
-    class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
-        @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
-            pass
-
-        def __init__(self, config: Config):
-            super().__init__(config)
-            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-            from torchao.quantization.quant_api import quantize_
-
-            quantize_(
-                self,
-                config=Float8TrainingOpConfig(),
-                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-            )
-
-    Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
-    Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
-    _float8_experts_cache[parent_cls] = Float8GroupedExperts
-    return Float8GroupedExperts
-
-
 class Float8GroupedExpertsConverter(QuantizationConverter):
     """Apply FP8 quantization to MoE expert grouped GEMMs."""
 
@@ -233,12 +197,39 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             )
 
     def convert(self, model_config) -> None:
+        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+        from torchao.quantization.quant_api import quantize_
+
+        _converted_config_cache: dict[type, type] = {}
+
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-            base_module_cls = type(config)._owner
-            quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
-                **{f.name: getattr(config, f.name) for f in fields(config)},
+
+            base_cls = type(config)
+            if base_cls not in _converted_config_cache:
+
+                @dataclass(kw_only=True, slots=True)
+                class Float8GroupedExpertsConfig(
+                    base_cls, _QuantizedGroupedExpertsConfig
+                ):
+                    def build(self, **kwargs):
+                        instance = base_cls.build(self, **kwargs)
+                        # torchao's quantize_ defaults filter_fn to _is_linear,
+                        # which skips GroupedExperts. Match the built module so
+                        # its nn.Parameters (w1/w2/w3) get wrapped for FP8
+                        # grouped GEMMs.
+                        quantize_(
+                            instance,
+                            config=Float8TrainingOpConfig(),
+                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+                        )
+                        return instance
+
+                _converted_config_cache[base_cls] = Float8GroupedExpertsConfig
+
+            ConfigCls = _converted_config_cache[base_cls]
+            new_config = ConfigCls(
+                **{f.name: getattr(config, f.name) for f in fields(config)}
             )
             if isinstance(parent, list):
                 parent[attr] = new_config

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -169,6 +169,42 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
+_float8_experts_cache: dict[type, type] = {}
+
+
+def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create a Float8-quantized subclass of *parent_cls*.
+
+    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
+    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _float8_experts_cache:
+        return _float8_experts_cache[parent_cls]
+
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+
+    class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
+            pass
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+            from torchao.quantization.quant_api import quantize_
+
+            quantize_(
+                self,
+                config=Float8TrainingOpConfig(),
+                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            )
+
+    Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
+    Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
+    _float8_experts_cache[parent_cls] = Float8GroupedExperts
+    return Float8GroupedExperts
+
+
 class Float8GroupedExpertsConverter(QuantizationConverter):
     """Apply FP8 quantization to MoE expert grouped GEMMs."""
 
@@ -197,39 +233,12 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             )
 
     def convert(self, model_config) -> None:
-        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-        from torchao.quantization.quant_api import quantize_
-
-        _converted_config_cache: dict[type, type] = {}
-
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-
-            base_cls = type(config)
-            if base_cls not in _converted_config_cache:
-
-                @dataclass(kw_only=True, slots=True)
-                class Float8GroupedExpertsConfig(
-                    base_cls, _QuantizedGroupedExpertsConfig
-                ):
-                    def build(self, **kwargs):
-                        instance = base_cls.build(self, **kwargs)
-                        # torchao's quantize_ defaults filter_fn to _is_linear,
-                        # which skips GroupedExperts. Match the built module so
-                        # its nn.Parameters (w1/w2/w3) get wrapped for FP8
-                        # grouped GEMMs.
-                        quantize_(
-                            instance,
-                            config=Float8TrainingOpConfig(),
-                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-                        )
-                        return instance
-
-                _converted_config_cache[base_cls] = Float8GroupedExpertsConfig
-
-            ConfigCls = _converted_config_cache[base_cls]
-            new_config = ConfigCls(
-                **{f.name: getattr(config, f.name) for f in fields(config)}
+            base_module_cls = type(config)._owner
+            quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
+            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
+                **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):
                 parent[attr] = new_config

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -11,10 +11,7 @@ from typing import Literal
 
 import torch
 import torch._inductor.config
-from torchtitan.components.quantization import (
-    QuantizationConverter,
-    QuantizedLinearConfig,
-)
+from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.protocols.module import Module
@@ -35,7 +32,7 @@ try:
         """
 
         @dataclass(kw_only=True, slots=True)
-        class Config(QuantizedLinearConfig):
+        class Config(Linear.Config):
             """Drop-in replacement for Linear.Config that builds Float8Linear."""
 
             _torchao_config: object = None
@@ -180,7 +177,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore[missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -238,7 +235,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config  # pyrefly: ignore[missing-attribute]
+            config_cls = quantized_cls.Config
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -169,23 +169,40 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
-class Float8GroupedExperts(GroupedExperts):
-    """GroupedExperts that applies Float8 quantization in its constructor."""
+_float8_experts_cache: dict[type, type] = {}
 
-    @dataclass(kw_only=True, slots=True)
-    class Config(GroupedExperts.Config, _QuantizedGroupedExpertsConfig):
-        pass
 
-    def __init__(self, config: Config):
-        super().__init__(config)
-        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-        from torchao.quantization.quant_api import quantize_
+def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create a Float8-quantized subclass of *parent_cls*.
 
-        quantize_(
-            self,
-            config=Float8TrainingOpConfig(),
-            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-        )
+    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
+    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _float8_experts_cache:
+        return _float8_experts_cache[parent_cls]
+
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+
+    class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
+            pass
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+            from torchao.quantization.quant_api import quantize_
+
+            quantize_(
+                self,
+                config=Float8TrainingOpConfig(),
+                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            )
+
+    Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
+    Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
+    _float8_experts_cache[parent_cls] = Float8GroupedExperts
+    return Float8GroupedExperts
 
 
 class Float8GroupedExpertsConverter(QuantizationConverter):
@@ -218,7 +235,9 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-            new_config = Float8GroupedExperts.Config(
+            base_module_cls = type(config)._owner  # pyrefly: ignore [missing-attribute]
+            quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
+            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -177,7 +177,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -235,7 +235,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config
+            config_cls = quantized_cls.Config  # type: ignore[attr-defined]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -201,7 +201,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
 
     class _Float8GroupedExperts(parent_cls, Float8GroupedExperts):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -246,7 +246,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(
+            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -171,6 +171,8 @@ class Float8LinearConverter(QuantizationConverter):
 class Float8GroupedExperts(GroupedExperts):
     """GroupedExperts with Float8 quantization applied in __init__."""
 
+    _is_quantized_experts = True
+
     @dataclass(kw_only=True, slots=True)
     class Config(GroupedExperts.Config):
         pass
@@ -187,38 +189,13 @@ class Float8GroupedExperts(GroupedExperts):
         )
 
 
-_float8_experts_cache: dict[type, type] = {}
-
-
-def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
-    """Get or create a Float8-quantized subclass of *parent_cls*.
-
-    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
-    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
-    """
-    if parent_cls is GroupedExperts:
-        return Float8GroupedExperts
-    if parent_cls in _float8_experts_cache:
-        return _float8_experts_cache[parent_cls]
-
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
-
-    class _Float8GroupedExperts(parent_cls, Float8GroupedExperts):  # type: ignore[valid-type, misc]
-        @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls, Float8GroupedExperts.Config):  # type: ignore[misc]
-            pass
-
-    _Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
-    _Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
-    _float8_experts_cache[parent_cls] = _Float8GroupedExperts
-    return _Float8GroupedExperts
-
-
 class Float8GroupedExpertsConverter(QuantizationConverter):
     """Apply FP8 quantization to MoE expert grouped GEMMs."""
 
     # FP8: 16 byte alignment / 1 byte per elem = 16 elements.
     PAD_MULTIPLE = 16
+
+    _quantized_cls_cache: dict[type, type] = {}
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
@@ -241,12 +218,47 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 "enable it with --compile.enable"
             )
 
+    @classmethod
+    def _quantized_cls(cls, parent_cls: type) -> type:
+        """Return a Float8-quantized subclass of *parent_cls*."""
+        if parent_cls is GroupedExperts:
+            return Float8GroupedExperts
+        if parent_cls in cls._quantized_cls_cache:
+            return cls._quantized_cls_cache[parent_cls]
+
+        parent_config_cls = parent_cls.Config
+
+        class _Float8Experts(parent_cls):  # type: ignore[valid-type, misc]
+            _is_quantized_experts = True
+
+            @dataclass(kw_only=True, slots=True)
+            class Config(parent_config_cls):  # type: ignore[misc]
+                pass
+
+            def __init__(self, config: Config):
+                parent_cls.__init__(  # pyrefly: ignore [no-matching-overload]
+                    self, config
+                )
+                from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+                from torchao.quantization.quant_api import quantize_
+
+                quantize_(
+                    self,
+                    config=Float8TrainingOpConfig(),
+                    filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+                )
+
+        _Float8Experts.__name__ = f"Float8{parent_cls.__name__}"
+        _Float8Experts.__qualname__ = f"Float8{parent_cls.__name__}"
+        cls._quantized_cls_cache[parent_cls] = _Float8Experts
+        return _Float8Experts
+
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
-            quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
+            quantized_cls = self._quantized_cls(base_module_cls)
+            new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -168,6 +168,25 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
+class Float8GroupedExperts(GroupedExperts):
+    """GroupedExperts with Float8 quantization applied in __init__."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+        from torchao.quantization.quant_api import quantize_
+
+        quantize_(
+            self,
+            config=Float8TrainingOpConfig(),
+            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+        )
+
+
 _float8_experts_cache: dict[type, type] = {}
 
 
@@ -177,31 +196,22 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
     The returned class has a proper ``_owner`` set by ``__init_subclass__``.
     """
+    if parent_cls is GroupedExperts:
+        return Float8GroupedExperts
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
-    class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+    class _Float8GroupedExperts(parent_cls, Float8GroupedExperts):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls):  # type: ignore[misc]
+        class Config(parent_config_cls, Float8GroupedExperts.Config):  # type: ignore[misc]
             pass
 
-        def __init__(self, config: Config):
-            super().__init__(config)
-            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-            from torchao.quantization.quant_api import quantize_
-
-            quantize_(
-                self,
-                config=Float8TrainingOpConfig(),
-                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-            )
-
-    Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
-    Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
-    _float8_experts_cache[parent_cls] = Float8GroupedExperts
-    return Float8GroupedExperts
+    _Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
+    _Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
+    _float8_experts_cache[parent_cls] = _Float8GroupedExperts
+    return _Float8GroupedExperts
 
 
 class Float8GroupedExpertsConverter(QuantizationConverter):
@@ -236,7 +246,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
+            new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -180,7 +180,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -238,7 +238,8 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(
+            config_cls = quantized_cls.Config
+            new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )
             if isinstance(parent, list):

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -180,7 +180,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _float8_experts_cache:
         return _float8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore[missing-attribute]
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -238,7 +238,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config
+            config_cls = quantized_cls.Config  # pyrefly: ignore[missing-attribute]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -168,25 +168,42 @@ class Float8LinearConverter(QuantizationConverter):
         logger.info("Swapped to Float8Linear layers")
 
 
-class Float8GroupedExperts(GroupedExperts):
-    """GroupedExperts with Float8 quantization applied in __init__."""
+_float8_experts_cache: dict[type, type] = {}
 
-    _is_quantized_experts = True
 
-    @dataclass(kw_only=True, slots=True)
-    class Config(GroupedExperts.Config):
-        pass
+def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create a Float8-quantized subclass of *parent_cls*.
 
-    def __init__(self, config: Config):
-        super().__init__(config)
-        from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-        from torchao.quantization.quant_api import quantize_
+    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
+    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _float8_experts_cache:
+        return _float8_experts_cache[parent_cls]
 
-        quantize_(
-            self,
-            config=Float8TrainingOpConfig(),
-            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-        )
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+
+    class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        _is_quantized_experts = True
+
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls):  # type: ignore[misc]
+            pass
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+            from torchao.quantization.quant_api import quantize_
+
+            quantize_(
+                self,
+                config=Float8TrainingOpConfig(),
+                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            )
+
+    Float8GroupedExperts.__name__ = f"Float8{parent_cls.__name__}"
+    Float8GroupedExperts.__qualname__ = f"Float8{parent_cls.__name__}"
+    _float8_experts_cache[parent_cls] = Float8GroupedExperts
+    return Float8GroupedExperts
 
 
 class Float8GroupedExpertsConverter(QuantizationConverter):
@@ -194,8 +211,6 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
 
     # FP8: 16 byte alignment / 1 byte per elem = 16 elements.
     PAD_MULTIPLE = 16
-
-    _quantized_cls_cache: dict[type, type] = {}
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
@@ -218,46 +233,11 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 "enable it with --compile.enable"
             )
 
-    @classmethod
-    def _quantized_cls(cls, parent_cls: type) -> type:
-        """Return a Float8-quantized subclass of *parent_cls*."""
-        if parent_cls is GroupedExperts:
-            return Float8GroupedExperts
-        if parent_cls in cls._quantized_cls_cache:
-            return cls._quantized_cls_cache[parent_cls]
-
-        parent_config_cls = parent_cls.Config
-
-        class _Float8Experts(parent_cls):  # type: ignore[valid-type, misc]
-            _is_quantized_experts = True
-
-            @dataclass(kw_only=True, slots=True)
-            class Config(parent_config_cls):  # type: ignore[misc]
-                pass
-
-            def __init__(self, config: Config):
-                parent_cls.__init__(  # pyrefly: ignore [no-matching-overload]
-                    self, config
-                )
-                from torchao.prototype.moe_training.config import Float8TrainingOpConfig
-                from torchao.quantization.quant_api import quantize_
-
-                quantize_(
-                    self,
-                    config=Float8TrainingOpConfig(),
-                    filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-                )
-
-        _Float8Experts.__name__ = f"Float8{parent_cls.__name__}"
-        _Float8Experts.__qualname__ = f"Float8{parent_cls.__name__}"
-        cls._quantized_cls_cache[parent_cls] = _Float8Experts
-        return _Float8Experts
-
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
-            quantized_cls = self._quantized_cls(base_module_cls)
+            quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
             new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
             )

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -235,7 +235,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-            base_module_cls = type(config)._owner  # pyrefly: ignore [missing-attribute]
+            base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
             new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -12,7 +12,6 @@ from typing import Literal
 import torch
 import torch._inductor.config
 from torchtitan.components.quantization import (
-    _QuantizedGroupedExpertsConfig,
     QuantizationConverter,
     QuantizedLinearConfig,
 )
@@ -185,7 +184,7 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
 
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
+        class Config(parent_config_cls):  # type: ignore[misc]
             pass
 
         def __init__(self, config: Config):

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -104,6 +104,30 @@ class MXFP8LinearConverter(QuantizationConverter):
         )
 
 
+class MXFP8GroupedExperts(GroupedExperts):
+    """GroupedExperts that applies MXFP8 quantization in its constructor."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config, _QuantizedGroupedExpertsConfig):
+        _recipe_name: str = "mxfp8_rceil"
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        from torchao.prototype.moe_training.config import (
+            MXFP8TrainingOpConfig,
+            MXFP8TrainingRecipe,
+        )
+        from torchao.quantization.quant_api import quantize_
+
+        recipe = MXFP8TrainingRecipe(config._recipe_name)
+        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+        quantize_(
+            self,
+            config=mxfp8_op_config,
+            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+        )
+
+
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
     """Apply MXFP8 quantization to MoE expert grouped GEMMs."""
 
@@ -138,46 +162,11 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             )
 
     def convert(self, model_config) -> None:
-        from torchao.prototype.moe_training.config import (
-            MXFP8TrainingOpConfig,
-            MXFP8TrainingRecipe,
-        )
-        from torchao.quantization.quant_api import quantize_
-
-        recipe_name = self.config.recipe_name
-
-        _converted_config_cache: dict[type, type] = {}
-
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-
-            base_cls = type(config)
-            if base_cls not in _converted_config_cache:
-
-                @dataclass(kw_only=True, slots=True)
-                class MXFP8GroupedExpertsConfig(
-                    base_cls, _QuantizedGroupedExpertsConfig
-                ):
-                    def build(self, **kwargs):
-                        instance = base_cls.build(self, **kwargs)
-                        recipe = MXFP8TrainingRecipe(recipe_name)
-                        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-                        # torchao's quantize_ defaults filter_fn to _is_linear,
-                        # which skips GroupedExperts. Pass a filter that matches
-                        # the built GroupedExperts instance so its nn.Parameters
-                        # (w1/w2/w3) get swapped to MXFP8 wrapper subclasses.
-                        quantize_(
-                            instance,
-                            config=mxfp8_op_config,
-                            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-                        )
-                        return instance
-
-                _converted_config_cache[base_cls] = MXFP8GroupedExpertsConfig
-
-            ConfigCls = _converted_config_cache[base_cls]
-            new_config = ConfigCls(
-                **{f.name: getattr(config, f.name) for f in fields(config)}
+            new_config = MXFP8GroupedExperts.Config(
+                **{f.name: getattr(config, f.name) for f in fields(config)},
+                _recipe_name=self.config.recipe_name,
             )
             if isinstance(parent, list):
                 parent[attr] = new_config

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -115,7 +115,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -184,7 +184,8 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(
+            config_cls = quantized_cls.Config
+            new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -115,7 +115,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore[missing-attribute]
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -184,7 +184,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config
+            config_cls = quantized_cls.Config  # pyrefly: ignore[missing-attribute]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -121,7 +121,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
         class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
-            _recipe_name: str = "mxfp8_rceil"
+            recipe_name: str = "mxfp8_rceil"
 
         def __init__(self, config: Config):
             super().__init__(config)
@@ -131,7 +131,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
             )
             from torchao.quantization.quant_api import quantize_
 
-            recipe = MXFP8TrainingRecipe(config._recipe_name)
+            recipe = MXFP8TrainingRecipe(config.recipe_name)
             mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
             quantize_(
                 self,
@@ -185,7 +185,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
             new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},
-                _recipe_name=self.config.recipe_name,
+                recipe_name=self.config.recipe_name,
             )
             if isinstance(parent, list):
                 parent[attr] = new_config

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -115,8 +115,6 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
-        _is_quantized_experts = True
-
         @dataclass(kw_only=True, slots=True)
         class Config(parent_config_cls):  # type: ignore[misc]
             recipe_name: str = "mxfp8_rceil"

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -141,7 +141,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
 
     class _MXFP8GroupedExperts(parent_cls, MXFP8GroupedExperts):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -192,7 +192,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(
+            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -8,10 +8,7 @@ from dataclasses import dataclass, field, fields
 from importlib.util import find_spec
 from typing import Literal
 
-from torchtitan.components.quantization import (
-    QuantizationConverter,
-    QuantizedLinearConfig,
-)
+from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.tools.logging import logger
@@ -24,7 +21,7 @@ class MXFP8Linear(Linear):
     """Linear that applies MXFP8 quantization in its constructor."""
 
     @dataclass(kw_only=True, slots=True)
-    class Config(QuantizedLinearConfig):
+    class Config(Linear.Config):
         """Drop-in replacement for Linear.Config that builds MXFP8Linear."""
 
         _recipe_name: str = "mxfp8_rceil"
@@ -115,7 +112,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore[missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -184,7 +181,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config  # pyrefly: ignore[missing-attribute]
+            config_cls = quantized_cls.Config
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -112,7 +112,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         _is_quantized_experts = True
@@ -181,7 +181,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            config_cls = quantized_cls.Config
+            config_cls = quantized_cls.Config  # type: ignore[attr-defined]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -104,28 +104,45 @@ class MXFP8LinearConverter(QuantizationConverter):
         )
 
 
-class MXFP8GroupedExperts(GroupedExperts):
-    """GroupedExperts that applies MXFP8 quantization in its constructor."""
+_mxfp8_experts_cache: dict[type, type] = {}
 
-    @dataclass(kw_only=True, slots=True)
-    class Config(GroupedExperts.Config, _QuantizedGroupedExpertsConfig):
-        _recipe_name: str = "mxfp8_rceil"
 
-    def __init__(self, config: Config):
-        super().__init__(config)
-        from torchao.prototype.moe_training.config import (
-            MXFP8TrainingOpConfig,
-            MXFP8TrainingRecipe,
-        )
-        from torchao.quantization.quant_api import quantize_
+def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create an MXFP8-quantized subclass of *parent_cls*.
 
-        recipe = MXFP8TrainingRecipe(config._recipe_name)
-        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-        quantize_(
-            self,
-            config=mxfp8_op_config,
-            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-        )
+    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
+    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _mxfp8_experts_cache:
+        return _mxfp8_experts_cache[parent_cls]
+
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+
+    class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
+            _recipe_name: str = "mxfp8_rceil"
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            from torchao.prototype.moe_training.config import (
+                MXFP8TrainingOpConfig,
+                MXFP8TrainingRecipe,
+            )
+            from torchao.quantization.quant_api import quantize_
+
+            recipe = MXFP8TrainingRecipe(config._recipe_name)
+            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+            quantize_(
+                self,
+                config=mxfp8_op_config,
+                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            )
+
+    MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
+    MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
+    _mxfp8_experts_cache[parent_cls] = MXFP8GroupedExperts
+    return MXFP8GroupedExperts
 
 
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
@@ -164,7 +181,9 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-            new_config = MXFP8GroupedExperts.Config(
+            base_module_cls = type(config)._owner  # pyrefly: ignore [missing-attribute]
+            quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
+            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 _recipe_name=self.config.recipe_name,
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -181,7 +181,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
-            base_module_cls = type(config)._owner  # pyrefly: ignore [missing-attribute]
+            base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
             new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
                 **{f.name: getattr(config, f.name) for f in fields(config)},

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -103,30 +103,47 @@ class MXFP8LinearConverter(QuantizationConverter):
         )
 
 
-class MXFP8GroupedExperts(GroupedExperts):
-    """GroupedExperts with MXFP8 quantization applied in __init__."""
+_mxfp8_experts_cache: dict[type, type] = {}
 
-    _is_quantized_experts = True
 
-    @dataclass(kw_only=True, slots=True)
-    class Config(GroupedExperts.Config):
-        recipe_name: str = "mxfp8_rceil"
+def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create an MXFP8-quantized subclass of *parent_cls*.
 
-    def __init__(self, config: Config):
-        super().__init__(config)
-        from torchao.prototype.moe_training.config import (
-            MXFP8TrainingOpConfig,
-            MXFP8TrainingRecipe,
-        )
-        from torchao.quantization.quant_api import quantize_
+    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
+    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _mxfp8_experts_cache:
+        return _mxfp8_experts_cache[parent_cls]
 
-        recipe = MXFP8TrainingRecipe(config.recipe_name)
-        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-        quantize_(
-            self,
-            config=mxfp8_op_config,
-            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-        )
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+
+    class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        _is_quantized_experts = True
+
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls):  # type: ignore[misc]
+            recipe_name: str = "mxfp8_rceil"
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            from torchao.prototype.moe_training.config import (
+                MXFP8TrainingOpConfig,
+                MXFP8TrainingRecipe,
+            )
+            from torchao.quantization.quant_api import quantize_
+
+            recipe = MXFP8TrainingRecipe(config.recipe_name)
+            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+            quantize_(
+                self,
+                config=mxfp8_op_config,
+                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            )
+
+    MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
+    MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
+    _mxfp8_experts_cache[parent_cls] = MXFP8GroupedExperts
+    return MXFP8GroupedExperts
 
 
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
@@ -134,8 +151,6 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
 
     # MXFP8: scaling block size is (1 x 32), so contracting dim must be divisible by 32.
     PAD_MULTIPLE = 32
-
-    _quantized_cls_cache: dict[type, type] = {}
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
@@ -164,51 +179,11 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                 "of MXFP8 dynamic quantization."
             )
 
-    @classmethod
-    def _quantized_cls(cls, parent_cls: type) -> type:
-        """Return an MXFP8-quantized subclass of *parent_cls*."""
-        if parent_cls is GroupedExperts:
-            return MXFP8GroupedExperts
-        if parent_cls in cls._quantized_cls_cache:
-            return cls._quantized_cls_cache[parent_cls]
-
-        parent_config_cls = parent_cls.Config
-
-        class _MXFP8Experts(parent_cls):  # type: ignore[valid-type, misc]
-            _is_quantized_experts = True
-
-            @dataclass(kw_only=True, slots=True)
-            class Config(parent_config_cls):  # type: ignore[misc]
-                recipe_name: str = "mxfp8_rceil"
-
-            def __init__(self, config: Config):
-                parent_cls.__init__(  # pyrefly: ignore [no-matching-overload]
-                    self, config
-                )
-                from torchao.prototype.moe_training.config import (
-                    MXFP8TrainingOpConfig,
-                    MXFP8TrainingRecipe,
-                )
-                from torchao.quantization.quant_api import quantize_
-
-                recipe = MXFP8TrainingRecipe(config.recipe_name)
-                mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-                quantize_(
-                    self,
-                    config=mxfp8_op_config,
-                    filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-                )
-
-        _MXFP8Experts.__name__ = f"MXFP8{parent_cls.__name__}"
-        _MXFP8Experts.__qualname__ = f"MXFP8{parent_cls.__name__}"
-        cls._quantized_cls_cache[parent_cls] = _MXFP8Experts
-        return _MXFP8Experts
-
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
-            quantized_cls = self._quantized_cls(base_module_cls)
+            quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
             new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -106,6 +106,8 @@ class MXFP8LinearConverter(QuantizationConverter):
 class MXFP8GroupedExperts(GroupedExperts):
     """GroupedExperts with MXFP8 quantization applied in __init__."""
 
+    _is_quantized_experts = True
+
     @dataclass(kw_only=True, slots=True)
     class Config(GroupedExperts.Config):
         recipe_name: str = "mxfp8_rceil"
@@ -127,38 +129,13 @@ class MXFP8GroupedExperts(GroupedExperts):
         )
 
 
-_mxfp8_experts_cache: dict[type, type] = {}
-
-
-def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
-    """Get or create an MXFP8-quantized subclass of *parent_cls*.
-
-    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
-    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
-    """
-    if parent_cls is GroupedExperts:
-        return MXFP8GroupedExperts
-    if parent_cls in _mxfp8_experts_cache:
-        return _mxfp8_experts_cache[parent_cls]
-
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
-
-    class _MXFP8GroupedExperts(parent_cls, MXFP8GroupedExperts):  # type: ignore[valid-type, misc]
-        @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls, MXFP8GroupedExperts.Config):  # type: ignore[misc]
-            pass
-
-    _MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
-    _MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
-    _mxfp8_experts_cache[parent_cls] = _MXFP8GroupedExperts
-    return _MXFP8GroupedExperts
-
-
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
     """Apply MXFP8 quantization to MoE expert grouped GEMMs."""
 
     # MXFP8: scaling block size is (1 x 32), so contracting dim must be divisible by 32.
     PAD_MULTIPLE = 32
+
+    _quantized_cls_cache: dict[type, type] = {}
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
@@ -187,12 +164,52 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                 "of MXFP8 dynamic quantization."
             )
 
+    @classmethod
+    def _quantized_cls(cls, parent_cls: type) -> type:
+        """Return an MXFP8-quantized subclass of *parent_cls*."""
+        if parent_cls is GroupedExperts:
+            return MXFP8GroupedExperts
+        if parent_cls in cls._quantized_cls_cache:
+            return cls._quantized_cls_cache[parent_cls]
+
+        parent_config_cls = parent_cls.Config
+
+        class _MXFP8Experts(parent_cls):  # type: ignore[valid-type, misc]
+            _is_quantized_experts = True
+
+            @dataclass(kw_only=True, slots=True)
+            class Config(parent_config_cls):  # type: ignore[misc]
+                recipe_name: str = "mxfp8_rceil"
+
+            def __init__(self, config: Config):
+                parent_cls.__init__(  # pyrefly: ignore [no-matching-overload]
+                    self, config
+                )
+                from torchao.prototype.moe_training.config import (
+                    MXFP8TrainingOpConfig,
+                    MXFP8TrainingRecipe,
+                )
+                from torchao.quantization.quant_api import quantize_
+
+                recipe = MXFP8TrainingRecipe(config.recipe_name)
+                mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+                quantize_(
+                    self,
+                    config=mxfp8_op_config,
+                    filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+                )
+
+        _MXFP8Experts.__name__ = f"MXFP8{parent_cls.__name__}"
+        _MXFP8Experts.__qualname__ = f"MXFP8{parent_cls.__name__}"
+        cls._quantized_cls_cache[parent_cls] = _MXFP8Experts
+        return _MXFP8Experts
+
     def convert(self, model_config) -> None:
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
-            quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
+            quantized_cls = self._quantized_cls(base_module_cls)
+            new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,
             )

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -9,7 +9,6 @@ from importlib.util import find_spec
 from typing import Literal
 
 from torchtitan.components.quantization import (
-    _QuantizedGroupedExpertsConfig,
     QuantizationConverter,
     QuantizedLinearConfig,
 )
@@ -120,7 +119,7 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
 
     class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls, _QuantizedGroupedExpertsConfig):  # type: ignore[misc]
+        class Config(parent_config_cls):  # type: ignore[misc]
             recipe_name: str = "mxfp8_rceil"
 
         def __init__(self, config: Config):

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -103,6 +103,30 @@ class MXFP8LinearConverter(QuantizationConverter):
         )
 
 
+class MXFP8GroupedExperts(GroupedExperts):
+    """GroupedExperts with MXFP8 quantization applied in __init__."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config):
+        recipe_name: str = "mxfp8_rceil"
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        from torchao.prototype.moe_training.config import (
+            MXFP8TrainingOpConfig,
+            MXFP8TrainingRecipe,
+        )
+        from torchao.quantization.quant_api import quantize_
+
+        recipe = MXFP8TrainingRecipe(config.recipe_name)
+        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+        quantize_(
+            self,
+            config=mxfp8_op_config,
+            filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+        )
+
+
 _mxfp8_experts_cache: dict[type, type] = {}
 
 
@@ -112,36 +136,22 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
     The returned class has a proper ``_owner`` set by ``__init_subclass__``.
     """
+    if parent_cls is GroupedExperts:
+        return MXFP8GroupedExperts
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
-    class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+    class _MXFP8GroupedExperts(parent_cls, MXFP8GroupedExperts):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls):  # type: ignore[misc]
-            recipe_name: str = "mxfp8_rceil"
+        class Config(parent_config_cls, MXFP8GroupedExperts.Config):  # type: ignore[misc]
+            pass
 
-        def __init__(self, config: Config):
-            super().__init__(config)
-            from torchao.prototype.moe_training.config import (
-                MXFP8TrainingOpConfig,
-                MXFP8TrainingRecipe,
-            )
-            from torchao.quantization.quant_api import quantize_
-
-            recipe = MXFP8TrainingRecipe(config.recipe_name)
-            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-            quantize_(
-                self,
-                config=mxfp8_op_config,
-                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
-            )
-
-    MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
-    MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
-    _mxfp8_experts_cache[parent_cls] = MXFP8GroupedExperts
-    return MXFP8GroupedExperts
+    _MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
+    _MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
+    _mxfp8_experts_cache[parent_cls] = _MXFP8GroupedExperts
+    return _MXFP8GroupedExperts
 
 
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
@@ -182,7 +192,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
-            new_config = quantized_cls.Config(  # pyrefly: ignore [missing-attribute]
+            new_config = quantized_cls.Config(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
                 recipe_name=self.config.recipe_name,
             )

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -71,15 +71,13 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization import QuantizedLinearConfig
-    from torchtitan.components.quantization.float8 import Float8GroupedExperts
-    from torchtitan.components.quantization.mx import MXFP8GroupedExperts
 
     has_quant_linear = any(
         isinstance(config, QuantizedLinearConfig)
         for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
     has_quant_moe = any(
-        isinstance(config, (MXFP8GroupedExperts.Config, Float8GroupedExperts.Config))
+        getattr(type(config)._owner, "_is_quantized_experts", False)
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -81,7 +81,7 @@ def has_quantization(model_config) -> bool:
         quant_linear_configs.append(Float8Linear.Config)
 
     quant_experts_configs = tuple(
-        cls.Config
+        cls.Config  # type: ignore[attr-defined]
         for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
     )
 

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -71,16 +71,10 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization.float8 import (
-        _get_float8_grouped_experts_cls,
+        _float8_experts_cache,
         Float8Linear,
     )
-    from torchtitan.components.quantization.mx import (
-        _get_mxfp8_grouped_experts_cls,
-        MXFP8Linear,
-    )
-
-    Float8GroupedExperts = _get_float8_grouped_experts_cls(GroupedExperts)
-    MXFP8GroupedExperts = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+    from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
 
     has_quant_linear = (
         any(
@@ -93,8 +87,12 @@ def has_quantization(model_config) -> bool:
             for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
         )
     )
-    has_quant_moe = any(
-        isinstance(config, (Float8GroupedExperts.Config, MXFP8GroupedExperts.Config))  # type: ignore[attr-defined]
+    quant_experts_types = tuple(
+        cls.Config  # type: ignore[attr-defined]
+        for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
+    )
+    has_quant_moe = bool(quant_experts_types) and any(
+        isinstance(config, quant_experts_types)
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -71,19 +71,15 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization import QuantizedLinearConfig
-    from torchtitan.components.quantization.float8 import _float8_experts_cache
-    from torchtitan.components.quantization.mx import _mxfp8_experts_cache
+    from torchtitan.components.quantization.float8 import Float8GroupedExperts
+    from torchtitan.components.quantization.mx import MXFP8GroupedExperts
 
     has_quant_linear = any(
         isinstance(config, QuantizedLinearConfig)
         for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
-    quantized_expert_configs = {
-        cls.Config  # pyrefly: ignore [missing-attribute]
-        for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
-    }
     has_quant_moe = any(
-        type(config) in quantized_expert_configs
+        isinstance(config, (MXFP8GroupedExperts.Config, Float8GroupedExperts.Config))
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -70,14 +70,27 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
-    from torchtitan.components.quantization import QuantizedLinearConfig
+    from torchtitan.components.quantization.float8 import (
+        _float8_experts_cache,
+        Float8Linear,
+    )
+    from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
+
+    quant_linear_configs: list[type] = [MXFP8Linear.Config]
+    if Float8Linear is not None:
+        quant_linear_configs.append(Float8Linear.Config)
+
+    quant_experts_configs = tuple(
+        cls.Config
+        for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
+    )
 
     has_quant_linear = any(
-        isinstance(config, QuantizedLinearConfig)
+        isinstance(config, tuple(quant_linear_configs))
         for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
-    has_quant_moe = any(
-        getattr(type(config)._owner, "_is_quantized_experts", False)
+    has_quant_moe = bool(quant_experts_configs) and any(
+        isinstance(config, quant_experts_configs)
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -71,26 +71,30 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization.float8 import (
-        _float8_experts_cache,
+        _get_float8_grouped_experts_cls,
         Float8Linear,
     )
-    from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
-
-    quant_linear_configs: list[type] = [MXFP8Linear.Config]
-    if Float8Linear is not None:
-        quant_linear_configs.append(Float8Linear.Config)
-
-    quant_experts_configs = tuple(
-        cls.Config  # type: ignore[attr-defined]
-        for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
+    from torchtitan.components.quantization.mx import (
+        _get_mxfp8_grouped_experts_cls,
+        MXFP8Linear,
     )
 
-    has_quant_linear = any(
-        isinstance(config, tuple(quant_linear_configs))
-        for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
+    Float8GroupedExperts = _get_float8_grouped_experts_cls(GroupedExperts)
+    MXFP8GroupedExperts = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+
+    has_quant_linear = (
+        any(
+            isinstance(config, (Float8Linear.Config, MXFP8Linear.Config))
+            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
+        )
+        if Float8Linear is not None
+        else any(
+            isinstance(config, MXFP8Linear.Config)
+            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
+        )
     )
-    has_quant_moe = bool(quant_experts_configs) and any(
-        isinstance(config, quant_experts_configs)
+    has_quant_moe = any(
+        isinstance(config, (Float8GroupedExperts.Config, MXFP8GroupedExperts.Config))  # type: ignore[attr-defined]
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -70,17 +70,20 @@ def swap_token_dispatcher(config, pad_multiple: int) -> None:
 
 def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
-    from torchtitan.components.quantization import (
-        _QuantizedGroupedExpertsConfig,
-        QuantizedLinearConfig,
-    )
+    from torchtitan.components.quantization import QuantizedLinearConfig
+    from torchtitan.components.quantization.float8 import _float8_experts_cache
+    from torchtitan.components.quantization.mx import _mxfp8_experts_cache
 
     has_quant_linear = any(
         isinstance(config, QuantizedLinearConfig)
         for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
+    quantized_expert_configs = {
+        cls.Config  # pyrefly: ignore [missing-attribute]
+        for cls in (*_float8_experts_cache.values(), *_mxfp8_experts_cache.values())
+    }
     has_quant_moe = any(
-        isinstance(config, _QuantizedGroupedExpertsConfig)
+        type(config) in quantized_expert_configs
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe


### PR DESCRIPTION
Previous flow (inline config, broken _owner):                                                                                             
```
  1. GroupedExperts is defined with nested Config:                                                                                          
     class GroupedExperts(Module):                                                                                                          
         class Config(Module.Config):  # __init_subclass__ sets Config._owner = GroupedExperts                                              
                                                                                                                                            
  2. Converter.convert() runs:                                                                                                              
     for config in model_config.traverse(GroupedExperts.Config):                                                                            
         base_cls = type(config)  # e.g. GroupedExperts.Config                                                                              
                                                                                                                                            
         # Create a NEW config class inline                                                                                                 
         @dataclass                                                                                                                         
         class MXFP8GroupedExpertsConfig(base_cls, _QuantizedGroupedExpertsConfig):
             def build(self, **kwargs):                                                                                                     
                 instance = base_cls.build(self, **kwargs)  # builds a GroupedExperts
                 quantize_(instance, ...)                    # wraps params for MXFP8                                                       
                 return instance                                                                                                            
                                                                                                                                            
         # Problem: MXFP8GroupedExpertsConfig._owner is inherited from base_cls                                                             
         # which is GroupedExperts.Config._owner = GroupedExperts 
         # There's no MXFP8GroupedExperts MODULE class at all — just a config hack                                                          
                                                                                                                                            
  3. Later, config.build() calls base_cls.build() then quantize_()                                                                          
     The returned instance is a GroupedExperts (not a quantized subclass)                                                                   
```
  The "quantization" was a post-build patch inside build(). No actual quantized module class existed.                                       
                                                                                                                                            
Current flow (class factory, correct _owner):                                                                                             
```
  1. Same GroupedExperts with Config._owner = GroupedExperts                                                                                
                                                                  
  2. _get_mxfp8_grouped_experts_cls(GroupedExperts) creates a real MODULE class:                                                            
     class MXFP8GroupedExperts(GroupedExperts):          # real subclass
         class Config(GroupedExperts.Config, _QuantizedGroupedExpertsConfig):                                                               
             # __init_subclass__ fires → Config._owner = MXFP8GroupedExperts ✓                                                              
                                                                                                                                            
         def __init__(self, config):                                                                                                        
             super().__init__(config)     # builds GroupedExperts normally                                                                  
             quantize_(self, ...)         # wraps params for MXFP8                                                                          
                                                                                                                                            
  3. Converter.convert() runs:                                                                                                              
     for config in model_config.traverse(GroupedExperts.Config):                                                                            
         base_module_cls = type(config)._owner           # GroupedExperts
         quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)  # MXFP8GroupedExperts                                             
         new_config = quantized_cls.Config(...)           # _owner = MXFP8GroupedExperts ✓
                                                                                                                                            
  4. Later, config.build() calls MXFP8GroupedExperts.__init__()                                                                             
     The returned instance IS an MXFP8GroupedExperts
 ```