### PR TITLE
[graph_trainer] Refactor passes.py into focused modules

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -22,6 +22,7 @@ from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 
 from torchtitan.config.function import Function
+from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
 from torchtitan.tools.logging import logger
 
 
@@ -406,3 +407,137 @@ def get_static_input_indices(gm: torch.fx.GraphModule, is_forward: bool) -> list
         static_input_indices = list(range(fixed))
 
     return static_input_indices
+
+
+def insert_kernel_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Insert mark_kernels() calls at module boundaries in the FX graph.
+
+    Reads ``node.meta["custom"]["module_fqn"]`` (set via
+    ``annotate_module_fqns``) and inserts enter/exit calls so that
+    CUDA graph capture records the annotations.
+
+    Requires ``cuda-python`` package and CUDA toolkit/driver >= 13.1
+    (or cuda-compat >= 13.1).  Returns the graph unchanged when unavailable.
+
+    Also enables annotation capture on :class:`CUDAGraphWrapper` so that
+    ``enable_annotations=True`` is passed to ``torch.cuda.graph()``.
+
+    Alternative approaches:
+
+    1. **fx.Interpreter**: During cudagraph capture, run the graph via an
+       ``fx.Interpreter`` subclass that reads ``module_fqn`` metadata and
+       calls ``mark_kernels`` enter/exit around each node — avoids mutating
+       the graph.
+    2. **Custom CodeGen**: Use a custom ``torch.fx.graph.CodeGen`` to emit
+       enter/exit lines (or ``with`` blocks) directly in the generated
+       Python code.
+
+    The current graph-pass approach is the least invasive.
+    """
+    from torch.cuda._graph_annotations import _is_tools_id_unavailable
+
+    def _enter(annotation: dict) -> object:
+        from torch.cuda._graph_annotations import mark_kernels
+
+        ctx = mark_kernels(annotation)
+        ctx.__enter__()
+        return ctx
+
+    def _exit(ctx: object) -> None:
+        ctx.__exit__(None, None, None)  # type: ignore[union-attr]
+
+    if _is_tools_id_unavailable():
+        return gm
+
+    enable_cudagraph_annotations()
+
+    graph = gm.graph
+    current_fqn: str | None = None
+    current_ctx_node = None
+
+    for node in list(graph.nodes):
+        fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
+
+        if fqn != current_fqn:
+            # Close previous scope
+            if current_ctx_node is not None:
+                with graph.inserting_before(node):
+                    exit_node = graph.call_function(_exit, (current_ctx_node,))
+                    exit_node.meta["custom"] = {}
+                current_ctx_node = None
+
+            # Open new scope
+            if fqn is not None:
+                with graph.inserting_before(node):
+                    enter_node = graph.call_function(
+                        _enter,
+                        ({_MODULE_FQN: fqn},),
+                    )
+                    enter_node.meta["custom"] = {}
+                current_ctx_node = enter_node
+
+            current_fqn = fqn
+
+    # Close any trailing scope (before output/return)
+    if current_ctx_node is not None:
+        output_nodes = [n for n in graph.nodes if n.op == "output"]
+        if output_nodes:
+            with graph.inserting_before(output_nodes[0]):
+                exit_node = graph.call_function(_exit, (current_ctx_node,))
+                exit_node.meta["custom"] = {}
+
+    graph.lint()
+    gm.recompile()
+    return gm
+
+
+def cudagraph_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+    *,
+    is_forward: bool,
+    static_input_indices: list[int] | None = None,
+    tensor_input_indices: list[int] | None = None,
+) -> torch.fx.GraphModule:
+    """
+    Apply cudagraph.
+
+    This pass wraps the forward function with cudagraph during compilation and does
+    not record cudagraph until runtime.
+    - For the first run, it will warm up operators such as nccl.
+    - For the second run, it will record cudagraph and replay cudagraph.
+    - For the following runs, it will replay cudagraph.
+
+    Args:
+        gm: The graph module to wrap.
+        example_inputs: Example inputs for warmup/recording.
+        is_forward: Whether this is a forward graph (True) or backward graph
+            (False). Used to infer which inputs have stable tensor addresses
+            when ``static_input_indices`` is not provided.
+        static_input_indices: Explicit list of input indices with stable tensor
+            addresses. When provided, ``is_forward`` is not used for inference.
+        tensor_input_indices: Indices of graph inputs that are tensors (as
+            opposed to opaque values like DeviceMesh). Used to compute which
+            inputs need copying for cudagraph replay. When not provided, this
+            is inferred from ``example_inputs``.
+    """
+    if not isinstance(gm, torch.fx.GraphModule):
+        raise TypeError(
+            f"cudagraph_pass requires a GraphModule but got {type(gm).__name__}. "
+            f"Ensure cudagraph is not combined with passes that replace the "
+            f"GraphModule (e.g. full_inductor_compilation)."
+        )
+
+    if static_input_indices is None:
+        static_input_indices = get_static_input_indices(gm, is_forward)
+    gm.forward = CUDAGraphWrapper(
+        gm.forward,
+        example_inputs,
+        static_input_indices,
+        tensor_input_indices=tensor_input_indices,
+    )
+    logger.info("Applied cudagraph pass.")
+    return gm

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Inductor compilation passes for graph_trainer.
+
+Regional and full Inductor compilation, plus FlexAttention annotation for
+regional_inductor.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch._inductor.compile_fx import compile_fx_inner
+from torch.fx.passes.regional_inductor import regional_inductor
+
+from torchtitan.tools.logging import logger
+
+
+def _ops_filter_with_distributed(name: str) -> bool:
+    """Ops filter that allows distributed collective ops for serialization.
+
+    The default GraphPickler ops filter only allows aten and fbgemm ops.
+    SimpleFSDP uses _c10d_functional collectives that must also be
+    allowed for the graph to serialize correctly.  The device_mesh ops
+    (e.g. _get_submesh) appear in the backward graph when DTensor
+    reconstructs submeshes from tracked ancestor meshes.
+    """
+    return name.startswith(
+        (
+            "torch.ops.aten",
+            "torch.ops.fbgemm",
+            "torch.ops._c10d_functional",
+            "torch.ops._dtensor",
+            "torch.ops.device_mesh",
+        )
+    )
+
+
+def _node_metadata_key_filter_distributed(key: str) -> bool:
+    """Metadata key filter for regional_inductor with distributed ops.
+
+    Distributed ops (e.g. _get_submesh, mesh_get_process_group) produce
+    opaque values (DeviceMesh, ProcessGroup) in node.meta["val"] and
+    node.meta["eager_input_vals"] that cannot be pickled.  We strip
+    both — they are not needed at runtime.
+    """
+    if key in ("val", "eager_input_vals"):
+        return False
+    return key not in ["source_fn_stack", "nn_module_stack", "fwd_source_fn_stack"]
+
+
+def regional_inductor_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, serializable: bool = False
+) -> torch.fx.GraphModule:
+    """Compile tagged graph regions with ``regional_inductor``.
+
+    Scans the graph for nodes whose ``node.meta["custom"]`` contains a
+    ``compile_with_inductor`` key and compiles those regions with
+    TorchInductor.  Nodes without this tag are left unchanged.  If no
+    nodes are tagged the pass is a no-op.
+
+    Inductor is configured for bitwise-equal numerics so that the
+    compiled regions match eager execution exactly.
+
+    Args:
+        gm: The graph module to compile.
+        example_inputs: Example inputs for shape propagation.
+        serializable: When True (precompile mode), sets
+            ``force_autograd_cache`` so that ``regional_inductor`` wraps
+            its output in ``RegionalOutputCode``, and overrides the ops
+            filter to allow distributed collective ops.
+    """
+    import torch._inductor.config as ic
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
+        """Extract the FakeTensorMode from a graph module's placeholder metadata."""
+        for node in gm.graph.nodes:
+            if node.op == "placeholder" and "val" in node.meta:
+                val = node.meta["val"]
+                if isinstance(val, FakeTensor):
+                    return val.fake_mode
+        return None
+
+    # Ensure inductor produces bitwise-equal numerics vs eager.
+    ic.eager_numerics.division_rounding = True
+    # Recommended by inductor team — uncomment as needed:
+    # ic.emulate_precision_casts = True
+    # ic.eager_numerics.disable_ftz = True
+    # ic.eager_numerics.use_pytorch_libdevice = True
+    # ic.fallback_random = True
+
+    # regional_inductor calls standalone_compile with
+    # dynamic_shapes="from_tracing_context", which requires an active
+    # TracingContext with a FakeTensorMode.  When this pass is called
+    # outside torch.compile (e.g. after make_fx tracing in graph_trainer),
+    # no TracingContext exists, so we create one from the graph's fake
+    # tensor metadata.
+    fake_mode = _get_fake_mode_from_gm(gm)
+    tracing_ctx = torch._guards.TracingContext(fake_mode)
+
+    if serializable:
+        with (
+            torch._guards.tracing(tracing_ctx),
+            torch._functorch.config.patch("force_autograd_cache", True),
+        ):
+            result = regional_inductor(gm, example_inputs)
+        from torch._inductor.output_code import RegionalOutputCode
+
+        # Override the ops filter after compilation so that
+        # serialization (which happens later) allows distributed
+        # collective ops like _c10d_functional through GraphPickler.
+        if isinstance(result, RegionalOutputCode):
+            result._ops_filter = _ops_filter_with_distributed
+            result._node_metadata_key_filter = _node_metadata_key_filter_distributed
+        else:
+            logger.warning(
+                "regional_inductor with serializable=True did not produce "
+                "RegionalOutputCode; distributed ops may not serialize correctly."
+            )
+        return result
+
+    with torch._guards.tracing(tracing_ctx):
+        gm = regional_inductor(gm, example_inputs)
+
+    # regional_inductor may switch to boxed calling convention; reset to
+    # default so the graph can be called with positional args as usual.
+    gm.graph.set_codegen(torch.fx.graph.CodeGen())
+    gm.recompile()
+    return gm
+
+
+def annotate_flex_attention_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    flex_compile_config: dict | None,
+    mask_compile_config: dict | None = None,
+) -> torch.fx.GraphModule:
+    """Tag flex attention HOPs with compile_with_inductor for regional_inductor.
+
+    Annotates three sets of nodes so that regional_inductor correctly
+    scoops and compiles flex attention regions:
+    1. The HOP node itself (flex_attention / flex_attention_backward)
+    2. The get_attr nodes referencing score_mod / mask_mod submodules.
+    3. All nodes inside those submodule graphs.
+
+    Args:
+        gm: The graph module to annotate.
+        example_inputs: Example inputs (unused, required by pass interface).
+        flex_compile_config: Inductor config dict for flex attention HOP
+            nodes and their get_attr submodule references. When provided,
+            wrapped as ``{"inductor_configs": flex_compile_config}``.
+            When None, nodes are tagged with an empty annotation.
+        mask_compile_config: Inductor config dict for nodes inside mask_mod
+            subgraphs. When provided, wrapped as
+            ``{"inductor_configs": mask_compile_config}``.
+            When None, nodes are tagged with an empty annotation.
+    """
+    flex_compile_annotation: dict = (
+        {"inductor_configs": flex_compile_config}
+        if flex_compile_config is not None
+        else {}
+    )
+    mask_compile_annotation: dict = (
+        {"inductor_configs": mask_compile_config}
+        if mask_compile_config is not None
+        else {}
+    )
+
+    for node in gm.graph.nodes:
+        if node.target not in {
+            torch.ops.higher_order.flex_attention,
+            torch.ops.higher_order.flex_attention_backward,
+        }:
+            continue
+        node.meta.setdefault("custom", {})[
+            "compile_with_inductor"
+        ] = flex_compile_annotation
+        for inp in node.all_input_nodes:
+            if inp.op != "get_attr":
+                continue
+            submod = getattr(gm, inp.target, None)
+            if not isinstance(submod, torch.fx.GraphModule):
+                continue
+            inp.meta.setdefault("custom", {})[
+                "compile_with_inductor"
+            ] = flex_compile_annotation
+
+            # Following are the nodes in mask_mod subgraph
+            for sub_node in submod.graph.nodes:
+                sub_node.meta.setdefault("custom", {})[
+                    "compile_with_inductor"
+                ] = mask_compile_annotation
+    return gm
+
+
+def full_inductor_compilation_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple
+) -> torch.fx.GraphModule:
+    """Apply full Inductor compilation with code generation.
+
+    Applies inductor decompositions (e.g. ``aten.t`` → ``aten.permute``),
+    then compiles the graph into optimized Triton/C++ kernels via
+    ``compile_fx_inner`` and replaces the GraphModule's ``forward``
+    with the compiled callable.
+
+    Must be the **terminal** pass — no FX-graph-level passes (e.g.
+    ``custom_codegen_pass``, ``insert_kernel_annotations_pass``) can
+    run after this because the FX graph is no longer authoritative.
+    """
+
+    def _apply_decompositions(
+        gm: torch.fx.GraphModule, example_inputs: tuple
+    ) -> torch.fx.GraphModule:
+        """Retrace with ``select_decomp_table()`` so that ops like ``aten.t``
+        are decomposed before ``compile_fx_inner``."""
+        from torch._inductor.decomposition import select_decomp_table
+        from torch._subclasses.fake_tensor import FakeTensor
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        decomp_table = select_decomp_table()
+
+        fake_mode = None
+        for inp in example_inputs:
+            if isinstance(inp, FakeTensor):
+                fake_mode = inp.fake_mode
+                break
+
+        if fake_mode is not None:
+            with fake_mode:
+                gm = make_fx(
+                    gm,
+                    decomposition_table=decomp_table,
+                    _allow_non_fake_inputs=True,
+                )(*example_inputs)
+
+        return gm
+
+    gm = _apply_decompositions(gm, example_inputs)
+    output_code = compile_fx_inner(gm, example_inputs)
+
+    # compile_fx_inner returns OutputCode with boxed calling convention
+    # (single list arg). Adapt to positional args so the graph trainer's
+    # execution path (gm(*flat_inputs)) works unchanged.
+    def _compiled_forward(*args):
+        return output_code(list(args))
+
+    gm.forward = _compiled_forward
+    return gm

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -36,24 +36,11 @@ from torchtitan.experiments.graph_trainer.cpu_offload import (
 from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
     log_activation_memory_policy,
 )
