### PR TITLE
[optimizer] support mixed optimizers

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -369,7 +369,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--optimizer.name AdamW --optimizer.implementation foreach",
+                    "--optimizer.implementation foreach",
                 ]
             ],
             "Foreach Optimizer Test",
@@ -379,7 +379,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--optimizer.name AdamW --optimizer.implementation fused_opt_states_bf16",
+                    "--optimizer.implementation fused_opt_states_bf16",
                 ]
             ],
             "BF16 Optimizer States Test",

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -614,28 +614,6 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=4,
             skip_rocm_test=True,
         ),
-        # NOTE: temporarily disable due to test hanging in CI
-        # OverrideDefinitions(
-        #     [
-        #         [
-        #             "--module llama3 --config llama3_debugmodel_opt_in_bwd",
-        #             "--checkpoint.enable",
-        #             "--parallelism.tensor_parallel_degree=2",
-        #             "--parallelism.context_parallel_degree=2",
-        #             "--training.enable_cpu_offload",
-        #         ],
-        #         [
-        #             "--module llama3 --config llama3_debugmodel_opt_in_bwd",
-        #             "--parallelism.tensor_parallel_degree=2",
-        #             "--parallelism.context_parallel_degree=2",
-        #             "--parallelism.data_parallel_replicate_degree=2",
-        #             "--training.enable_cpu_offload",
-        #         ],
-        #     ],
-        #     "Enable CPU Offload, Optimizer in backward with TP, DP, CP",
-        #     "cpu_offload+opt_in_bwd+TP+DP+CP",
-        #     ngpu=8,
-        # ),
         OverrideDefinitions(
             [
                 [

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -79,7 +79,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module qwen3 --config qwen3_debugmodel_param_groups",
+                    "--module qwen3 --config qwen3_debugmodel_moe_param_groups",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
                 ],

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import unittest
 
 import torch
@@ -13,7 +12,6 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import (
     default_adamw,
     OptimizersContainer,
-    OptimizersInBackwardContainer,
     ParamGroupConfig,
 )
 
@@ -239,8 +237,8 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[1]["betas"], (0.9, 0.999))
         self.assertEqual(groups[2]["betas"], (0.9, 0.95))
 
-    def test_warning_on_zero_matches(self):
-        """Patterns that match no parameters emit a warning."""
+    def test_error_on_zero_matches(self):
+        """Patterns that match no parameters raise ValueError."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             param_groups=[
@@ -254,17 +252,10 @@ class TestParamGroupConfig(unittest.TestCase):
         )
         impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
 
-        with self.assertLogs(level=logging.WARNING) as cm:
-            groups_by_opt = OptimizersContainer._build_param_groups(
+        with self.assertRaises(ValueError):
+            OptimizersContainer._build_param_groups(
                 model, config.param_groups, impl_kwargs
             )
-
-        self.assertTrue(
-            any("nonexistent_layer" in msg for msg in cm.output),
-            f"Expected warning about unmatched pattern, got: {cm.output}",
-        )
-        groups = groups_by_opt.get("AdamW", [])
-        self.assertEqual(len(groups), 1)
 
     def test_all_params_covered(self):
         """Every requires_grad param appears in exactly one group."""
@@ -351,41 +342,6 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         container = config.build(model_parts=[model])
         opt = container.optimizers[0]
         self.assertEqual(len(opt.param_groups), 1)
-
-
-class TestOptimizersInBackwardWithParamGroups(unittest.TestCase):
-    def test_build_with_param_groups(self):
-        """OptimizersInBackwardContainer respects param groups."""
-        model = SimpleModel()
-        config = OptimizersInBackwardContainer.Config(
-            implementation="for-loop",
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r".*\.bias$",
-                    optimizer_name="AdamW",
-                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
-                ),
-                ParamGroupConfig(
-                    pattern=r".*",
-                    optimizer_name="AdamW",
-                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
-                ),
-            ],
-        )
-        container = config.build(model_parts=[model])
-        self.assertIsInstance(container, OptimizersInBackwardContainer)
-
-        param_to_name = {p: n for n, p in model.named_parameters()}
-        for opt in container.optimizers:
-            for pg in opt.param_groups:
-                for p in pg["params"]:
-                    name = param_to_name.get(p, "")
-                    if name.endswith(".bias"):
-                        self.assertEqual(
-                            pg["weight_decay"],
-                            0.0,
-                            f"Bias param {name} should have weight_decay=0",
-                        )
 
 
 class TestDCPWithParamGroups(unittest.TestCase):

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -44,6 +44,19 @@ class SimpleModel(nn.Module):
         return self.output(x)
 
 
+# Default AdamW param group for catch-all
+_DEFAULT_ADAMW = ParamGroupConfig(
+    pattern=r".*",
+    optimizer_name="AdamW",
+    optimizer_kwargs={
+        "lr": 1e-3,
+        "betas": (0.9, 0.95),
+        "eps": 1e-8,
+        "weight_decay": 0.1,
+    },
+)
+
+
 def _get_param_names_in_group(model, group):
     """Return the set of parameter FQNs in an optimizer param group."""
     param_to_name = {p: n for n, p in model.named_parameters()}
@@ -51,12 +64,15 @@ def _get_param_names_in_group(model, group):
 
 
 def _get_default_groups(model, config):
-    """Helper: build param groups and return the default optimizer's groups."""
-    default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-    groups_by_opt = OptimizersContainer._build_param_groups(
-        model, config, default_kwargs
+    """Helper: build param groups and return the AdamW optimizer's groups."""
+    impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
+    param_groups = config.param_groups or OptimizersContainer._default_param_groups(
+        config
     )
-    return groups_by_opt.get(config.name, [])
+    groups_by_opt = OptimizersContainer._build_param_groups(
+        model, param_groups, impl_kwargs
+    )
+    return groups_by_opt.get("AdamW", [])
 
 
 class TestParamGroupConfig(unittest.TestCase):
@@ -73,176 +89,229 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[0]["lr"], 1e-3)
         self.assertEqual(groups[0]["weight_decay"], 0.1)
 
-    def test_single_pattern_weight_decay_zero(self):
-        """Pattern matching bias params with weight_decay=0 via optimizer_kwargs."""
+    def test_default_sgd(self):
+        """Default optimizer can be changed to SGD via Config fields."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
+            name="SGD",
+            lr=1e-2,
+            optimizer_kwargs={"momentum": 0.9},
+            implementation="for-loop",
+        )
+        container = config.build(model_parts=[model])
+        self.assertEqual(len(container.optimizers), 1)
+        sgd = container.optimizers[0]
+        self.assertIsInstance(sgd, torch.optim.SGD)
+        self.assertEqual(sgd.param_groups[0]["lr"], 1e-2)
+        self.assertEqual(sgd.param_groups[0]["momentum"], 0.9)
+
+    def test_single_pattern_weight_decay_zero(self):
+        """Pattern matching bias params with weight_decay=0."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
             param_groups=[
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-3,
+                        "betas": (0.9, 0.95),
+                        "eps": 1e-8,
+                        "weight_decay": 0.0,
+                    },
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
         groups = _get_default_groups(model, config)
 
-        # Should have 2 groups: default + bias group
         self.assertEqual(len(groups), 2)
 
-        # Default group: non-bias params
-        default_names = _get_param_names_in_group(model, groups[0])
-        for name in default_names:
-            self.assertFalse(name.endswith(".bias"), f"{name} should not be in default")
-        self.assertEqual(groups[0]["weight_decay"], 0.1)
-        self.assertEqual(groups[0]["lr"], 1e-3)
-
-        # Bias group
-        bias_names = _get_param_names_in_group(model, groups[1])
+        # Bias group (first match)
+        bias_names = _get_param_names_in_group(model, groups[0])
         for name in bias_names:
             self.assertTrue(name.endswith(".bias"), f"{name} should end with .bias")
-        self.assertEqual(groups[1]["weight_decay"], 0.0)
-        self.assertEqual(groups[1]["lr"], 1e-3)
+        self.assertEqual(groups[0]["weight_decay"], 0.0)
+
+        # Default group (catch-all)
+        default_names = _get_param_names_in_group(model, groups[1])
+        for name in default_names:
+            self.assertFalse(name.endswith(".bias"), f"{name} should not be in default")
+        self.assertEqual(groups[1]["weight_decay"], 0.1)
 
     def test_embed_tokens_pattern(self):
         """Pattern matching embed_tokens with weight_decay=0."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-3,
+                        "betas": (0.9, 0.95),
+                        "eps": 1e-8,
+                        "weight_decay": 0.0,
+                    },
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
         groups = _get_default_groups(model, config)
 
         self.assertEqual(len(groups), 2)
-
-        embed_names = _get_param_names_in_group(model, groups[1])
+        embed_names = _get_param_names_in_group(model, groups[0])
         self.assertTrue(
             all("embed_tokens" in n for n in embed_names),
             f"Expected embed_tokens params, got {embed_names}",
         )
-        self.assertEqual(groups[1]["weight_decay"], 0.0)
+        self.assertEqual(groups[0]["weight_decay"], 0.0)
 
     def test_lr_override(self):
-        """lr override via optimizer_kwargs correctly sets the lr."""
+        """Different lr for a param group."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    optimizer_kwargs={"lr": 1e-4},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-4,
+                        "betas": (0.9, 0.95),
+                        "eps": 1e-8,
+                        "weight_decay": 0.1,
+                    },
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
         groups = _get_default_groups(model, config)
 
-        # Default group keeps base lr
-        self.assertEqual(groups[0]["lr"], 1e-3)
-        # Embed group gets overridden lr
-        self.assertAlmostEqual(groups[1]["lr"], 1e-4)
+        # Embed group
+        self.assertAlmostEqual(groups[0]["lr"], 1e-4)
+        # Default group
+        self.assertEqual(groups[1]["lr"], 1e-3)
 
     def test_first_match_wins(self):
         """When patterns overlap, the first match wins."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
                 # First pattern: all norm params get wd=0
                 ParamGroupConfig(
                     pattern=r".*norm.*",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-3,
+                        "betas": (0.9, 0.95),
+                        "eps": 1e-8,
+                        "weight_decay": 0.0,
+                    },
                 ),
                 # Second pattern: broader match that also covers norm
                 ParamGroupConfig(
                     pattern=r".*layers.*",
-                    optimizer_kwargs={"lr": 5e-4},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 5e-4,
+                        "betas": (0.9, 0.95),
+                        "eps": 1e-8,
+                        "weight_decay": 0.1,
+                    },
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
         groups = _get_default_groups(model, config)
 
-        # Norm params should be in group index 1 (first matched group after default)
-        norm_group = groups[1]
+        norm_group = groups[0]
         norm_names = _get_param_names_in_group(model, norm_group)
         self.assertTrue(all("norm" in n for n in norm_names))
-        # Norm group should have weight_decay=0 (from first pattern)
         self.assertEqual(norm_group["weight_decay"], 0.0)
-        # And default lr (not overridden by first pattern)
         self.assertEqual(norm_group["lr"], 1e-3)
 
     def test_betas_override(self):
-        """Per-group betas override via optimizer_kwargs works correctly."""
+        """Per-group betas override."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    optimizer_kwargs={"betas": (0.85, 0.99)},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-3,
+                        "betas": (0.85, 0.99),
+                        "eps": 1e-8,
+                        "weight_decay": 0.1,
+                    },
                 ),
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"betas": (0.9, 0.999)},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 1e-3,
+                        "betas": (0.9, 0.999),
+                        "eps": 1e-8,
+                        "weight_decay": 0.1,
+                    },
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
         groups = _get_default_groups(model, config)
 
-        # Default group keeps global betas
-        self.assertEqual(groups[0]["betas"], (0.9, 0.95))
-        # Embed group: both overridden
-        self.assertEqual(groups[1]["betas"], (0.85, 0.99))
-        # Bias group: overridden
-        self.assertEqual(groups[2]["betas"], (0.9, 0.999))
+        self.assertEqual(groups[0]["betas"], (0.85, 0.99))
+        self.assertEqual(groups[1]["betas"], (0.9, 0.999))
+        self.assertEqual(groups[2]["betas"], (0.9, 0.95))
 
     def test_warning_on_zero_matches(self):
         """Patterns that match no parameters emit a warning."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
-                ParamGroupConfig(pattern=r"nonexistent_layer"),
+                ParamGroupConfig(
+                    pattern=r"nonexistent_layer",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3},
+                ),
+                _DEFAULT_ADAMW,
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
 
         with self.assertLogs(level=logging.WARNING) as cm:
             groups_by_opt = OptimizersContainer._build_param_groups(
-                model, config, default_kwargs
+                model, config.param_groups, impl_kwargs
             )
 
         self.assertTrue(
             any("nonexistent_layer" in msg for msg in cm.output),
             f"Expected warning about unmatched pattern, got: {cm.output}",
         )
-        # All params should be in the default group
-        groups = groups_by_opt.get(config.name, [])
+        groups = groups_by_opt.get("AdamW", [])
         self.assertEqual(len(groups), 1)
 
     def test_all_params_covered(self):
         """Every requires_grad param appears in exactly one group."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
                 ),
                 ParamGroupConfig(
                     pattern=r".*norm.*",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
                 ),
+                _DEFAULT_ADAMW,
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
         groups_by_opt = OptimizersContainer._build_param_groups(
-            model, config, default_kwargs
+            model, config.param_groups, impl_kwargs
         )
 
         all_grouped_params = []
@@ -253,8 +322,25 @@ class TestParamGroupConfig(unittest.TestCase):
 
         self.assertEqual(len(all_grouped_params), len(all_model_params))
         self.assertEqual(
-            set(id(p) for p in all_grouped_params), set(id(p) for p in all_model_params)
+            set(id(p) for p in all_grouped_params),
+            set(id(p) for p in all_model_params),
         )
+
+    def test_uncovered_params_raises(self):
+        """Missing catch-all pattern raises on uncovered params."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3},
+                ),
+            ],
+        )
+        with self.assertRaises(AssertionError):
+            config.build(model_parts=[model])
 
 
 class TestOptimizersContainerWithParamGroups(unittest.TestCase):
@@ -262,32 +348,32 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         """End-to-end: build OptimizersContainer with param groups."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            name="AdamW",
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
         container = config.build(model_parts=[model])
         self.assertIsInstance(container, OptimizersContainer)
-
-        # Should have 1 optimizer (one model_part, same optimizer type)
         self.assertEqual(len(container.optimizers), 1)
         opt = container.optimizers[0]
-        # Should have 2 param groups
         self.assertEqual(len(opt.param_groups), 2)
 
     def test_build_optimizer_default_groups(self):
         """Empty param_groups produces standard single-group behavior."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            name="AdamW",
-            lr=1e-3,
             implementation="for-loop",
+            lr=1e-3,
         )
         container = config.build(model_parts=[model])
         opt = container.optimizers[0]
@@ -299,20 +385,23 @@ class TestOptimizersInBackwardWithParamGroups(unittest.TestCase):
         """OptimizersInBackwardContainer respects param groups."""
         model = SimpleModel()
         config = OptimizersInBackwardContainer.Config(
-            name="AdamW",
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
         container = config.build(model_parts=[model])
         self.assertIsInstance(container, OptimizersInBackwardContainer)
 
-        # Check that bias params have weight_decay=0
         param_to_name = {p: n for n, p in model.named_parameters()}
         for opt in container.optimizers:
             for pg in opt.param_groups:
@@ -331,39 +420,40 @@ class TestDCPWithParamGroups(unittest.TestCase):
         """Optimizer state_dict save/load works with multiple param groups."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            name="AdamW",
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r".*\.bias$",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
                 ),
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    optimizer_kwargs={"lr": 1e-4},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-4, "weight_decay": 0.1},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
         container = config.build(model_parts=[model])
 
