### PR TITLE
[Quantization] Add QAT (quantization-aware training) converter

### DIFF
--- a/tests/unit_tests/test_qat.py
+++ b/tests/unit_tests/test_qat.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import OrderedDict
-
 import pytest
 import torch
-import torch.nn as nn
 
-from torchtitan.components.quantization.qat import QATConverter
+from torchtitan.components.quantization.qat import (
+    convert_qat_to_linear,
+    QATConverter,
+    QATLinearConfig,
+)
 
 
 @pytest.mark.parametrize(
@@ -26,37 +27,18 @@ from torchtitan.components.quantization.qat import QATConverter
     ],
 )
 def test_qat_all_schemes(scheme, group_size, expected_linear_cls):
-    """Each QAT scheme should replace nn.Linear with the correct fake-quantized class."""
+    """Each QAT scheme should replace Linear with the correct fake-quantized class."""
     pytest.importorskip("torchao")
 
-    model = nn.Sequential(
-        OrderedDict(
-            [
-                ("fc1", nn.Linear(64, 64)),
-                ("relu", nn.ReLU()),
-                ("fc2", nn.Linear(64, 64)),
-            ]
-        )
-    )
-    original_dtypes = {name: param.dtype for name, param in model.named_parameters()}
-
-    config_kwargs = {"scheme": scheme}
+    config_kwargs = {"_scheme": scheme}
     if group_size is not None:
-        config_kwargs["group_size"] = group_size
-    converter = QATConverter(QATConverter.Config(**config_kwargs))
-    converter.convert(model)
+        config_kwargs["_group_size"] = group_size
+    config = QATLinearConfig(in_features=64, out_features=64, **config_kwargs)
+    mod = config.build()
 
     assert (
-        type(model.fc1).__name__ == expected_linear_cls
-    ), f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc1).__name__}"
-    assert (
-        type(model.fc2).__name__ == expected_linear_cls
-    ), f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc2).__name__}"
-
-    for name, param in model.named_parameters():
-        assert (
-            param.dtype == original_dtypes[name]
-        ), f"'{name}' dtype changed from {original_dtypes[name]} to {param.dtype}"
+        type(mod).__name__ == expected_linear_cls
+    ), f"scheme={scheme}: expected {expected_linear_cls}, got {type(mod).__name__}"
 
 
 def test_qat_unknown_scheme_raises():
@@ -83,20 +65,52 @@ def test_qat_forward():
     """QAT model forward should produce correct output shape."""
     pytest.importorskip("torchao")
 
