### PR TITLE
Fix loss logging when TP + CP enabled

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -324,6 +324,14 @@ class Validator(BaseValidator):
             global_avg_loss = dist_utils.dist_sum(
                 loss, parallel_dims.get_optional_mesh("loss")
             )
+            # When TP is enabled, ``loss`` is a TP DTensor and ``dist_sum``
+            # only reduces over the DTensor's TP mesh; the CP axis of
+            # ``loss_mesh`` was dropped. Reduce over CP explicitly here.
+            if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                cp_mesh = parallel_dims.get_mesh("cp")
+                global_avg_loss = dist_utils.dist_sum(
+                    torch.tensor(global_avg_loss, device=device_type), cp_mesh
+                )
         else:
             global_avg_loss = float(loss.item())
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -36,28 +36,32 @@ def _dist_reduce(
     """Perform distributed reduction on a tensor.
 
     For DTensor input, ``full_tensor()`` first collapses the DTensor's own
-    mesh (e.g. TP). The caller-supplied ``extra_pg`` and ``mesh`` are then
-    used to reduce *additional*, orthogonal axes (e.g. the CP process group
-    via ``extra_pg``, or the batch axes via ``mesh``). Only Replicate/Partial
-    placements are supported; Shard placements have ambiguous reduction
-    semantics.
+    mesh (e.g. TP), then ``mesh`` reduces *additional*, orthogonal axes
+    (e.g. ``loss_mesh = batch × cp``). Only Replicate/Partial placements
+    are supported; Shard placements have ambiguous reduction semantics.
 
     Args:
         x (torch.Tensor): Input tensor (plain or DTensor).
         reduceOp (str): Reduce operation to perform.
-        mesh (DeviceMesh | None): Device mesh to use for the final reduction.
-            If None, no mesh reduction is performed.
+        mesh (DeviceMesh | None): Device mesh to use for reduction.
+            If None, no reduction is performed but simply convert the tensor to a float.
         extra_pg (dist.ProcessGroup, optional): Extra process group reduced
-            after ``mesh``. Must be orthogonal to the DTensor's own mesh
-            (when ``x`` is a DTensor) and to ``mesh``.
+            before ``mesh``. Plain-tensor only — DTensor input combined with
+            ``extra_pg`` is rejected because the orthogonality contract
+            between ``extra_pg`` and the DTensor's mesh is not enforced here.
     """
     if isinstance(x, DTensor):
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
         )
-
-    if isinstance(x, DTensor):
+        if extra_pg is not None:
+            raise ValueError(
+                "_dist_reduce does not support DTensor input combined with "
+                "extra_pg: ``full_tensor()`` already reduces over the DTensor's "
+                "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
+                "to that mesh. Pass a plain tensor when using extra_pg."
+            )
         x = x.full_tensor()
 
     if extra_pg is not None:

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -35,27 +35,20 @@ def _dist_reduce(
 ) -> float:
     """Perform distributed reduction on a tensor.
 
-    For DTensor input, ``full_tensor()`` first collapses the DTensor's own
-    mesh (e.g. TP), then ``mesh`` reduces an additional axis the DTensor
-    doesn't carry (e.g. ``loss_mesh = batch × cp`` over a TP DTensor).
-
     Args:
-        x (torch.Tensor): Input tensor (plain or DTensor).
+        x (torch.Tensor): Input tensor.
         reduceOp (str): Reduce operation to perform.
-        mesh (DeviceMesh | None): 1D device mesh to use for reduction.
-            If None, no extra reduction is performed; the tensor is just
-            converted to a float (after ``full_tensor()`` for DTensor input).
+        mesh (DeviceMesh | None): Device mesh to use for reduction.
+            If None, no reduction is performed but simply convert the tensor to a float.
         extra_pg (dist.ProcessGroup, optional): Extra process group to use for reduction.
             Defaults to None. If provided, this all_reduce will be called for the extra
             process group, and then the result will be all_reduced for the mesh.
     """
     if isinstance(x, DTensor):
         # ``full_tensor()`` reduces the DTensor's own mesh (Partial → reduced,
-        # Replicate → no-op); ``mesh`` then reduces the orthogonal axis. The
-        # caller is responsible for passing a 1D ``mesh`` whose ranks are
-        # rank-orthogonal to the DTensor's own mesh — overlapping axes would
-        # be reduced twice. Shard placements are unsupported — reduction
-        # target is ambiguous.
+        # Replicate → no-op). The caller's ``mesh`` is *not* applied here —
+        # if a caller needs to reduce additional axes (e.g. CP), they must
+        # do so explicitly after this call.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
@@ -67,7 +60,7 @@ def _dist_reduce(
                 "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
                 "to that mesh. Pass a plain tensor when using extra_pg."
             )
