### PR TITLE
Wrong token count in validation when CP>1

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -256,11 +256,6 @@ class Validator(BaseValidator):
                 input_dict[k] = v.to(device_type)
             labels = labels.to(device_type)
 
-            # Process data (extract inputs, handle attention masks, CP sharding)
-            inputs, labels, extra_inputs, extra_kwargs = self.post_dataloading_process(
-                input_dict, labels, model_parts
-            )
-
             # Count valid tokens for this batch
             local_valid_tokens = torch.tensor(0, dtype=torch.int64, device=device_type)
             local_valid_tokens += (labels != IGNORE_INDEX).sum()
@@ -273,6 +268,11 @@ class Validator(BaseValidator):
                 )
             else:
                 global_valid_tokens = local_valid_tokens.float()
+
+           # Process data (extract inputs, handle attention masks, CP sharding)
+            inputs, labels, extra_inputs, extra_kwargs = self.post_dataloading_process(
+                input_dict, labels, model_parts
+            )
 
             if parallel_dims.pp_enabled:
                 assert self.pp_schedule is not None

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -21,6 +21,7 @@ from torchtitan.config import Configurable, ParallelismConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
 from torchtitan.tools import utils
@@ -188,6 +189,7 @@ class Validator(BaseValidator):
         positions = extra_inputs.pop("positions", None)
         if isinstance(model_config, Decoder.Config):
             attn_config = model_config.layers[0].attention
+            inner_attention = attn_config.inner_attention
 
             if attn_config.mask_type == "block_causal":
                 assert (
@@ -198,14 +200,13 @@ class Validator(BaseValidator):
                     inputs.shape[1], dtype=torch.int32, device=inputs.device
                 ).repeat(inputs.shape[0], 1)
 
-        try:
-            extra_kwargs["attention_masks"] = cast(
-                Decoder, model_parts[0]
-            ).get_attention_masks(
-                positions=positions,  # pyrefly: ignore [bad-argument-type]
-            )
-        except TypeError:
-            pass
+            if isinstance(
+                inner_attention, (FlexAttention.Config, VarlenAttention.Config)
+            ):
+                model = cast(Decoder, model_parts[0])
+                extra_kwargs["attention_masks"] = model.get_attention_masks(
+                    positions=positions,
+                )
 
         extra_kwargs["positions"] = positions
 

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -21,8 +21,8 @@ from torchtitan.config import Configurable, ParallelismConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
-from torchtitan.protocols import BaseModel
 from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 
@@ -184,29 +184,30 @@ class Validator(BaseValidator):
         # sequential positions when CP needs them for shard indexing,
         # or None (model uses sequential RoPE slice by default).
         model_config = getattr(model_parts[0], "config", None)
-        layer = getattr(model_config, "layer", None)
-        attn_config = getattr(layer, "attention", None) if layer else None
-        attn_mask_type = getattr(attn_config, "mask_type", "causal")
 
         positions = extra_inputs.pop("positions", None)
-        if attn_mask_type == "block_causal":
-            # Per-document positions from the dataloader
-            extra_kwargs["positions"] = positions
-        elif self.parallel_dims.cp_enabled:
-            # Sequential positions needed for correct RoPE after CP sharding
-            extra_kwargs["positions"] = torch.arange(
-                0, inputs.shape[1], dtype=torch.int32, device=inputs.device
-            ).expand(inputs.shape)
+        if isinstance(model_config, Decoder.Config):
+            attn_config = model_config.layers[0].attention
+
+            if attn_config.mask_type == "block_causal":
+                assert (
+                    positions is not None
+                ), "block_causal mask requires per-document positions from the dataloader"
+            else:
+                positions = torch.arange(
+                    inputs.shape[1], dtype=torch.int32, device=inputs.device
+                ).repeat(inputs.shape[0], 1)
 
         try:
-            # pyrefly: ignore [not-callable]
             extra_kwargs["attention_masks"] = cast(
-                BaseModel, model_parts[0]
+                Decoder, model_parts[0]
             ).get_attention_masks(
-                positions=extra_kwargs.get("positions"),
+                positions=positions,  # pyrefly: ignore [bad-argument-type]
             )
         except TypeError:
             pass
+
+        extra_kwargs["positions"] = positions
 
         if self.parallel_dims.cp_enabled:
             inputs, labels, extra_kwargs = prepare_context_parallel_input(
@@ -269,7 +270,7 @@ class Validator(BaseValidator):
             else:
                 global_valid_tokens = local_valid_tokens.float()
 
-           # Process data (extract inputs, handle attention masks, CP sharding)
+            # Process data (extract inputs, handle attention masks, CP sharding)
             inputs, labels, extra_inputs, extra_kwargs = self.post_dataloading_process(
                 input_dict, labels, model_parts
             )


### PR DESCRIPTION
## Wrong token count in validation

When `CP > 1`, `post_dataloading_process` shards inputs across ranks. During validation, this causes token counts to be incorrect because counting happens after sharding. This is not an issue during training, where tokens are counted before `post_dataloading_process`.

### Fix

Move `post_dataloading_process` to occur after token counting in validation.

## `post_dataloading_process` not receiving the correct `attn_config`

At some point, the validation and trainer implementations of `post_dataloading_process` became misaligned. In validation, `attn_config` was not being retrieved correctly and defaulted to `None`. As a consequence, the mask type defaulted to `causal` even when `block_causal` was configured.

### Fix

As a temporary fix, I copied the relevant logic from the trainer into the validation `post_dataloading_process`.

This comment highlights the issue:
https://github.com/pytorch/torchtitan/blob/ae5ff104999a937ce0d34d8a720969ae23110140/torchtitan/components/validate.py#L181-L185

I can open a follow-up PR to address this more cleanly. A few possible approaches:

* Make `Validator` inherit from the trainer so it reuses `post_dataloading_process` directly. This feels somewhat heavy-handed since that is the only functionality we need to share.
* Pass `post_dataloading_process` into `Validator.__init__`. We could also make the trainer implementation a `@staticmethod` to reduce coupling.