### PR TITLE
[Checkpoint] BaseModel state dict pipeline and pure I/O CheckpointManager

### DIFF
--- a/scripts/checkpoint_conversion/convert_from_hf.py
+++ b/scripts/checkpoint_conversion/convert_from_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageReader
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 
 
 @torch.inference_mode()
@@ -23,14 +23,12 @@ def convert_from_hf(input_dir, output_dir, model_name, model_flavor):
 
     with torch.device("cpu"):
         model = model_config.build()
-    model = ModelWrapper(model)
-
     sd_adapter = model_spec.state_dict_adapter(model_config, None)
     assert (
         sd_adapter is not None
     ), "trying to convert checkpoint from HF to DCP safetensors format, but sd_adapter is not provided."
     # get state dict in tt format with allocated memory
-    state_dict = model._get_state_dict()
+    state_dict = get_model_state_dict(model)
     # convert empty state dict to hf format so that hf weights can be loaded into it
     hf_state_dict = sd_adapter.to_hf(state_dict)
     dcp.load(

--- a/scripts/checkpoint_conversion/convert_from_hf.py
+++ b/scripts/checkpoint_conversion/convert_from_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageReader
-from torch.distributed.checkpoint.state_dict import get_model_state_dict
+from torchtitan.components.checkpoint import ModelWrapper
 
 
 @torch.inference_mode()
@@ -28,7 +28,7 @@ def convert_from_hf(input_dir, output_dir, model_name, model_flavor):
         sd_adapter is not None
     ), "trying to convert checkpoint from HF to DCP safetensors format, but sd_adapter is not provided."
     # get state dict in tt format with allocated memory