-        # Run a step to populate optimizer state
         dummy_input = torch.randint(0, 32, (2, 4))
         output = model(dummy_input)
         output.sum().backward()
         container.step()
 
-        # Save state dict
         state_dict = container.state_dict()
         self.assertIsInstance(state_dict, dict)
         self.assertTrue(len(state_dict) > 0)
 
-        # Load into a fresh container
         model2 = SimpleModel()
         container2 = config.build(model_parts=[model2])
         container2.load_state_dict(state_dict)
 
-        # Verify state was restored by checking optimizer states match
         state_dict2 = container2.state_dict()
         self.assertEqual(set(state_dict.keys()), set(state_dict2.keys()))
 
@@ -382,13 +472,17 @@ class TestMixedOptimizers(unittest.TestCase):
         """Different optimizer for a param group."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
@@ -406,13 +500,17 @@ class TestMixedOptimizers(unittest.TestCase):
         """All parameters should be covered across all optimizers."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
@@ -430,13 +528,17 @@ class TestMixedOptimizers(unittest.TestCase):
         model1 = SimpleModel()
         model2 = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
@@ -451,31 +553,40 @@ class TestMixedOptimizers(unittest.TestCase):
         """Param groups have correct _label for logging."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_kwargs={"weight_decay": 0.0},
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
         container = config.build(model_parts=[model])
         adamw = container.optimizers[0]
-        self.assertEqual(adamw.param_groups[0]["_label"], "default")
-        self.assertEqual(adamw.param_groups[1]["_label"], "output.")
+        self.assertEqual(adamw.param_groups[0]["_label"], "output.")
+        self.assertEqual(adamw.param_groups[1]["_label"], ".")
 
     def test_mixed_optimizer_state_dict_round_trip(self):
         """State dict save/load works with mixed optimizer types."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
@@ -518,7 +629,10 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
     def test_default_schedule(self):
         """Default schedule should work the same as before."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(lr=1e-3, implementation="for-loop")
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            lr=1e-3,
+        )
         lr_config = LRSchedulersContainer.Config(
             warmup_steps=10,
             decay_type="linear",
@@ -534,13 +648,17 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         """Mixed optimizers should each get their own scheduler."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )
@@ -555,13 +673,17 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         """Same schedule applied to different base lrs produces different absolute lrs."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            lr=1e-3,
             implementation="for-loop",
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
                     optimizer_name="SGD",
                     optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
                 ),
             ],
         )

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -78,7 +78,7 @@ class TestParamGroupConfig(unittest.TestCase):
     def test_default_no_param_groups(self):
         """Empty param_groups produces a single group with all params."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(param_groups=default_adamw(lr=1e-3))
+        config = default_adamw(lr=1e-3)
 
         groups = _get_default_groups(model, config)
 
@@ -141,34 +141,6 @@ class TestParamGroupConfig(unittest.TestCase):
         for name in default_names:
             self.assertFalse(name.endswith(".bias"), f"{name} should not be in default")
         self.assertEqual(groups[1]["weight_decay"], 0.1)
-
-    def test_embed_tokens_pattern(self):
-        """Pattern matching embed_tokens with weight_decay=0."""
-        model = SimpleModel()
-        config = OptimizersContainer.Config(
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r"embed_tokens\.",
-                    optimizer_name="AdamW",
-                    optimizer_kwargs={
-                        "lr": 1e-3,
-                        "betas": (0.9, 0.95),
-                        "eps": 1e-8,
-                        "weight_decay": 0.0,
-                    },
-                ),
-                _DEFAULT_ADAMW,
-            ],
-        )
-        groups = _get_default_groups(model, config)
-
-        self.assertEqual(len(groups), 2)
-        embed_names = _get_param_names_in_group(model, groups[0])
-        self.assertTrue(
-            all("embed_tokens" in n for n in embed_names),
-            f"Expected embed_tokens params, got {embed_names}",
-        )
-        self.assertEqual(groups[0]["weight_decay"], 0.0)
 
     def test_lr_override(self):
         """Different lr for a param group."""
@@ -372,12 +344,10 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         self.assertEqual(len(opt.param_groups), 2)
 
     def test_build_optimizer_default_groups(self):
-        """Empty param_groups produces standard single-group behavior."""
+        """default_adamw produces standard single-group behavior."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(
-            implementation="for-loop",
-            param_groups=default_adamw(lr=1e-3),
-        )
+        config = default_adamw(lr=1e-3)
+        config.implementation = "for-loop"
         container = config.build(model_parts=[model])
         opt = container.optimizers[0]
         self.assertEqual(len(opt.param_groups), 1)
@@ -499,33 +469,6 @@ class TestMixedOptimizers(unittest.TestCase):
         self.assertEqual(adam.param_groups[0]["lr"], 5e-4)
         self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
 
-    def test_mixed_optimizers_all_params_covered(self):
-        """All parameters should be covered across all optimizers."""
-        model = SimpleModel()
-        config = OptimizersContainer.Config(
-            implementation="for-loop",
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r"output\.",
-                    optimizer_name="Adam",
-                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
-                ),
-                ParamGroupConfig(
-                    pattern=r".*",
-                    optimizer_name="AdamW",
-                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
-                ),
-            ],
-        )
-        container = config.build(model_parts=[model])
-        all_opt_params = set()
-        for opt in container.optimizers:
-            for group in opt.param_groups:
-                for p in group["params"]:
-                    all_opt_params.add(id(p))
-        model_params = {id(p) for p in model.parameters() if p.requires_grad}
-        self.assertEqual(all_opt_params, model_params)
-
     def test_model_part_indices(self):
         """_model_part_indices correctly maps optimizers to model parts."""
         model1 = SimpleModel()
@@ -552,8 +495,8 @@ class TestMixedOptimizers(unittest.TestCase):
         self.assertEqual(container._model_part_indices[2], 1)
         self.assertEqual(container._model_part_indices[3], 1)
 
-    def test_param_group_labels(self):
-        """Param groups have correct _label for logging."""
+    def test_param_group_patterns(self):
+        """Param groups have correct pattern for logging."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
@@ -572,8 +515,8 @@ class TestMixedOptimizers(unittest.TestCase):
         )
         container = config.build(model_parts=[model])
         adamw = container.optimizers[0]
-        self.assertEqual(adamw.param_groups[0]["_label"], r"output\.")
-        self.assertEqual(adamw.param_groups[1]["_label"], ".*")
+        self.assertEqual(adamw.param_groups[0]["pattern"], r"output\.")
+        self.assertEqual(adamw.param_groups[1]["pattern"], ".*")
 
     def test_mixed_optimizer_state_dict_round_trip(self):
         """State dict save/load works with mixed optimizer types."""
@@ -632,10 +575,8 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
     def test_default_schedule(self):
         """Default schedule should work the same as before."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(
-            implementation="for-loop",
-            param_groups=default_adamw(lr=1e-3),
-        )
+        config = default_adamw(lr=1e-3)
+        config.implementation = "for-loop"
         lr_config = LRSchedulersContainer.Config(
             warmup_steps=10,
             decay_type="linear",

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -11,6 +11,7 @@ import torch
 import torch.nn as nn
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import (
+    default_adamw,
     OptimizersContainer,
     OptimizersInBackwardContainer,
     ParamGroupConfig,
@@ -66,9 +67,7 @@ def _get_param_names_in_group(model, group):
 def _get_default_groups(model, config):
     """Helper: build param groups and return the AdamW optimizer's groups."""
     impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
-    param_groups = config.param_groups or OptimizersContainer._default_param_groups(
-        config
-    )
+    param_groups = config.param_groups
     groups_by_opt = OptimizersContainer._build_param_groups(
         model, param_groups, impl_kwargs
     )
@@ -79,7 +78,7 @@ class TestParamGroupConfig(unittest.TestCase):
     def test_default_no_param_groups(self):
         """Empty param_groups produces a single group with all params."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(lr=1e-3)
+        config = OptimizersContainer.Config(param_groups=default_adamw(lr=1e-3))
 
         groups = _get_default_groups(model, config)
 
@@ -89,21 +88,25 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[0]["lr"], 1e-3)
         self.assertEqual(groups[0]["weight_decay"], 0.1)
 
-    def test_default_sgd(self):
-        """Default optimizer can be changed to SGD via Config fields."""
+    def test_default_adam(self):
+        """All params can use Adam via param_groups."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
-            name="SGD",
-            lr=1e-2,
-            optimizer_kwargs={"momentum": 0.9},
             implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 1e-2, "betas": (0.9, 0.95), "eps": 1e-8},
+                ),
+            ],
         )
         container = config.build(model_parts=[model])
         self.assertEqual(len(container.optimizers), 1)
-        sgd = container.optimizers[0]
-        self.assertIsInstance(sgd, torch.optim.SGD)
-        self.assertEqual(sgd.param_groups[0]["lr"], 1e-2)
-        self.assertEqual(sgd.param_groups[0]["momentum"], 0.9)
+        adam = container.optimizers[0]
+        self.assertIsInstance(adam, torch.optim.Adam)
+        self.assertEqual(adam.param_groups[0]["lr"], 1e-2)
+        self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
 
     def test_single_pattern_weight_decay_zero(self):
         """Pattern matching bias params with weight_decay=0."""
@@ -373,7 +376,7 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         model = SimpleModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
-            lr=1e-3,
+            param_groups=default_adamw(lr=1e-3),
         )
         container = config.build(model_parts=[model])
         opt = container.optimizers[0]
@@ -476,8 +479,8 @@ class TestMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -488,13 +491,13 @@ class TestMixedOptimizers(unittest.TestCase):
         )
         container = config.build(model_parts=[model])
         opt_types = {type(opt).__name__ for opt in container.optimizers}
-        self.assertEqual(opt_types, {"AdamW", "SGD"})
+        self.assertEqual(opt_types, {"AdamW", "Adam"})
 
-        sgd = next(
-            opt for opt in container.optimizers if isinstance(opt, torch.optim.SGD)
+        adam = next(
+            opt for opt in container.optimizers if type(opt) is torch.optim.Adam
         )
-        self.assertEqual(sgd.param_groups[0]["lr"], 5e-4)
-        self.assertEqual(sgd.param_groups[0]["momentum"], 0.9)
+        self.assertEqual(adam.param_groups[0]["lr"], 5e-4)
+        self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
 
     def test_mixed_optimizers_all_params_covered(self):
         """All parameters should be covered across all optimizers."""
@@ -504,8 +507,8 @@ class TestMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -532,8 +535,8 @@ class TestMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -569,8 +572,8 @@ class TestMixedOptimizers(unittest.TestCase):
         )
         container = config.build(model_parts=[model])
         adamw = container.optimizers[0]
-        self.assertEqual(adamw.param_groups[0]["_label"], "output.")
-        self.assertEqual(adamw.param_groups[1]["_label"], ".")
+        self.assertEqual(adamw.param_groups[0]["_label"], r"output\.")
+        self.assertEqual(adamw.param_groups[1]["_label"], ".*")
 
     def test_mixed_optimizer_state_dict_round_trip(self):
         """State dict save/load works with mixed optimizer types."""
@@ -580,8 +583,8 @@ class TestMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -631,7 +634,7 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         model = SimpleModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
-            lr=1e-3,
+            param_groups=default_adamw(lr=1e-3),
         )
         lr_config = LRSchedulersContainer.Config(
             warmup_steps=10,
@@ -652,8 +655,8 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -677,8 +680,8 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"output\.",
-                    optimizer_name="SGD",
-                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                    optimizer_name="Adam",
+                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
                 ),
                 ParamGroupConfig(
                     pattern=r".*",
@@ -696,7 +699,7 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
             scheduler.step()
         for opt in container.optimizers:
             base_lr = opt.param_groups[0]["lr"]
-            if isinstance(opt, torch.optim.SGD):
+            if type(opt) is torch.optim.Adam:
                 self.assertAlmostEqual(base_lr, 5e-4, places=6)
             else:
                 self.assertAlmostEqual(base_lr, 1e-3, places=6)

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -9,6 +9,7 @@ import unittest
 
 import torch
 import torch.nn as nn
+from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import (
     OptimizersContainer,
     OptimizersInBackwardContainer,
@@ -49,14 +50,22 @@ def _get_param_names_in_group(model, group):
     return {param_to_name[p] for p in group["params"]}
 
 
+def _get_default_groups(model, config):
+    """Helper: build param groups and return the default optimizer's groups."""
+    default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+    groups_by_opt = OptimizersContainer._build_param_groups(
+        model, config, default_kwargs
+    )
+    return groups_by_opt.get(config.name, [])
+
+
 class TestParamGroupConfig(unittest.TestCase):
     def test_default_no_param_groups(self):
         """Empty param_groups produces a single group with all params."""
         model = SimpleModel()
-        config = OptimizersContainer.Config(lr=1e-3, weight_decay=0.1)
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
+        config = OptimizersContainer.Config(lr=1e-3)
 
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
         self.assertEqual(len(groups), 1)
         all_params = [p for p in model.parameters() if p.requires_grad]
@@ -65,17 +74,18 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[0]["weight_decay"], 0.1)
 
     def test_single_pattern_weight_decay_zero(self):
-        """Pattern matching bias params with weight_decay_multiplier=0."""
+        """Pattern matching bias params with weight_decay=0 via optimizer_kwargs."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            weight_decay=0.1,
             param_groups=[
-                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
         # Should have 2 groups: default + bias group
         self.assertEqual(len(groups), 2)
@@ -95,20 +105,18 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[1]["lr"], 1e-3)
 
     def test_embed_tokens_pattern(self):
-        """Pattern matching embed_tokens with weight_decay_multiplier=0."""
+        """Pattern matching embed_tokens with weight_decay=0."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            weight_decay=0.1,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    weight_decay_multiplier=0.0,
+                    optimizer_kwargs={"weight_decay": 0.0},
                 ),
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
         self.assertEqual(len(groups), 2)
 
@@ -119,25 +127,23 @@ class TestParamGroupConfig(unittest.TestCase):
         )
         self.assertEqual(groups[1]["weight_decay"], 0.0)
 
-    def test_lr_multiplier(self):
-        """lr_multiplier correctly scales the base lr."""
+    def test_lr_override(self):
+        """lr override via optimizer_kwargs correctly sets the lr."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            weight_decay=0.1,
             param_groups=[
                 ParamGroupConfig(
                     pattern=r"embed_tokens\.",
-                    lr_multiplier=0.1,
+                    optimizer_kwargs={"lr": 1e-4},
                 ),
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
         # Default group keeps base lr
         self.assertEqual(groups[0]["lr"], 1e-3)
-        # Embed group gets 10% of base lr
+        # Embed group gets overridden lr
         self.assertAlmostEqual(groups[1]["lr"], 1e-4)
 
     def test_first_match_wins(self):
@@ -145,48 +151,53 @@ class TestParamGroupConfig(unittest.TestCase):
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            weight_decay=0.1,
             param_groups=[
                 # First pattern: all norm params get wd=0
-                ParamGroupConfig(pattern=r".*norm.*", weight_decay_multiplier=0.0),
+                ParamGroupConfig(
+                    pattern=r".*norm.*",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
                 # Second pattern: broader match that also covers norm
-                ParamGroupConfig(pattern=r".*layers.*", lr_multiplier=0.5),
+                ParamGroupConfig(
+                    pattern=r".*layers.*",
+                    optimizer_kwargs={"lr": 5e-4},
+                ),
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
-        # Norm params should be in group index 0 (the norm pattern), not group 1
-        norm_group = groups[1]  # first matched group (after default)
+        # Norm params should be in group index 1 (first matched group after default)
+        norm_group = groups[1]
         norm_names = _get_param_names_in_group(model, norm_group)
         self.assertTrue(all("norm" in n for n in norm_names))
         # Norm group should have weight_decay=0 (from first pattern)
         self.assertEqual(norm_group["weight_decay"], 0.0)
-        # And default lr (lr_multiplier=1.0 from first pattern)
+        # And default lr (not overridden by first pattern)
         self.assertEqual(norm_group["lr"], 1e-3)
 
     def test_betas_override(self):
-        """Per-group betas override works correctly."""
+        """Per-group betas override via optimizer_kwargs works correctly."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            beta1=0.9,
-            beta2=0.95,
             param_groups=[
-                # Override both betas
-                ParamGroupConfig(pattern=r"embed_tokens\.", beta1=0.85, beta2=0.99),
-                # Override only beta2
-                ParamGroupConfig(pattern=r".*\.bias$", beta2=0.999),
+                ParamGroupConfig(
+                    pattern=r"embed_tokens\.",
+                    optimizer_kwargs={"betas": (0.85, 0.99)},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"betas": (0.9, 0.999)},
+                ),
             ],
         )
