### PR TITLE
DeepEP compatibility fallback for EventOverlap import and one-time MoE backend selection logging

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -20,7 +20,13 @@ from torch.utils._python_dispatch import _disable_current_modes
 try:
     from deep_ep import Buffer
 
-    from deep_ep.utils import EventHandle, EventOverlap
+    try:
+        from deep_ep.utils import EventHandle, EventOverlap
+    except ImportError:
+        # Compatibility fallback for DeepEP versions where EventOverlap
+        # is not re-exported from deep_ep.utils.__init__.
+        from deep_ep.utils import EventHandle
+        from deep_ep.utils.event import EventOverlap
 except ImportError as e:
     raise ImportError(
         "DeepEP is required for this module. "

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -470,9 +470,12 @@ def apply_moe_ep_tp(
         else:
             experts_mesh = ep_mesh
             experts_plan = ExpertParallel()
-            _log_moe_comm_backend_once("standard", type(experts_plan).__name__)
             # pyrefly: ignore [missing-attribute]
             dispatcher = transformer_block.moe.experts.token_dispatcher
+            _log_moe_comm_backend_once(
+                getattr(dispatcher, "comm_backend", "standard"),
+                type(dispatcher).__name__,
+            )
             if tp_mesh is not None:
                 if isinstance(dispatcher, AllToAllTokenDispatcher):
                     # sp_size and sp_rank are set for sequence-parallel token splitting

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -43,6 +43,27 @@ from torchtitan.models.llama4.model import Llama4Model
 from torchtitan.tools.logging import logger
 
 
+_logged_moe_comm_backends: set[str] = set()
+
+
+def _log_moe_comm_backend_once(backend_name: str, implementation: str) -> None:
+    if backend_name in _logged_moe_comm_backends:
+        return
+
+    is_rank0 = not torch.distributed.is_initialized()
+    if torch.distributed.is_initialized():
+        is_rank0 = torch.distributed.get_rank() == 0
+
+    if is_rank0:
+        logger.info(
+            "MoE token dispatcher backend selected: %s (%s)",
+            backend_name,
+            implementation,
+        )
+
+    _logged_moe_comm_backends.add(backend_name)
+
+
 def parallelize_llama(
     model: Llama4Model,
     *,
@@ -445,9 +466,11 @@ def apply_moe_ep_tp(
         if ep_mesh is None:
             experts_mesh = tp_mesh
             experts_plan = TensorParallel()
+            _log_moe_comm_backend_once("standard", type(experts_plan).__name__)
         else:
             experts_mesh = ep_mesh
             experts_plan = ExpertParallel()
+            _log_moe_comm_backend_once("standard", type(experts_plan).__name__)
             # pyrefly: ignore [missing-attribute]
             dispatcher = transformer_block.moe.experts.token_dispatcher
             if tp_mesh is not None:


### PR DESCRIPTION
Summary
This PR fixes a DeepEP compatibility issue and improves MoE backend observability in logs.

Problem

Some DeepEP versions do not re-export EventOverlap from deep_ep.utils, causing import failures.
MoE communication backend selection was not clearly visible in logs for all paths.
Root Cause

TorchTitan assumed EventOverlap is always importable from deep_ep.utils.
Backend logging was missing or not consistently emitted in a low-noise way.
Changes

Added a compatibility import fallback in DeepEP integration:
First try: from deep_ep.utils import EventHandle, EventOverlap
Fallback: from deep_ep.utils.event import EventOverlap
Added one-time rank-0 backend selection logging for MoE communication:
Logs selected backend and implementation class
Avoids per-layer log spam
Why This Is Safe

Existing behavior is unchanged when EventOverlap is already exported from deep_ep.utils.
Fallback path runs only when the primary import fails.
Logging is emitted once per backend and only on rank 0.
Validation

Branch builds and pushes cleanly.
Change scope is limited to two files.
No public API changes.
Notes
This PR is a compatibility and observability improvement; it does not change model math or training semantics.