-    state_dict = get_model_state_dict(model)
+    state_dict = ModelWrapper([model]).state_dict()
     # convert empty state dict to hf format so that hf weights can be loaded into it
     hf_state_dict = sd_adapter.to_hf(state_dict)
     dcp.load(

--- a/scripts/checkpoint_conversion/convert_to_hf.py
+++ b/scripts/checkpoint_conversion/convert_to_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageWriter
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.config import TORCH_DTYPE_MAP
 
 
@@ -31,15 +31,13 @@ def convert_to_hf(
 
     with torch.device("cpu"):
         model = model_config.build()
-    model = ModelWrapper(model)
-
     sd_adapter = model_spec.state_dict_adapter(model_config, hf_assets_path)
     assert (
         sd_adapter is not None
     ), "trying to convert checkpoint from DCP to HF safetensors format, but sd_adapter is not provided."
 
     # allocate state dict memory with empty weights to load checkpoint
-    state_dict = model._get_state_dict()
+    state_dict = get_model_state_dict(model)
     dcp.load(
         state_dict,
         checkpoint_id=input_dir,

--- a/scripts/checkpoint_conversion/convert_to_hf.py
+++ b/scripts/checkpoint_conversion/convert_to_hf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint import HuggingFaceStorageWriter
-from torch.distributed.checkpoint.state_dict import get_model_state_dict
+from torchtitan.components.checkpoint import ModelWrapper
 from torchtitan.config import TORCH_DTYPE_MAP
 
 
@@ -37,7 +37,7 @@ def convert_to_hf(
     ), "trying to convert checkpoint from DCP to HF safetensors format, but sd_adapter is not provided."
 
     # allocate state dict memory with empty weights to load checkpoint
-    state_dict = get_model_state_dict(model)
+    state_dict = ModelWrapper([model]).state_dict()
     dcp.load(
         state_dict,
         checkpoint_id=input_dir,

--- a/scripts/checkpoint_conversion/numerical_tests_example.py
+++ b/scripts/checkpoint_conversion/numerical_tests_example.py
@@ -8,7 +8,7 @@ import torch
 
 import torch.distributed.checkpoint as dcp
 import torch.nn.functional as F
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.config import ConfigManager
 from torchtitan.tools.logging import logger
 
@@ -77,8 +77,7 @@ def forward_tt(model_name, config_name, checkpoint_path, test_set):
     model.init_weights(buffer_device=device)
     model.eval()
 
-    modelWrapper = ModelWrapper(model)
-    state_dict = modelWrapper._get_state_dict()
+    state_dict = get_model_state_dict(model)
 
     # Checkpoint Loading
     logger.info(f"Loading checkpoint at: {checkpoint_path}")

--- a/scripts/checkpoint_conversion/numerical_tests_example.py
+++ b/scripts/checkpoint_conversion/numerical_tests_example.py
@@ -8,7 +8,7 @@ import torch
 
 import torch.distributed.checkpoint as dcp
 import torch.nn.functional as F
-from torch.distributed.checkpoint.state_dict import get_model_state_dict
+from torchtitan.components.checkpoint import ModelWrapper
 from torchtitan.config import ConfigManager
 from torchtitan.tools.logging import logger
 
@@ -77,7 +77,7 @@ def forward_tt(model_name, config_name, checkpoint_path, test_set):
     model.init_weights(buffer_device=device)
     model.eval()
 
-    state_dict = get_model_state_dict(model)
+    state_dict = ModelWrapper([model]).state_dict()
 
     # Checkpoint Loading
     logger.info(f"Loading checkpoint at: {checkpoint_path}")

--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
@@ -33,7 +33,7 @@ import torch.nn.functional as F
 
 torch._dynamo.config.disable = True
 
-from torchtitan.components.checkpoint import ModelWrapper
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torchtitan.models.qwen3_vl import model_registry
 from transformers import AutoProcessor
 
@@ -251,7 +251,7 @@ def run_tt(model_flavor, checkpoint_path, tt_inputs, device):
     model.init_weights(buffer_device=torch.device("cpu"))
     model.half()
 
-    state_dict = ModelWrapper(model)._get_state_dict()
+    state_dict = get_model_state_dict(model)
     print(f"  Loading checkpoint: {checkpoint_path}")
     dcp.load(state_dict, checkpoint_id=checkpoint_path)
     model.to(device)

--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
@@ -33,7 +33,7 @@ import torch.nn.functional as F
 
 torch._dynamo.config.disable = True
 
-from torch.distributed.checkpoint.state_dict import get_model_state_dict
+from torchtitan.components.checkpoint import ModelWrapper
 from torchtitan.models.qwen3_vl import model_registry
 from transformers import AutoProcessor
 
@@ -251,7 +251,7 @@ def run_tt(model_flavor, checkpoint_path, tt_inputs, device):
     model.init_weights(buffer_device=torch.device("cpu"))
     model.half()
 
-    state_dict = get_model_state_dict(model)
+    state_dict = ModelWrapper([model]).state_dict()
     print(f"  Loading checkpoint: {checkpoint_path}")
     dcp.load(state_dict, checkpoint_id=checkpoint_path)
     model.to(device)

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -584,6 +584,7 @@ class TestCheckpointManager(unittest.TestCase):
                 super().__init__()
                 self.weight = nn.Parameter(torch.randn(2, 2))
                 self.bias = nn.Parameter(torch.randn(2))
+                # Register freqs_cis as a buffer (common pattern in transformer models)
                 self.register_buffer("freqs_cis", torch.randn(10, 5), persistent=False)
                 self.other_param = nn.Parameter(torch.randn(3, 3))
 

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -592,9 +592,7 @@ class TestCheckpointManager(unittest.TestCase):
                 return None
 
             def get_sd(self, mode=None):
-                from torch.distributed.checkpoint.state_dict import (
-                    get_model_state_dict,
-                )
+                from torch.distributed.checkpoint.state_dict import get_model_state_dict
 
                 return get_model_state_dict(self)
 

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -19,6 +19,35 @@ from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import CheckpointManager
 
 
+class FakeBaseModel(nn.Linear):
+    """A fake BaseModel for checkpoint tests.
+
+    Inherits nn.Linear so get_model_state_dict works directly, and
+    provides the BaseModel transform methods that CheckpointManager expects.
+    """
+
+    def __init__(self, in_features: int = 2, out_features: int = 2):
+        super().__init__(in_features, out_features)
+
+    @property
+    def sd_adapter(self):
+        return None
+
+    def get_sd(self, mode=None):
+        from torch.distributed.checkpoint.state_dict import get_model_state_dict
+
+        return get_model_state_dict(self)
+
+    def to_hf(self, sd):
+        return sd
+
+    def from_hf(self, sd):
+        return sd
+
+    def adapter_to_hf(self, sd):
+        return sd
+
+
 class FakeOptimizersContainer:
     """A fake OptimizersContainer that returns fake state dicts."""
 
@@ -106,8 +135,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.test_folder = os.path.join(self.base_temp_dir, self._testMethodName)
         os.makedirs(self.test_folder, exist_ok=True)
 
-        self.model_part = nn.Linear(2, 2)
-        self.model_parts = [self.model_part]
+        self.model = FakeBaseModel(2, 2)
         self.states = {"trainer": torch.tensor([1.2347])}
         # TODO: Use a real OptimizerContainer here so that we can actually verify
         # some optimizer.state_dict() behavior (e.g., the key being the parameter name.)
@@ -170,27 +198,26 @@ class TestCheckpointManager(unittest.TestCase):
         mock_load.side_effect = self.fake_load
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
-        w0 = self.model_part.weight.clone()
-        b0 = self.model_part.bias.clone()
+        w0 = self.model.weight.clone()
+        b0 = self.model.bias.clone()
         p0 = self.optimizers._fake_param.clone()
         manager.save(curr_step=1)
         with torch.no_grad():
-            self.model_part.weight.zero_()
-            self.model_part.bias.zero_()
+            self.model.weight.zero_()
+            self.model.bias.zero_()
         self.optimizers._fake_param = torch.tensor([42.0], dtype=torch.float32)
         manager.load(step=1)
 
-        self.assertTrue(torch.equal(self.model_part.weight, w0))
-        self.assertTrue(torch.equal(self.model_part.bias, b0))
+        self.assertTrue(torch.equal(self.model.weight, w0))
+        self.assertTrue(torch.equal(self.model.bias, b0))
         self.assertTrue(torch.equal(self.optimizers._fake_param, p0))
         manager.close()
 
@@ -203,12 +230,11 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -244,12 +270,11 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -267,12 +292,11 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "nonexistent"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         self.assertFalse(manager.load(step=-1))
@@ -291,12 +315,11 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.folder = "checkpoints"
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         res = manager.load(step=-1)
@@ -321,12 +344,11 @@ class TestCheckpointManager(unittest.TestCase):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager.save(curr_step=1)
@@ -355,12 +377,11 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.last_save_model_only = True
         manager1 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         manager1.save(curr_step=1, last_step=True)
@@ -375,12 +396,11 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.dump_folder = self.test_folder
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
         r1 = manager2.load(step=1)
@@ -430,12 +450,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=checkpoint_config,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -471,12 +490,11 @@ class TestCheckpointManager(unittest.TestCase):
         states = {"trainer": torch.tensor([0])}
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=states,
             config=checkpoint_config,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -508,12 +526,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -534,12 +551,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -568,9 +584,28 @@ class TestCheckpointManager(unittest.TestCase):
                 super().__init__()
                 self.weight = nn.Parameter(torch.randn(2, 2))
                 self.bias = nn.Parameter(torch.randn(2))
-                # Register freqs_cis as a buffer (common pattern in transformer models)
                 self.register_buffer("freqs_cis", torch.randn(10, 5), persistent=False)
                 self.other_param = nn.Parameter(torch.randn(3, 3))
+
+            @property
+            def sd_adapter(self):
+                return None
+
+            def get_sd(self, mode=None):
+                from torch.distributed.checkpoint.state_dict import (
+                    get_model_state_dict,
+                )
+
+                return get_model_state_dict(self)
+
+            def to_hf(self, sd):
+                return sd
+
+            def from_hf(self, sd):
+                return sd
+
+            def adapter_to_hf(self, sd):
+                return sd
 
         fake_model = FakeModelWithFreqsCis()
         mock_save.side_effect = self.fake_save
@@ -585,7 +620,6 @@ class TestCheckpointManager(unittest.TestCase):
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -618,12 +652,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -645,12 +678,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 
@@ -686,12 +718,11 @@ class TestCheckpointManager(unittest.TestCase):
         self.trainer_config.checkpoint.initial_load_model_only = False
         manager = CheckpointManager(
             dataloader=self.data_loader,
-            model_parts=self.model_parts,
+            model_parts=[self.model],
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
             config=self.trainer_config.checkpoint,
-            sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
 

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -158,8 +158,6 @@ class CheckpointManager(Configurable):
         config (Checkpoint): The config used to configure the checkpointing.
         base_folder (str): The base folder to save the checkpoint. Will be concatenated
             with config.folder
-        The model's ``sd_adapter`` attribute provides HF I/O config (storage
-            reader/writer, fqn mapping, assets path) and key transforms.
 
     """
 
@@ -590,8 +588,6 @@ class CheckpointManager(Configurable):
         else:
             dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
-            # TODO: Since we flatten the model states in state_dict, we need to
-            # manually call load_state_dict() for the model. Need to fix this.
             if MODEL in self.states:
                 self.model_wrapper.load_state_dict(state_dict)
 
@@ -616,6 +612,7 @@ class CheckpointManager(Configurable):
         if not self._should_save(curr_step, last_step):
             return False
 
+        sl.add_step_tag("checkpoint_save")
         begin = time.monotonic()
         logger.info("Saving the checkpoint (or staging if async is enabled).")
         checkpoint_id = self._create_checkpoint_id(curr_step)
@@ -852,9 +849,9 @@ class CheckpointManager(Configurable):
     def _flattened_model_states_sd(
         self, state_dict: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Flatten the model states into a single dictionary.
+        """Flatten model keys alongside training states.
 
-        Note that other states, such as optimizer states, are not flattened.
+        The caller must set ``self.model_wrapper.mode`` before calling.
         """
         states = state_dict if state_dict is not None else self.states
         sd = {k: v for k, v in states.items() if k != MODEL}
@@ -868,7 +865,6 @@ class CheckpointManager(Configurable):
         Resume always loads FULL model (base + adapters if present).
         The caller sets ``self.model_wrapper.mode`` to FULL before calling.
         """
-        # For the first step, we will only load the model.
         if model_only:
             return self.states[MODEL].state_dict()
 
@@ -883,10 +879,6 @@ class CheckpointManager(Configurable):
         return self._flattened_model_states_sd(states_to_load)
 
     def _save_last_step(self, curr_step: int) -> None:
-        # We only consider saving model only at the end of the training. So this
-        # won't affect preemption and training resume. We also only allow dtype
-        # conversion when we are checkpointing model only and the current dtype
-        # is not the same as the export dtype at the end of the training.
         if self.last_save_trainable_only:
             save_mode = StateDictMode.TRAINABLE
         else:

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import enum
-import functools
 import os
 import queue
 import re
@@ -28,7 +27,6 @@ from torch.distributed.checkpoint._consolidate_hf_safetensors import (
 )
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
 from torch.distributed.checkpoint.state_dict import (
-    get_model_state_dict,
     set_model_state_dict,
     StateDictOptions,
 )
@@ -42,10 +40,10 @@ from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
-from torchtitan.observability import structured_logger as sl
-from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
+from torchtitan.protocols.model import BaseModel, StateDictMode
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
+
 
 MODEL = "model"
 OPTIMIZER = "optimizer"
@@ -54,36 +52,36 @@ DATALOADER = "dataloader"
 TRAIN_STATE = "train_state"
 
 
+class ModelWrapper(Stateful):
+    """Thin wrapper that merges state dicts across PP stages.
+
+    Iterates ``model_parts`` and delegates filtering to each part's
+    ``get_sd(mode)``.  Set ``mode`` before each save/load.
+    """
+
+    def __init__(self, model_parts: list[nn.Module]) -> None:
+        self.model_parts = model_parts
+        self.mode = StateDictMode.FULL
+
+    def state_dict(self) -> dict[str, Any]:
+        sd: dict[str, Any] = {}
+        for part in self.model_parts:
+            sd.update(part.get_sd(self.mode))  # pyrefly: ignore [missing-attribute]
+        return sd
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        for part in self.model_parts:
+            set_model_state_dict(
+                part,
+                model_state_dict=state_dict,
+                options=StateDictOptions(strict=False),
+            )
+
+
 class AsyncMode(str, enum.Enum):
     DISABLED = "disabled"
     ASYNC = "async"
     ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
-
-
-class ModelWrapper(Stateful):
-    def __init__(self, model: nn.Module | list[nn.Module]) -> None:
-        self.model = [model] if isinstance(model, nn.Module) else model
-        self.cache_state_dict = self._get_state_dict()
-
-    def _get_state_dict(self) -> dict[str, Any]:
-        state_dict = {
-            k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()
-        }
-        return state_dict
-
-    def state_dict(self) -> dict[str, Any]:
-        return self.cache_state_dict
-
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        func = functools.partial(
-            set_model_state_dict,
-            model_state_dict=state_dict,
-            options=StateDictOptions(strict=False),
-        )
-        list(map(func, self.model))
-        # `set_model_state_dict()` does change the keys of the input state_dict,
-        # we will need to reinitialize the cache_state_dict.
-        self.cache_state_dict = self._get_state_dict()
 
 
 class Terminate:
@@ -151,7 +149,7 @@ class CheckpointManager(Configurable):
 
     Args:
         dataloader (DataLoader): The dataloader used to load the data.
-        model_parts (List[nn.Module]): List of model parts to be optimized.
+        model_parts (list[nn.Module]): Model parts (one per PP stage, or single-element list).
         optimizers (OptimizersContainer): The optimizers used to optimize the model.
         lr_schedulers (LRSchedulersContainer): The lr schedulers used to optimize the model.
         states (Dict[str, Any]): The states that need to be saved, other than the
@@ -159,8 +157,8 @@ class CheckpointManager(Configurable):
         config (Checkpoint): The config used to configure the checkpointing.
         base_folder (str): The base folder to save the checkpoint. Will be concatenated
             with config.folder
-        sd_adapter (Optional[type[BaseStateDictAdapter]]): The adapter used to convert model state
-            dicts between native format and other formats.
+        The model's ``sd_adapter`` attribute provides HF I/O config (storage
+            reader/writer, fqn mapping, assets path) and key transforms.
 
     """
 
@@ -282,6 +280,21 @@ class CheckpointManager(Configurable):
         This will load the model only, excluding the specified keys.
         """
 
+        initial_load_frozen: bool = False
+        """
+        When True, initial load only loads frozen/base params (adapter training).
+        Adapters are freshly initialized at build time by the converter (e.g.
+        LoRAConverter). On resume, the full model (base + adapters) is loaded
+        from the checkpoint folder.
+        """
+
+        last_save_trainable_only: bool = False
+        """
+        When True, last step save only saves trainable params (e.g. LoRA
+        adapters). Combine with ``last_save_in_hf=True`` to export adapters
+        in PEFT safetensors format.
+        """
+
         enable_first_step_checkpoint: bool = False
         """
         Enable the checkpoint save at first step. This will save a checkpoint immediately
@@ -314,16 +327,17 @@ class CheckpointManager(Configurable):
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
-        sd_adapter: BaseStateDictAdapter | None,
         base_folder: str = "",
     ) -> None:
         self.enable = config.enable
         self.load_only = config.load_only
 
+        self.model = cast(BaseModel, model_parts[0])
+        self.model_wrapper = ModelWrapper(model_parts)
         self.states = states
         self.states.update(
             {
-                MODEL: ModelWrapper(model_parts),
+                MODEL: self.model_wrapper,
                 OPTIMIZER: optimizers,
                 DATALOADER: dataloader,
                 LR_SCHEDULER: lr_schedulers,
@@ -354,15 +368,36 @@ class CheckpointManager(Configurable):
         self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
         self.last_save_model_only = config.last_save_model_only
         self.last_save_in_hf = config.last_save_in_hf
+        self.create_seed_checkpoint = config.create_seed_checkpoint
+
         if self.last_save_in_hf:
             assert (
-                sd_adapter is not None
-            ), "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
-        self.sd_adapter = sd_adapter
+                self.model.sd_adapter is not None
+            ), "checkpoint.last_save_in_hf is True, but model has no sd_adapter."
+        self.initial_load_frozen = config.initial_load_frozen
+        self.last_save_trainable_only = config.last_save_trainable_only
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
         self.exclude_from_loading = config.exclude_from_loading
         self.interval = config.interval
         self.enable_first_step_checkpoint = config.enable_first_step_checkpoint
+
+        if self.initial_load_in_hf and not self.initial_load_model_only:
+            raise ValueError(
+                "checkpoint.initial_load_in_hf requires "
+                "checkpoint.initial_load_model_only=True because "
+                "safetensors only contains model weights."
+            )
+        if self.initial_load_in_hf_quantized and not self.initial_load_in_hf:
+            raise ValueError(
+                "checkpoint.initial_load_in_hf_quantized requires "
+                "checkpoint.initial_load_in_hf=True."
+            )
+        if self.last_save_in_hf and not self.last_save_model_only:
+            raise ValueError(
+                "checkpoint.last_save_in_hf requires "
+                "checkpoint.last_save_model_only=True because "
+                "safetensors only contains model weights."
+            )
 
         # Async checkpoint related fields.
         async_mode = config.async_mode.lower()
@@ -429,15 +464,17 @@ class CheckpointManager(Configurable):
         checkpoint_id: str,
         async_mode: AsyncMode,
         enable_garbage_collection: bool = False,
-        to_hf: bool = False,
+        hf_storage: bool = False,
     ) -> Future | AsyncSaveResponse | None:
         """Save the checkpoint with dcp.
         Args:
-            state_dict (dict): The state dict to save.
+            state_dict (dict): The state dict to save (key transforms already applied).
             checkpoint_id (str): The checkpoint id to save.
             async_mode (AsyncMode): Whether the checkpoint is async.
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
-            to_hf (bool): Whether to save in HF model definition and safetensors format.
+            hf_storage (bool): Whether to use HF safetensors storage writer.
+                Key transforms must be applied by the caller via
+                model.to_hf() or model.adapter_to_hf() before calling this method.
 
         Returns:
             Future: The future object if the checkpoint is async, otherwise None.
@@ -448,14 +485,19 @@ class CheckpointManager(Configurable):
         storage_writer: HuggingFaceStorageWriter | None = None
         checkpoint_save_id: str | None = None
         fqn_to_index_mapping: dict[Any, int] | None = None
-        if to_hf:
+        keys_match_mapping = False
+        if hf_storage:
             assert (
-                self.sd_adapter is not None
-            ), "trying to save checkpoint in HF safetensors format, but sd_adapter is not provided."
-            state_dict = self.sd_adapter.to_hf(state_dict)
-
-            fqn_to_index_mapping = self.sd_adapter.fqn_to_index_mapping
-            if fqn_to_index_mapping:
+                self.model.sd_adapter is not None
+            ), "trying to save in HF safetensors format, but model has no sd_adapter."
+            fqn_to_index_mapping = self.model.sd_adapter.fqn_to_index_mapping
+            # Only use sharded mapping when saved keys match the mapping
+            # (e.g. base model HF save). For adapter-only saves (PEFT),
+            # keys won't be in the base mapping — fall through to consolidation.
+            keys_match_mapping = fqn_to_index_mapping and any(
+                k in fqn_to_index_mapping for k in state_dict
+            )
+            if keys_match_mapping:
                 storage_writer = HuggingFaceStorageWriter(
                     path=os.path.join(checkpoint_id, "sharded"),
                     save_distributed=True,
@@ -499,7 +541,8 @@ class CheckpointManager(Configurable):
                 checkpoint_id=checkpoint_save_id,
             )
 
-        if to_hf and fqn_to_index_mapping:
+        if hf_storage and keys_match_mapping:
+            assert fqn_to_index_mapping is not None
             consolidate_safetensors_files_on_every_rank(
                 input_dir=os.path.join(checkpoint_id, "sharded"),
                 output_dir=checkpoint_id,
@@ -512,48 +555,39 @@ class CheckpointManager(Configurable):
 
         return ret
 
-    def dcp_load(
+    def _load_from_hf(
         self,
         state_dict: dict[str, Any],
         checkpoint_id: str,
-        from_hf: bool,
-        from_quantized: bool,
+        from_quantized: bool = False,
     ) -> None:
-        """Load the checkpoint with dcp.
-        Args:
-            state_dict (dict): The state dict to load.
-            checkpoint_id (str): The checkpoint id to load.
-            from_hf (bool): Whether to load from HuggingFace checkpoint with
-                its own model definition and safetensors format.
+        """Load weights from a HuggingFace checkpoint into ``state_dict``.
+
+        Pure I/O — the caller provides the container (via
+        ``model_wrapper.state_dict()`` then ``model.to_hf()``) and
+        handles conversion back via ``model.from_hf()`` afterward.
         """
+        assert (
+            self.model.sd_adapter is not None
+        ), "trying to load checkpoint in HF safetensors format, but model has no sd_adapter."
+        hf_storage_reader = self.model.sd_adapter.get_hf_storage_reader(
+            checkpoint_id, from_quantized
+        )
+        dcp.load(state_dict, storage_reader=hf_storage_reader)
 
-        if from_hf:
-            assert (
-                self.sd_adapter is not None
-            ), "trying to load checkpoint in HF safetensors format, but sd_adapter is not provided."
-            hf_state_dict = self.sd_adapter.to_hf(state_dict)
-            hf_storage_reader = self.sd_adapter.get_hf_storage_reader(
-                checkpoint_id, from_quantized
-            )
+    def _load_from_dcp(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+    ) -> None:
+        """Load weights from a DCP checkpoint into ``state_dict``.
 
-            dcp.load(
-                hf_state_dict,
-                storage_reader=hf_storage_reader,
-            )
+        Pure I/O — the caller provides the container.
+        """
+        dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
-            state_dict = self.sd_adapter.from_hf(hf_state_dict)
-            self.states[MODEL].load_state_dict(state_dict)
-        else:
-            dcp.load(state_dict, checkpoint_id=checkpoint_id)
-
-            # TODO: Since we flatten the model states in state_dict, we need to
-            # manually call load_state_dict() for the model. Need to fix this.
-            if MODEL in self.states:
-                self.states[MODEL].load_state_dict(state_dict)
-
-    @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> bool:
+    def save(self, curr_step: int, last_step: bool = False) -> None:
         """Save the checkpoint for the current step.
 
         This function will save the checkpoint for the current step. If ``last_step`` is
@@ -566,13 +600,11 @@ class CheckpointManager(Configurable):
             last_step (bool, optional): Whether this is the last step of training.
 
         Returns:
-            bool: True if a checkpoint was written (or staged, for async modes) on
-            this step.
+            None
         """
         if not self._should_save(curr_step, last_step):
-            return False
+            return
 
-        sl.add_step_tag("checkpoint_save")
         begin = time.monotonic()
         logger.info("Saving the checkpoint (or staging if async is enabled).")
         checkpoint_id = self._create_checkpoint_id(curr_step)
@@ -582,8 +614,9 @@ class CheckpointManager(Configurable):
         # freed until _async_wait()
         if last_step:
             self._save_last_step(curr_step)
-            return True
+            return
 
+        self.model_wrapper.mode = StateDictMode.FULL
         states = self._flattened_model_states_sd()
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             GarbageCollection.collect("GC collection invoked by checkpointer.")
@@ -617,9 +650,7 @@ class CheckpointManager(Configurable):
             "Finished saving the checkpoint (or staging if async is enabled) "
             f"in {time.monotonic() - begin:.2f} seconds."
         )
-        return True
 
-    @sl.log_trace_span("checkpoint_load")
     @torch.no_grad()
     def load(self, step: int = -1) -> bool:
         """Load the checkpoint for the given step.
@@ -637,86 +668,120 @@ class CheckpointManager(Configurable):
         if not self.enable:
             return False
 
-        model_only = False
-        from_hf = False
-        from_quantized = False
+        begin = time.monotonic()
+
         if not os.path.exists(self.folder):
-            model_only = self.initial_load_model_only
-            from_hf = self.initial_load_in_hf
-            from_quantized = self.initial_load_in_hf_quantized
-            if from_hf:
-                assert (
-                    model_only
-                ), "Only model can be loaded when loading from HF's safetensors checkpoint."
-
-            if from_quantized:
-                assert (
-                    from_hf
-                ), "Quantized checkpoint can only be loaded from HuggingFace format."
-
-            if self.initial_load_path:
-                checkpoint_id = self.initial_load_path
-                if not os.path.isdir(checkpoint_id):
-                    raise ValueError(
-                        "checkpoint.initial_load_path is specified but the path is not valid."
-                    )
-                if from_hf:
-                    logger.info(
-                        f"loading from HF safetensors from --checkpoint.initial_load_path: {self.initial_load_path}"
-                    )
-            elif from_hf:
-                assert (
-                    self.sd_adapter is not None
-                    and self.sd_adapter.hf_assets_path is not None
-                ), "from_hf is True but sd_adapter or hf_assets_path is not provided."
-                hf_assets_path = self.sd_adapter.hf_assets_path
-                checkpoint_id = hf_assets_path
-                if not os.path.isdir(checkpoint_id):
-                    raise ValueError(
-                        "model.hf_assets_path is being used to load HF weights but the path is not valid. \
-                        Either make sure hf_assets_path is correct or provide a valid checkpoint.initial_load_path"
-                    )
-                logger.info(
-                    f"loading HF safetensors from --model.hf_assets_path: {hf_assets_path}"
-                )
-            else:
+            # No checkpoint folder — try initial load
+            if not self._load_initial():
                 return False
         else:
+            # Resume from checkpoint folder
             if self.initial_load_path:
                 logger.warning(
-                    "checkpoint.initial_load_path is provided but the checkpoint.folder exists. "
-                    f"Checkpointer will use the checkpoints from the checkpoint.folder {self.folder}."
+                    "checkpoint.initial_load_path is provided but the "
+                    "checkpoint.folder exists. Checkpointer will use the "
+                    f"checkpoints from the checkpoint.folder {self.folder}."
                 )
             if self.initial_load_in_hf:
                 logger.warning(
-                    "checkpoint.initial_load_in_hf is True but the checkpoint.folder exists. "
-                    "Checkpointer will not load from HF safetensors"
+                    "checkpoint.initial_load_in_hf is True but the "
+                    "checkpoint.folder exists. Checkpointer will not load "
+                    "from HF safetensors."
                 )
             step = self._find_load_step() if step == -1 else step
             if step == -1:
                 return False
-            model_only = step == 0
             checkpoint_id = self._create_checkpoint_id(step)
-
             if not os.path.isdir(checkpoint_id):
                 raise FileNotFoundError(
-                    f"--checkpoint.load_step={step} but checkpoint {checkpoint_id} is not found."
+                    f"--checkpoint.load_step={step} but "
+                    f"checkpoint {checkpoint_id} is not found."
                 )
+            model_only = step == 0
+            logger.info(f"Loading checkpoint from {checkpoint_id}.")
+            self.model_wrapper.mode = StateDictMode.FULL
+            states = self._states_to_load(model_only)
+            self._load_from_dcp(states, checkpoint_id)
+            self.model_wrapper.load_state_dict(states)
 
-        logger.info(f"Loading the checkpoint from {checkpoint_id}.")
-        begin = time.monotonic()
-        states = self._states_to_load(model_only)
-        self.dcp_load(
-            states,
-            checkpoint_id=checkpoint_id,
-            from_hf=from_hf,
-            from_quantized=from_quantized,
-        )
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
-            f"Finished loading the checkpoint in {time.monotonic() - begin:.2f} seconds."
+            f"Finished loading the checkpoint in "
+            f"{time.monotonic() - begin:.2f} seconds."
         )
         return True
+
+    def _load_initial(self) -> bool:
+        """Load initial weights from initial_load_path or hf_assets_path.
+
+        When ``initial_load_frozen`` is True (adapter training), only BASE
+        (frozen) params are loaded; adapters are freshly initialized.
+        Otherwise, FULL model is loaded.
+
+        Returns:
+            True if initial weights were loaded.
+        """
+        load_mode = (
+            StateDictMode.BASE if self.initial_load_frozen else StateDictMode.FULL
+        )
+        from_hf = self.initial_load_in_hf
+        from_quantized = self.initial_load_in_hf_quantized
+
+        if from_hf:
+            if self.initial_load_path:
+                checkpoint_id = self.initial_load_path
+                if not os.path.isdir(checkpoint_id):
+                    raise ValueError(
+                        "checkpoint.initial_load_path is specified "
+                        "but the path is not valid."
+                    )
+                logger.info(
+                    "Loading HF safetensors from "
+                    f"--checkpoint.initial_load_path: {checkpoint_id}"
+                )
+            elif (
+                self.model.sd_adapter is not None
+                and self.model.sd_adapter.hf_assets_path is not None
+            ):
+                checkpoint_id = self.model.sd_adapter.hf_assets_path
+                if not os.path.isdir(checkpoint_id):
+                    raise ValueError(
+                        "model.hf_assets_path is being used to load HF weights "
+                        "but the path is not valid."
+                    )
+                logger.info(
+                    "Loading HF safetensors from "
+                    f"--model.hf_assets_path: {checkpoint_id}"
+                )
+            else:
+                return False
+
+            self.model_wrapper.mode = load_mode
+            sd = self.model_wrapper.state_dict()
+            hf_sd = self.model.to_hf(sd)
+            self._load_from_hf(hf_sd, checkpoint_id, from_quantized)
+            native_sd = self.model.from_hf(hf_sd)
+            self.model_wrapper.load_state_dict(native_sd)
+            return True
+
+        if self.initial_load_path:
+            checkpoint_id = self.initial_load_path
+            if not os.path.isdir(checkpoint_id):
+                raise ValueError(
+                    "checkpoint.initial_load_path is specified "
+                    "but the path is not valid."
+                )
+            logger.info(f"Loading DCP checkpoint from {checkpoint_id}.")
+            self.model_wrapper.mode = load_mode
+            if self.initial_load_model_only:
+                sd = self.model_wrapper.state_dict()
+            else:
+                sd = self._flattened_model_states_sd()
+            self._load_from_dcp(sd, checkpoint_id)
+            self.model_wrapper.load_state_dict(sd)
+            return True
+
+        return False
 
     def maybe_wait_for_staging(self) -> None:
         """Wait for the staging to finish if it is enabled.
@@ -767,9 +832,9 @@ class CheckpointManager(Configurable):
     def _flattened_model_states_sd(
         self, state_dict: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Flatten the model states into a single dictionary.
+        """Flatten model keys alongside training states.
 
-        Note that other states, such as optimizer states, are not flattened.
+        The caller must set ``self.model_wrapper.mode`` before calling.
         """
         states = state_dict if state_dict is not None else self.states
         sd = {k: v for k, v in states.items() if k != MODEL}
@@ -780,16 +845,9 @@ class CheckpointManager(Configurable):
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         """Determines which states to load for the given step.
 
-        This API is used to determine which states to load based on the
-        configurations.
-
-        Args:
-            model_only (bool): Whether to load the model only.
-
-        Returns:
-            Dict[str, Any]: The states to load for the given step.
+        Resume always loads FULL model (base + adapters if present).
+        The caller sets ``self.model_wrapper.mode`` to FULL before calling.
         """
-        # For the first step, we will only load the model.
         if model_only:
             return self.states[MODEL].state_dict()
 
@@ -801,40 +859,49 @@ class CheckpointManager(Configurable):
             k: v for k, v in self.states.items() if k not in self.exclude_from_loading
         }
 
-        states_to_load = self._flattened_model_states_sd(states_to_load)
-
-        return states_to_load
+        return self._flattened_model_states_sd(states_to_load)
 
     def _save_last_step(self, curr_step: int) -> None:
-        # We only consider saving model only at the end of the training. So this
-        # won't affect preemption and training resume. We also only allow dtype
-        # conversion when we are checkpointing model only and the current dtype
-        # is not the same as the export dtype at the end of the training.
+        if self.last_save_trainable_only:
+            save_mode = StateDictMode.TRAINABLE
+        else:
+            save_mode = StateDictMode.FULL
 
         if self.last_save_model_only:
-            states = self.states[MODEL].state_dict()
-
-            if self.export_dtype != torch.float32:
-                states = {k: v.to(self.export_dtype) for k, v in states.items()}
+            export_dtype = (
+                self.export_dtype
+                if self.export_dtype != TORCH_DTYPE_MAP["float32"]
+                else None
+            )
+            self.model_wrapper.mode = save_mode
+            states = self.model_wrapper.state_dict()
+            if self.last_save_in_hf:
+                if self.last_save_trainable_only:
+                    states = self.model.adapter_to_hf(states)
+                else:
+                    states = self.model.to_hf(states)
+            if export_dtype is not None:
+                states = {
+                    k: v.to(export_dtype) if isinstance(v, torch.Tensor) else v
+                    for k, v in states.items()
+                }
             logger.info(
                 f"Saving a model only checkpoint in {self.export_dtype} "
                 f"at last step, step {curr_step}."
             )
         else:
             logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
+            self.model_wrapper.mode = save_mode
             states = self._flattened_model_states_sd()
 
-        if self.last_save_in_hf:
-            assert (
-                self.last_save_model_only
-            ), "Only model can be saved when saving in HF safetensors format."
+        checkpoint_id = self._create_checkpoint_id(curr_step)
 
         self.dcp_save(
             states,
-            checkpoint_id=self._create_checkpoint_id(curr_step),
+            checkpoint_id=checkpoint_id,
             async_mode=AsyncMode.DISABLED,
             enable_garbage_collection=True,
-            to_hf=self.last_save_in_hf,
+            hf_storage=self.last_save_in_hf,
         )
 
     def _should_save(self, curr_step: int, last_step: bool = False) -> bool:

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -559,7 +559,7 @@ class CheckpointManager(Configurable):
         state_dict: dict[str, Any],
         checkpoint_id: str,
         from_hf: bool,
-        from_quantized: bool,
+        from_quantized: bool = False,
     ) -> None:
         """Load the checkpoint with dcp.
         Args:
@@ -567,6 +567,8 @@ class CheckpointManager(Configurable):
             checkpoint_id (str): The checkpoint id to load.
             from_hf (bool): Whether to load from HuggingFace checkpoint with
                 its own model definition and safetensors format.
+            from_quantized (bool): Whether the HF checkpoint has quantized
+                state dict keys. Only used when ``from_hf`` is True.
         """
 
         if from_hf:
@@ -716,7 +718,6 @@ class CheckpointManager(Configurable):
                 states,
                 checkpoint_id=checkpoint_id,
                 from_hf=False,
-                from_quantized=False,
             )
 
         GarbageCollection.collect("GC collection for checkpoint loading.")
@@ -740,7 +741,6 @@ class CheckpointManager(Configurable):
             StateDictMode.BASE if self.initial_load_frozen else StateDictMode.FULL
         )
         from_hf = self.initial_load_in_hf
-        from_quantized = self.initial_load_in_hf_quantized
 
         if from_hf:
             if self.initial_load_path:
@@ -777,7 +777,7 @@ class CheckpointManager(Configurable):
                 sd,
                 checkpoint_id=checkpoint_id,
                 from_hf=True,
-                from_quantized=from_quantized,
+                from_quantized=self.initial_load_in_hf_quantized,
             )
             return True
 
@@ -798,7 +798,6 @@ class CheckpointManager(Configurable):
                 sd,
                 checkpoint_id=checkpoint_id,
                 from_hf=False,
-                from_quantized=False,
             )
             return True
 

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -588,6 +588,8 @@ class CheckpointManager(Configurable):
         else:
             dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
+            # TODO: Since we flatten the model states in state_dict, we need to
+            # manually call load_state_dict() for the model. Need to fix this.
             if MODEL in self.states:
                 self.model_wrapper.load_state_dict(state_dict)
 
@@ -681,10 +683,12 @@ class CheckpointManager(Configurable):
         begin = time.monotonic()
 
         if not os.path.exists(self.folder):
-            # No checkpoint folder — try initial load
+            # Initial load: from HF or external DCP path. Supports
+            # BASE mode (frozen params only) for adapter training.
             if not self._load_initial():
                 return False
         else:
+            # Resume: always FULL mode, always DCP, includes all states.
             # Resume from checkpoint folder
             if self.initial_load_path:
                 logger.warning(

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -553,36 +553,44 @@ class CheckpointManager(Configurable):
 
         return ret
 
-    def _load_from_hf(
+    def dcp_load(
         self,
         state_dict: dict[str, Any],
         checkpoint_id: str,
-        from_quantized: bool = False,
+        from_hf: bool,
+        from_quantized: bool,
     ) -> None:
-        """Load weights from a HuggingFace checkpoint into ``state_dict``.
-
-        Pure I/O — the caller provides the container (via
-        ``model_wrapper.state_dict()`` then ``model.to_hf()``) and
-        handles conversion back via ``model.from_hf()`` afterward.
+        """Load the checkpoint with dcp.
+        Args:
+            state_dict (dict): The state dict to load.
+            checkpoint_id (str): The checkpoint id to load.
+            from_hf (bool): Whether to load from HuggingFace checkpoint with
+                its own model definition and safetensors format.
         """
-        assert (
-            self.model.sd_adapter is not None
-        ), "trying to load checkpoint in HF safetensors format, but model has no sd_adapter."
-        hf_storage_reader = self.model.sd_adapter.get_hf_storage_reader(
-            checkpoint_id, from_quantized
-        )
-        dcp.load(state_dict, storage_reader=hf_storage_reader)
 
-    def _load_from_dcp(
-        self,
-        state_dict: dict[str, Any],
-        checkpoint_id: str,
-    ) -> None:
-        """Load weights from a DCP checkpoint into ``state_dict``.
+        if from_hf:
+            assert (
+                self.model.sd_adapter is not None
+            ), "trying to load checkpoint in HF safetensors format, but model has no sd_adapter."
+            hf_state_dict = self.model.sd_adapter.to_hf(state_dict)
+            hf_storage_reader = self.model.sd_adapter.get_hf_storage_reader(
+                checkpoint_id, from_quantized
+            )
 
-        Pure I/O — the caller provides the container.
-        """
-        dcp.load(state_dict, checkpoint_id=checkpoint_id)
+            dcp.load(
+                hf_state_dict,
+                storage_reader=hf_storage_reader,
+            )
+
+            state_dict = self.model.sd_adapter.from_hf(hf_state_dict)
+            self.model_wrapper.load_state_dict(state_dict)
+        else:
+            dcp.load(state_dict, checkpoint_id=checkpoint_id)
+
+            # TODO: Since we flatten the model states in state_dict, we need to
+            # manually call load_state_dict() for the model. Need to fix this.
+            if MODEL in self.states:
+                self.model_wrapper.load_state_dict(state_dict)
 
     @torch.no_grad()
     def save(self, curr_step: int, last_step: bool = False) -> None:
@@ -699,8 +707,10 @@ class CheckpointManager(Configurable):
             logger.info(f"Loading checkpoint from {checkpoint_id}.")
             self.model_wrapper.mode = StateDictMode.FULL
             states = self._states_to_load(model_only)
-            self._load_from_dcp(states, checkpoint_id)
-            self.model_wrapper.load_state_dict(states)
+            self.dcp_load(
+                states, checkpoint_id=checkpoint_id,
+                from_hf=False, from_quantized=False,
+            )
 
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
@@ -756,10 +766,10 @@ class CheckpointManager(Configurable):
 
             self.model_wrapper.mode = load_mode
             sd = self.model_wrapper.state_dict()
-            hf_sd = self.model.to_hf(sd)
-            self._load_from_hf(hf_sd, checkpoint_id, from_quantized)
-            native_sd = self.model.from_hf(hf_sd)
-            self.model_wrapper.load_state_dict(native_sd)
+            self.dcp_load(
+                sd, checkpoint_id=checkpoint_id,
+                from_hf=True, from_quantized=from_quantized,
+            )
             return True
 
         if self.initial_load_path:
@@ -775,8 +785,10 @@ class CheckpointManager(Configurable):
                 sd = self.model_wrapper.state_dict()
             else:
                 sd = self._flattened_model_states_sd()
-            self._load_from_dcp(sd, checkpoint_id)
-            self.model_wrapper.load_state_dict(sd)
+            self.dcp_load(
+                sd, checkpoint_id=checkpoint_id,
+                from_hf=False, from_quantized=False,
+            )
             return True
 
         return False
@@ -846,6 +858,7 @@ class CheckpointManager(Configurable):
         Resume always loads FULL model (base + adapters if present).
         The caller sets ``self.model_wrapper.mode`` to FULL before calling.
         """
+        # For the first step, we will only load the model.
         if model_only:
             return self.states[MODEL].state_dict()
 
@@ -860,6 +873,10 @@ class CheckpointManager(Configurable):
         return self._flattened_model_states_sd(states_to_load)
 
     def _save_last_step(self, curr_step: int) -> None:
+        # We only consider saving model only at the end of the training. So this
+        # won't affect preemption and training resume. We also only allow dtype
+        # conversion when we are checkpointing model only and the current dtype
+        # is not the same as the export dtype at the end of the training.
         if self.last_save_trainable_only:
             save_mode = StateDictMode.TRAINABLE
         else:

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -66,7 +66,7 @@ class ModelWrapper(Stateful):
     def state_dict(self) -> dict[str, Any]:
         sd: dict[str, Any] = {}
         for part in self.model_parts:
-            sd.update(part.get_sd(self.mode))  # pyrefly: ignore [missing-attribute]
+            sd.update(part.get_sd(self.mode))  # pyrefly: ignore [not-callable]
         return sd
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -40,6 +40,7 @@ from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model import BaseModel, StateDictMode
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
@@ -592,6 +593,7 @@ class CheckpointManager(Configurable):
             if MODEL in self.states:
                 self.model_wrapper.load_state_dict(state_dict)
 
+    @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
     def save(self, curr_step: int, last_step: bool = False) -> None:
         """Save the checkpoint for the current step.
@@ -657,6 +659,7 @@ class CheckpointManager(Configurable):
             f"in {time.monotonic() - begin:.2f} seconds."
         )
 
+    @sl.log_trace_span("checkpoint_load")
     @torch.no_grad()
     def load(self, step: int = -1) -> bool:
         """Load the checkpoint for the given step.
@@ -708,8 +711,10 @@ class CheckpointManager(Configurable):
             self.model_wrapper.mode = StateDictMode.FULL
             states = self._states_to_load(model_only)
             self.dcp_load(
-                states, checkpoint_id=checkpoint_id,
-                from_hf=False, from_quantized=False,
+                states,
+                checkpoint_id=checkpoint_id,
+                from_hf=False,
+                from_quantized=False,
             )
 
         GarbageCollection.collect("GC collection for checkpoint loading.")
@@ -767,8 +772,10 @@ class CheckpointManager(Configurable):
             self.model_wrapper.mode = load_mode
             sd = self.model_wrapper.state_dict()
             self.dcp_load(
-                sd, checkpoint_id=checkpoint_id,
-                from_hf=True, from_quantized=from_quantized,
+                sd,
+                checkpoint_id=checkpoint_id,
+                from_hf=True,
+                from_quantized=from_quantized,
             )
             return True
 
@@ -786,8 +793,10 @@ class CheckpointManager(Configurable):
             else:
                 sd = self._flattened_model_states_sd()
             self.dcp_load(
-                sd, checkpoint_id=checkpoint_id,
-                from_hf=False, from_quantized=False,
+                sd,
+                checkpoint_id=checkpoint_id,
+                from_hf=False,
+                from_quantized=False,
             )
             return True
 

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -467,7 +467,7 @@ class CheckpointManager(Configurable):
     ) -> Future | AsyncSaveResponse | None:
         """Save the checkpoint with dcp.
         Args:
-            state_dict (dict): The state dict to save (key transforms already applied).
+            state_dict (dict): The state dict to save.
             checkpoint_id (str): The checkpoint id to save.
             async_mode (AsyncMode): Whether the checkpoint is async.
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
@@ -595,7 +595,7 @@ class CheckpointManager(Configurable):
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> None:
+    def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Save the checkpoint for the current step.
 
         This function will save the checkpoint for the current step. If ``last_step`` is
@@ -608,10 +608,11 @@ class CheckpointManager(Configurable):
             last_step (bool, optional): Whether this is the last step of training.
 
         Returns:
-            None
+            bool: True if a checkpoint was written (or staged, for async modes)
+            on this step.
         """
         if not self._should_save(curr_step, last_step):
-            return
+            return False
 
         begin = time.monotonic()
         logger.info("Saving the checkpoint (or staging if async is enabled).")
@@ -622,7 +623,7 @@ class CheckpointManager(Configurable):
         # freed until _async_wait()
         if last_step:
             self._save_last_step(curr_step)
-            return
+            return True
 
         self.model_wrapper.mode = StateDictMode.FULL
         states = self._flattened_model_states_sd()
@@ -658,6 +659,7 @@ class CheckpointManager(Configurable):
             "Finished saving the checkpoint (or staging if async is enabled) "
             f"in {time.monotonic() - begin:.2f} seconds."
         )
+        return True
 
     @sl.log_trace_span("checkpoint_load")
     @torch.no_grad()
@@ -851,9 +853,9 @@ class CheckpointManager(Configurable):
     def _flattened_model_states_sd(
         self, state_dict: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Flatten model keys alongside training states.
+        """Flatten the model states into a single dictionary.
 
-        The caller must set ``self.model_wrapper.mode`` before calling.
+        Note that other states, such as optimizer states, are not flattened.
         """
         states = state_dict if state_dict is not None else self.states
         sd = {k: v for k, v in states.items() if k != MODEL}

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -52,6 +52,12 @@ DATALOADER = "dataloader"
 TRAIN_STATE = "train_state"
 
 
+class AsyncMode(str, enum.Enum):
+    DISABLED = "disabled"
+    ASYNC = "async"
+    ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
+
+
 class ModelWrapper(Stateful):
     """Thin wrapper that merges state dicts across PP stages.
 
@@ -76,12 +82,6 @@ class ModelWrapper(Stateful):
                 model_state_dict=state_dict,
                 options=StateDictOptions(strict=False),
             )
-
-
-class AsyncMode(str, enum.Enum):
-    DISABLED = "disabled"
-    ASYNC = "async"
-    ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
 
 
 class Terminate:
@@ -368,8 +368,6 @@ class CheckpointManager(Configurable):
         self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
         self.last_save_model_only = config.last_save_model_only
         self.last_save_in_hf = config.last_save_in_hf
-        self.create_seed_checkpoint = config.create_seed_checkpoint
-
         if self.last_save_in_hf:
             assert (
                 self.model.sd_adapter is not None
@@ -464,7 +462,7 @@ class CheckpointManager(Configurable):
         checkpoint_id: str,
         async_mode: AsyncMode,
         enable_garbage_collection: bool = False,
-        hf_storage: bool = False,
+        to_hf: bool = False,
     ) -> Future | AsyncSaveResponse | None:
         """Save the checkpoint with dcp.
         Args:
@@ -472,7 +470,7 @@ class CheckpointManager(Configurable):
             checkpoint_id (str): The checkpoint id to save.
             async_mode (AsyncMode): Whether the checkpoint is async.
             enable_garbage_collection (bool): Whether to enable garbage collection after save.
-            hf_storage (bool): Whether to use HF safetensors storage writer.
+            to_hf (bool): Whether to use HF safetensors storage writer.
                 Key transforms must be applied by the caller via
                 model.to_hf() or model.adapter_to_hf() before calling this method.
 
@@ -486,7 +484,7 @@ class CheckpointManager(Configurable):
         checkpoint_save_id: str | None = None
         fqn_to_index_mapping: dict[Any, int] | None = None
         keys_match_mapping = False
-        if hf_storage:
+        if to_hf:
             assert (
                 self.model.sd_adapter is not None
             ), "trying to save in HF safetensors format, but model has no sd_adapter."
@@ -541,7 +539,7 @@ class CheckpointManager(Configurable):
                 checkpoint_id=checkpoint_save_id,
             )
 
-        if hf_storage and keys_match_mapping:
+        if to_hf and keys_match_mapping:
             assert fqn_to_index_mapping is not None
             consolidate_safetensors_files_on_every_rank(
                 input_dir=os.path.join(checkpoint_id, "sharded"),
@@ -901,7 +899,7 @@ class CheckpointManager(Configurable):
             checkpoint_id=checkpoint_id,
             async_mode=AsyncMode.DISABLED,
             enable_garbage_collection=True,
-            hf_storage=self.last_save_in_hf,
+            to_hf=self.last_save_in_hf,
         )
 
     def _should_save(self, curr_step: int, last_step: bool = False) -> bool:

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -7,7 +7,7 @@
 import os
 from collections.abc import Generator
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record
@@ -255,17 +255,20 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             training_steps=config.training.steps,
         )
 
+        model_ref = cast(BaseModel, self.model_parts[0])
+        sd_adapter = (
+            self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if self.train_spec.state_dict_adapter
+            else None
+        )
+        model_ref.set_sd_adapter(sd_adapter)
+
         self.checkpointer = config.checkpoint.build(
             dataloader=None,
             model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                self.train_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if self.train_spec.state_dict_adapter
-                else None
-            ),
             base_folder=config.dump_folder,
         )
 

--- a/torchtitan/experiments/ft/checkpoint.py
+++ b/torchtitan/experiments/ft/checkpoint.py
@@ -36,7 +36,6 @@ from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.experiments.ft.manager import FTManager
-from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
@@ -78,7 +77,6 @@ class FTCheckpointManager(CheckpointManager):
         optimizers: OptimizersContainer,
         lr_schedulers: LRSchedulersContainer,
         states: dict[str, Any],
-        sd_adapter: BaseStateDictAdapter | None,
         base_folder: str = "",
         ft_manager: FTManager | None = None,
     ) -> None:
@@ -90,7 +88,6 @@ class FTCheckpointManager(CheckpointManager):
             optimizers=optimizers,
             lr_schedulers=lr_schedulers,
             states=states,
-            sd_adapter=sd_adapter,
             base_folder=base_folder,
         )
 
@@ -213,12 +210,7 @@ class FTCheckpointManager(CheckpointManager):
         begin = time.monotonic()
         logger.info(f"Loading the FT checkpoint at step {step}.")
         checkpoint_id = self._create_checkpoint_id(step, folder=self._ft_folder())
-        self.dcp_load(
-            self.ft_states,
-            checkpoint_id=checkpoint_id,
-            from_hf=False,
-            from_quantized=False,
-        )
+        self._load_from_dcp(self.ft_states, checkpoint_id)
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
             f"Finished loading the ft checkpoint in "

--- a/torchtitan/experiments/ft/checkpoint.py
+++ b/torchtitan/experiments/ft/checkpoint.py
@@ -214,7 +214,6 @@ class FTCheckpointManager(CheckpointManager):
             self.ft_states,
             checkpoint_id=checkpoint_id,
             from_hf=False,
-            from_quantized=False,
         )
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(

--- a/torchtitan/experiments/ft/checkpoint.py
+++ b/torchtitan/experiments/ft/checkpoint.py
@@ -210,7 +210,12 @@ class FTCheckpointManager(CheckpointManager):
         begin = time.monotonic()
         logger.info(f"Loading the FT checkpoint at step {step}.")
         checkpoint_id = self._create_checkpoint_id(step, folder=self._ft_folder())
-        self._load_from_dcp(self.ft_states, checkpoint_id)
+        self.dcp_load(
+            self.ft_states,
+            checkpoint_id=checkpoint_id,
+            from_hf=False,
+            from_quantized=False,
+        )
         GarbageCollection.collect("GC collection for checkpoint loading.")
         logger.info(
             f"Finished loading the ft checkpoint in "

--- a/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
+++ b/torchtitan/experiments/ft/tests/test_ft_checkpoint.py
@@ -18,6 +18,31 @@ from torch.utils.data import DataLoader
 from torchtitan.experiments.ft.checkpoint import FTCheckpointManager
 
 
+class FakeBaseModel(nn.Linear):
+    """A fake BaseModel for FT checkpoint tests."""
+
+    def __init__(self, in_features: int = 2, out_features: int = 2):
+        super().__init__(in_features, out_features)
+
+    @property
+    def sd_adapter(self):
+        return None
+
+    def get_sd(self, mode=None):
+        from torch.distributed.checkpoint.state_dict import get_model_state_dict
+
+        return get_model_state_dict(self)
+
+    def to_hf(self, sd):
+        return sd
+
+    def from_hf(self, sd):
+        return sd
+
+    def adapter_to_hf(self, sd):
+        return sd
+
+
 class FakeOptimizersContainer:
     def __init__(self):
         self._fake_param = torch.tensor([1.0], dtype=torch.float32)
@@ -83,7 +108,8 @@ class TestFTCheckpointManager(unittest.TestCase):
         self.base_temp_dir = tempfile.mkdtemp()
         self.test_folder = os.path.join(self.base_temp_dir, self._testMethodName)
         os.makedirs(self.test_folder, exist_ok=True)
-        self.model_parts = [nn.Linear(2, 2)]
+        self.model = FakeBaseModel(2, 2)
+        self.model_parts = [self.model]
         self.states = {"trainer": torch.tensor([1.2347])}
         self.optimizers = FakeOptimizersContainer()
         self.lr_schedulers = FakeLRSchedulersContainer()
@@ -133,7 +159,6 @@ class TestFTCheckpointManager(unittest.TestCase):
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states=self.states,
-            sd_adapter=None,
             base_folder=self.test_folder,
             ft_manager=self.ft_manager,
         )

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -278,6 +278,14 @@ class FaultTolerantTrainer(Trainer):
         self.step = 0
         self.ntokens_seen = 0
 
+        model_ref = cast(BaseModel, self.model_parts[0])
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if model_spec.state_dict_adapter
+            else None
+        )
+        model_ref.set_sd_adapter(sd_adapter)
+
         # FT addition: pass ft_manager to CheckpointManager
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
@@ -285,11 +293,6 @@ class FaultTolerantTrainer(Trainer):
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
             base_folder=config.dump_folder,
             ft_manager=self.ft_manager,
         )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -124,18 +124,18 @@ class PolicyTrainer(Actor, Configurable):
             distinct_seed_mesh_dims=["pp"],
         )
 
-        # Initialize state dict adapter for HF checkpoint loading
-        if model_spec.state_dict_adapter is not None:
-            self.sd_adapter = model_spec.state_dict_adapter(
-                model_spec.model, hf_assets_path
-            )
-        else:
-            self.sd_adapter = None
-
         # Create training policy model
         model = self._build_model(model_spec, config, device_type, hf_assets_path)
         model.train()
         self.model = model
+
+        # Store state dict adapter on the model for HF checkpoint loading
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_spec.model, hf_assets_path)
+            if model_spec.state_dict_adapter is not None
+            else None
+        )
+        model.set_sd_adapter(sd_adapter)
         self.model_parts = [model]
 
         # Build optimizer and LR scheduler
@@ -175,7 +175,7 @@ class PolicyTrainer(Actor, Configurable):
             model: The model to load weights into.
             checkpoint_path: Path to HF checkpoint directory.
         """
-        if self.sd_adapter is None:
+        if model.sd_adapter is None:
             logger.warning(
                 "No state_dict_adapter available, skipping initial weight load"
             )
@@ -187,10 +187,10 @@ class PolicyTrainer(Actor, Configurable):
                 "Please provide a valid path to a HuggingFace checkpoint directory."
             )
 