+from torchtitan.experiments.graph_trainer.registry import (
+    MEMORY_POLICY_REGISTRY,
+    register_memory_policy,
+)
 from torchtitan.tools.logging import logger
-
-
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
-
-MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
-
-
-def register_memory_policy(key: str):
-    """Decorator that registers a memory policy function."""
-
-    def decorator(fn: Callable) -> Callable:
-        MEMORY_POLICY_REGISTRY[key] = fn
-        return fn
-
-    return decorator
 
 
 def _make_default_memory_policy(

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Memory policy passes for graph_trainer.
+
+Selective activation checkpointing (SAC) tagging and memory policy dispatch.
+Each saved forward activation can independently be tagged as MUST_SAVE,
+MUST_RECOMPUTE, or MUST_CPU_OFFLOAD.  The ``tag_with_memory_policy_pass``
+entry point selects a tagging strategy via ``--compile.memory_policy``.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections import defaultdict
+from collections.abc import Callable
+
+import torch
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.distributed.activation_checkpoint import _get_save_ops
+from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
+    _is_backward_node,
+    _MODULE_FQN,
+    _NOT_IN_LAYERS,
+)
+from torchtitan.experiments.graph_trainer.cpu_offload import (
+    tag_all_offloadable_activations,
+)
+from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
+    log_activation_memory_policy,
+)
+from torchtitan.tools.logging import logger
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
+
+
+def register_memory_policy(key: str):
+    """Decorator that registers a memory policy function."""
+
+    def decorator(fn: Callable) -> Callable:
+        MEMORY_POLICY_REGISTRY[key] = fn
+        return fn
+
+    return decorator
+
+
+def _make_default_memory_policy(
+    save_ops: set | None = None,
+    *,
+    fsdp_reshard_after_forward: bool = True,
+) -> Callable:
+    """Create a SAC policy function from a set of op targets to save."""
+    if save_ops is None:
+        save_ops = _get_save_ops()
+        if not fsdp_reshard_after_forward:
+            save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        if node.target in save_ops:
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return policy_fn
+
+
+def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
+    """Eager-compatible SAC policy that alternates mm ops between save/recompute.
+
+    Matches the behavior of torchtitan.distributed.activation_checkpoint:
+    every second mm/linear op is marked PREFER_RECOMPUTE instead of MUST_SAVE.
+    """
+    if save_ops is None:
+        save_ops = _get_save_ops()
+    mm_ops = {torch.ops.aten.mm.default, torch.ops.aten.linear.default}
+    mm_count = 0
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        nonlocal mm_count
+        if node.target in mm_ops:
+            mm_count += 1
+            if node.target in save_ops and mm_count % 2 == 0:
+                return CheckpointPolicy.PREFER_RECOMPUTE
+        if node.target in save_ops:
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return policy_fn
+
+
+def apply_sac_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
+) -> torch.fx.GraphModule:
+    """Apply selective activation checkpointing on the joint graph.
+
+    Annotates forward ``call_function`` nodes with a ``CheckpointPolicy``
+    determined by ``policy_fn``. After tagging, a boundary pass forces
+    ``MUST_SAVE`` on recomputable nodes whose output crosses a layer
+    boundary (layer N → layer N+1), since recomputing them would require
+    rerunning the entire preceding layer.
+
+    ``getitem`` / ``wait_tensor`` nodes inherit the parent's tag.
+
+    The model must have been annotated with ``annotate_module_fqns`` before
+    tracing so that nodes carry ``module_fqn`` metadata.
+
+    Args:
+        gm: The joint forward-backward graph module.
+        policy_fn: Callable that takes a node and returns a CheckpointPolicy.
+            Defaults to ``_make_default_memory_policy()`` if None.
+
+    Returns:
+        The annotated graph module
+    """
+    if policy_fn is None:
+        policy_fn = _make_default_memory_policy()
+
+    layer_stats: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"save": 0, "recompute": 0}
+    )
+
+    # Pass 1: Tag each forward node with a recompute policy.
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+
+        # Skip backward nodes — they must not carry recompute tags,
+        # otherwise the remat pass would try to duplicate backward ops.
+        if _is_backward_node(node):
+            continue
+
+        # Skip the post-layer epilogue (lm_head + loss). Chunked-loss
+        # regions split backward into multiple disjoint regions, and the
+        # remat pass only supports one region with must_recompute deps.
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+        if fqn.startswith(("lm_head", "loss")):
+            continue
+
+        if node.target in (
+            operator.getitem,
+            torch.ops._c10d_functional.wait_tensor.default,
+        ):
+            # Propagate from parent: getitem extracts tuple elements,
+            # wait_tensor is tied to its async collective — both must
+            # share the parent's save/recompute decision.
+            parent = node.args[0]
+            if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
+                node.meta["recompute"] = parent.meta["recompute"]
+            continue
+
+        layer_id = _get_layer_id(node)
+
+        # NOTE: The eager SAC policy (activation_checkpoint.py) alternates
+        # mm ops between MUST_SAVE and PREFER_RECOMPUTE. We omit that here
+        # because the alternating heuristic is arbitrary.
+        node.meta["recompute"] = policy_fn(node)
+        key = (
+            "save"
+            if node.meta["recompute"] == CheckpointPolicy.MUST_SAVE
+            else "recompute"
+        )
+        layer_stats[layer_id][key] += 1
+
+    # Pass 2: Force MUST_SAVE at layer boundaries. If a recomputable node
+    # feeds into a node in a higher layer, saving it is cheaper than
+    # recomputing the entire preceding layer.
+    def _is_recomputable(n: torch.fx.Node) -> bool:
+        return n.meta.get("recompute") in (
+            CheckpointPolicy.PREFER_RECOMPUTE,
+            CheckpointPolicy.MUST_RECOMPUTE,
+        )
+
+    boundary_saves = 0
+    for node in gm.graph.nodes:
+        if _is_backward_node(node) or not _is_recomputable(node):
+            continue
+        node_layer_id = _get_layer_id(node)
+        for user in node.users:
+            if (
+                not _is_backward_node(user)
+                and _is_recomputable(user)
+                and _get_layer_id(user) > node_layer_id
+            ):
+                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+                boundary_saves += 1
+                break
+
+    gm.recompile()
+    logger.info("Applied selective activation checkpointing (SAC) graph pass.")
+    if boundary_saves:
+        logger.info(f"  Forced {boundary_saves} nodes to MUST_SAVE at layer boundaries")
+    for layer_id in sorted(layer_stats):
+        stats = layer_stats[layer_id]
+        label = "non-layer" if layer_id == _NOT_IN_LAYERS else str(layer_id)
+        logger.info(
+            f"  Layer {label}: "
+            f"{stats['save']} MUST_SAVE, "
+            f"{stats['recompute']} PREFER_RECOMPUTE"
+        )
+    return gm
+
+
+@register_memory_policy("default")
+def _default_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """SAC policy that saves all compute-intensive ops and FSDP all_gathers."""
+    fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
+        config.parallelism.fsdp_reshard_after_forward,
+        pp_enabled=config.parallelism.pipeline_parallel_degree > 1,
+    )
+    policy_fn = _make_default_memory_policy(
+        fsdp_reshard_after_forward=fsdp_reshard_after_forward,
+    )
+    apply_sac_pass(gm, policy_fn=policy_fn)
+    return gm
+
+
+@register_memory_policy("eager")
+def _eager_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """SAC policy that alternates mm ops between save/recompute."""
+    apply_sac_pass(gm, policy_fn=_make_eager_memory_policy())
+    return gm
+
+
+@register_memory_policy("budget_limited_offload")
+def _budget_limited_offload_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """SAC + CPU offload: apply default SAC, then offload within budget."""
+    _default_memory_policy_pass(gm, config=config)
+    tag_all_offloadable_activations(
+        gm, cpu_budget_gb=config.compile.cpu_offload_budget_gb
+    )
+    return gm
+
+
+def tag_with_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """Tag forward nodes with MUST_SAVE, PREFER_RECOMPUTE, or MUST_CPU_OFFLOAD.
+
+    The ``config.compile.memory_policy`` selects the tagging strategy:
+        default: SAC with all compute-intensive ops saved.
+        eager: SAC alternating mm ops between save/recompute.
+        budget_limited_offload: SAC + CPU offload within budget.
+
+    Other memory policies combining SAC and CPU offload can be added
+    via ``register_memory_policy`` without modifying this function.
+    """
+    memory_policy = config.compile.memory_policy
+    if memory_policy not in MEMORY_POLICY_REGISTRY:
+        raise ValueError(
+            f"Unknown memory_policy: {memory_policy!r}. "
+            f"Available: {list(MEMORY_POLICY_REGISTRY.keys())}"
+        )
+    gm = MEMORY_POLICY_REGISTRY[memory_policy](gm, config=config)
+    log_activation_memory_policy(gm)
+    return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -7,39 +7,34 @@
 """
 Compiler passes for graph_trainer training.
 
-This module provides various compiler passes that can be applied to graph modules
-during compilation. Passes can be selected and configured via job config.
+This module provides pass orchestration: building the pass list, applying passes
+in order, and the pass registries.  Individual passes live in dedicated modules:
 
-Pass Types:
-- Joint custom passes: Applied to the joint forward-backward graph before partitioning
-- Compiler passes: Applied to the partitioned forward/backward graphs
+- ``memory_policy.py`` — SAC tagging and memory policy dispatch
+- ``inductor_passes.py`` — regional and full Inductor compilation
+- ``cudagraph.py`` — cudagraph wrapping and kernel annotations
+- ``fsdp_passes.py`` — FSDP bucketing and resharding
+- ``remove_noop_passes.py`` — no-op removal (detach, identity view/slice)
+- ``performance_passes.py`` — opt-in numerics-changing optimizations
+- ``selective_activation_remat.py`` — activation rematerialization
+- ``cpu_offload.py`` — CPU offload insertion
+- ``custom_codegen.py`` — custom code generation for profiling/debugging
 """
 
 from __future__ import annotations
 
 import functools