-        x = x.full_tensor()
+        return float(x.full_tensor().item())
 
     if extra_pg is not None:
         x = funcol.all_reduce(x, reduceOp=reduceOp, group=extra_pg)

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -36,21 +36,25 @@ def _dist_reduce(
     """Perform distributed reduction on a tensor.
 
     For DTensor input, ``full_tensor()`` first collapses the DTensor's own
-    mesh (e.g. TP), then ``mesh`` reduces *additional*, orthogonal axes
-    (e.g. ``loss_mesh = batch × cp``). Only Replicate/Partial placements
-    are supported; Shard placements have ambiguous reduction semantics.
+    mesh (e.g. TP), then ``mesh`` reduces an additional axis the DTensor
+    doesn't carry (e.g. ``loss_mesh = batch × cp`` over a TP DTensor).
 
     Args:
         x (torch.Tensor): Input tensor (plain or DTensor).
         reduceOp (str): Reduce operation to perform.
-        mesh (DeviceMesh | None): Device mesh to use for reduction.
-            If None, no reduction is performed but simply convert the tensor to a float.
-        extra_pg (dist.ProcessGroup, optional): Extra process group reduced
-            before ``mesh``. Plain-tensor only — DTensor input combined with
-            ``extra_pg`` is rejected because the orthogonality contract
-            between ``extra_pg`` and the DTensor's mesh is not enforced here.
+        mesh (DeviceMesh | None): 1D device mesh to use for reduction.
+            If None, no extra reduction is performed; the tensor is just
+            converted to a float (after ``full_tensor()`` for DTensor input).
+        extra_pg (dist.ProcessGroup, optional): Extra process group to use for reduction.
+            Defaults to None. If provided, this all_reduce will be called for the extra
+            process group, and then the result will be all_reduced for the mesh.
     """
     if isinstance(x, DTensor):
+        # ``full_tensor()`` reduces the DTensor's own mesh (Partial → reduced,
+        # Replicate → no-op). If ``mesh``'s axis is already part of the
+        # DTensor's mesh, full_tensor handles it; skip the explicit mesh
+        # all-reduce to avoid double-counting. Shard placements are
+        # unsupported — reduction target is ambiguous.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
@@ -62,6 +66,17 @@ def _dist_reduce(
                 "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
                 "to that mesh. Pass a plain tensor when using extra_pg."
             )
+        if mesh is not None and mesh.mesh_dim_names is not None:
+            dtensor_axes = set(x.device_mesh.mesh_dim_names or ())
+            (mesh_axis,) = mesh.mesh_dim_names
+            if mesh_axis in dtensor_axes:
+                logger.warning(
+                    "_dist_reduce: mesh axis %r is already covered by the "
+                    "DTensor's mesh %s; skipping the redundant reduction.",
+                    mesh_axis,
+                    sorted(dtensor_axes),
+                )
+                mesh = None
         x = x.full_tensor()
 
     if extra_pg is not None:

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -51,10 +51,11 @@ def _dist_reduce(
     """
     if isinstance(x, DTensor):
         # ``full_tensor()`` reduces the DTensor's own mesh (Partial → reduced,
-        # Replicate → no-op). If ``mesh``'s axis is already part of the
-        # DTensor's mesh, full_tensor handles it; skip the explicit mesh
-        # all-reduce to avoid double-counting. Shard placements are
-        # unsupported — reduction target is ambiguous.
+        # Replicate → no-op); ``mesh`` then reduces the orthogonal axis. The
+        # caller is responsible for passing a 1D ``mesh`` whose ranks are
+        # rank-orthogonal to the DTensor's own mesh — overlapping axes would
+        # be reduced twice. Shard placements are unsupported — reduction
+        # target is ambiguous.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
@@ -66,17 +67,6 @@ def _dist_reduce(
                 "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
                 "to that mesh. Pass a plain tensor when using extra_pg."
             )
-        if mesh is not None and mesh.mesh_dim_names is not None:
-            dtensor_axes = set(x.device_mesh.mesh_dim_names or ())
-            (mesh_axis,) = mesh.mesh_dim_names
-            if mesh_axis in dtensor_axes:
-                logger.warning(
-                    "_dist_reduce: mesh axis %r is already covered by the "
-                    "DTensor's mesh %s; skipping the redundant reduction.",
-                    mesh_axis,
-                    sorted(dtensor_axes),
-                )
-                mesh = None
         x = x.full_tensor()
 
     if extra_pg is not None:

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -35,35 +35,31 @@ def _dist_reduce(
 ) -> float:
     """Perform distributed reduction on a tensor.
 
+    For DTensor input, ``full_tensor()`` first collapses the DTensor's own
+    mesh (e.g. TP). The caller-supplied ``extra_pg`` and ``mesh`` are then
+    used to reduce *additional*, orthogonal axes (e.g. the CP process group
+    via ``extra_pg``, or the batch axes via ``mesh``). Only Replicate/Partial
+    placements are supported; Shard placements have ambiguous reduction
+    semantics.
+
     Args:
-        x (torch.Tensor): Input tensor.
+        x (torch.Tensor): Input tensor (plain or DTensor).
         reduceOp (str): Reduce operation to perform.
-        mesh (DeviceMesh | None): Device mesh to use for reduction.
-            If None, no reduction is performed but simply convert the tensor to a float.
-        extra_pg (dist.ProcessGroup, optional): Extra process group to use for reduction.
-            Defaults to None. If provided, this all_reduce will be called for the extra
-            process group, and then the result will be all_reduced for the mesh.
+        mesh (DeviceMesh | None): Device mesh to use for the final reduction.
+            If None, no mesh reduction is performed.
+        extra_pg (dist.ProcessGroup, optional): Extra process group reduced
+            after ``mesh``. Must be orthogonal to the DTensor's own mesh
+            (when ``x`` is a DTensor) and to ``mesh``.
     """
     if isinstance(x, DTensor):
-        # DTensor path: ``full_tensor()`` already performs the mesh reduction
-        # for Partial placements and is a no-op for Replicate. Skipping the
-        # subsequent mesh all-reduce is required to avoid double-counting.
-        # Shard placements are not supported — semantics are undefined since
-        # the reduction target is ambiguous.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
         )
-        if extra_pg is not None:
-            raise ValueError(
-                "_dist_reduce does not support DTensor input combined with "
-                "extra_pg: ``full_tensor()`` already reduces over the DTensor's "
-                "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
-                "to that mesh. Pass a plain tensor when using extra_pg."
-            )
-        return float(x.full_tensor().item())
 
-    # Plain tensor path.
+    if isinstance(x, DTensor):
+        x = x.full_tensor()
+
     if extra_pg is not None:
         x = funcol.all_reduce(x, reduceOp=reduceOp, group=extra_pg)
     if mesh is None:
@@ -249,9 +245,7 @@ def set_batch_invariance(enable: bool) -> None:
 
     # Register batch-invariant ATen overrides via upstream package
     # https://github.com/thinking-machines-lab/batch_invariant_ops
-    from batch_invariant_ops import (  # pyrefly: ignore [missing-import]
-        enable_batch_invariant_mode as _upstream_enable,
-    )
+    from batch_invariant_ops import enable_batch_invariant_mode as _upstream_enable
 
     _upstream_enable()
 
@@ -417,7 +411,7 @@ def init_distributed(
     device_id: torch.device | None = None
     if comm_config.mode == "torchcomms":
         try:
-            import torchcomms  # noqa: F401  # pyrefly: ignore [missing-import]
+            import torchcomms  # noqa: F401
         except ImportError as err:
             raise ImportError(
                 "torchcomms package is required for --comm.mode=torchcomms."

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -326,6 +326,17 @@ class Trainer(ForgeEngine):
                 dist_utils.dist_sum(loss, parallel_dims.get_optional_mesh("loss")),
                 dist_utils.dist_max(loss, parallel_dims.get_optional_mesh("loss")),
             )
+            # When TP is enabled, ``loss`` was a TP DTensor and ``dist_*``
+            # only reduced over the DTensor's TP mesh; the CP axis of
+            # ``loss_mesh`` was dropped. Reduce over CP explicitly here.
+            if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                cp_mesh = parallel_dims.get_mesh("cp")
+                global_avg_loss = dist_utils.dist_sum(
+                    torch.tensor(global_avg_loss, device=loss.device), cp_mesh
+                )
+                global_max_loss = dist_utils.dist_max(
+                    torch.tensor(global_max_loss, device=loss.device), cp_mesh
+                )
         else:
             global_avg_loss = global_max_loss = loss.detach().item()
 

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -456,6 +456,28 @@ class FaultTolerantTrainer(Trainer):
                     ft_pg,
                 ),
             )
+
+            # When TP is enabled, ``loss`` was a TP DTensor and ``dist_*``
+            # only reduced over the DTensor's TP mesh; the CP axis of
+            # ``loss_mesh`` was dropped. Reduce over CP explicitly here.
+            if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                cp_mesh = parallel_dims.get_mesh("cp")
+                global_avg_loss = dist_utils.dist_sum(
+                    torch.tensor(global_avg_loss, device=self.device), cp_mesh
+                )
+                global_max_loss = dist_utils.dist_max(
+                    torch.tensor(global_max_loss, device=self.device), cp_mesh
+                )
+                global_ntokens_seen = int(
+                    dist_utils.dist_sum(
+                        torch.tensor(
+                            global_ntokens_seen,
+                            dtype=torch.int64,
+                            device=self.device,
+                        ),
+                        cp_mesh,
+                    )
+                )
         else:
             global_avg_loss = global_max_loss = loss.detach().item()
             global_ntokens_seen = self.ntokens_seen

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -309,6 +309,28 @@ class FluxTrainer(Trainer):
                     loss_mesh,
                 ),
             )
+
+            # When TP is enabled, ``loss`` was a TP DTensor and ``dist_*``
+            # only reduced over the DTensor's TP mesh; the CP axis of
+            # ``loss_mesh`` was dropped. Reduce over CP explicitly here.
+            if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                cp_mesh = parallel_dims.get_mesh("cp")
+                global_avg_loss = dist_utils.dist_sum(
+                    torch.tensor(global_avg_loss, device=self.device), cp_mesh
+                )
+                global_max_loss = dist_utils.dist_max(
+                    torch.tensor(global_max_loss, device=self.device), cp_mesh
+                )
+                global_ntokens_seen = int(
+                    dist_utils.dist_sum(
+                        torch.tensor(
+                            global_ntokens_seen,
+                            dtype=torch.int64,
+                            device=self.device,
+                        ),
+                        cp_mesh,
+                    )
+                )
         else:
             global_avg_loss = global_max_loss = float(loss.detach().item())
             global_ntokens_seen = self.ntokens_seen

--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -296,6 +296,14 @@ class FluxValidator(Validator):
             global_avg_loss = dist_utils.dist_mean(
                 loss, parallel_dims.get_optional_mesh("loss")
             )
+            # When TP is enabled, ``loss`` is a TP DTensor and ``dist_mean``
+            # only reduces over the DTensor's TP mesh; the CP axis of
+            # ``loss_mesh`` was dropped. Reduce over CP explicitly here.
+            if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                cp_mesh = parallel_dims.get_mesh("cp")
+                global_avg_loss = dist_utils.dist_mean(
+                    torch.tensor(global_avg_loss, device=loss.device), cp_mesh
+                )
         else:
             global_avg_loss = float(loss.item())
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -763,7 +763,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             if parallel_dims.dp_cp_enabled:
                 loss = loss.detach()
-                loss_mesh = parallel_dims.get_optional_mesh("loss")
+
+                # CP is not a model DTensor mesh axis (the model is parallelized
+                # only on the TP mesh), so the loss DTensor carries no CP
+                # placement. Pass the CP process group as ``extra_pg`` so that
+                # the reduction helper folds CP into the DP/batch reduction.
+                cp_pg = (
+                    parallel_dims.get_mesh("cp").get_group()
+                    if parallel_dims.cp_enabled
+                    else None
+                )
+                batch_mesh = parallel_dims.get_optional_mesh("batch")
 
                 # For global_avg_loss, we want the average loss across all ranks:
                 # loss = local_loss_sum / global_valid_tokens
@@ -776,13 +786,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 # global_max_loss = max(local_avg_loss)
                 local_avg_loss = loss * global_valid_tokens / local_valid_tokens
                 global_avg_loss, global_max_loss, global_ntokens_seen = (
-                    dist_utils.dist_sum(loss, loss_mesh),
-                    dist_utils.dist_max(local_avg_loss, loss_mesh),
+                    dist_utils.dist_sum(loss, batch_mesh, extra_pg=cp_pg),
+                    dist_utils.dist_max(local_avg_loss, batch_mesh, extra_pg=cp_pg),
                     dist_utils.dist_sum(
                         torch.tensor(
                             self.ntokens_seen, dtype=torch.int64, device=self.device
                         ),
-                        loss_mesh,
+                        batch_mesh,
+                        extra_pg=cp_pg,
                     ),
                 )
             else:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -763,12 +763,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             if parallel_dims.dp_cp_enabled:
                 loss = loss.detach()
-
-                # ``loss_mesh`` is the flattened ``batch × cp`` mesh —
-                # everything orthogonal to the model's TP DTensor mesh that
-                # contributes to the global loss. ``dist_sum`` collapses the
-                # TP axis via ``full_tensor()`` and then all-reduces over
-                # ``loss_mesh``, covering DP and CP in one pass.
                 loss_mesh = parallel_dims.get_optional_mesh("loss")
 
                 # For global_avg_loss, we want the average loss across all ranks:
@@ -791,6 +785,29 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         loss_mesh,
                     ),
                 )
+
+                # When TP is enabled, ``loss`` was a DTensor and ``dist_*``
+                # only reduced over the DTensor's TP mesh via ``full_tensor()``;
+                # the CP axis of ``loss_mesh`` was dropped. Reduce over CP
+                # explicitly here. Without TP, ``loss`` was plain.
+                if parallel_dims.tp_enabled and parallel_dims.cp_enabled:
+                    cp_mesh = parallel_dims.get_mesh("cp")
+                    global_avg_loss = dist_utils.dist_sum(
+                        torch.tensor(global_avg_loss, device=self.device), cp_mesh
+                    )
+                    global_max_loss = dist_utils.dist_max(
+                        torch.tensor(global_max_loss, device=self.device), cp_mesh
+                    )
+                    global_ntokens_seen = int(
+                        dist_utils.dist_sum(
+                            torch.tensor(
+                                global_ntokens_seen,
+                                dtype=torch.int64,
+                                device=self.device,
+                            ),
+                            cp_mesh,
+                        )
+                    )
             else:
                 global_avg_loss = global_max_loss = float(loss.detach().item())
                 global_ntokens_seen = self.ntokens_seen

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -764,16 +764,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if parallel_dims.dp_cp_enabled:
                 loss = loss.detach()
 
-                # CP is not a model DTensor mesh axis (the model is parallelized
-                # only on the TP mesh), so the loss DTensor carries no CP
-                # placement. Pass the CP process group as ``extra_pg`` so that
-                # the reduction helper folds CP into the DP/batch reduction.
-                cp_pg = (
-                    parallel_dims.get_mesh("cp").get_group()
-                    if parallel_dims.cp_enabled
-                    else None
-                )
-                batch_mesh = parallel_dims.get_optional_mesh("batch")
+                # ``loss_mesh`` is the flattened ``batch × cp`` mesh —
+                # everything orthogonal to the model's TP DTensor mesh that
+                # contributes to the global loss. ``dist_sum`` collapses the
+                # TP axis via ``full_tensor()`` and then all-reduces over
+                # ``loss_mesh``, covering DP and CP in one pass.
+                loss_mesh = parallel_dims.get_optional_mesh("loss")
 
                 # For global_avg_loss, we want the average loss across all ranks:
                 # loss = local_loss_sum / global_valid_tokens
@@ -786,14 +782,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 # global_max_loss = max(local_avg_loss)
                 local_avg_loss = loss * global_valid_tokens / local_valid_tokens
                 global_avg_loss, global_max_loss, global_ntokens_seen = (
-                    dist_utils.dist_sum(loss, batch_mesh, extra_pg=cp_pg),
-                    dist_utils.dist_max(local_avg_loss, batch_mesh, extra_pg=cp_pg),
+                    dist_utils.dist_sum(loss, loss_mesh),
+                    dist_utils.dist_max(local_avg_loss, loss_mesh),
                     dist_utils.dist_sum(
                         torch.tensor(
                             self.ntokens_seen, dtype=torch.int64, device=self.device
                         ),
-                        batch_mesh,
-                        extra_pg=cp_pg,
+                        loss_mesh,
                     ),
                 )
             else:


### PR DESCRIPTION
Fix #3280 

## Root cause
When TP + CP is enabled CP is the not in DTensor's mesh and DTensor mesh only have "tp". So `_dist_reduce` in `torchtitan/distributed/utils.py` directly return without reduction on CP mesh. 
```
if isinstance(x, DTensor):
      return float(x.full_tensor().item())  # ← drops the caller's `mesh`
 return float(funcol.all_reduce(x, group=mesh).item())  # plain branch correctly uses mesh
```

## Fix
- Add a explicit reduction on CP  mesh 
- The meaning of function `_dist_reduce` is vague: When CP is enabled, it doesn't being represented in DTensor mesh. 
    -  I tried alternative method: eg, don't return from the DTensor path, continue reduction on mesh. This is very error-prone because the `mesh` has assumption: `mesh` is flattened to be 1D. It's very easy to double-reduce on DTensor's mesh and `mesh` parameter

## Why it only happen when TP x CP?
- When TP enabled, the `loss` is a DTensor, which will hit the DTensor path