### PR TITLE
[graph_trainer] Add graph EP chunking pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -91,7 +91,7 @@ real expert-parallel collectives. Enable it only with `aot_fx_trace` and
 `expert_parallel_degree > 1`:
 
 ```bash
-NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_ep \
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel \
     ./run_train.sh \
     --compile.mode aot_fx_trace \
     --compile.ep_overlap.enabled \
@@ -147,7 +147,7 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel ./run_train.s
 DeepSeek V3 debug model:
 
 ```bash
-MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_ep ./run_train.sh \
+MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel ./run_train.sh \
   --compile.mode aot_fx_trace \
   --compile.enable_autoparallel \
   --parallelism.data_parallel_shard_degree 4 \

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -66,6 +66,7 @@ def build_decoder_config_for_backend(
 
 
 _MODULE_FQN = "module_fqn"
+_EP_TOKEN_EXCHANGE = "EP_token_exchange"
 _NOT_IN_LAYERS = -1
 
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -53,7 +53,13 @@ class EpOverlapConfig:
     """
 
     disable_early_grad_accumulation: bool = False
-    """Disable the scheduler optimization that accumulates chunk gradients early."""
+    """Disable graph chunking's early parameter-gradient accumulation.
+
+    Early accumulation is the performant default: graph chunking materializes
+    parameter-gradient live-outs before distributed grad cast/communication
+    when legal. This flag preserves eager chunking's cast/reduction order for
+    strict bitwise tests.
+    """
 
 
 @dataclass(kw_only=True, slots=True)

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -26,12 +26,6 @@ def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
     return config
 
 
-def graph_trainer_deepseek_v3_debugmodel_ep() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
-    config.compile = GraphTrainerCompileConfig(enable=True)
-    return config
-
-
 def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
@@ -50,14 +44,6 @@ def graph_trainer_deepseek_v3_debugmodel_minimal_async_ep() -> GraphTrainer.Conf
     )
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
-
-
-def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> GraphTrainer.Config:
-    return graph_trainer_deepseek_v3_debugmodel()
-
-
-def graph_trainer_deepseek_v3_debugmodel_flex_attn_ep() -> GraphTrainer.Config:
-    return graph_trainer_deepseek_v3_debugmodel_ep()
 
 
 def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:

--- a/torchtitan/experiments/graph_trainer/ep_chunk_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_chunk_pass.py
@@ -1,0 +1,2449 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Graph chunking for EP overlap.
+
+The pass is a graph implementation of the eager wrapper:
+
+    split selected live-ins -> run selected module on each chunk -> materialize
+    full live-outs when a non-chunked consumer needs them.
+
+The correctness target is numerical equivalence to eager chunking, not an
+identical lowered graph. ``module_fqn`` seeds the candidate region, but body
+ownership is dataflow based: only nodes reached by chunk-influenced values are
+duplicated. Boundary nodes that the pass creates (split/getitem/scalar
+halves/cat/add) use the parent-wrapper metadata, while copied body nodes keep
+the selected module metadata and receive ``chunk_id``.
+
+Terms:
+- live-in: a value consumed by the selected body and produced outside it.
+  Tensor live-ins whose fake shape contains the selected unbacked chunk symbol
+  are split. Per-chunk provenance from an earlier region is reused directly.
+  Static state, params, buffers, and other full values are shared by both chunks.
+- live-out: a value produced by the selected body and consumed outside it.
+  Chunked consumers receive the matching per-chunk value through provenance.
+  Full consumers receive a materialized value: ``cat`` for values carrying the
+  chunk dimension and ``add`` for backward parameter-gradient reductions.
+- provenance: the internal ``full_value -> (chunk0, chunk1)`` table. It is not
+  materialized as tuple nodes because no downstream pass needs tuple plumbing.
+
+The implementation deliberately stays local. It does not special-case SAC,
+activation offload, or bucketing nodes; those interactions are expressed as
+ordinary dataflow through live-ins and live-outs. The selected unbacked SymInt is
+the only source of truth for chunk influence; graph metadata records only
+symbol->hint pairs so cleanup can erase the symbols after scheduling. The
+selected dimension is symbolic while this pass and scheduling run, then
+``concretize_ep_chunk_symbolic_shapes_pass`` replaces chunk-derived symbolic
+shapes with their config hints before backend codegen.
+
+V1 creates two equal chunks because the EP schedule is pairwise. The data
+structures use per-chunk maps, so extending to N equal chunks is mechanical, but
+the overlap scheduler and tests must be generalized at the same time.
+
+Pseudo-code
+===========
+1. Mark the requested input dimension dynamic before tracing, then import the
+   selected symbol hints onto placeholders after tracing.
+2. Discover selected module roots and plan forward/backward body nodes by
+   following only values influenced by the selected chunk symbol.
+3. Split chunked live-ins, reuse provenance from earlier chunked regions, and
+   create half-size symbolic scalars used by copied body nodes.
+4. Rewrite one chunk body in place and copy the peer chunk body, preserving
+   eager-like metadata, fake values, and mutation alias dependencies.
+5. For every live-out, either route per-chunk provenance to chunked consumers or
+   materialize a full value with cat/add for full consumers.
+6. Erase unused copied nodes, validate selected-symbol shapes, lint, recompile,
+   and leave final symbol concretization to the cleanup pass after scheduling.
+"""
+
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import sympy
+import torch
+import torch.fx as fx
+from torch.utils._pytree import tree_leaves, tree_map
+from torch.utils._sympy.functions import FloorDiv
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _EP_TOKEN_EXCHANGE,
+    _get_module_fqn,
+    _is_backward_node,
+    _MODULE_FQN,
+)
+from torchtitan.experiments.graph_trainer.configs import validate_ep_overlap_config
+from torchtitan.experiments.graph_trainer.ep_pass_utils import (
+    _eval_hint,
+    chunk_symbol_hints_for_mode,
+    CHUNK_SYMBOL_HINTS_META,
+    depends_on_chunk_symbol,
+    expr_key,
+    free_symbols,
+    is_c10d_functional_node,
+    is_module_fqn_inside_root,
+    is_view_target,
+    ordered_nodes,
+    same_shape_with_hints,
+    same_symbolic_expr,
+    same_tensor_domain,
+    statically_equals_hint,
+    symbolic_expr,
+    tensor_meta,
+    view_shape_arg_index,
+)
+from torchtitan.experiments.graph_trainer.registry import (
+    register_trace_call_input_preparer,
+    register_trace_input_preparer,
+)
+from torchtitan.tools.logging import logger
+
+aten = torch.ops.aten
+ChunkMode = Literal["batch", "seq"]
+
+
+# Step 0: Metadata and small graph utilities used by the lowering steps below.
+
+
+@dataclass(frozen=True)
+class _Region:
+    root_fqn: str
+    synthetic_parent_fqn: str
+    is_backward: bool
+    nodes: tuple[fx.Node, ...]
+
+
+@dataclass
+class _Plan:
+    region: _Region
+    body: frozenset[fx.Node]
+    live_ins: frozenset[fx.Node]
+    live_out_users: dict[fx.Node, tuple[fx.Node, ...]]
+    grad_escape_boundaries: frozenset[fx.Node]
+
+
+@dataclass(frozen=True)
+class _ChunkDim:
+    dim: int
+    hint: int | None
+
+
+@dataclass(frozen=True)
+class _MaterializationBoundary:
+    node: fx.Node
+    suffix: tuple[fx.Node, ...]
+
+
+@dataclass(frozen=True)
+class _MatchedRoot:
+    root_fqn: str
+    synthetic_parent_fqn: str
+
+
+def _custom_meta(node: fx.Node) -> dict[str, Any]:
+    """Return mutable custom metadata when present, otherwise an empty dict."""
+    custom = node.meta.get("custom")
+    return custom if isinstance(custom, dict) else {}
+
+
+def _mutates_input(node: fx.Node) -> bool:
+    """Return whether a call_function schema writes through an aliased input."""
+    return bool(_mutable_arg_indices(node))
+
+
+def _mutable_arg_indices(node: fx.Node) -> tuple[int, ...]:
+    """Return positional schema arg indices written by ``node``."""
+    schema = getattr(node.target, "_schema", None)
+    if node.op != "call_function" or schema is None:
+        return ()
+    return tuple(
+        idx
+        for idx, arg in enumerate(schema.arguments)
+        if arg.alias_info is not None and arg.alias_info.is_write
+    )
+
+
+def _is_semantic_user(node: fx.Node) -> bool:
+    """Return whether a user must be preserved when crossing a chunk boundary."""
+    return node.op == "output" or bool(node.users) or _mutates_input(node)
+
+
+def _copy_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    copied = dict(meta)
+    if "custom" in copied:
+        copied["custom"] = dict(copied["custom"])
+    if "unbacked_bindings" in copied:
+        copied["unbacked_bindings"] = dict(copied["unbacked_bindings"])
+    return copied
+
+
+def _set_direction_meta(node: fx.Node, *, is_backward: bool) -> None:
+    if is_backward:
+        node.meta["autograd_backward"] = True
+    else:
+        node.meta.pop("autograd_backward", None)
+
+
+def _set_chunk_meta(
+    node: fx.Node,
+    *,
+    region: _Region,
+    role: str,
+    chunk_id: int | None = None,
+) -> None:
+    _set_direction_meta(node, is_backward=region.is_backward)
+    node.meta["chunked_region_fqn"] = region.root_fqn
+    node.meta["chunked_region_is_backward"] = region.is_backward
+    node.meta["chunked_region_producer"] = "graph"
+    node.meta["chunked_region_role"] = role
+    if chunk_id is None:
+        node.meta.pop("chunk_id", None)
+    else:
+        node.meta["chunk_id"] = chunk_id
+
+
+def _set_synthetic_meta(
+    node: fx.Node,
+    *,
+    region: _Region,
+    role: str,
+    chunk_id: int | None = None,
+) -> None:
+    """Attach parent-wrapper metadata to nodes introduced by graph chunking."""
+    custom = dict(_custom_meta(node))
+    parent_fqn = region.synthetic_parent_fqn
+    if parent_fqn:
+        custom[_MODULE_FQN] = parent_fqn
+        node.meta["custom"] = custom
+    elif custom:
+        custom.pop(_MODULE_FQN, None)
+        node.meta["custom"] = custom
+    else:
+        node.meta.pop("custom", None)
+    _set_chunk_meta(node, region=region, role=role, chunk_id=chunk_id)
+
+
+def _pattern_root(pattern: str, fqn: str) -> _MatchedRoot | None:
+    """Return the matched root and synthetic-parent FQN for a module pattern."""
+    pattern_parts = pattern.split(".")
+    fqn_parts = fqn.split(".")
+    if len(fqn_parts) < len(pattern_parts):
+        return None
+    for pattern_part, fqn_part in zip(pattern_parts, fqn_parts):
+        if pattern_part != "*" and pattern_part != fqn_part:
+            return None
+    root_parts = fqn_parts[: len(pattern_parts)]
+    return _MatchedRoot(
+        root_fqn=".".join(root_parts),
+        synthetic_parent_fqn=".".join(root_parts[:-1]),
+    )
+
+
+def _region_roots(gm: fx.GraphModule, patterns: list[str]) -> list[_MatchedRoot]:
+    """Find concrete module roots matching the configured chunk patterns."""
+    roots: dict[str, _MatchedRoot] = {}
+    for node in gm.graph.nodes:
+        fqn = _get_module_fqn(node)
+        if not fqn:
+            continue
+        for pattern in patterns:
+            if (matched := _pattern_root(pattern, fqn)) is not None:
+                roots.setdefault(matched.root_fqn, matched)
+    return sorted(
+        roots.values(),
+        key=lambda matched: (matched.root_fqn.count("."), matched.root_fqn),
+    )
+
+
+def _region_nodes(
+    gm: fx.GraphModule,
+    root: str,
+    *,
+    is_backward: bool,
+    symbol_hints: dict[object, int],
+    grad_escape_boundaries: set[fx.Node],
+    per_chunk_sources: set[fx.Node],
+) -> tuple[fx.Node, ...]:
+    """Return selected-symbol-influenced nodes inside one root/direction."""
+    candidates = {
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function"
+        and node.meta.get("chunked_region_role") is None
+        and _is_backward_node(node) == is_backward
+        and (fqn := _get_module_fqn(node))
+        and is_module_fqn_inside_root(fqn, root)
+    }
+    if is_backward:
+        changed = True
+        while changed:
+            changed = False
+            for node in gm.graph.nodes:
+                neighbors = (*node.all_input_nodes, *node.users)
+                if (
+                    node in candidates
+                    or node.op != "call_function"
+                    or _get_module_fqn(node)
+                    or not _is_backward_node(node)
+                    or is_c10d_functional_node(node)
+                ):
+                    continue
+                anchored_to_root = any(neighbor in candidates for neighbor in neighbors)
+                if not anchored_to_root:
+                    anchored_to_root = any(
+                        neighbor in per_chunk_sources
+                        and is_module_fqn_inside_root(_get_module_fqn(neighbor), root)
+                        for neighbor in neighbors
+                    )
+                if not anchored_to_root:
+                    continue
+                neighbor_fqns = [
+                    fqn for neighbor in neighbors if (fqn := _get_module_fqn(neighbor))
+                ]
+                if not neighbor_fqns or all(
+                    is_module_fqn_inside_root(fqn, root) for fqn in neighbor_fqns
+                ):
+                    candidates.add(node)
+                    changed = True
+    return _chunk_influenced_region_nodes(
+        gm,
+        candidates,
+        is_backward,
+        symbol_hints,
+        grad_escape_boundaries,
+        per_chunk_sources,
+    )
+
+
+def _node_depends_on_chunk_symbol(
+    node: fx.Node, symbol_hints: dict[object, int]
+) -> bool:
+    """Return whether a node's fake value carries the selected chunk symbol."""
+    return any(
+        depends_on_chunk_symbol(value, symbol_hints)
+        for value in tree_leaves(node.meta.get("val"))
+    )
+
+
+def _is_ep_collective_node(node: fx.Node, body: frozenset[fx.Node]) -> bool:
+    """Return whether a c10d node belongs to EP token exchange/count plumbing."""
+    custom = _custom_meta(node)
+    if "EP" in custom or _EP_TOKEN_EXCHANGE in custom:
+        return True
+    if (
+        node.target == torch.ops._c10d_functional.wait_tensor.default
+        and node.all_input_nodes
+        and node.all_input_nodes[0] in body
+    ):
+        waited_custom = _custom_meta(node.all_input_nodes[0])
+        return "EP" in waited_custom or _EP_TOKEN_EXCHANGE in waited_custom
+    return False
+
+
+def _validate_no_non_ep_collectives(plan: _Plan) -> None:
+    """Graph chunking may only duplicate EP collectives inside chunk bodies."""
+    offenders = [
+        node
+        for node in plan.body
+        if is_c10d_functional_node(node) and not _is_ep_collective_node(node, plan.body)
+    ]
+    if offenders:
+        order = {node: idx for idx, node in enumerate(plan.region.nodes)}
+        details = ", ".join(
+            f"{node.name}:{getattr(node.target, '__name__', node.target)}"
+            for node in sorted(offenders, key=order.get)
+        )
+        raise ValueError(
+            "Graph EP chunking requires chunk bodies to contain only EP "
+            f"collectives. Found non-EP c10d node(s) in {plan.region.root_fqn}: "
+            f"{details}."
+        )
+
+
+def _owned_chunk_dependencies(
+    body: set[fx.Node],
+    candidates: set[fx.Node],
+    symbol_hints: dict[object, int],
+) -> set[fx.Node]:
+    """Return selected-symbol producers owned by an eager chunk body.
+
+    The selected module root defines the eager chunk body. In flattened FX,
+    Python shape computations and shape-derived tensor values can appear as
+    ancestors of body nodes even though they do not data-depend on an activation
+    live-in. These are part of invoking the module on a chunk, not live-ins to
+    split. Ownership is still bounded: a producer is included only when it is in
+    the same candidate root and every semantic user is also inside this closure.
+    """
+
+    deps: set[fx.Node] = set()
+    work = [inp for node in body for inp in node.all_input_nodes]
+    while work:
+        node = work.pop()
+        if (
+            node in body
+            or node in deps
+            or not _node_depends_on_chunk_symbol(node, symbol_hints)
+        ):
+            continue
+        # Shape scalar helpers do not always carry module FQN metadata, but
+        # they are still part of invoking the selected body when every escaping
+        # user remains in the chunk closure.
+        if node not in candidates and not (
+            node.op == "call_function" and tensor_meta(node) is None
+        ):
+            continue
+        deps.add(node)
+        work.extend(node.all_input_nodes)
+
+    changed = True
+    while changed:
+        changed = False
+        owned = body | deps
+        for dep in tuple(deps):
+            if any(user not in owned and _is_semantic_user(user) for user in dep.users):
+                deps.remove(dep)
+                changed = True
+    return deps
+
+
+def _grad_output_suffix_nodes(
+    gm: fx.GraphModule, grad_escape_boundaries: set[fx.Node]
+) -> set[fx.Node]:
+    """Return post-materialization grad-output plumbing outside chunk bodies."""
+    suffix_nodes: set[fx.Node] = set()
+    for output in _graph_output_nodes(gm)[1:]:
+        node = output
+        seen: set[fx.Node] = set()
+        while (
+            node not in seen
+            and node not in grad_escape_boundaries
+            and tensor_meta(node) is not None
+        ):
+            seen.add(node)
+            suffix_nodes.add(node)
+            inputs = _tensor_inputs(node)
+            if len(inputs) != 1:
+                break
+            node = inputs[0]
+    return suffix_nodes
+
+
+def _semantic_body_closure(body: set[fx.Node]) -> set[fx.Node]:
+    """Keep only nodes needed to produce chunked tensor outputs.
+
+    Symbolic shape helpers are part of the body only when they feed real tensor
+    compute inside the body. Shape-only template chains whose only semantic
+    consumer is a full parent-region allocation should remain full; otherwise
+    the pass would need to "materialize" scalar metadata that has no meaningful
+    chunk reconstruction.
+    """
+    seeds = {
+        node
+        for node in body
+        if _mutates_input(node)
+        or any(user.op == "output" for user in node.users)
+        or (
+            tensor_meta(node) is not None
+            and any(user not in body and _is_semantic_user(user) for user in node.users)
+        )
+    }
+    required: set[fx.Node] = set()
+    work = list(seeds)
+    while work:
+        node = work.pop()
+        if node in required:
+            continue
+        required.add(node)
+        work.extend(inp for inp in node.all_input_nodes if inp in body)
+    return required
+
+
+def _chunk_influenced_region_nodes(
+    gm: fx.GraphModule,
+    candidates: set[fx.Node],
+    is_backward: bool,
+    symbol_hints: dict[object, int],
+    grad_escape_boundaries: set[fx.Node],
+    per_chunk_sources: set[fx.Node],
+) -> tuple[fx.Node, ...]:
+    """Shrink module candidates to the body that must be duplicated per chunk."""
+    influenced: set[fx.Node] = set()
+    for node in gm.graph.nodes:
+        if node not in candidates:
+            continue
+        if not is_backward and any(
+            inp not in candidates
+            and inp.op == "call_function"
+            and tensor_meta(inp) is not None
+            and _is_backward_node(inp)
+            for inp in node.all_input_nodes
+        ):
+            raise ValueError(
+                f"Chunk pass crossed into the opposite graph direction through {node.name}."
+            )
+        if any(
+            inp in influenced
+            or inp in per_chunk_sources
+            or (inp not in candidates and _is_tensor_with_chunk_dim(inp, symbol_hints))
+            for inp in node.all_input_nodes
+        ):
+            influenced.add(node)
+
+    body: set[fx.Node] = set()
+    work = list(influenced)
+    while work:
+        node = work.pop()
+        if node in body:
+            continue
+        body.add(node)
+        work.extend(
+            inp
+            for inp in node.all_input_nodes
+            if inp in candidates and inp in influenced
+        )
+    body |= _owned_chunk_dependencies(body, candidates, symbol_hints)
+    body = _semantic_body_closure(body)
+    if is_backward:
+        body -= _grad_output_suffix_nodes(gm, grad_escape_boundaries)
+    return tuple(node for node in gm.graph.nodes if node in body)
+
+
+def _find_regions(
+    gm: fx.GraphModule,
+    patterns: list[str],
+    *,
+    symbol_hints: dict[object, int],
+    grad_escape_boundaries: set[fx.Node],
+    per_chunk_sources: set[fx.Node],
+) -> list[_Region]:
+    """Build ordered forward/backward regions for all matched roots."""
+    regions = []
+    for matched in _region_roots(gm, patterns):
+        for is_backward in (False, True):
+            nodes = _region_nodes(
+                gm,
+                matched.root_fqn,
+                is_backward=is_backward,
+                symbol_hints=symbol_hints,
+                grad_escape_boundaries=grad_escape_boundaries,
+                per_chunk_sources=per_chunk_sources,
+            )
+            if nodes:
+                regions.append(
+                    _Region(
+                        matched.root_fqn,
+                        matched.synthetic_parent_fqn,
+                        is_backward,
+                        nodes,
+                    )
+                )
+    order = ordered_nodes(gm)
+    return sorted(regions, key=lambda region: order[region.nodes[0]])
+
+
+# Step 1: Populate/prepare the selected dynamic dimension used as chunk truth.
+
+
+def populate_chunk_dim_metadata_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    mode: ChunkMode,
+) -> fx.GraphModule:
+    """Step 1: record selected dynamic symbol hints on placeholders."""
+    del example_inputs
+    if mode not in ("batch", "seq"):
+        raise ValueError(f"Unknown chunk mode: {mode!r}")
+    # The chunk pass uses the selected unbacked SymInt as its only source of
+    # truth. This populate pass records only symbol->hint pairs on placeholders
+    # so later cleanup can concretize exactly the symbols we introduced; it does
+    # not propagate per-node chunk-dimension metadata.
+    symbol_hints: dict[object, int] = chunk_symbol_hints_for_mode(gm, mode)
+    if not symbol_hints:
+        raise ValueError(
+            "ep_overlap graph chunking expected at least one selected dynamic "
+            "placeholder dimension, but none was found."
+        )
+    for node in gm.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        val = tensor_meta(node)
+        node_symbols = (
+            {
+                symbol: hint
+                for symbol, hint in symbol_hints.items()
+                if any(symbol in free_symbols(extent) for extent in val.shape)
+            }
+            if val is not None
+            else {}
+        )
+        if node_symbols:
+            node.meta[CHUNK_SYMBOL_HINTS_META] = node_symbols
+    return gm
+
+
+def mark_chunk_dynamic_dims(tensor: torch.Tensor, *, mode: ChunkMode) -> None:
+    """Step 1: mark the user-selected tensor dimension unbacked with a hint."""
+    from torch._dynamo.decorators import mark_unbacked
+
+    dim = {"batch": 0, "seq": 1}.get(mode)
+    if dim is None:
+        raise ValueError(f"Unknown chunk mode: {mode!r}")
+    if tensor.dim() <= dim:
+        raise ValueError(
+            f"Cannot mark {mode} dim {dim} for shape {tuple(tensor.shape)}."
+        )
+    chunk_dim_shape = int(tensor.shape[dim])
+    if chunk_dim_shape < 2 or chunk_dim_shape % 2:
+        raise ValueError(
+            "EP overlap graph chunking requires an even selected dimension, "
+            f"got {mode} size {chunk_dim_shape} for shape {tuple(tensor.shape)}."
+        )
+    mark_unbacked(
+        tensor,
+        dim,
+        hint_override=chunk_dim_shape,
+        # Graph chunking splits the selected dimension into two equal pieces.
+        # Use the original half-size as the lower bound so downstream shape
+        # checks can still prove non-singleton subchunks after further local
+        # chunking (for example ChunkedCELoss over sequence).
+        min=chunk_dim_shape // 2,
+        max=chunk_dim_shape,
+        specialize_on=[
+            lambda extent, chunk_dim_shape=chunk_dim_shape: extent == chunk_dim_shape
+        ],
+        shape_id=f"torchtitan_chunk_{mode}",
+    )
+
+
+@register_trace_input_preparer("ep_overlap")
+def prepare_ep_overlap_trace_inputs(
+    compile_config: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    """Step 1: prepare trace inputs for graph chunking when EP overlap is enabled."""
+    if not compile_config.ep_overlap.enabled:
+        return
+    mode, chunk_strategy, _ = validate_ep_overlap_config(compile_config.ep_overlap)
+    if chunk_strategy == "eager":
+        return
+    dim = {"batch": 0, "seq": 1}[mode]
+    if not args or not isinstance(args[0], torch.Tensor):
+        raise ValueError("ep_overlap tracing expects first user input to be a Tensor")
+    hint = int(args[0].shape[dim])
+
+    def mark_leaf(value: object) -> None:
+        if (
+            isinstance(value, torch.Tensor)
+            and value.dim() > dim
+            and int(value.shape[dim]) == hint
+        ):
+            # TODO(sanketpurandare): replace this bounded shape-equality
+            # heuristic with explicit token-grid input role metadata.
+            mark_chunk_dynamic_dims(value, mode=mode)
+
+    # The traced training step is `(inputs, labels, global_valid_tokens,
+    # extra_inputs, extra_kwargs)`. Mark only tensors with semantic training
+    # roles tied to the model token grid; skip scalar loss bookkeeping.
+    model_inputs = [args[0]]
+    if len(args) > 1:
+        model_inputs.append(args[1])
+    if len(args) > 3:
+        model_inputs.append(args[3])
+    if len(args) > 4:
+        model_inputs.append(args[4])
+    model_inputs.append(kwargs)
+
+    for leaf in tree_leaves(model_inputs):
+        mark_leaf(leaf)
+
+
+@register_trace_call_input_preparer("ep_overlap")
+def prepare_ep_overlap_trace_call_inputs(
+    compile_config: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]] | None:
+    """Bind FlexAttention mask lengths to fake token-grid dims during tracing."""
+    if not compile_config.ep_overlap.enabled:
+        return None
+    _, chunk_strategy, _ = validate_ep_overlap_config(compile_config.ep_overlap)
+    if chunk_strategy == "eager" or len(args) <= 3 or not isinstance(args[3], dict):
+        return None
+
+    extra_kwargs = args[3]
+    positions = extra_kwargs.get("positions")
+    attention_masks = extra_kwargs.get("attention_masks")
+    if not isinstance(positions, torch.Tensor) or attention_masks is None:
+        return None
+    if positions.dim() < 2:
+        return None
+
+    from torch.nn.attention.flex_attention import BlockMask
+
+    seq_len = positions.shape[1]
+
+    def rebind(mask: object) -> object:
+        if not isinstance(mask, BlockMask):
+            return mask
+        return BlockMask(
+            seq_lengths=(seq_len, seq_len),
+            kv_num_blocks=mask.kv_num_blocks,
+            kv_indices=mask.kv_indices,
+            full_kv_num_blocks=mask.full_kv_num_blocks,
+            full_kv_indices=mask.full_kv_indices,
+            q_num_blocks=mask.q_num_blocks,
+            q_indices=mask.q_indices,
+            full_q_num_blocks=mask.full_q_num_blocks,
+            full_q_indices=mask.full_q_indices,
+            BLOCK_SIZE=mask.BLOCK_SIZE,
+            mask_mod=mask.mask_mod,
+            dq_write_order=mask.dq_write_order,
+            dq_write_order_full=mask.dq_write_order_full,
+            dq_kv_order=mask.dq_kv_order,
+            dq_kv_order_spt=mask.dq_kv_order_spt,
+        )
+
+    if isinstance(attention_masks, dict):
+        rebound_masks = {key: rebind(mask) for key, mask in attention_masks.items()}
+    else:
+        rebound_masks = rebind(attention_masks)
+    if rebound_masks is attention_masks:
+        return None
+
+    rebound_extra_kwargs = dict(extra_kwargs)
+    rebound_extra_kwargs["attention_masks"] = rebound_masks
+    rebound_args = list(args)
+    rebound_args[3] = rebound_extra_kwargs
+    return tuple(rebound_args), kwargs
+
+
+# Step 2: Discover selected-symbol body regions and classify their boundaries.
+
+
+def _chunk_dim_from_symbols(
+    val: torch.Tensor | None, symbol_hints: dict[object, int]
+) -> _ChunkDim | None:
+    """Map the selected unbacked symbol to the tensor dimension it appears in."""
+    if val is None or not symbol_hints:
+        return None
+    matches: list[_ChunkDim] = []
+    for dim, size in enumerate(val.shape):
+        if not (free_symbols(size) & symbol_hints.keys()):
+            continue
+        hint = _eval_hint(size, symbol_hints)
+        matches.append(_ChunkDim(dim, int(hint) if hint is not None else None))
+    if len(matches) > 1:
+        raise ValueError(
+            f"Chunk pass found selected chunk symbols in multiple dims: {tuple(val.shape)}."
+        )
+    return matches[0] if matches else None
+
+
+def _validate_selected_symbol_shapes(gm: fx.GraphModule, *, mode: ChunkMode) -> None:
+    """Check every chunk-created selected-symbol tensor is still classifiable."""
+    symbol_hints = chunk_symbol_hints_for_mode(gm, mode)
+    if not symbol_hints:
+        return
+    for node in gm.graph.nodes:
+        if node.meta.get("chunked_region_role") is None:
+            continue
+        val = tensor_meta(node)
+        if val is None:
+            continue
+        if not any(free_symbols(size) & symbol_hints.keys() for size in val.shape):
+            continue
+        if _chunk_dim_from_symbols(val, symbol_hints) is None:
+            raise ValueError(
+                "Chunk pass could not classify selected-symbol shape for "
+                f"{node.name}: {tuple(val.shape)}."
+            )
+
+
+def _chunk_dim_for_live_in(node: fx.Node, symbol_hints: dict[object, int]) -> int:
+    dim_hint = _chunk_dim_from_symbols(tensor_meta(node), symbol_hints)
+    val = tensor_meta(node)
+    if dim_hint is None or val is None:
+        raise ValueError(f"{node.name} does not carry the selected chunk symbol.")
+    dim, hint = dim_hint.dim, dim_hint.hint
+    if dim >= val.dim():
+        raise ValueError(f"Selected chunk dim {dim} is invalid for {node.name}.")
+    if hint is not None and hint % 2:
+        raise ValueError(
+            f"Cannot split selected chunk dimension of {node.name}: {hint}."
+        )
+    return dim
+
+
+def _split_view_meta(val: torch.Tensor, dim: int) -> torch.Tensor:
+    shape = list(val.shape)
+    shape[dim] = shape[dim] // 2
+    return val.new_empty_strided(tuple(shape), val.stride())
+
+
+def _contiguous_chunk_meta(val: torch.Tensor, dim: int) -> torch.Tensor:
+    shape = list(val.shape)
+    shape[dim] = shape[dim] // 2
+    return val.new_empty(tuple(shape))
+
+
+def _is_contiguous_with_hints(
+    val: torch.Tensor, symbol_hints: dict[object, int]
+) -> bool:
+    """Return contiguity using explicit hints instead of symbolic guards."""
+    expected_stride = 1
+    for size, stride in reversed(tuple(zip(val.shape, val.stride(), strict=True))):
+        size_hint = _eval_hint(size, symbol_hints)
+        stride_hint = _eval_hint(stride, symbol_hints)
+        if size_hint is None or stride_hint is None:
+            return False
+        if size_hint == 1:
+            continue
+        if stride_hint != expected_stride:
+            return False
+        expected_stride *= size_hint
+    return True
+
+
+def _is_chunkable(
+    node: fx.Node,
+    *,
+    mode: ChunkMode,
+    static_nodes: set[fx.Node],
+    symbol_hints: dict[object, int],
+) -> bool:
+    if node in static_nodes or tensor_meta(node) is None:
+        return False
+    if not _is_tensor_with_chunk_dim(node, symbol_hints):
+        return False
+    _chunk_dim_for_live_in(node, symbol_hints)
+    return True
+
+
+def _is_tensor_with_chunk_dim(node: fx.Node, symbol_hints: dict[object, int]) -> bool:
+    return _chunk_dim_from_symbols(tensor_meta(node), symbol_hints) is not None
+
+
+def _chunk_symbol_subs(symbol_hints: dict[object, int]) -> dict[object, object]:
+    return {symbol: FloorDiv(symbol, 2) for symbol in symbol_hints}
+
+
+def _materialize_symint_args(
+    gm: fx.GraphModule,
+    values: list[torch.SymInt | int] | tuple[torch.SymInt | int, ...],
+    *,
+    region: _Region,
+    role: str,
+    chunk_id: int | None = None,
+) -> list[fx.Node | int]:
+    """Materialize symbolic scalar args as FX nodes at the current insertion point."""
+    before = set(gm.graph.nodes)
+    materialized = gm.graph.materialize_symints(values)
+    for node in gm.graph.nodes:
+        if node not in before:
+            _set_synthetic_meta(node, region=region, role=role, chunk_id=chunk_id)
+    return materialized
+
+
+def _materialize_symint_arg(
+    gm: fx.GraphModule,
+    value: torch.SymInt | int,
+    *,
+    region: _Region,
+    role: str,
+    chunk_id: int | None = None,
+) -> fx.Node | int:
+    return _materialize_symint_args(
+        gm, [value], region=region, role=role, chunk_id=chunk_id
+    )[0]
+
+
+def _create_size_or_stride_node(
+    gm: fx.GraphModule,
+    target: object,
+    tensor_node: fx.Node,
+    dim: int,
+    *,
+    region: _Region,
+    role: str,
+    chunk_id: int | None = None,
+) -> fx.Node:
+    if target is aten.sym_size.int:
+        node = gm.graph.create_size_node(tensor_node, dim)
+    elif target is aten.sym_stride.int:
+        node = gm.graph.create_stride_node(tensor_node, dim)
+    else:
+        raise ValueError(f"Unsupported symbolic tensor property target: {target}.")
+    _set_synthetic_meta(node, region=region, role=role, chunk_id=chunk_id)
+    return node
+
+
+def _create_half_extent_node(
+    gm: fx.GraphModule, live_in: fx.Node, dim: int, *, region: _Region
+) -> tuple[fx.Node, fx.Node]:
+    size = gm.graph.create_size_node(live_in, dim)
+    _set_synthetic_meta(size, region=region, role="split_boundary")
+    half = gm.graph.call_function(operator.floordiv, args=(size, 2))
+    _set_synthetic_meta(half, region=region, role="chunk_input")
+    val = tensor_meta(live_in)
+    if val is not None:
+        half.meta["val"] = val.shape[dim] // 2
+    return size, half
+
+
+def _rewrite_chunk_symint(
+    value: object,
+    symbol_hints: dict[object, int],
+) -> object:
+    return _rewrite_symbolic_value(
+        value, _chunk_symbol_subs(symbol_hints), symbol_hints
+    )
+
+
+def _rewrite_symbolic_value(
+    value: object,
+    symbol_subs: dict[object, object],
+    symbol_hints: dict[object, int],
+) -> object:
+    symbols = free_symbols(value)
+    if not symbols or not (symbols & symbol_subs.keys()):
+        return value
+    if not hasattr(value, "node"):
+        return value.subs(symbol_subs) if hasattr(value, "subs") else value
+
+    expr = value.node.expr.subs(symbol_subs)
+    shape_env = value.node.shape_env
+    hint = _eval_hint(expr, symbol_hints)
+    if isinstance(value, torch.SymInt):
+        return shape_env.create_symintnode(expr, hint=hint)
+    if isinstance(value, torch.SymFloat):
+        return shape_env.create_symfloatnode(expr, hint=hint)
+    if isinstance(value, torch.SymBool):
+        return shape_env.create_symboolnode(expr)
+    return value
+
+
+def _symbolic_scalars(value: object) -> list[object]:
+    scalars = []
+    for leaf in tree_leaves(value):
+        if isinstance(leaf, torch.Tensor):
+            scalars.extend((*leaf.shape, *leaf.stride(), leaf.storage_offset()))
+        else:
+            scalars.append(leaf)
+    return scalars
+
+
+def _shape_env_for_symbol(meta: dict[str, Any], symbol: sympy.Symbol) -> object:
+    for scalar in _symbolic_scalars(meta.get("val")):
+        if hasattr(scalar, "node") and symbol in free_symbols(scalar):
+            return scalar.node.shape_env
+    raise ValueError(
+        "Chunk pass found an unbacked binding whose symbol is not present in "
+        f"the node metadata value: {symbol}."
+    )
+
+
+def _symbol_has_selected_runtime_assert(
+    shape_env: object,
+    symbol: sympy.Symbol,
+    symbol_hints: dict[object, int],
+) -> bool:
+    for runtime_assert in getattr(shape_env, "deferred_runtime_asserts", {}).get(
+        symbol, ()
+    ):
+        expr = getattr(runtime_assert, "expr", runtime_assert)
+        if free_symbols(expr) & symbol_hints.keys():
+            return True
+    return False
+
+
+def _hint_for_copied_unbacked_symbol(
+    shape_env: object,
+    symbol: sympy.Symbol,
+    hint: int,
+    symbol_hints: dict[object, int],
+) -> int:
+    if not _symbol_has_selected_runtime_assert(shape_env, symbol, symbol_hints):
+        return hint
+    # The copied scalar is constrained by a value whose selected dimension was
+    # split by this pass, so its representative value must be chunk-local too.
+    return max(1, (hint + 1) // 2)
+
+
+def _fresh_unbacked_symbol_for_copy(
+    shape_env: object,
+    symbol: sympy.Symbol,
+    symbol_hints: dict[object, int],
+) -> sympy.Symbol:
+    symint = shape_env.create_unbacked_symint()
+    new_symbol = symint.node.expr
+    # This pass is cloning metadata, not running a fake kernel. The new symbol
+    # is immediately bound through copied node.meta["unbacked_bindings"].
+    if new_symbol in shape_env.pending_fresh_unbacked_symbols:
+        shape_env.pending_fresh_unbacked_symbols.remove(new_symbol)
+    if symbol in shape_env.var_to_range:
+        shape_env.var_to_range[new_symbol] = shape_env.var_to_range[symbol]
+    if symbol in shape_env.var_to_range_sloc:
+        shape_env.var_to_range_sloc[new_symbol] = shape_env.var_to_range_sloc[symbol]
+    if symbol in shape_env.var_to_hint_override:
+        hint = shape_env.var_to_hint_override[symbol]
+        shape_env.var_to_hint_override[new_symbol] = _hint_for_copied_unbacked_symbol(
+            shape_env, symbol, hint, symbol_hints
+        )
+    if symbol in shape_env.size_like:
+        shape_env.size_like.add(new_symbol)
+    return new_symbol
+
+
+def _rewrite_unbacked_keypath(
+    keypath: tuple[object, ...],
+    symbol_subs: dict[object, object],
+    symbol_hints: dict[object, int],
+) -> tuple[object, ...]:
+    from torch.fx.experimental.symbolic_shapes import DivideByKey
+
+    rewritten = []
+    for key in keypath:
+        if isinstance(key, DivideByKey):
+            rewritten.append(
+                DivideByKey(
+                    _rewrite_symbolic_value(key.divisor, symbol_subs, symbol_hints)
+                )
+            )
+        else:
+            rewritten.append(key)
+    return tuple(rewritten)
+
+
+def _freshen_copied_unbacked_bindings(
+    copied_meta: dict[str, Any],
+    symbol_replacements: dict[object, object],
+    symbol_hints: dict[object, int],
+) -> None:
+    bindings = copied_meta.get("unbacked_bindings")
+    if not bindings:
+        return
+
+    fresh_bindings = {}
+    for symbol, keypath in bindings.items():
+        shape_env = _shape_env_for_symbol(copied_meta, symbol)
+        new_symbol = _fresh_unbacked_symbol_for_copy(shape_env, symbol, symbol_hints)
+        symbol_replacements[symbol] = new_symbol
+        fresh_bindings[new_symbol] = keypath
+    copied_meta["unbacked_bindings"] = fresh_bindings
+
+
+def _chunk_tensor_meta(
+    val: torch.Tensor,
+    symbol_hints: dict[object, int],
+    symbol_replacements: dict[object, object] | None = None,
+) -> torch.Tensor:
+    symbol_subs = {
+        **(symbol_replacements or {}),
+        **_chunk_symbol_subs(symbol_hints),
+    }
+    if not any(
+        free_symbols(size_or_stride) & symbol_subs.keys()
+        for size_or_stride in (*val.shape, *val.stride(), val.storage_offset())
+    ):
+        return val
+    shape = tuple(
+        _rewrite_symbolic_value(dim, symbol_subs, symbol_hints) for dim in val.shape
+    )
+    stride = tuple(
+        _rewrite_symbolic_value(dim, symbol_subs, symbol_hints) for dim in val.stride()
+    )
+    return val.new_empty_strided(shape, stride)
+
+
+def _chunk_meta_value(
+    value: object,
+    symbol_hints: dict[object, int],
+    symbol_replacements: dict[object, object],
+) -> object:
+    if isinstance(value, torch.Tensor):
+        return _chunk_tensor_meta(value, symbol_hints, symbol_replacements)
+    if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        symbol_subs = {**symbol_replacements, **_chunk_symbol_subs(symbol_hints)}
+        return _rewrite_symbolic_value(value, symbol_subs, symbol_hints)
+    return value
+
+
+def _chunk_copied_meta(
+    meta: dict[str, Any],
+    symbol_hints: dict[object, int],
+    symbol_replacements: dict[object, object] | None = None,
+) -> dict[str, Any]:
+    symbol_replacements = symbol_replacements if symbol_replacements is not None else {}
+    copied = _copy_meta(meta)
+    _freshen_copied_unbacked_bindings(copied, symbol_replacements, symbol_hints)
+    symbol_subs = {**symbol_replacements, **_chunk_symbol_subs(symbol_hints)}
+    if "unbacked_bindings" in copied:
+        copied["unbacked_bindings"] = {
+            symbol: _rewrite_unbacked_keypath(tuple(keypath), symbol_subs, symbol_hints)
+            for symbol, keypath in copied["unbacked_bindings"].items()
+        }
+    if "val" in copied:
+        copied["val"] = tree_map(
+            lambda value: _chunk_meta_value(value, symbol_hints, symbol_replacements),
+            copied["val"],
+        )
+    return copied
+
+
+def _validate_materialized(
+    materialized: fx.Node,
+    original: fx.Node,
+    *,
+    original_val: torch.Tensor | None = None,
+    symbol_hints: dict[object, int],
+) -> None:
+    """Verify a materialized full value matches the original fake shape."""
+    mat_val, orig_val = tensor_meta(materialized), tensor_meta(original)
+    orig_val = original_val if original_val is not None else orig_val
+    if (
+        mat_val is not None
+        and orig_val is not None
+        and not same_shape_with_hints(mat_val, orig_val, original, symbol_hints)
+    ):
+        raise RuntimeError(
+            f"Chunk pass materialized {materialized.name} with shape "
+            f"{tuple(mat_val.shape)}, expected {tuple(orig_val.shape)} from {original.name}."
+        )
+
+
+def _graph_output_nodes(gm: fx.GraphModule) -> list[fx.Node]:
+    output = next(node for node in gm.graph.nodes if node.op == "output")
+    return [leaf for leaf in tree_leaves(output.args[0]) if isinstance(leaf, fx.Node)]
+
+
+def _tensor_inputs(node: fx.Node) -> list[fx.Node]:
+    return [inp for inp in node.all_input_nodes if tensor_meta(inp) is not None]
+
+
+def _is_shape_preserving_reduction(
+    node: fx.Node, symbol_hints: dict[object, int]
+) -> bool:
+    if node.target is torch.ops._c10d_functional.all_reduce.default:
+        return True
+    if node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default:
+        inputs = _tensor_inputs(node)
+        node_val = tensor_meta(node)
+        input_val = tensor_meta(inputs[0]) if len(inputs) == 1 else None
+        return (
+            node_val is not None
+            and input_val is not None
+            and same_shape_with_hints(node_val, input_val, node, symbol_hints)
+        )
+    return node.target is torch.ops._c10d_functional.wait_tensor.default
+
+
+def _is_materialization_suffix_node(
+    node: fx.Node,
+    *,
+    optimize_grad_live_out: bool,
+    symbol_hints: dict[object, int],
+) -> bool:
+    del optimize_grad_live_out
+    if node.op != "call_function" or len(_tensor_inputs(node)) != 1:
+        return False
+    if is_view_target(node.target) or _is_shape_preserving_reduction(
+        node, symbol_hints
+    ):
+        return True
+    # Dtype/device casts are intentional materialization boundaries.  We still
+    # materialize the collective suffix once, but we do not move accumulation before
+    # casts because that changes eager chunking's cast/add order.
+    return False
+
+
+def _materialization_boundary(
+    live_out: fx.Node,
+    *,
+    plan: _Plan,
+    optimize_grad_live_out: bool,
+    symbol_hints: dict[object, int],
+) -> _MaterializationBoundary:
+    """Choose the earliest safe boundary before materializing a grad suffix once."""
+    if not plan.region.is_backward or not optimize_grad_live_out:
+        return _MaterializationBoundary(live_out, ())
+    suffix: list[fx.Node] = []
+    node = live_out
+    while node in plan.body and _is_materialization_suffix_node(
+        node,
+        optimize_grad_live_out=optimize_grad_live_out,
+        symbol_hints=symbol_hints,
+    ):
+        inputs = _tensor_inputs(node)
+        assert len(inputs) == 1
+        inp = inputs[0]
+        # Keep this optimization chain-local. Branches are real compute or
+        # accumulation points and must be handled by the normal live-out logic.
+        if any(user is not node and user in plan.body for user in inp.users):
+            break
+        suffix.append(node)
+        node = inp
+    return _MaterializationBoundary(node, tuple(reversed(suffix)))
+
+
+def _grad_escape_boundaries(
+    gm: fx.GraphModule,
+    *,
+    mode: ChunkMode,
+    symbol_hints: dict[object, int],
+    optimize_grad_live_out: bool,
+) -> set[fx.Node]:
+    """Step 2: identify backward no-chunk-dim grad escape boundaries."""
+    del mode, optimize_grad_live_out
+    boundaries: set[fx.Node] = set()
+    # GraphTrainer returns [loss, *param_grads]. The loss is not a grad escape
+    # path; each remaining output is authoritative evidence for one grad escape
+    # path. Optimized graph chunking walks through single-input grad plumbing to
+    # the first no-chunk-dim producer, so casts and distributed grad
+    # materialization remain outside the chunk body. Dtype/device-domain changes
+    # are always boundaries; moving accumulation across them changes eager
+    # chunking's exact cast/add order.
+    for output in _graph_output_nodes(gm)[1:]:
+        if tensor_meta(output) is None or _is_tensor_with_chunk_dim(
+            output, symbol_hints
+        ):
+            continue
+        node = output
+        seen: set[fx.Node] = set()
+        while node not in seen and tensor_meta(node) is not None:
+            seen.add(node)
+            inputs = _tensor_inputs(node)
+            if len(inputs) != 1:
+                boundaries.add(node)
+                break
+            inp = inputs[0]
+            if _is_tensor_with_chunk_dim(inp, symbol_hints):
+                boundaries.add(node)
+                break
+            if not same_tensor_domain(node, inp):
+                boundaries.add(node)
+                break
+            node = inp
+    return boundaries
+
+
+# Step 2 continued: build concrete region plans.
+
+
+def _plan_regions(
+    gm: fx.GraphModule,
+    patterns: list[str],
+    *,
+    mode: ChunkMode,
+    optimize_grad_live_out: bool,
+    per_chunk_sources: set[fx.Node] | None = None,
+) -> list[_Plan]:
+    """Step 2: plan all selected regions before lowering one direction."""
+    symbol_hints = chunk_symbol_hints_for_mode(gm, mode)
+    grad_escape_boundaries = _grad_escape_boundaries(
+        gm,
+        mode=mode,
+        symbol_hints=symbol_hints,
+        optimize_grad_live_out=optimize_grad_live_out,
+    )
+    per_chunk_sources = per_chunk_sources or set()
+    plans = []
+    for region in _find_regions(
+        gm,
+        patterns,
+        symbol_hints=symbol_hints,
+        grad_escape_boundaries=grad_escape_boundaries,
+        per_chunk_sources=per_chunk_sources,
+    ):
+        plans.append(_build_plan(region, grad_escape_boundaries))
+    logger.debug(
+        "Chunk pass planned %d region(s): mode=%s patterns=%s "
+        "grad_escape_boundaries=%d per_chunk_sources=%d",
+        len(plans),
+        mode,
+        patterns,
+        len(grad_escape_boundaries),
+        len(per_chunk_sources),
+    )
+    return plans
+
+
+def _build_plan(
+    region: _Region, grad_escape_boundaries: set[fx.Node] | frozenset[fx.Node]
+) -> _Plan:
+    """Step 2: compute live-ins and live-outs for the current graph."""
+    body = frozenset(region.nodes)
+    live_ins = frozenset(
+        inp for node in region.nodes for inp in node.all_input_nodes if inp not in body
+    )
+    live_out_users = {}
+    for node in region.nodes:
+        users = tuple(
+            user for user in node.users if user not in body and _is_semantic_user(user)
+        )
+        if users:
+            live_out_users[node] = users
+    return _Plan(
+        region, body, live_ins, live_out_users, frozenset(grad_escape_boundaries)
+    )
+
+
+def _map_arg(
+    arg: object,
+    *,
+    copied: dict[fx.Node, fx.Node],
+    chunks: dict[fx.Node, tuple[fx.Node, fx.Node]],
+    scalars: dict[object, object],
+    symbol_replacements: dict[object, object],
+    symbol_hints: dict[object, int],
+    chunk_id: int,
+    map_symbolic_exprs: bool = False,
+) -> object:
+    """Map original node/scalar arguments to the selected chunk equivalents."""
+
+    def scalar_for_chunk(value: object) -> object:
+        if (
+            isinstance(value, tuple)
+            and len(value) == 2
+            and all(isinstance(item, fx.Node) for item in value)
+        ):
+            return value[chunk_id]
+        return value
+
+    if isinstance(arg, fx.Node):
+        if arg in copied:
+            return copied[arg]
+        if arg in chunks:
+            return chunks[arg][chunk_id]
+        if arg in scalars:
+            return scalar_for_chunk(scalars[arg])
+        return arg
+    if not map_symbolic_exprs:
+        return arg
+    if isinstance(arg, torch.SymInt):
+        expr = arg.node.expr
+    elif hasattr(arg, "free_symbols"):
+        expr = arg
+    else:
+        return arg
+    symbols = free_symbols(arg)
+    if len(symbols) == 1:
+        if expr_key(expr) in scalars:
+            return scalar_for_chunk(scalars[expr_key(expr)])
+    symbol_subs = {**symbol_replacements, **_chunk_symbol_subs(symbol_hints)}
+    return _rewrite_symbolic_value(arg, symbol_subs, symbol_hints)
+
+
+# Step 4 helper definitions: shape-copy helpers are defined before Step 3
+# lowering because live-in splitting and body copying both use them.
+
+
+def _linear_extent_coeff(
+    value: object, symbols: set[object]
+) -> tuple[object, int] | None:
+    value_symbols = free_symbols(value)
+    if len(value_symbols) != 1 or not value_symbols <= symbols:
+        return None
+    symbol = next(iter(value_symbols))
+    expr = symbolic_expr(value)
+    try:
+        zero = expr.subs(symbol, 0)
+        one = expr.subs(symbol, 1)
+        if free_symbols(zero):
+            return None
+        coeff = int(one - zero)
+        if int(zero) != 0 or coeff <= 0:
+            return None
+        return symbol, coeff
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return None
+
+
+def _is_contiguous_chunk_input_stride(
+    value: object,
+    split_live_ins: list[fx.Node],
+    symbol_hints: dict[object, int],
+) -> bool:
+    """Return whether ``value`` is a stride from the contiguous chunk input."""
+    for live_in in split_live_ins:
+        val = tensor_meta(live_in)
+        if val is None:
+            continue
+        dim_hint = _chunk_dim_from_symbols(val, symbol_hints)
+        if dim_hint is None:
+            continue
+        chunk_val = _contiguous_chunk_meta(val, dim_hint.dim)
+        if any(same_symbolic_expr(value, stride) for stride in chunk_val.stride()):
+            return True
+    return False
+
+
+def _shape_arg_depends_on_chunk_symbol(
+    shape_arg: object, symbol_hints: dict[object, int]
+) -> bool:
+    for item in tree_leaves(shape_arg):
+        if isinstance(item, fx.Node):
+            if depends_on_chunk_symbol(item.meta.get("val"), symbol_hints):
+                return True
+        elif depends_on_chunk_symbol(item, symbol_hints):
+            return True
+    return False
+
+
+def _source_stack(node: fx.Node) -> str:
+    stack = getattr(node, "stack_trace", None) or node.meta.get("stack_trace")
+    return stack if isinstance(stack, str) and stack else "<source stack unavailable>"
+
+
+def _validate_view_shape_uses_symbolic_extent(
+    node: fx.Node,
+    args: tuple[Any, ...],
+    *,
+    original_meta: dict[str, Any],
+    symbol_hints: dict[object, int],
+) -> None:
+    """Reject baked Python shape constants in chunk-influenced view ops."""
+    shape_arg_idx = view_shape_arg_index(node.target)
+    if shape_arg_idx is None or len(args) <= shape_arg_idx:
+        return
+    size_arg = args[shape_arg_idx]
+    original_output_val = original_meta.get("val")
+    if (
+        not isinstance(original_output_val, torch.Tensor)
+        or not isinstance(size_arg, (list, tuple))
+        or any(dim == -1 for dim in size_arg)
+        or _chunk_dim_from_symbols(original_output_val, symbol_hints) is None
+        or _shape_arg_depends_on_chunk_symbol(size_arg, symbol_hints)
+    ):
+        return
+
+    target = getattr(node.target, "__name__", str(node.target))
+    module_fqn = _get_module_fqn(node)
+    raise ValueError(
+        "Graph EP chunking found a view/reshape shape that baked a Python "
+        "constant where the selected unbacked SymInt extent should flow. "
+        f"node={node.name}, target={target}, module_fqn={module_fqn!r}, "
+        f"shape_arg={tuple(size_arg)}, output_shape={tuple(original_output_val.shape)}.\n"
+        "Use tensor-derived shape values such as x.shape[i] / x.size(i), or "
+        "use -1 when this dimension should be inferred by view/reshape.\n"
+        f"Source stack:\n{_source_stack(node)}"
+    )
+
+
+def _copy_body(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    *,
+    chunks: dict[fx.Node, tuple[fx.Node, fx.Node]],
+    scalars: dict[object, object],
+    symbol_hints: dict[object, int],
+    mode: ChunkMode,
+    chunk_id: int,
+    originals: dict[
+        fx.Node, tuple[tuple[Any, ...], dict[str, Any], dict[str, Any], str]
+    ],
+    in_place: bool,
+    prior_chunk_copies: dict[fx.Node, fx.Node] | None = None,
+    preserve_originals: set[fx.Node] | None = None,
+) -> dict[fx.Node, fx.Node]:
+    """Step 4: rewrite/copy one chunk body with remapped args and metadata."""
+    preserve_originals = preserve_originals or set()
+    copied: dict[fx.Node, fx.Node] = {}
+    symbol_replacements: dict[object, object] = {}
+
+    def materialize_raw_chunk_symbol_arg(arg: object, *, chunk_id: int) -> object:
+        if not isinstance(arg, torch.SymInt):
+            return arg
+        if not (free_symbols(arg) & symbol_hints.keys()):
+            return arg
+        chunked = _rewrite_chunk_symint(arg, symbol_hints)
+        if not isinstance(chunked, torch.SymInt):
+            return chunked
+        return _materialize_symint_arg(
+            gm,
+            chunked,
+            region=plan.region,
+            role="chunk_input",
+            chunk_id=chunk_id,
+        )
+
+    for node in plan.region.nodes:
+        args, kwargs, meta, name = originals[node]
+        insert_before = (
+            node if in_place and node not in preserve_originals else node.next
+        )
+        with gm.graph.inserting_before(insert_before):
+            new_args = tree_map(
+                lambda arg: _map_arg(
+                    arg,
+                    copied=copied,
+                    chunks=chunks,
+                    scalars=scalars,
+                    symbol_replacements=symbol_replacements,
+                    symbol_hints=symbol_hints,
+                    chunk_id=chunk_id,
+                    map_symbolic_exprs=True,
+                ),
+                args,
+            )
+            new_kwargs = tree_map(
+                lambda arg: _map_arg(
+                    arg,
+                    copied=copied,
+                    chunks=chunks,
+                    scalars=scalars,
+                    symbol_replacements=symbol_replacements,
+                    symbol_hints=symbol_hints,
+                    chunk_id=chunk_id,
+                    map_symbolic_exprs=True,
+                ),
+                kwargs,
+            )
+            new_args = tree_map(
+                lambda arg: materialize_raw_chunk_symbol_arg(arg, chunk_id=chunk_id),
+                new_args,
+            )
+            new_kwargs = tree_map(
+                lambda arg: materialize_raw_chunk_symbol_arg(arg, chunk_id=chunk_id),
+                new_kwargs,
+            )
+            if isinstance(new_args, tuple):
+                _validate_view_shape_uses_symbolic_extent(
+                    node,
+                    new_args,
+                    original_meta=meta,
+                    symbol_hints=symbol_hints,
+                )
+            if (
+                prior_chunk_copies is not None
+                and node in prior_chunk_copies
+                and isinstance(args, tuple)
+                and isinstance(new_args, tuple)
+            ):
+                mutable_indices = [
+                    idx
+                    for idx in _mutable_arg_indices(node)
+                    if idx < len(args)
+                    and idx < len(new_args)
+                    and isinstance(args[idx], fx.Node)
+                    and args[idx] not in copied
+                ]
+                if mutable_indices:
+                    if len(mutable_indices) != 1:
+                        raise ValueError(
+                            "Graph EP chunking only supports duplicated mutable ops "
+                            "with one schema-declared mutable positional input. "
+                            f"Found mutable arg indices {mutable_indices} on "
+                            f"{node.name} ({node.target})."
+                        )
+                    # Match eager chunking for shared mutable live-ins such as MoE
+                    # token-count buffers: later chunks consume earlier chunks'
+                    # mutation results through the schema-declared write aliases.
+                    updated_args = list(new_args)
+                    for idx in mutable_indices:
+                        updated_args[idx] = prior_chunk_copies[node]
+                    new_args = tuple(updated_args)
+            if in_place and node not in preserve_originals:
+                new_node = node
+                new_node.args = new_args
+                new_node.kwargs = new_kwargs
+            else:
+                new_node = gm.graph.create_node(
+                    node.op, node.target, new_args, new_kwargs, type_expr=node.type
+                )
+        new_node._rename(f"{name}_chunk{chunk_id}")
+        new_node.meta = _chunk_copied_meta(meta, symbol_hints, symbol_replacements)
+        _set_chunk_meta(
+            new_node,
+            region=plan.region,
+            role="body",
+            chunk_id=chunk_id,
+        )
+        new_node.meta["chunked_original_name"] = name
+        copied[node] = new_node
+    return copied
+
+
+def _validate_no_raw_chunk_symbol_args(
+    gm: fx.GraphModule, symbol_hints: dict[object, int]
+) -> None:
+    """Reject chunk-created executable args that still embed selected SymInts."""
+    if not symbol_hints:
+        return
+    chunk_symbols = symbol_hints.keys()
+    for node in gm.graph.nodes:
+        if node.meta.get("chunked_region_role") is None:
+            continue
+        for value in tree_leaves((node.args, node.kwargs)):
+            if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)) and (
+                free_symbols(value) & chunk_symbols
+            ):
+                raise ValueError(
+                    "Graph EP chunking left a raw selected symbolic scalar in "
+                    f"executable args for {node.name}: {value}."
+                )
+
+
+# Step 3: Split live-ins and recover provenance.
+
+
+def _split_live_ins(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    *,
+    mode: ChunkMode,
+    static_nodes: set[fx.Node],
+    per_chunk: dict[fx.Node, tuple[fx.Node, fx.Node]],
+) -> tuple[
+    dict[fx.Node, tuple[fx.Node, fx.Node]], dict[object, object], dict[object, int]
+]:
+    """Step 3: split chunked live-ins or recover existing provenance chunks."""
+    order = ordered_nodes(gm)
+    chunks = {
+        node: values for node, values in per_chunk.items() if node in plan.live_ins
+    }
+    chunked_by_origin = {
+        (
+            node.meta.get("chunked_region_fqn"),
+            node.meta.get("chunked_region_is_backward"),
+            node.meta.get("chunked_original_name"),
+            node.meta.get("chunk_id"),
+        ): node
+        for node in gm.graph.nodes
+        if node.meta.get("chunked_original_name") is not None
+        and node.meta.get("chunk_id") in (0, 1)
+    }
+    for live_in in plan.live_ins:
+        if live_in in chunks:
+            continue
+        key = (
+            live_in.meta.get("chunked_region_fqn"),
+            live_in.meta.get("chunked_region_is_backward"),
+            live_in.meta.get("chunked_original_name"),
+        )
+        if key[0] is not None and key[2] is not None:
+            node0 = chunked_by_origin.get((*key, 0))
+            node1 = chunked_by_origin.get((*key, 1))
+            if isinstance(node0, fx.Node) and isinstance(node1, fx.Node):
+                chunks[live_in] = (node0, node1)
+    scalars: dict[object, object] = {}
+    symbol_hints = chunk_symbol_hints_for_mode(gm, mode)
+    selected_symbols: set[object] = set(symbol_hints)
+    split_live_ins = [
+        live_in
+        for live_in in plan.live_ins
+        if live_in not in chunks
+        and _is_chunkable(
+            live_in,
+            mode=mode,
+            static_nodes=static_nodes,
+            symbol_hints=symbol_hints,
+        )
+    ]
+    for live_in in plan.live_ins:
+        if (
+            not plan.region.is_backward
+            and live_in.op == "call_function"
+            and live_in not in chunks
+            and (live_in_val := tensor_meta(live_in)) is not None
+            and live_in_val.dim() > 0
+            and _is_backward_node(live_in)
+        ):
+            raise ValueError(
+                "Chunk pass crossed into the opposite graph direction through "
+                f"live-in {live_in.name} for region {plan.region.root_fqn!r}."
+            )
+    if not split_live_ins and not chunks:
+        raise ValueError(
+            f"Chunk pass found no chunkable activation live-ins for "
+            f"{plan.region.root_fqn!r}."
+        )
+    logger.debug(
+        "Chunk pass live-ins: root=%s direction=%s live_ins=%d split=%d provenance=%d",
+        plan.region.root_fqn,
+        "backward" if plan.region.is_backward else "forward",
+        len(plan.live_ins),
+        len(split_live_ins),
+        len(chunks),
+    )
+
+    def first_body_user(node: fx.Node) -> fx.Node:
+        return min((user for user in node.users if user in plan.body), key=order.get)
+
+    def first_chunk_symbol_consumer(node: fx.Node) -> fx.Node:
+        def value_depends_on_chunk_symbol(value: object) -> bool:
+            if isinstance(value, fx.Node):
+                return _node_depends_on_chunk_symbol(value, symbol_hints)
+            return depends_on_chunk_symbol(value, symbol_hints)
+
+        consumers = [
+            body_node
+            for body_node in plan.region.nodes
+            if body_node in plan.body
+            and order[body_node] > order[node]
+            and (
+                node in body_node.all_input_nodes
+                or any(
+                    value_depends_on_chunk_symbol(value)
+                    for value in tree_leaves((body_node.args, body_node.kwargs))
+                )
+            )
+        ]
+        return min(consumers, key=order.get)
+
+    for live_in in sorted(split_live_ins, key=order.get):
+        dim = _chunk_dim_for_live_in(live_in, symbol_hints)
+        val = tensor_meta(live_in)
+        assert val is not None
+        with gm.graph.inserting_before(first_chunk_symbol_consumer(live_in)):
+            _, half = _create_half_extent_node(gm, live_in, dim, region=plan.region)
+            scalars[expr_key(val.shape[dim])] = half
+            # Do not promote every symbol in a flattened extent to a chunk
+            # symbol. For seq chunking, token extents can contain batch*seq;
+            # only the user-selected seq symbol should drive scalar rewrites.
+        with gm.graph.inserting_before(first_chunk_symbol_consumer(live_in)):
+            split = gm.graph.call_function(
+                aten.split_with_sizes.default,
+                args=(live_in, [half, half], dim),
+            )
+            _set_synthetic_meta(split, region=plan.region, role="split_boundary")
+            get0 = gm.graph.call_function(operator.getitem, args=(split, 0))
+            get1 = gm.graph.call_function(operator.getitem, args=(split, 1))
+            for chunk_id, get in ((0, get0), (1, get1)):
+                _set_synthetic_meta(
+                    get,
+                    region=plan.region,
+                    role="split_boundary",
+                    chunk_id=chunk_id,
+                )
+                get.meta["val"] = _split_view_meta(val, dim)
+            # Match eager ``chunk.contiguous()`` exactly: clone only when the
+            # split view is non-contiguous. Batch splits are often already
+            # contiguous, and forcing a clone there changes bitwise numerics.
+            contig_chunks = []
+            for chunk_id, get in ((0, get0), (1, get1)):
+                split_val = tensor_meta(get)
+                if split_val is not None and _is_contiguous_with_hints(
+                    split_val, symbol_hints
+                ):
+                    contig_chunks.append(get)
+                    continue
+                contig = gm.graph.call_function(
+                    aten.clone.default,
+                    args=(get,),
+                    kwargs={"memory_format": torch.contiguous_format},
+                )
+                _set_synthetic_meta(
+                    contig,
+                    region=plan.region,
+                    role="chunk_input",
+                    chunk_id=chunk_id,
+                )
+                contig.meta["val"] = _contiguous_chunk_meta(val, dim)
+                contig_chunks.append(contig)
+            chunks[live_in] = (contig_chunks[0], contig_chunks[1])
+
+    for live_in in sorted(plan.live_ins, key=order.get):
+        if live_in in chunks or live_in in scalars:
+            continue
+        val = live_in.meta.get("val")
+        if isinstance(val, torch.SymInt):
+            expr = val.node.expr
+        elif hasattr(val, "free_symbols"):
+            expr = val
+        else:
+            continue
+        symbols = free_symbols(val)
+        if not symbols:
+            continue
+        if not symbols & selected_symbols:
+            continue
+        if (
+            live_in.op == "call_function"
+            and live_in.target in (aten.sym_size.int, aten.sym_stride.int)
+            and len(live_in.args) >= 2
+            and isinstance(live_in.args[0], fx.Node)
+            and live_in.args[0] in chunks
+            and isinstance(live_in.args[1], int)
+        ):
+            source, prop_dim = live_in.args[:2]
+            props = []
+            with gm.graph.inserting_after(chunks[source][1]):
+                for chunk_id, chunk in enumerate(chunks[source]):
+                    prop = _create_size_or_stride_node(
+                        gm,
+                        live_in.target,
+                        chunk,
+                        prop_dim,
+                        region=plan.region,
+                        role="chunk_input",
+                        chunk_id=chunk_id,
+                    )
+                    chunk_val = tensor_meta(chunk)
+                    if chunk_val is None or prop_dim >= chunk_val.dim():
+                        raise ValueError(
+                            "Chunk pass could not derive chunk-local tensor "
+                            f"metadata scalar for {live_in.name}."
+                        )
+                    prop.meta["val"] = (
+                        chunk_val.shape[prop_dim]
+                        if live_in.target is aten.sym_size.int
+                        else chunk_val.stride()[prop_dim]
+                    )
+                    props.append(prop)
+            scalars[live_in] = (props[0], props[1])
+            scalars[expr_key(expr)] = (props[0], props[1])
+            continue
+        hint = _eval_hint(val, symbol_hints)
+        if _is_contiguous_chunk_input_stride(val, split_live_ins, symbol_hints):
+            continue
+        if (
+            not symbols <= selected_symbols
+            or _linear_extent_coeff(val, selected_symbols) is None
+        ):
+            if hint is not None and statically_equals_hint(val, hint):
+                continue
+            chunked_val = _rewrite_chunk_symint(val, symbol_hints)
+            if isinstance(chunked_val, torch.SymInt):
+                with gm.graph.inserting_before(first_body_user(live_in)):
+                    chunked_val = _materialize_symint_arg(
+                        gm,
+                        chunked_val,
+                        region=plan.region,
+                        role="chunk_input",
+                    )
+            scalars[live_in] = chunked_val
+            scalars[expr_key(expr)] = chunked_val
+            continue
+        if hint is None:
+            raise ValueError(
+                "Chunk pass found a symbolic scalar live-in without a chunk "
+                f"hint: {live_in.name}={val}."
+            )
+        if hint % 2:
+            raise ValueError(
+                "Chunk pass found a symbolic scalar live-in without an even "
+                f"chunk hint: {live_in.name}={val}."
+            )
+        with gm.graph.inserting_before(first_body_user(live_in)):
+            half = gm.graph.call_function(operator.floordiv, args=(live_in, 2))
+            _set_synthetic_meta(half, region=plan.region, role="chunk_input")
+            half.meta["val"] = val // 2
+        scalars[live_in] = half
+        scalars[expr_key(expr)] = half
+    return chunks, scalars, symbol_hints
+
+
+# Step 5: Route per-chunk provenance or materialize full live-outs.
+
+
+def _split_live_out_users(
+    users: tuple[fx.Node, ...],
+    plans: list[_Plan],
+    producer_region: _Region,
+    symbol_hints: dict[object, int],
+) -> tuple[tuple[fx.Node, ...], tuple[fx.Node, ...]]:
+    """Step 5: classify live-out consumers as chunked or full."""
+    owner_by_node = {node: plan.region for plan in plans for node in plan.body}
+    chunked = []
+    full = []
+    for user in users:
+        consumer_region = owner_by_node.get(user)
+        same_root_consumer = (
+            consumer_region is not None
+            and consumer_region.root_fqn == producer_region.root_fqn
+        )
+        same_root_backward_consumer = (
+            same_root_consumer
+            and not producer_region.is_backward
+            and consumer_region.is_backward
+        )
+        if same_root_backward_consumer or (
+            not producer_region.is_backward
+            and _is_backward_node(user)
+            and (
+                is_module_fqn_inside_root(
+                    _get_module_fqn(user), producer_region.root_fqn
+                )
+                or (
+                    not _get_module_fqn(user)
+                    and _node_depends_on_chunk_symbol(user, symbol_hints)
+                    and all(
+                        is_module_fqn_inside_root(fqn, producer_region.root_fqn)
+                        for neighbor in (*user.all_input_nodes, *user.users)
+                        if (fqn := _get_module_fqn(neighbor))
+                    )
+                )
+            )
+        ):
+            chunked.append(user)
+        else:
+            full.append(user)
+    return tuple(chunked), tuple(full)
+
+
+def _add_materialization_proof(
+    live_out: fx.Node,
+    users: tuple[fx.Node, ...],
+    *,
+    is_backward: bool,
+    grad_escape_boundaries: frozenset[fx.Node],
+) -> str | None:
+    """Step 5: prove when add reconstructs a no-chunk-dim live-out."""
+    if live_out.op == "call_function" and live_out.target is aten.sym_size.int:
+        return "symbolic_size"
+    if tensor_meta(live_out) is None:
+        return None
+    if is_backward and users and all(user.op == "output" for user in users):
+        return "graph_output_partial_sum"
+    if not is_backward:
+        return None
+    if live_out not in grad_escape_boundaries:
+        return None
+    logger.debug(
+        "Chunk pass add-materialized %s: graph-output grad escape boundary",
+        live_out.name,
+    )
+    return "backward_partial_sum"
+
+
+def _materialize_live_out(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    live_out: fx.Node,
+    copies: tuple[fx.Node, fx.Node],
+    users: tuple[fx.Node, ...],
+    *,
+    mode: ChunkMode,
+    symbol_hints: dict[object, int],
+    original_meta: dict[str, Any],
+) -> fx.Node:
+    """Step 5: reconstruct one full live-out from its two chunk values."""
+    original_val = original_meta.get("val")
+    original_dim = _chunk_dim_from_symbols(
+        original_val if isinstance(original_val, torch.Tensor) else None,
+        symbol_hints,
+    )
+    live_out_dim = _chunk_dim_from_symbols(tensor_meta(live_out), symbol_hints)
+    if live_out_dim is not None or original_dim is not None:
+        dim = live_out_dim.dim if live_out_dim is not None else original_dim.dim
+        assert dim is not None
+        materialized = gm.graph.call_function(
+            aten.cat.default, args=([copies[0], copies[1]], dim)
+        )
+        materialized.meta["val"] = original_val
+    elif (
+        proof := _add_materialization_proof(
+            live_out,
+            users,
+            is_backward=plan.region.is_backward,
+            grad_escape_boundaries=plan.grad_escape_boundaries,
+        )
+    ) is not None:
+        # Add is semantic reconstruction, not shape reconstruction. Keep the
+        # proof explicit so future extensions do not silently broaden it.
+        materialized = gm.graph.call_function(
+            aten.add.Tensor, args=(copies[0], copies[1])
+        )
+        materialized.meta["val"] = original_val
+        materialized.meta["chunked_materialization_proof"] = proof
+    else:
+        if tensor_meta(live_out) is None:
+            raise ValueError(
+                f"Chunk pass cannot materialize scalar live-out {live_out.name}: "
+                "the scalar is not proven to reconstruct from chunk values."
+            )
+        raise ValueError(
+            "Chunk pass cannot materialize live-out without chunk dimension; "
+            f"{live_out.name} from {plan.region.root_fqn!r} has full users "
+            f"{[_describe_node(user) for user in users]} and requires a forward "
+            "accumulation proof or a backward parameter-gradient consumer."
+        )
+    materialized._rename(f"{live_out.name}_chunk_materialized")
+    _set_synthetic_meta(materialized, region=plan.region, role="materialization")
+    _validate_materialized(
+        materialized,
+        live_out,
+        original_val=original_val if isinstance(original_val, torch.Tensor) else None,
+        symbol_hints=symbol_hints,
+    )
+    return materialized
+
+
+def _materialize_suffix_from_full_boundary(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    boundary: fx.Node,
+    materialized: fx.Node,
+    suffix: tuple[fx.Node, ...],
+    *,
+    originals: dict[
+        fx.Node, tuple[tuple[Any, ...], dict[str, Any], dict[str, Any], str]
+    ],
+) -> fx.Node:
+    """Step 5: copy tensor or shape suffixes after a boundary is full."""
+    remapped: dict[fx.Node, fx.Node] = {boundary: materialized}
+    current = materialized
+    for node in suffix:
+        args, kwargs, meta, name = originals[node]
+        new_args = tree_map(lambda arg: remapped.get(arg, arg), args)
+        new_kwargs = tree_map(lambda arg: remapped.get(arg, arg), kwargs)
+        original_val = meta.get("val")
+        shape_arg_idx = view_shape_arg_index(node.target)
+        if (
+            shape_arg_idx is not None
+            and isinstance(new_args, tuple)
+            and len(new_args) > shape_arg_idx
+            and isinstance(new_args[shape_arg_idx], (list, tuple))
+            and isinstance(original_val, torch.Tensor)
+        ):
+            # The first chunk is rewritten in place, so saved FX shape args may
+            # now refer to half-size values. A full-value suffix must use the
+            # original full extent recorded by tensor metadata.
+            materialized_shape = _materialize_symint_args(
+                gm,
+                list(original_val.shape),
+                region=plan.region,
+                role="materialization",
+            )
+            new_args = (
+                *new_args[:shape_arg_idx],
+                materialized_shape,
+                *new_args[shape_arg_idx + 1 :],
+            )
+        with gm.graph.inserting_after(current):
+            current = gm.graph.create_node(
+                node.op, node.target, new_args, new_kwargs, type_expr=node.type
+            )
+        current._rename(f"{name}_chunk_materialized")
+        current.meta = _copy_meta(meta)
+        _set_synthetic_meta(current, region=plan.region, role="materialization")
+        remapped[node] = current
+    return current
+
+
+def _materialize_full_live_out(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    live_out: fx.Node,
+    users: tuple[fx.Node, ...],
+    *,
+    mode: ChunkMode,
+    symbol_hints: dict[object, int],
+    originals: dict[
+        fx.Node, tuple[tuple[Any, ...], dict[str, Any], dict[str, Any], str]
+    ],
+    copied_by_chunk: dict[int, dict[fx.Node, fx.Node]],
+    optimize_grad_live_out: bool,
+    memo: dict[fx.Node, fx.Node],
+) -> fx.Node:
+    """Step 5: materialize a full live-out, possibly before a suffix chain."""
+    if live_out in memo:
+        return memo[live_out]
+
+    boundary = _MaterializationBoundary(live_out, ())
+    if _is_tensor_with_chunk_dim(live_out, symbol_hints):
+        boundary = _materialization_boundary(
+            live_out,
+            plan=plan,
+            optimize_grad_live_out=optimize_grad_live_out,
+            symbol_hints=symbol_hints,
+        )
+        if boundary.node not in copied_by_chunk[0]:
+            boundary = _MaterializationBoundary(live_out, ())
+    if boundary.node is not live_out:
+        materialized = _materialize_full_live_out(
+            gm,
+            plan,
+            boundary.node,
+            users,
+            mode=mode,
+            symbol_hints=symbol_hints,
+            originals=originals,
+            copied_by_chunk=copied_by_chunk,
+            optimize_grad_live_out=optimize_grad_live_out,
+            memo=memo,
+        )
+        if boundary.suffix:
+            materialized = _materialize_suffix_from_full_boundary(
+                gm,
+                plan,
+                boundary.node,
+                materialized,
+                boundary.suffix,
+                originals=originals,
+            )
+            _validate_materialized(
+                materialized,
+                live_out,
+                original_val=originals[live_out][2].get("val"),
+                symbol_hints=symbol_hints,
+            )
+        memo[live_out] = materialized
+        return materialized
+    copies = (
+        copied_by_chunk[0][boundary.node],
+        copied_by_chunk[1][boundary.node],
+    )
+    materialized = _materialize_live_out(
+        gm,
+        plan,
+        boundary.node,
+        copies,
+        users,
+        mode=mode,
+        symbol_hints=symbol_hints,
+        original_meta=originals[boundary.node][2],
+    )
+    if boundary.suffix:
+        materialized = _materialize_suffix_from_full_boundary(
+            gm,
+            plan,
+            boundary.node,
+            materialized,
+            boundary.suffix,
+            originals=originals,
+        )
+        _validate_materialized(
+            materialized,
+            live_out,
+            original_val=originals[live_out][2].get("val"),
+            symbol_hints=symbol_hints,
+        )
+    memo[live_out] = materialized
+    return materialized
+
+
+def _describe_node(node: fx.Node) -> str:
+    target = getattr(node.target, "__name__", str(node.target))
+    fqn = _get_module_fqn(node)
+    return f"{node.name}:{target}:fqn={fqn or '<none>'}"
+
+
+# Step 6: Clean up, validate, and expose public graph chunking passes.
+
+
+def _erase_unused_copied_body(
+    gm: fx.GraphModule,
+    copied_by_chunk: dict[int, dict[fx.Node, fx.Node]],
+    *,
+    protected: set[fx.Node],
+) -> None:
+    """Step 6: erase unused copied nodes while preserving side effects/provenance."""
+    copied = {
+        node for by_origin in copied_by_chunk.values() for node in by_origin.values()
+    }
+    for node in reversed(tuple(gm.graph.nodes)):
+        if (
+            node in copied
+            and node not in protected
+            and not node.users
+            and not _mutates_input(node)
+        ):
+            gm.graph.erase_node(node)
+
+
+def _transform_region(
+    gm: fx.GraphModule,
+    plan: _Plan,
+    *,
+    mode: ChunkMode,
+    static_nodes: set[fx.Node],
+    plans: list[_Plan],
+    per_chunk: dict[fx.Node, tuple[fx.Node, fx.Node]],
+    optimize_grad_live_out: bool,
+) -> None:
+    """Steps 3-6: lower one planned region into two chunks."""
+    if mode == "seq" and any(
+        "attention" in _get_module_fqn(n).split(".") for n in plan.region.nodes
+    ):
+        raise NotImplementedError(
+            "seq chunking through attention needs full-K/V handling"
+        )
+    _validate_no_non_ep_collectives(plan)
+
+    chunks, scalars, symbol_hints = _split_live_ins(
+        gm,
+        plan,
+        mode=mode,
+        static_nodes=static_nodes,
+        per_chunk=per_chunk,
+    )
+    logger.debug(
+        "Chunk pass lowering region: root=%s direction=%s body=%d live_ins=%d "
+        "live_outs=%d chunks=%d scalars=%d optimize_grad_live_out=%s",
+        plan.region.root_fqn,
+        "backward" if plan.region.is_backward else "forward",
+        len(plan.body),
+        len(plan.live_ins),
+        len(plan.live_out_users),
+        len(chunks),
+        len(scalars),
+        optimize_grad_live_out,
+    )
+    originals = {
+        node: (node.args, node.kwargs, _copy_meta(node.meta), node.name)
+        for node in plan.region.nodes
+    }
+    live_out_user_classes = {
+        live_out: _split_live_out_users(users, plans, plan.region, symbol_hints)
+        for live_out, users in plan.live_out_users.items()
+    }
+    preserved_scalar_live_outs = {
+        live_out
+        for live_out, full_users in plan.live_out_users.items()
+        if full_users
+        and tensor_meta(live_out) is None
+        and any(user in plan.body for user in live_out.users)
+    }
+    first_chunk = 0
+    second_chunk = 1
+    copied_by_chunk: dict[int, dict[fx.Node, fx.Node]] = {}
+    copied_by_chunk[first_chunk] = _copy_body(
+        gm,
+        plan,
+        chunks=chunks,
+        scalars=scalars,
+        symbol_hints=symbol_hints,
+        mode=mode,
+        chunk_id=first_chunk,
+        originals=originals,
+        in_place=True,
+        preserve_originals=preserved_scalar_live_outs,
+    )
+    copied_by_chunk[second_chunk] = _copy_body(
+        gm,
+        plan,
+        chunks=chunks,
+        scalars=scalars,
+        symbol_hints=symbol_hints,
+        mode=mode,
+        chunk_id=second_chunk,
+        originals=originals,
+        in_place=False,
+        prior_chunk_copies=copied_by_chunk[first_chunk],
+    )
+    order = ordered_nodes(gm)
+    materialized_live_outs: dict[fx.Node, fx.Node] = {}
+    live_out_items = []
+
+    for live_out, (chunked_users, full_users) in live_out_user_classes.items():
+        first_full_user = (
+            order[min(full_users, key=order.get)] if full_users else len(order)
+        )
+        live_out_items.append((first_full_user, live_out, chunked_users, full_users))
+
+    for _, live_out, chunked_users, full_users in sorted(
+        live_out_items, key=lambda item: item[0]
+    ):
+        logger.debug(
+            "Chunk pass live-out: root=%s node=%s chunked_users=%d full_users=%d",
+            plan.region.root_fqn,
+            live_out.name,
+            len(chunked_users),
+            len(full_users),
+        )
+        if chunked_users:
+            copies = (copied_by_chunk[0][live_out], copied_by_chunk[1][live_out])
+            per_chunk[live_out] = copies
+            per_chunk[copies[0]] = copies
+            per_chunk[copies[1]] = copies
+        if not full_users:
+            continue
+        if live_out in preserved_scalar_live_outs:
+            # Scalar shape expressions are not reconstructed from chunk values.
+            # Keep the original full scalar for full users and route chunked
+            # users through the chunk-local scalar copies recorded above.
+            continue
+        if (
+            chunked_users
+            and _chunk_dim_from_symbols(
+                originals[live_out][2].get("val")
+                if isinstance(originals[live_out][2].get("val"), torch.Tensor)
+                else None,
+                symbol_hints,
+            )
+            is None
+            and not _is_tensor_with_chunk_dim(live_out, symbol_hints)
+        ):
+            raise ValueError(
+                "Chunk pass does not support hybrid live-out consumers without "
+                "the selected chunk dimension. "
+                f"root={plan.region.root_fqn!r}, live_out={_describe_node(live_out)}, "
+                f"chunked_users={[user.name for user in chunked_users]}, "
+                f"full_users={[user.name for user in full_users]}, "
+                f"live_out_shape={getattr(tensor_meta(live_out), 'shape', None)}, "
+                f"original_shape={getattr(originals[live_out][2].get('val'), 'shape', None)}."
+            )
+        with gm.graph.inserting_before(min(full_users, key=order.get)):
+            materialized = _materialize_full_live_out(
+                gm,
+                plan,
+                live_out,
+                full_users,
+                mode=mode,
+                symbol_hints=symbol_hints,
+                originals=originals,
+                copied_by_chunk=copied_by_chunk,
+                optimize_grad_live_out=optimize_grad_live_out and not chunked_users,
+                memo=materialized_live_outs,
+            )
+            _validate_materialized(
+                materialized,
+                live_out,
+                original_val=originals[live_out][2].get("val"),
+                symbol_hints=symbol_hints,
+            )
+        for user in full_users:
+            user.replace_input_with(live_out, materialized)
+    protected = {chunk for chunks in per_chunk.values() for chunk in chunks}
+    _erase_unused_copied_body(gm, copied_by_chunk, protected=protected)
+
+
+def _static_placeholders(gm: fx.GraphModule, num_static_inputs: int) -> set[fx.Node]:
+    """Return placeholders that represent static model state."""
+    return {
+        node
+        for idx, node in enumerate(n for n in gm.graph.nodes if n.op == "placeholder")
+        if idx < num_static_inputs
+    }
+
+
+def _ep_roots(gm: fx.GraphModule, module_pattern: str) -> list[str]:
+    """Find selected roots that contain real all-to-all collectives."""
+    roots = set()
+    for node in gm.graph.nodes:
+        if (
+            node.op != "call_function"
+            or node.target != torch.ops._c10d_functional.all_to_all_single.default
+        ):
+            continue
+        fqn = _get_module_fqn(node)
+        if not fqn:
+            continue
+        matched = _pattern_root(module_pattern, fqn)
+        if matched is not None:
+            roots.add(matched.root_fqn)
+    return sorted(roots)
+
+
+def _ep_annotated_roots(gm: fx.GraphModule, module_pattern: str) -> list[str]:
+    """Find selected roots from EP annotations when no real EP PG is present."""
+    roots = set()
+    for node in gm.graph.nodes:
+        custom = _custom_meta(node)
+        if "EP" not in custom and _EP_TOKEN_EXCHANGE not in custom:
+            continue
+        fqn = _get_module_fqn(node)
+        if not fqn:
+            continue
+        matched = _pattern_root(module_pattern, fqn)
+        if matched is not None:
+            roots.add(matched.root_fqn)
+    return sorted(roots)
+
+
+def apply_chunk_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    mode: ChunkMode,
+    module_patterns: list[str],
+    num_static_inputs: int = 0,
+    optimize_grad_live_out: bool = True,
+) -> fx.GraphModule:
+    """Run graph chunking for the requested mode and module patterns."""
+    del example_inputs
+    if mode not in ("batch", "seq"):
+        raise ValueError(f"Unknown chunk mode: {mode!r}")
+    logger.debug(
+        "Chunk pass start: mode=%s patterns=%s num_static_inputs=%d "
+        "optimize_grad_live_out=%s",
+        mode,
+        module_patterns,
+        num_static_inputs,
+        optimize_grad_live_out,
+    )
+    static_nodes = _static_placeholders(gm, num_static_inputs)
+    per_chunk: dict[fx.Node, tuple[fx.Node, fx.Node]] = {}
+    num_regions = 0
+    for is_backward in (False, True):
+        # Step 2: plan regions for the current graph before lowering this
+        # direction; forward lowering can create provenance used by backward.
+        plans = _plan_regions(
+            gm,
+            module_patterns,
+            mode=mode,
+            optimize_grad_live_out=optimize_grad_live_out,
+            per_chunk_sources=set(per_chunk),
+        )
+        directional_plans = [
+            plan for plan in plans if plan.region.is_backward == is_backward
+        ]
+        logger.debug(
+            "Chunk pass direction plan: direction=%s regions=%d",
+            "backward" if is_backward else "forward",
+            len(directional_plans),
+        )
+        for plan in directional_plans:
+            # Steps 3-6: rebuild the region boundary from the current graph,
+            # then lower one region completely before moving to the next.
+            plan = _build_plan(plan.region, plan.grad_escape_boundaries)
+            _transform_region(
+                gm,
+                plan,
+                mode=mode,
+                static_nodes=static_nodes,
+                plans=plans,
+                per_chunk=per_chunk,
+                optimize_grad_live_out=optimize_grad_live_out,
+            )
+            num_regions += 1
+    if num_regions == 0:
+        raise ValueError(f"Chunk pass found no regions for {module_patterns}.")
+    _validate_selected_symbol_shapes(gm, mode=mode)
+    _validate_no_raw_chunk_symbol_args(gm, chunk_symbol_hints_for_mode(gm, mode))
+    gm.graph.lint()
+    gm.recompile()
+    logger.info(
+        "Applied %s chunking to %d region(s): patterns=%s optimize_grad_live_out=%s",
+        mode,
+        num_regions,
+        module_patterns,
+        optimize_grad_live_out,
+    )
+    return gm
+
+
+def ep_overlap_chunk_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    mode: ChunkMode,
+    module_pattern: str,
+    num_static_inputs: int = 0,
+    optimize_grad_live_out: bool = True,
+    require_all_to_all: bool = True,
+) -> fx.GraphModule:
+    """Resolve EP roots from one pattern, then run graph chunking."""
+    roots = _ep_roots(gm, module_pattern)
+    if not roots:
+        if require_all_to_all:
+            raise ValueError(f"No EP all-to-all regions matched {module_pattern!r}.")
+        roots = _ep_annotated_roots(gm, module_pattern)
+    if not roots:
+        raise ValueError(f"No EP regions matched {module_pattern!r}.")
+    return apply_chunk_pass(
+        gm,
+        example_inputs,
+        mode=mode,
+        module_patterns=roots,
+        num_static_inputs=num_static_inputs,
+        optimize_grad_live_out=optimize_grad_live_out,
+    )