-        default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups = _get_default_groups(model, config)
 
         # Default group keeps global betas
         self.assertEqual(groups[0]["betas"], (0.9, 0.95))
         # Embed group: both overridden
         self.assertEqual(groups[1]["betas"], (0.85, 0.99))
-        # Bias group: only beta2 overridden, beta1 stays global
+        # Bias group: overridden
         self.assertEqual(groups[2]["betas"], (0.9, 0.999))
 
     def test_warning_on_zero_matches(self):
@@ -201,7 +212,7 @@ class TestParamGroupConfig(unittest.TestCase):
         default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
 
         with self.assertLogs(level=logging.WARNING) as cm:
-            groups = OptimizersContainer._build_param_groups(
+            groups_by_opt = OptimizersContainer._build_param_groups(
                 model, config, default_kwargs
             )
 
@@ -210,6 +221,7 @@ class TestParamGroupConfig(unittest.TestCase):
             f"Expected warning about unmatched pattern, got: {cm.output}",
         )
         # All params should be in the default group
+        groups = groups_by_opt.get(config.name, [])
         self.assertEqual(len(groups), 1)
 
     def test_all_params_covered(self):
@@ -217,18 +229,26 @@ class TestParamGroupConfig(unittest.TestCase):
         model = SimpleModel()
         config = OptimizersContainer.Config(
             lr=1e-3,
-            weight_decay=0.1,
             param_groups=[
-                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
-                ParamGroupConfig(pattern=r".*norm.*", weight_decay_multiplier=0.0),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*norm.*",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
             ],
         )
         default_kwargs = OptimizersContainer._build_optimizer_kwargs(config)
-        groups = OptimizersContainer._build_param_groups(model, config, default_kwargs)
+        groups_by_opt = OptimizersContainer._build_param_groups(
+            model, config, default_kwargs
+        )
 
         all_grouped_params = []
-        for g in groups:
-            all_grouped_params.extend(g["params"])
+        for opt_groups in groups_by_opt.values():
+            for g in opt_groups:
+                all_grouped_params.extend(g["params"])
         all_model_params = [p for p in model.parameters() if p.requires_grad]
 
         self.assertEqual(len(all_grouped_params), len(all_model_params))
@@ -244,16 +264,18 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         config = OptimizersContainer.Config(
             name="AdamW",
             lr=1e-3,
-            weight_decay=0.1,
             implementation="for-loop",
             param_groups=[
-                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
             ],
         )
         container = config.build(model_parts=[model])
         self.assertIsInstance(container, OptimizersContainer)
 
-        # Should have 1 optimizer (one model_part)
+        # Should have 1 optimizer (one model_part, same optimizer type)
         self.assertEqual(len(container.optimizers), 1)
         opt = container.optimizers[0]
         # Should have 2 param groups
@@ -265,7 +287,6 @@ class TestOptimizersContainerWithParamGroups(unittest.TestCase):
         config = OptimizersContainer.Config(
             name="AdamW",
             lr=1e-3,
-            weight_decay=0.1,
             implementation="for-loop",
         )
         container = config.build(model_parts=[model])
@@ -280,10 +301,12 @@ class TestOptimizersInBackwardWithParamGroups(unittest.TestCase):
         config = OptimizersInBackwardContainer.Config(
             name="AdamW",
             lr=1e-3,
-            weight_decay=0.1,
             implementation="for-loop",
             param_groups=[
-                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
             ],
         )
         container = config.build(model_parts=[model])
@@ -310,11 +333,16 @@ class TestDCPWithParamGroups(unittest.TestCase):
         config = OptimizersContainer.Config(
             name="AdamW",
             lr=1e-3,
-            weight_decay=0.1,
             implementation="for-loop",
             param_groups=[
-                ParamGroupConfig(pattern=r".*\.bias$", weight_decay_multiplier=0.0),
-                ParamGroupConfig(pattern=r"embed_tokens\.", lr_multiplier=0.1),
+                ParamGroupConfig(
+                    pattern=r".*\.bias$",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r"embed_tokens\.",
+                    optimizer_kwargs={"lr": 1e-4},
+                ),
             ],
         )
         container = config.build(model_parts=[model])
@@ -347,6 +375,209 @@ class TestDCPWithParamGroups(unittest.TestCase):
                     torch.equal(v1, v2),
                     f"State mismatch for key {key}",
                 )
+
+
+class TestMixedOptimizers(unittest.TestCase):
+    def test_mixed_optimizer_types(self):
+        """Different optimizer for a param group."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        opt_types = {type(opt).__name__ for opt in container.optimizers}
+        self.assertEqual(opt_types, {"AdamW", "SGD"})
+
+        sgd = next(
+            opt for opt in container.optimizers if isinstance(opt, torch.optim.SGD)
+        )
+        self.assertEqual(sgd.param_groups[0]["lr"], 5e-4)
+        self.assertEqual(sgd.param_groups[0]["momentum"], 0.9)
+
+    def test_mixed_optimizers_all_params_covered(self):
+        """All parameters should be covered across all optimizers."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        all_opt_params = set()
+        for opt in container.optimizers:
+            for group in opt.param_groups:
+                for p in group["params"]:
+                    all_opt_params.add(id(p))
+        model_params = {id(p) for p in model.parameters() if p.requires_grad}
+        self.assertEqual(all_opt_params, model_params)
+
+    def test_model_part_indices(self):
+        """_model_part_indices correctly maps optimizers to model parts."""
+        model1 = SimpleModel()
+        model2 = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model1, model2])
+        self.assertEqual(len(container.optimizers), 4)
+        self.assertEqual(container._model_part_indices[0], 0)
+        self.assertEqual(container._model_part_indices[1], 0)
+        self.assertEqual(container._model_part_indices[2], 1)
+        self.assertEqual(container._model_part_indices[3], 1)
+
+    def test_param_group_labels(self):
+        """Param groups have correct _label for logging."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_kwargs={"weight_decay": 0.0},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        adamw = container.optimizers[0]
+        self.assertEqual(adamw.param_groups[0]["_label"], "default")
+        self.assertEqual(adamw.param_groups[1]["_label"], "output.")
+
+    def test_mixed_optimizer_state_dict_round_trip(self):
+        """State dict save/load works with mixed optimizer types."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+
+        dummy_input = torch.randint(0, 32, (2, 4))
+        output = model(dummy_input)
+        output.sum().backward()
+        container.step()
+
+        state_dict = container.state_dict()
+        self.assertTrue(len(state_dict) > 0)
+
+        model2 = SimpleModel()
+        container2 = config.build(model_parts=[model2])
+        container2.load_state_dict(state_dict)
+
+        state_dict2 = container2.state_dict()
+        self.assertEqual(set(state_dict.keys()), set(state_dict2.keys()))
+        for key in state_dict:
+            v1 = state_dict[key]
+            v2 = state_dict2[key]
+            if isinstance(v1, torch.Tensor):
+                self.assertTrue(torch.equal(v1, v2), f"State mismatch for key {key}")
+
+
+class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
+    def _build_scheduler(self, config, lr_config, model, training_steps=100):
+        container = config.build(model_parts=[model])
+        for opt in container.optimizers:
+            opt._opt_called = True
+        return (
+            lr_config.build(
+                optimizers=container,
+                training_steps=training_steps,
+            ),
+            container,
+        )
+
+    def test_default_schedule(self):
+        """Default schedule should work the same as before."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(lr=1e-3, implementation="for-loop")
+        lr_config = LRSchedulersContainer.Config(
+            warmup_steps=10,
+            decay_type="linear",
+        )
+        scheduler, container = self._build_scheduler(config, lr_config, model)
+        self.assertEqual(len(scheduler.schedulers), 1)
+        for _ in range(10):
+            scheduler.step()
+        lr = scheduler.schedulers[0].optimizer.param_groups[0]["lr"]
+        self.assertAlmostEqual(lr, 1e-3, places=6)
+
+    def test_mixed_optimizer_gets_separate_schedulers(self):
+        """Mixed optimizers should each get their own scheduler."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        lr_config = LRSchedulersContainer.Config(
+            warmup_steps=10,
+            decay_type="linear",
+        )
+        scheduler, container = self._build_scheduler(config, lr_config, model)
+        self.assertEqual(len(scheduler.schedulers), 2)
+
+    def test_mixed_optimizer_same_schedule_different_base_lr(self):
+        """Same schedule applied to different base lrs produces different absolute lrs."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            lr=1e-3,
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="SGD",
+                    optimizer_kwargs={"lr": 5e-4, "momentum": 0.9},
+                ),
+            ],
+        )
+        lr_config = LRSchedulersContainer.Config(
+            warmup_steps=10,
+            decay_type="linear",
+        )
+        scheduler, container = self._build_scheduler(config, lr_config, model)
+        for _ in range(10):
+            scheduler.step()
+        for opt in container.optimizers:
+            base_lr = opt.param_groups[0]["lr"]
+            if isinstance(opt, torch.optim.SGD):
+                self.assertAlmostEqual(base_lr, 5e-4, places=6)
+            else:
+                self.assertAlmostEqual(base_lr, 1e-3, places=6)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -110,9 +110,7 @@ class TestModelSpec:
         optimizers = OptimizersContainer.Config(
             name="Adam",
             lr=0.1,
-            beta1=0.9,
-            beta2=0.95,
-            weight_decay=0.1,
+            optimizer_kwargs={"betas": (0.9, 0.95), "weight_decay": 0.1},
             implementation="fused",
         ).build(model_parts=model_parts)
         spec.post_optimizer_build_fn(optimizers, model_parts, None, my_hook)

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import torch
 import torch.nn as nn
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.llama3 import model_registry, parallelize_llama
@@ -108,10 +108,18 @@ class TestModelSpec:
 
         # Build optimizers directly and apply post-build hook
         optimizers = OptimizersContainer.Config(
-            name="Adam",
-            lr=0.1,
-            optimizer_kwargs={"betas": (0.9, 0.95), "weight_decay": 0.1},
             implementation="fused",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="Adam",
+                    optimizer_kwargs={
+                        "lr": 0.1,
+                        "betas": (0.9, 0.95),
+                        "weight_decay": 0.1,
+                    },
+                ),
+            ],
         ).build(model_parts=model_parts)
         spec.post_optimizer_build_fn(optimizers, model_parts, None, my_hook)
 

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -38,8 +38,7 @@ class LRSchedulersContainer(Stateful, Configurable):
 
     **Checkpoint behavior**
     All schedulers share the same lambda and step together. On save, only
-    ``last_epoch`` is needed for restore; full per-scheduler state is saved
-    alongside for observability. On load, ``last_epoch`` is restored and each
+    ``last_epoch`` is saved. On load, ``last_epoch`` is restored and each
     scheduler recomputes its lr from its own optimizer's ``base_lrs``. This
     handles mixed optimizers (different base lrs) and resharding (different
     number of schedulers between save and load).
@@ -211,25 +210,24 @@ class LRSchedulersContainer(Stateful, Configurable):
 
     def get_metrics(self) -> dict[str, float]:
         """Return per-param-group learning rates keyed for logging."""
-        lr_metrics = {}
+        metrics = {}
         for scheduler in self.schedulers:
             opt = scheduler.optimizer
             opt_name = type(opt).__name__
             for group, lr_val in zip(opt.param_groups, scheduler.get_last_lr()):
-                lr_metrics[f"lr/{opt_name}_{group['_label']}"] = float(lr_val)
-        return lr_metrics
+                metrics[f"lr/{opt_name}_{group['pattern']}"] = float(lr_val)
+        return metrics
 
     def step(self) -> None:
         for scheduler in self.schedulers:
             scheduler.step()
 
     def state_dict(self) -> dict[str, Any]:
-        # Save last_epoch (the step counter, shared across all schedulers) for
-        # loading, plus full per-scheduler state for observability/debugging.
-        return {
-            "last_epoch": self.schedulers[0].last_epoch,
-            "schedulers": [s.state_dict() for s in self.schedulers],
-        }
+        # Only last_epoch is needed — each scheduler recomputes its lr from
+        # its own optimizer's base_lrs on load. Per-scheduler state (base_lrs,
+        # _last_lr) is not saved because it's reconstructed from the optimizer
+        # config at construction time.
+        return {"last_epoch": self.schedulers[0].last_epoch}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         # Only restore last_epoch. Each scheduler recomputes _last_lr from its

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -209,7 +209,7 @@ class LRSchedulersContainer(Stateful, Configurable):
     def __len__(self) -> int:
         return len(self.schedulers)
 
-    def get_lr_metrics(self) -> dict[str, float]:
+    def get_metrics(self) -> dict[str, float]:
         """Return per-param-group learning rates keyed for logging."""
         lr_metrics = {}
         for scheduler in self.schedulers:
@@ -236,6 +236,11 @@ class LRSchedulersContainer(Stateful, Configurable):
         # own optimizer's base_lrs and the shared lambda. This is correct for
         # mixed optimizers (different base_lrs) and resharding (different number
         # of schedulers between save and load).
+        #
+        # NOTE: torchtitan's LR schedules are stateless functions
+        # of (last_epoch, base_lr) — LambdaLR with a pure lambda. If a stateful
+        # scheduler (e.g. ReduceLROnPlateau) is added, this method must be updated
+        # to restore additional state.
         last_epoch = state_dict["last_epoch"]
         for scheduler in self.schedulers:
             scheduler.last_epoch = last_epoch

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 import functools
 import math
 from collections.abc import Callable, Iterator
@@ -37,11 +36,13 @@ class LRSchedulersContainer(Stateful, Configurable):
     signature as ``torch.optim.lr_scheduler.LRScheduler`` class: ``step()``, ``state_dict()``,
     ``load_state_dict()``.
 
-    **Limitations**
-    This class assumes all the lr schedulers are the same. There is no easy way to support
-    resharding for multiple different LRSchedulers because LRScheduler.state_dict() is not
-    resharding friendly. Therefore, the limitation is used to allow TorchTitan to support
-    lr scheduler resharding.
+    **Checkpoint behavior**
+    All schedulers share the same lambda and step together. On save, only
+    ``last_epoch`` is needed for restore; full per-scheduler state is saved
+    alongside for observability. On load, ``last_epoch`` is restored and each
+    scheduler recomputes its lr from its own optimizer's ``base_lrs``. This
+    handles mixed optimizers (different base lrs) and resharding (different
+    number of schedulers between save and load).
 
     Args:
         optimizers (OptimizersContainer): The corresponding optimizers for the lr_schedulers.
@@ -208,21 +209,35 @@ class LRSchedulersContainer(Stateful, Configurable):
     def __len__(self) -> int:
         return len(self.schedulers)
 
+    def get_lr_metrics(self) -> dict[str, float]:
+        """Return per-param-group learning rates keyed for logging."""
+        lr_metrics = {}
+        for scheduler in self.schedulers:
+            opt = scheduler.optimizer
+            opt_name = type(opt).__name__
+            for group, lr_val in zip(opt.param_groups, scheduler.get_last_lr()):
+                lr_metrics[f"lr/{opt_name}_{group['_label']}"] = float(lr_val)
+        return lr_metrics
+
     def step(self) -> None:
         for scheduler in self.schedulers:
             scheduler.step()
 
     def state_dict(self) -> dict[str, Any]:
-        # While there may be multiple schedulers, we only save the first one because
-        # the state_dict is the same for all. See the limitations section in the
-        # docstring.
-        return self.schedulers[0].state_dict()
+        # Save last_epoch (the step counter, shared across all schedulers) for
+        # loading, plus full per-scheduler state for observability/debugging.
+        return {
+            "last_epoch": self.schedulers[0].last_epoch,
+            "schedulers": [s.state_dict() for s in self.schedulers],
+        }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        # Load the same state_dict for all schedulers. The key value we're concerned
-        # within ``LRScheduler.state_dict()`` is ``last_epoch``, which is an integer
-        # that is immutable. As long as ``training.steps`` and ``lr_scheduler.warmup_steps``
-        # in the config remain unchanged when resuming from a checkpoint, this
-        # approach is safe. We call ``copy()`` here to ensure extra safety.
+        # Only restore last_epoch. Each scheduler recomputes _last_lr from its
+        # own optimizer's base_lrs and the shared lambda. This is correct for
+        # mixed optimizers (different base_lrs) and resharding (different number
+        # of schedulers between save and load).
+        last_epoch = state_dict["last_epoch"]
         for scheduler in self.schedulers:
-            scheduler.load_state_dict(copy.deepcopy(state_dict))
+            scheduler.last_epoch = last_epoch
+            scheduler._step_count = last_epoch + 1
+            scheduler._last_lr = scheduler.get_lr()

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -67,28 +67,6 @@ class ParamGroupConfig:
     Must include all required kwargs (e.g. ``lr``). No implicit defaults."""
 
 
