### PR TITLE
Remove MoE expert for-loop fallback

### DIFF
--- a/tests/unit_tests/test_compile_moe.py
+++ b/tests/unit_tests/test_compile_moe.py
@@ -49,23 +49,30 @@ class TestApplyCompile(unittest.TestCase):
 
         apply_compile(model, compile_config)
 
-        from torchtitan.models.common import moe as moe_module
+        from torchtitan.models.common.moe import GroupedExperts
+        from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher
 
         num_experts = 8
         dim = 128
         hidden_dim = 256
-        w1 = torch.randn(num_experts, hidden_dim, dim, device="cuda")
-        w2 = torch.randn(num_experts, dim, hidden_dim, device="cuda")
-        w3 = torch.randn(num_experts, hidden_dim, dim, device="cuda")
+        experts = GroupedExperts(
+            GroupedExperts.Config(
+                dim=dim,
+                hidden_dim=hidden_dim,
+                num_experts=num_experts,
+                token_dispatcher=LocalTokenDispatcher.Config(
+                    num_experts=num_experts,
+                    top_k=1,
+                ),
+            )
+        ).cuda()
         num_tokens_per_expert = torch.tensor(
             [10, 8, 12, 9, 11, 7, 10, 13], dtype=torch.int32, device="cuda"
         )
         total_tokens = num_tokens_per_expert.sum().item()
         x = torch.randn(total_tokens, dim, device="cuda")
 
-        output = moe_module._run_experts_grouped_mm(
-            w1, w2, w3, x, num_tokens_per_expert
-        )
+        output = experts._experts_forward(x, num_tokens_per_expert)
 
         self.assertEqual(output.shape, x.shape)
 

--- a/torchtitan/experiments/graph_trainer/graph_utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_utils.py
@@ -75,8 +75,6 @@ def export_joint(
     )
     with coor_ctx:
         with (
-            # TODO Investigate error on MOE model with use_grouped_mm=False.
-            # For repro, see: https://gist.github.com/zhxchen17/d794ff58236243d9faddf713b9fc6a61
             torch._dynamo.config.patch(fake_tensor_cache_enabled=False),
             torch.fx.traceback.preserve_node_meta(),
         ):

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -246,7 +246,6 @@ def make_experts_config(
     top_k: int,
     param_init: dict[str, Callable],
     score_before_experts: bool = True,
-    use_grouped_mm: bool = True,
     comm_backend: str,
     non_blocking_capacity_factor: float | None = None,
 ) -> GroupedExperts.Config:
@@ -255,7 +254,6 @@ def make_experts_config(
         dim=dim,
         hidden_dim=hidden_dim,
         num_experts=num_experts,
-        use_grouped_mm=use_grouped_mm,
         param_init=param_init,
         token_dispatcher=make_token_dispatcher_config(
             num_experts=num_experts,

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -20,66 +20,12 @@ from torchtitan.protocols.module import Module
 from .token_dispatcher import LocalTokenDispatcher
 
 
-# NOTE: keeping this for-loop implementation for comparison
-#       and readability, may remove later
-def _run_experts_for_loop(
-    w1: torch.Tensor,
-    w2: torch.Tensor,
-    w3: torch.Tensor,
-    x: torch.Tensor,
-    num_tokens_per_expert: torch.Tensor,
-) -> torch.Tensor:
-    # NOTE: this would incur a synchronization between device and host
-    num_tokens_per_expert_list = num_tokens_per_expert.tolist()
-
-    # a tuple of tensors indexed by experts
-    # each with shape (tokens_per_expert(varying), dim)
-    # NOTE: x is not sliced because padding was removed in #2774, so
-    # sum(num_tokens_per_expert) == x.shape[0] always holds.
-    x_splits = torch.split(
-        x,
-        split_size_or_sections=num_tokens_per_expert_list,
-        dim=0,
-    )
-    out_experts_splits = []
-    for expert_idx, x_expert in enumerate(x_splits):
-        h = F.silu(torch.matmul(x_expert, w1[expert_idx].transpose(-2, -1)))
-        h = h * torch.matmul(x_expert, w3[expert_idx].transpose(-2, -1))
-        h = torch.matmul(h, w2[expert_idx].transpose(-2, -1))
-        # h shape (tokens_per_expert(varying), dim)
-        out_experts_splits.append(h)
-    out = torch.cat(out_experts_splits, dim=0)
-
-    return out
-
-
-def _run_experts_grouped_mm(
-    w1: torch.Tensor,
-    w2: torch.Tensor,
-    w3: torch.Tensor,
-    x: torch.Tensor,
-    num_tokens_per_expert: torch.Tensor,
-) -> torch.Tensor:
-    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-
-    h = F.silu(
-        torch._grouped_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets)
-    )
-    h = h * torch._grouped_mm(
-        x.bfloat16(), w3.bfloat16().transpose(-2, -1), offs=offsets
-    )
-    out = torch._grouped_mm(h, w2.bfloat16().transpose(-2, -1), offs=offsets).type_as(x)
-
-    return out
-
-
 class GroupedExperts(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         dim: int
         hidden_dim: int
         num_experts: int
-        use_grouped_mm: bool = True
         token_dispatcher: LocalTokenDispatcher.Config
 
     def __init__(self, config: Config):
@@ -94,7 +40,6 @@ class GroupedExperts(Module):
         self.w3 = nn.Parameter(
             torch.empty(config.num_experts, config.hidden_dim, config.dim)
         )
-        self.use_grouped_mm = config.use_grouped_mm
         self.token_dispatcher = config.token_dispatcher.build()
 
     def _experts_forward(
@@ -116,10 +61,19 @@ class GroupedExperts(Module):
             w2 = self.w2
             w3 = self.w3
 
-        if self.use_grouped_mm:
-            return _run_experts_grouped_mm(w1, w2, w3, x, num_tokens_per_expert)
-        else:
-            return _run_experts_for_loop(w1, w2, w3, x, num_tokens_per_expert)
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+
+        h = F.silu(
+            torch._grouped_mm(
+                x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets
+            )
+        )
+        h = h * torch._grouped_mm(
+            x.bfloat16(), w3.bfloat16().transpose(-2, -1), offs=offsets
+        )
+        return torch._grouped_mm(
+            h, w2.bfloat16().transpose(-2, -1), offs=offsets
+        ).type_as(x)
 
     def forward(
         self,

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -23,7 +23,6 @@ from torchtitan.models.common.rope import apply_rotary_emb_single_complex
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import has_cuda_capability
 
 
 class Attention(BaseAttention):
@@ -212,14 +211,6 @@ class DeepSeekV3Model(Decoder):
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:
-                    if (
-                        layer_cfg.moe.experts.use_grouped_mm
-                        and not has_cuda_capability(9, 0)
-                    ):
-                        logger.warning(
-                            "Failed to use grouped mm, which is only supported on SM90 or later",
-                        )
-                        layer_cfg.moe.experts.use_grouped_mm = False
                     layer_cfg.moe.router._debug_force_load_balance = (
                         debug.moe_force_load_balance
                     )

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -28,7 +28,6 @@ from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import has_cuda_capability
 
 
 class Attention(BaseAttention):
@@ -200,17 +199,6 @@ class GptOssModel(Decoder):
 
             # Sync rope max_seq_len
             self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
-
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    if (
-                        layer_cfg.moe.experts.use_grouped_mm
-                        and not has_cuda_capability(9, 0)
-                    ):
-                        logger.warning(
-                            "Failed to use grouped mm, which is only supported on SM90 or later",
-                        )
-                        layer_cfg.moe.experts.use_grouped_mm = False
 
             tp = parallelism.tensor_parallel_degree
             if tp > 1:

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -50,82 +50,6 @@ def swiglu(x, alpha: float = 1.702, limit: float = 7.0):
     return out_glu * (x_linear + 1)
 
 
-def _run_experts_for_loop(
-    mlp1_weight: torch.Tensor,
-    mlp1_bias: torch.Tensor,
-    mlp2_weight: torch.Tensor,
-    mlp2_bias: torch.Tensor,
-    swiglu_limit: float,
-    x: torch.Tensor,
-    num_tokens_per_expert: torch.Tensor,
-    tp_degree: int = 1,
-) -> torch.Tensor:
-    # NOTE: this would incur a synchronization between device and host
-    # pyrefly: ignore [bad-assignment]
-    num_tokens_per_expert = num_tokens_per_expert.tolist()
-
-    # a tuple of tensors indexed by experts
-    # each with shape (tokens_per_expert(varying), dim)
-    # pyrefly: ignore [bad-assignment]
-    x = torch.split(
-        x[: sum(num_tokens_per_expert)],
-        # pyrefly: ignore [bad-argument-type]
-        split_size_or_sections=num_tokens_per_expert,
-        dim=0,
-    )
-    out_experts_splits = []
-    for expert_idx, x_expert in enumerate(x):
-        h = (
-            torch.matmul(x_expert, mlp1_weight[expert_idx].transpose(-2, -1))
-            + mlp1_bias[expert_idx]
-        )
-        h = swiglu(h, limit=swiglu_limit)
-        # Apply custom autograd function to scale bias in forward but not in backward
-        b2 = ScaleBiasForward.apply(mlp2_bias[expert_idx], tp_degree)
-        h = torch.matmul(h, mlp2_weight[expert_idx].transpose(-2, -1)) + b2
-        out_experts_splits.append(h)
-    out = torch.cat(out_experts_splits, dim=0)
-
-    return out
-
-
-def _run_experts_grouped_mm(
-    mlp1_weight: torch.Tensor,
-    mlp1_bias: torch.Tensor,
-    mlp2_weight: torch.Tensor,
-    mlp2_bias: torch.Tensor,
-    swiglu_limit: float,
-    x: torch.Tensor,
-    num_tokens_per_expert: torch.Tensor,
-    tp_degree: int = 1,
-) -> torch.Tensor:
-    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-    # Pad num_tokens_per_expert with tail slack so that repeat_interleave
-    # with output_size=x.shape[0] directly produces a static-shaped output,
-    # avoiding the D2H sync that repeat_interleave incurs without output_size.
-    tail_slack = (x.shape[0] - offsets[-1]).unsqueeze(0).to(num_tokens_per_expert.dtype)
-    num_tokens_per_expert_long = torch.cat([num_tokens_per_expert, tail_slack]).long()
-
-    h = torch._grouped_mm(
-        x.bfloat16(), mlp1_weight.transpose(-2, -1).bfloat16(), offs=offsets
-    )
-
-    b1 = torch.cat([mlp1_bias, mlp1_bias.new_zeros(1, mlp1_bias.shape[-1])])
-    b1 = b1.repeat_interleave(num_tokens_per_expert_long, dim=0, output_size=x.shape[0])
-    h = h + b1.to(h.dtype)
-
-    h = swiglu(h, limit=swiglu_limit)
-    h = torch._grouped_mm(h, mlp2_weight.transpose(-2, -1).bfloat16(), offs=offsets)
-
-    # Apply custom autograd function to scale bias in forward but not in backward
-    b2 = torch.cat([mlp2_bias, mlp2_bias.new_zeros(1, mlp2_bias.shape[-1])])
-    b2 = b2.repeat_interleave(num_tokens_per_expert_long, dim=0, output_size=x.shape[0])
-    b2 = ScaleBiasForward.apply(b2, tp_degree)
-    h = h + b2.to(h.dtype)
-
-    return h
-
-
 class GptOssGroupedExperts(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(GroupedExperts.Config):
@@ -137,7 +61,6 @@ class GptOssGroupedExperts(Module):
         hidden_dim = config.hidden_dim
         num_experts = config.num_experts
         self.num_experts = num_experts
-        self.use_grouped_mm = config.use_grouped_mm
         self.swiglu_limit = config.swiglu_limit
 
         self.mlp1_weight = nn.Parameter(
@@ -183,28 +106,37 @@ class GptOssGroupedExperts(Module):
                 tp_dim_idx = mesh_dim_names.index("tp")
                 tp_degree = self.mlp1_weight.device_mesh.size(tp_dim_idx)
 
-        if self.use_grouped_mm:
-            return _run_experts_grouped_mm(
-                mlp1_weight,
-                mlp1_bias,
-                mlp2_weight,
-                mlp2_bias,
-                self.swiglu_limit,
-                x,
-                num_tokens_per_expert,
-                tp_degree,
-            )
-        else:
-            return _run_experts_for_loop(
-                mlp1_weight,
-                mlp1_bias,
-                mlp2_weight,
-                mlp2_bias,
-                self.swiglu_limit,
-                x,
-                num_tokens_per_expert,
-                tp_degree,
-            )
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+        # Pad num_tokens_per_expert with tail slack so that repeat_interleave
+        # with output_size=x.shape[0] directly produces a static-shaped output,
+        # avoiding the D2H sync that repeat_interleave incurs without output_size.
+        tail_slack = (
+            (x.shape[0] - offsets[-1]).unsqueeze(0).to(num_tokens_per_expert.dtype)
+        )
+        num_tokens_per_expert_long = torch.cat(
+            [num_tokens_per_expert, tail_slack]
+        ).long()
+
+        h = torch._grouped_mm(
+            x.bfloat16(), mlp1_weight.transpose(-2, -1).bfloat16(), offs=offsets
+        )
+
+        b1 = torch.cat([mlp1_bias, mlp1_bias.new_zeros(1, mlp1_bias.shape[-1])])
+        b1 = b1.repeat_interleave(
+            num_tokens_per_expert_long, dim=0, output_size=x.shape[0]
+        )
+        h = h + b1.to(h.dtype)
+
+        h = swiglu(h, limit=self.swiglu_limit)
+        h = torch._grouped_mm(h, mlp2_weight.transpose(-2, -1).bfloat16(), offs=offsets)
+
+        # Apply custom autograd function to scale bias in forward but not in backward
+        b2 = torch.cat([mlp2_bias, mlp2_bias.new_zeros(1, mlp2_bias.shape[-1])])
+        b2 = b2.repeat_interleave(
+            num_tokens_per_expert_long, dim=0, output_size=x.shape[0]
+        )
+        b2 = ScaleBiasForward.apply(b2, tp_degree)
+        return h + b2.to(h.dtype)
 
     def forward(
         self,
@@ -238,7 +170,6 @@ class GptOssMoE(MoE):
             hidden_dim=config.experts.hidden_dim,
             num_experts=config.experts.num_experts,
             swiglu_limit=config.swiglu_limit,
-            use_grouped_mm=config.experts.use_grouped_mm,
             param_init=config.experts.param_init,
             token_dispatcher=config.experts.token_dispatcher,
         )

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -21,7 +21,6 @@ from torchtitan.models.common.attention import (
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import has_cuda_capability
 
 
 def compute_moe_hidden_dim(
@@ -137,14 +136,6 @@ class Llama4Model(Decoder):
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:
-                    if (
-                        layer_cfg.moe.experts.use_grouped_mm
-                        and not has_cuda_capability(9, 0)
-                    ):
-                        logger.warning(
-                            "Failed to use grouped mm, which is only supported on SM90 or later",
-                        )
-                        layer_cfg.moe.experts.use_grouped_mm = False
                     layer_cfg.moe.router._debug_force_load_balance = (
                         debug.moe_force_load_balance
                     )


### PR DESCRIPTION

torch._grouped_mm already provides a CUDA fallback path when the fused grouped GEMM kernel is unavailable, including on pre-SM90 hardware. Keeping a separate Python for-loop expert implementation duplicates that fallback, carries an extra configuration branch, and makes MoE behavior diverge across models.

Use the grouped-mm path unconditionally and rely on PyTorch to choose either the fused kernel or its built-in loopy fallback.