--- a/torchtitan/experiments/graph_trainer/ep_pass_utils.py
+++ b/torchtitan/experiments/graph_trainer/ep_pass_utils.py
@@ -1,0 +1,767 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared EP chunk/overlap metadata and symbolic-shape helpers.
+
+The EP passes use this module as their common contract layer:
+
+1. Region discovery reads chunk metadata produced by eager or graph chunking and
+   groups nodes by ``(module_fqn, direction, chunk_id)``.
+2. Symbol helpers treat the unbacked SymInt selected by mark_unbacked as the
+   source of truth for chunk influence and use optimization hints only for pass
+   decisions that require concrete extents.
+3. The final concretization pass removes chunk-introduced SymInts and their
+   scalar plumbing after EP scheduling, so downstream compilers see static
+   metadata for these temporary symbols.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+import operator
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.utils._pytree import tree_leaves, tree_map
+
+from torchtitan.experiments.graph_trainer.common_utils import _is_backward_node
+from torchtitan.tools.logging import logger
+
+aten = torch.ops.aten
+CHUNK_SYMBOL_HINTS_META = "torchtitan_chunk_symbol_hints"
+_DEAD_CHUNK_SCALAR_TARGETS = {
+    aten.sym_size.int,
+    torch.sym_ite,
+    operator.add,
+    operator.and_,
+    operator.floordiv,
+    operator.mod,
+    operator.mul,
+    operator.or_,
+    operator.sub,
+    operator.eq,
+    operator.ge,
+    operator.gt,
+    operator.le,
+    operator.lt,
+}
+_ASSERT_TARGETS = {aten._assert_scalar.default}
+
+
+def is_module_fqn_inside_root(fqn: str, root_fqn: str) -> bool:
+    """Return whether ``fqn`` is exactly ``root_fqn`` or one of its children."""
+    return fqn == root_fqn or fqn.startswith(root_fqn + ".")
+
+
+def tensor_meta(node: fx.Node) -> torch.Tensor | None:
+    """Return tensor fake value metadata, if this node has tensor metadata."""
+    val = node.meta.get("val")
+    return val if isinstance(val, torch.Tensor) else None
+
+
+def is_c10d_functional_node(node: fx.Node) -> bool:
+    """Return whether a node is a distributed functional op (AG/RS/A2A/wait)."""
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.OpOverload)
+        and node.target.namespace == "_c10d_functional"
+    )
+
+
+def is_view_target(target: object) -> bool:
+    """Return whether a target is a true PyTorch view op overload."""
+    return isinstance(target, torch._ops.OpOverload) and target.is_view
+
+
+def same_tensor_domain(lhs: fx.Node, rhs: fx.Node) -> bool:
+    """Return whether two tensor nodes share dtype/device/layout metadata."""
+    lhs_val, rhs_val = tensor_meta(lhs), tensor_meta(rhs)
+    if lhs_val is None or rhs_val is None:
+        return False
+    return (
+        lhs_val.dtype == rhs_val.dtype
+        and lhs_val.device == rhs_val.device
+        and lhs_val.layout == rhs_val.layout
+    )
+
+
+def view_shape_arg_index(target: object) -> int | None:
+    """Return the positional shape arg index for Tensor -> Tensor view ops."""
+    if not isinstance(target, torch._ops.OpOverload):
+        return None
+    schema = target._schema
+    if (
+        not schema.arguments
+        or str(schema.arguments[0].type) != "Tensor"
+        or len(schema.returns) != 1
+        or str(schema.returns[0].type) != "Tensor"
+    ):
+        return None
+    schema_text = str(schema)
+    for idx, arg in enumerate(schema.arguments[1:], start=1):
+        if (
+            not arg.kwarg_only
+            and arg.name in {"shape", "size"}
+            and f"SymInt[] {arg.name}" in schema_text
+        ):
+            return idx
+    return None
+
+
+def free_symbols(value: object) -> frozenset[object]:
+    """Return symbolic-shape free symbols for values accepted by PyTorch."""
+    from torch.fx.experimental.symbolic_shapes import free_symbols
+
+    return frozenset(free_symbols(value))
+
+
+def ordered_nodes(gm: fx.GraphModule) -> dict[fx.Node, int]:
+    """Map each graph node to its current topological position."""
+    return {node: idx for idx, node in enumerate(gm.graph.nodes)}
+
+
+@dataclass(frozen=True)
+class ChunkOwner:
+    """Stable identity for one chunk body in one direction of one module."""
+
+    root_fqn: str
+    is_backward: bool
+    chunk_id: int
+
+
+@dataclass(frozen=True)
+class ChunkBody:
+    """A planned chunk body plus its external graph inputs."""
+
+    owner: ChunkOwner
+    nodes: tuple[fx.Node, ...]
+    node_set: frozenset[fx.Node]
+    live_ins: frozenset[fx.Node]
+    producer: str
+
+
+@dataclass(frozen=True)
+class ChunkedRegion:
+    """The chunk bodies for one module/direction pair."""
+
+    root_fqn: str
+    is_backward: bool
+    bodies_by_chunk: dict[int, ChunkBody]
+
+
+def _chunk_owner(node: fx.Node) -> ChunkOwner | None:
+    if node.meta.get("chunked_region_role") != "body":
+        return None
+    chunk_id = node.meta.get("chunk_id")
+    root = node.meta.get("chunked_region_fqn")
+    if chunk_id not in (0, 1) or not isinstance(root, str):
+        raise ValueError(f"Chunk body node {node.name} has incomplete chunk metadata.")
+    return ChunkOwner(
+        root_fqn=root,
+        is_backward=bool(
+            node.meta.get("chunked_region_is_backward", _is_backward_node(node))
+        ),
+        chunk_id=chunk_id,
+    )
+
+
+def collect_chunked_regions(
+    gm: fx.GraphModule, *, module_pattern: str
+) -> list[ChunkedRegion]:
+    """Collect chunk bodies matching ``module_pattern`` in graph order."""
+    nodes_by_owner: dict[ChunkOwner, list[fx.Node]] = defaultdict(list)
+    for node in gm.graph.nodes:
+        owner = _chunk_owner(node)
+        if owner and fnmatch.fnmatchcase(owner.root_fqn, module_pattern):
+            nodes_by_owner[owner].append(node)
+
+    grouped: dict[tuple[str, bool], dict[int, ChunkBody]] = defaultdict(dict)
+    for owner, nodes in nodes_by_owner.items():
+        node_set = frozenset(nodes)
+        grouped[(owner.root_fqn, owner.is_backward)][owner.chunk_id] = ChunkBody(
+            owner=owner,
+            nodes=tuple(nodes),
+            node_set=node_set,
+            live_ins=frozenset(
+                inp
+                for node in nodes
+                for inp in node.all_input_nodes
+                if inp not in node_set
+            ),
+            producer=str(nodes[0].meta.get("chunked_region_producer", "graph")),
+        )
+
+    return [
+        ChunkedRegion(root, is_backward, by_chunk)
+        for (root, is_backward), by_chunk in grouped.items()
+    ]
+
+
+def _hint(value: object) -> int | None:
+    """Return a concrete/optimization hint when PyTorch exposes one."""
+    if isinstance(value, int):
+        return value
+    if hasattr(value, "node"):
+        if value.node.hint is not None:
+            return int(value.node.hint)
+        shape_env = getattr(value.node, "shape_env", None)
+        if shape_env is not None:
+            try:
+                return int(shape_env.optimization_hint(value.node.expr))
+            except Exception:
+                return None
+    return None
+
+
+def _eval_hint(value: object, hints: dict[object, int]) -> int | bool | None:
+    """Evaluate ``value`` by substituting known symbol hints."""
+    symbols = free_symbols(value)
+    if not symbols:
+        if (hint := _hint(value)) is not None:
+            return hint
+        try:
+            return int(value)  # Handles concrete SymPy integers.
+        except (TypeError, ValueError, OverflowError):
+            return None
+    if not symbols <= hints.keys():
+        return None
+    try:
+        expr = value.node.expr if hasattr(value, "node") else value
+        evaluated = expr.subs({symbol: hints[symbol] for symbol in symbols})
+        if free_symbols(evaluated):
+            return None
+        if isinstance(value, torch.SymBool):
+            return bool(evaluated)
+        return int(evaluated)
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return None
+
+
+def _derive_symbol_hint(expr: object, extent_hint: int, symbol: object) -> int | None:
+    expr = expr.node.expr if isinstance(expr, torch.SymInt) else expr
+    try:
+        zero = expr.subs(symbol, 0)
+        one = expr.subs(symbol, 1)
+        if free_symbols(zero):
+            return None
+        offset = int(zero)
+        coeff = int(one - zero)
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return None
+    if offset != 0 or coeff <= 0 or extent_hint % coeff:
+        return None
+    return extent_hint // coeff
+
+
+def _merge_symbol_hint(
+    hints: dict[object, int], symbol: object, hint: int, *, source: str
+) -> None:
+    existing = hints.get(symbol)
+    if existing is not None and existing != hint:
+        raise ValueError(
+            f"Chunk symbol {symbol} has conflicting hints: {existing} and "
+            f"{hint} from {source}."
+        )
+    hints[symbol] = hint
+
+
+def _record_symbols_from_extent(
+    hints: dict[object, int], extent: object, *, source: str
+) -> None:
+    symbols = free_symbols(extent)
+    if not symbols:
+        return
+    extent_hint = _hint(extent)
+    if extent_hint is None:
+        raise ValueError(
+            f"Chunk pass found selected dynamic extent {extent} from {source} "
+            "without an optimization hint."
+        )
+    for symbol in symbols:
+        hint = _derive_symbol_hint(extent, int(extent_hint), symbol)
+        if hint is None:
+            raise ValueError(
+                f"Chunk pass could not derive a base hint for symbol {symbol} "
+                f"from {source} extent {extent}."
+            )
+        _merge_symbol_hint(hints, symbol, hint, source=source)
+
+
+def _selected_symbol_hints(node: fx.Node) -> dict[object, int]:
+    hints = node.meta.get(CHUNK_SYMBOL_HINTS_META, {})
+    return hints if isinstance(hints, dict) else {}
+
+
+def chunk_symbol_hints_for_mode(
+    gm: fx.GraphModule, mode: str | None = None
+) -> dict[object, int]:
+    """Collect the selected chunk symbols and their optimization hints."""
+    hints: dict[object, int] = {}
+    for node in gm.graph.nodes:
+        for symbol, hint in _selected_symbol_hints(node).items():
+            _merge_symbol_hint(hints, symbol, int(hint), source=node.name)
+        if (
+            mode is None
+            or node.op != "placeholder"
+            or (val := tensor_meta(node)) is None
+        ):
+            continue
+        dim = {"batch": 0, "seq": 1}.get(mode)
+        if dim is None:
+            raise ValueError(f"Unknown chunk mode: {mode!r}")
+        if dim < len(val.shape):
+            _record_symbols_from_extent(
+                hints, val.shape[dim], source=f"{node.name}.shape[{dim}]"
+            )
+    return hints
+
+
+def _placeholder_symbol_hints(gm: fx.GraphModule) -> dict[object, int]:
+    hints: dict[object, int] = {}
+    for node in gm.graph.nodes:
+        if node.op != "placeholder" or (val := tensor_meta(node)) is None:
+            continue
+        for dim, extent in enumerate(val.shape):
+            _record_symbols_from_extent(
+                hints, extent, source=f"{node.name}.shape[{dim}]"
+            )
+    return hints
+
+
+def same_shape_with_hints(
+    lhs: object,
+    rhs: object,
+    node: fx.Node,
+    symbol_hints: dict[object, int] | None = None,
+) -> bool:
+    """Compare tensor shapes after substituting available chunk hints."""
+    if (
+        tensor_meta(node) is None
+        or not hasattr(lhs, "shape")
+        or not hasattr(rhs, "shape")
+    ):
+        return False
+    hints = symbol_hints or _selected_symbol_hints(node)
+    return len(lhs.shape) == len(rhs.shape) and all(
+        same_symbolic_expr(a, b)
+        or (_hint(a) is not None and _hint(a) == _hint(b))
+        or (
+            (a_hint := _eval_hint(a, hints)) is not None
+            and (b_hint := _eval_hint(b, hints)) is not None
+            and a_hint == b_hint
+        )
+        for a, b in zip(lhs.shape, rhs.shape)
+    )
+
+
+def symbolic_expr(value: object) -> object:
+    """Return the symbolic expression object for a PyTorch symbolic scalar."""
+    return value.node.expr if hasattr(value, "node") else value
+
+
+def same_symbolic_expr(lhs: object, rhs: object) -> bool:
+    """Return whether two symbolic/concrete expressions are structurally equal."""
+    lhs_expr, rhs_expr = symbolic_expr(lhs), symbolic_expr(rhs)
+    try:
+        equal = lhs_expr == rhs_expr
+        if isinstance(equal, bool):
+            return equal
+        if bool(equal):
+            return True
+    except (RuntimeError, TypeError, ValueError):
+        pass
+    try:
+        equals = getattr(lhs_expr - rhs_expr, "equals", None)
+        return callable(equals) and equals(0) is True
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def expr_key(value: object) -> object:
+    """Return the canonical object used to match identical symbolic expressions."""
+    return symbolic_expr(value)
+
+
+def dim_hint(dim: object, symbol_hints: dict[object, int]) -> int | None:
+    """Return the hinted integer value for a dimension-like object."""
+    if isinstance(dim, fx.Node):
+        val = dim.meta.get("val")
+        return None if val is None else dim_hint(val, symbol_hints)
+    return _eval_hint(dim, symbol_hints) if free_symbols(dim) else _hint(dim)
+
+
+def numel_hint(shape: object, symbol_hints: dict[object, int]) -> int | None:
+    """Return hinted numel for a shape, or ``None`` if it is not provable."""
+    if not isinstance(shape, (list, tuple, torch.Size)):
+        return None
+    result = 1
+    for dim in shape:
+        if dim == -1:
+            return None
+        hint = dim_hint(dim, symbol_hints)
+        if hint is None:
+            return None
+        result *= int(hint)
+    return result
+
+
+def same_dim_hint(lhs: object, rhs: object, symbol_hints: dict[object, int]) -> bool:
+    """Return whether two dimensions are equal under chunk hints."""
+    if same_symbolic_expr(lhs, rhs):
+        return True
+    lhs_hint = dim_hint(lhs, symbol_hints)
+    rhs_hint = dim_hint(rhs, symbol_hints)
+    return lhs_hint is not None and lhs_hint == rhs_hint
+
+
+def statically_equals_hint(value: object, hint: int | bool) -> bool:
+    """Return whether symbolic reasoning proves ``value == hint``."""
+    if isinstance(value, (torch.SymInt, torch.SymBool)):
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        return statically_known_true(value == hint)
+    expr = value.node.expr if isinstance(value, torch.SymInt) else value
+    equals = getattr(expr, "equals", None)
+    return callable(equals) and equals(hint) is True
+
+
+def depends_on_chunk_symbol(value: object, symbol_hints: dict[object, int]) -> bool:
+    """Return whether ``value`` still references any selected chunk symbol."""
+    if isinstance(value, torch.Tensor):
+        return any(
+            free_symbols(size_or_stride) & symbol_hints.keys()
+            for size_or_stride in (*value.shape, *value.stride())
+        )
+    if isinstance(value, fx.Node):
+        return False
+    if not isinstance(
+        value,
+        (
+            torch.SymInt,
+            torch.SymFloat,
+            torch.SymBool,
+            int,
+            float,
+            bool,
+            str,
+            type(None),
+        ),
+    ):
+        return False
+    return bool(free_symbols(value) & symbol_hints.keys())
+
+
+def _concretize_value(value: object, symbol_hints: dict[object, int]) -> object:
+    symbols = free_symbols(value)
+    if symbols:
+        concrete = _eval_hint(value, symbol_hints)
+        if concrete is not None:
+            return concrete
+        chunk_symbols = symbols & symbol_hints.keys()
+        if not chunk_symbols:
+            hint = _hint(value)
+            if hint is not None:
+                return hint
+        if chunk_symbols and hasattr(value, "node"):
+            expr = value.node.expr.subs(
+                {symbol: symbol_hints[symbol] for symbol in chunk_symbols}
+            )
+            shape_env = value.node.shape_env
+            if isinstance(value, torch.SymInt):
+                return shape_env.create_symintnode(expr, hint=None)
+            if isinstance(value, torch.SymFloat):
+                return shape_env.create_symfloatnode(expr, hint=None)
+            if isinstance(value, torch.SymBool):
+                return shape_env.create_symboolnode(expr)
+        return value
+    return value
+
+
+def _concretize_arg(arg: object, symbol_hints: dict[object, int]) -> object:
+    if isinstance(arg, tuple):
+        return tuple(_concretize_arg(item, symbol_hints) for item in arg)
+    if isinstance(arg, list):
+        mapped = [_concretize_arg(item, symbol_hints) for item in arg]
+        try:
+            return type(arg)(mapped)
+        except TypeError:
+            return mapped
+    if isinstance(arg, dict):
+        return {key: _concretize_arg(value, symbol_hints) for key, value in arg.items()}
+    if isinstance(arg, (torch.SymInt, torch.SymFloat, torch.SymBool, int)):
+        return _concretize_value(arg, symbol_hints)
+    return arg
+
+
+def _concretize_tensor_meta(
+    val: torch.Tensor, symbol_hints: dict[object, int]
+) -> torch.Tensor:
+    if not any(
+        free_symbols(size_or_stride) & symbol_hints.keys()
+        for size_or_stride in (*val.shape, *val.stride())
+    ):
+        return val
+    shape = tuple(_concretize_value(size, symbol_hints) for size in val.shape)
+    stride = tuple(_concretize_value(extent, symbol_hints) for extent in val.stride())
+    return val.new_empty_strided(shape, stride)
+
+
+def _concretize_meta_value(value: object, symbol_hints: dict[object, int]) -> object:
+    if isinstance(value, torch.Tensor):
+        return _concretize_tensor_meta(value, symbol_hints)
+    if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return _concretize_value(value, symbol_hints)
+    return value
+
+
+def _clear_chunk_tensor_marks(
+    tensor: torch.Tensor, symbol_hints: dict[object, int]
+) -> None:
+    dims = {
+        dim
+        for dim, extent in enumerate(tensor.shape)
+        if bool(free_symbols(extent) & symbol_hints.keys())
+    }
+    if not dims:
+        return
+    for attr in (
+        "_dynamo_unbacked_indices",
+        "_dynamo_strict_unbacked_indices",
+        "_dynamo_dynamic_indices",
+    ):
+        values = getattr(tensor, attr, None)
+        if isinstance(values, set):
+            values.difference_update(dims)
+            if not values:
+                delattr(tensor, attr)
+    for attr in (
+        "_dynamo_hint_overrides",
+        "_dynamo_unbacked_bounds",
+        "_dynamo_shape_ids",
+        "_specialize_on",
+    ):
+        values = getattr(tensor, attr, None)
+        if isinstance(values, dict):
+            for dim in dims:
+                values.pop(dim, None)
+            if not values:
+                delattr(tensor, attr)
+
+
+def _concretize_chunk_example_inputs(
+    example_inputs: list[Any] | tuple[Any, ...] | None,
+    symbol_hints: dict[object, int],
+) -> None:
+    if example_inputs is None:
+        return
+    for idx, inp in enumerate(example_inputs):
+        if not isinstance(inp, torch.Tensor):
+            continue
+        concrete = _concretize_tensor_meta(inp, symbol_hints)
+        if concrete is not inp and isinstance(example_inputs, list):
+            example_inputs[idx] = concrete
+            inp = concrete
+        _clear_chunk_tensor_marks(inp, symbol_hints)
+
+
+def _validate_no_chunk_symbols(
+    gm: fx.GraphModule, symbol_hints: dict[object, int]
+) -> None:
+    chunk_symbols = symbol_hints.keys()
+    for graph_module in _iter_graph_modules(gm):
+        for node in graph_module.graph.nodes:
+            for value in tree_leaves(
+                (
+                    node.args,
+                    node.kwargs,
+                    node.meta.get("val"),
+                    node.meta.get("example_value"),
+                )
+            ):
+                if depends_on_chunk_symbol(value, symbol_hints):
+                    raise ValueError(
+                        "concretize_ep_chunk_symbolic_shapes_pass left chunk "
+                        f"symbol(s) {free_symbols(value) & chunk_symbols} in "
+                        f"{node.name}."
+                    )
+
+
+def _iter_graph_modules(gm: fx.GraphModule) -> list[fx.GraphModule]:
+    """Return ``gm`` and GraphModule subgraphs referenced by its nodes."""
+    seen: set[int] = set()
+    ordered: list[fx.GraphModule] = []
+    work = [gm]
+    while work:
+        graph_module = work.pop()
+        if id(graph_module) in seen:
+            continue
+        seen.add(id(graph_module))
+        ordered.append(graph_module)
+        for node in graph_module.graph.nodes:
+            if node.op == "get_attr" and isinstance(node.target, str):
+                attr = getattr(graph_module, node.target, None)
+                if isinstance(attr, fx.GraphModule):
+                    work.append(attr)
+            for value in tree_leaves((node.args, node.kwargs)):
+                if isinstance(value, fx.GraphModule):
+                    work.append(value)
+    return ordered
+
+
+def _concretize_graph_module(
+    gm: fx.GraphModule, symbol_hints: dict[object, int]
+) -> dict[fx.Node, int | bool]:
+    scalar_constants: dict[fx.Node, int | bool] = {}
+    for node in list(gm.graph.nodes):
+        if node.op == "output":
+            continue
+        node.args = _concretize_arg(node.args, symbol_hints)
+        node.kwargs = _concretize_arg(node.kwargs, symbol_hints)
+        for meta_key in ("val", "example_value"):
+            if meta_key not in node.meta:
+                continue
+            val = node.meta[meta_key]
+            new_val = tree_map(
+                lambda item: _concretize_meta_value(item, symbol_hints), val
+            )
+            node.meta[meta_key] = new_val
+            if (
+                isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool))
+                and (concrete := _eval_hint(val, symbol_hints)) is not None
+            ):
+                scalar_constants[node] = concrete
+        node.meta.pop(CHUNK_SYMBOL_HINTS_META, None)
+    return scalar_constants
+
+
+def _is_dead_chunk_scalar_plumbing(node: fx.Node) -> bool:
+    """Return whether ``node`` is dead scalar shape/assert plumbing."""
+    return (
+        node.op == "call_function"
+        and not node.users
+        and (
+            node.target in _DEAD_CHUNK_SCALAR_TARGETS or _is_assert_target(node.target)
+        )
+    )
+
+
+def _is_assert_target(target: object) -> bool:
+    return target in _ASSERT_TARGETS
+
+
+def _concretized_guard_value(
+    value: object,
+    symbol_hints: dict[object, int],
+    scalar_constants: dict[fx.Node, int | bool],
+) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, fx.Node):
+        if value in scalar_constants:
+            concrete = scalar_constants[value]
+            return concrete if isinstance(concrete, bool) else None
+        value = value.meta.get("val")
+    if isinstance(value, torch.SymBool):
+        concrete = _eval_hint(value, symbol_hints)
+        return concrete if isinstance(concrete, bool) else None
+    return None
+
+
+def _validate_no_false_guards(
+    gm: fx.GraphModule,
+    symbol_hints: dict[object, int],
+    scalar_constants: dict[fx.Node, int | bool],
+) -> None:
+    for node in gm.graph.nodes:
+        if (
+            node.op != "call_function"
+            or not _is_assert_target(node.target)
+            or not node.args
+        ):
+            continue
+        concrete = _concretized_guard_value(
+            node.args[0], symbol_hints, scalar_constants
+        )
+        if concrete is False:
+            message = node.args[1] if len(node.args) > 1 else ""
+            raise ValueError(
+                "concretize_ep_chunk_symbolic_shapes_pass found a guard that "
+                f"evaluates to False after chunk-symbol substitution: "
+                f"{node.name} {message}"
+            )
+
+
+def concretize_ep_chunk_symbolic_shapes_pass(
+    gm: fx.GraphModule,
+    example_inputs: list[Any] | tuple[Any, ...] | None = None,
+) -> fx.GraphModule:
+    """Concretize EP chunk symbolic shapes after scheduling.
+
+    Graph chunking temporarily introduces unbacked SymInts as the selected
+    chunk dimension. Once EP scheduling has consumed that symbolic contract,
+    downstream compiler passes should see concrete hinted sizes. This pass
+    rewrites graph args, metadata, scalar SymInt nodes, and example-input
+    dynamic marks, then removes dead scalar/assert plumbing.
+    """
+    symbol_hints = chunk_symbol_hints_for_mode(gm)
+    if not symbol_hints:
+        return gm
+    # Final FX codegen cannot reference raw SymPy names from partially
+    # concretized expressions such as ``batch * chunked_seq``. Use placeholder
+    # hints for non-selected symbols while keeping ``symbol_hints`` as the set
+    # of symbols introduced/owned by EP chunking.
+    concretization_hints = dict(_placeholder_symbol_hints(gm))
+    concretization_hints.update(symbol_hints)
+
+    logger.debug(
+        "Concretizing %d EP chunk symbol(s) after scheduling", len(symbol_hints)
+    )
+
+    graph_modules = _iter_graph_modules(gm)
+    scalar_constants: dict[fx.GraphModule, dict[fx.Node, int | bool]] = {
+        graph_module: _concretize_graph_module(graph_module, concretization_hints)
+        for graph_module in graph_modules
+    }
+
+    if total_scalar_constants := sum(
+        len(constants) for constants in scalar_constants.values()
+    ):
+        logger.debug(
+            "Replacing %d EP chunk scalar node(s) with hinted constants",
+            total_scalar_constants,
+        )
+        for graph_module, constants in scalar_constants.items():
+            if not constants:
+                continue
+
+            for node in graph_module.graph.nodes:
+
+                def replace_scalar(arg):
+                    if arg in constants:
+                        return constants[arg]
+                    return arg
+
+                node.args = fx.map_arg(node.args, replace_scalar)
+                node.kwargs = fx.map_arg(node.kwargs, replace_scalar)
+
+    for graph_module, constants in scalar_constants.items():
+        _validate_no_false_guards(graph_module, concretization_hints, constants)
+
+    for graph_module in graph_modules:
+        for node in reversed(list(graph_module.graph.nodes)):
+            if _is_dead_chunk_scalar_plumbing(node):
+                graph_module.graph.erase_node(node)
+
+        graph_module.graph.lint()
+        graph_module.recompile()
+    _concretize_chunk_example_inputs(example_inputs, symbol_hints)
+    _validate_no_chunk_symbols(gm, symbol_hints)
+    logger.info("Concretized EP chunk symbols after scheduling")
+    return gm

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -54,7 +54,10 @@ def _node_metadata_key_filter_distributed(key: str) -> bool:
 
 
 def regional_inductor_pass(
-    gm: torch.fx.GraphModule, example_inputs: tuple, *, serializable: bool = False
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+    *,
+    serializable: bool = False,
 ) -> torch.fx.GraphModule:
     """Compile tagged graph regions with ``regional_inductor``.
 
@@ -242,7 +245,6 @@ def full_inductor_compilation_pass(
     pre_collapse_cudagraph_compatible = is_cudagraph_compatible(
         gm, skip_flex_attention_check=True
     )
-
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():
         if not isinstance(module, torch.fx.GraphModule):

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -454,6 +454,10 @@ def minimal_fx_tracer(
             user_args, user_kwargs = pytree.tree_unflatten(
                 list(user_flat), user_inputs_spec
             )
+            if prepare_call_inputs is not None:
+                prepared = prepare_call_inputs(user_args, user_kwargs)
+                if prepared is not None:
+                    user_args, user_kwargs = prepared
 
             with _reparametrize_train_state(
                 module, optimizer, model_state_t, optim_state_t

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -43,8 +43,15 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     snapshot_graph,
     tlparse_log_graph_pass,
 )
+from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
+    ep_overlap_chunk_pass,
+    populate_chunk_dim_metadata_pass,
+)
 from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
     populate_eager_chunk_metadata_pass,
+)
+from torchtitan.experiments.graph_trainer.ep_pass_utils import (
+    concretize_ep_chunk_symbolic_shapes_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     get_fsdp_param_module_order,
@@ -110,6 +117,13 @@ def async_tensor_parallel_pass(
     return gm
 
 
+def _tensor_parallel_degree(config, parallel_dims=None) -> int:
+    """Return TP degree from ``ParallelDims`` when available, else config."""
+    if parallel_dims is not None and hasattr(parallel_dims, "tp"):
+        return int(parallel_dims.tp)
+    return int(getattr(config.parallelism, "tensor_parallel_degree", 1))
+
+
 def compile_time_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
@@ -143,12 +157,79 @@ def compile_time_passes(
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
     ]
+    ep_overlap_chunk_passes: list[Callable] = []
     if config.compile.ep_overlap.enabled:
-        _overlap_dim, chunk_strategy, _module_fqn = validate_ep_overlap_config(
+        overlap_dim, chunk_strategy, module_fqn = validate_ep_overlap_config(
             config.compile.ep_overlap
         )
+        if (
+            chunk_strategy == "graph"
+            and overlap_dim == "seq"
+            and _tensor_parallel_degree(config) > 1
+        ):
+            # TODO: Support graph EP chunking with TP after the MoE TP/SP
+            # boundary has a placement-aware contract.  Today, after DTensor
+            # lowering, the FX graph contains physical TP-local tensors.  For
+            # MoE sequence chunking, splitting a local ``Shard(1)`` sequence
+            # shard chunks ``u0 // tp_degree`` tokens per rank instead of the
+            # logical ``u0`` sequence.  The desired TP+EP MoE contract is for
+            # the MoE wrapper to own the TP/SP layout transition:
+            #
+            #   prologue: Shard(1) -> Replicate
+            #   body:     logical full-sequence chunks with EP collectives only
+            #   epilogue: Partial/Replicate -> Shard(1)
+            #
+            # With that contract, the chunk planner can move live-ins forward
+            # through the pure layout prologue until the chunked axis has the
+            # full symbolic dim, and move live-outs backward through the
+            # inverse epilogue before chunking.  The walk must be guarded: only
+            # cross allowlisted view/slice/cat and known non-EP c10d layout
+            # redistributes; require a unique dominance-safe chain; stop before
+            # router/top-k/groupedMM/shared-expert/dense compute; and validate
+            # that the final chunk body contains no non-EP collectives.
+            #
+            # This also avoids redundant inner MoE TP collectives: router can
+            # slice the replicated boundary input to its owned tokens, while
+            # shared experts can reuse that replicated input instead of issuing
+            # their own input all-gathers and leave the final reduction to the
+            # MoE boundary epilogue.
+            #
+            # Batch graph chunking with TP is temporarily allowed so we can
+            # root-cause it separately. The current lowering is not proven
+            # correct there either: DTensor TP/SP layout helper tensors can
+            # encode both batch and sequence structure in flattened index maps,
+            # so naive selected-symbol rewriting may split the layout map
+            # differently from eager chunking.
+            raise ValueError(
+                "Graph EP seq chunking does not support tensor_parallel_degree > 1. "
+                "After DTensor lowering, the FX graph contains TP-local sequence "
+                "shards; splitting those local tensors is not equivalent to eager "
+                "DTensor-level chunking. Use tensor_parallel_degree=1, eager "
+                "chunking, or a non-seq overlap dimension for this configuration."
+            )
         if chunk_strategy == "eager":
-            passes.append(populate_eager_chunk_metadata_pass)
+            ep_overlap_chunk_passes.append(populate_eager_chunk_metadata_pass)
+        else:
+            ep_overlap_chunk_passes.extend(
+                [
+                    functools.partial(
+                        populate_chunk_dim_metadata_pass,
+                        mode=overlap_dim,
+                    ),
+                    functools.partial(
+                        ep_overlap_chunk_pass,
+                        mode=overlap_dim,
+                        module_pattern=module_fqn,
+                        num_static_inputs=traced_result.num_static_inputs,
+                        optimize_grad_live_out=not (
+                            config.compile.ep_overlap.disable_early_grad_accumulation
+                        ),
+                        require_all_to_all=(
+                            getattr(config.parallelism, "expert_parallel_degree", 1) > 1
+                        ),
+                    ),
+                ]
+            )
     passes.extend(
         [
             functools.partial(
@@ -161,6 +242,13 @@ def compile_time_passes(
                 defer_n_layers=config.compile.cpu_offload_defer_n_layers,
             ),
             selective_activation_remat_pass,
+        ]
+    )
+    if ep_overlap_chunk_passes:
+        passes.extend(ep_overlap_chunk_passes)
+        passes.append(eliminate_dead_code_pass)
+    passes.extend(
+        [
             # Run before bucketing so bucketed collectives inherit the dedicated PG.
             reassign_collective_pgs_pass,
             functools.partial(
@@ -177,6 +265,8 @@ def compile_time_passes(
             ),
         ]
     )
+    if ep_overlap_chunk_passes:
+        passes.append(concretize_ep_chunk_symbolic_shapes_pass)
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -71,7 +71,6 @@ def compute_config_fingerprint(
         "compile:ep_overlap:disable_early_grad_accumulation:"
         f"{compile_config.ep_overlap.disable_early_grad_accumulation}\n".encode()
     )
-
     h.update(f"torch_version:{torch.__version__}\n".encode())
 
     if torch.cuda.is_available():

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -32,6 +32,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
+from torchtitan.experiments.graph_trainer.configs import trace_input_preparer_keys
 from torchtitan.experiments.graph_trainer.precompile import _FX_TRACE_ARTIFACT_KEY
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
@@ -258,14 +259,36 @@ def _precompile_aot_fx_trace(
 
     maybe_register_blockmask_pytree_node()
 
+    from torchtitan.experiments.graph_trainer.registry import (
+        TRACE_CALL_INPUT_PREPARERS,
+        TRACE_INPUT_PREPARERS,
+    )
+
+    def prepare_trace_inputs(args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        for pass_name in trace_input_preparer_keys(config.compile):
+            prepare = TRACE_INPUT_PREPARERS.get(pass_name)
+            if prepare is not None:
+                prepare(config.compile, args, kwargs)
+
+    def prepare_trace_call_inputs(
+        args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        for pass_name in trace_input_preparer_keys(config.compile):
+            prepare = TRACE_CALL_INPUT_PREPARERS.get(pass_name)
+            if prepare is not None:
+                prepared = prepare(config.compile, args, kwargs)
+                if prepared is not None:
+                    args, kwargs = prepared
+        return args, kwargs
+
     logger.info("Tracing fwd+loss+bwd via make_fx...")
     with loss_parallel_ctx:
-        traced_result = minimal_fx_tracer(fwd_bwd_fn, module=model)(
-            dummy_inputs,
-            dummy_labels,
-            dummy_global_valid_tokens,
-            extra_kwargs,
-        )
+        traced_result = minimal_fx_tracer(
+            fwd_bwd_fn,
+            module=model,
+            prepare_inputs=prepare_trace_inputs,
+            prepare_call_inputs=prepare_trace_call_inputs,
+        )(dummy_inputs, dummy_labels, dummy_global_valid_tokens, extra_kwargs)
     logger.info(
         f"Traced graph has {len(list(traced_result.gm.graph.nodes))} nodes, "
         f"{len(traced_result.state_fqns)} state entries"

--- a/torchtitan/experiments/graph_trainer/registry.py
+++ b/torchtitan/experiments/graph_trainer/registry.py
@@ -43,9 +43,13 @@ PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
 POST_INIT_HOOKS: dict[str, Callable] = {}
 PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
 TRACE_INPUT_PREPARERS: dict[str, Callable] = {}
+TRACE_CALL_INPUT_PREPARERS: dict[str, Callable] = {}
 
 register_memory_policy = _make_registry_decorator(MEMORY_POLICY_REGISTRY)
 register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
 register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
 register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)
 register_trace_input_preparer = _make_registry_decorator(TRACE_INPUT_PREPARERS)
+register_trace_call_input_preparer = _make_registry_decorator(
+    TRACE_CALL_INPUT_PREPARERS
+)

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -32,11 +32,18 @@ from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
+from torchtitan.experiments.graph_trainer.configs import (
+    EpOverlapConfig,
+    GraphTrainerCompileConfig,
+)
 from torchtitan.experiments.graph_trainer.deepseek_v3 import (
     model_registry as dsv3_model_registry,
 )
 from torchtitan.experiments.graph_trainer.deepseek_v3.parallelize import (
     annotate_deepseekv3,
+)
+from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
+    maybe_apply_ep_overlap_eager_chunking,
 )
 from torchtitan.experiments.graph_trainer.llama3 import (
     model_registry as llama3_model_registry,
@@ -163,6 +170,13 @@ class BitwiseDeterministicBase(unittest.TestCase):
         trainer_cls: type,
         *,
         enable_passes: bool = True,
+        compile_passes: list[str] | None = None,
+        compile_ep_overlap_enabled: bool = False,
+        compile_ep_overlap_chunk_dim: str = "batch",
+        compile_ep_overlap_module_fqn: str = "layers.*",
+        compile_ep_overlap_disable_early_grad_accumulation: bool = False,
+        compile_inductor_compilation: str = "regional",
+        compile_disable_passes: list[str] | None = None,
         numerics_changing_optim: bool = False,
     ) -> tuple[torch.Tensor, str, str]:
         """Run forward-backward-optimizer steps using the given trainer class."""
@@ -174,6 +188,15 @@ class BitwiseDeterministicBase(unittest.TestCase):
             self.model_config,
             trainer_cls,
             compile_enable_passes=enable_passes,
+            compile_passes=compile_passes,
+            compile_ep_overlap_enabled=compile_ep_overlap_enabled,
+            compile_ep_overlap_chunk_dim=compile_ep_overlap_chunk_dim,
+            compile_ep_overlap_module_fqn=compile_ep_overlap_module_fqn,
+            compile_ep_overlap_disable_early_grad_accumulation=(
+                compile_ep_overlap_disable_early_grad_accumulation
+            ),
+            compile_inductor_compilation=compile_inductor_compilation,
+            compile_disable_passes=compile_disable_passes,
             compile_numerics_changing_optim=numerics_changing_optim,
             tokenizer=HuggingFaceTokenizer(tokenizer_path=_TOKENIZER_PATH),
         )
@@ -245,13 +268,9 @@ class BitwiseDeterministicBase(unittest.TestCase):
         if enable_passes:
             config = SimpleNamespace(
                 model_spec=SimpleNamespace(model=self.model_config),
-                compile=SimpleNamespace(
-                    memory_policy="default",
-                    inductor_compilation="regional",
-                    numerics_changing_optim=False,
-                    cpu_offload_prefetch_n_layers=1,
-                    cpu_offload_defer_n_layers=1,
-                    cpu_offload_budget_gb=100.0,
+                compile=GraphTrainerCompileConfig(
+                    enable=True,
+                    mode="aot_fx_trace",
                 ),
                 parallelism=SimpleNamespace(
                     pipeline_parallel_degree=1,
@@ -277,10 +296,10 @@ class BitwiseDeterministicBase(unittest.TestCase):
         if enable_passes:
             load_config = SimpleNamespace(
                 model_spec=SimpleNamespace(model=self.model_config),
-                compile=SimpleNamespace(
+                compile=GraphTrainerCompileConfig(
+                    enable=True,
+                    mode="aot_fx_trace",
                     precompile_artifact_dir="precompiled",
-                    inductor_compilation="regional",
-                    disable_passes=[],
                 ),
             )
             passes = construct_default_graph_passes(loaded_result, load_config)
@@ -537,6 +556,28 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_deepseekv3)
 
+    def _wrap_ep_chunk_eager_baseline(self, model: nn.Module, case: str) -> None:
+        if case == "transformer_batch":
+            mode, module_fqn = "batch", "layers.*"
+        elif case == "moe_batch":
+            mode, module_fqn = "batch", "layers.*.moe"
+        elif case == "moe_seq":
+            mode, module_fqn = "seq", "layers.*.moe"
+        else:
+            raise AssertionError(f"unknown EP chunk case {case}")
+        maybe_apply_ep_overlap_eager_chunking(
+            model,
+            GraphTrainerCompileConfig(
+                enable=True,
+                ep_overlap=EpOverlapConfig(
+                    enabled=True,
+                    strategy="eager",
+                    chunk_dim=mode,
+                    module_fqn=module_fqn,
+                ),
+            ),
+        )
+
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -601,6 +642,50 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         )
 
         self._assert_runs_match(run_a, run_b, "numerics_changing_optim run-to-run: ")
+
+    @unittest.skipUnless(
+        has_cuda_capability(9, 0),
+        "flex_attention compilation exceeds resource limits on pre-Hopper GPUs",
+    )
+    def test_ep_chunk_matches_eager_chunking_bitwise(self):
+        """Fast single-GPU prerequisite for FlexAttention EP chunking numerics.
+
+        This validates chunking logic, pass composability, and eager-chunked vs.
+        graph-chunked numerics with and without the post-schedule concretization
+        pass. It does not exercise real EP all-to-all communication,
+        distributed sharding, or overlap behavior; the distributed DSV3 numerics
+        tests provide that end-to-end coverage.
+        """
+        cases = [
+            ("transformer_batch", "batch", "layers.*"),
+            ("moe_batch", "batch", "layers.*.moe"),
+            ("moe_seq", "seq", "layers.*.moe"),
+        ]
+        for case, mode, modules in cases:
+            with self.subTest(case=case):
+                eager_model = copy.deepcopy(self.model)
+                self._wrap_ep_chunk_eager_baseline(eager_model, case)
+
+                run_eager = self._run_steps(eager_model, Trainer)
+                graph_model = copy.deepcopy(self.model)
+                # The eager FlexAttention baseline compiles with concrete dims.
+                # Reset Dynamo before tracing the graph-chunked production path,
+                # which starts symbolic and then concretizes before Inductor.
+                torch._dynamo.reset()
+                run_traced = self._run_steps(
+                    graph_model,
+                    GraphTrainer,
+                    compile_ep_overlap_enabled=True,
+                    compile_ep_overlap_chunk_dim=mode,
+                    compile_ep_overlap_module_fqn=modules,
+                    compile_ep_overlap_disable_early_grad_accumulation=True,
+                )
+
+                self._assert_runs_match(
+                    run_eager,
+                    run_traced,
+                    f"eager chunk vs ep_chunk {case}: ",
+                )
 
 
 class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -177,20 +177,98 @@ DSV3_PARALLELISM = (
     " --parallelism.tensor_parallel_degree=2"
     " --parallelism.expert_parallel_degree=2"
 )
+DSV3_EP_OVERLAP_GRAPH_PARALLELISM = (
+    "--parallelism.data_parallel_shard_degree=8"
+    " --parallelism.tensor_parallel_degree=1"
+    " --parallelism.expert_parallel_degree=2"
+)
+DSV3_EP_OVERLAP_OPTIONS = (
+    "--compile.mode aot_fx_trace"
+    " --compile.ep_overlap.enabled"
+    " --compile.ep_overlap.chunk_dim batch"
+    " --compile.ep_overlap.module_fqn layers.*"
+)
+DSV3_EP_OVERLAP_MOE_SEQ_OPTIONS = (
+    "--compile.mode aot_fx_trace"
+    " --compile.ep_overlap.enabled"
+    " --compile.ep_overlap.chunk_dim seq"
+    " --compile.ep_overlap.module_fqn layers.*.moe"
+)
+DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS = (
+    "--compile.mode aot_fx_trace"
+    " --compile.ep_overlap.enabled"
+    " --compile.ep_overlap.chunk_dim batch"
+    " --compile.ep_overlap.module_fqn layers.*.moe"
+)
+DSV3_EP_OVERLAP_EAGER = " --compile.ep_overlap.strategy eager"
+DSV3_EP_OVERLAP_GRAPH = " --compile.ep_overlap.strategy graph"
+DSV3_EP_OVERLAP_GRAPH_BITWISE = (
+    DSV3_EP_OVERLAP_GRAPH + " --compile.ep_overlap.disable_early_grad_accumulation"
+)
 
 
-def _run_deepseek_v3_loss_compare(test_options_extra: str = "") -> bool:
+def _run_deepseek_v3_loss_compare(
+    test_options_extra: str = "",
+    *,
+    baseline_module: str = "deepseek_v3",
+    baseline_config: str = "deepseek_v3_debugmodel",
+    test_config: str = "graph_trainer_deepseek_v3_debugmodel",
+    parallelism: str = DSV3_PARALLELISM,
+    baseline_options_extra: str = "",
+) -> bool:
     """Run loss_compare for deepseek_v3 vs graph_trainer.deepseek_v3."""
-    test_options = DSV3_PARALLELISM
+    baseline_options = parallelism
+    if baseline_options_extra:
+        baseline_options += f" {baseline_options_extra}"
+    test_options = parallelism
     if test_options_extra:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
-        baseline_module="deepseek_v3",
-        baseline_config="deepseek_v3_debugmodel",
+        baseline_module=baseline_module,
+        baseline_config=baseline_config,
         test_module="graph_trainer.deepseek_v3",
-        test_config="graph_trainer_deepseek_v3_debugmodel",
-        baseline_options=DSV3_PARALLELISM,
+        test_config=test_config,
+        baseline_options=baseline_options,
         test_options=test_options,
+    )
+
+
+def _run_deepseek_v3_ep_overlap_loss_compare() -> bool:
+    """Run distributed DeepSeek-v3 EP overlap against eager chunking."""
+    return _run_deepseek_v3_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel",
+        test_config="graph_trainer_deepseek_v3_debugmodel",
+        parallelism=DSV3_EP_OVERLAP_GRAPH_PARALLELISM,
+        baseline_options_extra=DSV3_EP_OVERLAP_OPTIONS + DSV3_EP_OVERLAP_EAGER,
+        test_options_extra=DSV3_EP_OVERLAP_OPTIONS + DSV3_EP_OVERLAP_GRAPH_BITWISE,
+    )
+
+
+def _run_deepseek_v3_ep_overlap_moe_seq_loss_compare() -> bool:
+    """Run distributed DeepSeek-v3 MoE seq overlap against eager chunking."""
+    return _run_deepseek_v3_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel",
+        test_config="graph_trainer_deepseek_v3_debugmodel",
+        parallelism=DSV3_EP_OVERLAP_GRAPH_PARALLELISM,
+        baseline_options_extra=DSV3_EP_OVERLAP_MOE_SEQ_OPTIONS + DSV3_EP_OVERLAP_EAGER,
+        test_options_extra=DSV3_EP_OVERLAP_MOE_SEQ_OPTIONS
+        + DSV3_EP_OVERLAP_GRAPH_BITWISE,
+    )
+
+
+def _run_deepseek_v3_ep_overlap_moe_batch_loss_compare() -> bool:
+    """Run distributed DeepSeek-v3 MoE batch overlap against eager chunking."""
+    return _run_deepseek_v3_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel",
+        test_config="graph_trainer_deepseek_v3_debugmodel",
+        parallelism=DSV3_EP_OVERLAP_GRAPH_PARALLELISM,
+        baseline_options_extra=DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
+        + DSV3_EP_OVERLAP_EAGER,
+        test_options_extra=DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
+        + DSV3_EP_OVERLAP_GRAPH_BITWISE,
     )
 
 
@@ -350,6 +428,15 @@ class TestGraphTrainerNumerics(unittest.TestCase):
                 test_options_extra="--compile.mode aot_fx_trace"
             ),
         )
+
+    def test_moe_dsv3_ep_overlap_aot_fx_trace_vs_eager_chunked(self):
+        self.assertTrue(_run_deepseek_v3_ep_overlap_loss_compare())
+
+    def test_moe_dsv3_ep_overlap_moe_seq_aot_fx_trace_vs_eager_chunked(self):
+        self.assertTrue(_run_deepseek_v3_ep_overlap_moe_seq_loss_compare())
+
+    def test_moe_dsv3_ep_overlap_moe_batch_aot_fx_trace_vs_eager_chunked(self):
+        self.assertTrue(_run_deepseek_v3_ep_overlap_moe_batch_loss_compare())
 
     def test_dense_qwen3_aot_fx_trace_vs_eager(self):
         self.assertTrue(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -25,6 +25,7 @@ from torch.utils.checkpoint import checkpoint, CheckpointPolicy
 
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _EP_TOKEN_EXCHANGE,
     _MODULE_FQN,
     annotate_module_fqns,
 )
@@ -37,9 +38,25 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
     is_cudagraphable,
     is_full_cudagraphable,
 )
+from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
+    _chunk_copied_meta,
+    _materialize_symint_arg,
+    _Region,
+    _rewrite_chunk_symint,
+    apply_chunk_pass,
+    ep_overlap_chunk_pass,
+    mark_chunk_dynamic_dims,
+    populate_chunk_dim_metadata_pass,
+    prepare_ep_overlap_trace_call_inputs,
+    prepare_ep_overlap_trace_inputs,
+)
 from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
     maybe_apply_ep_overlap_eager_chunking,
     populate_eager_chunk_metadata_pass,
+)
+from torchtitan.experiments.graph_trainer.ep_pass_utils import (
+    CHUNK_SYMBOL_HINTS_META,
+    concretize_ep_chunk_symbolic_shapes_pass,
 )
 from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
@@ -48,13 +65,19 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     reassign_collective_pgs_pass,
 )
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
-from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    run_traced,
+)
 from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_default_memory_policy,
     _make_full_memory_policy,
     tag_sac_policy,
 )
-from torchtitan.experiments.graph_trainer.passes import selective_activation_remat_pass
+from torchtitan.experiments.graph_trainer.passes import (
+    compile_time_passes,
+    selective_activation_remat_pass,
+)
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
@@ -271,14 +294,14 @@ class TestReassignCollectivePgsPass(FSDPTest):
 
         bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
 
-        # Create a second PG to simulate expert-FSDP
+        # Create a second PG to simulate expert-FSDP.
         second_pg = dist.new_group(
             ranks=list(range(self.world_size)),
             use_local_synchronization=True,
         )
         second_pg_name = second_pg.group_name
 
-        # Rewrite half the AG nodes to use the second PG
+        # Rewrite half the AG nodes to use the second PG.
         ag_nodes = [n for n in bw_gm.graph.nodes if is_all_gather(n)]
         self.assertGreater(len(ag_nodes), 1)
         half = len(ag_nodes) // 2
@@ -294,7 +317,7 @@ class TestReassignCollectivePgsPass(FSDPTest):
         _EXTRA_FSDP_PG_REGISTRY.pop(second_pg_name, None)
         reassign_collective_pgs_pass(bw_gm, bw_example_inputs)
 
-        # Both source PGs should have their own extra PG
+        # Both source PGs should have their own extra PG.
         self.assertIn(fsdp_pg_name, _EXTRA_FSDP_PG_REGISTRY)
         self.assertIn(second_pg_name, _EXTRA_FSDP_PG_REGISTRY)
         extra_pg1 = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
@@ -303,11 +326,11 @@ class TestReassignCollectivePgsPass(FSDPTest):
             extra_pg1, extra_pg2, "Each source PG must map to a distinct extra PG"
         )
 
-        # No AG nodes should still use original PGs
+        # No AG nodes should still use original PGs.
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name), 0)
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, second_pg_name), 0)
 
-        # All AG nodes should use their respective extra PGs
+        # All AG nodes should use their respective extra PGs.
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg1), ag_pg1_before)
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg2), ag_pg2_before)
 
@@ -335,7 +358,11 @@ class TestReassignCollectivePgsPass(FSDPTest):
         a2a = graph.call_function(
             c10d.all_to_all_single.default, args=(x, [], [], fsdp_pg_name)
         )
-        a2a.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+        a2a.meta["custom"] = {
+            _MODULE_FQN: "layers.0.moe",
+            "EP": "dispatch",
+            _EP_TOKEN_EXCHANGE: "dispatch",
+        }
         graph.output((wait, rs_wait, a2a))
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
@@ -382,7 +409,11 @@ class TestReassignCollectivePgsPass(FSDPTest):
         a2a = graph.call_function(
             c10d.all_to_all_single.default, args=(x, [], [], ep_pg_name)
         )
-        a2a.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+        a2a.meta["custom"] = {
+            _MODULE_FQN: "layers.0.moe",
+            "EP": "combine",
+            _EP_TOKEN_EXCHANGE: "combine",
+        }
         graph.output((wait, rs_wait, a2a))
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
@@ -1132,6 +1163,2022 @@ class TestRemoveDetachPass(TestCase):
         self.assertEqual(gm(x), expected)
 
 
+class TestChunkPasses(TestCase):
+    def _assert_symbolic_dim_from_sources(self, actual, source, expected_hint: int):
+        from torch.fx.experimental.symbolic_shapes import (
+            free_symbols,
+            optimization_hint,
+        )
+
+        self.assertEqual(free_symbols(actual), free_symbols(source))
+        self.assertEqual(optimization_hint(actual), expected_hint)
+
+    def _symbolic_batch_fake_mode(self, batch: int = 4):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            sym_batch = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(sym_batch, batch)
+        return fake_mode, sym_batch
+
+    def _chunk_batch(self, gm, **kwargs):
+        return apply_chunk_pass(gm, mode="batch", **kwargs)
+
+    def _chunk_seq(self, gm, **kwargs):
+        return apply_chunk_pass(gm, mode="seq", **kwargs)
+
+    def test_concretize_chunk_symbols_updates_nested_graph_modules(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols
+
+        def call_with_subgraph(subgraph, x):
+            del subgraph
+            return x
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode(4)
+        batch_symbol = next(iter(free_symbols(sym_batch)))
+        with fake_mode:
+            x_val = torch.empty(sym_batch, 3)
+
+        sub_graph = torch.fx.Graph()
+        sub_x = sub_graph.placeholder("sub_x")
+        sub_graph.output(sub_x)
+        sub_gm = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+        sub_x.meta["val"] = x_val
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        call = graph.call_function(call_with_subgraph, args=(sub_gm, x))
+        graph.output(call)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = x_val
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {batch_symbol: 4}
+        call.meta["val"] = x_val
+
+        concretize_ep_chunk_symbolic_shapes_pass(gm)
+
+        self.assertEqual(free_symbols(x.meta["val"].shape[0]), set())
+        self.assertEqual(free_symbols(sub_x.meta["val"].shape[0]), set())
+
+    def test_concretize_chunk_symbols_updates_nested_scalar_example_values(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols
+
+        def call_with_subgraph(subgraph, length):
+            del subgraph
+            return length
+
+        _, sym_batch = self._symbolic_batch_fake_mode(4)
+        batch_symbol = next(iter(free_symbols(sym_batch)))
+
+        sub_graph = torch.fx.Graph()
+        sub_length = sub_graph.placeholder("sub_length")
+        sub_graph.output(sub_length)
+        sub_gm = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+        sub_length.meta["example_value"] = sym_batch
+
+        graph = torch.fx.Graph()
+        length = graph.placeholder("length")
+        call = graph.call_function(call_with_subgraph, args=(sub_gm, length))
+        graph.output(call)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        length.meta["example_value"] = sym_batch
+        length.meta[CHUNK_SYMBOL_HINTS_META] = {batch_symbol: 4}
+        call.meta["example_value"] = sym_batch
+
+        concretize_ep_chunk_symbolic_shapes_pass(gm)
+
+        self.assertEqual(length.meta["example_value"], 4)
+        self.assertEqual(sub_length.meta["example_value"], 4)
+
+    def _build_linear_region_gm(
+        self, *, input_shape=(4, 3), fqn="layers.0", mode: str = "batch"
+    ):
+        graph = torch.fx.Graph()
+        w = graph.placeholder("w")
+        x = graph.placeholder("x")
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, w))
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(mm,))
+        graph.output(relu)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        dim = {"batch": 0, "seq": 1}[mode]
+        fake_mode, sym_extent = self._symbolic_batch_fake_mode(input_shape[dim])
+        x_shape = list(input_shape)
+        x_shape[dim] = sym_extent
+        with fake_mode:
+            w_val = torch.empty(input_shape[-1], input_shape[-1])
+            x_val = torch.empty(*x_shape)
+            out_val = torch.empty(*x_shape)
+
+        w.meta["val"] = w_val
+        x.meta["val"] = x_val
+        for node in (mm, relu):
+            node.meta["val"] = out_val
+            node.meta["custom"] = {_MODULE_FQN: fqn}
+            node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+        return gm
+
+    def _build_view_region_gm(
+        self, *, shape_arg, fqn: str = "layers.0.moe"
+    ) -> torch.fx.GraphModule:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        view = graph.call_function(torch.ops.aten.view.default, args=(x, shape_arg))
+        graph.output(view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode(4)
+        with fake_mode:
+            x_val = torch.empty(sym_batch, 3)
+            out_val = torch.empty(sym_batch, 3)
+
+        x.meta["val"] = x_val
+        view.meta["val"] = out_val
+        view.meta["custom"] = {_MODULE_FQN: fqn}
+        view.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+        view.stack_trace = "model.py:12 in forward\n    x = x.view(4, 3)"
+        return gm
+
+    def _nodes_by_target(self, gm, target):
+        return [
+            n for n in gm.graph.nodes if n.op == "call_function" and n.target is target
+        ]
+
+    def _assert_no_raw_selected_symbol_args(self, gm, symbol_hints):
+        from torch.fx.experimental.symbolic_shapes import free_symbols
+        from torch.utils._pytree import tree_leaves
+
+        chunk_symbols = symbol_hints.keys()
+        for node in gm.graph.nodes:
+            if node.meta.get("chunked_region_role") is None:
+                continue
+            for value in tree_leaves((node.args, node.kwargs)):
+                if isinstance(
+                    value, (torch.SymInt, torch.SymFloat, torch.SymBool)
+                ) and (free_symbols(value) & chunk_symbols):
+                    self.fail(
+                        "chunk-created executable args must materialize "
+                        f"selected symbols as FX nodes: node={node.name}, "
+                        f"value={value}"
+                    )
+
+    def test_static_view_shape_constant_errors_with_source_stack(self):
+        gm = self._build_view_region_gm(shape_arg=[4, 3])
+
+        with self.assertRaises(ValueError) as cm:
+            self._chunk_batch(gm, module_patterns=["layers.*.moe"])
+        message = str(cm.exception)
+        self.assertIn("baked a Python constant", message)
+        self.assertIn("model.py:12", message)
+        self.assertIn("x.shape", message)
+        self.assertIn("-1", message)
+
+    def test_view_inferred_dim_is_valid_symbolic_shape_source(self):
+        gm = self._build_view_region_gm(shape_arg=[-1, 3])
+
+        self._chunk_batch(gm, module_patterns=["layers.*.moe"])
+
+    def test_view_dim_list_is_not_treated_as_shape(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        squeeze = graph.call_function(torch.ops.aten.squeeze.dims, args=(x, [1]))
+        graph.output(squeeze)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode(4)
+        with fake_mode:
+            x.meta["val"] = torch.empty(sym_batch, 1, 3)
+            squeeze.meta["val"] = torch.empty(sym_batch, 3)
+        squeeze.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+        squeeze.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+
+        self._chunk_batch(gm, module_patterns=["layers.*.moe"])
+
+    def _set_fake_tensor_meta(
+        self,
+        node,
+        val,
+        *,
+        fqn: str | None = None,
+        backward: bool = False,
+    ):
+        node.meta["val"] = val
+        if fqn is not None:
+            node.meta["custom"] = {_MODULE_FQN: fqn}
+        if backward:
+            node.meta["autograd_backward"] = True
+        return node
+
+    def _mark_chunk_body(
+        self,
+        node,
+        *,
+        fqn: str = "layers.0.moe",
+        chunk_id: int,
+        backward: bool = False,
+        ep: str | None = None,
+        token_exchange: bool = False,
+        producer: str | None = None,
+    ):
+        custom = dict(node.meta.get("custom", {}))
+        custom[_MODULE_FQN] = fqn
+        if ep is not None:
+            custom["EP"] = ep
+            if token_exchange:
+                custom[_EP_TOKEN_EXCHANGE] = ep
+        node.meta["custom"] = custom
+        node.meta["chunk_id"] = chunk_id
+        node.meta["chunked_region_fqn"] = fqn
+        node.meta["chunked_region_role"] = "body"
+        if producer is not None:
+            node.meta["chunked_region_producer"] = producer
+        if backward:
+            node.meta["autograd_backward"] = True
+        return node
+
+    def _build_backward_grad_chain_gm(
+        self,
+        *,
+        cast: bool = False,
+        collective: str | None = None,
+        wait: bool = False,
+        full_consumer: bool = False,
+    ):
+        graph = torch.fx.Graph()
+        w = graph.placeholder("w")
+        x = graph.placeholder("x")
+        grad_out = graph.placeholder("grad_out")
+        x_t = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        grad_w = graph.call_function(torch.ops.aten.mm.default, args=(x_t, grad_out))
+        value = grad_w
+        cast_node = None
+        if cast:
+            cast_node = graph.call_function(
+                torch.ops.aten._to_copy.default,
+                args=(value,),
+                kwargs={"dtype": torch.float32},
+            )
+            value = cast_node
+
+        c10d = torch.ops._c10d_functional
+        collective_node = None
+        if collective == "reduce_scatter":
+            collective_node = graph.call_function(
+                c10d.reduce_scatter_tensor.default,
+                args=(value, "sum", 2, "dp"),
+            )
+            value = collective_node
+        elif collective == "all_reduce":
+            collective_node = graph.call_function(
+                c10d.all_reduce.default,
+                args=(value, "sum", "dp"),
+            )
+            value = collective_node
+        elif collective is not None:
+            raise AssertionError(f"unknown collective {collective}")
+
+        wait_node = None
+        if wait:
+            if collective_node is None:
+                raise AssertionError("wait=True requires a collective")
+            wait_node = graph.call_function(c10d.wait_tensor.default, args=(value,))
+            value = wait_node
+
+        full_consumer_node = None
+        if full_consumer:
+            full_consumer_node = graph.call_function(
+                torch.ops.aten.neg.default, args=(value,)
+            )
+            value = full_consumer_node
+
+        graph.output((grad_out, value))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        dtype = torch.bfloat16 if cast else torch.float32
+        with fake_mode:
+            w_val = torch.empty(3, 3, dtype=dtype)
+            act_val = torch.empty(sym_batch, 3, dtype=dtype)
+            x_t_val = torch.empty(3, sym_batch, dtype=dtype)
+            grad_val = torch.empty(3, 3, dtype=dtype)
+            grad_fp32_val = torch.empty(3, 3, dtype=torch.float32)
+
+        self._set_fake_tensor_meta(w, w_val)
+        self._set_fake_tensor_meta(x, act_val)
+        self._set_fake_tensor_meta(grad_out, act_val)
+        self._set_fake_tensor_meta(x_t, x_t_val, fqn="layers.0", backward=True)
+        self._set_fake_tensor_meta(grad_w, grad_val, fqn="layers.0", backward=True)
+        if cast_node is not None:
+            self._set_fake_tensor_meta(
+                cast_node, grad_fp32_val, fqn="layers.0", backward=True
+            )
+        if collective_node is not None:
+            self._set_fake_tensor_meta(
+                collective_node,
+                grad_fp32_val if cast else grad_val,
+                fqn="layers.0",
+                backward=True,
+            )
+        if wait_node is not None:
+            self._set_fake_tensor_meta(
+                wait_node,
+                grad_fp32_val if cast else grad_val,
+                fqn="layers.0",
+                backward=True,
+            )
+        if full_consumer_node is not None:
+            self._set_fake_tensor_meta(
+                full_consumer_node,
+                grad_fp32_val if cast else grad_val,
+                fqn="layers.0",
+                backward=True,
+            )
+        return gm, {
+            "grad_w": grad_w,
+            "cast": cast_node,
+            "collective": collective_node,
+            "wait": wait_node,
+            "full_consumer": full_consumer_node,
+        }
+
+    def _build_dense_then_moe_gm(self, *, include_all_to_all: bool = True):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        dense = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        moe = graph.call_function(torch.ops.aten.neg.default, args=(dense,))
+        if include_all_to_all:
+            a2a = graph.call_function(
+                torch.ops._c10d_functional.all_to_all_single.default,
+                args=(moe, [], [], "ep"),
+            )
+            graph.output(a2a)
+        else:
+            a2a = None
+            graph.output(moe)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+
+        x.meta["val"] = val
+        node_fqns = [
+            (dense, "layers.0"),
+            (moe, "layers.1.moe"),
+        ]
+        if a2a is not None:
+            node_fqns.append((a2a, "layers.1.moe"))
+        for node, fqn in node_fqns:
+            node.meta["val"] = val
+            node.meta["custom"] = {_MODULE_FQN: fqn}
+        moe.meta["custom"]["EP"] = "compute"
+        if a2a is not None:
+            a2a.meta["custom"]["EP"] = "dispatch"
+        return gm
+
+    def _build_previous_module_live_in_gm(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        prev = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        cur = graph.call_function(torch.ops.aten.neg.default, args=(prev,))
+        graph.output(cur)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+
+        x.meta["val"] = val
+        for node, fqn in ((prev, "layers.0"), (cur, "layers.1")):
+            node.meta["val"] = val
+            node.meta["custom"] = {_MODULE_FQN: fqn}
+        return gm
+
+    def _build_scalar_live_out_gm(self, *, valid: bool):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        size = graph.call_function(torch.ops.aten.sym_size.int, args=(relu, 0))
+        if valid:
+            scalar = size
+        else:
+            neg = graph.call_function(torch.ops.aten.neg.default, args=(x,))
+            other_size = graph.call_function(torch.ops.aten.sym_size.int, args=(neg, 0))
+            scalar = graph.call_function(operator.add, args=(size, other_size))
+        graph.output((relu, scalar))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+
+        x.meta["val"] = val
+        relu.meta["val"] = val
+        relu.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        size.meta["val"] = sym_batch
+        size.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        if not valid:
+            neg.meta["val"] = val
+            neg.meta["custom"] = {_MODULE_FQN: "layers.0"}
+            other_size.meta["val"] = sym_batch
+            other_size.meta["custom"] = {_MODULE_FQN: "layers.0"}
+            scalar.meta["val"] = sym_batch + sym_batch
+            scalar.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        return gm
+
+    def _build_tuple_dead_getitem_gm(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        max_tuple = graph.call_function(torch.ops.aten.max.dim, args=(x, 1))
+        values = graph.call_function(operator.getitem, args=(max_tuple, 0))
+        graph.call_function(operator.getitem, args=(max_tuple, 1))
+        neg = graph.call_function(torch.ops.aten.neg.default, args=(values,))
+        graph.output(neg)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+            out_val = torch.empty(sym_batch)
+
+        x.meta["val"] = val
+        max_tuple.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        max_tuple.meta["autograd_backward"] = True
+        values.meta["val"] = out_val
+        for node in (values, neg):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+            node.meta["autograd_backward"] = True
+        neg.meta["val"] = out_val
+        return gm
+
+    def _build_opposite_direction_gm(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        backward_node = graph.call_function(torch.ops.aten.neg.default, args=(x,))
+        forward_node = graph.call_function(
+            torch.ops.aten.relu.default, args=(backward_node,)
+        )
+        graph.output(forward_node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+
+        x.meta["val"] = val
+        backward_node.meta["val"] = val
+        backward_node.meta["autograd_backward"] = True
+        forward_node.meta["val"] = val
+        forward_node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        return gm
+
+    def _build_forward_non_additive_no_dim_live_out_gm(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        amax = graph.call_function(torch.ops.aten.amax.default, args=(relu, [0], False))
+        graph.output((relu, amax))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+            reduced_val = torch.empty(3)
+
+        x.meta["val"] = val
+        relu.meta["val"] = val
+        relu.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        amax.meta["val"] = reduced_val
+        amax.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        return gm
+
+    def _build_buffer_mutation_gm(self):
+        graph = torch.fx.Graph()
+        buf = graph.placeholder("buf")
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        count = graph.call_function(torch.ops.aten.sum.dim_IntList, args=(x, [0]))
+        add_ = graph.call_function(torch.ops.aten.add_.Tensor, args=(buf, count))
+        graph.output(relu)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+            reduced_val = torch.empty(3)
+
+        buf.meta["val"] = reduced_val
+        x.meta["val"] = val
+        relu.meta["val"] = val
+        relu.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        for node in (count, add_):
+            node.meta["val"] = reduced_val
+            node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        return gm
+
+    def _build_backward_internal_no_dim_live_out_gm(self):
+        graph = torch.fx.Graph()
+        w = graph.placeholder("w")
+        x = graph.placeholder("x")
+        grad_out = graph.placeholder("grad_out")
+        grad_act = graph.call_function(torch.ops.aten.mm.default, args=(grad_out, w))
+        x_t = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        grad_w = graph.call_function(torch.ops.aten.mm.default, args=(x_t, grad_out))
+        post = graph.call_function(torch.ops.aten.neg.default, args=(grad_w,))
+        graph.output((grad_act, post))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            w_val = torch.empty(3, 3)
+            val = torch.empty(sym_batch, 3)
+            x_t_val = torch.empty(3, sym_batch)
+
+        w.meta["val"] = w_val
+        x.meta["val"] = val
+        grad_out.meta["val"] = val
+        grad_act.meta["val"] = val
+        x_t.meta["val"] = x_t_val
+        grad_w.meta["val"] = w_val
+        post.meta["val"] = w_val
+        for node in (grad_act, x_t, grad_w):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+            node.meta["autograd_backward"] = True
+        return gm
+
+    def _build_indirect_per_chunk_live_out_gm(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        grad = graph.placeholder("grad")
+        fwd = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        saved = graph.call_function(torch.ops.aten.amax.default, args=(fwd, [0], False))
+        indirect_helper = graph.call_function(
+            torch.ops.aten.unsqueeze.default, args=(saved, 0)
+        )
+        bwd = graph.call_function(
+            torch.ops.aten.add.Tensor, args=(grad, indirect_helper)
+        )
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+            chunkless_val = torch.empty(3)
+            helper_val = torch.empty(1, 3)
+
+        for node in (x, grad):
+            node.meta["val"] = val
+        fwd.meta["val"] = val
+        fwd.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        saved.meta["val"] = chunkless_val
+        saved.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        for node, meta_val in ((indirect_helper, helper_val), (bwd, val)):
+            node.meta["val"] = meta_val
+            node.meta["custom"] = {_MODULE_FQN: "layers.1"}
+            node.meta["autograd_backward"] = True
+        return gm
+
+    def test_chunk_batch_forward_region_semantics(self):
+        gm = self._build_linear_region_gm()
+        w = torch.randn(3, 3)
+        x = torch.randn(4, 3)
+        expected = gm(w, x)
+
+        self._chunk_batch(
+            gm,
+            module_patterns=["layers.*"],
+            num_static_inputs=1,
+        )
+
+        actual = gm(w, x)
+        self.assertEqual(actual, expected)
+
+        split_nodes = self._nodes_by_target(gm, torch.ops.aten.split_with_sizes.default)
+        cat_nodes = self._nodes_by_target(gm, torch.ops.aten.cat.default)
+        mm_nodes = self._nodes_by_target(gm, torch.ops.aten.mm.default)
+
+        self.assertEqual(len(split_nodes), 1)
+        self.assertEqual(split_nodes[0].args[0].name, "x")
+        self.assertEqual(len(cat_nodes), 1)
+        self.assertEqual(cat_nodes[0].args[1], 0)
+        self.assertEqual(
+            cat_nodes[0].meta.get("chunked_region_role"), "materialization"
+        )
+        self.assertEqual(
+            len(self._nodes_by_target(gm, torch.ops.aten.clone.default)), 0
+        )
+        self.assertNotIn("chunk_id", cat_nodes[0].meta)
+        self.assertEqual(len(mm_nodes), 2)
+        self.assertEqual({n.meta.get("chunk_id") for n in mm_nodes}, {0, 1})
+        self.assertEqual([n.meta.get("chunk_id") for n in mm_nodes], [0, 1])
+        self.assertTrue(
+            all(n.meta.get("chunked_region_role") == "body" for n in mm_nodes)
+        )
+
+    def test_chunk_batch_treats_previous_module_output_as_live_in(self):
+        gm = self._build_previous_module_live_in_gm()
+        inp = torch.randn(4, 3)
+        expected = gm(inp)
+
+        self._chunk_batch(gm, module_patterns=["layers.1"])
+
+        actual = gm(inp)
+        self.assertEqual(actual, expected)
+
+        relu_nodes = self._nodes_by_target(gm, torch.ops.aten.relu.default)
+        neg_nodes = self._nodes_by_target(gm, torch.ops.aten.neg.default)
+        self.assertEqual(len(relu_nodes), 1)
+        self.assertEqual(len(neg_nodes), 2)
+        self.assertEqual({n.meta.get("chunk_id") for n in neg_nodes}, {0, 1})
+
+    def test_chunk_batch_materializes_between_selected_roots(self):
+        gm = self._build_previous_module_live_in_gm()
+
+        self._chunk_batch(gm, module_patterns=["layers.*"])
+
+        cat_nodes = self._nodes_by_target(gm, torch.ops.aten.cat.default)
+        split_nodes = self._nodes_by_target(gm, torch.ops.aten.split_with_sizes.default)
+        self.assertEqual(len(cat_nodes), 2)
+        self.assertEqual(len(split_nodes), 2)
+        self.assertIs(split_nodes[1].args[0], cat_nodes[0])
+
+    def test_chunk_batch_materializes_scalar_live_out(self):
+        gm = self._build_scalar_live_out_gm(valid=True)
+        inp = torch.randn(4, 3)
+        expected = gm(inp)
+
+        self._chunk_batch(gm, module_patterns=["layers.*"])
+
+        actual = gm(inp)
+        self.assertEqual(actual[0], expected[0])
+        self.assertEqual(actual[1], expected[1])
+
+    def test_chunk_batch_rejects_invalid_region_boundaries(self):
+        with self.assertRaisesRegex(ValueError, "Cannot split selected chunk"):
+            self._chunk_batch(
+                self._build_linear_region_gm(input_shape=(3, 3)),
+                module_patterns=["layers.*"],
+                num_static_inputs=1,
+            )
+
+        with self.assertRaisesRegex(ValueError, "opposite graph direction"):
+            self._chunk_batch(
+                self._build_opposite_direction_gm(),
+                module_patterns=["layers.*"],
+            )
+
+        with self.assertRaisesRegex(NotImplementedError, "full-K/V"):
+            self._chunk_seq(
+                self._build_linear_region_gm(
+                    input_shape=(2, 4, 3),
+                    fqn="layers.0.attention",
+                    mode="seq",
+                ),
+                module_patterns=["layers.*.attention"],
+                num_static_inputs=1,
+            )
+
+    def test_chunk_seq_preserves_split_view_stride_scalar_live_in(self):
+        fake_mode, sym_seq = self._symbolic_batch_fake_mode(4)
+        with fake_mode:
+            x_val = torch.empty(2, sym_seq, 256)
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        stride0 = graph.call_function(torch.ops.aten.sym_stride.int, args=(x, 0))
+        view = graph.call_function(
+            torch.ops.aten.as_strided.default,
+            args=(x, [2, sym_seq, 256], [stride0, 256, 1]),
+        )
+        graph.output(view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = x_val
+        stride0.meta["val"] = x_val.stride(0)
+        view.meta["val"] = x_val
+        view.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+        view.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+
+        self._chunk_seq(gm, module_patterns=["layers.*.moe"])
+
+    def test_chunk_seq_keeps_parent_shape_template_full(self):
+        fake_mode, sym_seq = self._symbolic_batch_fake_mode(4)
+        with fake_mode:
+            x_val = torch.empty(8, sym_seq, 256)
+            moe_val = torch.empty(8, sym_seq, 256)
+            template_flat_val = torch.empty(8 * sym_seq, 256)
+            template_val = torch.empty(8, sym_seq, 256)
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        seq = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 1))
+        flat = graph.call_function(operator.mul, args=(8, seq))
+        body_zeros = graph.call_function(
+            torch.ops.aten.zeros.default,
+            args=([flat, 256],),
+            kwargs={
+                "dtype": torch.bfloat16,
+                "device": torch.device("cpu"),
+                "pin_memory": False,
+            },
+        )
+        body_view = graph.call_function(
+            torch.ops.aten.view.default, args=(body_zeros, [8, seq, 256])
+        )
+        moe_out = graph.call_function(torch.ops.aten.add.Tensor, args=(x, body_view))
+        template_flat = graph.call_function(
+            torch.ops.aten.empty_strided.default,
+            args=([flat, 256], [256, 1]),
+            kwargs={
+                "dtype": torch.bfloat16,
+                "device": torch.device("cpu"),
+                "pin_memory": False,
+            },
+        )
+        template = graph.call_function(
+            torch.ops.aten.view.default, args=(template_flat, [8, seq, 256])
+        )
+        stride0 = graph.call_function(torch.ops.aten.sym_stride.int, args=(template, 0))
+        parent_empty = graph.call_function(
+            torch.ops.aten.empty_strided.default,
+            args=([8, seq, 256], [stride0, 256, 1]),
+            kwargs={
+                "dtype": torch.bfloat16,
+                "device": torch.device("cpu"),
+                "pin_memory": False,
+            },
+        )
+        graph.output((moe_out, parent_empty))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = x_val
+        seq.meta["val"] = sym_seq
+        flat.meta["val"] = 8 * sym_seq
+        body_zeros.meta["val"] = template_flat_val
+        body_view.meta["val"] = template_val
+        moe_out.meta["val"] = moe_val
+        template_flat.meta["val"] = template_flat_val
+        template.meta["val"] = template_val
+        stride0.meta["val"] = template_val.stride(0)
+        parent_empty.meta["val"] = template_val
+        for node in (body_zeros, body_view, moe_out, template_flat, template, stride0):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+        parent_empty.meta["custom"] = {_MODULE_FQN: "layers.0"}
+
+        self._chunk_seq(gm, module_patterns=["layers.*.moe"])
+
+        self.assertIs(stride0.args[0], template)
+        self.assertIs(parent_empty.args[1][0], stride0)
+        self.assertIs(flat.args[0], 8)
+        self.assertIs(flat.args[1], seq)
+        self.assertNotEqual(stride0.meta.get("chunked_region_role"), "body")
+        self.assertNotEqual(template.meta.get("chunked_region_role"), "body")
+
+    def test_chunk_seq_matches_eager_symbolic_flatten_view_contract(self):
+        class FlatMoe(torch.nn.Module):
+            def forward(self, x):
+                batch, seq, dim = x.shape
+                flat = x.view(-1, dim)
+                return (flat + 1).view(batch, seq, dim)
+
+        class ChunkModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([torch.nn.Module()])
+                self.layers[0].moe = FlatMoe()
+
+            def forward(self, x):
+                return self.layers[0].moe(x)
+
+        def trace_model(strategy: str):
+            model = ChunkModel()
+            annotate_module_fqns(model)
+            if strategy == "eager":
+                maybe_apply_ep_overlap_eager_chunking(
+                    model,
+                    GraphTrainerCompileConfig(
+                        enable=True,
+                        ep_overlap=EpOverlapConfig(
+                            enabled=True,
+                            strategy="eager",
+                            chunk_dim="seq",
+                            module_fqn="layers.*.moe",
+                        ),
+                    ),
+                )
+
+            x = torch.randn(2, 4, 8)
+            mark_chunk_dynamic_dims(x, mode="seq")
+            traced = minimal_fx_tracer(lambda inp: model(inp), module=model)(x)
+            if strategy == "eager":
+                populate_eager_chunk_metadata_pass(traced.gm)
+            else:
+                populate_chunk_dim_metadata_pass(
+                    traced.gm, traced.example_inputs, mode="seq"
+                )
+                self._chunk_seq(
+                    traced.gm,
+                    module_patterns=["layers.*.moe"],
+                    num_static_inputs=traced.num_static_inputs,
+                )
+            return model, traced
+
+        eager_model, eager = trace_model("eager")
+        graph_model, graph = trace_model("graph")
+
+        eager_clones = self._nodes_by_target(eager.gm, torch.ops.aten.clone.default)
+        graph_clones = [
+            node
+            for node in self._nodes_by_target(graph.gm, torch.ops.aten.clone.default)
+            if node.meta.get("chunked_region_role") == "chunk_input"
+        ]
+        self.assertEqual(len(eager_clones), 2)
+        self.assertEqual(len(graph_clones), 2)
+        self.assertEqual({node.meta.get("chunk_id") for node in graph_clones}, {0, 1})
+        self.assertEqual(
+            [tuple(node.meta["val"].shape) for node in graph_clones],
+            [tuple(node.meta["val"].shape) for node in eager_clones],
+        )
+        self.assertEqual(
+            [node.meta["val"].stride() for node in graph_clones],
+            [node.meta["val"].stride() for node in eager_clones],
+        )
+
+        graph_body_targets = {
+            node.meta.get("chunk_id"): [
+                body.target
+                for body in graph.gm.graph.nodes
+                if body.meta.get("chunked_region_role") == "body"
+                and body.meta.get("chunk_id") == node.meta.get("chunk_id")
+            ]
+            for node in graph_clones
+        }
+        for targets in graph_body_targets.values():
+            self.assertIn(torch.ops.aten.view.default, targets)
+            self.assertIn(torch.ops.aten.add.Tensor, targets)
+
+        x_input = torch.randn(2, 4, 8)
+        self.assertEqual(
+            run_traced(graph, module=graph_model)(x_input),
+            run_traced(eager, module=eager_model)(x_input),
+        )
+
+    def test_chunk_seq_rewrites_dependent_symbolic_scalar_live_in(self):
+        fake_mode, sym_seq = self._symbolic_batch_fake_mode(4)
+        with fake_mode:
+            x_val = torch.empty(8, sym_seq, 256)
+            out_val = torch.empty_strided(
+                (8, sym_seq, 256),
+                (256 * torch.sym_max(1, sym_seq), 256, 1),
+            )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        stride0 = graph.call_function(torch.ops.aten.sym_stride.int, args=(x, 0))
+        empty = graph.call_function(
+            torch.ops.aten.empty_strided.default,
+            args=([8, sym_seq, 256], [stride0, 256, 1]),
+            kwargs={
+                "dtype": torch.float32,
+                "device": torch.device("cpu"),
+                "pin_memory": False,
+            },
+        )
+        add = graph.call_function(torch.ops.aten.add.Tensor, args=(x, empty))
+        graph.output(add)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = x_val
+        stride0.meta["val"] = x_val.stride(0)
+        empty.meta["val"] = out_val
+        add.meta["val"] = out_val
+        for node in (empty, add):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+
+        self._chunk_seq(gm, module_patterns=["layers.*.moe"])
+        concretize_ep_chunk_symbolic_shapes_pass(gm)
+
+        out = gm(torch.empty(8, 4, 256))
+        self.assertEqual(out.shape, (8, 4, 256))
+        self.assertEqual(out.stride(), (1024, 256, 1))
+
+    def test_chunk_batch_rewrites_mixed_symbolic_scalar_live_in(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            width = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            torch._dynamo.override_optimization_hint(width, 5)
+            x_val = torch.empty(batch, width)
+            flat_val = torch.empty(batch * width)
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        batch_size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        width_size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 1))
+        flat_size = graph.call_function(operator.mul, args=(batch_size, width_size))
+        view = graph.call_function(torch.ops.aten.view.default, args=(x, [flat_size]))
+        graph.output(view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x.meta["val"] = x_val
+        batch_size.meta["val"] = batch
+        width_size.meta["val"] = width
+        flat_size.meta["val"] = batch * width
+        view.meta["val"] = flat_val
+        view.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        view.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+
+        self._chunk_batch(gm, module_patterns=["layers.*"])
+        self._assert_no_raw_selected_symbol_args(gm, {batch.node.expr: 4})
+
+        chunk_views = [
+            node
+            for node in self._nodes_by_target(gm, torch.ops.aten.view.default)
+            if node.meta.get("chunked_region_role") == "body"
+        ]
+        self.assertEqual(len(chunk_views), 2)
+        self.assertTrue(
+            all(isinstance(node.args[1][0], torch.fx.Node) for node in chunk_views)
+        )
+        self.assertEqual(
+            {str(node.meta["val"].shape[0]) for node in chunk_views},
+            {f"{width}*(({batch}//2))"},
+        )
+        self.assertEqual(gm(torch.randn(4, 5)).shape, (20,))
+
+    def test_chunk_rewrite_materializes_nested_floor_div(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            seq = shape_env.create_unbacked_symint()
+            width = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(seq, 8)
+            torch._dynamo.override_optimization_hint(width, 5)
+            x_val = torch.empty(seq, width)
+            tp_local_flat = (seq // 2) * width
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = x_val
+
+        chunked_flat = _rewrite_chunk_symint(tp_local_flat, {seq.node.expr: 8})
+        self.assertNotIn("floor(", str(chunked_flat))
+
+        region = _Region(
+            root_fqn="layers.0",
+            synthetic_parent_fqn="layers.0",
+            is_backward=False,
+            nodes=(),
+        )
+        with gm.graph.inserting_after(x):
+            materialized = _materialize_symint_arg(
+                gm, chunked_flat, region=region, role="chunk_input"
+            )
+
+        self.assertIsInstance(materialized, torch.fx.Node)
+        self.assertEqual(materialized.target, operator.mul)
+        self.assertTrue(
+            any(node.target is operator.floordiv for node in gm.graph.nodes)
+        )
+
+    def test_chunk_dim_classifies_derived_shapes_without_hint(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
+
+        from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
+            _chunk_dim_from_symbols,
+        )
+        from torchtitan.experiments.graph_trainer.ep_pass_utils import (
+            statically_equals_hint,
+        )
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            routed = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            torch._check(batch >= 2)
+            val = torch.empty(batch + routed, 8)
+
+        batch_symbol = next(iter(free_symbols(batch)))
+        symbol_hints = {batch_symbol: 4}
+        chunk_dim = _chunk_dim_from_symbols(val, symbol_hints)
+        self.assertIsNotNone(chunk_dim)
+        self.assertEqual(chunk_dim.dim, 0)
+        self.assertIsNone(chunk_dim.hint)
+
+        invariant = torch.sym_min(0, 2048 * batch)
+        self.assertTrue(statically_equals_hint(invariant, 0))
+
+    def test_chunk_batch_rejects_unsupported_live_outs(self):
+        with self.assertRaisesRegex(ValueError, "cannot materialize scalar live-out"):
+            self._chunk_batch(
+                self._build_scalar_live_out_gm(valid=False),
+                module_patterns=["layers.*"],
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "forward accumulation proof or a backward parameter-gradient consumer",
+        ):
+            self._chunk_batch(
+                self._build_forward_non_additive_no_dim_live_out_gm(),
+                module_patterns=["layers.*"],
+            )
+
+        gm = self._build_indirect_per_chunk_live_out_gm()
+        with self.assertRaisesRegex(ValueError, "without chunk dimension"):
+            self._chunk_batch(gm, module_patterns=["layers.*"])
+
+    def test_chunk_batch_ignores_dead_tuple_getitem_user(self):
+        gm = self._build_tuple_dead_getitem_gm()
+        self._chunk_batch(gm, module_patterns=["layers.*"])
+
+        max_nodes = self._nodes_by_target(gm, torch.ops.aten.max.dim)
+        self.assertEqual(len(max_nodes), 2)
+        self.assertEqual({node.meta.get("chunk_id") for node in max_nodes}, {0, 1})
+
+    def test_chunk_batch_backward_sums_internal_no_dim_live_out(self):
+        gm = self._build_backward_internal_no_dim_live_out_gm()
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        self.assertEqual(len(sum_nodes), 1)
+        self.assertTrue(
+            all(
+                node.meta.get("chunked_region_role") != "body"
+                for node in self._nodes_by_target(gm, torch.ops.aten.neg.default)
+            )
+        )
+
+    def test_chunk_batch_preserves_buffer_mutation_order(self):
+        gm = self._build_buffer_mutation_gm()
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+        add_mutations = self._nodes_by_target(gm, torch.ops.aten.add_.Tensor)
+        self.assertEqual(len(add_mutations), 2)
+        self.assertEqual({node.meta.get("chunk_id") for node in add_mutations}, {0, 1})
+        by_chunk = {node.meta.get("chunk_id"): node for node in add_mutations}
+        self.assertIs(by_chunk[1].args[0], by_chunk[0])
+
+    def test_ep_overlap_chunk_accepts_moe_module_pattern(self):
+        self._chunk_batch(
+            self._build_linear_region_gm(fqn="layers.0.moe"),
+            module_patterns=["layers.*.moe"],
+            num_static_inputs=1,
+        )
+
+    def _compile_config_for_ep_overlap_test(self):
+        from types import SimpleNamespace
+
+        traced_result = SimpleNamespace(num_static_inputs=2, state_fqns=[])
+        config = SimpleNamespace(
+            model_spec=SimpleNamespace(model=SimpleNamespace(layers=[object()])),
+            parallelism=SimpleNamespace(
+                enable_async_tensor_parallel=False,
+                expert_parallel_degree=1,
+                fsdp_reshard_after_forward="default",
+                pipeline_parallel_degree=1,
+            ),
+            compile=GraphTrainerCompileConfig(
+                enable=True,
+                ep_overlap=EpOverlapConfig(
+                    enabled=True,
+                    chunk_dim="batch",
+                    strategy="graph",
+                    module_fqn="layers.*",
+                    disable_early_grad_accumulation=False,
+                ),
+                cpu_offload_prefetch_n_layers=1,
+                cpu_offload_defer_n_layers=1,
+                cpu_offload_budget_gb=1.0,
+                memory_policy="default",
+                inductor_compilation="full",
+                numerics_changing_optim=False,
+                enable_fsdp_ag_rs_overlap=False,
+            ),
+        )
+        return traced_result, config
+
+    def test_ep_overlap_pass_pipeline_order(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+
+        def pass_name(pass_fn):
+            return (
+                pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            )
+
+        names = [
+            pass_name(pass_fn)
+            for pass_fn in compile_time_passes(
+                traced_result, config, use_cudagraph=False
+            )
+        ]
+        dead_code_indices = [
+            i for i, name in enumerate(names) if name == "eliminate_dead_code_pass"
+        ]
+        self.assertLess(
+            names.index("canonicalize_graph_pass"),
+            names.index("tag_with_memory_policy_pass"),
+        )
+        self.assertLess(
+            names.index("apply_cpu_offload_pass"),
+            names.index("selective_activation_remat_pass"),
+        )
+        self.assertLess(
+            names.index("selective_activation_remat_pass"),
+            names.index("populate_chunk_dim_metadata_pass"),
+        )
+        self.assertLess(
+            names.index("populate_chunk_dim_metadata_pass"),
+            names.index("ep_overlap_chunk_pass"),
+        )
+        self.assertLess(
+            names.index("ep_overlap_chunk_pass"),
+            dead_code_indices[-1],
+        )
+        self.assertLess(
+            dead_code_indices[-1],
+            names.index("joint_transformer_block_bucketing_reordering_pass"),
+        )
+        self.assertLess(
+            names.index("joint_transformer_block_bucketing_reordering_pass"),
+            names.index("concretize_ep_chunk_symbolic_shapes_pass"),
+        )
+        self.assertLess(
+            names.index("concretize_ep_chunk_symbolic_shapes_pass"),
+            names.index("full_inductor_compilation_pass"),
+        )
+
+    def test_graph_ep_seq_chunking_rejects_tensor_parallel(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "seq"
+        config.compile.ep_overlap.module_fqn = "layers.*.moe"
+        config.parallelism.tensor_parallel_degree = 2
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Graph EP seq chunking does not support tensor_parallel_degree > 1",
+        ):
+            compile_time_passes(traced_result, config, use_cudagraph=False)
+
+    def test_graph_ep_batch_chunking_allows_tensor_parallel_guard(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "batch"
+        config.compile.ep_overlap.module_fqn = "layers.*"
+        config.parallelism.tensor_parallel_degree = 2
+
+        compile_time_passes(traced_result, config, use_cudagraph=False)
+
+    def test_prepare_ep_overlap_trace_inputs_marks_batch_dims(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        x = torch.randn(4, 4)
+        labels = torch.ones(4, 4)
+        positions = torch.arange(4).repeat(4, 1)
+        prepare_ep_overlap_trace_inputs(
+            config.compile,
+            (x, labels, torch.tensor(16), {}, {"positions": positions}),
+            {},
+        )
+        self.assertIn(0, x._dynamo_unbacked_indices)
+        self.assertIn(0, labels._dynamo_unbacked_indices)
+        self.assertIn(0, positions._dynamo_unbacked_indices)
+        self.assertEqual(x._dynamo_unbacked_bounds[0], (2, 4))
+
+    def test_prepare_ep_overlap_trace_inputs_marks_seq_dims(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "seq"
+        config.compile.ep_overlap.module_fqn = "layers.*.moe"
+        x = torch.randn(4, 4)
+        positions = torch.arange(4).repeat(4, 1)
+        prepare_ep_overlap_trace_inputs(
+            config.compile,
+            (x, torch.ones(4, 4), torch.tensor(16), {}, {"positions": positions}),
+            {},
+        )
+        self.assertIn(1, x._dynamo_unbacked_indices)
+        self.assertIn(1, positions._dynamo_unbacked_indices)
+        self.assertEqual(x._dynamo_unbacked_bounds[1], (2, 4))
+
+    def test_prepare_ep_overlap_trace_inputs_bounds_seq_dim_to_original_half(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "seq"
+        config.compile.ep_overlap.module_fqn = "layers.*.moe"
+        x = torch.randn(2, 32, 4)
+        labels = torch.ones(2, 32, dtype=torch.long)
+        prepare_ep_overlap_trace_inputs(
+            config.compile,
+            (x, labels, torch.tensor(64), {}, {}),
+            {},
+        )
+
+        self.assertEqual(x._dynamo_unbacked_bounds[1], (16, 32))
+        self.assertEqual(labels._dynamo_unbacked_bounds[1], (16, 32))
+
+    def test_seq_chunk_marker_traces_chunked_loss_backward(self):
+        from torchtitan.components.loss import ChunkedCELoss
+
+        torch.manual_seed(42)
+        batch, seq_len, dim, vocab_size = 2, 32, 4, 8
+        lm_head = torch.nn.Linear(dim, vocab_size, bias=False)
+        loss_fn = ChunkedCELoss(ChunkedCELoss.Config(num_chunks=8))
+        loss_fn.lm_head = lm_head
+
+        hidden_states = torch.randn(batch, seq_len, dim, requires_grad=True)
+        labels = torch.randint(0, vocab_size, (batch, seq_len))
+        mark_chunk_dynamic_dims(hidden_states, mode="seq")
+        mark_chunk_dynamic_dims(labels, mode="seq")
+
+        traced = minimal_fx_tracer(lambda h, y: loss_fn(h, y))(hidden_states, labels)
+
+        self.assertGreater(len(list(traced.gm.graph.nodes)), 0)
+
+    def test_prepare_ep_overlap_trace_inputs_rejects_empty_module_pattern(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.module_fqn = ""
+        with self.assertRaisesRegex(ValueError, "ep_overlap.module_fqn"):
+            prepare_ep_overlap_trace_inputs(config.compile, (torch.randn(4, 4),), {})
+
+    def test_prepare_ep_overlap_trace_call_inputs_rebinds_block_mask_seq_lengths(self):
+        from torch._dynamo.source import LocalSource
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            StatelessSymbolicContext,
+        )
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "seq"
+        config.compile.ep_overlap.module_fqn = "layers.*.moe"
+
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        positions = fake_mode.from_tensor(
+            torch.arange(4).repeat(2, 1),
+            source=LocalSource("positions", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.STATIC, DimDynamic.UNBACKED],
+                shape_ids={1: "torchtitan_chunk_seq"},
+            ),
+        )
+        block_mask = create_block_mask(
+            lambda b, h, q_idx, kv_idx: q_idx >= kv_idx,
+            B=2,
+            H=None,
+            Q_LEN=4,
+            KV_LEN=4,
+            device="cpu",
+        )
+
+        prepared = prepare_ep_overlap_trace_call_inputs(
+            config.compile,
+            (
+                torch.empty(2, 4),
+                torch.empty(2, 4),
+                torch.tensor(8),
+                {"positions": positions, "attention_masks": block_mask},
+            ),
+            {},
+        )
+
+        self.assertIsNotNone(prepared)
+        prepared_args, _ = prepared
+        rebound_mask = prepared_args[3]["attention_masks"]
+        seq_len = positions.shape[1]
+        self.assertEqual(rebound_mask.seq_lengths[0].node.expr, seq_len.node.expr)
+        self.assertEqual(rebound_mask.seq_lengths[1].node.expr, seq_len.node.expr)
+
+    def test_eager_chunking_traces_overlap_metadata(self):
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = Model()
+        annotate_module_fqns(model)
+        maybe_apply_ep_overlap_eager_chunking(
+            model,
+            GraphTrainerCompileConfig(
+                enable=True,
+                ep_overlap=EpOverlapConfig(
+                    enabled=True,
+                    strategy="eager",
+                    module_fqn="layers.*",
+                ),
+            ),
+        )
+
+        def step(inputs):
+            y = model(inputs)
+            loss = y.sum()
+            params = [p for p in model.parameters() if p.requires_grad]
+            return [loss] + list(torch.autograd.grad(loss, params))
+
+        traced = minimal_fx_tracer(step, module=model)(torch.randn(4, 3))
+        gm = populate_eager_chunk_metadata_pass(traced.gm)
+
+        body_chunks = {
+            node.meta.get("chunk_id")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+        }
+        backward_body_chunks = {
+            node.meta.get("chunk_id")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+            and node.meta.get("autograd_backward", False)
+        }
+        boundary_roles = {
+            node.meta.get("chunked_region_role")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_fqn") == "layers.0"
+        }
+        self.assertEqual(body_chunks, {0, 1})
+        self.assertEqual(backward_body_chunks, {0, 1})
+        self.assertIn("split_boundary", boundary_roles)
+        self.assertIn("materialization", boundary_roles)
+
+    def test_ep_overlap_chunk_skips_regions_without_ep_metadata(self):
+        gm = self._build_dense_then_moe_gm()
+        ep_overlap_chunk_pass(gm, mode="batch", module_pattern="layers.*")
+
+        chunked_roots = {
+            node.meta.get("chunked_region_fqn")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+        }
+        self.assertEqual(chunked_roots, {"layers.1"})
+
+        with self.assertRaisesRegex(ValueError, "No EP all-to-all regions"):
+            ep_overlap_chunk_pass(
+                self._build_linear_region_gm(fqn="layers.0"),
+                mode="batch",
+                module_pattern="layers.*",
+            )
+
+    def test_ep_overlap_chunk_single_rank_fallback_uses_ep_annotations(self):
+        gm = self._build_dense_then_moe_gm(include_all_to_all=False)
+
+        ep_overlap_chunk_pass(
+            gm,
+            mode="batch",
+            module_pattern="layers.*",
+            require_all_to_all=False,
+        )
+
+        chunked_roots = {
+            node.meta.get("chunked_region_fqn")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+        }
+        self.assertEqual(chunked_roots, {"layers.1"})
+
+    def test_concretize_ep_chunk_symbolic_shapes_preserves_tensor_strides(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            other = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            base_meta = torch.empty_strided(
+                (batch, 4096, 16, 192),
+                (4096 * 16 * 192, 16 * 192, 192, 1),
+                device="cuda",
+            )
+            transpose_meta = base_meta.transpose(1, 2)
+            mixed_meta = torch.empty(other + batch, device="cuda")
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        tuple_meta_node = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        sym_size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        ge = graph.call_function(operator.ge, args=(sym_size, 0))
+        graph.call_function(
+            torch.ops.aten._assert_scalar.default,
+            args=(ge, "chunk dim must be non-negative"),
+        )
+        sym_ite = graph.call_function(torch.sym_ite, args=(ge, 1, 0))
+        transpose = graph.call_function(torch.ops.aten.transpose.int, args=(x, 1, 2))
+        graph.output(transpose)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = base_meta
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {next(iter(free_symbols(batch))): 4}
+        tuple_meta_node.meta["val"] = (base_meta, transpose_meta, mixed_meta)
+        sym_size.meta["val"] = batch
+        ge.meta["val"] = batch >= 0
+        sym_ite.meta["val"] = torch.sym_ite(batch >= 0, 1, 0)
+        transpose.meta["val"] = transpose_meta
+
+        fake_inputs = [base_meta]
+        fake_inputs[0]._dynamo_unbacked_indices = {0}
+
+        concretize_ep_chunk_symbolic_shapes_pass(gm, fake_inputs)
+
+        self.assertEqual(tuple(transpose.meta["val"].shape), (4, 16, 4096, 192))
+        self.assertEqual(
+            transpose.meta["val"].stride(), (4096 * 16 * 192, 192, 16 * 192, 1)
+        )
+        self.assertEqual(
+            tuple(tuple_meta_node.meta["val"][0].shape), (4, 4096, 16, 192)
+        )
+        self.assertEqual(
+            tuple(tuple_meta_node.meta["val"][1].shape), (4, 16, 4096, 192)
+        )
+        mixed_symbols = free_symbols(tuple_meta_node.meta["val"][2].shape[0])
+        self.assertIn(other.node.expr, mixed_symbols)
+        self.assertNotIn(batch.node.expr, mixed_symbols)
+        self.assertEqual(tuple(fake_inputs[0].shape), (4, 4096, 16, 192))
+        self.assertFalse(hasattr(fake_inputs[0], "_dynamo_unbacked_indices"))
+        self.assertNotIn(ge, gm.graph.nodes)
+        self.assertNotIn(sym_ite, gm.graph.nodes)
+
+    def test_concretize_ep_chunk_symbolic_shapes_rejects_false_guard(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            x_meta = torch.empty(batch, 16, device="cuda")
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        sym_size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        eq = graph.call_function(operator.eq, args=(sym_size, 8))
+        graph.call_function(
+            torch.ops.aten._assert_scalar.default,
+            args=(eq, "chunked split factor must match traced unroll count"),
+        )
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = x_meta
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {next(iter(free_symbols(batch))): 4}
+        sym_size.meta["val"] = batch
+        eq.meta["val"] = batch == 8
+
+        with self.assertRaisesRegex(ValueError, "evaluates to False"):
+            concretize_ep_chunk_symbolic_shapes_pass(gm, [x_meta])
+
+    def test_concretize_ep_chunk_symbolic_shapes_does_not_replay_fake_metadata(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            stale = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            x_meta = torch.empty(256 * batch, device="cuda")
+            stale_slice_meta = torch.empty(stale, device="cuda")
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        sliced = graph.call_function(torch.ops.aten.slice.Tensor, args=(x, 0, 0, size))
+        graph.output(sliced)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = x_meta
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {next(iter(free_symbols(batch))): 4}
+        size.meta["val"] = 256 * batch
+        sliced.meta["val"] = stale_slice_meta
+
+        concretize_ep_chunk_symbolic_shapes_pass(gm, [x_meta])
+
+        self.assertEqual(sliced.args[3], 1024)
+        self.assertEqual(tuple(sliced.meta["val"].shape), (stale,))
+
+    def test_concretize_ep_chunk_symbolic_shapes_uses_placeholder_hints_for_codegen(
+        self,
+    ):
+        from torch.fx.experimental.symbolic_shapes import free_symbols, ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            seq = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            torch._dynamo.override_optimization_hint(seq, 8)
+            x_meta = torch.empty(batch, seq, device="cuda")
+
+        batch_symbol = next(iter(free_symbols(batch)))
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        x.meta["val"] = x_meta
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {batch_symbol: 4}
+
+        fake_inputs = [x_meta]
+        concretize_ep_chunk_symbolic_shapes_pass(gm, fake_inputs)
+
+        self.assertEqual(tuple(x.meta["val"].shape), (4, 8))
+        self.assertEqual(tuple(fake_inputs[0].shape), (4, 8))
+        self.assertFalse(free_symbols(x.meta["val"].shape[1]))
+        self.assertNotIn(batch_symbol, free_symbols(x.meta["val"].shape[0]))
+
+    def test_chunk_copied_meta_rewrites_chunk_symbol_inside_product(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            width = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            torch._dynamo.override_optimization_hint(width, 8)
+            val = torch.empty(batch * width, device="cuda")
+
+        copied = _chunk_copied_meta({"val": val}, {batch.node.expr: 4})
+        chunked_extent = copied["val"].shape[0]
+
+        self.assertEqual(str(chunked_extent), f"{width}*(({batch}//2))")
+
+    def test_chunk_batch_freshens_body_local_unbacked_bindings(self):
+        from torch.fx.experimental.symbolic_shapes import free_symbols
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        shape_env = sym_batch.node.shape_env
+        with fake_mode:
+            x_val = torch.empty(sym_batch, 3)
+            scalar_tensor_val = torch.empty(())
+            split_val = shape_env.create_unbacked_symint()
+            other_split_val = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(split_val, 2)
+            torch._dynamo.override_optimization_hint(other_split_val, 2)
+            total_val = split_val + other_split_val
+            torch._check(split_val <= sym_batch, lambda: "split fits the token grid")
+            torch._check(
+                other_split_val <= sym_batch,
+                lambda: "other split fits the token grid",
+            )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        scalar_tensor = graph.call_function(torch.ops.aten.sum.default, args=(x,))
+        split = graph.call_function(
+            torch.ops.aten._local_scalar_dense.default, args=(scalar_tensor,)
+        )
+        other_scalar_tensor = graph.call_function(torch.ops.aten.sum.default, args=(x,))
+        other_split = graph.call_function(
+            torch.ops.aten._local_scalar_dense.default, args=(other_scalar_tensor,)
+        )
+        size = graph.call_function(torch.ops.aten.sym_size.int, args=(x, 0))
+        total = graph.call_function(operator.add, args=(split, other_split))
+        eq = graph.call_function(operator.eq, args=(total, size))
+        graph.call_function(
+            torch.ops.aten._assert_scalar.default,
+            args=(eq, "split sizes must cover the local token grid"),
+        )
+        view = graph.call_function(torch.ops.aten.view.default, args=(x, [total, -1]))
+        graph.output(view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        batch_symbol = next(iter(free_symbols(sym_batch)))
+        split_symbol = split_val.node.expr
+        other_split_symbol = other_split_val.node.expr
+        x.meta["val"] = x_val
+        x.meta[CHUNK_SYMBOL_HINTS_META] = {batch_symbol: 4}
+        for node in (
+            scalar_tensor,
+            split,
+            other_scalar_tensor,
+            other_split,
+            size,
+            total,
+            eq,
+            view,
+        ):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+        scalar_tensor.meta["val"] = scalar_tensor_val
+        other_scalar_tensor.meta["val"] = scalar_tensor_val
+        split.meta["val"] = split_val
+        split.meta["unbacked_bindings"] = {split_symbol: ()}
+        other_split.meta["val"] = other_split_val
+        other_split.meta["unbacked_bindings"] = {other_split_symbol: ()}
+        size.meta["val"] = sym_batch
+        total.meta["val"] = total_val
+        eq.meta["val"] = total.meta["val"] == size.meta["val"]
+        view.meta["val"] = x_val
+
+        self._chunk_batch(gm, module_patterns=["layers.*"])
+
+        split_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten._local_scalar_dense.default
+            and node.meta.get("chunked_region_role") == "body"
+        ]
+        self.assertEqual(len(split_nodes), 4)
+        copied_symbols = {
+            next(iter(node.meta["unbacked_bindings"])) for node in split_nodes
+        }
+        self.assertEqual(len(copied_symbols), 4)
+        self.assertNotIn(split_symbol, copied_symbols)
+        self.assertNotIn(other_split_symbol, copied_symbols)
+        self.assertEqual(
+            {shape_env.var_to_hint_override[symbol] for symbol in copied_symbols},
+            {1},
+        )
+
+        view_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten.view.default
+            and node.meta.get("chunked_region_role") == "body"
+        ]
+        self.assertEqual(len(view_nodes), 2)
+        for node in view_nodes:
+            shape_arg_symbols = set()
+            for arg in node.args[1]:
+                value = arg.meta["val"] if isinstance(arg, torch.fx.Node) else arg
+                shape_arg_symbols.update(free_symbols(value))
+            self.assertFalse(split_symbol in shape_arg_symbols)
+            self.assertFalse(other_split_symbol in shape_arg_symbols)
+            self.assertTrue(copied_symbols & shape_arg_symbols)
+            self._assert_symbolic_dim_from_sources(
+                node.meta["val"].shape[0], sym_batch, expected_hint=2
+            )
+
+    def test_chunk_batch_backward_cats_activation_grad_and_sums_param_grad(self):
+        graph = torch.fx.Graph()
+        w = graph.placeholder("w")
+        x = graph.placeholder("x")
+        grad_out = graph.placeholder("grad_out")
+        grad_act = graph.call_function(torch.ops.aten.mm.default, args=(grad_out, w))
+        x_t = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        grad_w = graph.call_function(torch.ops.aten.mm.default, args=(x_t, grad_out))
+        graph.output((grad_act, grad_w))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            w_val = torch.empty(3, 3)
+            act_val = torch.empty(sym_batch, 3)
+            x_t_val = torch.empty(3, sym_batch)
+
+        w.meta["val"] = w_val
+        x.meta["val"] = act_val
+        grad_out.meta["val"] = act_val
+        grad_act.meta["val"] = act_val
+        x_t.meta["val"] = x_t_val
+        grad_w.meta["val"] = w_val
+        for node in (grad_act, x_t, grad_w):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0"}
+            node.meta["autograd_backward"] = True
+
+        w_real = torch.randn(3, 3)
+        x_real = torch.randn(4, 3)
+        grad_out_real = torch.randn(4, 3)
+        expected = gm(w_real, x_real, grad_out_real)
+
+        self._chunk_batch(
+            gm,
+            module_patterns=["layers.*"],
+            num_static_inputs=1,
+        )
+
+        actual = gm(w_real, x_real, grad_out_real)
+        self.assertEqual(actual[0], expected[0])
+        self.assertEqual(actual[1], expected[1])
+
+        cat_nodes = self._nodes_by_target(gm, torch.ops.aten.cat.default)
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        self.assertEqual(len(cat_nodes), 1)
+        self.assertEqual(len(sum_nodes), 1)
+        self.assertNotIn("chunk_id", cat_nodes[0].meta)
+        self.assertNotIn("chunk_id", sum_nodes[0].meta)
+        self.assertTrue(all(n.meta.get("autograd_backward") for n in sum_nodes))
+        body_chunk_ids = [
+            node.meta.get("chunk_id")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+            and node.meta.get("chunked_region_fqn") == "layers.0"
+        ]
+        self.assertIn(1, body_chunk_ids)
+        self.assertIn(0, body_chunk_ids)
+        self.assertTrue(
+            all(
+                n.meta.get("autograd_backward")
+                for n in gm.graph.nodes
+                if n.meta.get("chunked_region_fqn") == "layers.0"
+            )
+        )
+
+    def test_chunk_batch_backward_sums_grad_before_grad_collective(self):
+        c10d = torch.ops._c10d_functional
+        collective_specs = {
+            "reduce_scatter": c10d.reduce_scatter_tensor.default,
+            "all_reduce": c10d.all_reduce.default,
+        }
+        for name, target in collective_specs.items():
+            with self.subTest(name=name):
+                gm, refs = self._build_backward_grad_chain_gm(collective=name)
+
+                self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+
+                sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+                self.assertEqual(len(sum_nodes), 1)
+                self.assertEqual(len(self._nodes_by_target(gm, target)), 1)
+                self.assertIs(refs["collective"].args[0], sum_nodes[0])
+                self.assertNotIn("chunk_id", sum_nodes[0].meta)
+
+    def test_chunk_batch_backward_sums_after_dtype_change(self):
+        gm, refs = self._build_backward_grad_chain_gm(cast=True)
+
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        self.assertEqual(len(sum_nodes), 1)
+        output = next(node for node in gm.graph.nodes if node.op == "output")
+        self.assertIs(output.args[0][1], sum_nodes[0])
+        peer_cast = next(
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops.aten._to_copy.default
+            and node.meta.get("chunk_id") == 1
+        )
+        self.assertEqual(sum_nodes[0].args, (refs["cast"], peer_cast))
+        self.assertEqual(sum_nodes[0].meta["val"].dtype, torch.float32)
+
+    def test_chunk_batch_backward_replays_grad_collective_after_dtype_change(self):
+        c10d = torch.ops._c10d_functional
+        gm, _refs = self._build_backward_grad_chain_gm(
+            cast=True, collective="reduce_scatter", wait=True
+        )
+
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        rs_nodes = self._nodes_by_target(gm, c10d.reduce_scatter_tensor.default)
+        self.assertEqual(len(sum_nodes), 1)
+        self.assertEqual(len(rs_nodes), 1)
+        self.assertIs(rs_nodes[0].args[0], sum_nodes[0])
+        self.assertEqual(sum_nodes[0].meta["val"].dtype, torch.float32)
+
+    def test_chunk_batch_backward_keeps_same_fqn_grad_plumbing_chunked(self):
+        x_real = torch.randn(4, 3)
+        grad_out_real = torch.randn(4, 3)
+        w_real = torch.randn(3, 3)
+        gm, refs = self._build_backward_grad_chain_gm(full_consumer=True)
+        expected = gm(w_real, x_real, grad_out_real)
+
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+
+        actual = gm(w_real, x_real, grad_out_real)
+        self.assertEqual(actual, expected)
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        self.assertEqual(len(sum_nodes), 1)
+        self.assertNotEqual(
+            refs["full_consumer"].meta.get("chunked_region_role"), "body"
+        )
+        self.assertIs(refs["full_consumer"].args[0], sum_nodes[0])
+        self.assertNotIn("chunk_id", sum_nodes[0].meta)
+
+    def test_chunk_batch_keeps_no_dim_control_path_to_ep_marker(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        counts = graph.call_function(torch.ops.aten.sum.dim_IntList, args=(x, [0]))
+        scale = graph.call_function(torch.ops.aten.sum.default, args=(counts,))
+        y = graph.call_function(torch.ops.aten.mul.Tensor, args=(x, scale))
+        a2a = graph.call_function(
+            torch.ops._c10d_functional.all_to_all_single.default,
+            args=(y, [], [], "ep"),
+        )
+        graph.output(a2a)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            x_val = torch.empty(sym_batch, 3)
+            counts_val = torch.empty(3)
+            scale_val = torch.empty(())
+
+        x.meta["val"] = x_val
+        counts.meta["val"] = counts_val
+        scale.meta["val"] = scale_val
+        y.meta["val"] = x_val
+        a2a.meta["val"] = x_val
+        for node in (counts, scale, y, a2a):
+            node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+
+        self._chunk_batch(gm, module_patterns=["layers.*.moe"])
+
+        self.assertEqual(counts.meta.get("chunked_region_role"), "body")
+        self.assertEqual(scale.meta.get("chunked_region_role"), "body")
+        sum_nodes = self._nodes_by_target(gm, torch.ops.aten.add.Tensor)
+        self.assertEqual(len(sum_nodes), 0)
+
+    def test_chunk_batch_on_traced_toy_model(self):
+        class ChunkBlock(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        class ChunkModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([ChunkBlock()])
+
+            def forward(self, x):
+                return checkpoint(self.layers[0], x, use_reentrant=False)
+
+        model = ChunkModel()
+        annotate_module_fqns(model)
+        x = torch.randn(4, 4)
+        mark_chunk_dynamic_dims(x, mode="batch")
+
+        def step(inputs):
+            y = model(inputs)
+            loss = y.sum()
+            params = [p for p in model.parameters() if p.requires_grad]
+            return [loss] + list(torch.autograd.grad(loss, params))
+
+        traced = minimal_fx_tracer(step, module=model)(x)
+        expected = step(x)
+
+        populate_chunk_dim_metadata_pass(
+            traced.gm,
+            traced.example_inputs,
+            mode="batch",
+        )
+        self._chunk_batch(
+            traced.gm,
+            module_patterns=["layers.*"],
+            num_static_inputs=traced.num_static_inputs,
+        )
+
+        actual = run_traced(traced, module=model)(x)
+        self.assertEqual(len(actual), len(expected))
+        for actual_tensor, expected_tensor in zip(actual, expected):
+            self.assertEqual(actual_tensor, expected_tensor)
+        self.assertGreater(
+            sum(1 for node in traced.gm.graph.nodes if node.meta.get("chunk_id") == 0),
+            0,
+        )
+
+    def _trace_and_chunk_batch_module(self, block):
+        class ChunkModel(torch.nn.Module):
+            def __init__(self, block):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([block])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = ChunkModel(block)
+        annotate_module_fqns(model)
+        x = torch.randn(4, 4)
+        mark_chunk_dynamic_dims(x, mode="batch")
+        traced = minimal_fx_tracer(lambda inp: model(inp), module=model)(x)
+
+        populate_chunk_dim_metadata_pass(traced.gm, traced.example_inputs, mode="batch")
+        self._chunk_batch(
+            traced.gm,
+            module_patterns=["layers.*"],
+            num_static_inputs=traced.num_static_inputs,
+        )
+        return model, traced, x
+
+    def test_chunk_batch_symbolic_factory_metadata(self):
+        class NewZerosBlock(torch.nn.Module):
+            def forward(self, x):
+                return x + x.new_zeros((x.shape[0], x.shape[1]))
+
+        class DerivedNewZerosBlock(torch.nn.Module):
+            def forward(self, x):
+                zeros = x.new_zeros((x.shape[0] + 2, x.shape[1]))
+                return x + zeros[: x.shape[0]]
+
+        class ZerosBlock(torch.nn.Module):
+            def forward(self, x):
+                zeros = torch.zeros(
+                    (x.shape[0] * 2, x.shape[1]), device=x.device, dtype=x.dtype
+                )
+                return x + zeros[: x.shape[0]]
+
+        class EmptyStridedBlock(torch.nn.Module):
+            def forward(self, x):
+                empty = torch.empty_strided(
+                    (x.shape[0] * 2, x.shape[1]),
+                    (x.shape[1], 1),
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+                return x + empty[: x.shape[0]]
+
+        cases = (
+            ("new_zeros", NewZerosBlock(), torch.ops.aten.new_zeros.default, 2),
+            (
+                "derived_new_zeros",
+                DerivedNewZerosBlock(),
+                torch.ops.aten.new_zeros.default,
+                4,
+            ),
+            ("zeros", ZerosBlock(), torch.ops.aten.zeros.default, 4),
+            (
+                "empty_strided",
+                EmptyStridedBlock(),
+                torch.ops.aten.empty_strided.default,
+                4,
+            ),
+        )
+        for name, block, target, expected_hint in cases:
+            with self.subTest(name=name):
+                _model, traced, _x = self._trace_and_chunk_batch_module(block)
+                factory_nodes = [
+                    node
+                    for node in traced.gm.graph.nodes
+                    if node.target is target
+                    and node.meta.get("chunked_region_role") == "body"
+                ]
+                self.assertEqual(len(factory_nodes), 2)
+                self.assertEqual(
+                    {node.meta.get("chunk_id") for node in factory_nodes}, {0, 1}
+                )
+                batch_dim = traced.example_inputs[0].shape[0]
+                for node in factory_nodes:
+                    self._assert_symbolic_dim_from_sources(
+                        node.meta["val"].shape[0],
+                        batch_dim,
+                        expected_hint=expected_hint,
+                    )
+
+    def test_chunk_batch_recomputes_owned_symbolic_index_tensors(self):
+        class IndexBlock(torch.nn.Module):
+            def forward(self, x):
+                positions = torch.arange(x.shape[0], device=x.device)
+                order = torch.flip(positions, (0,))
+                return torch.index_select(x, 0, order)
+
+        model, traced, x = self._trace_and_chunk_batch_module(IndexBlock())
+        expected = torch.cat((model(x[:2]), model(x[2:])), dim=0)
+
+        actual = run_traced(traced, module=model)(x)
+        self.assertEqual(actual, expected)
+
+        index_nodes = [
+            node
+            for node in traced.gm.graph.nodes
+            if node.target is torch.ops.aten.index_select.default
+            and node.meta.get("chunked_region_role") == "body"
+        ]
+        self.assertEqual(len(index_nodes), 2)
+        self.assertEqual({node.meta.get("chunk_id") for node in index_nodes}, {0, 1})
+        split_inputs = {
+            node.args[0].target
+            for node in self._nodes_by_target(
+                traced.gm, torch.ops.aten.split_with_sizes.default
+            )
+            if isinstance(node.args[0], torch.fx.Node)
+        }
+        self.assertNotIn(torch.ops.aten.flip.default, split_inputs)
+
+
 class TestRemoveIdentityViewPass(TestCase):
     """Unit tests for the remove_identity_view_pass graph pass."""
 
@@ -1732,8 +3779,8 @@ class TestAnnotateModuleFqns(TestCase):
     def test_same_class_instances_get_distinct_fqns(self):
         """Two parameterless instances of the same class get distinct fqns.
 