-    model = nn.Sequential(
-        OrderedDict(
-            [
-                ("fc1", nn.Linear(64, 64)),
-                ("relu", nn.ReLU()),
-                ("fc2", nn.Linear(64, 32)),
-            ]
-        )
+    config = QATLinearConfig(
+        in_features=64, out_features=32, _scheme="intx_weight_only", _group_size=64
     )
-    converter = QATConverter(
-        QATConverter.Config(scheme="intx_weight_only", group_size=64)
-    )
-    converter.convert(model)
+    mod = config.build()
 
     x = torch.randn(4, 64)
-    out = model(x)
+    out = mod(x)
     assert out.shape == (4, 32)
+
+
+def test_qat_converter_config_tree():
+    """QATConverter should swap Linear.Config -> QATLinear.Config in config tree."""
+    pytest.importorskip("torchao")
+    from torchtitan.models.llama3 import model_registry
+
+    spec = model_registry(
+        "debugmodel",
+        quantization=[
+            QATConverter.Config(scheme="int4_weight_only", group_size=64),
+        ],
+    )
+
+    with torch.device("meta"):
+        model = spec.model.build()
+
+    fake_quant_count = 0
+    for name, mod in model.named_modules():
+        if "FakeQuantized" in type(mod).__name__:
+            fake_quant_count += 1
+
+    assert fake_quant_count > 0, "No FakeQuantizedLinear modules found after QAT"
+
+
+def test_convert_qat_to_linear():
+    """convert_qat_to_linear should strip fake quant back to nn.Linear."""
+    pytest.importorskip("torchao")
+    import torch.nn as nn
+
+    config = QATLinearConfig(
+        in_features=64, out_features=64, _scheme="int4_weight_only", _group_size=64
+    )
+    mod = config.build()
+    assert "FakeQuantized" in type(mod).__name__
+
+    parent = nn.Sequential(mod)
+    convert_qat_to_linear(parent)
+
+    assert type(parent[0]) is nn.Linear
+    assert parent[0].weight.shape == (64, 64)

--- a/tests/unit_tests/test_qat.py
+++ b/tests/unit_tests/test_qat.py
@@ -1,0 +1,102 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import OrderedDict
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchtitan.components.quantization.qat import QATConverter
+
+
+@pytest.mark.parametrize(
+    "scheme, group_size, expected_linear_cls",
+    [
+        ("int4_weight_only", 64, "FakeQuantizedLinear"),
+        ("intx_weight_only", 64, "FakeQuantizedLinear"),
+        ("int8_dynamic_act_intx_weight", 64, "FakeQuantizedLinear"),
+        ("float8_dynamic_act_float8_weight", None, "FakeQuantizedLinear"),
+        ("float8_dynamic_act_int4_weight", None, "FakeQuantizedLinear"),
+        ("nvfp4", None, "NVFP4FakeQuantizedLinear"),
+        ("mx", None, "MXFakeQuantizedLinear"),
+    ],
+)
+def test_qat_all_schemes(scheme, group_size, expected_linear_cls):
+    """Each QAT scheme should replace nn.Linear with the correct fake-quantized class."""
+    pytest.importorskip("torchao")
+
+    model = nn.Sequential(
+        OrderedDict(
+            [
+                ("fc1", nn.Linear(64, 64)),
+                ("relu", nn.ReLU()),
+                ("fc2", nn.Linear(64, 64)),
+            ]
+        )
+    )
+    original_dtypes = {name: param.dtype for name, param in model.named_parameters()}
+
+    config_kwargs = {"scheme": scheme}
+    if group_size is not None:
+        config_kwargs["group_size"] = group_size
+    converter = QATConverter(QATConverter.Config(**config_kwargs))
+    converter.convert(model)
+
+    assert type(model.fc1).__name__ == expected_linear_cls, (
+        f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc1).__name__}"
+    )
+    assert type(model.fc2).__name__ == expected_linear_cls, (
+        f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc2).__name__}"
+    )
+
+    for name, param in model.named_parameters():
+        assert param.dtype == original_dtypes[name], (
+            f"'{name}' dtype changed from {original_dtypes[name]} to {param.dtype}"
+        )
+
+
+def test_qat_unknown_scheme_raises():
+    """QATConverter should raise ValueError for unknown schemes."""
+    with pytest.raises(ValueError, match="Unknown QAT scheme"):
+        QATConverter(QATConverter.Config(scheme="not_a_real_scheme"))
+
+
+def test_qat_group_size_warning_for_unsupported_scheme(caplog):
+    """QATConverter should warn when group_size is set for a scheme that ignores it."""
+    pytest.importorskip("torchao")
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        QATConverter(
+            QATConverter.Config(
+                scheme="float8_dynamic_act_float8_weight", group_size=64
+            )
+        )
+    assert "does not use group_size" in caplog.text
+
+
+def test_qat_forward():
+    """QAT model forward should produce correct output shape."""
+    pytest.importorskip("torchao")
+
+    model = nn.Sequential(
+        OrderedDict(
+            [
+                ("fc1", nn.Linear(64, 64)),
+                ("relu", nn.ReLU()),
+                ("fc2", nn.Linear(64, 32)),
+            ]
+        )
+    )
+    converter = QATConverter(
+        QATConverter.Config(scheme="intx_weight_only", group_size=64)
+    )
+    converter.convert(model)
+
+    x = torch.randn(4, 64)
+    out = model(x)
+    assert out.shape == (4, 32)

--- a/tests/unit_tests/test_qat.py
+++ b/tests/unit_tests/test_qat.py
@@ -46,17 +46,17 @@ def test_qat_all_schemes(scheme, group_size, expected_linear_cls):
     converter = QATConverter(QATConverter.Config(**config_kwargs))
     converter.convert(model)
 
-    assert type(model.fc1).__name__ == expected_linear_cls, (
-        f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc1).__name__}"
-    )
-    assert type(model.fc2).__name__ == expected_linear_cls, (
-        f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc2).__name__}"
-    )
+    assert (
+        type(model.fc1).__name__ == expected_linear_cls
+    ), f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc1).__name__}"
+    assert (
+        type(model.fc2).__name__ == expected_linear_cls
+    ), f"scheme={scheme}: expected {expected_linear_cls}, got {type(model.fc2).__name__}"
 
     for name, param in model.named_parameters():
-        assert param.dtype == original_dtypes[name], (
-            f"'{name}' dtype changed from {original_dtypes[name]} to {param.dtype}"
-        )
+        assert (
+            param.dtype == original_dtypes[name]
+        ), f"'{name}' dtype changed from {original_dtypes[name]} to {param.dtype}"
 
 
 def test_qat_unknown_scheme_raises():