-import operator
 import time
-from collections import defaultdict
+import warnings
 from collections.abc import Callable
 
 import torch
-from torch._inductor.compile_fx import compile_fx_inner
 from torch._logging import trace_structured
-from torch.fx.passes.regional_inductor import regional_inductor
-from torch.utils.checkpoint import CheckpointPolicy
 
-from torchtitan.distributed.activation_checkpoint import _get_save_ops
-from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
-from torchtitan.experiments.graph_trainer.common_utils import (
-    _get_layer_id,
-    _is_backward_node,
-    _MODULE_FQN,
-    _NOT_IN_LAYERS,
-)
-from torchtitan.experiments.graph_trainer.cpu_offload import (
-    apply_cpu_offload_pass,
-    tag_all_offloadable_activations,
+from torchtitan.experiments.graph_trainer.cpu_offload import apply_cpu_offload_pass
+from torchtitan.experiments.graph_trainer.cudagraph import (
+    cudagraph_pass,
+    insert_kernel_annotations_pass,
 )
 from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.debug_utils import (
@@ -53,10 +48,16 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     overlap_fsdp_ag_rs_pass,
     transformer_block_bucketing_reordering_pass,
 )
-from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
-    log_activation_memory_policy,
+from torchtitan.experiments.graph_trainer.inductor_passes import (
+    annotate_flex_attention_for_regional_inductor_pass,
+    full_inductor_compilation_pass,
+    regional_inductor_pass,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+from torchtitan.experiments.graph_trainer.memory_policy import (
+    apply_sac_pass,
+    tag_with_memory_policy_pass,
+)
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_detach_pass,
     remove_identity_slice_pass,
@@ -75,7 +76,6 @@ c10d = torch.ops._c10d_functional
 # Registries — keyed by string name
 # ---------------------------------------------------------------------------
 
-MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
 PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
 POST_INIT_HOOKS: dict[str, Callable] = {}
 PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
@@ -94,7 +94,6 @@ def _make_registry_decorator(registry: dict):
     return register
 
 
-register_memory_policy = _make_registry_decorator(MEMORY_POLICY_REGISTRY)
 register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
 register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
 register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)
@@ -127,8 +126,6 @@ def async_tensor_parallel_pass(
     and matmul + reduce-scatter into
     ``symm_mem.fused_matmul_reduce_scatter``.
     """
-    import warnings
-
     from torch._inductor.fx_passes.micro_pipeline_tp import micro_pipeline_tp_pass
     from torch._inductor.fx_passes.overlap_scheduling import get_group_name
     from torch.distributed._symmetric_memory import enable_symm_mem_for_group
@@ -364,614 +361,6 @@ def apply_graph_passes(
             log_graph_diff(before_snapshot, after_snapshot, pass_name)
     all_passes_elapsed = time.perf_counter() - all_passes_start
     logger.info(f"All {len(passes)} graph passes took {all_passes_elapsed:.3f}s")
-    return gm
-
-
-def _ops_filter_with_distributed(name: str) -> bool:
-    """Ops filter that allows distributed collective ops for serialization.
-
-    The default GraphPickler ops filter only allows aten and fbgemm ops.
-    SimpleFSDP uses _c10d_functional collectives that must also be
-    allowed for the graph to serialize correctly.  The device_mesh ops
-    (e.g. _get_submesh) appear in the backward graph when DTensor
-    reconstructs submeshes from tracked ancestor meshes.
-    """
-    return name.startswith(
-        (
-            "torch.ops.aten",
-            "torch.ops.fbgemm",
-            "torch.ops._c10d_functional",
-            "torch.ops._dtensor",
-            "torch.ops.device_mesh",
-        )
-    )
-
-
-def _node_metadata_key_filter_distributed(key: str) -> bool:
-    """Metadata key filter for regional_inductor with distributed ops.
-
-    Distributed ops (e.g. _get_submesh, mesh_get_process_group) produce
-    opaque values (DeviceMesh, ProcessGroup) in node.meta["val"] and
-    node.meta["eager_input_vals"] that cannot be pickled.  We strip
-    both — they are not needed at runtime.
-    """
-    if key in ("val", "eager_input_vals"):
-        return False
-    return key not in ["source_fn_stack", "nn_module_stack", "fwd_source_fn_stack"]
-
-
-def regional_inductor_pass(
-    gm: torch.fx.GraphModule, example_inputs: tuple, *, serializable: bool = False
-) -> torch.fx.GraphModule:
-    """Compile tagged graph regions with ``regional_inductor``.
-
-    Scans the graph for nodes whose ``node.meta["custom"]`` contains a
-    ``compile_with_inductor`` key and compiles those regions with
-    TorchInductor.  Nodes without this tag are left unchanged.  If no
-    nodes are tagged the pass is a no-op.
-
-    Inductor is configured for bitwise-equal numerics so that the
-    compiled regions match eager execution exactly.
-
-    Args:
-        gm: The graph module to compile.
-        example_inputs: Example inputs for shape propagation.
-        serializable: When True (precompile mode), sets
-            ``force_autograd_cache`` so that ``regional_inductor`` wraps
-            its output in ``RegionalOutputCode``, and overrides the ops
-            filter to allow distributed collective ops.
-    """
-    import torch._inductor.config as ic
-    from torch._subclasses.fake_tensor import FakeTensor
-
-    def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
-        """Extract the FakeTensorMode from a graph module's placeholder metadata."""
-        for node in gm.graph.nodes:
-            if node.op == "placeholder" and "val" in node.meta:
-                val = node.meta["val"]
-                if isinstance(val, FakeTensor):
-                    return val.fake_mode
-        return None
-
-    # Ensure inductor produces bitwise-equal numerics vs eager.
-    ic.eager_numerics.division_rounding = True
-    # Recommended by inductor team — uncomment as needed:
-    # ic.emulate_precision_casts = True
-    # ic.eager_numerics.disable_ftz = True
-    # ic.eager_numerics.use_pytorch_libdevice = True
-    # ic.fallback_random = True
-
-    # regional_inductor calls standalone_compile with
-    # dynamic_shapes="from_tracing_context", which requires an active
-    # TracingContext with a FakeTensorMode.  When this pass is called
-    # outside torch.compile (e.g. after make_fx tracing in graph_trainer),
-    # no TracingContext exists, so we create one from the graph's fake
-    # tensor metadata.
-    fake_mode = _get_fake_mode_from_gm(gm)
-    tracing_ctx = torch._guards.TracingContext(fake_mode)
-
-    if serializable:
-        with (
-            torch._guards.tracing(tracing_ctx),
-            torch._functorch.config.patch("force_autograd_cache", True),
-        ):
-            result = regional_inductor(gm, example_inputs)
-        from torch._inductor.output_code import RegionalOutputCode
-
-        # Override the ops filter after compilation so that
-        # serialization (which happens later) allows distributed
-        # collective ops like _c10d_functional through GraphPickler.
-        if isinstance(result, RegionalOutputCode):
-            result._ops_filter = _ops_filter_with_distributed
-            result._node_metadata_key_filter = _node_metadata_key_filter_distributed
-        else:
-            logger.warning(
-                "regional_inductor with serializable=True did not produce "
-                "RegionalOutputCode; distributed ops may not serialize correctly."
-            )
-        return result
-
-    with torch._guards.tracing(tracing_ctx):
-        gm = regional_inductor(gm, example_inputs)
-
-    # regional_inductor may switch to boxed calling convention; reset to
-    # default so the graph can be called with positional args as usual.
-    gm.graph.set_codegen(torch.fx.graph.CodeGen())
-    gm.recompile()
-    return gm
-
-
-def insert_kernel_annotations_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-) -> torch.fx.GraphModule:
-    """Insert mark_kernels() calls at module boundaries in the FX graph.
-
-    Reads ``node.meta["custom"]["module_fqn"]`` (set via
-    ``annotate_module_fqns``) and inserts enter/exit calls so that
-    CUDA graph capture records the annotations.
-
-    Requires ``cuda-python`` package and CUDA toolkit/driver >= 13.1
-    (or cuda-compat >= 13.1).  Returns the graph unchanged when unavailable.
-
-    Also enables annotation capture on :class:`CUDAGraphWrapper` so that
-    ``enable_annotations=True`` is passed to ``torch.cuda.graph()``.
-
-    Alternative approaches:
-
-    1. **fx.Interpreter**: During cudagraph capture, run the graph via an
-       ``fx.Interpreter`` subclass that reads ``module_fqn`` metadata and
-       calls ``mark_kernels`` enter/exit around each node — avoids mutating
-       the graph.
-    2. **Custom CodeGen**: Use a custom ``torch.fx.graph.CodeGen`` to emit
-       enter/exit lines (or ``with`` blocks) directly in the generated
-       Python code.
-
-    The current graph-pass approach is the least invasive.
-    """
-    from torch.cuda._graph_annotations import _is_tools_id_unavailable
-
-    from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
-    from torchtitan.experiments.graph_trainer.cudagraph import (
-        enable_cudagraph_annotations,
-    )
-
-    def _enter(annotation: dict) -> object:
-        from torch.cuda._graph_annotations import mark_kernels
-
-        ctx = mark_kernels(annotation)
-        ctx.__enter__()
-        return ctx
-
-    def _exit(ctx: object) -> None:
-        ctx.__exit__(None, None, None)  # type: ignore[union-attr]
-
-    if _is_tools_id_unavailable():
-        return gm
-
-    enable_cudagraph_annotations()
-
-    graph = gm.graph
-    current_fqn: str | None = None
-    current_ctx_node = None
-
-    for node in list(graph.nodes):
-        fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
-
-        if fqn != current_fqn:
-            # Close previous scope
-            if current_ctx_node is not None:
-                with graph.inserting_before(node):
-                    exit_node = graph.call_function(_exit, (current_ctx_node,))
-                    exit_node.meta["custom"] = {}
-                current_ctx_node = None
-
-            # Open new scope
-            if fqn is not None:
-                with graph.inserting_before(node):
-                    enter_node = graph.call_function(
-                        _enter,
-                        ({_MODULE_FQN: fqn},),
-                    )
-                    enter_node.meta["custom"] = {}
-                current_ctx_node = enter_node
-
-            current_fqn = fqn
-
-    # Close any trailing scope (before output/return)
-    if current_ctx_node is not None:
-        output_nodes = [n for n in graph.nodes if n.op == "output"]
-        if output_nodes:
-            with graph.inserting_before(output_nodes[0]):
-                exit_node = graph.call_function(_exit, (current_ctx_node,))
-                exit_node.meta["custom"] = {}
-
-    graph.lint()
-    gm.recompile()
-    return gm
-
-
-def cudagraph_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple,
-    *,
-    is_forward: bool,
-    static_input_indices: list[int] | None = None,
-    tensor_input_indices: list[int] | None = None,
-) -> torch.fx.GraphModule:
-    """
-    Apply cudagraph.
-
-    This pass wraps the forward function with cudagraph during compilation and does
-    not record cudagraph until runtime.
-    - For the first run, it will warm up operators such as nccl.
-    - For the second run, it will record cudagraph and replay cudagraph.
-    - For the following runs, it will replay cudagraph.
-
-    Args:
-        gm: The graph module to wrap.
-        example_inputs: Example inputs for warmup/recording.
-        is_forward: Whether this is a forward graph (True) or backward graph
-            (False). Used to infer which inputs have stable tensor addresses
-            when ``static_input_indices`` is not provided.
-        static_input_indices: Explicit list of input indices with stable tensor
-            addresses. When provided, ``is_forward`` is not used for inference.
-        tensor_input_indices: Indices of graph inputs that are tensors (as
-            opposed to opaque values like DeviceMesh). Used to compute which
-            inputs need copying for cudagraph replay. When not provided, this
-            is inferred from ``example_inputs``.
-    """
-    if not isinstance(gm, torch.fx.GraphModule):
-        raise TypeError(
-            f"cudagraph_pass requires a GraphModule but got {type(gm).__name__}. "
-            f"Ensure cudagraph is not combined with passes that replace the "
-            f"GraphModule (e.g. full_inductor_compilation)."
-        )
-
-    # Lazy import: cudagraph.py runs init_global_graph_pool() at import time,
-    # which must happen after torch.cuda.set_device(local_rank).
-    from torchtitan.experiments.graph_trainer.cudagraph import (
-        CUDAGraphWrapper,
-        get_static_input_indices,
-    )
-
-    if static_input_indices is None:
-        static_input_indices = get_static_input_indices(gm, is_forward)
-    gm.forward = CUDAGraphWrapper(
-        gm.forward,
-        example_inputs,
-        static_input_indices,
-        tensor_input_indices=tensor_input_indices,
-    )
-    logger.info("Applied cudagraph pass.")
-    return gm
-
-
-def annotate_flex_attention_for_regional_inductor_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-    *,
-    flex_compile_config: dict | None,
-    mask_compile_config: dict | None = None,
-) -> torch.fx.GraphModule:
-    """Tag flex attention HOPs with compile_with_inductor for regional_inductor.
-
-    Annotates three sets of nodes so that regional_inductor correctly
-    scoops and compiles flex attention regions:
-    1. The HOP node itself (flex_attention / flex_attention_backward)
-    2. The get_attr nodes referencing score_mod / mask_mod submodules.
-    3. All nodes inside those submodule graphs.
-
-    Args:
-        gm: The graph module to annotate.
-        example_inputs: Example inputs (unused, required by pass interface).
-        flex_compile_config: Inductor config dict for flex attention HOP
-            nodes and their get_attr submodule references. When provided,
-            wrapped as ``{"inductor_configs": flex_compile_config}``.
-            When None, nodes are tagged with an empty annotation.
-        mask_compile_config: Inductor config dict for nodes inside mask_mod
-            subgraphs. When provided, wrapped as
-            ``{"inductor_configs": mask_compile_config}``.
-            When None, nodes are tagged with an empty annotation.
-    """
-    flex_compile_annotation: dict = (
-        {"inductor_configs": flex_compile_config}
-        if flex_compile_config is not None
-        else {}
-    )
-    mask_compile_annotation: dict = (
-        {"inductor_configs": mask_compile_config}
-        if mask_compile_config is not None
-        else {}
-    )
-
-    for node in gm.graph.nodes:
-        if node.target not in {
-            torch.ops.higher_order.flex_attention,
-            torch.ops.higher_order.flex_attention_backward,
-        }:
-            continue
-        node.meta.setdefault("custom", {})[
-            "compile_with_inductor"
-        ] = flex_compile_annotation
-        for inp in node.all_input_nodes:
-            if inp.op != "get_attr":
-                continue
-            submod = getattr(gm, inp.target, None)
-            if not isinstance(submod, torch.fx.GraphModule):
-                continue
-            inp.meta.setdefault("custom", {})[
-                "compile_with_inductor"
-            ] = flex_compile_annotation
-
-            # Following are the nodes in mask_mod subgraph
-            for sub_node in submod.graph.nodes:
-                sub_node.meta.setdefault("custom", {})[
-                    "compile_with_inductor"
-                ] = mask_compile_annotation
-    return gm
-
-
-def _make_default_memory_policy(
-    save_ops: set | None = None,
-    *,
-    fsdp_reshard_after_forward: bool = True,
-) -> Callable:
-    """Create a SAC policy function from a set of op targets to save."""
-    if save_ops is None:
-        save_ops = _get_save_ops()
-        if not fsdp_reshard_after_forward:
-            save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
-
-    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
-        if node.target in save_ops:
-            return CheckpointPolicy.MUST_SAVE
-        return CheckpointPolicy.PREFER_RECOMPUTE
-
-    return policy_fn
-
-
-def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
-    """Eager-compatible SAC policy that alternates mm ops between save/recompute.
-
-    Matches the behavior of torchtitan.distributed.activation_checkpoint:
-    every second mm/linear op is marked PREFER_RECOMPUTE instead of MUST_SAVE.
-    """
-    if save_ops is None:
-        save_ops = _get_save_ops()
-    mm_ops = {torch.ops.aten.mm.default, torch.ops.aten.linear.default}
-    mm_count = 0
-
-    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
-        nonlocal mm_count
-        if node.target in mm_ops:
-            mm_count += 1
-            if node.target in save_ops and mm_count % 2 == 0:
-                return CheckpointPolicy.PREFER_RECOMPUTE
-        if node.target in save_ops:
-            return CheckpointPolicy.MUST_SAVE
-        return CheckpointPolicy.PREFER_RECOMPUTE
-
-    return policy_fn
-
-
-def apply_sac_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-    *,
-    policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
-) -> torch.fx.GraphModule:
-    """Apply selective activation checkpointing on the joint graph.
-
-    Annotates forward ``call_function`` nodes with a ``CheckpointPolicy``
-    determined by ``policy_fn``. After tagging, a boundary pass forces
-    ``MUST_SAVE`` on recomputable nodes whose output crosses a layer
-    boundary (layer N → layer N+1), since recomputing them would require
-    rerunning the entire preceding layer.
-
-    ``getitem`` / ``wait_tensor`` nodes inherit the parent's tag.
-
-    The model must have been annotated with ``annotate_module_fqns`` before
-    tracing so that nodes carry ``module_fqn`` metadata.
-
-    Args:
-        gm: The joint forward-backward graph module.
-        policy_fn: Callable that takes a node and returns a CheckpointPolicy.
-            Defaults to ``_make_default_memory_policy()`` if None.
-
-    Returns:
-        The annotated graph module
-    """
-    if policy_fn is None:
-        policy_fn = _make_default_memory_policy()
-
-    layer_stats: dict[int, dict[str, int]] = defaultdict(
-        lambda: {"save": 0, "recompute": 0}
-    )
-
-    # Pass 1: Tag each forward node with a recompute policy.
-    for node in gm.graph.nodes:
-        if node.op != "call_function":
-            continue
-
-        # Skip backward nodes — they must not carry recompute tags,
-        # otherwise the remat pass would try to duplicate backward ops.
-        if _is_backward_node(node):
-            continue
-
-        # Skip the post-layer epilogue (lm_head + loss). Chunked-loss
-        # regions split backward into multiple disjoint regions, and the
-        # remat pass only supports one region with must_recompute deps.
-        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
-        if fqn.startswith(("lm_head", "loss")):
-            continue
-
-        if node.target in (
-            operator.getitem,
-            torch.ops._c10d_functional.wait_tensor.default,
-        ):
-            # Propagate from parent: getitem extracts tuple elements,
-            # wait_tensor is tied to its async collective — both must
-            # share the parent's save/recompute decision.
-            parent = node.args[0]
-            if isinstance(parent, torch.fx.Node) and "recompute" in parent.meta:
-                node.meta["recompute"] = parent.meta["recompute"]
-            continue
-
-        layer_id = _get_layer_id(node)
-
-        # NOTE: The eager SAC policy (activation_checkpoint.py) alternates
-        # mm ops between MUST_SAVE and PREFER_RECOMPUTE. We omit that here
-        # because the alternating heuristic is arbitrary.
-        node.meta["recompute"] = policy_fn(node)
-        key = (
-            "save"
-            if node.meta["recompute"] == CheckpointPolicy.MUST_SAVE
-            else "recompute"
-        )
-        layer_stats[layer_id][key] += 1
-
-    # Pass 2: Force MUST_SAVE at layer boundaries. If a recomputable node
-    # feeds into a node in a higher layer, saving it is cheaper than
-    # recomputing the entire preceding layer.
-    def _is_recomputable(n: torch.fx.Node) -> bool:
-        return n.meta.get("recompute") in (
-            CheckpointPolicy.PREFER_RECOMPUTE,
-            CheckpointPolicy.MUST_RECOMPUTE,
-        )
-
-    boundary_saves = 0
-    for node in gm.graph.nodes:
-        if _is_backward_node(node) or not _is_recomputable(node):
-            continue
-        node_layer_id = _get_layer_id(node)
-        for user in node.users:
-            if (
-                not _is_backward_node(user)
-                and _is_recomputable(user)
-                and _get_layer_id(user) > node_layer_id
-            ):
-                node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
-                boundary_saves += 1
-                break
-
-    gm.recompile()
-    logger.info("Applied selective activation checkpointing (SAC) graph pass.")
-    if boundary_saves:
-        logger.info(f"  Forced {boundary_saves} nodes to MUST_SAVE at layer boundaries")
-    for layer_id in sorted(layer_stats):
-        stats = layer_stats[layer_id]
-        label = "non-layer" if layer_id == _NOT_IN_LAYERS else str(layer_id)
-        logger.info(
-            f"  Layer {label}: "
-            f"{stats['save']} MUST_SAVE, "
-            f"{stats['recompute']} PREFER_RECOMPUTE"
-        )
-    return gm
-
-
-@register_memory_policy("default")
-def _default_memory_policy_pass(
-    gm: torch.fx.GraphModule,
-    *,
-    config: "GraphTrainer.Config",
-) -> torch.fx.GraphModule:
-    """SAC policy that saves all compute-intensive ops and FSDP all_gathers."""
-    fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
-        config.parallelism.fsdp_reshard_after_forward,
-        pp_enabled=config.parallelism.pipeline_parallel_degree > 1,
-    )
-    policy_fn = _make_default_memory_policy(
-        fsdp_reshard_after_forward=fsdp_reshard_after_forward,
-    )
-    apply_sac_pass(gm, policy_fn=policy_fn)
-    return gm
-
-
-@register_memory_policy("eager")
-def _eager_memory_policy_pass(
-    gm: torch.fx.GraphModule,
-    *,
-    config: "GraphTrainer.Config",
-) -> torch.fx.GraphModule:
-    """SAC policy that alternates mm ops between save/recompute."""
-    apply_sac_pass(gm, policy_fn=_make_eager_memory_policy())
-    return gm
-
-
-@register_memory_policy("budget_limited_offload")
-def _budget_limited_offload_memory_policy_pass(
-    gm: torch.fx.GraphModule,
-    *,
-    config: "GraphTrainer.Config",
-) -> torch.fx.GraphModule:
-    """SAC + CPU offload: apply default SAC, then offload within budget."""
-    _default_memory_policy_pass(gm, config=config)
-    tag_all_offloadable_activations(
-        gm, cpu_budget_gb=config.compile.cpu_offload_budget_gb
-    )
-    return gm
-
-
-def tag_with_memory_policy_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-    *,
-    config: "GraphTrainer.Config",
-) -> torch.fx.GraphModule:
-    """Tag forward nodes with MUST_SAVE, PREFER_RECOMPUTE, or MUST_CPU_OFFLOAD.
-
-    The ``config.compile.memory_policy`` selects the tagging strategy:
-        default: SAC with all compute-intensive ops saved.
-        eager: SAC alternating mm ops between save/recompute.
-        budget_limited_offload: SAC + CPU offload within budget.
-
-    Other memory policies combining SAC and CPU offload can be added
-    via ``register_memory_policy`` without modifying this function.
-    """
-    memory_policy = config.compile.memory_policy
-    if memory_policy not in MEMORY_POLICY_REGISTRY:
-        raise ValueError(
-            f"Unknown memory_policy: {memory_policy!r}. "
-            f"Available: {list(MEMORY_POLICY_REGISTRY.keys())}"
-        )
-    gm = MEMORY_POLICY_REGISTRY[memory_policy](gm, config=config)
-    log_activation_memory_policy(gm)
-    return gm
-
-
-def full_inductor_compilation_pass(
-    gm: torch.fx.GraphModule, example_inputs: tuple
-) -> torch.fx.GraphModule:
-    """Apply full Inductor compilation with code generation.
-
-    Applies inductor decompositions (e.g. ``aten.t`` → ``aten.permute``),
-    then compiles the graph into optimized Triton/C++ kernels via
-    ``compile_fx_inner`` and replaces the GraphModule's ``forward``
-    with the compiled callable.
-
-    Must be the **terminal** pass — no FX-graph-level passes (e.g.
-    ``custom_codegen_pass``, ``insert_kernel_annotations_pass``) can
-    run after this because the FX graph is no longer authoritative.
-    """
-
-    def _apply_decompositions(
-        gm: torch.fx.GraphModule, example_inputs: tuple
-    ) -> torch.fx.GraphModule:
-        """Retrace with ``select_decomp_table()`` so that ops like ``aten.t``
-        are decomposed before ``compile_fx_inner``."""
-        from torch._inductor.decomposition import select_decomp_table
-        from torch._subclasses.fake_tensor import FakeTensor
-        from torch.fx.experimental.proxy_tensor import make_fx
-
-        decomp_table = select_decomp_table()
-
-        fake_mode = None
-        for inp in example_inputs:
-            if isinstance(inp, FakeTensor):
-                fake_mode = inp.fake_mode
-                break
-
-        if fake_mode is not None:
-            with fake_mode:
-                gm = make_fx(
-                    gm,
-                    decomposition_table=decomp_table,
-                    _allow_non_fake_inputs=True,
-                )(*example_inputs)
-
-        return gm
-
-    gm = _apply_decompositions(gm, example_inputs)
-    output_code = compile_fx_inner(gm, example_inputs)
-
-    # compile_fx_inner returns OutputCode with boxed calling convention
-    # (single list arg). Adapt to positional args so the graph trainer's
-    # execution path (gm(*flat_inputs)) works unchanged.
-    def _compiled_forward(*args):
-        return output_code(list(args))
-
-    gm.forward = _compiled_forward
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -72,33 +72,6 @@ aten = torch.ops.aten
 c10d = torch.ops._c10d_functional
 
 