-def default_adamw(lr: float = 8e-4, **kwargs: Any) -> list[ParamGroupConfig]:
-    """Create a catch-all AdamW param group with standard defaults.
-
-    Use as a convenience for the common case::
-
-        OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4))
-    """
-    return [
-        ParamGroupConfig(
-            pattern=r".*",
-            optimizer_name="AdamW",
-            optimizer_kwargs={
-                "lr": lr,
-                "betas": (0.9, 0.95),
-                "eps": 1e-8,
-                "weight_decay": 0.1,
-                **kwargs,
-            },
-        )
-    ]
-
-
 T = TypeVar("T", bound=Optimizer)
 
 
@@ -117,13 +95,18 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
+        param_groups: list[ParamGroupConfig] = field(default_factory=list)
+        """Per-parameter-group optimizer configurations. Each entry specifies a
+        regex pattern and a self-contained optimizer setup.
+        Patterns are checked in order; first match wins."""
+
         implementation: Literal[
             "for-loop", "foreach", "fused", "fused_opt_states_bf16"
         ] = "fused"
         """
         Optimizer implementation mode applied to all optimizer instances.
         Per-param-group ``optimizer_kwargs`` can override this (e.g.
-        ``"fused": False`` for optimizers that don't support fused with DTensor).
+        ``"fused": False`` for optimizers that don't support fused).
 
         - 'fused': Use fused implementation (CUDA only) for best performance.
         - 'foreach': Use some horizontal fusion of tensors for better performance.
@@ -135,12 +118,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
           OptimizersInBackwardContainer). See docs/bf16_optimizer_states.md.
         - more info: https://pytorch.org/docs/stable/optim.html
         """
-
-        param_groups: list[ParamGroupConfig] = field(default_factory=default_adamw)
-        """Per-parameter-group optimizer configurations. Each entry specifies a
-        regex pattern and a self-contained optimizer setup.
-        Patterns are checked in order; first match wins.
-        Defaults to ``default_adamw()``."""
 
     optimizers: list[T]
     model_parts: list[nn.Module]
@@ -173,7 +150,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     @staticmethod
     def _build_param_groups(
         model: nn.Module,
-        param_groups: list[ParamGroupConfig],
+        param_group_configs: list[ParamGroupConfig],
         impl_kwargs: dict[str, Any],
     ) -> dict[str, list[dict[str, Any]]]:
         """Build PyTorch param groups from model parameters, partitioned by optimizer.
@@ -181,13 +158,13 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         Each parameter is assigned to the first matching ParamGroupConfig pattern.
         Returns a dict mapping optimizer name to a list of param group dicts.
 
-        Each param group dict includes a ``_label`` key with the regex pattern
+        Each param group dict includes a ``pattern`` key with the regex pattern
         string for logging.
         """
         result: dict[str, list[dict[str, Any]]] = defaultdict(list)
         claimed: set[str] = set()  # first-match-wins
 
-        for pg in param_groups:
+        for pg in param_group_configs:
             pattern = re.compile(pg.pattern)
             matched = []
             for name, param in model.named_parameters():
@@ -205,17 +182,17 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             result[pg.optimizer_name].append(
                 {
                     "params": matched,
-                    "_label": pg.pattern,
+                    "pattern": pg.pattern,
                     **impl_kwargs,
                     **pg.optimizer_kwargs,
                 }
             )
 
-        return dict(result)
+        return result
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
-        param_groups = config.param_groups
+        param_group_configs = config.param_groups
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
@@ -224,7 +201,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
         for part_idx, model in enumerate(self.model_parts):
             groups_by_opt_name = self._build_param_groups(
-                model, param_groups, impl_kwargs
+                model, param_group_configs, impl_kwargs
             )
             for opt_name, opt_param_groups in groups_by_opt_name.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
@@ -258,10 +235,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             for group in opt.param_groups:
                 num_params = len(group["params"])
                 kwargs = {k: v for k, v in group.items() if k in _KEY_KWARGS}
-                label = group["_label"]
+                pattern = group["pattern"]
                 logger.info(
                     f"Optimizer {opt_name} (model_part={part_idx}): "
-                    f"{num_params} params [{label}] {kwargs}"
+                    f"{num_params} params [{pattern}] {kwargs}"
                 )
 
     def _validate_params(self, all_params: list[nn.Parameter]) -> None:
@@ -393,7 +370,7 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
-        param_groups = config.param_groups
+        param_group_configs = config.param_groups
         all_params = []
         self.model_parts = model_parts
         # Maps each optimizer to its model part (for state_dict/load_state_dict)
@@ -402,18 +379,18 @@ class OptimizersInBackwardContainer(OptimizersContainer):
         optim_dict: dict[nn.Parameter, Optimizer] = {}
         for part_idx, model in enumerate(self.model_parts):
             groups_by_opt_name = self._build_param_groups(
-                model, param_groups, impl_kwargs
+                model, param_group_configs, impl_kwargs
             )
             for opt_name, opt_param_groups in groups_by_opt_name.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
                 for group in opt_param_groups:
-                    label = group["_label"]
+                    pattern = group["pattern"]
                     kwargs = {
-                        k: v for k, v in group.items() if k not in ("params", "_label")
+                        k: v for k, v in group.items() if k not in ("params", "pattern")
                     }
                     for p in group["params"]:
                         optim_dict[p] = opt_cls(
-                            [{"params": [p], "_label": label, **kwargs}]
+                            [{"params": [p], "pattern": pattern, **kwargs}]
                         )
                         self._model_part_indices.append(part_idx)
             all_params.extend(p for p in model.parameters())