-        Calls minimal_fx_tracer without ``module=`` because parameterless
-        models cannot produce gradients via autograd.grad.
+        Uses minimal_fx_tracer directly (not trace_train_step) because
+        parameterless models cannot produce gradients via autograd.grad.
         """
 
         class Block(torch.nn.Module):
@@ -1752,10 +3799,10 @@ class TestAnnotateModuleFqns(TestCase):
         model = Model()
         annotate_module_fqns(model)
 
-        def fwd_only(x):
+        def fwd_only(state, x):
             return model(x)
 
-        traced = minimal_fx_tracer(fwd_only)(torch.randn(4))
+        traced = minimal_fx_tracer(fwd_only)({}, torch.randn(4))
         fqns = set()
         for node in traced.gm.graph.nodes:
             fqn = (node.meta.get("custom") or {}).get(_MODULE_FQN)
@@ -2062,6 +4109,25 @@ class TestSelectiveActivationRematPass(TestCase):
         for inp in bwd.all_input_nodes:
             self.assertEqual(inp.name, e_name + "_recomputed")
         self.assertNotIn(e_name, [n.name for n in nodes])
+
+    def test_multiple_backward_regions_recompute_errors(self):
+        graph = torch.fx.Graph()
+        inp1 = graph.placeholder("inp1")
+        inp2 = graph.placeholder("inp2")
+        a = graph.call_function(torch.ops.aten.clone.default, args=(inp1,))
+        b = graph.call_function(torch.ops.aten.clone.default, args=(inp2,))
+        bwd1 = graph.call_function(torch.ops.aten.add.Tensor, args=(a, a))
+        sep = graph.call_function(torch.ops.aten.neg.default, args=(inp1,))
+        bwd2 = graph.call_function(torch.ops.aten.mul.Tensor, args=(b, b))
+        graph.output((bwd1, sep, bwd2))
+        for node in (a, b):
+            node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        for node in (bwd1, bwd2):
+            node.meta["autograd_backward"] = True
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        with self.assertRaisesRegex(RuntimeError, "disjoint backward regions"):
+            selective_activation_remat_pass(gm)
 
     def test_forward_consumer_keeps_original(self):
         """When a must_recompute node has both forward and backward
