### PR TITLE
[graph_trainer] Disable cpu_offload_all CI test for upstream cuDNN regression

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -335,6 +335,11 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
         ),
+        # TODO: Disabled due to upstream PyTorch cuDNN regression in nightly
+        # dev20260506. _scaled_dot_product_cudnn_attention fails with
+        # "mha_graph.execute ... is_good() to be true, but got false" on A10G
+        # when attention inputs are CPU-offloaded and reloaded. Re-enable once
+        # the upstream fix lands.
         OverrideDefinitions(
             [
                 [
@@ -350,6 +355,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_cpu_offload_all",
             ngpu=8,
             skip_rocm_test=True,
+            disabled=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
## Summary
- Disables the `aot_fx_trace_llama3_fsdp_tp_cpu_offload_all` integration test which has been failing on every CI run since 2026-05-06 12:37 UTC
- Root cause: PyTorch nightly `dev20260506` introduced a cuDNN regression where `_scaled_dot_product_cudnn_attention` fails with `mha_graph.execute ... is_good() to be true, but got false` on A10G (Ampere) GPUs when attention inputs go through CPU offload/reload
- The same model config *without* cpu_offload (`aot_fx_trace_llama3_fsdp_tp`) passes, confirming this is specific to the offload + cuDNN SDPA interaction in the new nightly

## Test plan
- [x] Verify CI passes with this change (the disabled test will be skipped)
- [ ] Re-enable once the upstream PyTorch cuDNN fix lands