@@ -445,6 +422,30 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         pass
+
+
+def default_adamw(lr: float = 8e-4, **kwargs: Any) -> OptimizersContainer.Config:
+    """Create an OptimizersContainer.Config with a catch-all AdamW param group.
+
+    Use as a convenience for the common case::
+
+        optimizer=default_adamw(lr=3e-4)
+    """
+    return OptimizersContainer.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                    **kwargs,
+                },
+            )
+        ]
+    )
 
 
 def register_moe_load_balancing_hook(

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -39,37 +39,51 @@ __all__ = [
 class ParamGroupConfig:
     """Configuration for a parameter group with custom optimizer settings.
 
-    Parameters matching the regex pattern will use lr and weight_decay values
-    derived by multiplying the global optimizer values with the specified multipliers.
+    Each entry specifies a regex pattern matching parameter FQNs. Parameters
+    matching the pattern can override optimizer hyperparameters or switch to a
+    different optimizer entirely.
+
+    There are two override modes:
+
+    1. **Same optimizer, different hyperparams** (``optimizer_name`` is None):
+       ``optimizer_kwargs`` are merged on top of the global optimizer defaults.
+       Unspecified kwargs inherit from the global config.
+
+    2. **Different optimizer** (``optimizer_name`` is set):
+       ``optimizer_kwargs`` must be self-contained — no fallbacks from the global
+       config. If required kwargs (e.g. ``lr``) are missing, PyTorch's optimizer
+       constructor will raise at init time.
     """
 
     pattern: str
     """Regex pattern matched against parameter fully qualified names (FQNs).
     E.g. '.*bias$', '.*norm.*', '.*\\.embed_tokens\\..*'"""
 
-    lr_multiplier: float = 1.0
-    """Multiplied with the global optimizer lr to get this group's lr."""
+    optimizer_name: str | None = None
+    """Override the optimizer type for this group. None means use the global
+    default. When set, ``optimizer_kwargs`` must provide all required kwargs."""
 
-    weight_decay_multiplier: float = 1.0
-    """Multiplied with the global optimizer weight_decay to get this group's weight_decay."""
-
-    beta1: float | None = None
-    beta2: float | None = None
-    """Override betas for this group. None means use the global optimizer betas.
-    Each can be overridden independently."""
+    optimizer_kwargs: dict[str, Any] = field(default_factory=dict)
+    """Optimizer-specific keyword arguments.
+    When ``optimizer_name`` is None: merged on top of global defaults.
+    When ``optimizer_name`` is set: standalone kwargs for the new optimizer."""
 
 
 T = TypeVar("T", bound=Optimizer)
 
 
-# TODO: Right now this class is biased towards AdamW. We should refactor to
-# support mixed optimizers, including Muon.
 class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
-    """A container for multiple optimizers.
+    """A container for multiple optimizers, supporting mixed optimizer types.
 
-    This class is used to wrap multiple optimizers into a single object that can be
-    used to reduce the complexity of the training loop. This mimics the behavior of
-    ``torch.optim.Optimizer``. This class currently only supports ``Adam`` and ``AdamW``.
+    This class wraps multiple optimizers into a single object to simplify the
+    training loop. It supports a two-layer configuration:
+
+    - **Global defaults** (``Config``): the default optimizer type and kwargs.
+    - **Per-group overrides** (``ParamGroupConfig``): override kwargs within the
+      same optimizer, or switch to a different optimizer entirely.
+
+    Each model part (from pipeline parallelism) may have multiple optimizer
+    instances if different parameter groups use different optimizer types.
 
     **Note**
     Users who want to customize the optimizer behavior can inherit from this class and
@@ -77,42 +91,35 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     as ``torch.optim.Optimizer`` class: ``step()``, ``zero_grad()``, ``state_dict()``,
     ``load_state_dict()``.
 
-    **Limitations**
-    This class assumes that all the optimizers are the same type and have the same
-    configurations. With this assumption, TorchTitan can support lr scheduler resharding
-    (e.g., loading a checkpoint with a different number of GPUs and/or different
-    parallelization strategy). Note that ``get_optimizer_state_dict`` already enables the
-    resharding for the optimizer state but not for the lr scheduler state, hence the limitation.
-
     Args:
+        config (Config): Optimizer configuration including param group overrides.
         model_parts (List[nn.Module]): List of model parts to be optimized.
-        optimizer_kwargs (Dict[str, Any]): Keyword arguments for the optimizers.
-        name (str): Name of the optimizers.
     """
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
         name: str = "AdamW"
-        """Optimizer to use"""
+        """Default optimizer to use"""
 
         lr: float = 8e-4
         """Learning rate to use"""
 
-        beta1: float = 0.9
-        beta2: float = 0.95
-        """Exponential moving average hyperparameters to use"""
-
-        eps: float = 1e-8
-        """Epsilon value to use"""
-
-        weight_decay: float = 0.1
-        """Weight decay to use"""
+        optimizer_kwargs: dict[str, Any] = field(
+            default_factory=lambda: {
+                "betas": (0.9, 0.95),
+                "eps": 1e-8,
+                "weight_decay": 0.1,
+            }
+        )
+        """Optimizer-specific keyword arguments passed to the optimizer constructor.
+        Defaults are for AdamW. Override entirely when using a different optimizer,
+        e.g. ``{"momentum": 0.9}`` for SGD."""
 
         implementation: Literal[
             "for-loop", "foreach", "fused", "fused_opt_states_bf16"
         ] = "fused"
         """
-        Specify which optimizer implementation to use:
+        Specify which optimizer implementation to use for the default optimizer:
         - 'fused': Use fused implementation (CUDA only) for best performance.
         - 'foreach': Use some horizontal fusion of tensors for better performance.
         - 'for-loop': Use the default implementation for the optimizer (slowest).
@@ -126,7 +133,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
         param_groups: list[ParamGroupConfig] = field(default_factory=list)
         """Optional per-parameter-group overrides. Each entry specifies a regex
-        pattern matching parameter FQNs and multipliers for lr and weight_decay.
+        pattern matching parameter FQNs. Parameters can override optimizer kwargs
+        or switch to a different optimizer entirely.
         Parameters not matching any pattern use the global defaults.
         Patterns are checked in order; first match wins."""
 
@@ -143,7 +151,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     @staticmethod
     def _resolve_optimizer_cls(name: str) -> type:
-        optimizer_classes = {"Adam": torch.optim.Adam, "AdamW": torch.optim.AdamW}
+        optimizer_classes = {
+            "Adam": torch.optim.Adam,
+            "AdamW": torch.optim.AdamW,
+            "SGD": torch.optim.SGD,
+        }
         if name not in optimizer_classes:
             raise NotImplementedError(f"Optimizer {name} not added.")
         return optimizer_classes[name]
@@ -159,11 +171,9 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         fused = config.implementation in ("fused", "fused_opt_states_bf16")
         return {
             "lr": config.lr,
-            "betas": (config.beta1, config.beta2),
-            "eps": config.eps,
-            "weight_decay": config.weight_decay,
             "fused": fused,
             "foreach": config.implementation == "foreach",
+            **config.optimizer_kwargs,
         }
 
     @staticmethod
@@ -171,79 +181,133 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         model: nn.Module,
         config: Config,
         default_kwargs: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        """Build PyTorch param groups from model parameters and config.
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Build PyTorch param groups from model parameters, partitioned by optimizer.
 
         Each parameter is assigned to the first matching ParamGroupConfig pattern,
-        or to the default group if no pattern matches. Returns a list of dicts
-        with "params" key and optimizer kwargs, suitable for passing to an optimizer.
+        or to the default group if no pattern matches. Returns a dict mapping
+        optimizer name to a list of param group dicts for that optimizer.
+
+        Each param group dict includes a ``_label`` key with a sanitized pattern
+        string (or ``"default"`` for unmatched params) for logging.
+
+        Override modes:
+        - ``optimizer_name`` is None: ``optimizer_kwargs`` merge on top of defaults.
+        - ``optimizer_name`` is set: ``optimizer_kwargs`` are standalone.
         """
         if not config.param_groups:
             params = [p for p in model.parameters() if p.requires_grad]
-            return [{"params": params, **default_kwargs}]
+            return {
+                config.name: [{"params": params, "_label": "default", **default_kwargs}]
+            }
 
-        compiled_patterns = [re.compile(pg.pattern) for pg in config.param_groups]
+        result: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        claimed: set[
+            str
+        ] = set()  # first-match-wins: a param is assigned to the first matching pattern
 
-        # group_index -> list of params; None means default group
-        grouped_params: dict[int | None, list[nn.Parameter]] = defaultdict(list)
+        for pg in config.param_groups:
+            pattern = re.compile(pg.pattern)
+            matched = []
+            for name, param in model.named_parameters():
+                if param.requires_grad and name not in claimed and pattern.search(name):
+                    matched.append(param)
+                    claimed.add(name)
 
-        for name, param in model.named_parameters():
-            if not param.requires_grad:
-                continue
-            matched_index = None
-            for i, pat in enumerate(compiled_patterns):
-                if pat.search(name):
-                    matched_index = i
-                    break
-            grouped_params[matched_index].append(param)
-
-        # Warn for patterns that matched nothing
-        for i, pg in enumerate(config.param_groups):
-            if i not in grouped_params:
+            if not matched:
                 logger.warning(
                     f"Optimizer param_groups pattern '{pg.pattern}' "
                     f"matched no parameters"
                 )
-
-        result = []
-        # Default group first (unmatched params)
-        if None in grouped_params:
-            result.append({"params": grouped_params[None], **default_kwargs})
-
-        # Then each matched group in pattern order
-        for i, pg in enumerate(config.param_groups):
-            if i not in grouped_params:
                 continue
-            group_kwargs = {**default_kwargs}
-            group_kwargs["lr"] = default_kwargs["lr"] * pg.lr_multiplier
-            group_kwargs["weight_decay"] = (
-                default_kwargs["weight_decay"] * pg.weight_decay_multiplier
-            )
-            if pg.beta1 is not None or pg.beta2 is not None:
-                default_beta1, default_beta2 = default_kwargs["betas"]
-                group_kwargs["betas"] = (
-                    pg.beta1 if pg.beta1 is not None else default_beta1,
-                    pg.beta2 if pg.beta2 is not None else default_beta2,
-                )
-            result.append({"params": grouped_params[i], **group_kwargs})
 
-        return result
+            label = re.sub(r"[^a-zA-Z0-9._]", "", pg.pattern.replace("|", "_or_"))
+            opt_name = pg.optimizer_name or config.name
+            base_kwargs = {} if pg.optimizer_name else default_kwargs
+            # optimizer_kwargs comes last so user overrides take precedence
+            result[opt_name].append(
+                {
+                    "params": matched,
+                    "_label": label,
+                    **base_kwargs,
+                    **pg.optimizer_kwargs,
+                }
+            )
+
+        # Default group: unclaimed params
+        default_params = [
+            p
+            for name, p in model.named_parameters()
+            if p.requires_grad and name not in claimed
+        ]
+        if default_params:
+            result[config.name].insert(
+                0, {"params": default_params, "_label": "default", **default_kwargs}
+            )
+
+        return dict(result)
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
-        optimizer_cls = self._resolve_optimizer_cls(config.name)
-        optimizer_kwargs = self._build_optimizer_kwargs(config)
+        default_kwargs = self._build_optimizer_kwargs(config)
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
-        for model in self.model_parts:
-            param_groups = self._build_param_groups(model, config, optimizer_kwargs)
-            self.optimizers.append(optimizer_cls(param_groups))
-            for group in param_groups:
-                all_params.extend(group["params"])
+        # Maps each optimizer to its model part (for state_dict/load_state_dict)
+        self._model_part_indices: list[int] = []
+
+        for part_idx, model in enumerate(self.model_parts):
+            groups_by_opt = self._build_param_groups(model, config, default_kwargs)
+            for opt_name, param_groups in groups_by_opt.items():
+                opt_cls = self._resolve_optimizer_cls(opt_name)
+                self.optimizers.append(opt_cls(param_groups))
+                self._model_part_indices.append(part_idx)
+                for group in param_groups:
+                    all_params.extend(group["params"])
+
+        self._validate_params(all_params)
+
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
-        self._validate_length(len(self.model_parts))
-        self._post_init(all_params, optimizer_kwargs)
+        self._post_init(all_params, default_kwargs)
+        self._log_summary()
+
+    def _log_summary(self) -> None:
+        """Log a summary of optimizer assignments."""
+        _KEY_KWARGS = {
+            "lr",
+            "weight_decay",
+            "betas",
+            "eps",
+            "momentum",
+            "nesterov",
+            "fused",
+            "foreach",
+        }
+        for i, opt in enumerate(self.optimizers):
+            opt_name = type(opt).__name__
+            part_idx = self._model_part_indices[i]
+            for group in opt.param_groups:
+                num_params = len(group["params"])
+                kwargs = {k: v for k, v in group.items() if k in _KEY_KWARGS}
+                label = group["_label"]
+                logger.info(
+                    f"Optimizer {opt_name} (model_part={part_idx}): "
+                    f"{num_params} params [{label}] {kwargs}"
+                )
+
+    def _validate_params(self, all_params: list[nn.Parameter]) -> None:
+        """Verify every trainable param is assigned to exactly one optimizer."""
+        expected = {
+            id(p)
+            for model in self.model_parts
+            for p in model.parameters()
+            if p.requires_grad
+        }
+        actual = {id(p) for p in all_params}
+        assert expected == actual, (
+            f"Parameter mismatch: {len(expected)} trainable params in model, "
+            f"{len(actual)} in optimizers"
+        )
 
     def __iter__(self) -> Iterator[T]:
         return iter(self.optimizers)
@@ -274,11 +338,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             get_optimizer_state_dict,
             options=StateDictOptions(flatten_optimizer_state_dict=True),
         )
-        return {
-            k: v
-            for sd in map(func, self.model_parts, self.optimizers)
-            for k, v in sd.items()
-        }
+        result = {}
+        for opt, part_idx in zip(self.optimizers, self._model_part_indices):
+            sd = func(self.model_parts[part_idx], opt)
+            result.update(sd)
+        return result
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         func = functools.partial(
@@ -286,13 +350,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             optim_state_dict=state_dict,
             options=StateDictOptions(flatten_optimizer_state_dict=True),
         )
-        list(map(func, self.model_parts, self.optimizers))
-
-    def _validate_length(self, expected_length: int) -> None:
-        assert expected_length == len(self.optimizers), (
-            "Must pass one optimizer per model part or per param if "
-            "using OptimizersInBackwardContainer."
-        )
+        for opt, part_idx in zip(self.optimizers, self._model_part_indices):
+            func(self.model_parts[part_idx], opt)
 
     def _post_init(
         self, all_params: list[nn.Parameter], optimizer_kwargs: dict[str, Any]
@@ -339,7 +398,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                             )
 
         for optim in self.optimizers:
-            optim.register_step_pre_hook(_bf16_state_init_hook)
+            if isinstance(optim, (torch.optim.Adam, torch.optim.AdamW)):
+                optim.register_step_pre_hook(_bf16_state_init_hook)
 
     def init_cache_state_dict(self) -> None:
         """Initialize cached state dict for TorchFT. No-op for base class."""
@@ -366,26 +426,28 @@ class OptimizersInBackwardContainer(OptimizersContainer):
             OptimizersContainer.Config.__post_init__(self)
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
-        optimizer_cls = self._resolve_optimizer_cls(config.name)
-        optimizer_kwargs = self._build_optimizer_kwargs(config)
+        default_kwargs = self._build_optimizer_kwargs(config)
         all_params = []
         self.model_parts = model_parts
+        # Maps each optimizer to its model part (for state_dict/load_state_dict)
+        self._model_part_indices: list[int] = []
 
-        # Build a mapping from param -> effective kwargs using param group config
-        param_to_kwargs: dict[nn.Parameter, dict[str, Any]] = {}
-        for model in self.model_parts:
-            param_groups = self._build_param_groups(model, config, optimizer_kwargs)
-            for group in param_groups:
-                group_kwargs = {k: v for k, v in group.items() if k != "params"}
-                for p in group["params"]:
-                    param_to_kwargs[p] = group_kwargs
-
-        optim_dict = {}
-        for model in self.model_parts:
-            for p in model.parameters():
-                if p.requires_grad:
-                    optim_dict[p] = optimizer_cls([p], **param_to_kwargs[p])
-                all_params.append(p)
+        optim_dict: dict[nn.Parameter, Optimizer] = {}
+        for part_idx, model in enumerate(self.model_parts):
+            groups_by_opt = self._build_param_groups(model, config, default_kwargs)
+            for opt_name, param_groups in groups_by_opt.items():
+                opt_cls = self._resolve_optimizer_cls(opt_name)
+                for group in param_groups:
+                    label = group["_label"]
+                    kwargs = {
+                        k: v for k, v in group.items() if k not in ("params", "_label")
+                    }
+                    for p in group["params"]:
+                        optim_dict[p] = opt_cls(
+                            [{"params": [p], "_label": label, **kwargs}]
+                        )
+                        self._model_part_indices.append(part_idx)
+            all_params.extend(p for p in model.parameters())
 
         def optim_hook(param) -> None:
             optim_dict[param].step()
@@ -397,11 +459,9 @@ class OptimizersInBackwardContainer(OptimizersContainer):
                     param.register_post_accumulate_grad_hook(optim_hook)
 
         self.optimizers = list(optim_dict.values())
-
-        self._validate_length(
-            sum(len(list(model.parameters())) for model in self.model_parts)
-        )
-        self._post_init(all_params, optimizer_kwargs)
+        self._validate_params(all_params)
+        self._post_init(all_params, default_kwargs)
+        self._log_summary()
 
     @overload
     def step(self, closure: None = None) -> None:

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -37,36 +37,33 @@ __all__ = [
 
 @dataclass(kw_only=True, slots=True)
 class ParamGroupConfig:
-    """Configuration for a parameter group with custom optimizer settings.
+    """Configuration for a parameter group with its own optimizer.
 
-    Each entry specifies a regex pattern matching parameter FQNs. Parameters
-    matching the pattern can override optimizer hyperparameters or switch to a
-    different optimizer entirely.
+    Each entry specifies a regex pattern matching parameter FQNs and a
+    self-contained optimizer setup. ``optimizer_name`` and ``optimizer_kwargs``
+    fully define the optimizer for matched parameters — no implicit inheritance.
 
-    There are two override modes:
+    Patterns are checked in order; first match wins. Place specific patterns
+    before broad ones, and use ``r".*"`` as the last entry to catch all
+    remaining parameters. Example::
 
-    1. **Same optimizer, different hyperparams** (``optimizer_name`` is None):
-       ``optimizer_kwargs`` are merged on top of the global optimizer defaults.
-       Unspecified kwargs inherit from the global config.
-
-    2. **Different optimizer** (``optimizer_name`` is set):
-       ``optimizer_kwargs`` must be self-contained — no fallbacks from the global
-       config. If required kwargs (e.g. ``lr``) are missing, PyTorch's optimizer
-       constructor will raise at init time.
+        param_groups=[
+            ParamGroupConfig(pattern=r"\\.bias$", ...),   # specific: biases first
+            ParamGroupConfig(pattern=r"\\.router\\.", ...),  # specific: routers
+            ParamGroupConfig(pattern=r".*", ...),          # catch-all: everything else
+        ]
     """
 
     pattern: str
     """Regex pattern matched against parameter fully qualified names (FQNs).
-    E.g. '.*bias$', '.*norm.*', '.*\\.embed_tokens\\..*'"""
+    E.g. '.*bias$', '.*norm.*', '.*\\.embed_tokens\\..*', '.*' (catch-all)"""
 
-    optimizer_name: str | None = None
-    """Override the optimizer type for this group. None means use the global
-    default. When set, ``optimizer_kwargs`` must provide all required kwargs."""
+    optimizer_name: str = "AdamW"
+    """Optimizer type for this group."""
 
     optimizer_kwargs: dict[str, Any] = field(default_factory=dict)
-    """Optimizer-specific keyword arguments.
-    When ``optimizer_name`` is None: merged on top of global defaults.
-    When ``optimizer_name`` is set: standalone kwargs for the new optimizer."""
+    """Keyword arguments passed to the optimizer constructor.
+    Must include all required kwargs (e.g. ``lr``). No implicit defaults."""
 
 
 T = TypeVar("T", bound=Optimizer)
@@ -76,11 +73,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     """A container for multiple optimizers, supporting mixed optimizer types.
 
     This class wraps multiple optimizers into a single object to simplify the
-    training loop. It supports a two-layer configuration:
-
-    - **Global defaults** (``Config``): the default optimizer type and kwargs.
-    - **Per-group overrides** (``ParamGroupConfig``): override kwargs within the
-      same optimizer, or switch to a different optimizer entirely.
+    training loop. Each parameter group is configured via ``ParamGroupConfig``
+    with its own optimizer type and kwargs. Parameters are matched to groups
+    by regex pattern (first match wins), and groups using the same optimizer
+    type are batched into a single optimizer instance for performance.
 
     Each model part (from pipeline parallelism) may have multiple optimizer
     instances if different parameter groups use different optimizer types.
@@ -92,17 +88,17 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     ``load_state_dict()``.
 
     Args:
-        config (Config): Optimizer configuration including param group overrides.
+        config (Config): Optimizer configuration with param group definitions.
         model_parts (List[nn.Module]): List of model parts to be optimized.
     """
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
         name: str = "AdamW"
-        """Default optimizer to use"""
+        """Default optimizer type, used when param_groups is not specified."""
 
         lr: float = 8e-4
-        """Learning rate to use"""
+        """Default learning rate, used when param_groups is not specified."""
 
         optimizer_kwargs: dict[str, Any] = field(
             default_factory=lambda: {
@@ -111,15 +107,17 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                 "weight_decay": 0.1,
             }
         )
-        """Optimizer-specific keyword arguments passed to the optimizer constructor.
-        Defaults are for AdamW. Override entirely when using a different optimizer,
-        e.g. ``{"momentum": 0.9}`` for SGD."""
+        """Default optimizer kwargs, used when param_groups is not specified.
+        Defaults are for AdamW."""
 
         implementation: Literal[
             "for-loop", "foreach", "fused", "fused_opt_states_bf16"
         ] = "fused"
         """
-        Specify which optimizer implementation to use for the default optimizer:
+        Optimizer implementation mode applied to all optimizer instances.
+        Per-param-group ``optimizer_kwargs`` can override this (e.g.
+        ``"fused": False`` for optimizers that don't support fused with DTensor).
+
         - 'fused': Use fused implementation (CUDA only) for best performance.
         - 'foreach': Use some horizontal fusion of tensors for better performance.
         - 'for-loop': Use the default implementation for the optimizer (slowest).
@@ -132,19 +130,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         """
 
         param_groups: list[ParamGroupConfig] = field(default_factory=list)
-        """Optional per-parameter-group overrides. Each entry specifies a regex
-        pattern matching parameter FQNs. Parameters can override optimizer kwargs
-        or switch to a different optimizer entirely.
-        Parameters not matching any pattern use the global defaults.
-        Patterns are checked in order; first match wins."""
-
-        def __post_init__(self):
-            if self.implementation == "fused_opt_states_bf16":
-                if self.name not in ("Adam", "AdamW"):
-                    raise ValueError(
-                        "implementation='fused_opt_states_bf16' is only supported "
-                        f"for Adam/AdamW, got optimizer '{self.name}'"
-                    )
+        """Per-parameter-group optimizer configurations. Each entry specifies a
+        regex pattern and a self-contained optimizer setup.
+        Patterns are checked in order; first match wins.
+        If empty, all parameters use the default optimizer (name, lr, optimizer_kwargs)."""
 
     optimizers: list[T]
     model_parts: list[nn.Module]
@@ -161,7 +150,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         return optimizer_classes[name]
 
     @staticmethod
-    def _build_optimizer_kwargs(config: Config) -> dict[str, Any]:
+    def _build_impl_kwargs(config: Config) -> dict[str, Any]:
+        """Build implementation-related kwargs (fused/foreach) from config."""
         assert config.implementation in [
             "fused",
             "foreach",
@@ -170,43 +160,39 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         ]
         fused = config.implementation in ("fused", "fused_opt_states_bf16")
         return {
-            "lr": config.lr,
             "fused": fused,
             "foreach": config.implementation == "foreach",
-            **config.optimizer_kwargs,
         }
+
+    @staticmethod
+    def _default_param_groups(config: Config) -> list[ParamGroupConfig]:
+        """Return a catch-all param group from config's default optimizer fields."""
+        return [
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name=config.name,
+                optimizer_kwargs={"lr": config.lr, **config.optimizer_kwargs},
+            )
+        ]
 
     @staticmethod
     def _build_param_groups(
         model: nn.Module,
-        config: Config,
-        default_kwargs: dict[str, Any],
+        param_groups: list[ParamGroupConfig],
+        impl_kwargs: dict[str, Any],
     ) -> dict[str, list[dict[str, Any]]]:
         """Build PyTorch param groups from model parameters, partitioned by optimizer.
 
-        Each parameter is assigned to the first matching ParamGroupConfig pattern,
-        or to the default group if no pattern matches. Returns a dict mapping
-        optimizer name to a list of param group dicts for that optimizer.
+        Each parameter is assigned to the first matching ParamGroupConfig pattern.
+        Returns a dict mapping optimizer name to a list of param group dicts.
 
         Each param group dict includes a ``_label`` key with a sanitized pattern
-        string (or ``"default"`` for unmatched params) for logging.
-
-        Override modes:
-        - ``optimizer_name`` is None: ``optimizer_kwargs`` merge on top of defaults.
-        - ``optimizer_name`` is set: ``optimizer_kwargs`` are standalone.
+        string for logging.
         """
-        if not config.param_groups:
-            params = [p for p in model.parameters() if p.requires_grad]
-            return {
-                config.name: [{"params": params, "_label": "default", **default_kwargs}]
-            }
-
         result: dict[str, list[dict[str, Any]]] = defaultdict(list)
-        claimed: set[
-            str
-        ] = set()  # first-match-wins: a param is assigned to the first matching pattern
+        claimed: set[str] = set()  # first-match-wins
 
-        for pg in config.param_groups:
+        for pg in param_groups:
             pattern = re.compile(pg.pattern)
             matched = []
             for name, param in model.named_parameters():
@@ -222,33 +208,20 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                 continue
 
             label = re.sub(r"[^a-zA-Z0-9._]", "", pg.pattern.replace("|", "_or_"))
-            opt_name = pg.optimizer_name or config.name
-            base_kwargs = {} if pg.optimizer_name else default_kwargs
-            # optimizer_kwargs comes last so user overrides take precedence
-            result[opt_name].append(
+            result[pg.optimizer_name].append(
                 {
                     "params": matched,
                     "_label": label,
-                    **base_kwargs,
+                    **impl_kwargs,
                     **pg.optimizer_kwargs,
                 }
-            )
-
-        # Default group: unclaimed params
-        default_params = [
-            p
-            for name, p in model.named_parameters()
-            if p.requires_grad and name not in claimed
-        ]
-        if default_params:
-            result[config.name].insert(
-                0, {"params": default_params, "_label": "default", **default_kwargs}
             )
 
         return dict(result)
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
-        default_kwargs = self._build_optimizer_kwargs(config)
+        impl_kwargs = self._build_impl_kwargs(config)
+        param_groups = config.param_groups or self._default_param_groups(config)
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
@@ -256,19 +229,19 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         self._model_part_indices: list[int] = []
 
         for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt = self._build_param_groups(model, config, default_kwargs)
-            for opt_name, param_groups in groups_by_opt.items():
+            groups_by_opt = self._build_param_groups(model, param_groups, impl_kwargs)
+            for opt_name, opt_param_groups in groups_by_opt.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
-                self.optimizers.append(opt_cls(param_groups))
+                self.optimizers.append(opt_cls(opt_param_groups))
                 self._model_part_indices.append(part_idx)
-                for group in param_groups:
+                for group in opt_param_groups:
                     all_params.extend(group["params"])
 
         self._validate_params(all_params)
 
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
-        self._post_init(all_params, default_kwargs)
+        self._post_init(all_params, impl_kwargs)
         self._log_summary()
 
     def _log_summary(self) -> None:
@@ -423,10 +396,10 @@ class OptimizersInBackwardContainer(OptimizersContainer):
                     "implementation='fused_opt_states_bf16' is not supported with "
                     "OptimizersInBackwardContainer"
                 )
-            OptimizersContainer.Config.__post_init__(self)
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
-        default_kwargs = self._build_optimizer_kwargs(config)
+        impl_kwargs = self._build_impl_kwargs(config)
+        param_groups = config.param_groups or self._default_param_groups(config)
         all_params = []
         self.model_parts = model_parts
         # Maps each optimizer to its model part (for state_dict/load_state_dict)
@@ -434,10 +407,10 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
         optim_dict: dict[nn.Parameter, Optimizer] = {}
         for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt = self._build_param_groups(model, config, default_kwargs)
-            for opt_name, param_groups in groups_by_opt.items():
+            groups_by_opt = self._build_param_groups(model, param_groups, impl_kwargs)
+            for opt_name, opt_param_groups in groups_by_opt.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
-                for group in param_groups:
+                for group in opt_param_groups:
                     label = group["_label"]
                     kwargs = {
                         k: v for k, v in group.items() if k not in ("params", "_label")
@@ -460,7 +433,7 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
         self.optimizers = list(optim_dict.values())
         self._validate_params(all_params)
-        self._post_init(all_params, default_kwargs)
+        self._post_init(all_params, impl_kwargs)
         self._log_summary()
 
     @overload

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -31,6 +31,7 @@ __all__ = [
     "OptimizersContainer",
     "OptimizersInBackwardContainer",
     "ParamGroupConfig",
+    "default_adamw",
     "register_moe_load_balancing_hook",
 ]
 
@@ -66,6 +67,28 @@ class ParamGroupConfig:
     Must include all required kwargs (e.g. ``lr``). No implicit defaults."""
 
 
+def default_adamw(lr: float = 8e-4, **kwargs: Any) -> list[ParamGroupConfig]:
+    """Create a catch-all AdamW param group with standard defaults.
+
+    Use as a convenience for the common case::
+
+        OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4))
+    """
+    return [
+        ParamGroupConfig(
+            pattern=r".*",
+            optimizer_name="AdamW",
+            optimizer_kwargs={
+                "lr": lr,
+                "betas": (0.9, 0.95),
+                "eps": 1e-8,
+                "weight_decay": 0.1,
+                **kwargs,
+            },
+        )
+    ]
+
+
 T = TypeVar("T", bound=Optimizer)
 
 
@@ -94,22 +117,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
-        name: str = "AdamW"
-        """Default optimizer type, used when param_groups is not specified."""
-
-        lr: float = 8e-4
-        """Default learning rate, used when param_groups is not specified."""
-
-        optimizer_kwargs: dict[str, Any] = field(
-            default_factory=lambda: {
-                "betas": (0.9, 0.95),
-                "eps": 1e-8,
-                "weight_decay": 0.1,
-            }
-        )
-        """Default optimizer kwargs, used when param_groups is not specified.
-        Defaults are for AdamW."""
-
         implementation: Literal[
             "for-loop", "foreach", "fused", "fused_opt_states_bf16"
         ] = "fused"
@@ -129,11 +136,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         - more info: https://pytorch.org/docs/stable/optim.html
         """
 
