### PR TITLE
[graph_trainer] Refactor selective activation remat to in-place

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -65,8 +65,9 @@ two-step process:
    are no-ops when no nodes carry the relevant tag):
    - `apply_cpu_offload_pass` — inserts offload/reload/wait ops for
      `MUST_CPU_OFFLOAD` nodes.
-   - `selective_activation_remat_pass` — duplicates `MUST_RECOMPUTE`
-     ops before backward and DCEs the originals.
+   - `remat_using_tags_for_fwd_loss_bwd_graph` — duplicates `MUST_RECOMPUTE`
+     ops in front of their backward consumers and erases originals whose
+     consumers were all backward.
 
 The `--compile.memory_policy` config selects the tagging strategy.
 New policies (e.g. budget-aware mixed SAC + offload) should be added

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -28,14 +28,6 @@ def _is_backward_node(node: torch.fx.Node) -> bool:
     return node.meta.get("autograd_backward", False)
 
 
-def _is_recomputed_node(node: torch.fx.Node) -> bool:
-    # TODO: Workaround — recomputed nodes (from SAC) should carry
-    # autograd_backward=True but remat_using_tags_for_fwd_loss_bwd_graph
-    # copies metadata from the original forward node. Fix upstream to
-    # tag recomputed nodes with autograd_backward=True.
-    return node.name.endswith("_recomputed")
-
-
 def _get_layer_id(node: torch.fx.Node) -> int:
     """Extract the layer index from the node's module_fqn metadata.
 

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -39,7 +39,6 @@ from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
-    _is_recomputed_node,
     _MODULE_FQN,
 )
 from torchtitan.tools.logging import logger
@@ -449,7 +448,7 @@ def joint_transformer_block_bucketing_reordering_pass(
     """
 
     def _is_backward(node: torch.fx.Node) -> bool:
-        return _is_backward_node(node) or _is_recomputed_node(node)
+        return _is_backward_node(node)
 
     def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN)

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -61,6 +61,9 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_identity_slice_pass,
     remove_identity_view_pass,
 )
+from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+    remat_using_tags_for_fwd_loss_bwd_graph,
+)
 from torchtitan.tools.logging import logger
 
 aten = torch.ops.aten
@@ -165,7 +168,7 @@ def compile_time_passes(
             prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
             defer_n_layers=config.compile.cpu_offload_defer_n_layers,
         ),
-        selective_activation_remat_pass,
+        remat_using_tags_for_fwd_loss_bwd_graph,
         overlap_fsdp_ag_rs_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
