### PR TITLE
[LoRA] Add LoRA converter and rename quantization to converters

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -588,10 +588,12 @@ def build_features_test_list() -> list[OverrideDefinitions]:
                 [
                     "--module llama3 --config llama3_debugmodel_lora",
                     "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_degree 2",
                 ],
             ],
             "LoRA training test",
             "lora",
+            ngpu=8,
         ),
         OverrideDefinitions(
             [

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -587,6 +587,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module llama3 --config llama3_debugmodel_lora",
+                    "--parallelism.tensor_parallel_degree 2",
                 ],
             ],
             "LoRA training test",

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -586,6 +586,15 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--module llama3 --config llama3_debugmodel_lora",
+                ],
+            ],
+            "LoRA training test",
+            "lora",
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--comm.mode torchcomms",
                     "--parallelism.context_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -11,7 +11,7 @@ from torchtitan.components.lora import _get_lora_cls, LoRAConverter
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import model_registry
-from torchtitan.protocols.model_spec import validate_converter_order
+from torchtitan.models.utils import validate_converter_order
 
 
 def test_lora_model_builds():
@@ -65,19 +65,18 @@ def test_lora_forward():
 
 def test_validate_converter_order():
     """Quantization before LoRA is valid; LoRA before quantization is not."""
-    lora = LoRAConverter(LoRAConverter.Config(rank=8, alpha=16.0))
+    lora_cfg = LoRAConverter.Config(rank=8, alpha=16.0)
 
     # Valid order: no error
-    validate_converter_order([lora])
+    validate_converter_order([lora_cfg])
 
     # Invalid order: quantization after LoRA
-    pytest.importorskip("torchao")
-    float8 = Float8LinearConverter(Float8LinearConverter.Config(emulate=True))
+    float8_cfg = Float8LinearConverter.Config(emulate=True)
     with pytest.raises(ValueError, match="must be applied before"):
-        validate_converter_order([lora, float8])
+        validate_converter_order([lora_cfg, float8_cfg])
 
     # Valid order: quantization before LoRA
-    validate_converter_order([float8, lora])
+    validate_converter_order([float8_cfg, lora_cfg])
 
 
 def test_lora_cls_cache():

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -27,16 +27,18 @@ def test_lora_model_builds():
     model = model_spec.model.build()
     model.init_states()
 
-    trainable = {n for n, p in model.named_parameters() if p.requires_grad}
-    frozen = {n for n, p in model.named_parameters() if not p.requires_grad}
+    lora_params = {
+        n for n, p in model.named_parameters() if "lora_a" in n or "lora_b" in n
+    }
+    frozen_linears = {n for n, p in model.named_parameters() if not p.requires_grad}
 
-    assert len(trainable) > 0, "No trainable parameters found"
-    assert len(frozen) > 0, "No frozen parameters found"
-    for name in trainable:
-        assert (
-            "lora_a" in name or "lora_b" in name
-        ), f"Trainable param '{name}' is not a LoRA adapter"
-    for name in frozen:
+    assert len(lora_params) > 0, "No LoRA parameters found"
+    assert len(frozen_linears) > 0, "No frozen parameters found"
+    for name in lora_params:
+        assert model.get_parameter(
+            name
+        ).requires_grad, f"LoRA param '{name}' should be trainable"
+    for name in frozen_linears:
         assert (
             "lora_a" not in name and "lora_b" not in name
         ), f"Frozen param '{name}' looks like a LoRA adapter"

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -8,10 +8,8 @@ import pytest
 import torch
 
 from torchtitan.components.lora import (
-    FrozenConfig,
-    LoRAConfig,
-    LoRAConverter,
     _get_lora_cls,
+    LoRAConverter,
 )
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.models.common.linear import Linear
@@ -38,13 +36,13 @@ def test_lora_model_builds():
     assert len(trainable) > 0, "No trainable parameters found"
     assert len(frozen) > 0, "No frozen parameters found"
     for name in trainable:
-        assert "lora_a" in name or "lora_b" in name, (
-            f"Trainable param '{name}' is not a LoRA adapter"
-        )
+        assert (
+            "lora_a" in name or "lora_b" in name
+        ), f"Trainable param '{name}' is not a LoRA adapter"
     for name in frozen:
-        assert "lora_a" not in name and "lora_b" not in name, (
-            f"Frozen param '{name}' looks like a LoRA adapter"
-        )
+        assert (
+            "lora_a" not in name and "lora_b" not in name
+        ), f"Frozen param '{name}' looks like a LoRA adapter"
 
 
 def test_lora_forward():
@@ -77,9 +75,7 @@ def test_validate_converter_order():
 
     # Invalid order: quantization after LoRA
     pytest.importorskip("torchao")
-    float8 = Float8LinearConverter(
-        Float8LinearConverter.Config(emulate=True)
-    )
+    float8 = Float8LinearConverter(Float8LinearConverter.Config(emulate=True))
     with pytest.raises(ValueError, match="must be applied before"):
         validate_converter_order([lora, float8])
 

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -7,10 +7,7 @@
 import pytest
 import torch
 
-from torchtitan.components.lora import (
-    _get_lora_cls,
-    LoRAConverter,
-)
+from torchtitan.components.lora import _get_lora_cls, LoRAConverter
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import model_registry

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -58,7 +58,6 @@ def test_lora_forward():
     model.init_states()
 
     vocab_size = model_spec.model.vocab_size