--- a/torchtitan/components/quantization/qat.py
+++ b/torchtitan/components/quantization/qat.py
@@ -4,10 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 import torch.nn as nn
-from torchtitan.config import Configurable
+
+from torchtitan.components.quantization import (
+    QuantizationConverter,
+    QuantizedLinearConfig,
+)
+from torchtitan.models.common.linear import Linear
+from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 
 _SUPPORTED_SCHEMES = (
@@ -82,81 +88,132 @@ def _build_base_config(scheme: str, group_size: int):
         )
 
 
-def apply_qat_prepare(
-    model: nn.Module,
-    scheme: str,
-    group_size: int,
-    *,
-    filter_fn=None,
-) -> None:
-    """Apply QAT PREPARE step: insert fake quantization into Linear modules.
+def _noop_init(param: nn.Parameter) -> None:
+    pass
 
-    After ``quantize_()``, patches ``init_weights`` onto all new module classes
-    so they satisfy the Module protocol.
 
-    Args:
-        model: The model (or subtree) to quantize.
-        scheme: QAT scheme name (must be in ``_SUPPORTED_SCHEMES``).
-        group_size: Group size for per-group schemes.
-        filter_fn: Optional ``(module, fqn) -> bool`` passed to ``quantize_()``.
-            When None, all ``nn.Linear`` modules are quantized.
+def _patch_module_protocol(mod: nn.Module) -> None:
+    """Make torchao-created modules satisfy torchtitan's Module protocol.
+
+    ``torchao.quantize_()`` replaces ``nn.Linear`` with classes like
+    ``FakeQuantizedLinear`` that don't inherit from torchtitan's ``Module``.
+    This patches the class hierarchy so ``verify_module_protocol()`` passes,
+    and sets ``_param_init`` to skip re-initialization (params are already
+    initialized by the original Linear).
     """
-    from torchao.quantization import quantize_
-    from torchao.quantization.qat import QATConfig
-    from torchao.quantization.qat.api import QATStep
+    for child in mod.modules():
+        if not isinstance(child, Module):
+            cls = type(child)
+            if cls not in _patched_classes:
+                patched = type(cls.__name__, (cls, Module), {})
+                _patched_classes[cls] = patched
+            child.__class__ = _patched_classes[cls]
+            child._param_init = {  # pyrefly: ignore [bad-argument-type]
+                name: _noop_init for name, _ in child.named_parameters(recurse=False)
+            }
 
-    init_params_cache: dict[str, tuple[float, float]] = {}
+
+_patched_classes: dict[type, type] = {}
+
+
+@dataclass(kw_only=True, slots=True)
+class QATLinearConfig(QuantizedLinearConfig):
+    """Config that builds a Linear then applies QAT fake quantization.
+
+    ``torchao.quantize_()`` replaces ``nn.Linear`` children of a parent
+    module, so ``build()`` wraps the freshly built Linear in a temporary
+    parent, runs ``quantize_()``, and returns the swapped child.
+    """
+
+    _scheme: str = "int4_weight_only"
+    _group_size: int = 128
+
+    def build(self, **kwargs):
+        from torchao.quantization import quantize_
+        from torchao.quantization.qat import QATConfig
+        from torchao.quantization.qat.api import QATStep
+
+        base_config_obj = Linear.Config(
+            in_features=self.in_features,
+            out_features=self.out_features,
+            bias=self.bias,
+            param_init=self.param_init,
+            sharding_config=self.sharding_config,
+        )
+        instance = base_config_obj.build(**kwargs)
+        wrapper = nn.Sequential(instance)
+        base_config = _build_base_config(self._scheme, self._group_size)
+        quantize_(wrapper, QATConfig(base_config, step=QATStep.PREPARE))
+        result = wrapper[0]
+        _patch_module_protocol(result)
+        return result
+
+
+def convert_qat_to_linear(model: nn.Module) -> None:
+    """Strip FakeQuantizedLinear back to plain nn.Linear.
+
+    Walks the module tree and replaces any FakeQuantizedLinear with
+    a plain nn.Linear carrying the same weight and bias. Called at
+    end of training so saved checkpoints have clean weights.
+    """
+    replacements: list[tuple[nn.Module, str, nn.Module]] = []
     for name, mod in model.named_modules():
-        if isinstance(mod, nn.Linear) and hasattr(mod, "_init_mean"):
-            init_params_cache[name] = (
-                getattr(mod, "_init_mean", 0.0),
-                getattr(mod, "_init_std", 0.02),
+        if type(mod).__name__ in (
+            "FakeQuantizedLinear",
+            "NVFP4FakeQuantizedLinear",
+            "MXFakeQuantizedLinear",
+        ):
+            new_linear = nn.Linear(
+                mod.in_features,  # pyrefly: ignore [bad-argument-type]
+                mod.out_features,  # pyrefly: ignore [bad-argument-type]
+                bias=mod.bias is not None,
+                device=mod.weight.device,
+                dtype=mod.weight.dtype,
             )
+            new_linear.weight = mod.weight  # pyrefly: ignore [bad-assignment]
+            if mod.bias is not None:
+                new_linear.bias = mod.bias  # pyrefly: ignore [bad-assignment]
+            replacements.append((name, mod, new_linear))
 
-    base_config = _build_base_config(scheme, group_size)
+    for name, _old, new_linear in replacements:
+        parts = name.rsplit(".", 1)
+        if len(parts) == 1:
+            setattr(model, parts[0], new_linear)
+        else:
+            parent = model.get_submodule(parts[0])
+            setattr(parent, parts[1], new_linear)
 
-    kwargs = {}
-    if filter_fn is not None:
-        kwargs["filter_fn"] = filter_fn
-    quantize_(model, QATConfig(base_config, step=QATStep.PREPARE), **kwargs)
-
-    # Restore init params on replaced modules
-    for name, mod in model.named_modules():
-        if isinstance(mod, nn.Linear) and name in init_params_cache:
-            init_mean, init_std = init_params_cache[name]
-            object.__setattr__(mod, "_init_mean", init_mean)
-            object.__setattr__(mod, "_init_std", init_std)
+    if replacements:
+        logger.info(
+            f"Converted {len(replacements)} FakeQuantizedLinear modules back to nn.Linear"
+        )
 
 
-class QATConverter(Configurable):
-    """Apply quantization-aware training via torchao's QATConfig.
+class QATConverter(QuantizationConverter):
+    """Apply quantization-aware training to Linear layers in a model.
 
-    Uses ``torchao.quantize_(model, QATConfig(base_config, step="prepare"))``
-    to insert fake quantization into ``nn.Linear`` modules. The ``scheme``
-    config field selects a torchao PTQ base config, which QATConfig uses to
-    infer the appropriate fake quantization for both weights and activations.
+    Operates on the model config tree: Linear configs are replaced with
+    ``QATLinear.Config`` which builds a QATLinear that applies fake
+    quantization via ``torchao.quantize_()`` in its constructor.
 
     Supported schemes:
-      - ``"int4_weight_only"`` — int4 weight-only fake quantization
-      - ``"intx_weight_only"`` — intx weight-only fake quantization
-      - ``"int8_dynamic_act_intx_weight"`` — int8 activation + int4 weight
-      - ``"float8_dynamic_act_float8_weight"`` — float8 activation + float8 weight
-      - ``"float8_dynamic_act_int4_weight"`` — float8 activation + int4 weight
-      - ``"nvfp4"`` — NVFP4 dynamic activation + NVFP4 weight
-      - ``"mx"`` — MX dynamic activation + MX weight
+      - ``"int4_weight_only"`` -- int4 weight-only fake quantization
+      - ``"intx_weight_only"`` -- intx weight-only fake quantization
+      - ``"int8_dynamic_act_intx_weight"`` -- int8 activation + int4 weight
+      - ``"float8_dynamic_act_float8_weight"`` -- float8 activation + float8 weight
+      - ``"float8_dynamic_act_int4_weight"`` -- float8 activation + int4 weight
+      - ``"nvfp4"`` -- NVFP4 dynamic activation + NVFP4 weight
+      - ``"mx"`` -- MX dynamic activation + MX weight
     """
 
     @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