-# ---------------------------------------------------------------------------
-# Registries — keyed by string name
-# ---------------------------------------------------------------------------
-
-PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
-POST_INIT_HOOKS: dict[str, Callable] = {}
-PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
-
-
-def _make_registry_decorator(registry: dict):
-    """Create a decorator that registers a function into the given registry."""
-
-    def register(key: str):
-        def decorator(fn: Callable) -> Callable:
-            registry[key] = fn
-            return fn
-
-        return decorator
-
-    return register
-
-
-register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
-register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
-register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)
-
-
 def normalize_view_ops_as_reshape(
     gm: torch.fx.GraphModule,
     example_inputs=None,

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -335,7 +335,7 @@ class PrecompiledFxTraceArtifact:
         """
         from torch.fx._graph_pickler import GraphPickler, Options
 
-        from torchtitan.experiments.graph_trainer.passes import (
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
             _node_metadata_key_filter_distributed,
         )
 

--- a/torchtitan/experiments/graph_trainer/registry.py
+++ b/torchtitan/experiments/graph_trainer/registry.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Pass and hook registries for graph_trainer.
+
+Centralizes all registries so that ``passes.py`` and ``memory_policy.py``
+can both import from here without circular dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+# ---------------------------------------------------------------------------
+# Registry helper
+# ---------------------------------------------------------------------------
+
+
+def _make_registry_decorator(registry: dict):
+    """Create a decorator that registers a function into the given registry."""
+
+    def register(key: str):
+        def decorator(fn: Callable) -> Callable:
+            registry[key] = fn
+            return fn
+
+        return decorator
+
+    return register
+
+
+# ---------------------------------------------------------------------------
+# Registries — keyed by string name
+# ---------------------------------------------------------------------------
+
+MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
+PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
+POST_INIT_HOOKS: dict[str, Callable] = {}
+PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
+
+register_memory_policy = _make_registry_decorator(MEMORY_POLICY_REGISTRY)
+register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
+register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
+register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -26,16 +26,20 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
     annotate_module_fqns,
 )
+from torchtitan.experiments.graph_trainer.cudagraph import (
+    insert_kernel_annotations_pass,
+)
 from torchtitan.experiments.graph_trainer.fsdp_passes import overlap_fsdp_ag_rs_pass
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
     trace_train_step,
 )
-from torchtitan.experiments.graph_trainer.passes import (
+from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_default_memory_policy,
     apply_sac_pass,
-    insert_kernel_annotations_pass,
+)
+from torchtitan.experiments.graph_trainer.passes import (
     remove_detach_pass,
     remove_identity_slice_pass,
     remove_identity_view_pass,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -27,6 +27,8 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
 from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
     construct_default_graph_passes,
+)
+from torchtitan.experiments.graph_trainer.registry import (
     PASS_PIPELINE_REGISTRY,
     POST_INIT_HOOKS,
     PRE_TRAIN_STEP_HOOKS,


### PR DESCRIPTION
Code Move Only! 

## Summary

- Split the monolithic `passes.py` (~1037 lines) into focused modules, keeping `passes.py` as the orchestration layer (~400 lines):
  - **`memory_policy.py`** — SAC tagging, default/eager/offload policies, and `tag_with_memory_policy_pass`
  - **`inductor_passes.py`** — `regional_inductor_pass`, `full_inductor_compilation_pass`, and `annotate_flex_attention_for_regional_inductor_pass`
  - **`cudagraph.py`** — `cudagraph_pass` and `insert_kernel_annotations_pass` (appended to existing file)
  - **`registry.py`** — `MEMORY_POLICY_REGISTRY`, `PASS_PIPELINE_REGISTRY`, `POST_INIT_HOOKS`, `PRE_TRAIN_STEP_HOOKS` and their decorators (breaks circular dep between `passes.py` and `memory_policy.py`)
- Code-move only — all function bodies are identical; the only diffs are removing local imports that became unnecessary when code moved to the same file
- Updated `test_passes.py` imports to use new module paths

## Test plan

- [ ] `ruff check --select F401` passes clean (no unused imports)
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py -x`
- [ ] `pre-commit run --all-files`