-    dim = model_spec.model.dim
     batch_size, seq_len = 2, 16
     tokens = torch.randint(0, vocab_size, (batch_size, seq_len))
     output = model(tokens)

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchtitan.components.lora import (
+    FrozenConfig,
+    LoRAConfig,
+    LoRAConverter,
+    _get_lora_cls,
+)
+from torchtitan.components.quantization import Float8LinearConverter
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.llama3 import model_registry
+from torchtitan.protocols.model_spec import validate_converter_order
+
+
+def test_lora_model_builds():
+    """LoRA debug model builds, has trainable adapters and frozen base."""
+    model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            LoRAConverter.Config(
+                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
+            ),
+        ],
+    )
+    model = model_spec.model.build()
+    model.init_states()
+
+    trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+    frozen = {n for n, p in model.named_parameters() if not p.requires_grad}
+
+    assert len(trainable) > 0, "No trainable parameters found"
+    assert len(frozen) > 0, "No frozen parameters found"
+    for name in trainable:
+        assert "lora_a" in name or "lora_b" in name, (
+            f"Trainable param '{name}' is not a LoRA adapter"
+        )
+    for name in frozen:
+        assert "lora_a" not in name and "lora_b" not in name, (
+            f"Frozen param '{name}' looks like a LoRA adapter"
+        )
+
+
+def test_lora_forward():
+    """LoRA model forward produces correct output shape."""
+    model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            LoRAConverter.Config(
+                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
+            ),
+        ],
+    )
+    model = model_spec.model.build()
+    model.init_states()
+
+    vocab_size = model_spec.model.vocab_size
+    dim = model_spec.model.dim
+    batch_size, seq_len = 2, 16
+    tokens = torch.randint(0, vocab_size, (batch_size, seq_len))
+    output = model(tokens)
+    assert output.shape == (batch_size, seq_len, vocab_size)
+
+
+def test_validate_converter_order():
+    """Quantization before LoRA is valid; LoRA before quantization is not."""
+    lora = LoRAConverter(LoRAConverter.Config(rank=8, alpha=16.0))
+
+    # Valid order: no error
+    validate_converter_order([lora])
+
+    # Invalid order: quantization after LoRA
+    pytest.importorskip("torchao")
+    float8 = Float8LinearConverter(
+        Float8LinearConverter.Config(emulate=True)
+    )
+    with pytest.raises(ValueError, match="must be applied before"):
+        validate_converter_order([lora, float8])
+
+    # Valid order: quantization before LoRA
+    validate_converter_order([float8, lora])
+
+
+def test_lora_cls_cache():
+    """Dynamic LoRA class creation is cached per parent class."""
+    cls1 = _get_lora_cls(Linear)
+    cls2 = _get_lora_cls(Linear)
+    assert cls1 is cls2
+    assert cls1.__name__ == "LoRALinear"
+    assert issubclass(cls1, Linear)
+
+
+def test_lora_rank_validation():
+    """LoRA rank must be positive."""
+    with pytest.raises(ValueError, match="rank must be positive"):
+        LoRAConverter(LoRAConverter.Config(rank=0))
+    with pytest.raises(ValueError, match="rank must be positive"):
+        LoRAConverter(LoRAConverter.Config(rank=-1))

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -60,7 +60,7 @@ def _get_lora_cls(parent_cls: type) -> type:
     if parent_cls in _lora_class_cache:
         return _lora_class_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
 
     class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -182,7 +182,7 @@ class LoRAConverter(ModelConfigConverter):
         """Create a LoRALinear.Config from a base Linear.Config."""
         assert cfg._owner is not None
         lora_cls = _get_lora_cls(cfg._owner)