-        param_groups: list[ParamGroupConfig] = field(default_factory=list)
+        param_groups: list[ParamGroupConfig] = field(default_factory=default_adamw)
         """Per-parameter-group optimizer configurations. Each entry specifies a
         regex pattern and a self-contained optimizer setup.
         Patterns are checked in order; first match wins.
-        If empty, all parameters use the default optimizer (name, lr, optimizer_kwargs)."""
+        Defaults to ``default_adamw()``."""
 
     optimizers: list[T]
     model_parts: list[nn.Module]
@@ -143,7 +150,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         optimizer_classes = {
             "Adam": torch.optim.Adam,
             "AdamW": torch.optim.AdamW,
-            "SGD": torch.optim.SGD,
         }
         if name not in optimizer_classes:
             raise NotImplementedError(f"Optimizer {name} not added.")
@@ -165,17 +171,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         }
 
     @staticmethod
-    def _default_param_groups(config: Config) -> list[ParamGroupConfig]:
-        """Return a catch-all param group from config's default optimizer fields."""
-        return [
-            ParamGroupConfig(
-                pattern=r".*",
-                optimizer_name=config.name,
-                optimizer_kwargs={"lr": config.lr, **config.optimizer_kwargs},
-            )
-        ]
-
-    @staticmethod
     def _build_param_groups(
         model: nn.Module,
         param_groups: list[ParamGroupConfig],
@@ -186,7 +181,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         Each parameter is assigned to the first matching ParamGroupConfig pattern.
         Returns a dict mapping optimizer name to a list of param group dicts.
 
-        Each param group dict includes a ``_label`` key with a sanitized pattern
+        Each param group dict includes a ``_label`` key with the regex pattern
         string for logging.
         """
         result: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -207,11 +202,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                 )
                 continue
 
-            label = re.sub(r"[^a-zA-Z0-9._]", "", pg.pattern.replace("|", "_or_"))
             result[pg.optimizer_name].append(
                 {
                     "params": matched,
-                    "_label": label,
+                    "_label": pg.pattern,
                     **impl_kwargs,
                     **pg.optimizer_kwargs,
                 }
@@ -221,7 +215,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
-        param_groups = config.param_groups or self._default_param_groups(config)
+        param_groups = config.param_groups
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
@@ -229,8 +223,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         self._model_part_indices: list[int] = []
 
         for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt = self._build_param_groups(model, param_groups, impl_kwargs)
-            for opt_name, opt_param_groups in groups_by_opt.items():
+            groups_by_opt_name = self._build_param_groups(
+                model, param_groups, impl_kwargs
+            )
+            for opt_name, opt_param_groups in groups_by_opt_name.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
                 self.optimizers.append(opt_cls(opt_param_groups))
                 self._model_part_indices.append(part_idx)
@@ -241,7 +237,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
-        self._post_init(all_params, impl_kwargs)
+        self._post_init(all_params)
         self._log_summary()
 
     def _log_summary(self) -> None:
@@ -326,12 +322,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         for opt, part_idx in zip(self.optimizers, self._model_part_indices):
             func(self.model_parts[part_idx], opt)
 
-    def _post_init(
-        self, all_params: list[nn.Parameter], optimizer_kwargs: dict[str, Any]
-    ) -> None:
+    def _post_init(self, all_params: list[nn.Parameter]) -> None:
         # We need to call Optimizer.__init__() to initialize some necessary optimizer
-        # functionality such as hooks.
-        Optimizer.__init__(self, all_params, optimizer_kwargs)
+        # functionality such as hooks (e.g. register_step_pre_hook for MoE load balancing).
+        Optimizer.__init__(self, all_params, {})
 
     def _register_bf16_optimizer_state_hook(self) -> None:
         """Register a step pre-hook to create Adam optimizer states in bfloat16.
@@ -399,7 +393,7 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
-        param_groups = config.param_groups or self._default_param_groups(config)
+        param_groups = config.param_groups
         all_params = []
         self.model_parts = model_parts
         # Maps each optimizer to its model part (for state_dict/load_state_dict)
@@ -407,8 +401,10 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
         optim_dict: dict[nn.Parameter, Optimizer] = {}
         for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt = self._build_param_groups(model, param_groups, impl_kwargs)
-            for opt_name, opt_param_groups in groups_by_opt.items():
+            groups_by_opt_name = self._build_param_groups(
+                model, param_groups, impl_kwargs
+            )
+            for opt_name, opt_param_groups in groups_by_opt_name.items():
                 opt_cls = self._resolve_optimizer_cls(opt_name)
                 for group in opt_param_groups:
                     label = group["_label"]
@@ -433,7 +429,7 @@ class OptimizersInBackwardContainer(OptimizersContainer):
 
         self.optimizers = list(optim_dict.values())
         self._validate_params(all_params)
-        self._post_init(all_params, impl_kwargs)
+        self._post_init(all_params)
         self._log_summary()
 
     @overload

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -467,6 +467,7 @@ def register_moe_load_balancing_hook(
                     tokens_per_expert_E_by_layer,
                     # pyrefly: ignore [unbound-name]
                     device_mesh=dtensor_mesh,
+                    # pyrefly: ignore [unbound-name]
                     placements=[Replicate()] * dtensor_mesh.ndim,
                     run_check=False,
                 )

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -29,7 +29,6 @@ from torchtitan.tools.logging import logger
 
 __all__ = [
     "OptimizersContainer",
-    "OptimizersInBackwardContainer",
     "ParamGroupConfig",
     "default_adamw",
     "register_moe_load_balancing_hook",
@@ -59,7 +58,7 @@ class ParamGroupConfig:
     """Regex pattern matched against parameter fully qualified names (FQNs).
     E.g. '.*bias$', '.*norm.*', '.*\\.embed_tokens\\..*', '.*' (catch-all)"""
 
-    optimizer_name: str = "AdamW"
+    optimizer_name: str
     """Optimizer type for this group."""
 
     optimizer_kwargs: dict[str, Any] = field(default_factory=dict)
@@ -114,8 +113,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         - 'fused_opt_states_bf16': Like 'fused', but initialize Adam/AdamW
           momentum and variance in bfloat16 via a step pre-hook so the fused
           CUDA kernel uses its mixed-precision path (fp32 params + bf16 states).
-          Only supported for Adam/AdamW with OptimizersContainer (not
-          OptimizersInBackwardContainer). See docs/bf16_optimizer_states.md.
+          Only supported for Adam/AdamW. See docs/bf16_optimizer_states.md.
         - more info: https://pytorch.org/docs/stable/optim.html
         """
 
@@ -173,11 +171,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                     claimed.add(name)
 
             if not matched:
-                logger.warning(
+                raise ValueError(
                     f"Optimizer param_groups pattern '{pg.pattern}' "
                     f"matched no parameters"
                 )
-                continue
 
             result[pg.optimizer_name].append(
                 {
@@ -350,80 +347,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         pass
 
 
-class OptimizersInBackwardContainer(OptimizersContainer):
-    """OptimizersContainer for executing ``optim.step()`` in backward pass.
-
-    This class extend ``OptimizersContainer`` to support optimizer step in
-    backward pass. ``step()`` and ``zero_grad()`` are no-op in this class.
-    Instead, ``register_post_accumulate_grad_hook`` is used to register a hook to
-    execute these methods when the gradient is accumulated.
-    """
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(OptimizersContainer.Config):
-        def __post_init__(self) -> None:
-            if self.implementation == "fused_opt_states_bf16":
-                raise ValueError(
-                    "implementation='fused_opt_states_bf16' is not supported with "
-                    "OptimizersInBackwardContainer"
-                )
-
-    def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
-        impl_kwargs = self._build_impl_kwargs(config)
-        param_group_configs = config.param_groups
-        all_params = []
-        self.model_parts = model_parts
-        # Maps each optimizer to its model part (for state_dict/load_state_dict)
-        self._model_part_indices: list[int] = []
-
-        optim_dict: dict[nn.Parameter, Optimizer] = {}
-        for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt_name = self._build_param_groups(
-                model, param_group_configs, impl_kwargs
-            )
-            for opt_name, opt_param_groups in groups_by_opt_name.items():
-                opt_cls = self._resolve_optimizer_cls(opt_name)
-                for group in opt_param_groups:
-                    pattern = group["pattern"]
-                    kwargs = {
-                        k: v for k, v in group.items() if k not in ("params", "pattern")
-                    }
-                    for p in group["params"]:
-                        optim_dict[p] = opt_cls(
-                            [{"params": [p], "pattern": pattern, **kwargs}]
-                        )
-                        self._model_part_indices.append(part_idx)
-            all_params.extend(p for p in model.parameters())
-
-        def optim_hook(param) -> None:
-            optim_dict[param].step()
-            optim_dict[param].zero_grad()
-
-        for model in self.model_parts:
-            for param in model.parameters():
-                if param.requires_grad:
-                    param.register_post_accumulate_grad_hook(optim_hook)
-
-        self.optimizers = list(optim_dict.values())
-        self._validate_params(all_params)
-        self._post_init(all_params)
-        self._log_summary()
-
-    @overload
-    def step(self, closure: None = None) -> None:
-        ...
-
-    @overload
-    def step(self, closure: Callable[[], float]) -> float:
-        ...
-
-    def step(self, closure: Callable[[], float] | None = None) -> float | None:
-        return None
-
-    def zero_grad(self, set_to_none: bool = True) -> None:
-        pass
-
-
 def default_adamw(lr: float = 8e-4, **kwargs: Any) -> OptimizersContainer.Config:
     """Create an OptimizersContainer.Config with a catch-all AdamW param group.
 
@@ -544,8 +467,7 @@ def register_moe_load_balancing_hook(
                     tokens_per_expert_E_by_layer,
                     # pyrefly: ignore [unbound-name]
                     device_mesh=dtensor_mesh,
-                    placements=[Replicate()]
-                    * dtensor_mesh.ndim,  # pyrefly: ignore [unbound-name]
+                    placements=[Replicate()] * dtensor_mesh.ndim,
                     run_check=False,
                 )
 

--- a/torchtitan/experiments/ft/llama3/config_registry.py
+++ b/torchtitan/experiments/ft/llama3/config_registry.py
@@ -7,6 +7,7 @@
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.validate import Validator
 from torchtitan.config import ActivationCheckpointConfig, CommConfig, TrainingConfig
 from torchtitan.experiments.ft.checkpoint import FTCheckpointManager
@@ -31,7 +32,7 @@ def llama3_ft_debugmodel() -> FaultTolerantTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
-        optimizer=FTOptimizersContainer.Config(lr=8e-4),
+        optimizer=FTOptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/experiments/ft/llama3/config_registry.py
+++ b/torchtitan/experiments/ft/llama3/config_registry.py
@@ -32,7 +32,9 @@ def llama3_ft_debugmodel() -> FaultTolerantTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
-        optimizer=FTOptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=FTOptimizersContainer.Config(
+            param_groups=default_adamw(lr=8e-4).param_groups
+        ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -13,7 +13,7 @@ Each function returns a complete ``RLTrainer.Config`` and is discoverable by
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.config import (
     CompileConfig,
     DebugConfig,
@@ -48,7 +48,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
+            optimizer=default_adamw(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -105,7 +105,7 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
+            optimizer=default_adamw(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -163,7 +163,7 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-6)),
+            optimizer=default_adamw(lr=1e-6),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -201,48 +201,6 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
     )
 
 
-def rl_grpo_qwen3_debug() -> RLTrainer.Config:
-    """Debug config for quick iteration -- small model, few steps (2 GPUs: 1 gen + 1 train)."""
-    group_size = 4
-    return RLTrainer.Config(
-        model_spec=model_registry("debugmodel", attn_backend="varlen"),
-        num_steps=5,
-        num_prompts_per_step=5,
-        num_validation_samples=20,
-        compile=CompileConfig(enable=True, backend="aot_eager"),
-        env=SumDigitsEnv.Config(seed=42, correctness_reward=1.0, format_reward=0.3),
-        validation_env=SumDigitsEnv.Config(
-            seed=99, correctness_reward=1.0, format_reward=0.3
-        ),
-        trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(lr=8e-4),
-            lr_scheduler=LRSchedulersContainer.Config(
-                warmup_steps=2,
-                decay_type="linear",
-            ),
-            training=TrainingConfig(),
-            parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
-                tensor_parallel_degree=1,
-                data_parallel_replicate_degree=1,
-            ),
-            loss=GRPOLoss.Config(),
-        ),
-        generator=VLLMGenerator.Config(
-            parallelism=ParallelismConfig(
-                tensor_parallel_degree=1,
-                data_parallel_replicate_degree=1,
-            ),
-            sampling=SamplingConfig(
-                n=group_size,
-                temperature=1.0,
-                top_p=0.95,
-                max_tokens=50,
-            ),
-        ),
-    )
-
-
 def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
     """On-policy GRPO config for Qwen3-0.6B under same parallelism (4 GPUs: 2 gen + 2 train).
 
@@ -266,7 +224,7 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
+            optimizer=default_adamw(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -13,7 +13,7 @@ Each function returns a complete ``RLTrainer.Config`` and is discoverable by
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.config import (
     CompileConfig,
     DebugConfig,
@@ -48,7 +48,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(lr=2e-6),
+            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -105,7 +105,7 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(lr=2e-6),
+            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -163,7 +163,7 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(lr=1e-6),
+            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-6)),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",
@@ -201,6 +201,48 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
     )
 
 
+def rl_grpo_qwen3_debug() -> RLTrainer.Config:
+    """Debug config for quick iteration -- small model, few steps (2 GPUs: 1 gen + 1 train)."""
+    group_size = 4
+    return RLTrainer.Config(
+        model_spec=model_registry("debugmodel", attn_backend="varlen"),
+        num_steps=5,
+        num_prompts_per_step=5,
+        num_validation_samples=20,
+        compile=CompileConfig(enable=True, backend="aot_eager"),
+        env=SumDigitsEnv.Config(seed=42, correctness_reward=1.0, format_reward=0.3),
+        validation_env=SumDigitsEnv.Config(
+            seed=99, correctness_reward=1.0, format_reward=0.3
+        ),
+        trainer=PolicyTrainer.Config(
+            optimizer=OptimizersContainer.Config(lr=8e-4),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=2,
+                decay_type="linear",
+            ),
+            training=TrainingConfig(),
+            parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
+                tensor_parallel_degree=1,
+                data_parallel_replicate_degree=1,
+            ),
+            loss=GRPOLoss.Config(),
+        ),
+        generator=VLLMGenerator.Config(
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=1,
+                data_parallel_replicate_degree=1,
+            ),
+            sampling=SamplingConfig(
+                n=group_size,
+                temperature=1.0,
+                top_p=0.95,
+                max_tokens=50,
+            ),
+        ),
+    )
+
+
 def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
     """On-policy GRPO config for Qwen3-0.6B under same parallelism (4 GPUs: 2 gen + 2 train).
 
@@ -224,7 +266,7 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
         ),
         trainer=PolicyTrainer.Config(
-            optimizer=OptimizersContainer.Config(lr=2e-6),
+            optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-6)),
             lr_scheduler=LRSchedulersContainer.Config(
                 warmup_steps=2,
                 decay_type="linear",

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.config import (
     ActivationCheckpointConfig,
     DebugConfig,
@@ -32,7 +32,7 @@ def transformers_modeling_backend_debugmodel() -> TransformersBackendConfig:
         debug=DebugConfig(print_config=True),
         model_spec=model_registry("debugmodel"),
         profiler=Profiler.Config(profile_freq=5),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -64,7 +64,7 @@ def transformers_modeling_backend_full() -> TransformersBackendConfig:
         debug=DebugConfig(print_config=True),
         model_spec=model_registry("full"),
         profiler=Profiler.Config(profile_freq=5),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.config import (
     ActivationCheckpointConfig,
     DebugConfig,
@@ -32,7 +32,7 @@ def transformers_modeling_backend_debugmodel() -> TransformersBackendConfig:
         debug=DebugConfig(print_config=True),
         model_spec=model_registry("debugmodel"),
         profiler=Profiler.Config(profile_freq=5),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -64,7 +64,7 @@ def transformers_modeling_backend_full() -> TransformersBackendConfig:
         debug=DebugConfig(print_config=True),
         model_spec=model_registry("full"),
         profiler=Profiler.Config(profile_freq=5),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.components.quantization import (
     Float8GroupedExpertsConverter,
     Float8LinearConverter,
@@ -32,7 +32,7 @@ def deepseek_v3_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -83,7 +83,7 @@ def deepseek_v3_16b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=2.2e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2.2e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             decay_ratio=0.8,
             decay_type="cosine",
@@ -130,7 +130,7 @@ def deepseek_v3_671b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=2.2e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2.2e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.quantization import (
     Float8GroupedExpertsConverter,
     Float8LinearConverter,
@@ -32,7 +32,7 @@ def deepseek_v3_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -83,7 +83,7 @@ def deepseek_v3_16b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2.2e-4)),
+        optimizer=default_adamw(lr=2.2e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             decay_ratio=0.8,
             decay_type="cosine",
@@ -130,7 +130,7 @@ def deepseek_v3_671b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2.2e-4)),
+        optimizer=default_adamw(lr=2.2e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import MSELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -40,7 +40,7 @@ def flux_debugmodel() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("flux-debug"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=1,
             decay_ratio=0.0,
@@ -99,7 +99,7 @@ def flux_dev() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
         model_spec=model_registry("flux-dev"),
-        optimizer=OptimizersContainer.Config(lr=1e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=3000,
             decay_ratio=0.0,
@@ -149,7 +149,7 @@ def flux_schnell() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
         model_spec=model_registry("flux-schnell"),
-        optimizer=OptimizersContainer.Config(lr=1e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=3000,
             decay_ratio=0.0,

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import MSELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -40,7 +40,7 @@ def flux_debugmodel() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("flux-debug"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=1,
             decay_ratio=0.0,
@@ -99,7 +99,7 @@ def flux_dev() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
         model_spec=model_registry("flux-dev"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-4)),
+        optimizer=default_adamw(lr=1e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=3000,
             decay_ratio=0.0,
@@ -149,7 +149,7 @@ def flux_schnell() -> FluxTrainer.Config:
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
         model_spec=model_registry("flux-schnell"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1e-4)),
+        optimizer=default_adamw(lr=1e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=3000,
             decay_ratio=0.0,

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -288,7 +288,6 @@ class FluxTrainer(Trainer):
         if self.gradient_accumulation_steps > 1:
             raise ValueError("FLUX doesn't support gradient accumulation for now.")
 
-        # pyrefly: ignore [no-matching-overload]
         input_dict, labels = next(data_iterator)
 
         loss = self.forward_backward_step(input_dict=input_dict, labels=labels)

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -288,6 +288,7 @@ class FluxTrainer(Trainer):
         if self.gradient_accumulation_steps > 1:
             raise ValueError("FLUX doesn't support gradient accumulation for now.")
 
+        # pyrefly: ignore [no-matching-overload]
         input_dict, labels = next(data_iterator)
 
         loss = self.forward_backward_step(input_dict=input_dict, labels=labels)

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.validate import Validator
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -30,7 +30,7 @@ def gpt_oss_debugmodel() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -71,7 +71,7 @@ def gpt_oss_20b() -> Trainer.Config:
         hf_assets_path="./assets/hf/gpt-oss-20b",
         model_spec=model_registry("20b"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,
@@ -97,7 +97,7 @@ def gpt_oss_120b() -> Trainer.Config:
         hf_assets_path="./assets/hf/gpt-oss-120b",
         model_spec=model_registry("120b"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.components.validate import Validator
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -30,7 +30,7 @@ def gpt_oss_debugmodel() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -71,7 +71,7 @@ def gpt_oss_20b() -> Trainer.Config:
         hf_assets_path="./assets/hf/gpt-oss-20b",
         model_spec=model_registry("20b"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,
@@ -97,7 +97,7 @@ def gpt_oss_120b() -> Trainer.Config:
         hf_assets_path="./assets/hf/gpt-oss-120b",
         model_spec=model_registry("120b"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
             decay_ratio=0.8,

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersInBackwardContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.components.validate import Validator
 from torchtitan.config import (
@@ -78,14 +78,6 @@ def llama3_debugmodel_flex_attn() -> Trainer.Config:
 def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     config = llama3_debugmodel()
     config.model_spec = model_registry("debugmodel", attn_backend="varlen")
-    return config
-
-
-def llama3_debugmodel_opt_in_bwd() -> Trainer.Config:
-    config = llama3_debugmodel()
-    config.optimizer = OptimizersInBackwardContainer.Config(
-        param_groups=default_adamw(lr=8e-4).param_groups
-    )
     return config
 
 

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -9,6 +9,7 @@ from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import (
+    default_adamw,
     OptimizersContainer,
     OptimizersInBackwardContainer,
 )
@@ -35,7 +36,7 @@ def llama3_debugmodel() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./tests/assets/tokenizer",
         model_spec=model_registry("debugmodel"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -86,7 +87,9 @@ def llama3_debugmodel_varlen_attn() -> Trainer.Config:
 
 def llama3_debugmodel_opt_in_bwd() -> Trainer.Config:
     config = llama3_debugmodel()
-    config.optimizer = OptimizersInBackwardContainer.Config(lr=8e-4)
+    config.optimizer = OptimizersInBackwardContainer.Config(
+        param_groups=default_adamw(lr=8e-4)
+    )
     return config
 
 
@@ -144,7 +147,7 @@ def llama3_8b() -> Trainer.Config:
             enable_tensorboard=True,
         ),
         model_spec=model_registry("8B"),
-        optimizer=OptimizersContainer.Config(lr=3e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
         training=TrainingConfig(
             local_batch_size=1,
             seq_len=8192,
@@ -176,7 +179,7 @@ def llama3_70b() -> Trainer.Config:
             enable_tensorboard=True,
         ),
         model_spec=model_registry("70B"),
-        optimizer=OptimizersContainer.Config(lr=1.5e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1.5e-4)),
         training=TrainingConfig(
             local_batch_size=8,
             seq_len=8192,
@@ -220,7 +223,7 @@ def llama3_405b() -> Trainer.Config:
                 ),
             ],
         ),
-        optimizer=OptimizersContainer.Config(lr=8e-5),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-5)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=2,
@@ -259,7 +262,7 @@ def sft_debugmodel() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./tests/assets/tokenizer",
         model_spec=model_spec,
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -8,11 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import (
-    default_adamw,
-    OptimizersContainer,
-    OptimizersInBackwardContainer,
-)
+from torchtitan.components.optimizer import default_adamw, OptimizersInBackwardContainer
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.components.validate import Validator
 from torchtitan.config import (
@@ -36,7 +32,7 @@ def llama3_debugmodel() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./tests/assets/tokenizer",
         model_spec=model_registry("debugmodel"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -88,7 +84,7 @@ def llama3_debugmodel_varlen_attn() -> Trainer.Config:
 def llama3_debugmodel_opt_in_bwd() -> Trainer.Config:
     config = llama3_debugmodel()
     config.optimizer = OptimizersInBackwardContainer.Config(
-        param_groups=default_adamw(lr=8e-4)
+        param_groups=default_adamw(lr=8e-4).param_groups
     )
     return config
 
@@ -147,7 +143,7 @@ def llama3_8b() -> Trainer.Config:
             enable_tensorboard=True,
         ),
         model_spec=model_registry("8B"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
+        optimizer=default_adamw(lr=3e-4),
         training=TrainingConfig(
             local_batch_size=1,
             seq_len=8192,
@@ -179,7 +175,7 @@ def llama3_70b() -> Trainer.Config:
             enable_tensorboard=True,
         ),
         model_spec=model_registry("70B"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=1.5e-4)),
+        optimizer=default_adamw(lr=1.5e-4),
         training=TrainingConfig(
             local_batch_size=8,
             seq_len=8192,
@@ -223,7 +219,7 @@ def llama3_405b() -> Trainer.Config:
                 ),
             ],
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-5)),
+        optimizer=default_adamw(lr=8e-5),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=2,
@@ -262,7 +258,7 @@ def sft_debugmodel() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./tests/assets/tokenizer",
         model_spec=model_spec,
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,

--- a/torchtitan/models/llama4/config_registry.py
+++ b/torchtitan/models/llama4/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.quantization import Float8GroupedExpertsConverter
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -31,9 +31,7 @@ def llama4_debugmodel() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(
-            param_groups=default_adamw(lr=4e-3, eps=1e-15),
-        ),
+        optimizer=default_adamw(lr=4e-3, eps=1e-15),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -83,9 +81,7 @@ def llama4_debugmodel_fp8() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(
-            param_groups=default_adamw(lr=4e-3, eps=1e-15),
-        ),
+        optimizer=default_adamw(lr=4e-3, eps=1e-15),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -119,9 +115,7 @@ def llama4_17bx128e() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(
-            param_groups=default_adamw(lr=4e-3, eps=1e-15),
-        ),
+        optimizer=default_adamw(lr=4e-3, eps=1e-15),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,
             min_lr_factor=0.1,
@@ -149,9 +143,7 @@ def llama4_17bx16e() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(
-            param_groups=default_adamw(lr=4e-3, eps=1e-15),
-        ),
+        optimizer=default_adamw(lr=4e-3, eps=1e-15),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,
             min_lr_factor=0.1,

--- a/torchtitan/models/llama4/config_registry.py
+++ b/torchtitan/models/llama4/config_registry.py
@@ -31,7 +31,10 @@ def llama4_debugmodel() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(lr=4e-3, eps=1e-15),
+        optimizer=OptimizersContainer.Config(
+            lr=4e-3,
+            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+        ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -81,7 +84,10 @@ def llama4_debugmodel_fp8() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(lr=4e-3, eps=1e-15),
+        optimizer=OptimizersContainer.Config(
+            lr=4e-3,
+            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+        ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -115,7 +121,10 @@ def llama4_17bx128e() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=4e-3, eps=1e-15),
+        optimizer=OptimizersContainer.Config(
+            lr=4e-3,
+            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+        ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,
             min_lr_factor=0.1,
@@ -143,7 +152,10 @@ def llama4_17bx16e() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=4e-3, eps=1e-15),
+        optimizer=OptimizersContainer.Config(
+            lr=4e-3,
+            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+        ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,
             min_lr_factor=0.1,

--- a/torchtitan/models/llama4/config_registry.py
+++ b/torchtitan/models/llama4/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.components.quantization import Float8GroupedExpertsConverter
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -32,8 +32,7 @@ def llama4_debugmodel() -> Trainer.Config:
             dataset="c4_test",
         ),
         optimizer=OptimizersContainer.Config(
-            lr=4e-3,
-            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+            param_groups=default_adamw(lr=4e-3, eps=1e-15),
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
@@ -85,8 +84,7 @@ def llama4_debugmodel_fp8() -> Trainer.Config:
             dataset="c4_test",
         ),
         optimizer=OptimizersContainer.Config(
-            lr=4e-3,
-            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+            param_groups=default_adamw(lr=4e-3, eps=1e-15),
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
@@ -122,8 +120,7 @@ def llama4_17bx128e() -> Trainer.Config:
             dataset="c4",
         ),
         optimizer=OptimizersContainer.Config(
-            lr=4e-3,
-            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+            param_groups=default_adamw(lr=4e-3, eps=1e-15),
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,
@@ -153,8 +150,7 @@ def llama4_17bx16e() -> Trainer.Config:
             dataset="c4",
         ),
         optimizer=OptimizersContainer.Config(
-            lr=4e-3,
-            optimizer_kwargs={"betas": (0.9, 0.95), "eps": 1e-15, "weight_decay": 0.1},
+            param_groups=default_adamw(lr=4e-3, eps=1e-15),
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=600,

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -34,7 +34,7 @@ def qwen3_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -75,7 +75,16 @@ def qwen3_debugmodel_moe_param_groups() -> Trainer.Config:
                 optimizer_name="Adam",
                 optimizer_kwargs={"lr": 1e-4, "betas": (0.9, 0.95), "eps": 1e-8},
             ),
-            *default_adamw(lr=8e-4),
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": 8e-4,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
         ],
     )
     return config
@@ -88,7 +97,7 @@ def qwen3_debugmodel_flex() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel", attn_backend="flex"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -117,7 +126,7 @@ def qwen3_debugmodel_flex_flash() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel", attn_backend="flex_flash"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -148,7 +157,7 @@ def qwen3_0_6b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
+        optimizer=default_adamw(lr=3e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=4,
@@ -174,7 +183,7 @@ def qwen3_1_7b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,
@@ -200,7 +209,7 @@ def qwen3_14b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=4,
@@ -232,7 +241,7 @@ def qwen3_32b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=2,
@@ -263,7 +272,7 @@ def qwen3_debugmodel_fused_qkv() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel_fused_qkv"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -294,7 +303,7 @@ def qwen3_moe_debug() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
+        optimizer=default_adamw(lr=3e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=4,
@@ -341,7 +350,7 @@ def sft_qwen3_8b_math() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/Qwen3-8B",
         model_spec=model_spec,
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-5)),
+        optimizer=default_adamw(lr=2e-5),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=15,
             decay_ratio=0.9,

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -52,22 +52,20 @@ def qwen3_debugmodel() -> Trainer.Config:
     )
 
 
-def qwen3_debugmodel_param_groups() -> Trainer.Config:
-    config = qwen3_debugmodel()
+def qwen3_debugmodel_moe_param_groups() -> Trainer.Config:
+    config = qwen3_moe_debug()
     config.optimizer = OptimizersContainer.Config(
+        name="AdamW",
         lr=8e-4,
         param_groups=[
             ParamGroupConfig(
-                pattern=r"tok_embeddings\.",
-                weight_decay_multiplier=0.0,
+                pattern=r"(?:tok_embeddings|output)\.",
+                optimizer_kwargs={"weight_decay": 0.0},
             ),
             ParamGroupConfig(
-                pattern=r"\.bias$",
-                weight_decay_multiplier=0.0,
-            ),
-            ParamGroupConfig(
-                pattern=r"(?:attention_norm|ffn_norm|norm)\.",
-                weight_decay_multiplier=0.0,
+                pattern=r"\.router\.gate\.",
+                optimizer_name="SGD",
+                optimizer_kwargs={"lr": 1e-4, "momentum": 0.0},
             ),
         ],
     )

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -8,7 +8,11 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
+from torchtitan.components.optimizer import (
+    default_adamw,
+    OptimizersContainer,
+    ParamGroupConfig,
+)
 from torchtitan.config import (
     ActivationCheckpointConfig,
     ParallelismConfig,
@@ -30,7 +34,7 @@ def qwen3_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -68,19 +72,10 @@ def qwen3_debugmodel_moe_param_groups() -> Trainer.Config:
             ),
             ParamGroupConfig(
                 pattern=r"\.router\.gate\.",
-                optimizer_name="SGD",
-                optimizer_kwargs={"lr": 1e-4, "momentum": 0.0, "fused": False},
+                optimizer_name="Adam",
+                optimizer_kwargs={"lr": 1e-4, "betas": (0.9, 0.95), "eps": 1e-8},
             ),
-            ParamGroupConfig(
-                pattern=r".*",
-                optimizer_name="AdamW",
-                optimizer_kwargs={
-                    "lr": 8e-4,
-                    "betas": (0.9, 0.95),
-                    "eps": 1e-8,
-                    "weight_decay": 0.1,
-                },
-            ),
+            *default_adamw(lr=8e-4),
         ],
     )
     return config
@@ -93,7 +88,7 @@ def qwen3_debugmodel_flex() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel", attn_backend="flex"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -122,7 +117,7 @@ def qwen3_debugmodel_flex_flash() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel", attn_backend="flex_flash"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -153,7 +148,7 @@ def qwen3_0_6b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=3e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=4,
@@ -179,7 +174,7 @@ def qwen3_1_7b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,
@@ -205,7 +200,7 @@ def qwen3_14b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=4,
@@ -237,7 +232,7 @@ def qwen3_32b() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4",
         ),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=600),
         training=TrainingConfig(
             local_batch_size=2,
@@ -268,7 +263,7 @@ def qwen3_debugmodel_fused_qkv() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel_fused_qkv"),
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -299,7 +294,7 @@ def qwen3_moe_debug() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
-        optimizer=OptimizersContainer.Config(lr=3e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=4,
@@ -346,7 +341,7 @@ def sft_qwen3_8b_math() -> Trainer.Config:
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./assets/hf/Qwen3-8B",
         model_spec=model_spec,
-        optimizer=OptimizersContainer.Config(lr=2e-5),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=2e-5)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=15,
             decay_ratio=0.9,

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -55,17 +55,31 @@ def qwen3_debugmodel() -> Trainer.Config:
 def qwen3_debugmodel_moe_param_groups() -> Trainer.Config:
     config = qwen3_moe_debug()
     config.optimizer = OptimizersContainer.Config(
-        name="AdamW",
-        lr=8e-4,
         param_groups=[
             ParamGroupConfig(
                 pattern=r"(?:tok_embeddings|output)\.",
-                optimizer_kwargs={"weight_decay": 0.0},
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": 8e-4,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.0,
+                },
             ),
             ParamGroupConfig(
                 pattern=r"\.router\.gate\.",
                 optimizer_name="SGD",
-                optimizer_kwargs={"lr": 1e-4, "momentum": 0.0},
+                optimizer_kwargs={"lr": 1e-4, "momentum": 0.0, "fused": False},
+            ),
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": 8e-4,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
             ),
         ],
     )

