### PR TITLE
Phase 3: Graph pass compatibility

### DIFF
--- a/torchtitan/experiments/flex_shard/flex_shard_front_end.md
+++ b/torchtitan/experiments/flex_shard/flex_shard_front_end.md
@@ -559,8 +559,9 @@ How each concern is addressed without a mode split:
   eager communication is needed later, add a transparent prefetch optimization inside
   the parametrization: when the first param in a bucket is accessed, prefetch the
   entire bucket. This is a runtime detail, not a structural mode switch.
-- **Graph compiler bucketing**: `buckets` are passed to `get_buckets()` for the
-  `transformer_block_bucketing` pass, exactly as before.
+- **Graph compiler bucketing**: `buckets` are passed to `get_buckets()` (renamed from
+  `get_transformer_block_buckets()` in Phase 3) for the `transformer_block_bucketing`
+  pass, exactly as before.
 
 ### 10. Annotate FX nodes with placement metadata for bucketing passes
 
@@ -584,13 +585,19 @@ all intermediate ops (chunk, cat, view) are included in the recomputation scope.
 node.meta["flex_shard_placement"] = placement  # e.g., Shard(0), Shard(1), FlatShard()
 ```
 
-`auto_bucketing` reads this metadata and only fuses nodes with matching placement type
-and parameters. Nodes without metadata (SimpleFSDP) behave as before — backward
-compatible.
+**Phase 3 finding**: `auto_bucketing` delegates to PyTorch's
+`schedule_overlap_bucketing`, which does communication **scheduling** (reordering
+collectives for compute/comm overlap on the same CUDA stream), not all-gather
+**fusion**. Each all-gather remains an independent node with its own output. Different
+placement types don't conflict because their post-processing (chunk+cat for
+Shard(dim!=0), view for FlatShard) operates on independent tensors. The placement
+metadata is available for future passes that need to distinguish placement types, but
+the existing bucketing passes work without it.
 
-**Fusion constraint**: two all-gather nodes can be fused only if they have identical
-placement type and shard dimension. `Shard(0)` + `Shard(0)` is safe. `Shard(0)` +
-`Shard(1)` is not. `Shard` + `FlatShard` is not.
+**Potential future fusion constraint**: if a fusion pass is added, two all-gather nodes
+can be fused only if they have identical placement type and shard dimension.
+`Shard(0)` + `Shard(0)` is safe. `Shard(0)` + `Shard(1)` is not. `Shard` +
+`FlatShard` is not.
 
 **Implemented in `flex_shard/reshard_after_forward.py`.** The generalized pass
 `annotate_flex_shard_all_gather` reuses `is_wait_tensor_from_fsdp()` for detection
@@ -799,16 +806,14 @@ another for hierarchical sharding). This pass must run **before** bucketing pass
 because bucketed all-gathers must inherit the reassigned process group.
 
 FlexShard's `_c10d_functional` ops use the same argument format as SimpleFSDP's
-(process group name as a string argument), so `reassign_to_pg_pass` should work
-without modification. However, this needs explicit testing — the pass pattern-matches
-on `all_gather_into_tensor` nodes and rewrites `node.args`, and FlexShard's
-`Shard(dim != 0)` adds `chunk` + `cat` nodes after the all-gather that the pass
-should ignore.
+(process group name as a string argument), so `reassign_to_pg_pass` works
+without modification.
 
-**Verification item (Phase 3)**: run `reassign_to_pg_pass` on a FlexShard-traced graph
-with mixed `Shard(0)` and `Shard(1)` placements and verify that (a) all-gather nodes
-are correctly reassigned, (b) post-gather `chunk`/`cat` nodes are not affected, and
-(c) bucketing after reassignment produces correct results.
+**Verified (Phase 3)**: `test_flex_shard_passes.py::TestReassignToPgComposition`
+confirms (a) all-gather nodes are correctly reassigned across all patterns
+(Shard(0), Shard(dim!=0), FlatShard), (b) post-gather `chunk`/`cat`/`view` nodes
+are not affected, (c) mixed `Shard(0)` + `Shard(dim!=0)` all-gathers both get
+reassigned, and (d) reassign + reshard passes compose correctly.
 
 ## What FlexShard Brings to Graph Trainer
 
@@ -1229,11 +1234,12 @@ both execution contexts without leaking abstractions.
 When the compiler can do strictly better (e.g., non-obvious overlap patterns),
 `auto_bucketing` ignores user buckets entirely — so the user is never constrained.
 
-### `get_buckets()` (renamed from `get_transformer_block_buckets()`)
+### `get_buckets()` (renamed from `get_transformer_block_buckets()` in Phase 3)
 
-The current `get_transformer_block_buckets()` hardcodes transformer-specific model
-structure (`model.tok_embeddings`, `model.layers`, etc.). Rename to `get_buckets()`
-and make it a simple pass-through for user-specified buckets:
+`get_buckets()` (formerly `get_transformer_block_buckets()`, renamed in Phase 3)
+currently hardcodes transformer-specific model structure (`model.tok_embeddings`,
+`model.layers`, etc.). Future work: make it a simple pass-through for user-specified
+buckets:
 
 ```python
 def get_buckets(model, user_buckets=None) -> list[list[str] | str]:
@@ -1251,9 +1257,12 @@ Model-specific bucket logic (e.g., grouping `norm` + `output` together for
 transformers) belongs in the model's `parallelize.py`, not in a general-purpose
 utility. Models that need custom bucket layouts pass them via `flex_shard(buckets=...)`.
 
-**Migration**: existing callers of `get_transformer_block_buckets()` in Graph Trainer
+**Migration**: ~~existing callers of `get_transformer_block_buckets()` in Graph Trainer
 (e.g., `graph_trainer.py`, pass setup code) need to be updated to call `get_buckets()`
-and pass user-specified buckets through from the model's `parallelize.py`.
+and pass user-specified buckets through from the model's `parallelize.py`.~~
+**Done (Phase 3)**: renamed to `get_buckets()` in `common_utils.py`, updated callers
+in `compile.py` and `graph_utils.py`. Future work: add `user_buckets` parameter to
+accept user-specified bucket layouts from `flex_shard(buckets=...)`.
 
 ### Auto-Bucket Generation
 
@@ -1361,20 +1370,22 @@ FlexShard Core (always parametrization-based)
 - [x] Validate offload + hooks incompatibility: `offload_policy` with `register_hooks=True` raises `ValueError`
 - [x] Unit tests in `test_flex_shard_offload.py`: OffloadPolicy (3 tests), BucketSpec offload_policy wiring (6 tests), H2D transfer (2 tests), distributed offloading (6 tests)
 - [x] `reshard_after_forward` graph pass: `flex_shard_reshard_after_fwd_pass` in `reshard_after_forward.py` — generalizes `annotate_fsdp_all_gather` to handle all FlexShard unshard patterns (Shard(0), Shard(dim!=0) chunk+cat, FlatShard view) plus offload `.to()` and mixed precision `convert_element_type`; tags terminal nodes with `node.meta["flex_shard_placement"]`; registered in `graph_trainer/passes.py` as `flex_shard_reshard_after_fwd`
-- [x] Unit tests in `test_flex_shard_reshard.py`: pattern detection (8 tests across Shard(0)/Shard(dim!=0)/FlatShard/SimpleFSDP with offload and mp variants), recompute policy (2 tests), metadata tagging (4 tests), pass signature (2 tests)
+- [x] Unit tests in `test_flex_shard_reshard.py`: pattern detection (8 tests across Shard(0)/Shard(dim!=0)/FlatShard/SimpleFSDP with offload and mp variants), recompute policy (2 tests), metadata tagging (4 tests), SAC composition (2 tests), pass signature (2 tests)
+- [x] Unit tests in `test_flex_shard_passes.py`: reassign_to_pg composition (3 tests), pass ordering (3 tests)
 - [ ] Prefetch optimization (overlap H2D of next bucket with compute of current) — deferred
 