-        return lora_cls.Config(
+        return lora_cls.Config(  # pyrefly: ignore [missing-attribute]
             **{f.name: getattr(cfg, f.name) for f in fields(cfg)},
             rank=self.rank,
             alpha=self.alpha,

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -54,29 +54,44 @@ def _get_lora_cls(parent_cls: type) -> type:
     """Get or create a LoRA subclass for *parent_cls* (e.g. Linear, Float8Linear).
 
     The returned class has a proper ``Config`` that extends the parent's Config
-    with LoRA adapter configs (``lora_a``, ``lora_b``) and ``lora_scaling``.
-    Adapters are built in ``__init__`` from their stored configs, following
-    the standard torchtitan Config → build pattern.
+    with ``rank`` and ``alpha``.  Adapters are built in ``__init__`` from the
+    base config's dimensions and sharding.
     """
     if parent_cls in _lora_class_cache:
         return _lora_class_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
         class Config(parent_config_cls):  # type: ignore[misc]
-            lora_a: Linear.Config
-            lora_b: Linear.Config
-            lora_scaling: float
+            rank: int
+            alpha: float
 
         def __init__(self, config: Config) -> None:
             super().__init__(config)
             for param in nn.Module.parameters(self):
                 param.requires_grad_(False)
-            self._lora_scaling = config.lora_scaling
-            self.lora_a = config.lora_a.build()
-            self.lora_b = config.lora_b.build()
+            self._lora_scaling = config.alpha / config.rank
+            lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(
+                config.sharding_config
+            )
+            self.lora_a = Linear.Config(
+                in_features=config.in_features,
+                out_features=config.rank,
+                bias=False,
+                sharding_config=lora_a_sharding,
+                param_init={
+                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
+                },
+            ).build()
+            self.lora_b = Linear.Config(
+                in_features=config.rank,
+                out_features=config.out_features,
+                bias=False,
+                sharding_config=lora_b_sharding,
+                param_init={"weight": nn.init.zeros_},
+            ).build()
 
         def forward(self, input: torch.Tensor) -> torch.Tensor:
             base_out = super().forward(input)
@@ -167,26 +182,10 @@ class LoRAConverter(ModelConfigConverter):
         """Create a LoRALinear.Config from a base Linear.Config."""
         assert cfg._owner is not None
         lora_cls = _get_lora_cls(cfg._owner)
-        lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(cfg.sharding_config)
-        return lora_cls.Config(  # pyrefly: ignore [missing-attribute]
+        return lora_cls.Config(
             **{f.name: getattr(cfg, f.name) for f in fields(cfg)},
-            lora_a=Linear.Config(
-                in_features=cfg.in_features,
-                out_features=self.rank,
-                bias=False,
-                sharding_config=lora_a_sharding,
-                param_init={
-                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
-                },
-            ),
-            lora_b=Linear.Config(
-                in_features=self.rank,
-                out_features=cfg.out_features,
-                bias=False,
-                sharding_config=lora_b_sharding,
-                param_init={"weight": nn.init.zeros_},
-            ),
-            lora_scaling=self.alpha / self.rank,
+            rank=self.rank,
+            alpha=self.alpha,
         )
 
     def convert(self, model_config) -> None:

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -61,7 +61,7 @@ def _get_lora_cls(parent_cls: type) -> type:
     if parent_cls in _lora_class_cache:
         return _lora_class_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
 
     class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -168,7 +168,7 @@ class LoRAConverter(ModelConfigConverter):
         assert cfg._owner is not None
         lora_cls = _get_lora_cls(cfg._owner)
         lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(cfg.sharding_config)
-        return lora_cls.Config(
+        return lora_cls.Config(  # pyrefly: ignore [missing-attribute]
             **{f.name: getattr(cfg, f.name) for f in fields(cfg)},
             lora_a=Linear.Config(
                 in_features=cfg.in_features,

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -1,0 +1,276 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from dataclasses import dataclass, fields
+
+import torch
+import torch.nn as nn
+
+from torch.distributed.tensor import Replicate
+
+from torchtitan.config import Configurable
+from torchtitan.models.common.decoder_sharding import dense_param_placement
+from torchtitan.models.common.linear import Linear
+from torchtitan.protocols.sharding import ShardingConfig
+from torchtitan.tools.logging import logger
+
+
+def _lora_adapter_sharding(
+    base_sharding: ShardingConfig | None,
+) -> tuple[ShardingConfig | None, ShardingConfig | None]:
+    """Derive LoRA adapter sharding from the base linear's TP sharding.
+
+    ``lora_b`` mirrors the base weight's TP shard so its output matches
+    ``base_out``'s placement (Shard(-1) for colwise, Partial for rowwise).
+
+    ``lora_a`` weight is Replicate (small rank dim, no benefit from TP
+    sharding).
+    """
+    base_weight_sharding = (
+        base_sharding.state_shardings.get("weight") if base_sharding else None
+    )
+    if base_weight_sharding is None:
+        return None, None
+
+    replicate_weight = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=Replicate())},
+    )
+    # lora_b: same TP shard as base weight → output matches base_out
+    lora_b_sharding = ShardingConfig(
+        state_shardings={"weight": base_weight_sharding},
+    )
+    return replicate_weight, lora_b_sharding
+
+
+_lora_class_cache: dict[type, type] = {}
+
+
+def _get_lora_cls(parent_cls: type) -> type:
+    """Get or create a LoRA subclass for *parent_cls* (e.g. Linear, Float8Linear).
+
+    The returned class has a proper ``Config`` that extends the parent's Config
+    with LoRA adapter configs (``lora_a``, ``lora_b``) and ``lora_scaling``.
+    Adapters are built in ``__init__`` from their stored configs, following
+    the standard torchtitan Config → build pattern.
+    """
+    if parent_cls in _lora_class_cache:
+        return _lora_class_cache[parent_cls]
+
+    parent_config_cls = parent_cls.Config
+
+    class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls):  # type: ignore[misc]
+            lora_a: Linear.Config
+            lora_b: Linear.Config
+            lora_scaling: float
+
+        def __init__(self, config: Config) -> None:
+            super().__init__(config)
+            for param in nn.Module.parameters(self):
+                param.requires_grad_(False)
+            self._lora_scaling = config.lora_scaling
+            self.lora_a = config.lora_a.build()
+            self.lora_b = config.lora_b.build()
+
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            base_out = super().forward(input)
+            lora_out = self.lora_b(self.lora_a(input))
+            return base_out + self._lora_scaling * lora_out
+
+    LoRALinear.__name__ = f"LoRA{parent_cls.__name__}"
+    LoRALinear.__qualname__ = f"LoRA{parent_cls.__name__}"
+    _lora_class_cache[parent_cls] = LoRALinear
+    return LoRALinear
+
+
+@dataclass(kw_only=True, slots=True)
+class LoRAConfig(Configurable.Config):
+    """Config wrapper that applies LoRA to any Linear.Config at build time.
+
+    Wraps an inner ``Linear.Config`` (which may be ``Float8Linear.Config``,
+    ``MXFP8Linear.Config``, or plain ``Linear.Config``) and builds a
+    LoRA subclass directly — one ``__init__`` that initialises both the
+    base linear and the LoRA adapters.
+
+    Delegates unknown attribute access (e.g. ``sharding_config``) to the
+    inner config so that sharding and other config-level operations work
+    transparently through the wrapper.
+    """
+
+    inner: Linear.Config
+    """The original Linear config (preserved for composition with quantization)."""
+
+    rank: int = 16
+    alpha: float = 16.0
+
+    def __getattr__(self, name: str):
+        try:
+            inner = object.__getattribute__(self, "inner")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(inner, name)
+
+    def __setattr__(self, name: str, value) -> None:
+        if name in type(self).__slots__:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self.inner, name, value)
+
+    def build(self, **kwargs):
+        inner = self.inner
+        assert inner._owner is not None
+        lora_cls = _get_lora_cls(inner._owner)
+
+        lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(inner.sharding_config)
+        config = lora_cls.Config(
+            **{f.name: getattr(inner, f.name) for f in fields(inner)},
+            lora_a=Linear.Config(
+                in_features=inner.in_features,
+                out_features=self.rank,
+                bias=False,
+                sharding_config=lora_a_sharding,
+                param_init={
+                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
+                },
+            ),
+            lora_b=Linear.Config(
+                in_features=self.rank,
+                out_features=inner.out_features,
+                bias=False,
+                sharding_config=lora_b_sharding,
+                param_init={"weight": nn.init.zeros_},
+            ),
+            lora_scaling=self.alpha / self.rank,
+        )
+        return config.build()
+
+
+@dataclass(kw_only=True, slots=True)
+class FrozenConfig(Configurable.Config):
+    """Config wrapper that freezes all parameters at build time.
+
+    Works with any ``Module.Config`` — used by ``LoRAConverter`` to freeze
+    non-target modules (linears, norms, embeddings) so that only LoRA
+    adapter parameters remain trainable.
+    """
+
+    inner: Configurable.Config
+
+    def __getattr__(self, name: str):
+        try:
+            inner = object.__getattribute__(self, "inner")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(inner, name)
+
+    def __setattr__(self, name: str, value) -> None:
+        if name in type(self).__slots__:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self.inner, name, value)
+
+    def build(self, **kwargs):
+        instance = self.inner.build(**kwargs)
+        instance.requires_grad_(False)
+        return instance
+
+
+class LoRAConverter(Configurable):
+    """Apply LoRA adapters to Linear layers in a model.
+
+    Operates on the model config tree: walks for ``Linear.Config`` entries
+    and wraps them in ``LoRAConfig``. The base module is built first by the
+    inner config, then ``apply_lora`` dynamically wraps it — preserving
+    composition with quantization (Float8, MX, etc.).
+
+    When ``target_modules`` is None (default), every ``Linear.Config`` is
+    wrapped.  When specified, only configs whose FQN's last segment matches
+    one of the entries are converted (e.g. ``["wq", "wv"]``).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        rank: int = 8
+        """Rank of the LoRA matrices."""
+
+        alpha: float = 16.0
+        """Scaling factor. Output is scaled by alpha/rank."""
+
+        target_modules: list[str] | None = None
+        """Module names to apply LoRA to (matched against the last segment of the FQN).
+        None means all Linear layers. An empty list means no layers."""
+
+    def __init__(self, config: Config, **kwargs):
+        if config.rank <= 0:
+            raise ValueError(f"LoRA rank must be positive, got {config.rank}")
+        self.config = config
+        self.rank = config.rank
+        self.alpha = config.alpha
+        self.target_modules = (
+            set(config.target_modules) if config.target_modules is not None else None
+        )
+        if self.target_modules is None:
+            logger.info(
+                f"LoRA training active with rank={self.rank}, alpha={self.alpha} "
+                f"(all Linear layers)"
+            )
+        else:
+            logger.info(
+                f"LoRA training active with rank={self.rank}, alpha={self.alpha}, "
+                f"target_modules={sorted(self.target_modules)}"
+            )
+
+    def convert(self, model_config) -> None:
+        """Walk the model config tree for all leaf modules.
+
+        Target Linear modules are wrapped with ``LoRAConfig`` (trainable
+        adapters, frozen base weight).  Everything else (non-target linears,
+        norms, embeddings) is wrapped with ``FrozenConfig``.  All freezing
+        happens at build time — no separate freeze step needed.
+        """
+        from torchtitan.models.common.embedding import Embedding
+        from torchtitan.models.common.rmsnorm import RMSNorm
+
+        matched = set()
+
+        # Wrap all Linear.Config entries
+        for fqn, cfg, parent, attr in model_config.traverse(Linear.Config):
+            last_segment = fqn.rsplit(".", 1)[-1]
+            is_target = (
+                self.target_modules is None or last_segment in self.target_modules
+            )
+            if is_target:
+                wrapped = LoRAConfig(
+                    inner=cfg,
+                    rank=self.rank,
+                    alpha=self.alpha,
+                )
+                matched.add(last_segment)
+            else:
+                wrapped = FrozenConfig(inner=cfg)
+
+            if isinstance(parent, list):
+                parent[attr] = wrapped
+            else:
+                setattr(parent, attr, wrapped)
+
+        # Freeze non-Linear leaf modules (norms, embeddings)
+        for config_cls in (RMSNorm.Config, Embedding.Config):
+            for _fqn, cfg, parent, attr in model_config.traverse(config_cls):
+                wrapped = FrozenConfig(inner=cfg)
+                if isinstance(parent, list):
+                    parent[attr] = wrapped
+                else:
+                    setattr(parent, attr, wrapped)
+
+        unmatched = (self.target_modules or set()) - matched
+        if unmatched:
+            logger.warning(
+                f"LoRA target_modules {sorted(unmatched)} did not match any "
+                f"Linear.Config in the model config tree."
+            )

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -60,7 +60,7 @@ def _get_lora_cls(parent_cls: type) -> type:
     if parent_cls in _lora_class_cache:
         return _lora_class_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config
+    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
 
     class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -127,7 +127,7 @@ class LoRAConfig(Configurable.Config):
         lora_cls = _get_lora_cls(inner._owner)
 
         lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(inner.sharding_config)
-        config = lora_cls.Config(
+        config = lora_cls.Config(  # pyrefly: ignore [missing-attribute]
             **{f.name: getattr(inner, f.name) for f in fields(inner)},
             lora_a=Linear.Config(
                 in_features=inner.in_features,

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -94,8 +94,7 @@ class FrozenConfig(Configurable.Config):
     """Config wrapper that freezes all parameters at build time.
 
     Works with any ``Module.Config`` — used by ``LoRAConverter`` to freeze
