### PR TITLE
Avoid repeat_interleave output-size sync

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -348,7 +348,9 @@ def _permute_tokens(
     sort_order = torch.argsort(valid_expert_ids, stable=True)
     permuted_indices = torch.arange(
         len(hidden_states), device=hidden_states.device
-    ).repeat_interleave(mask.sum(dim=1))[sort_order]
+    ).repeat_interleave(mask.sum(dim=1), output_size=valid_expert_ids.shape[0])[
+        sort_order
+    ]
     permuted_hidden_states = hidden_states.index_select(0, permuted_indices)
     permuted_scores = valid_scores[sort_order]
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -342,7 +342,11 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         Output layout: (e0,r0), (e0,r1), ..., (e1,r0), (e1,r1), ...  (expert-major)
         """
         device = num_tokens_per_expert_group.device
-        total = num_tokens_per_expert_group.sum()
+        # output_size must be host-known. num_tokens_per_expert_group.sum()
+        # is a CUDA scalar, but this unpadded all-to-all path keeps one
+        # routed_input row per received routed token assignment, so its shape
+        # equals the number of routed tokens.
+        total = routed_input.shape[0]
 
         # [R, E] matrix of token counts per (rank, expert)
         t_mat = num_tokens_per_expert_group.view(ep_size, num_local_experts)
@@ -359,7 +363,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # For each output position, find its input position:
         #   output[p] = input[input_starts[seg] + (p - output_starts[seg])]
         seg_ids = torch.arange(segment_lens.shape[0], device=device).repeat_interleave(
-            segment_lens
+            segment_lens, output_size=total
         )
         output_starts = segment_lens.cumsum(0) - segment_lens
         permuted_indices = (


### PR DESCRIPTION
Stacked PRs:
 * __->__#3274


--- --- ---

Avoid repeat_interleave output-size sync

repeat_interleave expands each input element by its repeat count and must know the total output length before allocation. In ATen, when output_size is omitted, repeat_interleave_common computes cumsum(repeats) and reads cumsum[-1].item<int64_t>(); for CUDA repeats, item() dispatches through _local_scalar_dense_cuda, which performs a device-to-host memcpy_and_sync and cudaStreamSynchronize: https://github.com/pytorch/pytorch/blob/4d519359b7b7bb5d68cfb97e9a8e77f154b4216a/aten/src/ATen/native/Repeat.h#L32-L38

Reuse host-known routing totals as output_size: the standard all-to-all path passes the receive split total that sizes the output buffer, and the DeepEP path passes the flattened valid assignment count. This avoids the sync without changing the repeated indices.


Before: 192 cudaStreamSynchronize, 
<img width="1004" height="150" alt="image" src="https://github.com/user-attachments/assets/6a68dc93-a9a5-4743-944b-048c5d9160ec" />

After: 36 cudaStreamSynchronize,
<img width="995" height="130" alt="image" src="https://github.com/user-attachments/assets/ce2611e3-ead9-409b-9c73-8e0a338c0560" />

Run logs:

Before: https://www.internalfb.com/intern/paste/P2313051540/
step=100 loss=4.757046700 grad_norm=0.966188014 max_reserved=67.210938GiB tps=7887.235 tflops=142.806259 mfu=14.439460%

After: https://www.internalfb.com/intern/paste/P2313051542/
step=100 loss=4.757046700 grad_norm=0.966188014 max_reserved=67.210938GiB tps=8369.046 tflops=151.529907 mfu=15.321527%