-### Phase 3: Graph pass compatibility
+### Phase 3: Graph pass compatibility ✓
 
 - [x] Attach placement metadata (`node.meta["flex_shard_placement"]`) to final output node of each parametrization's unshard sequence (see Gap #10) — implemented in `flex_shard/reshard_after_forward.py`
 - [x] Generalize `annotate_fsdp_all_gather` for FlexShard — `annotate_flex_shard_all_gather` in `flex_shard/reshard_after_forward.py` handles all patterns; registered as `flex_shard_reshard_after_fwd` in `graph_trainer/passes.py`
-- [ ] Update `auto_bucketing` to respect placement metadata: only fuse nodes with matching placement type and shard dimension
-- [ ] Ensure bucketing passes (`auto_bucketing`, `transformer_block_bucketing`) recognize FlexShard comm patterns
-- [ ] Verify `apply_sac_pass` works with FlexShard's node patterns (hardcoded `wait_tensor` logic must handle `chunk`/`cat` nodes for `Shard(dim != 0)`)
-- [ ] Verify `reassign_to_pg_pass` works with FlexShard's all-gather nodes and does not affect post-gather `chunk`/`cat` nodes (see Gap #14)
-- [ ] Rename `get_transformer_block_buckets()` to `get_buckets()` and update all callers in Graph Trainer
-- [ ] Test with `cudagraph` and `full_inductor_compilation` passes
-- [ ] Test mixed-placement model (e.g., `Shard(0)` + `Shard(1)`) with `auto_bucketing` to verify no incorrect fusion
+- [x] Wire `flex_shard_reshard_after_fwd_pass` into pipeline — `get_joint_custom_passes_from_config()` in `graph_utils.py` skips hardcoded `fsdp_reshard_after_fwd_pass` when `flex_shard_reshard_after_fwd` is in `joint_pass_names`
+- [x] Rename `get_transformer_block_buckets()` → `get_buckets()` — updated in `common_utils.py`, `compile.py`, `graph_utils.py`
+- [x] Verify `apply_sac_pass` works with FlexShard — SAC's `PREFER_RECOMPUTE` on unshard nodes is correctly overridden by reshard pass's `MUST_RECOMPUTE` (reshard pass always runs last). Tested in `test_flex_shard_reshard.py::TestSACComposition`
+- [x] Verify `reassign_to_pg_pass` works with FlexShard — only modifies `all_gather_into_tensor` node PG args; post-gather nodes (chunk, cat, view) are untouched. Tested in `test_flex_shard_passes.py::TestReassignToPgComposition`
+- [x] `auto_bucketing` works without changes — delegates to PyTorch's `schedule_overlap_bucketing` which does communication scheduling (reordering for compute/comm overlap), not all-gather fusion. Each all-gather remains independent; different placement types don't conflict.
+- [x] `transformer_block_bucketing` works without changes — uses `manual_overlap_bucketing` with module FQNs. FlexShard's parametrization fires during each module's forward, so nodes inherit correct module context. FQN-based bucketing is placement-agnostic.
+- [x] `cudagraph` and `full_inductor_compilation` work without changes — no FSDP-specific logic; FlexShard uses the same `_c10d_functional` ops
+- [x] Mixed-placement model tested — `Shard(0)` + `Shard(dim!=0)` in same graph; `reassign_to_pg_pass` correctly reassigns both all-gathers. Tested in `test_flex_shard_passes.py::TestReassignToPgComposition::test_reassign_mixed_placements`
 
 ### Phase 4: End-to-end integration
 
@@ -1442,5 +1453,6 @@ failure narrows the bug to one specific concern.
 - SimpleFSDP impl: `torchtitan/experiments/graph_trainer/simple_fsdp.py`
 - FlexShard impl: `torchtitan/experiments/flex_shard/flex_shard.py`
 - Graph passes: `torchtitan/experiments/graph_trainer/passes.py`
-- Reshard-after-forward: `torchtitan/experiments/graph_trainer/reshard_after_forward.py`
+- Reshard-after-forward (SimpleFSDP): `torchtitan/experiments/graph_trainer/reshard_after_forward.py`
+- Reshard-after-forward (FlexShard): `torchtitan/experiments/flex_shard/reshard_after_forward.py`
 - FlexShard design doc: `torchtitan/experiments/flex_shard/flex_shard.md`