-    non-target modules (linears, norms, embeddings) so that only LoRA
-    adapter parameters remain trainable.
+    non-target Linear modules.
     """
 
     inner: Configurable.Config
@@ -124,7 +123,7 @@ class LoRAConverter(ModelConfigConverter):
 
     Operates on the model config tree: target Linear configs are replaced
     with ``LoRALinear.Config`` (which builds a LoRA subclass with frozen base
-    and trainable adapters). Non-target modules are wrapped with
+    and trainable adapters). Non-target Linear modules are wrapped with
     ``FrozenConfig``.
 
     When ``target_modules`` is None (default), every ``Linear.Config`` is
@@ -191,11 +190,11 @@ class LoRAConverter(ModelConfigConverter):
         )
 
     def convert(self, model_config) -> None:
-        """Walk the model config tree for all leaf modules.
+        """Walk the model config tree for Linear modules.
 
         Target Linear modules get their config replaced with
-        ``LoRALinear.Config``.  Everything else is wrapped with
-        ``FrozenConfig``.
+        ``LoRALinear.Config``.  Non-target Linear modules are wrapped
+        with ``FrozenConfig``.
         """
         matched = set()
 

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -15,6 +15,7 @@ from torch.distributed.tensor import Replicate
 from torchtitan.config import Configurable
 from torchtitan.models.common.decoder_sharding import dense_param_placement
 from torchtitan.models.common.linear import Linear
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.sharding import ShardingConfig
 from torchtitan.tools.logging import logger
 
@@ -60,7 +61,7 @@ def _get_lora_cls(parent_cls: type) -> type:
     if parent_cls in _lora_class_cache:
         return _lora_class_cache[parent_cls]
 
