### PR TITLE
[graph_trainer] Add log_timer utility for tracing step timing

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -22,6 +22,7 @@ from torchtitan.experiments.graph_trainer.simple_fsdp import (
 )
 from torchtitan.tools.logging import logger
 
+
 @contextmanager
 def log_timer(label: str):
     start = time.perf_counter()

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import time
 from collections.abc import Callable
+from contextlib import contextmanager
 
 import torch
 import torch.nn as nn
@@ -19,6 +21,14 @@ from torchtitan.experiments.graph_trainer.simple_fsdp import (
     MixedPrecisionPolicy,
 )
 from torchtitan.tools.logging import logger
+
+@contextmanager
+def log_timer(label: str):
+    start = time.perf_counter()
+    yield
+    elapsed_s = time.perf_counter() - start
+    logger.info("%s took %.3fs", label, elapsed_s)
+
 
 _MODULE_FQN = "module_fqn"
 _NOT_IN_LAYERS = -1

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -14,6 +14,7 @@ from torch.fx.traceback import annotate_fn
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
+    log_timer,
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
@@ -163,7 +164,7 @@ class GraphTrainer(Trainer):
                 self._load_precompiled_fx_trace(model)
             else:
                 fwd_bwd_fn = make_fwd_bwd_step(self.loss_fn)
-                with self.train_context():
+                with self.train_context(), log_timer("trace_train_step"):
                     self._traced_step = trace_train_step(fwd_bwd_fn)(
                         model,
                         inputs,


### PR DESCRIPTION
## Summary
- Add a simple `log_timer` context manager to `common_utils.py` that measures wall-clock elapsed time and logs it to console (e.g. `trace_train_step took 0.043s`).
- Apply `log_timer` to the `trace_train_step` call in `GraphTrainer._make_fx_forward_backward_step` to measure tracing time.

## Test plan
- [x] Verify `log_timer` output appears in training logs during aot_fx_trace runs
- [ ] Existing unit tests pass: `pytest torchtitan/experiments/graph_trainer/tests/ -x`