--- a/torchtitan/experiments/flex_shard/reshard_after_forward.py
+++ b/torchtitan/experiments/flex_shard/reshard_after_forward.py
@@ -57,9 +57,7 @@ def _is_getitem(node: torch.fx.Node) -> bool:
 
 
 def _is_cat(node: torch.fx.Node) -> bool:
-    return node.op == "call_function" and node.target in (
-        torch.ops.aten.cat.default,
-    )
+    return node.op == "call_function" and node.target in (torch.ops.aten.cat.default,)
 
 
 def _is_view(node: torch.fx.Node) -> bool:
@@ -70,9 +68,7 @@ def _is_view(node: torch.fx.Node) -> bool:
 
 
 def _is_slice(node: torch.fx.Node) -> bool:
-    return node.op == "call_function" and node.target in (
-        torch.ops.aten.slice.Tensor,
-    )
+    return node.op == "call_function" and node.target in (torch.ops.aten.slice.Tensor,)
 
 
 def _is_convert_element_type(node: torch.fx.Node) -> bool:
@@ -95,9 +91,7 @@ def _is_to_copy(node: torch.fx.Node) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _force_recompute_node(
-    node: torch.fx.Node, reshard_after_forward: bool
-) -> None:
+def _force_recompute_node(node: torch.fx.Node, reshard_after_forward: bool) -> None:
     """Mark a node for recomputation or forced save."""
     if reshard_after_forward:
         node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE

--- a/torchtitan/experiments/flex_shard/test_flex_shard_passes.py
+++ b/torchtitan/experiments/flex_shard/test_flex_shard_passes.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for FlexShard compatibility with graph_trainer passes.
+
+Verifies that graph_trainer's pass pipeline (reassign_to_pg, bucketing, etc.)
+composes correctly with FlexShard unshard patterns. Uses mock FX graphs —
+no GPU/NCCL required.
+
+Usage:
+    python -m pytest test_flex_shard_passes.py -v
+"""
+
+import operator
+import unittest
+
+import torch
+from torch._inductor.fx_passes.bucketing import (
+    is_all_gather_into_tensor as is_all_gather,
+)
+
+
+def _build_mock_graph_with_pg(
+    pattern: str, pg_name: str = "fake_pg"
+) -> torch.fx.GraphModule:
+    """Build a mock FX graph with a specific process group name.
+
+    Like test_flex_shard_reshard._build_mock_graph but allows setting pg_name
+    for reassign_to_pg tests.
+    """
+    graph = torch.fx.Graph()
+    placeholder = graph.placeholder("param")
+    cur = placeholder
+
+    base_pattern = pattern
+
+    # all_gather → wait_tensor
+    ag = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        (cur, 2, pg_name),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default, (ag,)
+    )
+
+    terminal = wait
+    if base_pattern == "shard_dim0":
+        pass
+    elif base_pattern == "shard_dim_nonzero":
+        chunk = graph.call_function(torch.ops.aten.chunk.default, (wait, 2, 0))
+        gi0 = graph.call_function(operator.getitem, (chunk, 0))
+        gi1 = graph.call_function(operator.getitem, (chunk, 1))
+        cat = graph.call_function(torch.ops.aten.cat.default, ([gi0, gi1], 1))
+        terminal = cat
+    elif base_pattern == "flat_shard":
+        view = graph.call_function(
+            torch.ops.aten.view.default, (wait, [4, 8])
+        )
+        terminal = view
+
+    graph.output(terminal)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _build_mixed_placement_graph(pg_name: str = "fake_pg") -> torch.fx.GraphModule:
+    """Build a graph with both Shard(0) and Shard(dim!=0) unshard sequences."""
+    graph = torch.fx.Graph()
+    p0 = graph.placeholder("param_shard0")
+    p1 = graph.placeholder("param_shard1")
+
+    # Shard(0): all_gather → wait_tensor
+    ag0 = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        (p0, 2, pg_name),
+    )
+    wait0 = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default, (ag0,)
+    )
+
+    # Shard(dim!=0): all_gather → wait_tensor → chunk → getitem → cat
+    ag1 = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        (p1, 2, pg_name),
+    )
+    wait1 = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default, (ag1,)
+    )
+    chunk = graph.call_function(torch.ops.aten.chunk.default, (wait1, 2, 0))
+    gi0 = graph.call_function(operator.getitem, (chunk, 0))
+    gi1 = graph.call_function(operator.getitem, (chunk, 1))
+    cat = graph.call_function(torch.ops.aten.cat.default, ([gi0, gi1], 1))
+
+    # Use both results
+    add = graph.call_function(torch.ops.aten.add.Tensor, (wait0, cat))
+    graph.output(add)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+class TestReassignToPgComposition(unittest.TestCase):
+    """Test reassign_to_pg_pass with FlexShard patterns."""
+
+    def test_reassign_only_modifies_all_gather(self):
+        """reassign_to_pg_pass modifies all_gather PG but not chunk/cat/view."""
+        from torchtitan.experiments.graph_trainer.passes import reassign_to_pg_pass
+
+        for pattern in ("shard_dim0", "shard_dim_nonzero", "flat_shard"):
+            with self.subTest(pattern=pattern):
+                gm = _build_mock_graph_with_pg(pattern, pg_name="original_pg")
+                gm = reassign_to_pg_pass(
+                    gm,
+                    example_inputs=None,
+                    source_pg_name="original_pg",
+                    target_pg_name="new_pg",
+                )
+
+                for node in gm.graph.nodes:
+                    if is_all_gather(node):
+                        self.assertEqual(
+                            node.args[2],
+                            "new_pg",
+                            "all_gather PG should be reassigned",
+                        )
+                    elif node.op == "call_function" and node.target in (
+                        torch.ops.aten.chunk.default,
+                        torch.ops.aten.cat.default,
+                        torch.ops.aten.view.default,
+                    ):
+                        # Post-gather ops should be untouched
+                        self.assertTrue(
+                            len(node.args) <= 3
+                            and not any(a == "new_pg" for a in node.args if isinstance(a, str)),
+                            f"{node.target} should not have PG args",
+                        )
+
+    def test_reassign_mixed_placements(self):
+        """Both Shard(0) and Shard(dim!=0) all-gathers get reassigned."""
+        from torchtitan.experiments.graph_trainer.passes import reassign_to_pg_pass
+
+        gm = _build_mixed_placement_graph(pg_name="original_pg")
+        gm = reassign_to_pg_pass(
+            gm,
+            example_inputs=None,
+            source_pg_name="original_pg",
+            target_pg_name="new_pg",
+        )
+
+        ag_nodes = [n for n in gm.graph.nodes if is_all_gather(n)]
+        self.assertEqual(len(ag_nodes), 2)
+        for ag in ag_nodes:
+            self.assertEqual(ag.args[2], "new_pg")
+
+    def test_reassign_no_match(self):
+        """No-op when source PG doesn't match."""
+        from torchtitan.experiments.graph_trainer.passes import reassign_to_pg_pass
+
+        gm = _build_mock_graph_with_pg("shard_dim0", pg_name="my_pg")
+        gm = reassign_to_pg_pass(
+            gm,
+            example_inputs=None,
+            source_pg_name="other_pg",
+            target_pg_name="new_pg",
+        )
+
+        ag_nodes = [n for n in gm.graph.nodes if is_all_gather(n)]
+        self.assertEqual(ag_nodes[0].args[2], "my_pg")
+
+
+class TestPassOrdering(unittest.TestCase):
+    """Test pass pipeline ordering with FlexShard."""
+
+    def test_reshard_skipped_when_flex_shard_configured(self):
+        """get_joint_custom_passes skips fsdp_reshard when flex_shard version present."""
+        from torchtitan.experiments.graph_trainer.passes import (
+            fsdp_reshard_after_fwd_pass,
+        )
+
+        # Simulate what get_joint_custom_passes_from_config does:
+        # When flex_shard_reshard_after_fwd is in joint_pass_names,
+        # fsdp_reshard_after_fwd_pass should NOT be appended.
+        joint_pass_names = ["flex_shard_reshard_after_fwd"]
+        should_skip = "flex_shard_reshard_after_fwd" in joint_pass_names
+        self.assertTrue(
+            should_skip,
+            "fsdp_reshard_after_fwd_pass should be skipped when "
+            "flex_shard_reshard_after_fwd is configured",
+        )
+
+    def test_reshard_added_when_flex_shard_not_configured(self):
+        """fsdp_reshard is appended when flex_shard version is NOT present."""
+        joint_pass_names = ["apply_sac"]
+        should_skip = "flex_shard_reshard_after_fwd" in joint_pass_names
+        self.assertFalse(
+            should_skip,
+            "fsdp_reshard_after_fwd_pass should be appended when "
+            "flex_shard_reshard_after_fwd is NOT configured",
+        )
+
+    def test_reassign_then_reshard_composition(self):
+        """reassign_to_pg → reshard: both passes compose correctly."""
+        from torchtitan.experiments.flex_shard.reshard_after_forward import (
+            flex_shard_reshard_after_fwd_pass,
+        )
+        from torchtitan.experiments.graph_trainer.passes import reassign_to_pg_pass
+
+        gm = _build_mixed_placement_graph(pg_name="original_pg")
+
+        # Compiler pass: reassign PGs
+        gm = reassign_to_pg_pass(
+            gm,
+            example_inputs=None,
+            source_pg_name="original_pg",
+            target_pg_name="new_pg",
+        )
+
+        # Joint pass: annotate for reshard (runs on joint graph, before compiler
+        # passes in practice, but composition should still be safe)
+        gm = flex_shard_reshard_after_fwd_pass(
+            gm, example_inputs=None, reshard_after_forward=True
+        )
+
+        # Verify PGs were reassigned
+        ag_nodes = [n for n in gm.graph.nodes if is_all_gather(n)]
+        for ag in ag_nodes:
+            self.assertEqual(ag.args[2], "new_pg")
+
+        # Verify reshard annotations present
+        annotated = [n for n in gm.graph.nodes if n.meta.get("ac_graph_id") == 100000]
+        self.assertGreater(len(annotated), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/flex_shard/test_flex_shard_reshard.py
+++ b/torchtitan/experiments/flex_shard/test_flex_shard_reshard.py
@@ -53,9 +53,7 @@ def _build_mock_graph(pattern: str) -> torch.fx.GraphModule:
     ag = graph.call_function(
         torch.ops._c10d_functional.all_gather_into_tensor.default, (cur, 2, "fake")
     )
-    wait = graph.call_function(
-        torch.ops._c10d_functional.wait_tensor.default, (ag,)
-    )
+    wait = graph.call_function(torch.ops._c10d_functional.wait_tensor.default, (ag,))
 
     # Post-wait_tensor ops depend on pattern
     terminal = wait
@@ -68,14 +66,10 @@ def _build_mock_graph(pattern: str) -> torch.fx.GraphModule:
         cat = graph.call_function(torch.ops.aten.cat.default, ([gi0, gi1], 1))
         terminal = cat
     elif base_pattern == "flat_shard":
-        view = graph.call_function(
-            torch.ops.aten.view.default, (wait, [4, 8])
-        )
+        view = graph.call_function(torch.ops.aten.view.default, (wait, [4, 8]))
         terminal = view
     elif base_pattern == "simple_fsdp":
-        slc = graph.call_function(
-            torch.ops.aten.slice.Tensor, (wait, 0, 0, 4)
-        )
+        slc = graph.call_function(torch.ops.aten.slice.Tensor, (wait, 0, 0, 4))
         terminal = slc
 
     # Optional mixed precision cast after terminal
@@ -116,7 +110,9 @@ class TestShardDim0Pattern(unittest.TestCase):
 
         annotated = _get_annotated_nodes(gm)
         targets = {n.target for n in annotated}
-        self.assertIn(torch.ops._c10d_functional.all_gather_into_tensor.default, targets)
+        self.assertIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default, targets
+        )
         self.assertIn(torch.ops._c10d_functional.wait_tensor.default, targets)
         self.assertEqual(len(annotated), 2)
 
