### PR TITLE
[GraphTrainer] Log graph pass names and total time

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -278,6 +278,15 @@ def apply_graph_passes(
             and before/after graphs to tlparse for each pass.
     """
     debug = compile_config is not None and compile_config.debug_graph_passes
+    pass_names = [
+        pass_fn.func.__name__
+        if isinstance(pass_fn, functools.partial)
+        else pass_fn.__name__
+        for pass_fn in passes
+    ]
+    pass_list = "\n  ".join(f"{i}. {name}" for i, name in enumerate(pass_names, 1))
+    logger.info(f"Applying {len(passes)} graph passes:\n  {pass_list}")
+    all_passes_start = time.perf_counter()
     tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
     for pass_fn in passes:
         pass_name = (
@@ -299,6 +308,8 @@ def apply_graph_passes(
             tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}", debug=debug)
             after_snapshot = snapshot_graph(gm)
             log_graph_diff(before_snapshot, after_snapshot, pass_name)
+    all_passes_elapsed = time.perf_counter() - all_passes_start
+    logger.info(f"All {len(passes)} graph passes took {all_passes_elapsed:.3f}s")
     return gm
 
 


### PR DESCRIPTION
## Summary
- Log the full numbered list of graph passes at the start of `apply_graph_passes`, one per line, so it's easy to see what will run.
- Log total wall-clock time for all passes at the end.
- This runs unconditionally (no need for `--compile.debug_graph_passes`), since the per-pass timing/diff logging still requires the debug flag.

## Test plan
- Ran `run_graph_trainer_llama3_8b.sh` with the debugmodel config end-to-end (10 steps, FSDP+TP) and verified the new log lines appear correctly.


```
[rank0]:[titan] 2026-05-07 10:40:23,196 - root - INFO - Applying 12 graph passes:
[rank0]:  1. remove_detach_pass
[rank0]:  2. remove_identity_view_pass
[rank0]:  3. remove_identity_slice_pass
[rank0]:  4. normalize_view_ops_as_reshape
[rank0]:  5. tag_with_memory_policy_pass
[rank0]:  6. apply_cpu_offload_pass
[rank0]:  7. selective_activation_remat_pass
[rank0]:  8. overlap_fsdp_ag_rs_pass
[rank0]:  9. joint_transformer_block_bucketing_reordering_pass
[rank0]:  10. annotate_flex_attention_for_regional_inductor_pass
[rank0]:  11. regional_inductor_pass
[rank0]:  12. custom_codegen_pass

....



All 12 graph passes took 5.574s
```