-        storage_reader = self.sd_adapter.get_hf_storage_reader(checkpoint_path)
-        hf_state_dict = self.sd_adapter.to_hf(model.state_dict())
+        storage_reader = model.sd_adapter.get_hf_storage_reader(checkpoint_path)
+        hf_state_dict = model.sd_adapter.to_hf(model.state_dict())
         dcp.load(hf_state_dict, storage_reader=storage_reader)
-        torchtitan_state_dict = self.sd_adapter.from_hf(hf_state_dict)
+        torchtitan_state_dict = model.sd_adapter.from_hf(hf_state_dict)
 
         set_model_state_dict(
             model=model,

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -135,10 +135,11 @@ def build_trainer_model(
     # Load HF checkpoint
     if model_spec.state_dict_adapter is not None:
         sd_adapter = model_spec.state_dict_adapter(model_spec.model, hf_assets_path)
-        storage_reader = sd_adapter.get_hf_storage_reader(hf_assets_path)
-        hf_state_dict = sd_adapter.to_hf(model.state_dict())
+        model.set_sd_adapter(sd_adapter)
+        storage_reader = model.sd_adapter.get_hf_storage_reader(hf_assets_path)
+        hf_state_dict = model.to_hf(model.state_dict())
         dcp.load(hf_state_dict, storage_reader=storage_reader)
-        tt_state_dict = sd_adapter.from_hf(hf_state_dict)
+        tt_state_dict = model.from_hf(hf_state_dict)
         set_model_state_dict(
             model=model,
             model_state_dict=tt_state_dict,

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -542,10 +542,13 @@ def model_registry(
         moe_comm_backend=moe_comm_backend,
         non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="deepseek_v3",
         flavor=flavor,
@@ -554,4 +557,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -550,10 +550,13 @@ def model_registry(
     converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = flux_configs[flavor]()
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="flux",
         flavor=flavor,
@@ -562,4 +565,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=FluxStateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -353,10 +353,13 @@ def model_registry(
     config = gptoss_configs[flavor](
         moe_comm_backend=moe_comm_backend,
     )
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="gpt_oss",
         flavor=flavor,
@@ -365,4 +368,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=GptOssStateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -382,10 +382,13 @@ def model_registry(
     converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = llama3_configs[flavor](attn_backend=attn_backend)
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="llama3",
         flavor=flavor,
@@ -394,4 +397,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/llama4/__init__.py
+++ b/torchtitan/models/llama4/__init__.py
@@ -356,10 +356,13 @@ def model_registry(
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
     )
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="llama4",
         flavor=flavor,
@@ -368,4 +371,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=Llama4StateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -626,10 +626,13 @@ def model_registry(
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_configs[flavor](**kwargs)
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="qwen3",
         flavor=flavor,
@@ -638,4 +641,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3StateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -581,10 +581,13 @@ def model_registry(
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_vl_configs[flavor](**kwargs)
+    built_converters = []
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:
-            c.build().convert(config)
+            converter = c.build()
+            converter.convert(config)
+            built_converters.append(converter)
     return ModelSpec(
         name="qwen3_vl",
         flavor=flavor,
@@ -593,4 +596,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3VLStateDictAdapter,
+        converters=built_converters or None,
     )

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -4,12 +4,38 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
+import enum
 from abc import abstractmethod
 from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    StateDictOptions,
+)
 
 from torchtitan.config import Configurable
 
 from .module import Module
+
+if TYPE_CHECKING:
+    from .state_dict_adapter import BaseStateDictAdapter
+
+
+class StateDictMode(enum.Enum):
+    """Which parameters to include in a state dict operation.
+
+    FULL: all keys. For seed saves, DCP resume.
+    TRAINABLE: only requires_grad=True keys. For adapter export.
+    BASE: only requires_grad=False keys (or all if nothing frozen).
+        For initial load in adapter training.
+    """
+
+    FULL = "full"
+    TRAINABLE = "trainable"
+    BASE = "base"
 
 
 class ModelConfigConverter(Configurable):
@@ -38,6 +64,70 @@ class BaseModel(Module):
     ``init_states`` (from Module) auto-recurses; override only for custom
     ordering (e.g., weight tying before init).
     """
+
+    _sd_adapter: BaseStateDictAdapter | None = None
+    _adapter_to_hf_fns: list | None = None
+
+    @property
+    def sd_adapter(self) -> BaseStateDictAdapter | None:
+        return self._sd_adapter
+
+    def set_sd_adapter(
+        self,
+        sd_adapter: BaseStateDictAdapter | None = None,
+        converters: list | None = None,
+    ) -> None:
+        """Store the state dict adapter and build converter transforms.
+
+        Called once by the trainer after model build.
+        """
+        self._sd_adapter = sd_adapter
+        self._adapter_to_hf_fns = None
+        for converter in converters or []:
+            build_fn = getattr(converter, "build_external_transforms", None)
+            if build_fn is not None:
+                ct = build_fn(sd_adapter)
+                if ct is not None and "to_external" in ct:
+                    if self._adapter_to_hf_fns is None:
+                        self._adapter_to_hf_fns = []
+                    self._adapter_to_hf_fns.append(ct["to_external"])
+
+    def to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert native base model keys to HF format."""
+        if self._sd_adapter is not None:
+            sd = self._sd_adapter.to_hf(sd)
+        return sd
+
+    def from_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert HF-format keys back to native format."""
+        if self._sd_adapter is not None:
+            sd = self._sd_adapter.from_hf(sd)
+        return sd
+
+    def adapter_to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
+        """Convert native adapter keys to PEFT/HF format."""
+        if self._adapter_to_hf_fns:
+            for fn in self._adapter_to_hf_fns:
+                sd = fn(sd)
+        return sd
+
+    def get_sd(
+        self, mode: StateDictMode = StateDictMode.FULL
+    ) -> dict[str, Any]:
+        """Return this model's state dict filtered by mode."""
+        if mode == StateDictMode.TRAINABLE:
+            return get_model_state_dict(
+                self, options=StateDictOptions(ignore_frozen_params=True)
+            )
+        if mode == StateDictMode.BASE:
+            full_sd = get_model_state_dict(self)
+            trainable_sd = get_model_state_dict(
+                self, options=StateDictOptions(ignore_frozen_params=True)
+            )
+            if len(trainable_sd) == len(full_sd):
+                return full_sd
+            return {k: v for k, v in full_sd.items() if k not in trainable_sd}
+        return get_model_state_dict(self)
 
     def init_weights(self, **kwargs) -> None:
         """Backward-compatible alias for ``init_states``.

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -111,9 +111,7 @@ class BaseModel(Module):
                 sd = fn(sd)
         return sd
 
-    def get_sd(
-        self, mode: StateDictMode = StateDictMode.FULL
-    ) -> dict[str, Any]:
+    def get_sd(self, mode: StateDictMode = StateDictMode.FULL) -> dict[str, Any]:
         """Return this model's state dict filtered by mode."""
         if mode == StateDictMode.TRAINABLE:
             return get_model_state_dict(

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -82,15 +82,14 @@ class BaseModel(Module):
         Called once by the trainer after model build.
         """
         self._sd_adapter = sd_adapter
-        self._adapter_to_hf_fns = None
+        fns = []
         for converter in converters or []:
             build_fn = getattr(converter, "build_external_transforms", None)
             if build_fn is not None:
                 ct = build_fn(sd_adapter)
                 if ct is not None and "to_external" in ct:
-                    if self._adapter_to_hf_fns is None:
-                        self._adapter_to_hf_fns = []
-                    self._adapter_to_hf_fns.append(ct["to_external"])
+                    fns.append(ct["to_external"])
+        self._adapter_to_hf_fns = fns or None
 
     def to_hf(self, sd: dict[str, Any]) -> dict[str, Any]:
         """Convert native base model keys to HF format."""

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -41,3 +41,4 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+    converters: list | None = None

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -454,7 +454,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else None
         )
 
-        model_ref.set_sd_adapter(sd_adapter)
+        model_ref.set_sd_adapter(sd_adapter, converters=model_spec.converters)
 
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -446,17 +446,22 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.step = 0
         self.ntokens_seen = 0
 
+        model_ref = cast(BaseModel, self.model_parts[0])
+
+        sd_adapter = (
+            model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+            if model_spec.state_dict_adapter
+            else None
+        )
+
+        model_ref.set_sd_adapter(sd_adapter)
+
         self.checkpointer = config.checkpoint.build(
             dataloader=self.dataloader,
             model_parts=self.model_parts,
             optimizers=self.optimizers,
             lr_schedulers=self.lr_schedulers,
             states={"train_state": self},
-            sd_adapter=(
-                model_spec.state_dict_adapter(model_config, config.hf_assets_path)
-                if model_spec.state_dict_adapter
-                else None
-            ),
             base_folder=config.dump_folder,
         )
 


### PR DESCRIPTION
Move state dict logic into BaseModel:
- StateDictMode enum (FULL/TRAINABLE/BASE) for mode-based save/load
- get_sd(mode) returns filtered state dict via DCP StateDictOptions
- sd_adapter property and set_sd_adapter() for HF format transforms
- to_hf/from_hf/adapter_to_hf delegate to stored adapter

Refactor CheckpointManager:
- Remove sd_adapter constructor parameter; access via model.sd_adapter
- ModelWrapper uses part.get_sd(mode) instead of get_model_state_dict
- Add initial_load_frozen and last_save_trainable_only config fields
- Extract _load_initial, _load_from_dcp, _load_from_hf helpers
- _save_last_step supports TRAINABLE mode for adapter-only export

Update all callsites (trainer, experiments, scripts) to wire sd_adapter onto model before checkpoint build.