### PR TITLE
[codex] Fix shared BOS and EOS token inference

### DIFF
--- a/tests/unit_tests/test_tokenizer.py
+++ b/tests/unit_tests/test_tokenizer.py
@@ -90,6 +90,30 @@ class TestTokenizerIntegration(unittest.TestCase):
             # No chat template should be set
             self.assertIsNone(tok._chat_template)
 
+    def test_same_bos_eos_token_is_inferred_for_both_ids(self):
+        """Tokenizers like GPT-2 use one token as both BOS and EOS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shutil.copy2(
+                os.path.join(ASSETS_TOKENIZER, "tokenizer.json"),
+                os.path.join(tmpdir, "tokenizer.json"),
+            )
+            with open(os.path.join(tmpdir, "tokenizer_config.json"), "w") as f:
+                json.dump(
+                    {
+                        "bos_token": "<|end_of_text|>",
+                        "eos_token": "<|end_of_text|>",
+                    },
+                    f,
+                )
+
+            tok = HuggingFaceTokenizer(tokenizer_path=tmpdir)
+
+            self.assertIsNotNone(tok.bos_id)
+            self.assertEqual(tok.bos_id, tok.eos_id)
+            encoded = tok.encode("hello", add_bos=True, add_eos=True)
+            self.assertEqual(encoded[0], tok.bos_id)
+            self.assertEqual(encoded[-1], tok.eos_id)
+
     def _compare_tokenizers(self, our_tokenizer, reference_tokenizer, test_repo_id):
         """
         Comprehensive comparison between our tokenizer and a reference tokenizer.

--- a/torchtitan/components/tokenizer.py
+++ b/torchtitan/components/tokenizer.py
@@ -310,7 +310,7 @@ class HuggingFaceTokenizer(BaseTokenizer):
                 if token_id is not None
                 else self.tokenizer.token_to_id(token_str)
             )
-        elif token_str == config_eos_token:
+        if token_str == config_eos_token:
             self.eos_token = token_str
             self.eos_id = (
                 token_id


### PR DESCRIPTION
## Summary
- allow a tokenizer special token to be recorded as both BOS and EOS
- add a regression test for tokenizers that use one token for both roles, such as GPT-2-style `<|endoftext|>`

## Root cause
`HuggingFaceTokenizer._process_special_token` used `if/elif` when assigning BOS and EOS roles. If `bos_token` and `eos_token` were the same string, the BOS branch won and `eos_id` stayed unset. Calls to `encode(..., add_bos=True, add_eos=True)` then omitted the EOS token.

## Validation
- `/data/app/torchtitan/.venv/bin/python -m pytest -q tests/unit_tests/test_tokenizer.py::TestTokenizerIntegration::test_same_bos_eos_token_is_inferred_for_both_ids`
- `/data/app/torchtitan/.venv/bin/python -m pytest -q tests/unit_tests/test_dataloader.py`
