### PR TITLE
Revert "[graph_trainer] Pass global_valid_tokens into loss_fn instead of dividing externally" to fix ci

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -25,7 +25,7 @@ from expecttest import assert_expected_inline
 from tests.utils import hash_gradient, hash_model
 from torch.nn.attention.flex_attention import flex_attention
 
-from torchtitan.components.loss import CrossEntropyLoss
+from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
@@ -200,7 +200,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
 
         self.annotate_model(model)
-        loss_fn = CrossEntropyLoss.Config().build()
+        loss_fn = cross_entropy_loss
         fwd_bwd_fn = make_fwd_bwd_step(loss_fn)
 
         global_valid_tokens = torch.tensor(

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -39,17 +39,19 @@ def make_fwd_bwd_step(loss_fn):
     ``loss_fn`` is captured in the closure so it is not a graph input.
     """
 
+    # The loss function is not a submodule of the model, so
+    # annotate_module_fqns won't tag it. Annotate it here so that
+    # downstream passes (bucketing, SAC, kernel annotations) can
+    # attribute loss nodes in the traced graph.
+    @annotate_fn({_MODULE_FQN: "loss"})
+    def compute_loss(pred, labels, global_valid_tokens):
+        return loss_fn(pred, labels) / global_valid_tokens
+
     def fwd_bwd_step(
         model, inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
     ):
         pred = model(inputs, **extra_inputs, **extra_kwargs)
-        # The loss function is not a submodule of the model, so
-        # annotate_module_fqns won't tag it. Annotate it here so that
-        # downstream passes (bucketing, SAC, kernel annotations) can
-        # attribute loss nodes in the traced graph.
-        loss = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)(
-            pred, labels, global_valid_tokens
-        )
+        loss = compute_loss(pred, labels, global_valid_tokens)
         params = [
             p
             for _, p in model.named_parameters(remove_duplicate=False)


### PR DESCRIPTION
Reverts pytorch/torchtitan#3244