+    class Config(QuantizationConverter.Config):
         scheme: str = "int4_weight_only"
         """QAT scheme name. Maps to a torchao PTQ base config."""
 
         group_size: int = 128
         """Group size for per-group weight quantization.
         Used by schemes that support per-group granularity."""
-
-        convert_at_end: bool = False
-        """When True, finalize() applies QAT CONVERT step at end of training."""
 
     def __init__(self, config: Config, **kwargs):
         if config.scheme not in _SUPPORTED_SCHEMES:
@@ -166,41 +223,29 @@ class QATConverter(Configurable):
             )
         self.scheme = config.scheme
         self.group_size = config.group_size
-        self.convert_at_end = config.convert_at_end
         if config.scheme not in _SCHEMES_WITH_GROUP_SIZE:
             logger.warning(
                 f"QAT scheme '{config.scheme}' does not use group_size, "
                 f"ignoring group_size={config.group_size}"
             )
         logger.info(
-            f"QAT training active (scheme={self.scheme}, group_size={self.group_size}, "
-            f"convert_at_end={self.convert_at_end})"
+            f"QAT training active (scheme={self.scheme}, group_size={self.group_size})"
         )
 
-    def convert(self, model: nn.Module) -> None:
-        """Apply QAT PREPARE step to the model."""
-        apply_qat_prepare(model, self.scheme, self.group_size)
+    def convert(self, model_config) -> None:
+        """Walk the model config tree, replacing Linear configs with QATLinear configs."""
+        for _fqn, config, parent, attr in model_config.traverse(Linear.Config):
+            new_config = QATLinearConfig(
+                **{f.name: getattr(config, f.name) for f in fields(config)},
+                _scheme=self.scheme,
+                _group_size=self.group_size,
+            )
+            if isinstance(parent, list):
+                parent[attr] = new_config
+            else:
+                setattr(parent, attr, new_config)
+
         logger.info(
-            f"Applied QAT fake quantization (scheme={self.scheme}, "
+            f"Swapped to QATLinear layers (scheme={self.scheme}, "
             f"group_size={self.group_size})"
-        )
-
-    def finalize(self, model: nn.Module) -> None:
-        """Apply QAT CONVERT step, replacing FakeQuantizedLinear with real quantized modules.
-
-        Skipped when convert_at_end is False.
-        """
-        if not self.convert_at_end:
-            return
-
-        from torchao.quantization import quantize_
-        from torchao.quantization.qat import QATConfig
-        from torchao.quantization.qat.api import QATStep
-
-        base_config = _build_base_config(self.scheme, self.group_size)
-        quantize_(model, QATConfig(base_config, step=QATStep.CONVERT))
-
-        logger.info(
-            f"Applied QAT CONVERT (scheme={self.scheme}, group_size={self.group_size}): "
-            "FakeQuantizedLinear modules replaced with real quantized modules"
         )

