### PR TITLE
Add AGENTS.md symlinks for Codex usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/torchtitan/experiments/graph_trainer/AGENTS.md
+++ b/torchtitan/experiments/graph_trainer/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md


### PR DESCRIPTION

Add Codex-facing AGENTS.md symlinks that point at the existing Claude instruction files. This lets Codex reuse the same repo and graph_trainer guidance without duplicating instruction content or creating a second source of truth.

The root AGENTS.md points to the repo-level .claude/CLAUDE.md file. The graph_trainer AGENTS.md points to the graph_trainer-local .claude/CLAUDE.md file so directory-local instructions continue to apply when Codex is working in that subtree.

Test Plan:
- git ls-tree -l HEAD AGENTS.md torchtitan/experiments/graph_trainer/AGENTS.md
- git diff --name-status origin/main..HEAD