-    parent_config_cls = parent_cls.Config  # pyrefly: ignore [missing-attribute]
+    parent_config_cls = parent_cls.Config
 
     class LoRALinear(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
@@ -86,68 +87,6 @@ def _get_lora_cls(parent_cls: type) -> type:
     LoRALinear.__qualname__ = f"LoRA{parent_cls.__name__}"
     _lora_class_cache[parent_cls] = LoRALinear
     return LoRALinear
-
-
-@dataclass(kw_only=True, slots=True)
-class LoRAConfig(Configurable.Config):
-    """Config wrapper that applies LoRA to any Linear.Config at build time.
-
-    Wraps an inner ``Linear.Config`` (which may be ``Float8Linear.Config``,
-    ``MXFP8Linear.Config``, or plain ``Linear.Config``) and builds a
-    LoRA subclass directly — one ``__init__`` that initialises both the
-    base linear and the LoRA adapters.
-
-    Delegates unknown attribute access (e.g. ``sharding_config``) to the
-    inner config so that sharding and other config-level operations work
-    transparently through the wrapper.
-    """
-
-    inner: Linear.Config
-    """The original Linear config (preserved for composition with quantization)."""
-
-    rank: int = 16
-    alpha: float = 16.0
-
-    def __getattr__(self, name: str):
-        try:
-            inner = object.__getattribute__(self, "inner")
-        except AttributeError:
-            raise AttributeError(name) from None
-        return getattr(inner, name)
-
-    def __setattr__(self, name: str, value) -> None:
-        if name in type(self).__slots__:
-            object.__setattr__(self, name, value)
-        else:
-            setattr(self.inner, name, value)
-
-    def build(self, **kwargs):
-        inner = self.inner
-        assert inner._owner is not None
-        lora_cls = _get_lora_cls(inner._owner)
-
-        lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(inner.sharding_config)
-        config = lora_cls.Config(  # pyrefly: ignore [missing-attribute]
-            **{f.name: getattr(inner, f.name) for f in fields(inner)},
-            lora_a=Linear.Config(
-                in_features=inner.in_features,
-                out_features=self.rank,
-                bias=False,
-                sharding_config=lora_a_sharding,
-                param_init={
-                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
-                },
-            ),
-            lora_b=Linear.Config(
-                in_features=self.rank,
-                out_features=inner.out_features,
-                bias=False,
-                sharding_config=lora_b_sharding,
-                param_init={"weight": nn.init.zeros_},
-            ),
-            lora_scaling=self.alpha / self.rank,
-        )
-        return config.build()
 
 
 @dataclass(kw_only=True, slots=True)
@@ -180,21 +119,21 @@ class FrozenConfig(Configurable.Config):
         return instance
 
 
-class LoRAConverter(Configurable):
+class LoRAConverter(ModelConfigConverter):
     """Apply LoRA adapters to Linear layers in a model.
 
-    Operates on the model config tree: walks for ``Linear.Config`` entries
-    and wraps them in ``LoRAConfig``. The base module is built first by the
-    inner config, then ``apply_lora`` dynamically wraps it — preserving
-    composition with quantization (Float8, MX, etc.).
+    Operates on the model config tree: target Linear configs are replaced
+    with ``LoRALinear.Config`` (which builds a LoRA subclass with frozen base
+    and trainable adapters). Non-target modules are wrapped with
+    ``FrozenConfig``.
 
     When ``target_modules`` is None (default), every ``Linear.Config`` is
-    wrapped.  When specified, only configs whose FQN's last segment matches
+    converted.  When specified, only configs whose FQN's last segment matches
     one of the entries are converted (e.g. ``["wq", "wv"]``).
     """
 
     @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
+    class Config(ModelConfigConverter.Config):
         rank: int = 8
         """Rank of the LoRA matrices."""
 
@@ -225,48 +164,57 @@ class LoRAConverter(Configurable):
                 f"target_modules={sorted(self.target_modules)}"
             )
 
+    def _make_lora_config(self, cfg: Linear.Config):
+        """Create a LoRALinear.Config from a base Linear.Config."""
+        assert cfg._owner is not None
+        lora_cls = _get_lora_cls(cfg._owner)
+        lora_a_sharding, lora_b_sharding = _lora_adapter_sharding(cfg.sharding_config)
+        return lora_cls.Config(
+            **{f.name: getattr(cfg, f.name) for f in fields(cfg)},
+            lora_a=Linear.Config(
+                in_features=cfg.in_features,
+                out_features=self.rank,
+                bias=False,
+                sharding_config=lora_a_sharding,
+                param_init={
+                    "weight": lambda w: nn.init.kaiming_uniform_(w, a=math.sqrt(5)),
+                },
+            ),
+            lora_b=Linear.Config(
+                in_features=self.rank,
+                out_features=cfg.out_features,
+                bias=False,
+                sharding_config=lora_b_sharding,
+                param_init={"weight": nn.init.zeros_},
+            ),
+            lora_scaling=self.alpha / self.rank,
+        )
+
     def convert(self, model_config) -> None:
         """Walk the model config tree for all leaf modules.
 
-        Target Linear modules are wrapped with ``LoRAConfig`` (trainable
-        adapters, frozen base weight).  Everything else (non-target linears,
-        norms, embeddings) is wrapped with ``FrozenConfig``.  All freezing
-        happens at build time — no separate freeze step needed.
+        Target Linear modules get their config replaced with
+        ``LoRALinear.Config``.  Everything else is wrapped with
+        ``FrozenConfig``.
         """
-        from torchtitan.models.common.embedding import Embedding
-        from torchtitan.models.common.rmsnorm import RMSNorm
-
         matched = set()
 
-        # Wrap all Linear.Config entries
+        # First pass: replace target Linears with LoRA, freeze non-targets
         for fqn, cfg, parent, attr in model_config.traverse(Linear.Config):
             last_segment = fqn.rsplit(".", 1)[-1]
             is_target = (
                 self.target_modules is None or last_segment in self.target_modules
             )
             if is_target:
-                wrapped = LoRAConfig(
-                    inner=cfg,
-                    rank=self.rank,
-                    alpha=self.alpha,
-                )
+                new_cfg = self._make_lora_config(cfg)
                 matched.add(last_segment)
             else:
-                wrapped = FrozenConfig(inner=cfg)
+                new_cfg = FrozenConfig(inner=cfg)
 
             if isinstance(parent, list):
-                parent[attr] = wrapped
+                parent[attr] = new_cfg
             else:
-                setattr(parent, attr, wrapped)
-
-        # Freeze non-Linear leaf modules (norms, embeddings)
-        for config_cls in (RMSNorm.Config, Embedding.Config):
-            for _fqn, cfg, parent, attr in model_config.traverse(config_cls):
-                wrapped = FrozenConfig(inner=cfg)
-                if isinstance(parent, list):
-                    parent[attr] = wrapped
-                else:
-                    setattr(parent, attr, wrapped)
+                setattr(parent, attr, new_cfg)
 
         unmatched = (self.target_modules or set()) - matched
         if unmatched:

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -15,8 +15,8 @@
 
 from dataclasses import dataclass
 
-from torchtitan.config import Configurable
 from torchtitan.models.common.linear import Linear
+from torchtitan.protocols.model import ModelConfigConverter
 
 
 @dataclass(kw_only=True, slots=True)
@@ -32,7 +32,7 @@ class _QuantizedGroupedExpertsConfig:
     pass
 
 
-class QuantizationConverter(Configurable):
+class QuantizationConverter(ModelConfigConverter):
     """Base class for quantization converters.
 
     Subclasses define a nested Config and implement ``convert()``
@@ -40,12 +40,9 @@ class QuantizationConverter(Configurable):
     """
 
     @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
+    class Config(ModelConfigConverter.Config):
         model_compile_enabled: bool = False
         """Whether torch.compile is enabled for the model."""