--- a/torchtitan/components/quantization/qat.py
+++ b/torchtitan/components/quantization/qat.py
@@ -92,14 +92,15 @@ def _noop_init(param: nn.Parameter) -> None:
     pass
 
 
+_patched_classes: dict[type, type] = {}
+
+
 def _patch_module_protocol(mod: nn.Module) -> None:
     """Make torchao-created modules satisfy torchtitan's Module protocol.
 
-    ``torchao.quantize_()`` replaces ``nn.Linear`` with classes like
-    ``FakeQuantizedLinear`` that don't inherit from torchtitan's ``Module``.
-    This patches the class hierarchy so ``verify_module_protocol()`` passes,
-    and sets ``_param_init`` to skip re-initialization (params are already
-    initialized by the original Linear).
+    ``torchao.quantize_()`` creates classes like ``FakeQuantizedLinear``
+    that don't inherit from torchtitan's ``Module``. This patches the
+    class hierarchy and sets ``_param_init`` to skip re-initialization.
     """
     for child in mod.modules():
         if not isinstance(child, Module):
@@ -108,21 +109,21 @@ def _patch_module_protocol(mod: nn.Module) -> None:
                 patched = type(cls.__name__, (cls, Module), {})
                 _patched_classes[cls] = patched
             child.__class__ = _patched_classes[cls]