@@ -2373,6 +4439,27 @@ class TestEliminateDeadCodePass(TestCase):
         targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
         self.assertIn(torch.ops.aten.relu.default, targets)
         self.assertNotIn(torch.ops.aten.add.Tensor, targets)
+
+    def test_removes_unreachable_bad_node(self):
+        fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
+        with fake_mode:
+            a_meta = torch.empty(256, 8192, device="cuda")
+            b_meta = torch.empty(16384, 512, device="cuda")
+            out_meta = torch.empty(1, device="cuda")
+
+        graph = torch.fx.Graph()
+        out = graph.placeholder("out")
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+        graph.call_function(torch.ops.aten.mm.default, args=(a, b))
+        graph.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        out.meta["val"] = out_meta
+        a.meta["val"] = a_meta
+        b.meta["val"] = b_meta
+
+        eliminate_dead_code_pass(gm)
+        self.assertNotIn(torch.ops.aten.mm.default, {n.target for n in gm.graph.nodes})
 
     def test_keeps_impure_node_with_no_users(self):
         # copy_ mutates its first arg (impure); DCE must keep it even though its

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -35,6 +35,7 @@ from torchtitan.experiments.graph_trainer.registry import (
     PASS_PIPELINE_REGISTRY,
     POST_INIT_HOOKS,
     PRE_TRAIN_STEP_HOOKS,
+    TRACE_CALL_INPUT_PREPARERS,
     TRACE_INPUT_PREPARERS,
 )
 from torchtitan.tools.logging import logger