-
-    def convert(self, model_config) -> None:
-        raise NotImplementedError
 
 
 # Re-export all public symbols so callers can import from the package directly.

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -11,7 +11,7 @@ from typing import Literal
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -535,7 +535,7 @@ def model_registry(
     attn_backend: str = "sdpa",
     moe_comm_backend: str = "standard",
     non_blocking_capacity_factor: float | None = None,
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = deepseekv3_configs[flavor](
         attn_backend=attn_backend,

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -11,7 +11,7 @@ from typing import Literal
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -22,7 +22,7 @@ from torchtitan.models.common.config_utils import (
     make_router_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import Attention, DeepSeekV3Model, DeepSeekV3TransformerBlock
 from .parallelize import parallelize_deepseekv3
@@ -534,16 +534,20 @@ def model_registry(
     attn_backend: str = "sdpa",
     moe_comm_backend: str = "standard",
     non_blocking_capacity_factor: float | None = None,
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = deepseekv3_configs[flavor](
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
         non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="deepseek_v3",
         flavor=flavor,
@@ -552,4 +556,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -11,7 +11,6 @@ from typing import Literal
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -23,6 +22,7 @@ from torchtitan.models.common.config_utils import (
 )
 from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Attention, DeepSeekV3Model, DeepSeekV3TransformerBlock

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -22,7 +22,8 @@ from torchtitan.models.common.config_utils import (
     make_router_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Attention, DeepSeekV3Model, DeepSeekV3TransformerBlock
 from .parallelize import parallelize_deepseekv3
@@ -541,13 +542,10 @@ def model_registry(
         moe_comm_backend=moe_comm_backend,
         non_blocking_capacity_factor=non_blocking_capacity_factor,
     )
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="deepseek_v3",
         flavor=flavor,
@@ -556,5 +554,4 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -117,7 +117,7 @@ def deepseek_v3_671b() -> Trainer.Config:
         model_spec=model_registry(
             "671B",
             attn_backend="flex",
-            quantization=[
+            converters=[
                 Float8LinearConverter.Config(
                     filter_fqns=["output", "router.gate"],
                     model_compile_enabled=model_compile_enabled,

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -9,10 +9,10 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .flux_datasets import FluxDataLoader
 from .model.autoencoder import AutoEncoderParams
@@ -545,12 +545,16 @@ flux_configs = {
 
 def model_registry(
     flavor: str,
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = flux_configs[flavor]()
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="flux",
         flavor=flavor,
@@ -559,4 +563,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=FluxStateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -12,7 +12,8 @@ import torch.nn as nn
 from torchtitan.config import Configurable
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader
 from .model.autoencoder import AutoEncoderParams
@@ -548,13 +549,10 @@ def model_registry(
     converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = flux_configs[flavor]()
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="flux",
         flavor=flavor,
@@ -563,5 +561,4 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=FluxStateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.utils import validate_converter_order
@@ -546,7 +546,7 @@ flux_configs = {
 
 def model_registry(
     flavor: str,
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = flux_configs[flavor]()
     if converters is not None:

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -9,10 +9,11 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.utils import validate_converter_order
+
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -202,7 +202,7 @@ def flux_schnell_mxfp8() -> FluxTrainer.Config:
     )
     config.model_spec = model_registry(
         "flux-schnell",
-        quantization=[
+        converters=[
             MXFP8LinearConverter.Config(
                 model_compile_enabled=model_compile_enabled,
                 fqns=[
@@ -230,7 +230,7 @@ def flux_dev_mxfp8() -> FluxTrainer.Config:
     )
     config.model_spec = model_registry(
         "flux-dev",
-        quantization=[
+        converters=[
             MXFP8LinearConverter.Config(
                 model_compile_enabled=model_compile_enabled,
                 fqns=[

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -10,13 +10,13 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
 from torchtitan.models.common.config_utils import make_token_dispatcher_config
 from torchtitan.models.common.moe import TokenChoiceTopKRouter
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import Attention, GptOssModel, GptOssTransformerBlock
 
@@ -347,14 +347,18 @@ gptoss_configs = {
 def model_registry(
     flavor: str,
     moe_comm_backend: str = "standard",
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = gptoss_configs[flavor](
         moe_comm_backend=moe_comm_backend,
     )
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="gpt_oss",
         flavor=flavor,
@@ -363,4 +367,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=GptOssStateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -16,7 +16,8 @@ from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
 from torchtitan.models.common.config_utils import make_token_dispatcher_config
 from torchtitan.models.common.moe import TokenChoiceTopKRouter
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Attention, GptOssModel, GptOssTransformerBlock
 
@@ -352,13 +353,10 @@ def model_registry(
     config = gptoss_configs[flavor](
         moe_comm_backend=moe_comm_backend,
     )
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="gpt_oss",
         flavor=flavor,
@@ -367,5 +365,4 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=GptOssStateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
 from torchtitan.models.common.config_utils import make_token_dispatcher_config
@@ -348,7 +348,7 @@ gptoss_configs = {
 def model_registry(
     flavor: str,
     moe_comm_backend: str = "standard",
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = gptoss_configs[flavor](
         moe_comm_backend=moe_comm_backend,

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -10,13 +10,13 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.models.common import Embedding, Linear, RMSNorm, RoPE, TransformerBlock
 from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
 from torchtitan.models.common.config_utils import make_token_dispatcher_config
 from torchtitan.models.common.moe import TokenChoiceTopKRouter
 from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Attention, GptOssModel, GptOssTransformerBlock

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -25,7 +25,7 @@ from torchtitan.models.common.config_utils import (
     make_gqa_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import Llama3Model, Llama3TransformerBlock
 from .parallelize import parallelize_llama
@@ -377,12 +377,16 @@ llama3_configs = {
 def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = llama3_configs[flavor](attn_backend=attn_backend)
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="llama3",
         flavor=flavor,
@@ -391,4 +395,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -25,7 +25,8 @@ from torchtitan.models.common.config_utils import (
     make_gqa_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Llama3Model, Llama3TransformerBlock
 from .parallelize import parallelize_llama
@@ -380,13 +381,10 @@ def model_registry(
     converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = llama3_configs[flavor](attn_backend=attn_backend)
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="llama3",
         flavor=flavor,
@@ -395,5 +393,4 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -378,7 +378,7 @@ llama3_configs = {
 def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = llama3_configs[flavor](attn_backend=attn_backend)
     if converters is not None:

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -9,7 +9,6 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -26,6 +25,8 @@ from torchtitan.models.common.config_utils import (
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.utils import validate_converter_order
+
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Llama3Model, Llama3TransformerBlock

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -111,6 +111,10 @@ def llama3_debugmodel_lora() -> Trainer.Config:
     config.model_spec = model_registry(
         "debugmodel",
         converters=[
+            Float8LinearConverter.Config(
+                emulate=True,
+                model_compile_enabled=False,
+            ),
             LoRAConverter.Config(
                 rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
             ),

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -97,8 +97,23 @@ def llama3_debugmodel_float8() -> Trainer.Config:
     )
     config.model_spec = model_registry(
         "debugmodel",
-        quantization=[
+        converters=[
             Float8LinearConverter.Config(model_compile_enabled=model_compile_enabled),
+        ],
+    )
+    return config
+
+
+def llama3_debugmodel_lora() -> Trainer.Config:
+    from torchtitan.components.lora import LoRAConverter
+
+    config = llama3_debugmodel()
+    config.model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            LoRAConverter.Config(
+                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
+            ),
         ],
     )
     return config
@@ -117,7 +132,7 @@ def llama3_debugmodel_float8_emulate() -> Trainer.Config:
     config = llama3_debugmodel()
     config.model_spec = model_registry(
         "debugmodel",
-        quantization=[
+        converters=[
             Float8LinearConverter.Config(
                 emulate=True,
                 model_compile_enabled=(
@@ -208,7 +223,7 @@ def llama3_405b() -> Trainer.Config:
         ),
         model_spec=model_registry(
             "405B",
-            quantization=[
+            converters=[
                 Float8LinearConverter.Config(
                     filter_fqns=["output"],
                     model_compile_enabled=(

--- a/torchtitan/models/llama4/__init__.py
+++ b/torchtitan/models/llama4/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -29,7 +29,7 @@ from torchtitan.models.common.config_utils import (
     make_router_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import compute_moe_hidden_dim, Llama4Model, Llama4TransformerBlock
 from .parallelize import parallelize_llama
@@ -349,15 +349,19 @@ def model_registry(
     flavor: str,
     attn_backend: str = "flex",
     moe_comm_backend: str = "standard",
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     config = llama4_configs[flavor](
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
     )
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="llama4",
         flavor=flavor,
@@ -366,4 +370,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=Llama4StateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/llama4/__init__.py
+++ b/torchtitan/models/llama4/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -350,7 +350,7 @@ def model_registry(
     flavor: str,
     attn_backend: str = "flex",
     moe_comm_backend: str = "standard",
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     config = llama4_configs[flavor](
         attn_backend=attn_backend,

--- a/torchtitan/models/llama4/__init__.py
+++ b/torchtitan/models/llama4/__init__.py
@@ -29,7 +29,8 @@ from torchtitan.models.common.config_utils import (
     make_router_config,
 )
 from torchtitan.models.common.param_init import depth_scaled_std
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import compute_moe_hidden_dim, Llama4Model, Llama4TransformerBlock
 from .parallelize import parallelize_llama
@@ -355,13 +356,10 @@ def model_registry(
         attn_backend=attn_backend,
         moe_comm_backend=moe_comm_backend,
     )
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="llama4",
         flavor=flavor,
@@ -370,5 +368,4 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=Llama4StateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/llama4/__init__.py
+++ b/torchtitan/models/llama4/__init__.py
@@ -10,7 +10,6 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import (
     compute_ffn_hidden_dim,
@@ -30,6 +29,7 @@ from torchtitan.models.common.config_utils import (
 )
 from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import compute_moe_hidden_dim, Llama4Model, Llama4TransformerBlock

--- a/torchtitan/models/llama4/config_registry.py
+++ b/torchtitan/models/llama4/config_registry.py
@@ -70,7 +70,7 @@ def llama4_debugmodel_fp8() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry(
             "debugmodel",
-            quantization=[
+            converters=[
                 Float8GroupedExpertsConverter.Config(
                     model_compile_enabled=(
                         compile_config.enable and "model" in compile_config.components

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
@@ -24,7 +24,7 @@ from torchtitan.models.common.config_utils import (
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import Qwen3Model, Qwen3TransformerBlock
 from .parallelize import parallelize_qwen3
@@ -619,15 +619,19 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str | None = None,
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     kwargs = dict(attn_backend=attn_backend)
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_configs[flavor](**kwargs)
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="qwen3",
         flavor=flavor,
@@ -636,4 +640,5 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3StateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
@@ -620,7 +620,7 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str | None = None,
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     kwargs = dict(attn_backend=attn_backend)
     if moe_comm_backend is not None:

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -24,7 +24,8 @@ from torchtitan.models.common.config_utils import (
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Qwen3Model, Qwen3TransformerBlock
 from .parallelize import parallelize_qwen3
@@ -625,13 +626,10 @@ def model_registry(
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_configs[flavor](**kwargs)
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="qwen3",
         flavor=flavor,
@@ -640,5 +638,4 @@ def model_registry(
         pipelining_fn=pipeline_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3StateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -10,8 +10,6 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.protocols.model import ModelConfigConverter
-
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -25,6 +23,8 @@ from torchtitan.models.common.config_utils import (
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.utils import validate_converter_order
+
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Qwen3Model, Qwen3TransformerBlock

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.config import Configurable
 
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -23,7 +23,7 @@ from torchtitan.models.common.config_utils import (
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.qwen3.model import Qwen3TransformerBlock
-from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
 
 from .model import Qwen3VLModel
 from .parallelize import parallelize_qwen3_vl
@@ -574,15 +574,19 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str | None = None,
-    quantization: list[QuantizationConverter.Config] | None = None,
+    converters: list[Configurable.Config] | None = None,
 ) -> ModelSpec:
     kwargs = dict(attn_backend=attn_backend)
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_vl_configs[flavor](**kwargs)
-    if quantization is not None:
-        for q in quantization:
-            q.build().convert(config)
+    built_converters: list = []
+    if converters is not None:
+        for c in converters:
+            built_converters.append(c.build())
+        validate_converter_order(built_converters)
+        for converter in built_converters:
+            converter.convert(config)
     return ModelSpec(
         name="qwen3_vl",
         flavor=flavor,
@@ -591,4 +595,5 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3VLStateDictAdapter,
+        converters=built_converters,
     )

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -9,8 +9,6 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.protocols.model import ModelConfigConverter
-
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
     get_attention_config,
@@ -24,6 +22,8 @@ from torchtitan.models.common.param_init import depth_scaled_std, skip_param_ini
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.qwen3.model import Qwen3TransformerBlock
 from torchtitan.models.utils import validate_converter_order
+
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Qwen3VLModel

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.config import Configurable
+from torchtitan.protocols.model import ModelConfigConverter
 
 from torchtitan.models.common import Embedding, Linear, RoPE, TransformerBlock
 from torchtitan.models.common.config_utils import (
@@ -575,7 +575,7 @@ def model_registry(
     flavor: str,
     attn_backend: str = "sdpa",
     moe_comm_backend: str | None = None,
-    converters: list[Configurable.Config] | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
     kwargs = dict(attn_backend=attn_backend)
     if moe_comm_backend is not None:

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -23,7 +23,8 @@ from torchtitan.models.common.config_utils import (
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.qwen3.model import Qwen3TransformerBlock
-from torchtitan.protocols.model_spec import ModelSpec, validate_converter_order
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import Qwen3VLModel
 from .parallelize import parallelize_qwen3_vl
@@ -580,13 +581,10 @@ def model_registry(
     if moe_comm_backend is not None:
         kwargs["moe_comm_backend"] = moe_comm_backend
     config = qwen3_vl_configs[flavor](**kwargs)
-    built_converters: list = []
     if converters is not None:
+        validate_converter_order(converters)
         for c in converters:
-            built_converters.append(c.build())
-        validate_converter_order(built_converters)
-        for converter in built_converters:
-            converter.convert(config)
+            c.build().convert(config)
     return ModelSpec(
         name="qwen3_vl",
         flavor=flavor,
@@ -595,5 +593,4 @@ def model_registry(
         pipelining_fn=None,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3VLStateDictAdapter,
-        converters=built_converters,
     )

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -16,6 +16,28 @@ from torchtitan.protocols.state_dict_adapter import StateDictAdapter
 from torchtitan.tools.logging import logger
 
 
+def validate_converter_order(converters: list) -> None:
+    """Validate that quantization/QAT converters precede LoRA.
+
+    Raises ``ValueError`` if a quantization converter appears after a LoRA
+    converter in the list.
+    """
+    from torchtitan.components.lora import LoRAConverter
+    from torchtitan.components.quantization import QuantizationConverter
+
+    _BEFORE_LORA = (QuantizationConverter.Config,)
+
+    seen_lora = False
+    for converter in converters:
+        if isinstance(converter, LoRAConverter.Config):
+            seen_lora = True
+        elif seen_lora and isinstance(converter, _BEFORE_LORA):
+            raise ValueError(
+                f"{type(converter).__name__} must be applied before "
+                f"LoRAConverter. Reorder the converters list."
+            )
+
+
 class MoEStateDictAdapter(StateDictAdapter):
     """
     StateDictAdapter for MoE models.

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -7,7 +7,20 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 
+from torchtitan.config import Configurable
+
 from .module import Module
+
+
+class ModelConfigConverter(Configurable):
+    """Base class for converters that transform the model config tree.
+
+    Subclasses implement ``convert()`` to modify configs before model build
+    (e.g. quantization, LoRA).
+    """
+
+    def convert(self, model_config) -> None:
+        raise NotImplementedError
 
 
 class BaseModel(Module):

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -19,6 +19,11 @@ class ModelConfigConverter(Configurable):
     (e.g. quantization, LoRA).
     """
 
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        pass
+
+    @abstractmethod
     def convert(self, model_config) -> None:
         raise NotImplementedError
 

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
-from dataclasses import dataclass
-from typing import TypeAlias
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
 
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
@@ -21,6 +21,28 @@ PipeliningFunction: TypeAlias = Callable[
 ]
 FragmentFunction: TypeAlias = Callable[..., list[nn.Module]]
 PostOptimizerBuildFn: TypeAlias = Callable[..., None]
+
+
+def validate_converter_order(converters: list) -> None:
+    """Validate that quantization/QAT converters precede LoRA.
+
+    Raises ``ValueError`` if a quantization converter appears after a LoRA
+    converter in the list.
+    """
+    from torchtitan.components.lora import LoRAConverter
+    from torchtitan.components.quantization import QuantizationConverter
+
+    _BEFORE_LORA = (QuantizationConverter,)
+
+    seen_lora = False
+    for converter in converters:
+        if isinstance(converter, LoRAConverter):
+            seen_lora = True
+        elif seen_lora and isinstance(converter, _BEFORE_LORA):
+            raise ValueError(
+                f"{type(converter).__name__} must be applied before "
+                f"LoRAConverter. Reorder the converters list."
+            )
 
 
 @dataclass
@@ -41,3 +63,4 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+    converters: list[Any] = field(default_factory=list)

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
-from typing import Any, TypeAlias
+from dataclasses import dataclass
+from typing import TypeAlias
 
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
@@ -21,28 +21,6 @@ PipeliningFunction: TypeAlias = Callable[
 ]
 FragmentFunction: TypeAlias = Callable[..., list[nn.Module]]
 PostOptimizerBuildFn: TypeAlias = Callable[..., None]
-
-
-def validate_converter_order(converters: list) -> None:
-    """Validate that quantization/QAT converters precede LoRA.
-
-    Raises ``ValueError`` if a quantization converter appears after a LoRA
-    converter in the list.
-    """
-    from torchtitan.components.lora import LoRAConverter
-    from torchtitan.components.quantization import QuantizationConverter
-
-    _BEFORE_LORA = (QuantizationConverter,)
-
-    seen_lora = False
-    for converter in converters:
-        if isinstance(converter, LoRAConverter):
-            seen_lora = True
-        elif seen_lora and isinstance(converter, _BEFORE_LORA):
-            raise ValueError(
-                f"{type(converter).__name__} must be applied before "
-                f"LoRAConverter. Reorder the converters list."
-            )
 
 
 @dataclass
@@ -63,4 +41,3 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
-    converters: list[Any] = field(default_factory=list)

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -212,7 +212,10 @@ class Module(nn.Module, Configurable):
             )
             self.register_parameter(
                 name,
-                nn.Parameter(distribute_tensor(param, mesh, list(placements))),
+                nn.Parameter(
+                    distribute_tensor(param, mesh, list(placements)),
+                    requires_grad=param.requires_grad,
+                ),
             )
 
         for name, buffer in self.named_buffers(recurse=False):


### PR DESCRIPTION
Add config-level LoRA converter infrastructure:
- LoRAConfig wraps any Linear.Config, builds LoRA subclass with frozen base and trainable lora_a/lora_b adapters
- FrozenConfig wraps any Module.Config, freezes all params at build time
- LoRAConverter walks model config tree, wraps targets with LoRAConfig and non-targets with FrozenConfig
- Dynamic LoRA class factory (_get_lora_cls) composes with quantization (Float8, MXFP8)

Rename model_registry parameter from 'quantization' to 'converters' across all models (llama3, llama4, deepseek_v3, qwen3, qwen3_vl, gpt_oss, flux) to support both quantization and LoRA converters.

Add validate_converter_order to ensure quantization precedes LoRA. Preserve requires_grad through DTensor distribution in Module.