### PR TITLE
[graph_trainer] Add CP support

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -66,6 +66,25 @@ def annotate_module_fqns(model: nn.Module) -> None:
             submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
 
 
+def apply_context_parallel(model: nn.Module, parallel_dims: ParallelDims) -> None:
+    """Apply CP forward wrapping to graph trainer decoder models."""
+    if not parallel_dims.cp_enabled:
+        return
+
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        raise ValueError("Context Parallel requires the model to expose layers.")
+
+    layer_iter = layers.values() if hasattr(layers, "values") else layers
+    attention_modules = [block.attention.inner_attention for block in layer_iter]
+    if not attention_modules:
+        raise ValueError("Context Parallel requires at least one attention module.")
+
+    from torchtitan.distributed.context_parallel import apply_cp_to_forward
+
+    apply_cp_to_forward(attention_modules, parallel_dims.get_mesh("cp"))
+
+
 def parallelize_inputs(parallel_dims, args, kwargs):
     if not parallel_dims.tp_enabled:
         return args, kwargs

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -15,6 +15,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    apply_context_parallel,
     apply_simple_fsdp,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -77,6 +78,7 @@ def parallelize_deepseekv3(
     ):
         raise NotImplementedError("CP support is only supported for SDPA.")
 
+    apply_context_parallel(model, parallel_dims)
     annotate_deepseekv3(model)
 
     if parallel_dims.tp_enabled:

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -13,6 +13,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    apply_context_parallel,
     apply_simple_fsdp,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -53,6 +54,7 @@ def parallelize_llama(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
+    apply_context_parallel(model, parallel_dims)
     annotate_llama(model)
 
     if parallel_dims.tp_enabled:

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -6,7 +6,7 @@
 
 import copy
 from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -43,6 +43,14 @@ def _skip_nested_compile() -> Generator[None, None, None]:
         torch._dynamo.config.error_on_nested_fx_trace = prev
 
 
+def _patch_backward_tracing():
+    if hasattr(torch.compiler, "_patch_engine_backward"):
+        return torch.compiler._patch_engine_backward()
+    if hasattr(torch.compiler, "_patch_autograd_grad"):
+        return torch.compiler._patch_autograd_grad()
+    return nullcontext()
+
+
 @dataclass
 class SubclassMeta:
     cls: type
@@ -57,6 +65,11 @@ class SubclassMeta:
 class SubclassLayout:
     num_tensors: int
     meta: SubclassMeta | None
+
+
+@dataclass(frozen=True)
+class ProcessGroupInputSpec:
+    axis: str
 
 
 def _unwrap_subclass(t: torch.Tensor) -> tuple[list[torch.Tensor], SubclassMeta | None]:
@@ -284,6 +297,10 @@ class TracedResult:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int] = field(default_factory=list)
+    process_group_inputs: tuple[Any, ...] = field(default_factory=tuple)
+    process_group_input_specs: tuple[ProcessGroupInputSpec, ...] = field(
+        default_factory=tuple
+    )
 
     @property
     def num_static_inputs(self) -> int:
@@ -378,7 +395,7 @@ def minimal_fx_tracer(fn: Callable) -> Callable[..., TracedResult]:
 
             state_for_fn = dict(zip(state_fqns, state_wrapped, strict=True))
             user_list = pytree.tree_unflatten(list(user_flat), user_args_spec)
-            with torch.compiler._patch_engine_backward():
+            with _patch_backward_tracing():
                 result = fn(state_for_fn, *user_list)
 
             flat_outs, output_spec = pytree.tree_flatten(result)
@@ -464,6 +481,7 @@ def run_traced(
         )
     all_args = list(state_flat) + list(user_args_flat)
     flat_inputs, _ = _unwrap_subclasses(all_args)
+    flat_inputs.extend(traced_result.process_group_inputs)
 
     with torch.no_grad():
         flat_outputs = traced_result.gm(*flat_inputs)

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import operator
 import os
 import pickle
 from collections.abc import Callable
@@ -15,14 +16,18 @@ from dataclasses import dataclass, field
 from typing import Any, NewType, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
     from torchtitan.distributed import ParallelDims
     from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 
 import torch
+import torch.distributed as dist
 import torch.utils._pytree as pytree
 from torch._dynamo.aot_compile_types import BundledAOTAutogradSerializableCallable
 
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    ProcessGroupInputSpec,
     SubclassLayout,
     TracedResult,
 )
@@ -101,6 +106,7 @@ def _register_coor_ops() -> None:
 
     _register_distributed_opaque_types()
     from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