@@ -235,6 +236,7 @@ class GraphTrainer(Trainer):
                         fwd_bwd_fn,
                         module=model,
                         prepare_inputs=self._prepare_trace_inputs,
+                        prepare_call_inputs=self._prepare_trace_call_inputs,
                     )(
                         inputs,
                         labels,
@@ -283,6 +285,19 @@ class GraphTrainer(Trainer):
             prepare = TRACE_INPUT_PREPARERS.get(pass_name)
             if prepare is not None:
                 prepare(self.config.compile, args, kwargs)
+
+    def _prepare_trace_call_inputs(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        for pass_name in trace_input_preparer_keys(self.config.compile):
+            prepare = TRACE_CALL_INPUT_PREPARERS.get(pass_name)
+            if prepare is not None:
+                prepared = prepare(self.config.compile, args, kwargs)
+                if prepared is not None:
+                    args, kwargs = prepared
+        return args, kwargs
 
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]


### PR DESCRIPTION
Stacked PRs:
 * #3328
 * __->__#3325
 * #3363


--- --- ---

### [graph_trainer] Add graph EP chunking pass


Add the FX graph chunking implementation for EP overlap, including chunk metadata propagation, trace-call input preparation, symbolic chunk shape handling, and graph chunk pass tests. This builds on the eager metadata contract and keeps scheduling as a later pass.

Concretize graph-chunk symbolic shapes before Inductor so production graph chunking does not rely on regional Inductor handling raw chunk expressions such as u0 // 2.

Test Plan:\n- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_passes.py::TestChunkPasses\n- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py::TestDSv3FlexAttnBitwiseDeterministic::test_ep_chunk_matches_eager_chunking_bitwise