--- a/torchtitan/models/qwen3_vl/config_registry.py
+++ b/torchtitan/models/qwen3_vl/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import default_adamw, OptimizersContainer
+from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.tokenizer import MultiModalTokenizer
 
 from torchtitan.config import (
@@ -45,7 +45,7 @@ def qwen3_vl_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=_qwen3_vl_dataloader("cc12m-test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -75,7 +75,7 @@ def qwen3_vl_debugmodel_moe() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel_moe"),
         dataloader=_qwen3_vl_dataloader("cc12m-test"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-3)),
+        optimizer=default_adamw(lr=3e-3),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=1,
@@ -104,7 +104,7 @@ def qwen3_vl_2b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("2B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=8,
@@ -134,7 +134,7 @@ def qwen3_vl_8b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("8B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
+        optimizer=default_adamw(lr=8e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,
@@ -164,7 +164,7 @@ def qwen3_vl_30b_a3b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("30B-A3B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
+        optimizer=default_adamw(lr=3e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,

--- a/torchtitan/models/qwen3_vl/config_registry.py
+++ b/torchtitan/models/qwen3_vl/config_registry.py
@@ -8,7 +8,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import default_adamw, OptimizersContainer
 from torchtitan.components.tokenizer import MultiModalTokenizer
 
 from torchtitan.config import (
@@ -45,7 +45,7 @@ def qwen3_vl_debugmodel() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel"),
         dataloader=_qwen3_vl_dataloader("cc12m-test"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
             decay_ratio=0.8,
@@ -75,7 +75,7 @@ def qwen3_vl_debugmodel_moe() -> Trainer.Config:
         metrics=MetricsProcessor.Config(log_freq=1),
         model_spec=model_registry("debugmodel_moe"),
         dataloader=_qwen3_vl_dataloader("cc12m-test"),
-        optimizer=OptimizersContainer.Config(lr=3e-3),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-3)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
         training=TrainingConfig(
             local_batch_size=1,
@@ -104,7 +104,7 @@ def qwen3_vl_2b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("2B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=8,
@@ -134,7 +134,7 @@ def qwen3_vl_8b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("8B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(lr=8e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=8e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,
@@ -164,7 +164,7 @@ def qwen3_vl_30b_a3b() -> Trainer.Config:
         tokenizer=MultiModalTokenizer.Config(**QWEN3_VL_SPECIAL_TOKENS),
         model_spec=model_registry("30B-A3B"),
         dataloader=_qwen3_vl_dataloader("cc12m"),
-        optimizer=OptimizersContainer.Config(lr=3e-4),
+        optimizer=OptimizersContainer.Config(param_groups=default_adamw(lr=3e-4)),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
         training=TrainingConfig(
             local_batch_size=4,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -188,6 +188,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
+        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -24,10 +24,7 @@ from torchtitan.components.dataloader import BaseDataLoader, DataloaderExhausted
 from torchtitan.components.loss import BaseLoss, ChunkedCELoss, IGNORE_INDEX
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
-from torchtitan.components.optimizer import (
-    OptimizersContainer,
-    OptimizersInBackwardContainer,
-)
+from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.components.tokenizer import BaseTokenizer, HuggingFaceTokenizer
 from torchtitan.components.validate import BaseValidator, Validator
@@ -107,15 +104,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 raise ValueError(
                     "Batch-invariant mode is not supported in pre-training."
                 )
-            if isinstance(self.optimizer, OptimizersInBackwardContainer.Config):
-                if self.parallelism.expert_parallel_degree > 1:
-                    raise NotImplementedError(
-                        "Optimizers in backward is not supported with Expert Parallel."
-                    )
-                if self.parallelism.pipeline_parallel_degree > 1:
-                    raise NotImplementedError(
-                        "Optimizers in backward is not supported with Pipeline Parallel."
-                    )
 
         def to_dict(self) -> dict[str, Any]:
             d = {}

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -717,8 +717,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
         self.optimizers.zero_grad()
-        # Save the current step learning rate for logging
-        lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
+        # Save per-optimizer-group learning rates for logging
+        lr_metrics = self.lr_schedulers.get_lr_metrics()
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
@@ -813,7 +813,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         extra_metrics = {
             "n_tokens_seen": global_ntokens_seen,
-            "lr": lr,
+            **lr_metrics,
         }
         self.metrics_processor.log(
             self.step,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -200,7 +200,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
-        # pyrefly: ignore [read-only]
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
@@ -718,7 +717,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     ):
         self.optimizers.zero_grad()
         # Save per-optimizer-group learning rates for logging
-        lr_metrics = self.lr_schedulers.get_lr_metrics()
+        lr_metrics = self.lr_schedulers.get_metrics()
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.


### PR DESCRIPTION
Summary:
1. Add mixed optimizer support to `OptimizersContainer`: different parameter groups can now use different optimizers (e.g., SGD for MoE router gates, AdamW for everything else)
2. `ParamGroupConfig` redesigned with two override modes: same optimizer with kwargs overrides, or switch to a different optimizer entirely via optimizer_name + optimizer_kwargs                                                                                       
3. Move Adam-specific fields (beta1, beta2, eps, weight_decay) from default `OptimizersContainer.Config` into `optimizer_kwargs` dict for optimizer-agnostic config                                                                                                            
4. Adapt LR scheduler checkpointing for mixed optimizers: save only last_epoch (plus full state for observability), restore by recomputing lr from each scheduler's own `base_lr`s. Correct for mixed optimizers and resharding                                                                
5. Add per-optimizer-group LR logging to TensorBoard/WandB (e.g., lr/AdamW_default, lr/SGD_.router.gate.)
6. Add init-time optimizer summary log showing param counts, labels, and key kwargs per group                                         
7. Add `_validate_params` to verify every trainable parameter is assigned to exactly one optimizer                                      
8. Add `qwen3_debugmodel_moe_param_groups` config as a runnable example with AdamW + SGD