+    from torch.distributed.tensor import _collective_utils as _dtensor_ops  # noqa: F401
 
 
 def _unwrap_serializable(
@@ -116,6 +122,8 @@ def _unwrap_serializable(
     while current is not None:
         if isinstance(current, BundledAOTAutogradSerializableCallable):
             return current
+        if callable(getattr(current, "serialize", None)):
+            return BundledAOTAutogradSerializableCallable(current)
         current = getattr(current, "__wrapped__", None)
     raise TypeError(
         "precompile_save requires the compiled function to be a "
@@ -237,13 +245,14 @@ def precompile_load(
             *model.parameters(),
             *model.buffers(),
             *args,
+            *kwargs.values(),
         )
         # The deserialized fn returns flat outputs. We need to
         # unflatten them using the saved out_spec to match the
         # original model output structure. See also graph_utils.py:wrapper_fn
         # which does NOT unflatten because the live-compiled fn already
         # handles it via unflattened_compiled_fn.
-        flat_outputs = compiled_fn(*inputs, **kwargs)
+        flat_outputs = compiled_fn(*inputs)
         if out_spec is not None:
             return pytree.tree_unflatten(flat_outputs, out_spec)
         return flat_outputs
@@ -296,6 +305,404 @@ def _validate_config_fingerprint(
 _FX_TRACE_ARTIFACT_KEY = "fx_trace_default"
 
 
+def _get_graph_attr(module: torch.nn.Module, target: str) -> Any:
+    attr: Any = module
+    for atom in target.split("."):
+        attr = getattr(attr, atom)
+    return attr
+
+
+def _safe_placeholder_suffix(axis: str) -> str:
+    return "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in axis)
+
+
+def _process_group_axis_from_mesh(mesh: Any, mesh_axis: int) -> str:
+    mesh_axis_names = getattr(mesh, "mesh_dim_names", None)
+    if mesh_axis_names is None:
+        raise ValueError(
+            "Cannot hoist ProcessGroup input for an unnamed DeviceMesh axis. "
+            "Graph trainer precompile expects named mesh axes."
+        )
+    axis = mesh_axis_names[mesh_axis]
+    if axis is None:
+        raise ValueError(
+            "Cannot hoist ProcessGroup input for a DeviceMesh axis with name None."
+        )
+    return axis
+
+
+def _process_group_axis_from_parallel_dims(
+    process_group: dist.ProcessGroup,
+    parallel_dims: ParallelDims | None,
+) -> str:
+    if parallel_dims is None:
+        raise ValueError(
+            "Cannot infer the mesh axis for a captured ProcessGroup without "
+            "parallel_dims."
+        )
+
+    process_group_name = getattr(process_group, "group_name", None)
+    for axis, mesh in parallel_dims.get_all_one_dimensional_meshes().items():
+        candidate = mesh.get_group()
+        if candidate is process_group:
+            return axis
+        if (
+            process_group_name is not None
+            and getattr(candidate, "group_name", None) == process_group_name
+        ):
+            return axis
+
+    raise ValueError(
+        "Captured ProcessGroup does not match any one-dimensional mesh axis "
+        "in parallel_dims."
+    )
+
+
+def _is_mesh_get_process_group_node(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._dtensor.mesh_get_process_group.default
+    )
+
+
+def _process_group_from_mesh_get_process_group_node(
+    gm: torch.fx.GraphModule,
+    node: torch.fx.Node,
+) -> dist.ProcessGroup:
+    process_group = node.meta.get("val")
+    if isinstance(process_group, dist.ProcessGroup):
+        return process_group
+
+    mesh_arg, mesh_axis = node.args
+    if (
+        isinstance(mesh_arg, torch.fx.Node)
+        and mesh_arg.op == "get_attr"
+        and isinstance(mesh_arg.target, str)
+        and isinstance(mesh_axis, int)
+    ):
+        mesh = _get_graph_attr(gm, mesh_arg.target)
+        return mesh.get_group(mesh_axis)
+
+    raise ValueError("Could not recover ProcessGroup from mesh_get_process_group node.")
+
+
+def _axis_from_mesh_get_process_group_node(
+    gm: torch.fx.GraphModule,
+    node: torch.fx.Node,
+    parallel_dims: ParallelDims | None,
+) -> str:
+    mesh_arg, mesh_axis = node.args
+    if (
+        isinstance(mesh_arg, torch.fx.Node)
+        and mesh_arg.op == "get_attr"
+        and isinstance(mesh_arg.target, str)
+        and isinstance(mesh_axis, int)
+    ):
+        return _process_group_axis_from_mesh(
+            _get_graph_attr(gm, mesh_arg.target), mesh_axis
+        )
+
+    process_group = _process_group_from_mesh_get_process_group_node(gm, node)
+    return _process_group_axis_from_parallel_dims(process_group, parallel_dims)
+
+
+def _first_non_placeholder(graph: torch.fx.Graph) -> torch.fx.Node | None:
+    for node in graph.nodes:
+        if node.op != "placeholder":
+            return node
+    return None
+
+
+def _last_placeholder(graph: torch.fx.Graph) -> torch.fx.Node | None:
+    last_placeholder = None
+    for node in graph.nodes:
+        if node.op != "placeholder":
+            break
+        last_placeholder = node
+    return last_placeholder
+
+
+def _is_all_to_all_single_node(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.all_to_all_single.default
+    )
+
+
+def _validate_permute_tensor_split_sizes(split_sizes: Any) -> int | None:
+    if not (
+        isinstance(split_sizes, (list, tuple))
+        and split_sizes
+        and all(isinstance(size, int) for size in split_sizes)
+    ):
+        return None
+
+    nonzero_sizes = [size for size in split_sizes if size != 0]
+    if len(nonzero_sizes) != 1:
+        return None
+    return nonzero_sizes[0]
+
+
+def _runtime_coordinate_source_for_axis(
+    axis: str,
+    parallel_dims: ParallelDims | None,
+) -> tuple[DeviceMesh, int]:
+    if parallel_dims is None:
+        raise ValueError(
+            f"Cannot derive runtime coordinate source for mesh axis {axis!r} "
+            "without parallel_dims."
+        )
+
+    if axis == "cp":
+        # CP split sizes need the coordinate in the full dataloading mesh.
+        # The 1D CP mesh seen during a one-rank trace only describes the
+        # tracing rank's local slice.
+        global_meshes = getattr(parallel_dims, "_global_meshes", {}) or {}
+        global_mesh = global_meshes.get("dataloading")
+        mesh_axis_names = getattr(global_mesh, "mesh_dim_names", None)
+        if (
+            global_mesh is not None
+            and mesh_axis_names is not None
+            and axis in mesh_axis_names
+        ):
+            return global_mesh, mesh_axis_names.index(axis)
+
+    mesh = parallel_dims.get_mesh(axis)
+    return mesh, 0
+
+
+def _full_mesh_tensor_for_runtime_coordinate(mesh: DeviceMesh) -> torch.Tensor:
+    rank_map = torch.tensor(mesh._rank_map.tolist(), device="cpu", dtype=torch.int)
+    return mesh._layout.remap_to_tensor(rank_map)
+
+
+def hoist_process_group_inputs(
+    traced_result: TracedResult,
+    *,
+    parallel_dims: ParallelDims | None = None,
+) -> None:
+    """Replace captured ProcessGroups with explicit graph inputs.
+
+    ``compile_on_one_rank`` traces DeviceMesh-to-ProcessGroup resolution via
+    ``_dtensor.mesh_get_process_group``. Before serializing or compiling the
+    FX graph, hoist those ProcessGroups to placeholders so Inductor and
+    GraphPickler see them as opaque inputs rather than captured attributes.
+    """
+    _register_coor_ops()
+
+    gm = traced_result.gm
+    graph = gm.graph
+    axis_to_placeholder: dict[str, torch.fx.Node] = {}
+    axis_to_coordinate_source: dict[str, tuple[DeviceMesh, int]] = {}
+    axis_to_coordinate_node: dict[str, torch.fx.Node] = {}
+    process_group_inputs: list[Any] = []
+    process_group_input_specs: list[ProcessGroupInputSpec] = []
+    attrs_to_delete: set[str] = set()
+    last_placeholder = _last_placeholder(graph)
+    first_non_placeholder = _first_non_placeholder(graph)
+
+    def get_or_create_placeholder(
+        axis: str,
+        process_group: dist.ProcessGroup,
+    ) -> torch.fx.Node:
+        nonlocal last_placeholder
+        if axis in axis_to_placeholder:
+            return axis_to_placeholder[axis]
+
+        placeholder_name = f"_process_group_{_safe_placeholder_suffix(axis)}"
+        if last_placeholder is not None:
+            insert_ctx = graph.inserting_after(last_placeholder)
+        elif first_non_placeholder is not None:
+            insert_ctx = graph.inserting_before(first_non_placeholder)
+        else:
+            insert_ctx = graph.inserting_before(None)
+
+        with insert_ctx:
+            placeholder = graph.placeholder(placeholder_name)
+        placeholder.meta["val"] = process_group
+        placeholder.meta["mesh_axis"] = axis
+        axis_to_placeholder[axis] = placeholder
+        last_placeholder = placeholder
+        process_group_inputs.append(process_group)
+        process_group_input_specs.append(ProcessGroupInputSpec(axis=axis))
+        return placeholder
+
+    def record_coordinate_source_for_mesh_get(
+        axis: str,
+        node: torch.fx.Node,
+    ) -> None:
+        mesh_arg, mesh_axis = node.args
+        if (
+            isinstance(mesh_arg, torch.fx.Node)
+            and mesh_arg.op == "get_attr"
+            and isinstance(mesh_arg.target, str)
+            and isinstance(mesh_axis, int)
+        ):
+            axis_to_coordinate_source.setdefault(
+                axis, (_get_graph_attr(gm, mesh_arg.target), mesh_axis)
+            )
+
+    def copy_region_meta(dst: torch.fx.Node, src: torch.fx.Node) -> None:
+        if "autograd_backward" in src.meta:
+            dst.meta["autograd_backward"] = src.meta["autograd_backward"]
+        custom = src.meta.get("custom")
+        if custom is not None:
+            dst.meta["custom"] = custom.copy()
+
+    def get_or_create_coordinate_node(
+        axis: str,
+        before_node: torch.fx.Node,
+    ) -> torch.fx.Node:
+        if axis in axis_to_coordinate_node:
+            return axis_to_coordinate_node[axis]
+
+        if axis == "cp" and parallel_dims is not None:
+            mesh, mesh_axis = _runtime_coordinate_source_for_axis(axis, parallel_dims)
+        elif axis in axis_to_coordinate_source:
+            mesh, mesh_axis = axis_to_coordinate_source[axis]
+        else:
+            mesh, mesh_axis = _runtime_coordinate_source_for_axis(axis, parallel_dims)
+        full_mesh = _full_mesh_tensor_for_runtime_coordinate(mesh)
+        attr_name = f"_runtime_{_safe_placeholder_suffix(axis)}_full_mesh"
+        gm.register_buffer(attr_name, full_mesh, persistent=False)
+
+        with graph.inserting_before(before_node):
+            full_mesh_node = graph.get_attr(attr_name)
+            full_mesh_node.meta["val"] = full_mesh
+            copy_region_meta(full_mesh_node, before_node)
+            coordinate_node = graph.call_function(
+                torch.ops.device_mesh._runtime_compute_coordinate_on_dim.default,
+                (full_mesh_node, mesh_axis),
+            )
+            copy_region_meta(coordinate_node, before_node)
+        axis_to_coordinate_node[axis] = coordinate_node
+        return coordinate_node
+
+    def runtime_permute_tensor_split_sizes(
+        rank_node: torch.fx.Node,
+        *,
+        kind: str,
+        numel: int,
+        group_size: int,
+        before_node: torch.fx.Node,
+    ) -> list[torch.fx.Node]:
+        split_sizes: list[torch.fx.Node] = []
+        with graph.inserting_before(before_node):
+            for split_index in range(group_size):
+                if kind == "input":
+                    expected_rank = (split_index - 1) % group_size
+                else:
+                    expected_rank = (split_index + 1) % group_size
+                rank_matches = graph.call_function(
+                    operator.eq,
+                    (rank_node, expected_rank),
+                )
+                copy_region_meta(rank_matches, before_node)
+                split_size = graph.call_function(
+                    torch.sym_ite, (rank_matches, numel, 0)
+                )
+                copy_region_meta(split_size, before_node)
+                split_sizes.append(split_size)
+        return split_sizes
+
+    for node in list(graph.nodes):
+        if _is_mesh_get_process_group_node(node):
+            process_group = _process_group_from_mesh_get_process_group_node(gm, node)
+            axis = _axis_from_mesh_get_process_group_node(gm, node, parallel_dims)
+            record_coordinate_source_for_mesh_get(axis, node)
+            placeholder = get_or_create_placeholder(axis, process_group)
+            node.replace_all_uses_with(placeholder)
+            graph.erase_node(node)
+            continue
+
+        if (
+            node.op == "get_attr"
+            and isinstance(node.target, str)
+            and isinstance(_get_graph_attr(gm, node.target), dist.ProcessGroup)
+        ):
+            process_group = _get_graph_attr(gm, node.target)
+            axis = _process_group_axis_from_parallel_dims(process_group, parallel_dims)
+            axis_to_coordinate_source.setdefault(
+                axis, _runtime_coordinate_source_for_axis(axis, parallel_dims)
+            )
+            placeholder = get_or_create_placeholder(axis, process_group)
+            node.replace_all_uses_with(placeholder)
+            graph.erase_node(node)
+            attrs_to_delete.add(node.target)
+
+    for node in list(graph.nodes):
+        if not _is_all_to_all_single_node(node):
+            continue
+        if len(node.args) < 4:
+            continue
+
+        group_arg = node.args[3]
+        axis = (
+            group_arg.meta.get("mesh_axis")
+            if isinstance(group_arg, torch.fx.Node)
+            else None
+        )
+        if axis != "cp":
+            continue
+
+        args = list(node.args)
+        rank_node = get_or_create_coordinate_node(axis, node)
+        for arg_index, kind in ((1, "output"), (2, "input")):
+            split_sizes = args[arg_index]
+            numel = _validate_permute_tensor_split_sizes(split_sizes)
+            if numel is None:
+                raise ValueError(
+                    "Cannot rewrite CP all_to_all split sizes with unsupported "
+                    f"pattern: {split_sizes!r}"
+                )
+            args[arg_index] = runtime_permute_tensor_split_sizes(
+                rank_node,
+                kind=kind,
+                numel=numel,
+                group_size=len(split_sizes),
+                before_node=node,
+            )
+        node.args = tuple(args)
+
+    if not process_group_inputs:
+        return
+
+    graph.eliminate_dead_code()
+    graph.lint()
+    gm.recompile()
+
+    live_get_attrs = {
+        node.target
+        for node in graph.nodes
+        if node.op == "get_attr" and isinstance(node.target, str)
+    }
+    for target in attrs_to_delete - live_get_attrs:
+        if "." not in target and hasattr(gm, target):
+            delattr(gm, target)
+
+    remaining_process_group_attrs = [
+        name for name, attr in vars(gm).items() if isinstance(attr, dist.ProcessGroup)
+    ]
+    if remaining_process_group_attrs:
+        raise ValueError(
+            "ProcessGroup attrs remained after hoisting: "
+            f"{remaining_process_group_attrs}"
+        )
+
+    traced_result.example_inputs = (
+        *traced_result.example_inputs,
+        *process_group_inputs,
+    )
+    traced_result.process_group_inputs = (
+        *traced_result.process_group_inputs,
+        *process_group_inputs,
+    )
+    traced_result.process_group_input_specs = (
+        *traced_result.process_group_input_specs,
+        *process_group_input_specs,
+    )
+
+
 @dataclass
 class PrecompiledFxTraceArtifact:
     """Serialized form of a TracedResult for aot_fx_trace precompilation.
@@ -316,6 +723,9 @@ class PrecompiledFxTraceArtifact:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int]
+    process_group_input_specs: tuple[ProcessGroupInputSpec, ...] = field(
+        default_factory=tuple
+    )
     config_fingerprint: ConfigFingerprint = ConfigFingerprint("")
 
     @classmethod
@@ -332,6 +742,8 @@ class PrecompiledFxTraceArtifact:
         (e.g. the embedding vocab offset from
         _runtime_compute_coordinate_on_dim).
         """
+        _register_coor_ops()
+
         from torch.fx._graph_pickler import GraphPickler, Options
 
         from torchtitan.experiments.graph_trainer.passes import (
@@ -355,10 +767,14 @@ class PrecompiledFxTraceArtifact:
             output_subclass_layouts=traced_result.output_subclass_layouts,
             output_spec=traced_result.output_spec,
             tensor_input_indices=traced_result.tensor_input_indices,
+            process_group_input_specs=traced_result.process_group_input_specs,
             config_fingerprint=config_fingerprint or ConfigFingerprint(""),
         )
 
-    def to_traced_result(self) -> TracedResult:
+    def to_traced_result(
+        self,
+        process_group_inputs: tuple[Any, ...] = (),
+    ) -> TracedResult:
         """Deserialize back into a TracedResult.
 
         Registers CooR custom ops, then deserializes the GraphModule
@@ -378,9 +794,17 @@ class PrecompiledFxTraceArtifact:
         gm = GraphPickler.loads(self.serialized_gm, fake_mode)
         gm.recompile()
 
+        process_group_input_specs = getattr(self, "process_group_input_specs", ())
+        if len(process_group_inputs) != len(process_group_input_specs):
+            raise ValueError(
+                "Expected "
+                f"{len(process_group_input_specs)} ProcessGroup input(s) for "
+                f"the precompiled FX trace, got {len(process_group_inputs)}."
+            )
+
         return TracedResult(
             gm=gm,
-            example_inputs=(),
+            example_inputs=process_group_inputs,
             state_fqns=self.state_fqns,
             num_flat_inputs=self.num_flat_inputs,
             input_subclass_layouts=self.input_subclass_layouts,
@@ -388,6 +812,8 @@ class PrecompiledFxTraceArtifact:
             output_subclass_layouts=self.output_subclass_layouts,
             output_spec=self.output_spec,
             tensor_input_indices=self.tensor_input_indices,
+            process_group_inputs=process_group_inputs,
+            process_group_input_specs=process_group_input_specs,
         )
 
 
@@ -421,6 +847,7 @@ def precompile_fx_trace_save(
 def precompile_fx_trace_load(
     storage: StorageAdapter,
     expected_fingerprint: ConfigFingerprint,
+    parallel_dims: ParallelDims | None = None,
 ) -> TracedResult:
     """Load a precompiled aot_fx_trace artifact.
 
@@ -428,10 +855,9 @@ def precompile_fx_trace_load(
     metadata. The caller uses this with run_traced_train_step to
     execute the graph (same path as non-precompiled aot_fx_trace).
 
-    DeviceMesh objects are graph inputs (placeholders), not baked-in
-    constants, so ProcessGroup names are resolved at runtime from
-    the caller-provided DeviceMesh — no post-deserialization PG
-    remapping is needed.
+    ProcessGroups are explicit graph inputs. The artifact records their
+    mesh axes, and load resolves those axes to the live runtime
+    ProcessGroups from the caller-provided ParallelDims.
     """
     data = storage.load(_FX_TRACE_ARTIFACT_KEY)
     artifact: PrecompiledFxTraceArtifact = pickle.loads(data)
@@ -445,4 +871,17 @@ def precompile_fx_trace_load(
         f"fingerprint={artifact.config_fingerprint}"
     )
 
-    return artifact.to_traced_result()
+    process_group_inputs: tuple[Any, ...] = ()
+    process_group_input_specs = getattr(artifact, "process_group_input_specs", ())
+    if process_group_input_specs:
+        if parallel_dims is None:
+            raise ValueError(
+                "Loading an artifact with hoisted ProcessGroup inputs requires "
+                "parallel_dims to provide runtime process groups."
+            )
+        process_group_inputs = tuple(
+            parallel_dims.get_mesh(spec.axis).get_group()
+            for spec in process_group_input_specs
+        )
+
+    return artifact.to_traced_result(process_group_inputs)

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -302,6 +302,7 @@ def _precompile_aot_fx_trace(
     from torchtitan.experiments.graph_trainer.make_fx_tracer import trace_train_step
     from torchtitan.experiments.graph_trainer.precompile import (
         compute_config_fingerprint,
+        hoist_process_group_inputs,
         precompile_fx_trace_save,
     )
     from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
@@ -320,15 +321,14 @@ def _precompile_aot_fx_trace(
     dummy_labels = torch.randint(
         0, vocab_size, (local_batch_size, seq_len), device=device
     )
-    # The trainer computes global_valid_tokens via dist_sum (an
-    # all-reduce + .item()), which returns a Python float. Use the
-    # same type here so make_fx bakes it as a graph constant — not a
-    # graph input — identical to the non-precompile runtime trace.
+    # Must match Trainer.train_step (trainer.py): local_valid_tokens is
+    # counted from raw dataloader labels BEFORE CP sharding, then
+    # all-reduced over the "batch" mesh (dp_shard × dp_replicate).
+    # The batch mesh is defined as dp_replicate * dp_shard in
+    # ParallelDims.build_mesh and excludes CP, so CP must NOT be
+    # included here.
     global_batch_size = (
-        local_batch_size
-        * parallel_dims.dp_shard
-        * parallel_dims.dp_replicate
-        * parallel_dims.cp
+        local_batch_size * parallel_dims.dp_shard * parallel_dims.dp_replicate
     )
     dummy_global_valid_tokens = float(global_batch_size * seq_len)
     extra_inputs: dict[str, torch.Tensor] = {}
@@ -354,13 +354,18 @@ def _precompile_aot_fx_trace(
 
         extra_kwargs["positions"] = positions
 
-    # TODO: Add CP support — call prepare_context_parallel_input here
-    # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence
-    # dimension, matching the trainer's post_dataloading_process.
     if parallel_dims.cp_enabled:
-        raise NotImplementedError(
-            "CooR precompile does not yet support context parallelism. "
-            "Set --parallelism.context_parallel_degree 1."
+        from torchtitan.distributed.context_parallel import (
+            prepare_context_parallel_input,
+        )
+
+        dummy_inputs, dummy_labels, extra_kwargs = prepare_context_parallel_input(
+            dummy_inputs,
+            dummy_labels,
+            extra_kwargs,
+            parallel_dims.get_mesh("cp"),
+            device,
+            config.parallelism.context_parallel_load_balancer,
         )
 
     # Enable loss_parallel when TP is active and loss_parallel is not
@@ -398,6 +403,8 @@ def _precompile_aot_fx_trace(
         f"Traced graph has {len(list(traced_result.gm.graph.nodes))} nodes, "
         f"{len(traced_result.state_fqns)} state entries"
     )
+
+    hoist_process_group_inputs(traced_result, parallel_dims=parallel_dims)
 
     # Apply precompile-time graph passes (cleanup + regional_inductor)
     # so compiled Triton kernels are baked into the serialized artifact.

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -15,6 +15,7 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    apply_context_parallel,
     apply_simple_fsdp,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
@@ -71,6 +72,7 @@ def parallelize_qwen3(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}), i.e. {parallel_dims.seq_len_divisor}.
         """
 
+    apply_context_parallel(model, parallel_dims)
     annotate_qwen3(model)
 
     if parallel_dims.tp_enabled:

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -372,6 +372,21 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_full_inductor",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.context_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace llama3 FSDP+TP+CP",
+            "aot_fx_trace_llama3_fsdp_tp_cp",
+            ngpu=8,
+        ),
     ]
 
 

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -48,6 +48,9 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
     regional_precompile_dir = tempfile.mkdtemp(prefix="precompile_regional_")
     fx_trace_precompile_dir = tempfile.mkdtemp(prefix="fx_trace_precompile_")
     dsv3_fx_trace_precompile_dir = tempfile.mkdtemp(prefix="dsv3_fx_trace_precompile_")
+    fx_trace_fsdp_tp_cp_precompile_dir = tempfile.mkdtemp(
+        prefix="fx_trace_fsdp_tp_cp_precompile_"
+    )
     return [
         PrecompileTestDefinition(
             precompile_command=(
@@ -141,6 +144,30 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             ],
             test_descr="aot_fx_trace deepseek_v3 precompile FSDP+TP+EP",
             test_name="aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep",
+            ngpu=8,
+        ),
+        PrecompileTestDefinition(
+            precompile_command=(
+                "python -m torchtitan.experiments.graph_trainer.precompile_main"
+                " --module graph_trainer.llama3"
+                " --config graph_trainer_llama3_debugmodel"
+                " --compile.mode aot_fx_trace"
+                f" --compile.precompile_artifact_dir {fx_trace_fsdp_tp_cp_precompile_dir}"
+                " --parallelism.data_parallel_shard_degree 2"
+                " --parallelism.tensor_parallel_degree 2"
+                " --parallelism.context_parallel_degree 2"
+            ),
+            override_args=[
+                "--module graph_trainer.llama3",
+                "--config graph_trainer_llama3_debugmodel",
+                "--compile.mode aot_fx_trace",
+                f"--compile.precompile_artifact_dir {fx_trace_fsdp_tp_cp_precompile_dir}",
+                "--parallelism.data_parallel_shard_degree 2",
+                "--parallelism.tensor_parallel_degree 2",
+                "--parallelism.context_parallel_degree 2",
+            ],
+            test_descr="aot_fx_trace llama3 precompile FSDP+TP+CP",
+            test_name="aot_fx_trace_llama3_precompile_fsdp_tp_cp",
             ngpu=8,
         ),
     ]

--- a/torchtitan/experiments/graph_trainer/tests/test_context_parallel.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_context_parallel.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import inspect
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch.nn as nn
+
+from torchtitan.experiments.graph_trainer.common_utils import apply_context_parallel
+
+
+class _InnerAttention(nn.Module):
+    pass
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attention = SimpleNamespace(inner_attention=_InnerAttention())
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleDict({"0": _Block(), "1": _Block()})
+
+
+class TestGraphTrainerContextParallel(unittest.TestCase):
+    def test_apply_context_parallel_wraps_inner_attention_modules(self):
+        model = _Model()
+        mesh = object()
+        parallel_dims = SimpleNamespace(
+            cp_enabled=True,
+            get_mesh=MagicMock(return_value=mesh),
+        )
+
+        with patch(
+            "torchtitan.distributed.context_parallel.apply_cp_to_forward"
+        ) as mock_apply:
+            apply_context_parallel(model, parallel_dims)
+
+        expected_modules = [
+            block.attention.inner_attention for block in model.layers.values()
+        ]
+        mock_apply.assert_called_once_with(expected_modules, mesh)
+        parallel_dims.get_mesh.assert_called_once_with("cp")
+
+    def test_apply_context_parallel_skips_when_cp_disabled(self):
+        model = _Model()
+        parallel_dims = SimpleNamespace(
+            cp_enabled=False,
+            get_mesh=MagicMock(),
+        )
+
+        with patch(
+            "torchtitan.distributed.context_parallel.apply_cp_to_forward"
+        ) as mock_apply:
+            apply_context_parallel(model, parallel_dims)
+
+        mock_apply.assert_not_called()
+        parallel_dims.get_mesh.assert_not_called()
+
+    def test_graph_trainer_parallelizers_apply_cp_before_tp_parallelize(self):
+        from torchtitan.experiments.graph_trainer.deepseek_v3.parallelize import (
+            parallelize_deepseekv3,
+        )
+        from torchtitan.experiments.graph_trainer.llama3.parallelize import (
+            parallelize_llama,
+        )
+        from torchtitan.experiments.graph_trainer.qwen3.parallelize import (
+            parallelize_qwen3,
+        )
+
+        for parallelize_fn in (
+            parallelize_llama,
+            parallelize_qwen3,
+            parallelize_deepseekv3,
+        ):
+            with self.subTest(parallelize_fn=parallelize_fn.__name__):
+                source = inspect.getsource(parallelize_fn)
+                self.assertIn("apply_context_parallel", source)
+                self.assertIn("model.parallelize", source)
+                self.assertLess(
+                    source.index("apply_context_parallel"),
+                    source.index("model.parallelize"),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from unittest.mock import MagicMock, patch
 
 import torch
+import torch.distributed as dist
 
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 
@@ -391,6 +392,23 @@ class TestPrecompileSaveValidation(unittest.TestCase):
         result = _unwrap_serializable(wrapper)
         self.assertIs(result, inner)
 
+    def test_unwrap_from_serialize_attr(self):
+        """Current PyTorch may expose a plain callable with serialize()."""
+        from torch._dynamo.aot_compile_types import (
+            BundledAOTAutogradSerializableCallable,
+        )
+
+        from torchtitan.experiments.graph_trainer.precompile import _unwrap_serializable
+
+        def compiled_fn(*args, **kwargs):
+            return args, kwargs
+
+        compiled_fn.serialize = lambda: "serialized"
+
+        result = _unwrap_serializable(compiled_fn)
+        self.assertIsInstance(result, BundledAOTAutogradSerializableCallable)
+        self.assertIs(result.compiled_fn, compiled_fn)
+
 
 class TestConfigFingerprint(unittest.TestCase):
     def test_deterministic(self):
@@ -523,6 +541,175 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
                     expected_fingerprint="new_fp",
                 )
 
+    def test_mesh_get_process_group_hoisted_to_graph_input(self):
+        import torch.distributed.tensor._collective_utils  # noqa: F401
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+        from torchtitan.experiments.graph_trainer.precompile import (
+            hoist_process_group_inputs,
+        )
+
+        if dist.is_initialized():
+            self.skipTest("requires an uninitialized process group")
+        dist.init_process_group("fake", rank=0, world_size=2)
+        self.addCleanup(dist.destroy_process_group)
+
+        mesh = init_device_mesh("cpu", (2,), mesh_dim_names=("cp",))
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        mesh_node = graph.get_attr("_opaque_obj0")
+        process_group_node = graph.call_function(
+            torch.ops._dtensor.mesh_get_process_group.default,
+            (mesh_node, 0),
+        )
+        process_group_node.meta["val"] = mesh.get_group()
+        graph.output((x, process_group_node))
+
+        root = torch.nn.Module()
+        root._opaque_obj0 = mesh
+        gm = torch.fx.GraphModule(root, graph)
+        traced_result = TracedResult(
+            gm=gm,
+            example_inputs=(torch.zeros(1),),
+            state_fqns=[],
+            num_flat_inputs=1,
+            input_subclass_layouts={},
+            num_flat_outputs=2,
+            output_subclass_layouts={},
+            output_spec=torch.utils._pytree.tree_flatten((torch.zeros(1), None))[1],
+            tensor_input_indices=[0],
+        )
+
+        hoist_process_group_inputs(traced_result)
+
+        graph_nodes = list(traced_result.gm.graph.nodes)
+        self.assertFalse(
+            any(
+                node.op == "call_function"
+                and node.target == torch.ops._dtensor.mesh_get_process_group.default
+                for node in graph_nodes
+            )
+        )
+        placeholders = [node for node in graph_nodes if node.op == "placeholder"]
+        self.assertEqual(
+            [node.target for node in placeholders], ["x", "_process_group_cp"]
+        )
+        self.assertEqual(len(traced_result.example_inputs), 2)
+        self.assertEqual(len(traced_result.process_group_inputs), 1)
+        self.assertEqual(traced_result.process_group_input_specs[0].axis, "cp")
+
+    def test_all_to_all_process_group_hoisted_to_graph_input(self):
+        import torch.distributed.tensor._collective_utils  # noqa: F401
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+        from torchtitan.experiments.graph_trainer.precompile import (
+            hoist_process_group_inputs,
+        )
+
+        if dist.is_initialized():
+            self.skipTest("requires an uninitialized process group")
+        dist.init_process_group("fake", rank=0, world_size=2)
+        self.addCleanup(dist.destroy_process_group)
+
+        mesh = init_device_mesh("cpu", (2,), mesh_dim_names=("cp",))
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        mesh_node = graph.get_attr("_opaque_obj0")
+        process_group_node = graph.call_function(
+            torch.ops._dtensor.mesh_get_process_group.default,
+            (mesh_node, 0),
+        )
+        process_group_node.meta["val"] = mesh.get_group()
+        all_to_all = graph.call_function(
+            torch.ops._c10d_functional.all_to_all_single.default,
+            (x, [0, 8], [0, 8], process_group_node),
+        )
+        graph.output(all_to_all)
+
+        root = torch.nn.Module()
+        root._opaque_obj0 = mesh
+        gm = torch.fx.GraphModule(root, graph)
+        traced_result = TracedResult(
+            gm=gm,
+            example_inputs=(torch.zeros(8),),
+            state_fqns=[],
+            num_flat_inputs=1,
+            input_subclass_layouts={},
+            num_flat_outputs=1,
+            output_subclass_layouts={},
+            output_spec=torch.utils._pytree.tree_flatten(torch.zeros(8))[1],
+            tensor_input_indices=[0],
+        )
+
+        hoist_process_group_inputs(traced_result)
+
+        placeholders = [
+            node.target
+            for node in traced_result.gm.graph.nodes
+            if node.op == "placeholder"
+        ]
+        self.assertEqual(
+            placeholders,
+            [
+                "x",
+                "_process_group_cp",
+            ],
+        )
+        self.assertEqual(len(traced_result.example_inputs), 2)
+        all_to_all_nodes = [
+            node
+            for node in traced_result.gm.graph.nodes
+            if node.op == "call_function"
+            and node.target == torch.ops._c10d_functional.all_to_all_single.default
+        ]
+        self.assertEqual(len(all_to_all_nodes), 1)
+        for split_arg in all_to_all_nodes[0].args[1:3]:
+            self.assertIsInstance(split_arg, list)
+            self.assertEqual(len(split_arg), 2)
+            self.assertTrue(
+                all(
+                    isinstance(split_node, torch.fx.Node)
+                    and split_node.target == torch.sym_ite
+                    for split_node in split_arg
+                )
+            )
+        self.assertEqual(
+            all_to_all_nodes[0].args[3].target,
+            "_process_group_cp",
+        )
+
+    def test_fx_trace_load_hoisted_process_groups_require_parallel_dims(self):
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            ProcessGroupInputSpec,
+        )
+        from torchtitan.experiments.graph_trainer.precompile import (
+            _FX_TRACE_ARTIFACT_KEY,
+            precompile_fx_trace_load,
+            PrecompiledFxTraceArtifact,
+        )
+
+        flat_vals, spec = torch.utils._pytree.tree_flatten({"a": torch.zeros(2)})
+        artifact = PrecompiledFxTraceArtifact(
+            serialized_gm=b"fake",
+            state_fqns=["w"],
+            num_flat_inputs=2,
+            input_subclass_layouts={},
+            num_flat_outputs=1,
+            output_subclass_layouts={},
+            output_spec=spec,
+            tensor_input_indices=[0, 1],
+            process_group_input_specs=(ProcessGroupInputSpec(axis="cp"),),
+            config_fingerprint="fp",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save(_FX_TRACE_ARTIFACT_KEY, pickle.dumps(artifact))
+
+            with self.assertRaisesRegex(ValueError, "requires parallel_dims"):
+                precompile_fx_trace_load(storage, expected_fingerprint="fp")
+
 
 class TestCudagraphPass(unittest.TestCase):
     """Test cudagraph_pass behavior."""
@@ -599,6 +786,199 @@ class TestCudagraphFingerprintConsistency(unittest.TestCase):
         fp2 = compute_config_fingerprint(_make_stub_model(), cfg, dims)
 
         self.assertEqual(fp1, fp2)
+
+
+class TestPrecompileCPSupport(unittest.TestCase):
+    """Tests for context parallelism support in the precompile path."""
+
+    def test_prepare_cp_input_shards_inputs_and_labels(self):
+        """Verify prepare_context_parallel_input shards inputs, labels, and
+        positions along the sequence dimension, matching the shapes the
+        trainer's post_dataloading_process would produce."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if not dist.is_initialized():
+            dist.init_process_group("fake", rank=0, world_size=4)
+            self.addCleanup(dist.destroy_process_group)
+
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.distributed.context_parallel import (
+            prepare_context_parallel_input,
+        )
+
+        batch_size, seq_len, cp_degree = 2, 128, 4
+        device = torch.device("cuda:0")
+        mesh = init_device_mesh("cuda", (4,), mesh_dim_names=("cp",))
+
+        inputs = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+        labels = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+        positions = torch.arange(0, seq_len, dtype=torch.int32, device=device).expand(
+            batch_size, seq_len
+        )
+        extra_kwargs = {"positions": positions}
+
+        out_inputs, out_labels, out_kwargs = prepare_context_parallel_input(
+            inputs, labels, extra_kwargs, mesh, device
+        )
+
+        expected_seq = seq_len // cp_degree
+        self.assertEqual(out_inputs.shape, (batch_size, expected_seq))
+        self.assertEqual(out_labels.shape, (batch_size, expected_seq))
+        self.assertEqual(out_kwargs["positions"].shape, (batch_size, expected_seq))
+
+    def test_prepare_cp_input_preserves_extra_kwargs_keys(self):
+        """Extra kwargs other than positions/attention_masks pass through."""
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if not dist.is_initialized():
+            dist.init_process_group("fake", rank=0, world_size=2)
+            self.addCleanup(dist.destroy_process_group)
+
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.distributed.context_parallel import (
+            prepare_context_parallel_input,
+        )
+
+        batch_size, seq_len = 2, 64
+        device = torch.device("cuda:0")
+        mesh = init_device_mesh("cuda", (2,), mesh_dim_names=("cp",))
+
+        inputs = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+        labels = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+        positions = torch.arange(0, seq_len, dtype=torch.int32, device=device).expand(
+            batch_size, seq_len
+        )
+        extra_kwargs = {"positions": positions}
+
+        _, _, out_kwargs = prepare_context_parallel_input(
+            inputs, labels, extra_kwargs, mesh, device
+        )
+
+        self.assertIn("positions", out_kwargs)
+
+    def test_global_valid_tokens_excludes_cp(self):
+        """The dummy_global_valid_tokens calculation must NOT include the CP
+        dimension, matching the trainer's dist_sum over the batch mesh."""
+        dp_shard, dp_replicate, cp = 4, 2, 2
+        local_batch_size, seq_len = 2, 128
+
+        global_batch_size = local_batch_size * dp_shard * dp_replicate
+        dummy_global_valid_tokens = float(global_batch_size * seq_len)
+
+        self.assertEqual(
+            dummy_global_valid_tokens,
+            float(local_batch_size * dp_shard * dp_replicate * seq_len),
+        )
+        wrong_with_cp = float(local_batch_size * dp_shard * dp_replicate * cp * seq_len)
+        self.assertNotEqual(dummy_global_valid_tokens, wrong_with_cp)
+
+    def test_precompile_cp_code_path_exists(self):
+        """The precompile path must call prepare_context_parallel_input when
+        cp_enabled is True, not raise NotImplementedError."""
+        import inspect
+
+        from torchtitan.experiments.graph_trainer.precompile_main import (
+            _precompile_aot_fx_trace,
+        )
+
+        source = inspect.getsource(_precompile_aot_fx_trace)
+        self.assertIn("prepare_context_parallel_input", source)
+        self.assertNotIn(
+            "CooR precompile does not yet support context parallelism", source
+        )
+
+    def test_cp_disabled_skips_prepare(self):
+        """When cp_enabled is False, prepare_context_parallel_input must NOT
+        be called."""
+        parallel_dims = MagicMock()
+        parallel_dims.cp_enabled = False
+
+        with patch(
+            "torchtitan.distributed.context_parallel.prepare_context_parallel_input"
+        ) as mock_prepare:
+            self.assertFalse(parallel_dims.cp_enabled)
+            mock_prepare.assert_not_called()
+
+
+class TestPrecompileCPPositions(unittest.TestCase):
+    """Tests that positions are created correctly for CP in the precompile path."""
+
+    def test_positions_created_when_cp_enabled_without_block_causal(self):
+        """Even with mask_type='causal', positions must be created when
+        cp_enabled=True, because CP needs them for correct RoPE after sharding."""
+        from torchtitan.models.common.decoder import Decoder
+
+        batch_size, seq_len = 2, 128
+        device = torch.device("cpu")
+
+        dummy_inputs = torch.randint(0, 100, (batch_size, seq_len), device=device)
+        extra_kwargs: dict = {}
+
+        model_config = MagicMock(spec=Decoder.Config)
+        attn_config = MagicMock()
+        attn_config.mask_type = "causal"
+        attn_config.inner_attention = None
+        layer_config = MagicMock()
+        layer_config.attention = attn_config
+        model_config.layers = [layer_config]
+
+        cp_enabled = True
+
+        if model_config.layers:
+            mask_type = getattr(model_config.layers[0].attention, "mask_type", "causal")
+            if mask_type == "block_causal" or cp_enabled:
+                extra_kwargs["positions"] = torch.arange(
+                    0,
+                    dummy_inputs.shape[1],
+                    dtype=torch.int32,
+                    device=dummy_inputs.device,
+                ).expand(dummy_inputs.shape)
+
+        self.assertIn("positions", extra_kwargs)
+        self.assertEqual(extra_kwargs["positions"].shape, (batch_size, seq_len))
+        self.assertTrue(
+            torch.equal(
+                extra_kwargs["positions"][0],
+                torch.arange(seq_len, dtype=torch.int32),
+            )
+        )
+
+    def test_positions_not_created_without_cp_or_block_causal(self):
+        """With mask_type='causal' and cp_enabled=False, positions should NOT
+        be added to extra_kwargs."""
+        extra_kwargs: dict = {}
+        batch_size, seq_len = 2, 128
+        dummy_inputs = torch.randint(0, 100, (batch_size, seq_len))
+
+        mask_type = "causal"
+        cp_enabled = False
+
+        if mask_type == "block_causal" or cp_enabled:
+            extra_kwargs["positions"] = torch.arange(
+                0, dummy_inputs.shape[1], dtype=torch.int32
+            ).expand(dummy_inputs.shape)
+
+        self.assertNotIn("positions", extra_kwargs)
+
+
+class TestPrecompileCPFingerprint(unittest.TestCase):
+    """Test that the config fingerprint is sensitive to CP settings."""
+
+    def test_cp_degree_changes_fingerprint(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        cfg = _StubCompileConfig()
+
+        dims_cp1 = _StubParallelDims(cp=1)
+        dims_cp2 = _StubParallelDims(cp=2)
+
+        fp_cp1 = compute_config_fingerprint(_make_stub_model(), cfg, dims_cp1)
+        fp_cp2 = compute_config_fingerprint(_make_stub_model(), cfg, dims_cp2)
+        self.assertNotEqual(fp_cp1, fp_cp2)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -140,6 +140,7 @@ class GraphTrainer(Trainer):
         self._traced_step = precompile_fx_trace_load(
             storage,
             expected_fingerprint=config_fingerprint,
+            parallel_dims=self.parallel_dims,
         )
 
     def _make_fx_forward_backward_step(


### PR DESCRIPTION
## Summary
- wire context parallelism into graph-trainer model parallelization for Llama 3, Qwen3, and DeepSeek V3
- hoist distributed process groups as runtime inputs for `aot_fx_trace` precompile artifacts
- hoist rank-dependent CP `all_to_all_single` split sizes so precompiled traces can be reused across ranks
- add CP/precompile coverage and graph-trainer integration entries

## Test Plan
- `pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py torchtitan/experiments/graph_trainer/tests/test_context_parallel.py -q`
- `pytest tests/ -x` on the working tree before squashing: 312 passed
- `python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests <out> --test_name aot_fx_trace_llama3_precompile_fsdp_tp_cp --ngpu 8`
- `python -m torchtitan.experiments.graph_trainer.tests.integration_tests <out> --gpu_arch_type cuda --test_suite graph_trainer --ngpu 8`

Note: broader non-graph-trainer `models` GPU integration tests were not green in this environment; they failed during backward with `RuntimeError: The tensor has a non-zero number of elements, but its data is not allocated yet`.
