### PR TITLE
Phase 2a: Core parametrization

### DIFF
--- a/torchtitan/experiments/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .flex_shard import (
+    disable_active_parametrization,
     DStorage,
     flat_shard_placements,
     FlatShard,
@@ -26,6 +27,7 @@ from .flex_shard import (
 
 
 __all__ = [
+    "disable_active_parametrization",
     "DStorage",
     "flat_shard_placements",
     "FlatShard",

--- a/torchtitan/experiments/flex_shard/flex_shard.py
+++ b/torchtitan/experiments/flex_shard/flex_shard.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import sys
+from collections.abc import Callable, Generator
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -454,6 +455,7 @@ class FlatShard(Placement):
 
 
 __all__ = [
+    "disable_active_parametrization",
     "DStorage",
     "flat_shard_placements",
     "FlatShard",
@@ -538,6 +540,62 @@ def _validate_placements_for_tracing(
                         f"which is not evenly divisible by "
                         f"world_size={world_size}. Pad the parameter."
                     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2a: Parametrization guard and property-based registration
+# ---------------------------------------------------------------------------
+
+_active_parametrization = True
+
+
+@contextmanager
+def disable_active_parametrization() -> Generator[None, None, None]:
+    """Disable parametrization forward (returns raw sharded tensor).
+
+    Use during initialization, checkpointing, or any context where
+    parameter access should not trigger collective communication.
+    """
+    global _active_parametrization
+    try:
+        _active_parametrization = False
+        yield
+    finally:
+        _active_parametrization = True
+
+
+_wrap_class_counter = 0
+
+
+def _register_parametrization(
+    module: nn.Module,
+    param_parametrizations: dict[str, nn.Module],
+) -> None:
+    """Register per-parameter property getters that call parametrization forward.
+
+    Uses dynamic subclass creation (not nn.utils.parametrize) to avoid
+    state_dict key mangling. state_dict reads self._parameters directly,
+    bypassing property getters.
+
+    Args:
+        module: The leaf module owning the parameters.
+        param_parametrizations: Maps parameter name to its parametrization module.
+    """
+    global _wrap_class_counter
+    _wrap_class_counter += 1
+    param_name_to_property = {
+        param_name: property(
+            lambda self, pn=param_name, p=param: p(self._parameters[pn])
+        )
+        for param_name, param in param_parametrizations.items()
+    }
+    module_cls = type(
+        f"FlexShard{module.__class__.__name__}_{_wrap_class_counter}",
+        (module.__class__,),
+        param_name_to_property,
+    )
+    module.__class__ = module_cls
+    sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
 
 
 def set_sharding_info(
@@ -864,6 +922,8 @@ class ShardParametrization(nn.Module):
         self.world_size = world_size
 
     def forward(self, local_shard: torch.Tensor) -> torch.Tensor:
+        if not _active_parametrization:
+            return local_shard
         full = torch.ops._c10d_functional.all_gather_into_tensor(
             local_shard, self.world_size, self.group_name
         )
@@ -889,6 +949,8 @@ class FlatShardParametrization(nn.Module):
         self.original_shape = original_shape
 
     def forward(self, flat_shard: torch.Tensor) -> torch.Tensor:
+        if not _active_parametrization:
+            return flat_shard
         full_flat = torch.ops._c10d_functional.all_gather_into_tensor(
             flat_shard, self.world_size, self.group_name
         )
@@ -1603,16 +1665,16 @@ PlacementFn = Callable[
 ]
 
 # TODO: flex_shard(buckets=[module1, module2, ...]
-# prefer full fqn to nn.Parmeter(torch.Tensor)
+# prefer full fqn to nn.Parameter(torch.Tensor)
 # ._wrapped_(compile)._wrapped_(ac).xxx
 # FQN : string = nn.Parameter()
 # shard_placement_fn(model):
 
 #    for submodule in model.modules():
 #        if isinstancE(submodule, EPModule):
-#            reutnr {parame: Sahrd(1)}
+#            return {param: Shard(1)}
 #         else:
-#             reutrn {Shard(0)}
+#             return {Shard(0)}
 
 # model: nn.Module, top-level fqn,
 # shard_placement_fn: specify [module/param_fqn] : [placement]
@@ -1625,7 +1687,7 @@ def flex_shard(
     mesh: DeviceMesh,
     shard_placement_fn: PlacementFn | None = None,
     reshard_after_forward: bool = True,
-    register_hooks: bool = True,
+    register_hooks: bool = False,
     module_fqn: str = "",
 ) -> FlexShardModule:
     """
@@ -1756,5 +1818,46 @@ def flex_shard(
     cls = type(module)
     if not issubclass(cls, FlexShardModule):
         module.__class__ = type(cls.__name__, (cls, FlexShardModule), {})
+
+    # Register property-based parametrization (Phase 2a)
+    if not register_hooks:
+        group_name = mesh.get_group().group_name
+        world_size = mesh.size()
+
+        # Group parametrizations by leaf module
+        module_param_map: dict[nn.Module, dict[str, nn.Module]] = {}
+
+        for fqn, info in param_infos.items():
+            placement = info.placements[0]
+            if isinstance(placement, Shard):
+                p = ShardParametrization(
+                    shard_dim=placement.dim,
+                    group_name=group_name,
+                    world_size=world_size,
+                )
+            elif isinstance(placement, FlatShard):
+                p = FlatShardParametrization(
+                    group_name=group_name,
+                    world_size=world_size,
+                    original_shape=info.global_shape,
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported placement for parametrization: {placement}"
+                )
+
+            # Find the leaf module owning this param
+            parts = fqn.split(".")
+            leaf_mod = module
+            for part in parts[:-1]:
+                leaf_mod = getattr(leaf_mod, part)
+            local_name = parts[-1]
+
+            if leaf_mod not in module_param_map:
+                module_param_map[leaf_mod] = {}
+            module_param_map[leaf_mod][local_name] = p
+
+        for mod, param_map in module_param_map.items():
+            _register_parametrization(mod, param_map)
 
     return module

--- a/torchtitan/experiments/flex_shard/flex_shard_front_end.md
+++ b/torchtitan/experiments/flex_shard/flex_shard_front_end.md
@@ -1285,22 +1285,32 @@ FlexShard Core (always parametrization-based)
 - [x] **Blocking gate**: validated under `FakeTensorMode` that byte buffer `view(dtype).view(shape)` operations trace correctly — all three patterns pass (basic view, byte offset slice, mixed-dtype regions)
 - [x] Unit tests in `test_flex_shard_tracing.py`: FakeTensorMode byte buffer tests, FX graph structure tests (verify `all_gather_into_tensor`/`wait_tensor`/`chunk`/`cat`/`view` nodes), init validation tests, distributed correctness tests
 
-### Phase 2: Parametrization and API
+### Phase 2a: Core parametrization ✓
 
-- [ ] Implement unified `flex_shard()` entry point with `shard_placement_fn`, `buckets`, and `reshard_after_forward` parameters (see "Unified API" section)
+- [x] Replace hook-based unshard/reduce_grad with parametrization pattern using `ShardParametrization` and `FlatShardParametrization` — property-based param access triggers `_c10d_functional` all-gather; backward autograd generates reduce-scatter
+- [x] Use SimpleFSDP's custom property-based registration (`_register_parametrization()` in `flex_shard.py`) — dynamic subclass creation with property getters, not `nn.utils.parametrize`, to avoid `state_dict()` key mangling
+- [x] Implement `_active_parametrization` guard (`disable_active_parametrization()` context manager) to disable parametrization during init and `state_dict()` calls
+- [x] Default `register_hooks=False` in `flex_shard()` — parametrization is now the default path; `register_hooks=True` is a backward-compat escape hatch for hook-based flow
+- [x] `flex_shard()` creates per-param parametrization instances grouped by leaf module, wiring `Shard` → `ShardParametrization`, `FlatShard` → `FlatShardParametrization`
+- [x] Unit tests in `test_flex_shard_parametrization.py`: guard behavior (disable/restore/exception safety), property registration (dynamic subclass, state_dict bypass, multi-param), distributed correctness (param access triggers all-gather, state_dict returns sharded, guard disables all-gather, forward correctness)
+
+### Phase 2b: BucketSpec and bucket validation
+
 - [ ] Implement `BucketSpec` dataclass with `patterns`, `mp_policy`, `offload_policy`
 - [ ] Implement bucket validation: reject orphan params, overlapping params, mismatched placement type/dimension within a bucket; emit coverage summary at `logger.debug` level
+- [ ] Implement fnmatch-based `shard_placement_fn` dict form (see "Unified API" section)
 - [ ] Create per-bucket DStorage instances from bucket spec
-- [ ] Replace hook-based unshard/reduce_grad with parametrization pattern using `ShardParametrization` and `FlatShardParametrization`
-- [ ] Use SimpleFSDP's custom property-based registration (not `nn.utils.parametrize`) to avoid `state_dict()` key mangling
-- [ ] Implement `_active_parametrization` guard to disable parametrization during init and `state_dict()` calls
+- [ ] Implement auto-bucket generation (`_auto_buckets()`) for `buckets=None` default
+- [ ] Unit tests: bucket validation catches orphans and overlaps
+
+### Phase 2c: Memory management and mixed precision
+
 - [ ] Support `reshard_after_forward` via checkpoint policy annotations (like SimpleFSDP)
 - [ ] Implement `no_sync()` context manager for eager mode gradient accumulation (see Gap #8)
 - [ ] Ensure parametrization traces cleanly both with and without reduce-scatter for graph mode gradient accumulation
 - [ ] Implement mixed precision cast in parametrization forward (see Gap #11); `BucketSpec.mp_policy` controls per-bucket dtype
 - [ ] Implement CPU offloading device transfer in parametrization forward (see Gap #12); `BucketSpec.offload_policy` controls per-bucket offload
-- [ ] Implement auto-bucket generation (`_auto_buckets()`) for `buckets=None` default
-- [ ] Unit tests: FlexShard model traces correctly with `make_fx`; bucket validation catches orphans and overlaps
+- [ ] Unit tests: FlexShard model traces correctly with `make_fx`; mixed precision numerics
 
 ### Phase 3: Graph pass compatibility
 

--- a/torchtitan/experiments/flex_shard/test_flex_shard_parametrization.py
+++ b/torchtitan/experiments/flex_shard/test_flex_shard_parametrization.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for FlexShard parametrization (Phase 2a).
+
+Usage:
+    # Single-process tests (no GPU/NCCL required):
+    python -m pytest test_flex_shard_parametrization.py -v -k "not Distributed"
+
+    # Distributed correctness tests:
+    torchrun --nproc_per_node=2 test_flex_shard_parametrization.py
+"""
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Guard behavior tests (single-process, no NCCL)
+# ---------------------------------------------------------------------------
+
+
+class TestActiveParametrizationGuard(unittest.TestCase):
+    """Test _active_parametrization guard and disable_active_parametrization."""
+
+    def test_guard_disabled_returns_raw_shard(self):
+        """With guard disabled, ShardParametrization returns input unchanged."""
+        from torchtitan.experiments.flex_shard import (
+            disable_active_parametrization,
+            ShardParametrization,
+        )
+
+        param = ShardParametrization(shard_dim=0, group_name="fake", world_size=2)
+        shard = torch.randn(4, 8)
+        with disable_active_parametrization():
+            result = param(shard)
+        self.assertIs(result, shard)
+
+    def test_guard_disabled_returns_raw_flat_shard(self):
+        """With guard disabled, FlatShardParametrization returns input unchanged."""
+        from torchtitan.experiments.flex_shard import (
+            disable_active_parametrization,
+            FlatShardParametrization,
+        )
+
+        param = FlatShardParametrization(
+            group_name="fake",
+            world_size=2,
+            original_shape=torch.Size([4, 8]),
+        )
+        flat_shard = torch.randn(16)
+        with disable_active_parametrization():
+            result = param(flat_shard)
+        self.assertIs(result, flat_shard)
+
+    def test_guard_restores_after_context(self):
+        """Guard restores to True after context manager exits."""
+        import importlib
+
+        fs = importlib.import_module("torchtitan.experiments.flex_shard.flex_shard")
+
+        self.assertTrue(fs._active_parametrization)
+        with fs.disable_active_parametrization():
+            self.assertFalse(fs._active_parametrization)
+        self.assertTrue(fs._active_parametrization)
+
+    def test_guard_restores_on_exception(self):
+        """Guard restores to True even if exception is raised."""
+        import importlib
+
+        fs = importlib.import_module("torchtitan.experiments.flex_shard.flex_shard")
+
+        try:
+            with fs.disable_active_parametrization():
+                raise RuntimeError("test")
+        except RuntimeError:
+            pass
+        self.assertTrue(fs._active_parametrization)
+
+
+# ---------------------------------------------------------------------------
+# Property registration tests (single-process, no NCCL)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterParametrization(unittest.TestCase):
+    """Test _register_parametrization creates correct property getters."""
+
+    def test_property_created_on_module(self):
+        """Property getter is created on the module's dynamic subclass."""
+        from torchtitan.experiments.flex_shard.flex_shard import (
+            _register_parametrization,
+            ShardParametrization,
+        )
+
+        module = nn.Linear(8, 4, bias=False)
+        param = ShardParametrization(shard_dim=0, group_name="fake", world_size=2)
+        _register_parametrization(module, {"weight": param})
+
+        # The module's class should be a dynamic subclass
+        self.assertIn("FlexShard", type(module).__name__)
+        # Property should exist on the class
+        self.assertIsInstance(type(module).__dict__["weight"], property)
+
+    def test_state_dict_bypasses_property(self):
+        """state_dict reads _parameters directly, not through property."""
+        from torchtitan.experiments.flex_shard.flex_shard import (
+            _register_parametrization,
+            ShardParametrization,
+        )
+
+        module = nn.Linear(8, 4, bias=False)
+        original_shape = module.weight.shape
+
+        # Register parametrization with guard disabled so no NCCL needed
+        param = ShardParametrization(shard_dim=0, group_name="fake", world_size=2)
+        _register_parametrization(module, {"weight": param})
+
+        # state_dict should return the raw parameter (bypasses property)
+        sd = module.state_dict()
+        self.assertEqual(sd["weight"].shape, original_shape)
+
+    def test_multiple_params_on_same_module(self):
+        """Multiple parameters can be parametrized on the same module."""
+        from torchtitan.experiments.flex_shard.flex_shard import (
+            _register_parametrization,
+            ShardParametrization,
+        )
+
+        module = nn.Linear(8, 4)  # has weight and bias
+        param_w = ShardParametrization(shard_dim=0, group_name="fake", world_size=2)
+        param_b = ShardParametrization(shard_dim=0, group_name="fake", world_size=2)
+        _register_parametrization(module, {"weight": param_w, "bias": param_b})
+
+        self.assertIsInstance(type(module).__dict__["weight"], property)
+        self.assertIsInstance(type(module).__dict__["bias"], property)
+
+
+# ---------------------------------------------------------------------------
+# Distributed correctness tests (torchrun only)
+# ---------------------------------------------------------------------------
+
+
+class TestDistributedParametrization(unittest.TestCase):
+    """Multi-process correctness tests for parametrized FlexShard.
+
+    Run with: torchrun --nproc_per_node=2 test_flex_shard_parametrization.py
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(backend="nccl")
+        cls.rank = torch.distributed.get_rank()
+        cls.world_size = torch.distributed.get_world_size()
+        torch.cuda.set_device(cls.rank % torch.cuda.device_count())
+
+    @classmethod
+    def tearDownClass(cls):
+        if torch.distributed.is_initialized():
+            torch.cuda.synchronize()
+            torch.distributed.destroy_process_group()
+
+    def test_param_access_triggers_allgather(self):
+        """Accessing module.weight returns the full (unsharded) tensor."""
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.flex_shard import flex_shard
+
+        mesh = init_device_mesh("cuda", (self.world_size,))
+
+        model = nn.Linear(8, 4, bias=False, device="cuda")
+        # Broadcast weights so all ranks start with the same full tensor
+        torch.distributed.broadcast(model.weight.data, src=0)
+        full_ref = model.weight.data.clone()
+
+        flex_shard(model, mesh, register_hooks=False)
+
+        # Accessing model.weight should trigger all-gather via property
+        result = model.weight
+        torch.testing.assert_close(result, full_ref)
+
+    def test_state_dict_returns_sharded(self):
+        """state_dict() returns sharded params, not unsharded."""
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.flex_shard import flex_shard
+
+        mesh = init_device_mesh("cuda", (self.world_size,))
+
+        model = nn.Linear(8, 4, bias=False, device="cuda")
+        torch.distributed.broadcast(model.weight.data, src=0)
+
+        flex_shard(model, mesh, register_hooks=False)
+
+        sd = model.state_dict()
+        # state_dict bypasses property, returns local shard
+        expected_rows = 4 // self.world_size
+        self.assertEqual(sd["weight"].shape, (expected_rows, 8))
+
+    def test_disable_guard_returns_sharded(self):
+        """With guard disabled, param access returns raw sharded tensor."""
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.flex_shard import (
+            disable_active_parametrization,
+            flex_shard,
+        )
+
+        mesh = init_device_mesh("cuda", (self.world_size,))
+
+        model = nn.Linear(8, 4, bias=False, device="cuda")
+        torch.distributed.broadcast(model.weight.data, src=0)
+
+        flex_shard(model, mesh, register_hooks=False)
+
+        with disable_active_parametrization():
+            result = model.weight
+        expected_rows = 4 // self.world_size
+        self.assertEqual(result.shape, (expected_rows, 8))
+
+    def test_forward_produces_correct_output(self):
+        """Forward pass through parametrized model produces correct results."""
+        from torch.distributed.device_mesh import init_device_mesh
+
+        from torchtitan.experiments.flex_shard import flex_shard
+
+        mesh = init_device_mesh("cuda", (self.world_size,))
+
+        model = nn.Linear(8, 4, bias=False, device="cuda")
+        torch.distributed.broadcast(model.weight.data, src=0)
+        ref_weight = model.weight.data.clone()
+
+        # Reference output
+        x = torch.randn(2, 8, device="cuda")
+        torch.distributed.broadcast(x, src=0)
+        ref_output = x @ ref_weight.t()
+
+        flex_shard(model, mesh, register_hooks=False)
+        output = model(x)
+
+        torch.testing.assert_close(output, ref_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Replace hook-based unshard/reduce_grad with property-based parametrization.
Parameter access now triggers _c10d_functional all-gather ops visible to
FX tracing; backward autograd generates reduce-scatter.

- Add _active_parametrization guard and disable_active_parametrization()
  context manager for init/checkpoint safety
- Add _register_parametrization() using dynamic subclass creation with
  property getters (avoids nn.utils.parametrize state_dict key mangling)
- Add guard checks in ShardParametrization/FlatShardParametrization forward
- Wire parametrization into flex_shard() (default register_hooks=False)
- Add test_flex_shard_parametrization.py (7 single-process + 4 distributed)
- Update design doc: split Phase 2 into 2a/2b/2c sub-phases