-            child._param_init = {  # pyrefly: ignore [bad-argument-type]
-                name: _noop_init for name, _ in child.named_parameters(recurse=False)
+            child._param_init = {  # type: ignore[assignment]
+                name: _noop_init
+                for name, _ in child.named_parameters(recurse=False)
             }
-
-
-_patched_classes: dict[type, type] = {}
 
 
 @dataclass(kw_only=True, slots=True)
 class QATLinearConfig(QuantizedLinearConfig):
     """Config that builds a Linear then applies QAT fake quantization.
 
-    ``torchao.quantize_()`` replaces ``nn.Linear`` children of a parent
-    module, so ``build()`` wraps the freshly built Linear in a temporary
-    parent, runs ``quantize_()``, and returns the swapped child.
+    Unlike ``MXFP8Linear`` / ``Float8Linear`` which call ``quantize_(self)``
+    in ``__init__``, QAT's ``quantize_()`` *replaces* the module rather than
+    wrapping parameters in-place. So ``build()`` wraps the freshly built
+    Linear in a temporary parent, runs ``quantize_()``, and returns the
+    swapped ``FakeQuantizedLinear``.
     """
 
     _scheme: str = "int4_weight_only"
@@ -149,52 +150,15 @@ class QATLinearConfig(QuantizedLinearConfig):
         return result
 
 
-def convert_qat_to_linear(model: nn.Module) -> None:
-    """Strip FakeQuantizedLinear back to plain nn.Linear.
-
-    Walks the module tree and replaces any FakeQuantizedLinear with
-    a plain nn.Linear carrying the same weight and bias. Called at
-    end of training so saved checkpoints have clean weights.
-    """
-    replacements: list[tuple[nn.Module, str, nn.Module]] = []
-    for name, mod in model.named_modules():
-        if type(mod).__name__ in (
-            "FakeQuantizedLinear",
-            "NVFP4FakeQuantizedLinear",
-            "MXFakeQuantizedLinear",
-        ):
-            new_linear = nn.Linear(
-                mod.in_features,  # pyrefly: ignore [bad-argument-type]
-                mod.out_features,  # pyrefly: ignore [bad-argument-type]
-                bias=mod.bias is not None,
-                device=mod.weight.device,
-                dtype=mod.weight.dtype,
-            )
-            new_linear.weight = mod.weight  # pyrefly: ignore [bad-assignment]
-            if mod.bias is not None:
-                new_linear.bias = mod.bias  # pyrefly: ignore [bad-assignment]
-            replacements.append((name, mod, new_linear))
-
-    for name, _old, new_linear in replacements:
-        parts = name.rsplit(".", 1)
-        if len(parts) == 1:
-            setattr(model, parts[0], new_linear)
-        else:
-            parent = model.get_submodule(parts[0])
-            setattr(parent, parts[1], new_linear)
-
-    if replacements:
-        logger.info(
-            f"Converted {len(replacements)} FakeQuantizedLinear modules back to nn.Linear"
-        )
-
-
 class QATConverter(QuantizationConverter):
     """Apply quantization-aware training to Linear layers in a model.
 
     Operates on the model config tree: Linear configs are replaced with
-    ``QATLinear.Config`` which builds a QATLinear that applies fake
-    quantization via ``torchao.quantize_()`` in its constructor.
+    ``QATLinearConfig`` which builds a ``FakeQuantizedLinear`` via
+    ``torchao.quantize_()``.
+
+    QAT is mutually exclusive with other quantization converters
+    (Float8, MXFP8) — do not combine them in the same converters list.
 
     Supported schemes:
       - ``"int4_weight_only"`` -- int4 weight-only fake quantization
@@ -233,7 +197,7 @@ class QATConverter(QuantizationConverter):
         )
 
     def convert(self, model_config) -> None:
-        """Walk the model config tree, replacing Linear configs with QATLinear configs."""
+        """Walk the model config tree, replacing Linear configs with QATLinearConfig."""
         for _fqn, config, parent, attr in model_config.traverse(Linear.Config):
             new_config = QATLinearConfig(
                 **{f.name: getattr(config, f.name) for f in fields(config)},

--- a/torchtitan/components/quantization/qat.py
+++ b/torchtitan/components/quantization/qat.py
@@ -110,8 +110,7 @@ def _patch_module_protocol(mod: nn.Module) -> None:
                 _patched_classes[cls] = patched
             child.__class__ = _patched_classes[cls]
             child._param_init = {  # type: ignore[assignment]
-                name: _noop_init
-                for name, _ in child.named_parameters(recurse=False)
+                name: _noop_init for name, _ in child.named_parameters(recurse=False)
             }
 
 

--- a/torchtitan/components/quantization/qat.py
+++ b/torchtitan/components/quantization/qat.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+import torch.nn as nn
+from torchtitan.config import Configurable
+from torchtitan.tools.logging import logger
+
+_SUPPORTED_SCHEMES = (
+    "int4_weight_only",
+    "intx_weight_only",
+    "int8_dynamic_act_intx_weight",
+    "float8_dynamic_act_float8_weight",
+    "float8_dynamic_act_int4_weight",
+    "nvfp4",
+    "mx",
+)
+
+_SCHEMES_WITH_GROUP_SIZE = (
+    "int4_weight_only",
+    "intx_weight_only",
+    "int8_dynamic_act_intx_weight",
+)
+
+
+def _build_base_config(scheme: str, group_size: int):
+    """Return a torchao PTQ base config for the given scheme name."""
+    if scheme == "int4_weight_only":
+        from torchao.quantization import Int4WeightOnlyConfig
+
+        return Int4WeightOnlyConfig(group_size=group_size)
+
+    elif scheme == "intx_weight_only":
+        import torch
+        from torchao.quantization import IntxWeightOnlyConfig
+        from torchao.quantization.granularity import PerGroup
+
+        int4_dtype = torch.int4  # pyrefly: ignore[missing-attribute]
+        return IntxWeightOnlyConfig(
+            weight_dtype=int4_dtype,
+            granularity=PerGroup(group_size),
+        )
+
+    elif scheme == "int8_dynamic_act_intx_weight":
+        import torch
+        from torchao.quantization import Int8DynamicActivationIntxWeightConfig
+        from torchao.quantization.granularity import PerGroup
+
+        int4_dtype = torch.int4  # pyrefly: ignore[missing-attribute]
+        return Int8DynamicActivationIntxWeightConfig(
+            weight_dtype=int4_dtype,
+            weight_granularity=PerGroup(group_size),
+        )
+
+    elif scheme == "float8_dynamic_act_float8_weight":
+        from torchao.quantization import Float8DynamicActivationFloat8WeightConfig
+
+        return Float8DynamicActivationFloat8WeightConfig()
+
+    elif scheme == "float8_dynamic_act_int4_weight":
+        from torchao.quantization import Float8DynamicActivationInt4WeightConfig
+
+        return Float8DynamicActivationInt4WeightConfig()
+
+    elif scheme == "nvfp4":
+        from torchao.prototype.mx_formats import NVFP4DynamicActivationNVFP4WeightConfig
+
+        return NVFP4DynamicActivationNVFP4WeightConfig()
+
+    elif scheme == "mx":
+        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
+
+        return MXDynamicActivationMXWeightConfig()
+
+    else:
+        raise ValueError(
+            f"Unknown QAT scheme '{scheme}'. Supported: {_SUPPORTED_SCHEMES}"
+        )
+
+
+def apply_qat_prepare(
+    model: nn.Module,
+    scheme: str,
+    group_size: int,
+    *,
+    filter_fn=None,
+) -> None:
+    """Apply QAT PREPARE step: insert fake quantization into Linear modules.
+
+    After ``quantize_()``, patches ``init_weights`` onto all new module classes
+    so they satisfy the Module protocol.
+
+    Args:
+        model: The model (or subtree) to quantize.
+        scheme: QAT scheme name (must be in ``_SUPPORTED_SCHEMES``).
+        group_size: Group size for per-group schemes.
+        filter_fn: Optional ``(module, fqn) -> bool`` passed to ``quantize_()``.
+            When None, all ``nn.Linear`` modules are quantized.
+    """
+    from torchao.quantization import quantize_
+    from torchao.quantization.qat import QATConfig
+    from torchao.quantization.qat.api import QATStep
+
+    init_params_cache: dict[str, tuple[float, float]] = {}
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.Linear) and hasattr(mod, "_init_mean"):
+            init_params_cache[name] = (
+                getattr(mod, "_init_mean", 0.0),
+                getattr(mod, "_init_std", 0.02),
+            )
+
+    base_config = _build_base_config(scheme, group_size)
+
+    kwargs = {}
+    if filter_fn is not None:
+        kwargs["filter_fn"] = filter_fn
+    quantize_(model, QATConfig(base_config, step=QATStep.PREPARE), **kwargs)
+
+    # Restore init params on replaced modules
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.Linear) and name in init_params_cache:
+            init_mean, init_std = init_params_cache[name]
+            object.__setattr__(mod, "_init_mean", init_mean)
+            object.__setattr__(mod, "_init_std", init_std)
+
+
+class QATConverter(Configurable):
+    """Apply quantization-aware training via torchao's QATConfig.
+
+    Uses ``torchao.quantize_(model, QATConfig(base_config, step="prepare"))``
+    to insert fake quantization into ``nn.Linear`` modules. The ``scheme``
+    config field selects a torchao PTQ base config, which QATConfig uses to
+    infer the appropriate fake quantization for both weights and activations.
+
+    Supported schemes:
+      - ``"int4_weight_only"`` — int4 weight-only fake quantization
+      - ``"intx_weight_only"`` — intx weight-only fake quantization
+      - ``"int8_dynamic_act_intx_weight"`` — int8 activation + int4 weight
+      - ``"float8_dynamic_act_float8_weight"`` — float8 activation + float8 weight
+      - ``"float8_dynamic_act_int4_weight"`` — float8 activation + int4 weight
+      - ``"nvfp4"`` — NVFP4 dynamic activation + NVFP4 weight
+      - ``"mx"`` — MX dynamic activation + MX weight
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        scheme: str = "int4_weight_only"
+        """QAT scheme name. Maps to a torchao PTQ base config."""
+
+        group_size: int = 128
+        """Group size for per-group weight quantization.
+        Used by schemes that support per-group granularity."""
+
+        convert_at_end: bool = False
+        """When True, finalize() applies QAT CONVERT step at end of training."""
+
+    def __init__(self, config: Config, **kwargs):
+        if config.scheme not in _SUPPORTED_SCHEMES:
+            raise ValueError(
+                f"Unknown QAT scheme '{config.scheme}'. "
+                f"Supported: {_SUPPORTED_SCHEMES}"
+            )
+        self.scheme = config.scheme
+        self.group_size = config.group_size
+        self.convert_at_end = config.convert_at_end
+        if config.scheme not in _SCHEMES_WITH_GROUP_SIZE:
+            logger.warning(
+                f"QAT scheme '{config.scheme}' does not use group_size, "
+                f"ignoring group_size={config.group_size}"
+            )
+        logger.info(
+            f"QAT training active (scheme={self.scheme}, group_size={self.group_size}, "
+            f"convert_at_end={self.convert_at_end})"
+        )
+
+    def convert(self, model: nn.Module) -> None:
+        """Apply QAT PREPARE step to the model."""
+        apply_qat_prepare(model, self.scheme, self.group_size)
+        logger.info(
+            f"Applied QAT fake quantization (scheme={self.scheme}, "
+            f"group_size={self.group_size})"
+        )
+
+    def finalize(self, model: nn.Module) -> None:
+        """Apply QAT CONVERT step, replacing FakeQuantizedLinear with real quantized modules.
+
+        Skipped when convert_at_end is False.
+        """
+        if not self.convert_at_end:
+            return
+
+        from torchao.quantization import quantize_
+        from torchao.quantization.qat import QATConfig
+        from torchao.quantization.qat.api import QATStep
+
+        base_config = _build_base_config(self.scheme, self.group_size)
+        quantize_(model, QATConfig(base_config, step=QATStep.CONVERT))
+
+        logger.info(
+            f"Applied QAT CONVERT (scheme={self.scheme}, group_size={self.group_size}): "
+            "FakeQuantizedLinear modules replaced with real quantized modules"
+        )

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -123,6 +123,19 @@ def llama3_debugmodel_lora() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_qat() -> Trainer.Config:
+    from torchtitan.components.quantization.qat import QATConverter
+
+    config = llama3_debugmodel()
+    config.model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            QATConverter.Config(scheme="int4_weight_only", group_size=64),
+        ],
+    )
+    return config
+
+
 def llama3_debugmodel_ce_loss() -> Trainer.Config:
     """Debug model with standard (non-chunked) CrossEntropyLoss."""
     from torchtitan.components.loss import CrossEntropyLoss

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -17,18 +17,27 @@ from torchtitan.tools.logging import logger
 
 
 def validate_converter_order(converters: list) -> None:
-    """Validate that quantization/QAT converters precede LoRA.
+    """Validate converter ordering and mutual exclusivity.
 
-    Raises ``ValueError`` if a quantization converter appears after a LoRA
-    converter in the list.
+    Rules:
+    - Quantization converters must precede LoRA.
+    - QAT is mutually exclusive with other quantization converters
+      (Float8, MXFP8) since both replace Linear modules.
     """
     from torchtitan.components.lora import LoRAConverter
     from torchtitan.components.quantization import QuantizationConverter
+    from torchtitan.components.quantization.qat import QATConverter
 
     _BEFORE_LORA = (QuantizationConverter.Config,)
 
     seen_lora = False
+    has_qat = False
+    has_other_quant = False
     for converter in converters:
+        if isinstance(converter, QATConverter.Config):
+            has_qat = True
+        elif isinstance(converter, QuantizationConverter.Config):
+            has_other_quant = True
         if isinstance(converter, LoRAConverter.Config):
             seen_lora = True
         elif seen_lora and isinstance(converter, _BEFORE_LORA):
@@ -36,6 +45,12 @@ def validate_converter_order(converters: list) -> None:
                 f"{type(converter).__name__} must be applied before "
                 f"LoRAConverter. Reorder the converters list."
             )
+
+    if has_qat and has_other_quant:
+        raise ValueError(
+            "QATConverter is mutually exclusive with other quantization "
+            "converters (Float8, MXFP8). Use one or the other, not both."
+        )
 
 
 class MoEStateDictAdapter(StateDictAdapter):


### PR DESCRIPTION
Add QATConverter that inserts fake quantization into nn.Linear modules via torchao's QATConfig. Supports 7 quantization schemes: int4, intx, int8int4, float8, float8int4, nvfp4, mx.

QAT operates post-build (on nn.Module), unlike config-level converters. apply_qat_prepare() is the shared core for model-wide and targeted (e.g. adapter-only) application.

Includes finalize() for optional CONVERT step at end of training to replace FakeQuantizedLinear with real quantized modules.


### Test
Evaluated on Llama 3.1 8B with HellaSwag (200 samples). All models finetuned for 100 steps on c4_test with LR=1e-5, FSDP (DP=8), batch=1, seq_len=2048. 

QAT recovers ~30% of the accuracy drop from naive int4 quantization (acc: 0.520 vs 0.510, baseline 0.550). With only 100 steps on a toy dataset, the improvement is modest but directionally correct. The training loss curve shows QAT starting higher due to quantization penalty and converging toward the full finetune curve.                             
                                               
Quantization config: int8_dynamic_act_intx_weight, group_size=256.

<img width="2400" height="900" alt="qat_eval_results" src="https://github.com/user-attachments/assets/32b20716-4875-476f-b529-52eb238e8f08" />

