### PR TITLE
Mark FakeTensorMode blocking gate as resolved in design doc

### DIFF
--- a/torchtitan/experiments/flex_shard/flex_shard_front_end.md
+++ b/torchtitan/experiments/flex_shard/flex_shard_front_end.md
@@ -354,9 +354,13 @@ Typed-per-bucket fallback (graph mode only):
   .view(shape_A)   .view(shape_B)                 <-- no dtype cast needed
 ```
 
-**Decision gate**: The FakeTensorMode investigation is a **blocking item in Phase 1**
+**Decision gate**: ~~The FakeTensorMode investigation is a **blocking item in Phase 1**
 before proceeding to Phase 2. If `view(dtype)` reinterpretation fails under symbolic
-tracing, adopt the typed-storage fallback before building parametrization on top of it.
+tracing, adopt the typed-storage fallback before building parametrization on top of it.~~
+**Resolved (Phase 1)**: all three test patterns pass under `FakeTensorMode` —
+basic `view(dtype)`, byte offset slice + `view(dtype)` + `view(shape)`, and
+mixed-dtype regions (bf16 + fp32 in one uint8 buffer). The typed-per-bucket
+fallback is **not needed**. See `test_flex_shard_tracing.py::TestFakeTensorModeByteBuffer`.
 
 ### 6. Handle `RaggedShard` under symbolic tracing
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3301
* #3300
* #3299
* #3298
* #3297
* #3296
* #3295
* #3294
* #3293
* #3292
* #3291
* #3290
* #3289
* #3288
* #3287
* #3286
* __->__ #3285
* #3284
* #3283
* #3282

All three FakeTensorMode test patterns pass — typed-per-bucket
fallback is not needed.