@@ -815,22 +818,6 @@ def tag_with_memory_policy_pass(
 
     log_activation_memory_policy(gm)
     return gm
-
-
-def selective_activation_remat_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-) -> torch.fx.GraphModule:
-    """Duplicate recompute nodes for backward use, then DCE unused forward versions.
-
-    Wraps ``remat_using_tags_for_fwd_loss_bwd_graph`` with the graph pass
-    signature ``(gm, example_inputs)``.
-    """
-    from torchtitan.experiments.graph_trainer.selective_activation_remat import (
-        remat_using_tags_for_fwd_loss_bwd_graph,
-    )
-
-    return remat_using_tags_for_fwd_loss_bwd_graph(gm)
 
 
 def full_inductor_compilation_pass(

--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -4,11 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
+"""AC rematerialize pass: in-place duplicate recompute nodes for backward."""
 
-import itertools
 import logging
-from typing import Any, overload
+from typing import Any
 
 import torch
 import torch.fx as fx
@@ -18,28 +17,12 @@ from torch._functorch.partitioners import (
     force_save_bw_mutation_src,
     has_recomputable_ops,
     has_recomputable_rng_ops,
-    is_not_collective,
     must_recompute,
 )
 
 
 log = logging.getLogger(__name__)
 _EMPTY_CUSTOM_META: dict[str, object] = {}
-
-
-def is_impure_node_for_dce(node: fx.Node) -> bool:
-    # Check for special collectives that should be treated as pure
-    if not is_not_collective(node):
-        # It's a collective (wait_tensor, all_gather_into_tensor, etc.)
-        # Treat as pure - can be eliminated if unused
-        return False
-
-    # For everything else, fall back to the DEFAULT logic
-    # This is what eliminate_dead_code() calls when is_impure_node=None
-    impure_random = True
-    if torch._guards.TracingContext.try_get():
-        impure_random = torch._inductor.config.fallback_random
-    return node.is_impure(impure_random)
 
 
 def _is_backward_node(node: fx.Node, use_phase: bool = False) -> bool:
@@ -94,20 +77,34 @@ def _collect_backward_regions(
     return regions
 
 
-def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
-    """
-    Duplicate recompute nodes for backward use. DCE removes unused forward versions.
+def remat_using_tags_for_fwd_loss_bwd_graph(
+    gm: fx.GraphModule,
+    example_inputs: Any = None,
+) -> fx.GraphModule:
+    """In-place remat: insert recompute duplicates before backward consumers.
 
-    Backward regions are identified by custom["phase"] == "backward" (user
-    annotation) or node.meta["autograd_backward"] == True (set automatically when
-    Dynamo traces torch.autograd.grad). When the user provides phase
-    annotations, only those annotated regions are used.
+    For each ``must_recompute`` forward node consumed by a backward node, a
+    duplicate is inserted just before the backward consumer and that
+    consumer's args are redirected to the duplicate. Original forward nodes
+    whose consumers were all backward become dead and are erased; originals
+    with remaining forward consumers stay.
+
+    The graph is mutated in place: original node identities and names are
+    preserved, only the duplicates carry a ``_recomputed`` suffix. No
+    whole-graph DCE or topological reorder is performed.
+
+    Backward regions are identified by ``custom["phase"] == "backward"``
+    (user annotation) or ``node.meta["autograd_backward"] == True`` (set by
+    Dynamo when tracing ``torch.autograd.grad``). When the user provides
+    phase annotations, only those annotated regions are used.
 
     The graph may contain multiple disjoint backward regions (e.g. chunked
     loss). Regions that do not depend on recomputable forward nodes are
     skipped. Only one region may require remat; if multiple do, we error
     and ask the user to annotate which region to rematerialize.
     """
+    del example_inputs  # unused; accepted for graph pass signature compatibility
+
     if not has_recomputable_ops(gm):
         return gm
 
@@ -151,79 +148,128 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     bwd_start, bwd_end = remat_regions[0]
 
-    order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
-    new_graph = fx.Graph()
-    env: dict[fx.Node, fx.Node] = {}
-    recomputed_nodes: dict[fx.Node, fx.Node] = {}
+    all_nodes = list(gm.graph.nodes)
+    bwd_nodes = all_nodes[bwd_start:bwd_end]
+    order = {n: i for i, n in enumerate(all_nodes)}
 
-    # Insert forward nodes
-    for node in itertools.islice(gm.graph.nodes, 0, bwd_start):
-        env[node] = new_graph.node_copy(node, lambda x: env[x])
+    # Map each must_recompute fwd node to the bwd node its dup will be
+    # inserted in front of. The earliest bwd consumer (in graph order)
+    # wins via ``setdefault`` below.
+    remat_targets: dict[fx.Node, fx.Node] = {}
 
-    @overload
-    def remat_input(x: fx.Node) -> fx.Node:
-        ...
-
-    @overload
-    def remat_input(x: Any) -> Any:
-        ...
-
-    def remat_input(x: object) -> object:
-        # fx.Node can have args that are primitive types (e.g. int, float, bool)
-        if not isinstance(x, fx.Node):
-            return x
-        return recomputed_nodes.get(x, env[x])
-
-    def gather_recompute_deps(node: fx.Node) -> set[fx.Node]:
-        deps: set[fx.Node] = set()
+    def claim_for(bwd_node: fx.Node) -> None:
+        seen: set[fx.Node] = set()
 
         def _gather(n: fx.Node) -> None:
-            if n in deps or n in recomputed_nodes or not must_recompute(n):
+            if n in seen or not must_recompute(n):
                 return
-            deps.add(n)
+            seen.add(n)
+            remat_targets.setdefault(n, bwd_node)
             for inp in n.all_input_nodes:
                 _gather(inp)
 
-        # Can't call _gather(node) directly: node itself may not be must_recompute
-        # (e.g. backward nodes), so _gather would return early without visiting inputs.
-        for inp in node.all_input_nodes:
+        # bwd_node itself may not be must_recompute; start from its inputs.
+        for inp in bwd_node.all_input_nodes:
             _gather(inp)
-        return deps
 
-    # Insert backward nodes
-    for node in itertools.islice(gm.graph.nodes, bwd_start, bwd_end):
-        # Gather all deps that need to be recomputed for this node
-        deps = gather_recompute_deps(node)
+    for bwd_node in bwd_nodes:
+        claim_for(bwd_node)
 
-        # Insert deps in forward order (guaranteed disjoint from already-inserted)
-        # This is not as inefficient as it looks, because we only add fresh dependencies
-        # when they are not yet processed as recomputed nodes.
-        new_deps = sorted(deps, key=lambda n: order[n])
-        if new_deps:
-            log.debug(
-                "To compute backward node %s, recomputing [%s]",
-                node.name,
-                ", ".join(dep.name for dep in new_deps),
-            )
-        for dep in new_deps:
-            dup = new_graph.node_copy(dep, remat_input)
-            dup.name = dep.name + "_recomputed"
-            recomputed_nodes[dep] = dup
+    # Map original forward must_recompute node -> its recomputed duplicate.
+    recomputed_nodes: dict[fx.Node, fx.Node] = {}
+    # CPU offload: track which bwd target each reload-chain node was last
+    # hoisted before, so we can re-hoist if an earlier dup needs it later.
+    moved_offload: dict[fx.Node, fx.Node] = {}
 
-        env[node] = new_graph.node_copy(node, remat_input)
+    def ensure_offload_chain_before(reload_node: fx.Node, target: fx.Node) -> None:
+        """Move ``reload_node`` and its bwd-region deps in front of ``target``.
 
-    for node in itertools.islice(gm.graph.nodes, bwd_end, None):
-        env[node] = new_graph.node_copy(node, lambda x: env[x])
+        Mirrors upstream's ``_ensure_in_env``: a recompute dup consuming an
+        offloaded forward node must read from the reload chain on GPU, not
+        from F's freed storage. ``moved_offload`` keeps moves idempotent
+        and ensures the chain ends up before the earliest target across
+        repeated calls.
+        """
+        # ``bwd_reload_chain`` is the set of backward-region nodes that
+        # need to relocate together: ``reload_node`` (typically the
+        # ``ao.wait_tensor`` whose value the dup will read) plus every
+        # backward-region node it transitively depends on (typically the
+        # ``ao.reload`` op feeding it). Forward-region deps stop the walk —
+        # they're already before any backward target.
+        bwd_reload_chain: set[fx.Node] = set()
+        stack = [reload_node]
+        while stack:
+            n = stack.pop()
+            if n in bwd_reload_chain or not _is_backward_node(n):
+                continue
+            prev = moved_offload.get(n)
+            if prev is not None and order[prev] <= order[target]:
+                continue
+            bwd_reload_chain.add(n)
+            stack.extend(n.all_input_nodes)
 
-    new_gm = torch.fx.GraphModule(gm, new_graph)
+        for n in all_nodes:
+            if n in bwd_reload_chain:
+                target.prepend(n)
+                moved_offload[n] = target
 
-    # DCE with custom is_impure_node (like default_partition)
-    # Treats certain collectives as pure while delegating to default impurity logic
-    new_gm.graph.eliminate_dead_code(is_impure_node=is_impure_node_for_dce)
+    def remat_input(x: object) -> object:
+        """Arg-transform: redirect must_recompute originals to their dups, and
+        offloaded forward nodes to their CPU-reload chain. Hoisting of the
+        reload chain happens separately in the dup-creation loop."""
+        if not isinstance(x, fx.Node):
+            return x
+        if x in recomputed_nodes:
+            return recomputed_nodes[x]
+        reload_node = x.meta.get("cpu_offload_reload_node")
+        if reload_node is not None:
+            return reload_node
+        return x
+
+    # Walk the existing graph in forward order. Each claimed must_recompute
+    # node is duplicated immediately before its target backward node; topology
+    # is satisfied by the graph's own order — upstream deps appear earlier in
+    # the walk, so their duplicates are inserted (and visible via
+    # ``recomputed_nodes``) before any downstream duplicate references them.
+    for fwd_node in all_nodes[:bwd_start]:
+        bwd_target = remat_targets.get(fwd_node)
+        if bwd_target is None:
+            continue
+        # Pre-hoist offload reload chains for any args referencing offloaded
+        # forward nodes, so the chain executes before the dup we're about to
+        # create. Mirrors upstream's eager-copy-into-new-graph trick.
+        for arg in fwd_node.all_input_nodes:
+            reload_node = arg.meta.get("cpu_offload_reload_node")
+            if reload_node is not None:
+                ensure_offload_chain_before(reload_node, bwd_target)
+        with gm.graph.inserting_before(bwd_target):
+            dup = gm.graph.node_copy(fwd_node, remat_input)
+        dup.name = fwd_node.name + "_recomputed"
+        dup.meta["autograd_backward"] = True
+        recomputed_nodes[fwd_node] = dup
+        log.debug(
+            "Recomputing %s before backward node %s", fwd_node.name, bwd_target.name
+        )
+
+    # Redirect each backward node's inputs to the recomputed duplicates.
+    # Backward consumers of offloaded forward nodes were already redirected
+    # to their reload chain by the CPU offload pass, so the offload branch
+    # of remat_input is a no-op here.
+    for bwd_node in bwd_nodes:
+        bwd_node.args = torch.fx.map_arg(bwd_node.args, remat_input)
+        bwd_node.kwargs = torch.fx.map_arg(bwd_node.kwargs, remat_input)
+
+    # Targeted erase: original forward must_recompute nodes whose consumers
+    # were all backward now have no users and can be removed. Originals with
+    # remaining forward consumers stay in place. Iterate in reverse graph
+    # order so downstream originals are erased first, freeing their upstream
+    # originals' user lists for erase in the same pass.
+    for orig in reversed(list(recomputed_nodes)):
+        if not orig.users:
+            gm.graph.erase_node(orig)
 
     # raise_getitems pass for better memory (like default_partition)
-    new_gm = raise_getitems(new_gm)
+    gm = raise_getitems(gm)
 
-    new_gm.recompile()
-
-    return new_gm
+    gm.graph.lint()
+    return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -1403,6 +1403,213 @@ class TestAsyncTensorParallelPass(FSDPTest):
         self.assertTrue(any(n.target == fused for n in gm.graph.nodes))
 
 
+class TestSelectiveActivationRematPass(TestCase):
+    """Unit tests for ``remat_using_tags_for_fwd_loss_bwd_graph``."""
+
+    def test_topological_insertion_order(self):
+        """
+        When multiple independent ``must_recompute`` deps share a downstream
+        consumer, duplicates must be inserted in graph (topological) order so
+        each dup's args reference upstream dups rather than the originals.
+        Without that ordering (e.g. naive DFS or unordered set iteration), a
+        downstream dup created before its upstream dup would fall back to the
+        original ``must_recompute`` node, defeating recompute.
+
+            a = clone(inp1)        # must_recompute
+            b = clone(inp2)        # must_recompute
+            d = clone(inp3)        # must_recompute
+            c = a + b              # must_recompute
+            e = c + d              # must_recompute
+            bwd = e + e            # autograd_backward
+        """
+        from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+            remat_using_tags_for_fwd_loss_bwd_graph,
+        )
+
+        graph = torch.fx.Graph()
+        inp1 = graph.placeholder("inp1")
+        inp2 = graph.placeholder("inp2")
+        inp3 = graph.placeholder("inp3")
+        a = graph.call_function(torch.ops.aten.clone.default, args=(inp1,))
+        b = graph.call_function(torch.ops.aten.clone.default, args=(inp2,))
+        d = graph.call_function(torch.ops.aten.clone.default, args=(inp3,))
+        c = graph.call_function(torch.ops.aten.add.Tensor, args=(a, b))
+        e = graph.call_function(torch.ops.aten.add.Tensor, args=(c, d))
+        bwd = graph.call_function(torch.ops.aten.add.Tensor, args=(e, e))
+        graph.output(bwd)
+        for n in (a, b, c, d, e):
+            n.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        bwd.meta["autograd_backward"] = True
+
+        original_names_in_order = [n.name for n in (a, b, d, c, e)]
+        e_name = e.name
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        result = remat_using_tags_for_fwd_loss_bwd_graph(gm)
+
+        nodes = list(result.graph.nodes)
+        dups = [n for n in nodes if n.name.endswith("_recomputed")]
+        # All 5 must_recompute nodes are transitive deps of bwd.
+        self.assertEqual(len(dups), 5)
+
+        # Dup graph order matches the forward order of the originals
+        # (a, b, d, c, e).
+        self.assertEqual(
+            [n.name for n in dups],
+            [name + "_recomputed" for name in original_names_in_order],
+        )
+
+        # The backward node's must_recompute input was redirected to the dup
+        # of e; the original e (now dead) was erased. Use the Python ``bwd``
+        # reference rather than searching by ``autograd_backward`` because
+        # dups also carry that flag.
+        for inp in bwd.all_input_nodes:
+            self.assertEqual(inp.name, e_name + "_recomputed")
+        self.assertNotIn(e_name, [n.name for n in nodes])
+
+    def test_forward_consumer_keeps_original(self):
+        """When a must_recompute node has both forward and backward
+        consumers, the original stays (forward needs it) and a dup is
+        inserted for the backward consumer. The original is not erased.
+
+            a = clone(inp)              # must_recompute, used by both fwd + bwd
+            fwd_use = a + a             # forward consumer
+            bwd = a * a                 # autograd_backward consumer
+        """
+        from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+            remat_using_tags_for_fwd_loss_bwd_graph,
+        )
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        a = graph.call_function(torch.ops.aten.clone.default, args=(inp,))
+        fwd_use = graph.call_function(torch.ops.aten.add.Tensor, args=(a, a))
+        bwd = graph.call_function(torch.ops.aten.mul.Tensor, args=(a, a))
+        graph.output((fwd_use, bwd))
+        a.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        bwd.meta["autograd_backward"] = True
+
+        a_name = a.name
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        result = remat_using_tags_for_fwd_loss_bwd_graph(gm)
+
+        names = [n.name for n in result.graph.nodes]
+        # Original kept (forward consumer still needs it) and dup inserted.
+        self.assertIn(a_name, names)
+        self.assertIn(a_name + "_recomputed", names)
+
+        # bwd's args go to the dup; fwd_use still points to the original.
+        bwd_node = next(
+            n for n in result.graph.nodes if n.target is torch.ops.aten.mul.Tensor
+        )
+        for inp_node in bwd_node.all_input_nodes:
+            self.assertEqual(inp_node.name, a_name + "_recomputed")
+        fwd_use_node = next(
+            n for n in result.graph.nodes if n.target is torch.ops.aten.add.Tensor
+        )
+        for inp_node in fwd_use_node.all_input_nodes:
+            self.assertEqual(inp_node.name, a_name)
+
+    def test_offload_reload_chain_hoisted(self):
+        """Mirrors the graph the CPU-offload pass produces: a forward
+        offload chain (``ao.offload`` -> ``ao.wait_tensor``) and a backward
+        reload chain (``ao.reload`` -> ``ao.wait_tensor``), with
+        ``F.meta["cpu_offload_reload_node"]`` pointing at the backward
+        wait_tensor. When a recomputed node references the offloaded
+        forward node F, the dup must read from the backward wait_tensor on
+        GPU, not from F's freed-GPU storage. The remat pass therefore
+        hoists the backward reload chain in front of the dup's target.
+
+            # Forward (autograd_backward=False)
+            F           = clone(inp1)
+            offload_op  = ao.offload(F)
+            fwd_wait    = ao.wait_tensor(offload_op, F)
+            N           = add(F, inp2)             # must_recompute
+
+            # Backward (autograd_backward=True), placed after bwd_use so
+            # the hoist actually has work to do:
+            bwd_use     = mul(N, N)
+            reload_op   = ao.reload(fwd_wait, "cuda")
+            bwd_wait    = ao.wait_tensor(reload_op)
+            bwd_other   = mul(bwd_wait, bwd_wait)
+        """
+        # Importing this module registers the ao::offload / ao::reload /
+        # ao::wait_tensor ops with torch.ops.
+        import torch._functorch._activation_offloading.offload_ops  # noqa: F401
+
+        from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+            remat_using_tags_for_fwd_loss_bwd_graph,
+        )
+
+        graph = torch.fx.Graph()
+        inp1 = graph.placeholder("inp1")
+        inp2 = graph.placeholder("inp2")
+        f = graph.call_function(torch.ops.aten.clone.default, args=(inp1,))
+        offload_op = graph.call_function(torch.ops.ao.offload.default, args=(f,))
+        fwd_wait = graph.call_function(
+            torch.ops.ao.wait_tensor.default, args=(offload_op, f)
+        )
+        n = graph.call_function(torch.ops.aten.add.Tensor, args=(f, inp2))
+        bwd_use = graph.call_function(torch.ops.aten.mul.Tensor, args=(n, n))
+        reload_op = graph.call_function(
+            torch.ops.ao.reload.default, args=(fwd_wait, "cuda")
+        )
+        bwd_wait = graph.call_function(
+            torch.ops.ao.wait_tensor.default, args=(reload_op,)
+        )
+        bwd_other = graph.call_function(
+            torch.ops.aten.mul.Tensor, args=(bwd_wait, bwd_wait)
+        )
+        graph.output((bwd_use, bwd_other))
+
+        n.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        f.meta["cpu_offload_reload_node"] = bwd_wait
+        bwd_use.meta["autograd_backward"] = True
+        reload_op.meta["autograd_backward"] = True
+        bwd_wait.meta["autograd_backward"] = True
+        bwd_other.meta["autograd_backward"] = True
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        result = remat_using_tags_for_fwd_loss_bwd_graph(gm)
+
+        nodes = list(result.graph.nodes)
+
+        # Backward reload chain has been moved in front of the dup's target
+        # (bwd_use) in topological order (reload_op before bwd_wait).
+        reload_idx = nodes.index(reload_op)
+        wait_idx = nodes.index(bwd_wait)
+        bwd_use_idx = nodes.index(bwd_use)
+        self.assertLess(reload_idx, wait_idx)
+        self.assertLess(wait_idx, bwd_use_idx)
+
+        # The forward offload chain stayed in forward (no hoist needed).
+        offload_idx = nodes.index(offload_op)
+        fwd_wait_idx = nodes.index(fwd_wait)
+        self.assertLess(offload_idx, fwd_wait_idx)
+        # Forward chain is also before the (hoisted) backward chain.
+        self.assertLess(fwd_wait_idx, reload_idx)
+
+        # The dup of N references bwd_wait (via cpu_offload_reload_node
+        # redirect), not the original offloaded forward node F.
+        dup = next(d for d in nodes if d.name.endswith("_recomputed"))
+        self.assertIn(bwd_wait, dup.all_input_nodes)
+        self.assertNotIn(f, dup.all_input_nodes)
+        # The dup itself is positioned after the hoisted chain and before
+        # its target.
+        dup_idx = nodes.index(dup)
+        self.assertLess(wait_idx, dup_idx)
+        self.assertLess(dup_idx, bwd_use_idx)
+
+        # bwd_use's args were redirected to the dup.
+        for inp in bwd_use.all_input_nodes:
+            self.assertIs(inp, dup)
+
+        # bwd_other still consumes the (now hoisted) bwd_wait.
+        for inp in bwd_other.all_input_nodes:
+            self.assertIs(inp, bwd_wait)
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:
The remat pass previously rebuilt the graph wholesale (fx.Graph() +
node_copy of every node) and relied on whole-graph DCE to remove dead
must_recompute originals. Refactor to mutate gm.graph in place: dups
are inserted in front of their first backward consumer, backward args
are redirected to the dups, and only originals whose users became
empty are erased. Original node identities and names are preserved,
the topological-order assumption is explicit (input graph order
drives insertion, validated by gm.graph.lint() at the end), and the
underlying function takes the standard (gm, example_inputs) graph
pass signature.

CPU-offload reload chains are handled by hoisting (in-place move) the
chain in front of the earliest dup that needs it - the in-place
equivalent of upstream's "eagerly copy reload chain into the new
graph" trick. This restores offload + remat support that the local
port commit (D-equivalent of GitHub PR #3260) silently dropped: on
main today, --compile.memory_policy=budget_limited_offload crashes
with CUBLAS_STATUS_EXECUTION_FAILED because dups reference the
freed-GPU offloaded forward tensors.

Review order:

selective_activation_remat.py - the core refactor. A pre-pass
claim_for records the first backward node that transitively reaches
each must_recompute forward node (setdefault gives first-write-wins).
The insertion loop walks gm.graph.nodes in forward order, so each
dup's must_recompute deps are already in recomputed_nodes by the
time remat_input resolves them - no explicit sort. Dups are tagged
autograd_backward=True so downstream passes treat them as
backward-region nodes. remat_input also handles the
cpu_offload_reload_node case: when a dup references an offloaded
forward node, ensure_offload_chain_before walks the bwd-region
reload chain via an explicit DFS stack, then hoists chain members in
graph (topological) order by walking the all_nodes snapshot - again
no explicit sort. moved_offload bookkeeping ensures the chain ends
up before the earliest target across multiple iterations.
raise_getitems still runs at the end for the multi-output-op memory
benefit; gm.graph.lint() validates the final graph.

common_utils.py / fsdp_passes.py - drops the _is_recomputed_node
name-suffix workaround now that dups carry autograd_backward=True
directly.

passes.py - removes the selective_activation_remat_pass wrapper
since the underlying function matches the standard signature; the
pass list references it directly.

tests/test_passes.py - adds TestSelectiveActivationRematPass with
three cases: the reviewer scenario from pytorch/pytorch#168082
(pins topological insertion order), a forward+backward consumer mix
(targeted erase keeps originals with surviving forward users), and
the offload reload chain hoist - synthesizing the actual
ao.offload / ao.reload / ao.wait_tensor graph the offload pass
produces and pinning that the chain ends up before the dup with the
dup reading from the backward wait_tensor instead of F.

Authored with Claude.

Test Plan:
Unit tests:
  pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x
  -> 68 passed, 1 skipped (3 new in TestSelectiveActivationRematPass)

End-to-end on 8xH100 / Llama3 8B / FSDP=4 + TP=2 / aot_fx_trace /
no cudagraph, with --debug.seed=42 --debug.deterministic:

  No offload (memory_policy=default):
    loss / grad_norm / peak memory at step 10 are bitwise identical
    to the main baseline (1.65096 / 21.9799 / 30.78 GiB).

  --compile.memory_policy=budget_limited_offload:
    refactor matches a baseline patched to invoke upstream remat
    directly (1.65096 / 21.9799 / 29.42 GiB). main HEAD (which calls
    the local port) crashes with CUBLAS_STATUS_EXECUTION_FAILED on
    this same configuration; the refactor incidentally fixes that
    regression.