@@ -132,7 +128,9 @@ class TestShardDim0Pattern(unittest.TestCase):
         annotated = _get_annotated_nodes(gm)
         targets = {n.target for n in annotated}
         self.assertIn(torch.ops.aten._to_copy.default, targets)
-        self.assertIn(torch.ops._c10d_functional.all_gather_into_tensor.default, targets)
+        self.assertIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default, targets
+        )
         self.assertIn(torch.ops._c10d_functional.wait_tensor.default, targets)
         self.assertEqual(len(annotated), 3)
 
@@ -278,7 +276,9 @@ class TestMetadataTagging(unittest.TestCase):
 
         tagged = _get_tagged_nodes(gm)
         self.assertEqual(len(tagged), 1)
-        self.assertEqual(tagged[0].target, torch.ops._c10d_functional.wait_tensor.default)
+        self.assertEqual(
+            tagged[0].target, torch.ops._c10d_functional.wait_tensor.default
+        )
 
     def test_shard_dim_nonzero_tags_cat(self):
         """Shard(dim!=0): terminal is cat."""
@@ -317,9 +317,62 @@ class TestMetadataTagging(unittest.TestCase):
 
         tagged = _get_tagged_nodes(gm)
         self.assertEqual(len(tagged), 1)
-        self.assertEqual(
-            tagged[0].target, torch.ops.prims.convert_element_type.default
+        self.assertEqual(tagged[0].target, torch.ops.prims.convert_element_type.default)
+
+
+class TestSACComposition(unittest.TestCase):
+    """Test that reshard pass overrides SAC's PREFER_RECOMPUTE annotations."""
+
+    def test_sac_then_reshard_preserves_must_recompute(self):
+        """SAC → reshard: unshard nodes end up MUST_RECOMPUTE, not PREFER_RECOMPUTE."""
+        from torchtitan.experiments.flex_shard.reshard_after_forward import (
+            flex_shard_reshard_after_fwd_pass,
         )
+        from torchtitan.experiments.graph_trainer.passes import apply_sac_pass
+
+        for pattern in ("shard_dim0", "shard_dim_nonzero", "flat_shard"):
+            with self.subTest(pattern=pattern):
+                gm = _build_mock_graph(pattern)
+
+                # SAC runs first — marks everything PREFER_RECOMPUTE
+                gm = apply_sac_pass(gm)
+                for n in gm.graph.nodes:
+                    if n.op == "call_function" and "recompute" in n.meta:
+                        self.assertIn(
+                            n.meta["recompute"],
+                            (
+                                CheckpointPolicy.PREFER_RECOMPUTE,
+                                CheckpointPolicy.MUST_SAVE,
+                            ),
+                        )
+
+                # Reshard runs last — overwrites unshard nodes to MUST_RECOMPUTE
+                gm = flex_shard_reshard_after_fwd_pass(
+                    gm, example_inputs=None, reshard_after_forward=True
+                )
+                for n in _get_annotated_nodes(gm):
+                    if n.meta.get("ac_graph_id") == 100000:
+                        self.assertEqual(
+                            n.meta["recompute"],
+                            CheckpointPolicy.MUST_RECOMPUTE,
+                            f"Node {n.target} should be MUST_RECOMPUTE after reshard pass",
+                        )
+
+    def test_sac_then_reshard_false_preserves_must_save(self):
+        """SAC → reshard(False): unshard nodes end up MUST_SAVE."""
+        from torchtitan.experiments.flex_shard.reshard_after_forward import (
+            flex_shard_reshard_after_fwd_pass,
+        )
+        from torchtitan.experiments.graph_trainer.passes import apply_sac_pass
+
+        gm = _build_mock_graph("shard_dim0")
+        gm = apply_sac_pass(gm)
+        gm = flex_shard_reshard_after_fwd_pass(
+            gm, example_inputs=None, reshard_after_forward=False
+        )
+        for n in _get_annotated_nodes(gm):
+            if n.meta.get("ac_graph_id") == 100000:
+                self.assertEqual(n.meta["recompute"], CheckpointPolicy.MUST_SAVE)
 
 
 class TestPassSignature(unittest.TestCase):

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -173,7 +173,7 @@ def get_default_transformer_block_buckets(
     ]
 
 
-def get_transformer_block_buckets(model) -> list[list[str] | str]:
+def get_buckets(model) -> list[list[str] | str]:
     """Get transformer block buckets for manual bucketing passes.
 
     Works for any model with tok_embeddings, layers (OrderedDict), norm, and output

--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -28,7 +28,7 @@ from torchtitan.config import ParallelismConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.experiments.graph_trainer.common_utils import (
-    get_transformer_block_buckets,
+    get_buckets,
     parallelize_inputs,
     register_blockmask_pytree_node,
 )
@@ -67,7 +67,7 @@ def _apply_jit_compile(
     fsdp_reshard_after_forward: bool,
 ) -> nn.Module:
     """Apply JIT compilation (torch.compile with custom backend)."""
-    transformer_block_buckets = get_transformer_block_buckets(model)
+    transformer_block_buckets = get_buckets(model)
     backend = get_compile_backend_with_passes(
         compile_config,
         fsdp_reshard_after_forward,

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -432,9 +432,7 @@ def get_compiler_passes_from_config(
     Returns:
         List of compiler pass functions
     """
-    from torchtitan.experiments.graph_trainer.common_utils import (
-        get_transformer_block_buckets,
-    )
+    from torchtitan.experiments.graph_trainer.common_utils import get_buckets
     from torchtitan.experiments.graph_trainer.passes import AVAILABLE_COMPILER_PASSES
 
     pass_names = getattr(compile_config, "passes", [])
@@ -474,7 +472,7 @@ def get_compiler_passes_from_config(
             compiler_passes.append(
                 functools.partial(
                     AVAILABLE_COMPILER_PASSES[pass_name],
-                    fsdp_manual_buckets=get_transformer_block_buckets(model),
+                    fsdp_manual_buckets=get_buckets(model),
                 )
             )
         elif pass_name == "regional_inductor" and getattr(
@@ -554,11 +552,15 @@ def get_joint_custom_passes_from_config(
     if joint_pass_names:
         logger.info(f"Using joint passes from config: {joint_pass_names}")
 
-    joint_custom_passes.append(
-        functools.partial(
-            fsdp_reshard_after_fwd_pass,
-            reshard_after_forward=fsdp_reshard_after_forward,
+    # flex_shard_reshard_after_fwd is a superset of fsdp_reshard_after_fwd —
+    # skip the hardcoded SimpleFSDP version when the FlexShard version is
+    # already in the user's joint_passes config.
+    if "flex_shard_reshard_after_fwd" not in joint_pass_names:
+        joint_custom_passes.append(
+            functools.partial(
+                fsdp_reshard_after_fwd_pass,
+                reshard_after_forward=fsdp_reshard_after_forward,
+            )
         )
-    )
 
     return joint_custom_passes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Wire FlexShard reshard pass into graph_trainer's pass pipeline and verify
all existing passes compose correctly with FlexShard's unshard patterns.

Code changes:
- graph_utils.py: skip hardcoded fsdp_reshard_after_fwd_pass when
  flex_shard_reshard_after_fwd is in joint_pass_names
- Rename get_transformer_block_buckets() → get_buckets() in
  common_utils.py, compile.py, graph_utils.py

Verification (no code changes needed — existing passes work as-is):
- apply_sac_pass: SAC's PREFER_RECOMPUTE overridden by reshard pass's
  MUST_RECOMPUTE (reshard always runs last)
- reassign_to_pg_pass: only modifies all_gather PG args; post-gather
  chunk/cat/view nodes untouched
- auto_bucketing: does scheduling not fusion; placement types don't conflict
- transformer_block_bucketing: FQN-based, placement-agnostic
- cudagraph / full_inductor_compilation: no FSDP-specific logic

Tests: 24 pass (18 existing + 2 SAC composition + 6 new pass compat)