### PR TITLE
[GraphTrainer] Add compile.disable_passes to selectively skip graph passes

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -76,7 +76,10 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.memory_policy cpu_offload_all
 
 # Disable CUDA graphs (for debugging)
-MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.no-enable_cudagraph
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.disable_passes cudagraph_pass
+
+# Disable specific passes by name
+MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.disable_passes custom_codegen_pass,cudagraph_pass
 
 # Disable all graph passes (for debugging)
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.no-enable_passes

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -41,6 +41,11 @@ class GraphTrainerCompileConfig(CompileConfig):
     enable_passes: bool = True
     """When False, skip all graph passes (both default and user-configured)."""
 
+    disable_passes: list[str] = field(default_factory=list)
+    """Pass names to selectively disable for debugging and ablation
+    studies. A pass is skipped if its name exactly matches any entry.
+    Example: --compile.disable_passes custom_codegen_pass,cudagraph_pass"""
+
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
@@ -68,9 +73,6 @@ class GraphTrainerCompileConfig(CompileConfig):
     numerics_changing_optim: bool = False
     """Enable passes that improve performance but may change numerics
     compared to the uncompiled path (e.g. RMSNorm Inductor fusion)."""
-
-    enable_cudagraph: bool = True
-    """When False, skip the cudagraph pass even if the graph is compatible."""
 
     cpu_offload_prefetch_n_layers: int = 1
     """Prefetch reloads this many layers ahead in the backward graph

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -233,7 +233,8 @@ def construct_default_graph_passes(
     """
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
-    use_cudagraph = config.compile.enable_cudagraph and is_cudagraph_compatible(
+    cudagraph_disabled = "cudagraph_pass" in config.compile.disable_passes
+    use_cudagraph = not cudagraph_disabled and is_cudagraph_compatible(
         traced_result.gm
     )
 
@@ -259,6 +260,32 @@ def construct_default_graph_passes(
     return passes
 
 
+def _get_pass_name(pass_fn: Callable) -> str:
+    return (
+        pass_fn.func.__name__
+        if isinstance(pass_fn, functools.partial)
+        else pass_fn.__name__
+    )
+
+
+def _filter_disabled_passes(
+    passes: list[Callable], disable_names: list[str]
+) -> list[Callable]:
+    """Remove passes whose names exactly match any entry in ``disable_names``."""
+    disable_set = set(disable_names)
+    filtered = []
+    skipped = []
+    for pass_fn in passes:
+        name = _get_pass_name(pass_fn)
+        if name in disable_set:
+            skipped.append(name)
+        else:
+            filtered.append(pass_fn)
+    if skipped:
+        logger.info(f"Disabled {len(skipped)} graph passes: {skipped}")
+    return filtered
+
+
 def apply_graph_passes(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
@@ -278,22 +305,18 @@ def apply_graph_passes(
             and before/after graphs to tlparse for each pass.
     """
     debug = compile_config is not None and compile_config.debug_graph_passes
-    pass_names = [
-        pass_fn.func.__name__
-        if isinstance(pass_fn, functools.partial)
-        else pass_fn.__name__
-        for pass_fn in passes
-    ]
+    disable_patterns = (
+        compile_config.disable_passes if compile_config is not None else []
+    )
+    if disable_patterns:
+        passes = _filter_disabled_passes(passes, disable_patterns)
+    pass_names = [_get_pass_name(pass_fn) for pass_fn in passes]
     pass_list = "\n  ".join(f"{i}. {name}" for i, name in enumerate(pass_names, 1))
     logger.info(f"Applying {len(passes)} graph passes:\n  {pass_list}")
     all_passes_start = time.perf_counter()
     tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
     for pass_fn in passes:
-        pass_name = (
-            pass_fn.func.__name__
-            if isinstance(pass_fn, functools.partial)
-            else pass_fn.__name__
-        )
+        pass_name = _get_pass_name(pass_fn)
         if debug:
             tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}", debug=debug)
             before_snapshot = snapshot_graph(gm)

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -234,9 +234,7 @@ def construct_default_graph_passes(
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
     cudagraph_disabled = "cudagraph_pass" in config.compile.disable_passes
-    use_cudagraph = not cudagraph_disabled and is_cudagraph_compatible(
-        traced_result.gm
-    )
+    use_cudagraph = not cudagraph_disabled and is_cudagraph_compatible(traced_result.gm)
 
     has_precompile_artifact = bool(config.compile.precompile_artifact_dir)
 

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -53,6 +53,7 @@ def build_minimal_trainer(
                 memory_policy="default",
                 inductor_compilation="regional",
                 numerics_changing_optim=compile_numerics_changing_optim,
+                disable_passes=[],
                 debug_graph_passes=False,
                 cpu_offload_prefetch_n_layers=1,
                 cpu_offload_defer_n_layers=1,

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -53,7 +53,6 @@ def build_minimal_trainer(
                 memory_policy="default",
                 inductor_compilation="regional",
                 numerics_changing_optim=compile_numerics_changing_optim,
-                enable_cudagraph=True,
                 debug_graph_passes=False,
                 cpu_offload_prefetch_n_layers=1,
                 cpu_offload_defer_n_layers=1,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -263,6 +263,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
                 compile=SimpleNamespace(
                     precompile_artifact_dir="precompiled",
                     inductor_compilation="regional",
+                    disable_passes=[],
                 ),
             )
             passes = construct_default_graph_passes(loaded_result, load_config)

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -263,7 +263,6 @@ class BitwiseDeterministicBase(unittest.TestCase):
                 compile=SimpleNamespace(
                     precompile_artifact_dir="precompiled",
                     inductor_compilation="regional",
-                    enable_cudagraph=True,
                 ),
             )
             passes = construct_default_graph_passes(loaded_result, load_config)


### PR DESCRIPTION
## Summary
- Add `disable_passes` config field to `GraphTrainerCompileConfig` for selectively disabling graph passes by name (exact match) for debugging and ablation studies.
- Deprecate and remove `enable_cudagraph` — users can now use `--compile.disable_passes cudagraph_pass` instead.
- Refactor repeated pass-name resolution into `_get_pass_name` and filtering into `_filter_disabled_passes`.

## Test plan
- [ ] `python -m py_compile` on all modified files
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x`
- [x] Manual: `--compile.disable_passes custom_codegen_pass,cudagraph_pass` skips the named passes and logs which were disabled