### PR TITLE
[graph_trainer] Add EP overlap scheduling pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -65,8 +65,35 @@ def build_decoder_config_for_backend(
     return config
 
 
+def _local_stride(tensor: torch.Tensor) -> tuple[int, ...]:
+    return (
+        tensor.to_local().stride() if isinstance(tensor, DTensor) else tensor.stride()
+    )
+
+
+def _maybe_materialize_grad_for_param_layout(
+    param: torch.Tensor, grad: torch.Tensor
+) -> torch.Tensor:
+    """Match eager autograd's ``param.grad`` layout contract after graph replay.
+
+    Graph replay assigns ``torch.autograd.grad`` outputs manually, bypassing
+    AccumulateGrad's normal stride materialization. Copying through
+    ``empty_like(param)`` restores the param's global and DTensor-local layout
+    when Inductor returns an equivalent but differently-strided grad.
+    """
+    if grad.stride() == param.stride() and _local_stride(grad) == _local_stride(param):
+        return grad
+
+    materialized_grad = torch.empty_like(param)
+    materialized_grad.copy_(grad)
+    return materialized_grad
+
+
 _MODULE_FQN = "module_fqn"
+_EP_TOKEN_COUNT_EXCHANGE = "EP_token_count_exchange"
+_EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"
+_EP_TOKEN_EXCHANGE_WAIT = "EP_token_exchange_wait"
 _NOT_IN_LAYERS = -1
 
 
@@ -145,6 +172,18 @@ def annotate_moe_ep_regions() -> None:
     AllToAllTokenDispatcher.combine = annotate_fn({"EP": "combine"})(
         AllToAllTokenDispatcher.combine
     )
+    AllToAllTokenDispatcher._token_count_exchange = annotate_fn(
+        {_EP_TOKEN_COUNT_EXCHANGE: "dispatch"}
+    )(AllToAllTokenDispatcher._token_count_exchange)
+    AllToAllTokenDispatcher._sync_token_count_exchange = annotate_fn(
+        {_EP_TOKEN_COUNT_SYNC: "dispatch"}
+    )(AllToAllTokenDispatcher._sync_token_count_exchange)
+    AllToAllTokenDispatcher._dispatch_token_exchange = annotate_fn(
+        {_EP_TOKEN_EXCHANGE: "dispatch"}
+    )(AllToAllTokenDispatcher._dispatch_token_exchange)
+    AllToAllTokenDispatcher._combine_token_exchange = annotate_fn(
+        {_EP_TOKEN_EXCHANGE: "combine"}
+    )(AllToAllTokenDispatcher._combine_token_exchange)
     MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
     _MOE_EP_REGIONS_ANNOTATED = True
 
@@ -207,12 +246,31 @@ def get_default_transformer_block_buckets(
     n_layers: int,
     *,
     chunked_loss_enabled: bool = False,
+    moe_layer_ids: frozenset[int] = frozenset(),
+    split_moe_expert_buckets: bool = False,
 ) -> list[list[str] | str]:
     """Get default transformer block buckets for manual bucketing passes.
 
     Assumes the standard Decoder layout: tok_embeddings, layers.0..N-1,
     norm, and output (e.g., Llama3, DeepSeekV3, Qwen3).
     """
+    layer_buckets: list[list[str] | str] = []
+    for layer_id in range(n_layers):
+        if layer_id in moe_layer_ids and split_moe_expert_buckets:
+            layer_buckets.extend(
+                [
+                    [
+                        f"layers.{layer_id}.attention_norm",
+                        f"layers.{layer_id}.attention",
+                        f"layers.{layer_id}.ffn_norm",
+                        f"layers.{layer_id}.moe.router",
+                        f"layers.{layer_id}.moe.shared_experts",
+                    ],
+                    f"layers.{layer_id}.moe.experts",
+                ]
+            )
+        else:
+            layer_buckets.append(f"layers.{layer_id}")
     final_bucket = ["norm", "lm_head"]
     if chunked_loss_enabled:
         # Chunked loss moves the lm_head weight use under module_fqn "loss".
@@ -220,7 +278,7 @@ def get_default_transformer_block_buckets(
 
     return [
         "tok_embeddings",
-        *[f"layers.{i}" for i in range(n_layers)],
+        *layer_buckets,
         final_bucket,
     ]
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -139,6 +139,17 @@ class GraphTrainerCompileConfig(CompileConfig):
     two collectives can overlap. It is a no-op when the graph contains no
     FSDP all-gathers."""
 
+    enable_fsdp_dense_region_overlap: bool = False
+    """When True, schedule FSDP AG/RS buckets into neighboring dense regions.
+
+    This is disabled by default because it changes FSDP collective placement
+    and is intended for performance/integration validation, not
+    bitwise-equivalence tests. When EP overlap is also enabled, this scheduler
+    only composes with graph chunking rooted at ``layers.*.moe``; otherwise the
+    explicit request is skipped with a warning. Without EP overlap, it can run
+    as a standalone FSDP scheduling ablation.
+    """
+
     ep_overlap: EpOverlapConfig = field(default_factory=EpOverlapConfig)
     """Configuration for EP-overlap chunking and scheduling."""
 

--- a/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
@@ -1,0 +1,998 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Schedule already chunked EP token-exchange regions.
+
+Contract
+========
+This pass is intentionally a scheduler only.  It consumes a graph that has
+already been chunked by either eager chunking or ``ep_chunk_pass`` and must not
+change tensor values, live-in/live-out materialization, or provenance.  The only
+semantic input it relies on is chunk-body metadata collected by
+``collect_chunked_regions``.
+
+For each selected forward/backward region:
+
+* exactly two chunk bodies, chunk 0 and chunk 1, must be present;
+* true EP scheduling markers are
+  ``_c10d_functional.all_to_all_single.default`` launches inside the selected
+  chunk body;
+* ``custom[_EP_TOKEN_EXCHANGE]`` marks true token-exchange all-to-all launches;
+  waits may inherit the annotation from traceback and are normalized to
+  ``custom[_EP_TOKEN_EXCHANGE_WAIT]``;
+* marker counts and labels must match across chunks;
+* forward emits marker pairs in chunk order 0 then 1, backward emits 1 then 0;
+* MoE-root chunking pairs both chunks' first-marker setup before launching the
+  first marker pair; wider transformer-root chunking keeps the regular
+  wait-gated per-chunk closure schedule for every marker;
+* token-count sync CPU copies, when present in the first marker closure, are
+  launched before their CPU scalar/list consumers;
+* after each marker pair, ready non-collective body work is emitted as filler
+  before advancing to the next marker pair;
+* all graph nodes remain in the sorted graph exactly once and the final graph
+  must lint.
+
+The same contract covers eager and graph chunking.  If a chunked region violates
+the contract, the pass errors rather than producing a silent schedule change.
+
+Pseudo-code
+===========
+1. Collect chunked regions and build node -> chunk-owner lookup from shared EP
+   pass metadata.
+2. For each region, collect true token-exchange all-to-all markers per chunk
+   and normalize wait annotations inherited from traceback.
+3. Validate both chunks have the same marker signature, then build dependency
+   closures needed to launch each marker.
+4. Emit wait-gated phases: marker pair in chunk order, ready filler work that
+   does not need token-exchange waits, then final tail work with waits allowed.
+5. Apply the requested region phases through a stable topological sort, lint,
+   recompile, and validate that phase order materialized.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch._dynamo.graph_deduplication import _stable_topological_sort
+from torch.utils._ordered_set import OrderedSet
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _EP_TOKEN_COUNT_SYNC,
+    _EP_TOKEN_EXCHANGE,
+    _EP_TOKEN_EXCHANGE_WAIT,
+)
+from torchtitan.experiments.graph_trainer.ep_pass_utils import (
+    ChunkBody,
+    ChunkedRegion,
+    ChunkOwner,
+    collect_chunked_regions,
+    is_c10d_functional_node,
+    ordered_nodes,
+)
+from torchtitan.tools.logging import logger
+
+
+_GRAPH_BOUNDARY_OPS = {"placeholder", "get_attr"}
+_EP_PHASES = {"dispatch", "combine"}
+
+
+# Step 0: Small metadata helpers and local scheduling records.
+
+
+@dataclass(frozen=True)
+class _TokenExchange:
+    label: str
+    launch: fx.Node
+
+
+@dataclass(frozen=True)
+class _ScheduledRegion:
+    region: ChunkedRegion
+    phases: tuple[tuple[fx.Node, ...], ...]
+
+
+@dataclass(frozen=True)
+class _SyncClosureParts:
+    pre_copy: tuple[fx.Node, ...]
+    copies: tuple[fx.Node, ...]
+    post_copy: tuple[fx.Node, ...]
+    launches: tuple[fx.Node, ...]
+
+
+def _custom_meta(node: fx.Node) -> dict[str, Any]:
+    """Return mutable custom metadata when present, otherwise an empty dict."""
+    custom = node.meta.get("custom")
+    return custom if isinstance(custom, dict) else {}
+
+
+def _ep_label(node: fx.Node) -> str:
+    """Return the optional EP phase label for logs/wait metadata."""
+    phase = _custom_meta(node).get(_EP_TOKEN_EXCHANGE)
+    return phase if phase in _EP_PHASES else "all_to_all"
+
+
+def _is_token_exchange_launch(node: fx.Node) -> bool:
+    """Return whether a node is a token-exchange scheduling marker.
+
+    Only all-to-all ops annotated with ``EP_token_exchange`` (dispatch or
+    combine) are scheduling markers. The counts all-to-all (which only has
+    ``EP: dispatch`` without ``EP_token_exchange``) is NOT a marker; it
+    stays in the closure with shared expert + router compute so that
+    compute is available as filler during the data dispatch window.
+    """
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.all_to_all_single.default
+        and _custom_meta(node).get(_EP_TOKEN_EXCHANGE) in _EP_PHASES
+    )
+
+
+def _is_c10d_functional_node(node: fx.Node) -> bool:
+    """Return whether a node is a distributed functional op."""
+    return is_c10d_functional_node(node)
+
+
+def _is_token_count_sync_copy(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops.aten._to_copy.default
+        and _custom_meta(node).get(_EP_TOKEN_COUNT_SYNC) == "dispatch"
+    )
+
+
+def _is_cpu_destination_copy(node: fx.Node) -> bool:
+    device = node.kwargs.get("device")
+    if device is not None:
+        return torch.device(device).type == "cpu"
+
+    val = node.meta.get("val")
+    val_device = getattr(val, "device", None)
+    return val_device is not None and val_device.type == "cpu"
+
+
+def _set_copy_non_blocking(node: fx.Node, non_blocking: bool) -> None:
+    kwargs = dict(node.kwargs)
+    kwargs["non_blocking"] = non_blocking
+    node.kwargs = kwargs
+
+
+def _same_region_owner(
+    node: fx.Node,
+    *,
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    root_fqn: str,
+    is_backward: bool,
+) -> ChunkOwner | None:
+    """Return chunk ownership only when it belongs to the same selected region."""
+    owner = owner_by_node.get(node)
+    if (
+        owner is not None
+        and owner.root_fqn == root_fqn
+        and owner.is_backward == is_backward
+    ):
+        return owner
+    return None
+
+
+def _is_wait_for_token_exchange(node: fx.Node, node_set: set[fx.Node]) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.wait_tensor.default
+        and node.all_input_nodes
+        and node.all_input_nodes[0] in node_set
+        and _is_token_exchange_launch(node.all_input_nodes[0])
+    )
+
+
+def _collect_token_exchanges(
+    body: ChunkBody,
+    *,
+    order: dict[fx.Node, int],
+) -> tuple[_TokenExchange, ...]:
+    """Step 2: collect true token-exchange launches for one chunk body."""
+    node_set = set(body.nodes)
+    exchanges: list[_TokenExchange] = []
+    for node in body.nodes:
+        if not _is_token_exchange_launch(node):
+            phase = _custom_meta(node).get(_EP_TOKEN_EXCHANGE)
+            if phase is None:
+                continue
+            if _is_wait_for_token_exchange(node, node_set):
+                custom = dict(_custom_meta(node))
+                custom.pop(_EP_TOKEN_EXCHANGE, None)
+                custom[_EP_TOKEN_EXCHANGE_WAIT] = phase
+                node.meta["custom"] = custom
+                continue
+            raise ValueError(
+                "ep_overlap found EP token-exchange metadata on non-marker "
+                f"node {node.name} ({node.target}). Only all_to_all launches "
+                "and their wait_tensor nodes may carry this annotation."
+            )
+            continue
+
+        label = _ep_label(node)
+        waits = [
+            user
+            for user in node.users
+            if user in node_set
+            and user.op == "call_function"
+            and user.target == torch.ops._c10d_functional.wait_tensor.default
+        ]
+        if len(waits) != 1:
+            raise ValueError(
+                f"ep_overlap expected one token-exchange wait for {node.name}, "
+                f"found {len(waits)}."
+            )
+        wait = waits[0]
+        if order[wait] <= order[node]:
+            raise ValueError(
+                "ep_overlap expected token-exchange wait to appear after its "
+                f"launch, found launch={node.name} wait={wait.name} for "
+                f"{body.owner}."
+            )
+        custom = dict(_custom_meta(wait))
+        custom.pop(_EP_TOKEN_EXCHANGE, None)
+        custom[_EP_TOKEN_EXCHANGE_WAIT] = label
+        wait.meta["custom"] = custom
+        exchanges.append(_TokenExchange(label=label, launch=node))
+    return tuple(exchanges)
+
+
+def _exchange_signature(exchanges: tuple[_TokenExchange, ...]) -> tuple[str, ...]:
+    """Return the semantic marker sequence used to match chunk pairs."""
+    return ("all_to_all",) * len(exchanges)
+
+
+def _exchange_labels(exchanges: tuple[_TokenExchange, ...]) -> tuple[str, ...]:
+    """Return optional marker labels for diagnostics."""
+    return tuple(exchange.label for exchange in exchanges)
+
+
+def _validate_exchange_labels(
+    root: str,
+    direction: str,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+) -> None:
+    labels0 = _exchange_labels(exchanges_by_chunk[0])
+    labels1 = _exchange_labels(exchanges_by_chunk[1])
+    if labels0 != labels1:
+        raise ValueError(
+            f"ep_overlap expected matching token-exchange labels for "
+            f"{root!r} ({direction}), found chunk0={labels0} chunk1={labels1}."
+        )
+
+
+# Step 3: Build marker dependency closures and identify ready filler work.
+
+
+def _hidden_body_deps(
+    node: fx.Node,
+    *,
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    root_fqn: str,
+    is_backward: bool,
+) -> tuple[fx.Node, ...]:
+    """Find same-region body deps behind unowned graph plumbing."""
+    deps: list[fx.Node] = []
+    seen: set[fx.Node] = set()
+    stack = list(node.all_input_nodes)
+    while stack:
+        dep = stack.pop()
+        if dep in seen:
+            continue
+        seen.add(dep)
+        owner = _same_region_owner(
+            dep,
+            owner_by_node=owner_by_node,
+            root_fqn=root_fqn,
+            is_backward=is_backward,
+        )
+        if owner is not None:
+            deps.append(dep)
+        elif owner_by_node.get(dep) is None and dep.op not in _GRAPH_BOUNDARY_OPS:
+            stack.extend(dep.all_input_nodes)
+    return tuple(deps)
+
+
+def _body_deps(
+    node: fx.Node,
+    *,
+    body: ChunkBody,
+    owner_by_node: dict[fx.Node, ChunkOwner],
+) -> tuple[fx.Node, ...]:
+    """Return same-region body deps, including deps behind unowned plumbing."""
+    deps: list[fx.Node] = []
+    for dep in node.all_input_nodes:
+        owner = _same_region_owner(
+            dep,
+            owner_by_node=owner_by_node,
+            root_fqn=body.owner.root_fqn,
+            is_backward=body.owner.is_backward,
+        )
+        if owner is not None:
+            deps.append(dep)
+        elif owner_by_node.get(dep) is None and dep.op not in _GRAPH_BOUNDARY_OPS:
+            deps.extend(
+                _hidden_body_deps(
+                    dep,
+                    owner_by_node=owner_by_node,
+                    root_fqn=body.owner.root_fqn,
+                    is_backward=body.owner.is_backward,
+                )
+            )
+    return tuple(dict.fromkeys(deps))
+
+
+def _body_ancestors(
+    nodes: tuple[fx.Node, ...],
+    *,
+    body: ChunkBody,
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    node_set: set[fx.Node],
+) -> set[fx.Node]:
+    """Return same-body ancestors needed before the requested body nodes."""
+    ancestors: set[fx.Node] = set()
+    stack = [
+        dep
+        for node in nodes
+        for dep in _body_deps(node, body=body, owner_by_node=owner_by_node)
+        if dep in node_set
+    ]
+    while stack:
+        dep = stack.pop()
+        if dep in ancestors:
+            continue
+        ancestors.add(dep)
+        stack.extend(
+            next_dep
+            for next_dep in _body_deps(dep, body=body, owner_by_node=owner_by_node)
+            if next_dep in node_set
+        )
+    return ancestors
+
+
+def _split_token_count_sync_closure(
+    closure: tuple[fx.Node, ...],
+    *,
+    body: ChunkBody,
+    launch_nodes: set[fx.Node],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+) -> _SyncClosureParts | None:
+    """Split the first token-exchange closure around sync D2H copy launches."""
+    copies = tuple(node for node in closure if _is_token_count_sync_copy(node))
+    if not copies:
+        return None
+    direction = "backward" if body.owner.is_backward else "forward"
+    if len(copies) != 2:
+        raise ValueError(
+            "ep_overlap expected exactly two token-count sync CPU copies for "
+            f"{body.owner.root_fqn!r} chunk {body.owner.chunk_id} ({direction}), "
+            f"found {len(copies)}."
+        )
+    non_cpu_copies = [
+        copy.name for copy in copies if not _is_cpu_destination_copy(copy)
+    ]
+    if non_cpu_copies:
+        raise ValueError(
+            "ep_overlap token-count sync optimization only supports CPU "
+            f"_to_copy destinations; ambiguous/non-CPU copies for "
+            f"{body.owner.root_fqn!r} chunk {body.owner.chunk_id} ({direction}): "
+            f"{', '.join(non_cpu_copies)}."
+        )
+
+    closure_set = set(closure)
+    copy_set = set(copies)
+    pre_copy_set = _body_ancestors(
+        copies,
+        body=body,
+        owner_by_node=owner_by_node,
+        node_set=closure_set,
+    )
+    launches = tuple(node for node in closure if node in launch_nodes)
+    blocked = pre_copy_set | copy_set | set(launches)
+    return _SyncClosureParts(
+        pre_copy=tuple(node for node in closure if node in pre_copy_set),
+        copies=copies,
+        post_copy=tuple(node for node in closure if node not in blocked),
+        launches=launches,
+    )
+
+
+def _validate_token_count_sync_copies(
+    body: ChunkBody,
+    *,
+    first_closure: tuple[fx.Node, ...],
+) -> None:
+    first_closure_set = set(first_closure)
+    stray_copies = [
+        node.name
+        for node in body.nodes
+        if _is_token_count_sync_copy(node) and node not in first_closure_set
+    ]
+    if stray_copies:
+        direction = "backward" if body.owner.is_backward else "forward"
+        raise ValueError(
+            "ep_overlap only schedules token-count sync CPU copies in the first "
+            f"token-exchange closure for {body.owner.root_fqn!r} chunk "
+            f"{body.owner.chunk_id} ({direction}); found outside the first "
+            f"closure: {', '.join(stray_copies)}."
+        )
+
+
+def _marker_closure(
+    launch: fx.Node,
+    *,
+    body: ChunkBody,
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    exchange_index: int,
+    exchange_indices: dict[fx.Node, int],
+) -> tuple[fx.Node, ...]:
+    """Return the body nodes required to launch one token exchange."""
+    closure: list[fx.Node] = []
+    visiting: set[fx.Node] = set()
+    visited: set[fx.Node] = set()
+
+    def visit(node: fx.Node, *, allow_peer_chunk: bool = False) -> None:
+        if node in visited:
+            return
+        if node in visiting:
+            raise ValueError(
+                "ep_overlap found a cycle while building marker closure for "
+                f"{launch.name} in {body.owner}."
+            )
+
+        owner = _same_region_owner(
+            node,
+            owner_by_node=owner_by_node,
+            root_fqn=body.owner.root_fqn,
+            is_backward=body.owner.is_backward,
+        )
+        if owner is None:
+            for dep in sorted(
+                _hidden_body_deps(
+                    node,
+                    owner_by_node=owner_by_node,
+                    root_fqn=body.owner.root_fqn,
+                    is_backward=body.owner.is_backward,
+                ),
+                key=order.__getitem__,
+            ):
+                visit(dep, allow_peer_chunk=True)
+            return
+
+        if owner.chunk_id != body.owner.chunk_id and not allow_peer_chunk:
+            raise ValueError(
+                "ep_overlap cannot schedule a token exchange whose dependency "
+                f"{node.name} belongs to peer chunk {owner.chunk_id} of "
+                f"{body.owner.root_fqn!r}."
+            )
+        if owner.chunk_id == body.owner.chunk_id:
+            dep_exchange_idx = exchange_indices.get(node)
+            if dep_exchange_idx is not None and dep_exchange_idx > exchange_index:
+                raise ValueError(
+                    "ep_overlap token-exchange order is not topologically valid: "
+                    f"launch {launch.name} for {body.owner} needs later "
+                    f"same-chunk launch {node.name}."
+                )
+
+        visiting.add(node)
+        for dep in sorted(
+            _body_deps(node, body=body, owner_by_node=owner_by_node),
+            key=order.__getitem__,
+        ):
+            dep_owner = _same_region_owner(
+                dep,
+                owner_by_node=owner_by_node,
+                root_fqn=body.owner.root_fqn,
+                is_backward=body.owner.is_backward,
+            )
+            visit(
+                dep,
+                allow_peer_chunk=allow_peer_chunk
+                or (
+                    dep_owner is not None and dep_owner.chunk_id != body.owner.chunk_id
+                ),
+            )
+        visiting.remove(node)
+        visited.add(node)
+        closure.append(node)
+
+    visit(launch)
+    return tuple(sorted(closure, key=order.__getitem__))
+
+
+def _ready_nodes(
+    *,
+    candidates_by_chunk: dict[int, set[fx.Node]],
+    emitted: set[fx.Node],
+    region: ChunkedRegion,
+    chunk_order: tuple[int, ...],
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    include_waits: bool,
+) -> tuple[fx.Node, ...]:
+    """Return currently schedulable body nodes from candidate filler sets."""
+    ready: list[fx.Node] = []
+    for chunk_id in chunk_order:
+        body = region.bodies_by_chunk[chunk_id]
+        candidates = sorted(
+            candidates_by_chunk.get(chunk_id, set()) - emitted,
+            key=order.__getitem__,
+        )
+        for node in candidates:
+            if not include_waits and _is_c10d_functional_node(node):
+                continue
+            deps = _body_deps(node, body=body, owner_by_node=owner_by_node)
+            if all(dep in emitted for dep in deps):
+                ready.append(node)
+    return tuple(ready)
+
+
+def _append_ready_blocks(
+    blocks: list[tuple[fx.Node, ...]],
+    emitted: set[fx.Node],
+    *,
+    candidates_by_chunk: dict[int, set[fx.Node]],
+    region: ChunkedRegion,
+    chunk_order: tuple[int, ...],
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    include_waits: bool,
+) -> bool:
+    """Append ready filler/tail blocks until the candidate frontier stalls."""
+    made_progress = False
+    while True:
+        ready = tuple(
+            node
+            for node in _ready_nodes(
+                candidates_by_chunk=candidates_by_chunk,
+                emitted=emitted,
+                region=region,
+                chunk_order=chunk_order,
+                order=order,
+                owner_by_node=owner_by_node,
+                include_waits=include_waits,
+            )
+            if node not in emitted
+        )
+        if not ready:
+            return made_progress
+        blocks.append(ready)
+        emitted.update(ready)
+        made_progress = True
+
+
+def _build_region_phases(
+    *,
+    region: ChunkedRegion,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    pair_first_token_exchange: bool,
+    rewrite_token_count_sync_copies: bool,
+) -> tuple[tuple[fx.Node, ...], ...]:
+    """Step 4: construct wait-gated phases for one scheduled region."""
+    chunk_order = (1, 0) if region.is_backward else (0, 1)
+    exchange_indices = {
+        chunk_id: {
+            exchange.launch: idx
+            for idx, exchange in enumerate(exchanges_by_chunk[chunk_id])
+        }
+        for chunk_id in chunk_order
+    }
+    closures = {
+        chunk_id: tuple(
+            _marker_closure(
+                exchange.launch,
+                body=region.bodies_by_chunk[chunk_id],
+                order=order,
+                owner_by_node=owner_by_node,
+                exchange_index=idx,
+                exchange_indices=exchange_indices[chunk_id],
+            )
+            for idx, exchange in enumerate(exchanges_by_chunk[chunk_id])
+        )
+        for chunk_id in chunk_order
+    }
+    closure_nodes = {
+        chunk_id: {node for closure in chunk_closures for node in closure}
+        for chunk_id, chunk_closures in closures.items()
+    }
+    filler = {
+        chunk_id: set(region.bodies_by_chunk[chunk_id].nodes) - closure_nodes[chunk_id]
+        for chunk_id in chunk_order
+    }
+    launch_nodes = {
+        exchange.launch
+        for chunk_exchanges in exchanges_by_chunk.values()
+        for exchange in chunk_exchanges
+    }
+
+    def future_candidates(exchange_idx: int) -> dict[int, set[fx.Node]]:
+        return {
+            chunk_id: {
+                node
+                for closure in closures[chunk_id][exchange_idx + 1 :]
+                for node in closure
+                if node not in launch_nodes
+            }
+            | filler[chunk_id]
+            for chunk_id in chunk_order
+        }
+
+    blocks: list[tuple[fx.Node, ...]] = []
+    emitted: set[fx.Node] = set()
+
+    def append_pending(nodes: tuple[fx.Node, ...]) -> None:
+        pending = tuple(node for node in nodes if node not in emitted)
+        if pending:
+            blocks.append(pending)
+            emitted.update(pending)
+
+    def rewrite_sync_copies(copies: tuple[fx.Node, ...]) -> None:
+        if not rewrite_token_count_sync_copies:
+            return
+        for idx, copy in enumerate(copies):
+            _set_copy_non_blocking(copy, idx + 1 != len(copies))
+
+    sync_parts_by_chunk: dict[int, _SyncClosureParts | None] = {}
+    if exchanges_by_chunk[0]:
+        for chunk_id in chunk_order:
+            body = region.bodies_by_chunk[chunk_id]
+            first_closure = closures[chunk_id][0]
+            _validate_token_count_sync_copies(body, first_closure=first_closure)
+            sync_parts_by_chunk[chunk_id] = _split_token_count_sync_closure(
+                first_closure,
+                body=body,
+                launch_nodes=launch_nodes,
+                owner_by_node=owner_by_node,
+            )
+        if any(parts is not None for parts in sync_parts_by_chunk.values()) and not all(
+            parts is not None for parts in sync_parts_by_chunk.values()
+        ):
+            direction = "backward" if region.is_backward else "forward"
+            raise ValueError(
+                "ep_overlap expected token-count sync CPU copies for both chunks "
+                f"of {region.root_fqn!r} ({direction}) when optimizing sync "
+                "copy scheduling."
+            )
+
+    for exchange_idx in range(len(exchanges_by_chunk[0])):
+        if exchange_idx == 0 and pair_first_token_exchange:
+            paired_sync_parts = tuple(
+                sync_parts_by_chunk[chunk_id] for chunk_id in chunk_order
+            )
+            if all(parts is not None for parts in paired_sync_parts):
+                # Startup: issue both chunks' token-count D2H copies before any
+                # CPU split-size reads, so only the final copy has to block.
+                for parts in paired_sync_parts:
+                    assert parts is not None
+                    append_pending(parts.pre_copy)
+                paired_copies = tuple(
+                    copy
+                    for parts in paired_sync_parts
+                    for copy in (parts.copies if parts is not None else ())
+                )
+                rewrite_sync_copies(paired_copies)
+                append_pending(paired_copies)
+                for parts in paired_sync_parts:
+                    assert parts is not None
+                    append_pending(parts.post_copy)
+                for parts in paired_sync_parts:
+                    assert parts is not None
+                    append_pending(parts.launches)
+            else:
+                # Startup: emit both chunks up to the first token exchange before
+                # launching either chunk's exchange. This keeps count/sync setup
+                # together in forward and keeps backward combine launches paired.
+                for chunk_id in chunk_order:
+                    closure = closures[chunk_id][exchange_idx]
+                    deps = tuple(
+                        node
+                        for node in closure
+                        if node not in emitted and node not in launch_nodes
+                    )
+                    append_pending(deps)
+                for chunk_id in chunk_order:
+                    closure = closures[chunk_id][exchange_idx]
+                    launches = tuple(
+                        node
+                        for node in closure
+                        if node not in emitted and node in launch_nodes
+                    )
+                    append_pending(launches)
+        else:
+            # Regular wait-gated scheduling: emit each chunk's full closure
+            # sequentially. Later closures may intentionally include waits
+            # whose users are the next token-exchange launch.
+            for chunk_id in chunk_order:
+                sync_parts = (
+                    sync_parts_by_chunk.get(chunk_id) if exchange_idx == 0 else None
+                )
+                if sync_parts is not None:
+                    rewrite_sync_copies(sync_parts.copies)
+                    append_pending(sync_parts.pre_copy)
+                    append_pending(sync_parts.copies)
+                    append_pending(sync_parts.post_copy)
+                    append_pending(sync_parts.launches)
+                else:
+                    closure = closures[chunk_id][exchange_idx]
+                    append_pending(
+                        tuple(node for node in closure if node not in emitted)
+                    )
+        _append_ready_blocks(
+            blocks,
+            emitted,
+            candidates_by_chunk=future_candidates(exchange_idx),
+            region=region,
+            chunk_order=chunk_order,
+            order=order,
+            owner_by_node=owner_by_node,
+            include_waits=False,
+        )
+
+    remaining = {
+        chunk_id: set(region.bodies_by_chunk[chunk_id].nodes) - emitted
+        for chunk_id in chunk_order
+    }
+    made_progress = True
+    while made_progress:
+        made_progress = False
+        for chunk_id in chunk_order:
+            made_progress |= _append_ready_blocks(
+                blocks,
+                emitted,
+                candidates_by_chunk={chunk_id: remaining[chunk_id]},
+                region=region,
+                chunk_order=(chunk_id,),
+                order=order,
+                owner_by_node=owner_by_node,
+                include_waits=True,
+            )
+
+    missing = [
+        node
+        for chunk_id in chunk_order
+        for node in region.bodies_by_chunk[chunk_id].nodes
+        if node not in emitted
+    ]
+    if missing:
+        direction = "backward" if region.is_backward else "forward"
+        raise ValueError(
+            f"ep_overlap could not schedule all body nodes for {region.root_fqn!r} "
+            f"({direction}); remaining: {', '.join(n.name for n in missing[:8])}."
+        )
+    logger.debug(
+        "ep_overlap phases: root=%s direction=%s chunk_order=%s markers=%d "
+        "phase_sizes=%s",
+        region.root_fqn,
+        "backward" if region.is_backward else "forward",
+        chunk_order,
+        len(exchanges_by_chunk[0]),
+        [len(block) for block in blocks],
+    )
+    return tuple(blocks)
+
+
+def _plan_region(
+    region: ChunkedRegion,
+    *,
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    pair_first_token_exchange: bool,
+    rewrite_token_count_sync_copies: bool,
+) -> _ScheduledRegion | None:
+    """Steps 2-4: validate one chunked region and build its schedule phases."""
+    root = region.root_fqn
+    direction = "backward" if region.is_backward else "forward"
+    if set(region.bodies_by_chunk) != {0, 1}:
+        raise ValueError(
+            f"ep_overlap expected both chunks for {root!r} ({direction}), "
+            f"found {sorted(region.bodies_by_chunk)}."
+        )
+
+    exchanges_by_chunk = {
+        chunk_id: _collect_token_exchanges(
+            region.bodies_by_chunk[chunk_id],
+            order=order,
+        )
+        for chunk_id in (0, 1)
+    }
+    if not exchanges_by_chunk[0] and not exchanges_by_chunk[1]:
+        logger.debug(
+            "ep_overlap skipped region without token exchanges: root=%s direction=%s",
+            root,
+            direction,
+        )
+        return None
+    if not exchanges_by_chunk[0] or not exchanges_by_chunk[1]:
+        raise ValueError(
+            f"ep_overlap found EP token exchanges for only one chunk of "
+            f"{root!r} ({direction})."
+        )
+    if _exchange_signature(exchanges_by_chunk[0]) != _exchange_signature(
+        exchanges_by_chunk[1]
+    ):
+        raise ValueError(
+            f"ep_overlap expected matching EP all-to-all counts for "
+            f"{root!r} ({direction}), found "
+            f"chunk0={_exchange_signature(exchanges_by_chunk[0])} "
+            f"chunk1={_exchange_signature(exchanges_by_chunk[1])}."
+        )
+    _validate_exchange_labels(root, direction, exchanges_by_chunk)
+    logger.debug(
+        "ep_overlap planned region: root=%s direction=%s body_sizes=(%d,%d) "
+        "marker_count=%d marker_labels=(%s,%s)",
+        root,
+        direction,
+        len(region.bodies_by_chunk[0].nodes),
+        len(region.bodies_by_chunk[1].nodes),
+        len(exchanges_by_chunk[0]),
+        _exchange_labels(exchanges_by_chunk[0]),
+        _exchange_labels(exchanges_by_chunk[1]),
+    )
+
+    phases = _build_region_phases(
+        region=region,
+        exchanges_by_chunk=exchanges_by_chunk,
+        order=order,
+        owner_by_node=owner_by_node,
+        pair_first_token_exchange=pair_first_token_exchange,
+        rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+    )
+    return _ScheduledRegion(region=region, phases=phases) if phases else None
+
+
+def _phase_order_deps(
+    scheduled_regions: list[_ScheduledRegion],
+) -> dict[fx.Node, OrderedSet[fx.Node]]:
+    """Return extra ordering deps that preserve each region's phase schedule."""
+    deps: dict[fx.Node, OrderedSet[fx.Node]] = {}
+
+    def add_dep(node: fx.Node, dep: fx.Node) -> None:
+        if node is dep:
+            return
+        deps.setdefault(node, OrderedSet()).add(dep)
+
+    for region in scheduled_regions:
+        previous_phase_tail: fx.Node | None = None
+        for phase in region.phases:
+            previous_node: fx.Node | None = None
+            for node in phase:
+                if previous_node is not None:
+                    add_dep(node, previous_node)
+                elif previous_phase_tail is not None:
+                    add_dep(node, previous_phase_tail)
+                previous_node = node
+            if previous_node is not None:
+                previous_phase_tail = previous_node
+    return deps
+
+
+def _apply_schedule(
+    gm: fx.GraphModule,
+    scheduled_regions: list[_ScheduledRegion],
+) -> None:
+    """Step 5: apply scheduled order, lint, recompile, and validate phases."""
+    _stable_topological_sort(gm.graph, _phase_order_deps(scheduled_regions))
+    gm.graph.lint()
+    gm.recompile()
+    new_order = ordered_nodes(gm)
+    for region in scheduled_regions:
+        previous_max: int | None = None
+        for phase in region.phases:
+            if not phase:
+                continue
+            phase_min = min(new_order[node] for node in phase)
+            phase_max = max(new_order[node] for node in phase)
+            if previous_max is not None and previous_max >= phase_min:
+                direction = "backward" if region.region.is_backward else "forward"
+                raise ValueError(
+                    "ep_overlap failed to materialize requested block order for "
+                    f"{region.region.root_fqn!r} ({direction})."
+                )
+            previous_max = phase_max
+
+
+def _schedule_ep_overlap_regions(
+    gm: fx.GraphModule,
+    *,
+    module_pattern: str,
+    require_all_to_all: bool,
+    reorder: bool = True,
+    pair_first_token_exchange: bool = False,
+) -> int:
+    """Run validation or scheduling for all chunked regions matching a pattern."""
+    order = ordered_nodes(gm)
+    chunked_regions = collect_chunked_regions(gm, module_pattern=module_pattern)
+    owner_by_node = {
+        node: body.owner
+        for region in chunked_regions
+        for body in region.bodies_by_chunk.values()
+        for node in body.nodes
+    }
+    scheduled_regions = [
+        planned
+        for region in chunked_regions
+        if (
+            planned := _plan_region(
+                region,
+                order=order,
+                owner_by_node=owner_by_node,
+                pair_first_token_exchange=pair_first_token_exchange,
+                rewrite_token_count_sync_copies=reorder,
+            )
+        )
+        is not None
+    ]
+    logger.debug(
+        "ep_overlap discovered %d chunked region(s), scheduled %d: pattern=%s",
+        len(chunked_regions),
+        len(scheduled_regions),
+        module_pattern,
+    )
+
+    if scheduled_regions and reorder:
+        _apply_schedule(gm, scheduled_regions)
+    elif require_all_to_all:
+        raise ValueError(
+            f"ep_overlap did not find any chunked EP all-to-all regions for "
+            f"pattern {module_pattern}."
+        )
+    return len(scheduled_regions)
+
+
+def ep_overlap_validate_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    module_pattern: str,
+    require_all_to_all: bool = False,
+    pair_first_token_exchange: bool = False,
+) -> fx.GraphModule:
+    """Validate the already chunked graph without changing node order."""
+    del example_inputs
+    validated = _schedule_ep_overlap_regions(
+        gm,
+        module_pattern=module_pattern,
+        require_all_to_all=require_all_to_all,
+        reorder=False,
+        pair_first_token_exchange=pair_first_token_exchange,
+    )
+    logger.info(
+        "Validated %d ep_overlap chunked region(s): module=%s",
+        validated,
+        module_pattern,
+    )
+    return gm
+
+
+def ep_overlap_schedule_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    module_pattern: str,
+    require_all_to_all: bool = True,
+    pair_first_token_exchange: bool = False,
+) -> fx.GraphModule:
+    """Reorder already chunked regions around EP all-to-alls."""
+    del example_inputs
+    scheduled = _schedule_ep_overlap_regions(
+        gm,
+        module_pattern=module_pattern,
+        require_all_to_all=require_all_to_all,
+        pair_first_token_exchange=pair_first_token_exchange,
+    )
+    logger.info(
+        "Applied ep_overlap scheduling to %d chunked region(s): module=%s",
+        scheduled,
+        module_pattern,
+    )
+    return gm

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -14,8 +14,10 @@ collectives.  They are no-ops when the graph contains no FSDP collectives.
 from __future__ import annotations
 
 import heapq
+import operator
 from collections import Counter, defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -47,6 +49,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
 )
 from torchtitan.tools.logging import logger
+
+
+_FSDP_BUCKET_META = "fsdp_bucket"
 
 
 def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
@@ -150,7 +155,6 @@ def reassign_collective_pgs_pass(
     pg_mapping: dict[str, str] = {
         pg: _get_or_create_extra_fsdp_pg(pg) for pg in source_pg_names
     }
-
     ag_count = 0
     for node in gm.graph.nodes:
         if is_all_gather(node) and node.args[2] in pg_mapping:
@@ -285,13 +289,20 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
     def _manual_bucket_collectives(self) -> None:
         """Bucket per module, splitting by direction to keep fwd/bwd buckets disjoint."""
         self._obtain_nodes_in_subgraph()
-        for nodes in self.nodes_in_subgraph:
+        for bucket_plan, nodes in zip(
+            self.module_bucket_plans, self.nodes_in_subgraph, strict=True
+        ):
+            bucket_fqns = _bucket_plan_fqns(bucket_plan)
             fwd_nodes = [n for n in nodes if not self._is_backward_fn(n)]
             bwd_nodes = [n for n in nodes if self._is_backward_fn(n)]
             if fwd_nodes:
+                pre_nodes = set(self.graph.nodes)
                 self.bucketer.manual_bucket_collectives(nodes=fwd_nodes)
+                self._annotate_new_bucket_nodes(pre_nodes, bucket_fqns, "fwd")
             if bwd_nodes:
+                pre_nodes = set(self.graph.nodes)
                 self.bucketer.manual_bucket_collectives(nodes=bwd_nodes)
+                self._annotate_new_bucket_nodes(pre_nodes, bucket_fqns, "bwd")
 
         if _move_overlap_nodes is None:
             _stable_topological_sort(self.graph, {})
@@ -299,6 +310,26 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         self.graph.lint()
         self.nodes = list(self.graph.nodes)
         self.in_degree = Counter(user for node in self.nodes for user in node.users)
+
+    def _annotate_new_bucket_nodes(
+        self,
+        pre_nodes: set[fx.Node],
+        bucket_fqns: tuple[str, ...],
+        direction: str,
+    ) -> None:
+        # The upstream bucketer preserves sample ``custom`` metadata for
+        # readability, but bucket ownership is the bucketing plan itself. Store
+        # that provenance once, at bucket creation time, so later scheduling
+        # passes do not need to rediscover it by walking arbitrary users.
+        for node in self.graph.nodes:
+            if node in pre_nodes or node.op != "call_function":
+                continue
+            node.meta[_FSDP_BUCKET_META] = {
+                "plan_fqns": bucket_fqns,
+                "direction": direction,
+            }
+            if direction == "bwd":
+                node.meta["autograd_backward"] = True
 
     def _manual_reorder_graph(self) -> None:
         """Reorder pass with separate fwd/bwd buffers so AG pairing never
@@ -310,6 +341,12 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         self._schedule_rs_prefetch(overlap_deps)
         self._schedule_ag_prefetch(overlap_deps)
 
+        total_deps = sum(len(v) for v in overlap_deps.values())
+        logger.info(
+            "FSDP reorder: %d overlap deps across %d target nodes",
+            total_deps,
+            len(overlap_deps),
+        )
         _reorder_overlap_nodes(
             self.graph, overlap_deps, self.bucketer.bucketed_node_types
         )
@@ -478,7 +515,7 @@ def joint_transformer_block_bucketing_reordering_pass(
             return []
         return [(fqn, torch.nn.Module)]
 
-    overlapped_gm = JointManualOverlapScheduler(
+    scheduler = JointManualOverlapScheduler(
         gm,
         module_bucket_plans,
         insert_overlap_deps,
@@ -486,6 +523,754 @@ def joint_transformer_block_bucketing_reordering_pass(
         module_stack_fn=_stack_fn,
         bucket_mode=bucket_mode,
         fsdp_param_module_order=fsdp_param_module_order,
-    ).run()
+    )
+    overlapped_gm = scheduler.run()
     overlapped_gm.recompile()
     return overlapped_gm
+
+
+# --- EP-aware FSDP dense-region scheduling ---
+
+
+@dataclass(frozen=True)
+class _FsdpComm:
+    launch: fx.Node
+    wait: fx.Node
+    kind: str
+    direction: str
+    plan_fqns: tuple[str, ...]
+    logical_index: int | None
+
+
+def _bucket_plan_fqns(bucket: list[str] | str) -> tuple[str, ...]:
+    return (bucket,) if isinstance(bucket, str) else tuple(bucket)
+
+
+def _layer_id_from_fqn(fqn: str) -> int | None:
+    """Extract layer index from ``layers.N...`` FQN prefix."""
+    if not fqn.startswith("layers."):
+        return None
+    parts = fqn.split(".", 2)
+    if len(parts) < 2 or not parts[1].isdigit():
+        return None
+    return int(parts[1])
+
+
+def get_transformer_block_bucket_counts(
+    module_bucket_plans: list[list[str] | str],
+    *,
+    n_layers: int,
+) -> dict[int, int]:
+    """Count how many bucket-plan entries belong to each transformer block."""
+    bucket_counts = {layer_id: 0 for layer_id in range(n_layers)}
+    for bucket in module_bucket_plans:
+        fqns = [bucket] if isinstance(bucket, str) else bucket
+        layer_ids = {
+            layer_id
+            for fqn in fqns
+            if (layer_id := _layer_id_from_fqn(fqn)) is not None
+        }
+        if not layer_ids:
+            continue
+        if len(layer_ids) != 1:
+            raise ValueError(
+                "Transformer block bucket plans must not span multiple layers, "
+                f"got bucket {bucket!r} with layer ids {sorted(layer_ids)}."
+            )
+        layer_id = next(iter(layer_ids))
+        if layer_id not in bucket_counts:
+            raise ValueError(
+                f"Transformer block bucket plan references layer {layer_id}, "
+                f"but n_layers={n_layers}."
+            )
+        bucket_counts[layer_id] += 1
+    missing = [layer_id for layer_id, count in bucket_counts.items() if count == 0]
+    if missing:
+        raise ValueError(
+            "Transformer block bucket plan is missing layers "
+            f"{missing} for n_layers={n_layers}."
+        )
+    return bucket_counts
+
+
+def _is_moe_layer_dense_fqn(fqn: str) -> bool:
+    """Return whether an MoE-layer FQN belongs to the dense attention region."""
+    parts = fqn.split(".")
+    if len(parts) < 3:
+        return False
+    return parts[2] in {"attention", "attention_norm"}
+
+
+def _is_top_level_param_fqn(fqn: str) -> bool:
+    return fqn in {"norm", "lm_head"} or fqn.startswith(("norm.", "lm_head."))
+
+
+def _fsdp_bucket_logical_index(
+    plan_fqns: tuple[str, ...],
+    *,
+    n_layers: int,
+) -> int | None:
+    """Map bucket provenance to the logical model slot it owns.
+
+    ``0..N-1`` are transformer blocks. ``N`` is the post-transformer
+    norm/lm_head bucket. Embedding buckets return ``None`` because the dense
+    scheduler intentionally leaves the bottom edge to the upstream bucketer.
+    """
+    layer_ids = {
+        layer_id
+        for fqn in plan_fqns
+        if (layer_id := _layer_id_from_fqn(fqn)) is not None
+    }
+    if len(layer_ids) > 1:
+        raise ValueError(
+            "FSDP dense-region scheduling cannot place a bucket spanning "
+            f"multiple transformer blocks: {plan_fqns!r}"
+        )
+    if layer_ids:
+        layer_id = next(iter(layer_ids))
+        if layer_id >= n_layers:
+            raise ValueError(
+                f"FSDP bucket references layer {layer_id}, but n_layers={n_layers}."
+            )
+        return layer_id
+    if any(_is_top_level_param_fqn(fqn) for fqn in plan_fqns):
+        return n_layers
+    return None
+
+
+def _is_dense_region_target_node(node: fx.Node) -> bool:
+    """Return whether ``node`` is useful dense compute, not FSDP plumbing.
+
+    Dense-region scheduling uses these nodes as insertion anchors.  FSDP waits
+    and parameter-unpack view/copy nodes are part of getting parameters ready;
+    choosing them as anchors hoists future AG/RS launches out of the actual
+    compute window and can make them interfere with MoE token exchange.
+    """
+    if node.op != "call_function":
+        return False
+    if is_wait_tensor(node) or is_all_gather(node):
+        return False
+    if node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default:
+        return False
+    namespace = getattr(node.target, "namespace", None)
+    if namespace in {"_c10d_functional", "c10d_functional", "c10d"}:
+        return False
+    if namespace == "bucketing":
+        return False
+
+    non_compute_targets = {
+        operator.getitem,
+        torch.ops.aten._to_copy.default,
+        torch.ops.aten._unsafe_view.default,
+        torch.ops.aten.clone.default,
+        torch.ops.aten.reshape.default,
+        torch.ops.aten.slice.Tensor,
+        torch.ops.aten.split_with_sizes.default,
+        torch.ops.aten.sym_size.int,
+        torch.ops.aten.t.default,
+        torch.ops.aten.transpose.int,
+        torch.ops.aten.view.default,
+        torch.ops.aten.view.dtype,
+    }
+    if node.target in non_compute_targets:
+        return False
+
+    dense_compute_targets = {
+        torch.ops.aten._fused_rms_norm.default,
+        torch.ops.aten._fused_rms_norm_backward.default,
+        torch.ops.aten.relu.default,
+    }
+    return is_compute_node(node) or node.target in dense_compute_targets
+
+
+def _is_backward_or_recomputed_node(node: fx.Node) -> bool:
+    """Return whether ``node`` executes in the backward section."""
+    return _is_backward_node(node) or "_recomputed" in node.name
+
+
+def _build_layer_dense_regions(
+    gm: torch.fx.GraphModule,
+    n_layers: int,
+    moe_layer_ids: frozenset[int],
+) -> dict[int, dict[str, list[fx.Node]]]:
+    """Build per-layer dense-region node lists for forward and backward.
+
+    Dense region = the attention portion of a transformer block. For MoE
+    layers, generic ``layers.N`` boundary nodes, ffn_norm, and moe nodes are
+    deliberately excluded so FSDP launches do not overlap with MoE token
+    exchange. For dense-only layers (no MoE), the entire block is dense.
+    """
+    regions: dict[int, dict[str, list[fx.Node]]] = {
+        i: {"fwd_dense": [], "bwd_dense": []} for i in range(n_layers)
+    }
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+        if not fqn:
+            continue
+        layer_id = _layer_id_from_fqn(fqn)
+        if layer_id is None or layer_id not in regions:
+            continue
+        if layer_id in moe_layer_ids and not _is_moe_layer_dense_fqn(fqn):
+            continue
+        if not _is_dense_region_target_node(node):
+            continue
+        key = "bwd_dense" if _is_backward_node(node) else "fwd_dense"
+        regions[layer_id][key].append(node)
+    return regions
+
+
+def _build_top_dense_regions(gm: torch.fx.GraphModule) -> dict[str, list[fx.Node]]:
+    """Build dense compute regions for norm/lm_head outside transformer blocks."""
+    regions: dict[str, list[fx.Node]] = {"fwd_dense": [], "bwd_dense": []}
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+        if not fqn or not _is_top_level_param_fqn(fqn):
+            continue
+        if not _is_dense_region_target_node(node):
+            continue
+        key = "bwd_dense" if _is_backward_or_recomputed_node(node) else "fwd_dense"
+        regions[key].append(node)
+    return regions
+
+
+def _read_fsdp_bucket_meta(node: fx.Node) -> tuple[tuple[str, ...], str] | None:
+    meta = node.meta.get(_FSDP_BUCKET_META)
+    if not isinstance(meta, dict):
+        return None
+    plan_fqns = meta.get("plan_fqns")
+    direction = meta.get("direction")
+    if not isinstance(plan_fqns, tuple) or direction not in {"fwd", "bwd"}:
+        return None
+    return plan_fqns, direction
+
+
+def _collect_bucketed_fsdp_comms(
+    gm: torch.fx.GraphModule,
+    *,
+    n_layers: int,
+) -> tuple[dict[int, dict[str, list[tuple[fx.Node, fx.Node]]]], list[_FsdpComm]]:
+    """Collect bucketed FSDP AG and RS (launch, wait) pairs per layer and direction.
+
+    Returns ``({layer_id: {"fwd_ag": [...], "bwd_ag": [...], "bwd_rs": [...]}},
+    all_comms)``. The per-layer view is kept for validation and the historical
+    transformer-block placement rules; ``all_comms`` retains non-transformer
+    bucket provenance so edge buckets can be placed without user-walking
+    heuristics.
+    """
+    all_comms: list[_FsdpComm] = []
+    order = {node: i for i, node in enumerate(gm.graph.nodes)}
+    first_backward_pos = min(
+        (order[node] for node in gm.graph.nodes if _is_backward_node(node)),
+        default=None,
+    )
+
+    def _infer_fqn_and_direction(
+        launch: fx.Node, wait: fx.Node
+    ) -> tuple[str | None, bool]:
+        def _nearest_from(starts: Iterable[fx.Node]) -> tuple[str | None, bool]:
+            frontier = list(starts)
+            visited: set[fx.Node] = set()
+            while frontier:
+                next_frontier: list[fx.Node] = []
+                candidates: list[tuple[str, bool]] = []
+                for n in frontier:
+                    if n in visited or n.op == "output":
+                        continue
+                    visited.add(n)
+                    candidate = n.meta.get("custom", {}).get(_MODULE_FQN)
+                    if candidate:
+                        candidates.append(
+                            (candidate, _is_backward_or_recomputed_node(n))
+                        )
+                    next_frontier.extend(n.users)
+                if candidates:
+                    fqn = candidates[0][0]
+                    return fqn, any(is_bwd for _, is_bwd in candidates)
+                frontier = next_frontier
+            return None, False
+
+        # The wait use site is the semantic owner of a bucketed AG.  Do not
+        # classify direction by arbitrarily walking to transitive backward
+        # users; a forward parameter use naturally feeds backward later.
+        fqn, is_bwd = _nearest_from(wait.users)
+        if fqn is not None:
+            if first_backward_pos is not None and order[wait] >= first_backward_pos:
+                is_bwd = True
+            return fqn, is_bwd
+        fqn = wait.meta.get("custom", {}).get(_MODULE_FQN)
+        if fqn is not None:
+            is_bwd = _is_backward_or_recomputed_node(wait)
+            if first_backward_pos is not None and order[wait] >= first_backward_pos:
+                is_bwd = True
+            return fqn, is_bwd
+        fqn = launch.meta.get("custom", {}).get(_MODULE_FQN)
+        if fqn is not None:
+            is_bwd = _is_backward_or_recomputed_node(launch)
+            if first_backward_pos is not None and order[wait] >= first_backward_pos:
+                is_bwd = True
+            return fqn, is_bwd
+        return None, False
+
+    comms: dict[int, dict[str, list[tuple[fx.Node, fx.Node]]]] = {}
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        is_ag = is_all_gather(node)
+        is_rs = node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+        if not is_ag and not is_rs:
+            continue
+        wait_nodes = [user for user in node.users if is_wait_tensor(user)]
+        if not wait_nodes:
+            continue
+        wait = wait_nodes[0]
+        bucket_meta = _read_fsdp_bucket_meta(node) or _read_fsdp_bucket_meta(wait)
+        if bucket_meta is not None:
+            plan_fqns, direction = bucket_meta
+        else:
+            # Fallback for tests and legacy graphs. Bucketed launches created
+            # by this stack should carry _FSDP_BUCKET_META.
+            fqn, is_bwd = _infer_fqn_and_direction(node, wait)
+            if not fqn:
+                continue
+            plan_fqns = (fqn,)
+            direction = "bwd" if is_bwd else "fwd"
+
+        logical_index = _fsdp_bucket_logical_index(plan_fqns, n_layers=n_layers)
+        kind = "ag" if is_ag else "rs"
+        all_comms.append(
+            _FsdpComm(
+                launch=node,
+                wait=wait,
+                kind=kind,
+                direction=direction,
+                plan_fqns=plan_fqns,
+                logical_index=logical_index,
+            )
+        )
+
+        if logical_index is None or logical_index >= n_layers:
+            continue
+        layer_id = logical_index
+        comms.setdefault(layer_id, {"fwd_ag": [], "bwd_ag": [], "bwd_rs": []})
+        if kind == "ag" and direction == "fwd":
+            comms[layer_id]["fwd_ag"].append((node, wait))
+        elif kind == "ag" and direction == "bwd":
+            comms[layer_id]["bwd_ag"].append((node, wait))
+        elif kind == "rs" and direction == "bwd":
+            comms[layer_id]["bwd_rs"].append((node, wait))
+    logger.info(
+        "Collected FSDP comms for dense-region scheduling: fwd_ag=%d bwd_ag=%d bwd_rs=%d",
+        sum(len(layer_comms["fwd_ag"]) for layer_comms in comms.values()),
+        sum(len(layer_comms["bwd_ag"]) for layer_comms in comms.values()),
+        sum(len(layer_comms["bwd_rs"]) for layer_comms in comms.values()),
+    )
+    return comms, all_comms
+
+
+def _has_waited_fsdp_comm_launches(gm: torch.fx.GraphModule) -> bool:
+    """Return whether the graph contains any waited FSDP AG/RS launch."""
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if not (
+            is_all_gather(node)
+            or node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+        ):
+            continue
+        if any(is_wait_tensor(user) for user in node.users):
+            return True
+    return False
+
+
+def _validate_transformer_block_bucket_counts(
+    comms: dict[int, dict[str, list[tuple[fx.Node, fx.Node]]]],
+    *,
+    n_layers: int,
+    expected_bucket_counts: dict[int, int],
+) -> None:
+    missing_expected = [
+        layer_id
+        for layer_id in range(n_layers)
+        if layer_id not in expected_bucket_counts
+    ]
+    extra_expected = [
+        layer_id
+        for layer_id in expected_bucket_counts
+        if layer_id not in range(n_layers)
+    ]
+    errors: list[str] = []
+    if missing_expected:
+        errors.append(f"missing expected counts for layers {missing_expected}")
+    if extra_expected:
+        errors.append(f"unexpected expected-count layers {sorted(extra_expected)}")
+
+    empty_layer_comms: dict[str, list[tuple[fx.Node, fx.Node]]] = {
+        "fwd_ag": [],
+        "bwd_ag": [],
+        "bwd_rs": [],
+    }
+    for layer_id in range(n_layers):
+        expected = expected_bucket_counts.get(layer_id)
+        if expected is None:
+            continue
+        layer_comms = comms.get(layer_id, empty_layer_comms)
+        actual = {
+            "fwd_ag": len(layer_comms["fwd_ag"]),
+            "bwd_ag": len(layer_comms["bwd_ag"]),
+            "bwd_rs": len(layer_comms["bwd_rs"]),
+        }
+        mismatches = {
+            kind: count for kind, count in actual.items() if count != expected
+        }
+        if mismatches:
+            errors.append(
+                f"layer {layer_id}: expected {expected} buckets per kind, "
+                f"got fwd_ag={actual['fwd_ag']} bwd_ag={actual['bwd_ag']} "
+                f"bwd_rs={actual['bwd_rs']}"
+            )
+
+    if errors:
+        raise ValueError(
+            "FSDP dense-region scheduling requires one bucketed transformer-block "
+            "collective per expected bucket in each direction/type:\n"
+            + "\n".join(f"- {error}" for error in errors)
+        )
+
+
+def schedule_fsdp_comms_to_dense_regions_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    moe_layer_ids: frozenset[int],
+    n_layers: int,
+    transformer_bucket_counts_by_layer: dict[int, int] | None = None,
+    strict: bool = False,
+) -> torch.fx.GraphModule:
+    """Schedule bucketed FSDP comms to overlap with dense (attention) regions.
+
+    Physically moves AG/RS launch nodes in the FX graph so that Inductor
+    emits them at the desired positions. Inductor's
+    ``decide_global_ordering_of_comms`` chains collectives in FX graph
+    order, and the stable topological sort preserves FX order as a
+    tiebreaker, so FX graph order IS the execution order for comms.
+
+    Forward (execution order i-1 -> i):
+      AG(i) launch at start of dense_fwd(i-1), for i > 0.
+      AG(i) wait stays before layer i's first param use (unchanged).
+      AG(0) is left to the original bucketing schedule.
+
+    Backward (execution order i+1 -> i -> i-1):
+      AG(i) launch at start of dense_bwd(i+1), for i < N-1.
+      AG(i) wait stays before layer i's first param use (unchanged).
+      AG(N-1) launch at start of top-level backward dense compute when present.
+      RS(i) launch in dense_bwd(i-1), for i > 0, after its gradient input is ready.
+      RS(0) is left to the original bucketing schedule.
+      RS waits and pure output-unpack users are sunk to the graph tail.
+
+    Embedding buckets are left to the upstream bucketer. The top-level norm/lm_head
+    bucket is treated as the edge after transformer block N-1.
+    """
+    del example_inputs
+    regions = _build_layer_dense_regions(gm, n_layers, moe_layer_ids)
+    top_regions = _build_top_dense_regions(gm)
+    has_fsdp_comms = _has_waited_fsdp_comm_launches(gm)
+    comms, all_comms = _collect_bucketed_fsdp_comms(gm, n_layers=n_layers)
+
+    if not has_fsdp_comms:
+        return gm
+
+    if transformer_bucket_counts_by_layer is not None:
+        _validate_transformer_block_bucket_counts(
+            comms,
+            n_layers=n_layers,
+            expected_bucket_counts=transformer_bucket_counts_by_layer,
+        )
+
+    order = {node: i for i, node in enumerate(gm.graph.nodes)}
+
+    _FSDP_INFRA_OPS = {
+        torch.ops.bucketing._pre_bucket_all_gather.default,
+        torch.ops.bucketing._pre_bucket_reduce_scatter.default,
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        torch.ops._c10d_functional.all_gather_into_tensor_out.default,
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        torch.ops.aten.slice.Tensor,
+    }
+    _FSDP_WAIT_OUTPUT_OPS = {
+        operator.getitem,
+        torch.ops.aten._to_copy.default,
+        torch.ops.aten._unsafe_view.default,
+        torch.ops.aten.clone.default,
+        torch.ops.aten.detach.default,
+        torch.ops.aten.reshape.default,
+        torch.ops.aten.slice.Tensor,
+        torch.ops.aten.split_with_sizes.default,
+        torch.ops.aten.view.default,
+        torch.ops.aten.view.dtype,
+    }
+
+    wait_closures_sunk = 0
+
+    def _is_allowed_wait_tail_node(
+        node: fx.Node,
+        closure: set[fx.Node],
+        wait: fx.Node,
+    ) -> tuple[bool, str | None]:
+        if node.target in _FSDP_WAIT_OUTPUT_OPS:
+            return True, None
+        if node.target is not torch.ops.aten.add_.Tensor:
+            return False, f"{wait.name} has non-output user {node.name} ({node.target})"
+
+        mutated_arg = node.args[0] if node.args else None
+        if not isinstance(mutated_arg, fx.Node):
+            return False, f"{node.name} has non-node mutated input"
+
+        # Chunked loss can accumulate multiple reduce-scattered grad shards via
+        # an in-place add chain before returning the detached final shard. That
+        # chain is safe to sink only when nothing else reads the accumulator.
+        external_users = [
+            user
+            for user in mutated_arg.users
+            if user is not node and user not in closure and user.op != "output"
+        ]
+        if external_users:
+            users = ", ".join(user.name for user in external_users[:3])
+            return (
+                False,
+                f"{node.name} mutates {mutated_arg.name}, which has "
+                f"non-tail users: {users}",
+            )
+        return True, None
+
+    def _collect_launch_chain(launch: fx.Node) -> list[fx.Node]:
+        """Collect the FSDP infrastructure chain rooted at ``launch``."""
+        chain: list[fx.Node] = []
+        work = [launch]
+        visited: set[fx.Node] = set()
+        while work:
+            n = work.pop()
+            if n in visited or n.op in ("placeholder", "get_attr"):
+                continue
+            if n.target not in _FSDP_INFRA_OPS:
+                continue
+            visited.add(n)
+            chain.append(n)
+            work.extend(n.all_input_nodes)
+        return chain
+
+    def _find_dense_target(
+        launch: fx.Node, dense_region: list[fx.Node]
+    ) -> fx.Node | None:
+        """Pick the first dense node after the launch chain's external deps."""
+        chain = set(_collect_launch_chain(launch))
+        if not chain:
+            return None
+        min_pos = 0
+        for n in chain:
+            for inp in n.all_input_nodes:
+                if inp not in chain:
+                    min_pos = max(min_pos, order.get(inp, -1) + 1)
+        for target in dense_region:
+            if order[target] >= min_pos:
+                return target
+        return None
+
+    def _sink_output_only_wait_closure(wait: fx.Node) -> tuple[bool, str | None]:
+        """Sink an RS wait and tail-only output/grad-accum users."""
+        closure: set[fx.Node] = set()
+        work = [wait]
+        while work:
+            n = work.pop()
+            if n in closure:
+                continue
+            if n is not wait:
+                allowed, reason = _is_allowed_wait_tail_node(n, closure, wait)
+                if not allowed:
+                    return False, reason
+            closure.add(n)
+            for user in n.users:
+                if user.op == "output" or user in closure:
+                    continue
+                work.append(user)
+        output = next(node for node in gm.graph.nodes if node.op == "output")
+        for n in sorted(closure, key=lambda node: order.get(node, 0)):
+            output.prepend(n)
+        return True, None
+
+    def _move_chain_before(launch: fx.Node, target: fx.Node) -> tuple[bool, list[str]]:
+        """Move an AG/RS launch and its FSDP infrastructure chain before ``target``.
+
+        Only moves FSDP-specific infrastructure nodes. In particular, RS
+        gradient producers such as casts or adds stay where autograd produced
+        them; target selection ensures the launch moves after those producers.
+        """
+        target_pos = order[target]
+
+        chain = _collect_launch_chain(launch)
+
+        # Only move nodes whose inputs can remain before the insertion point
+        # and whose existing users will not be stranded before the moved node.
+        # This supports both pulling late RS launches earlier and delaying
+        # upstream-prefetched AG launches into the intended dense region.
+        movable = set(chain)
+        reasons: list[str] = []
+        changed = True
+        while changed:
+            changed = False
+            for n in list(movable):
+                for inp in n.all_input_nodes:
+                    if inp not in movable and order.get(inp, -1) >= target_pos:
+                        reasons.append(
+                            f"{n.name} is pinned before {target.name}: "
+                            f"input {inp.name} occurs at {order.get(inp, -1)}, "
+                            f"target at {target_pos}"
+                        )
+                        movable.discard(n)
+                        changed = True
+                        break
+                if n not in movable:
+                    continue
+                if order.get(n, -1) < target_pos:
+                    for user in n.users:
+                        if user not in movable and order.get(user, -1) < target_pos:
+                            reasons.append(
+                                f"{n.name} is pinned before {target.name}: "
+                                f"user {user.name} occurs at {order.get(user, -1)}, "
+                                f"target at {target_pos}"
+                            )
+                            movable.discard(n)
+                            changed = True
+                            break
+        to_move = sorted(movable, key=lambda x: order.get(x, 0))
+
+        if not to_move:
+            return False, reasons
+
+        # Prepend in ascending order: each successive prepend inserts
+        # between the previously moved node and target, producing
+        # correct topological order before target.
+        for n in to_move:
+            target.prepend(n)
+        return True, []
+
+    moved = 0
+    # Collect all moves first, then apply.  Recompute order after each
+    # successful move so stale positions don't cause violations.
+    moves: list[tuple[fx.Node, fx.Node, fx.Node, str]] = []
+    blockers: list[str] = []
+
+    def _add_move(
+        launch: fx.Node,
+        wait: fx.Node,
+        dense_region: list[fx.Node],
+        description: str,
+    ) -> None:
+        if not dense_region:
+            blockers.append(f"{description}: no dense target region")
+            return
+        target = _find_dense_target(launch, dense_region)
+        if target is None:
+            blockers.append(f"{description}: launch inputs are after dense region")
+            return
+        moves.append((launch, wait, target, description))
+
+    for layer_id, layer_comms in sorted(comms.items()):
+        for ag_launch, _ag_wait in layer_comms["fwd_ag"]:
+            prev = layer_id - 1
+            if prev >= 0 and regions[prev]["fwd_dense"]:
+                _add_move(
+                    ag_launch,
+                    _ag_wait,
+                    regions[prev]["fwd_dense"],
+                    f"fwd AG layer {layer_id} -> dense_fwd layer {prev}",
+                )
+        for ag_launch, _ag_wait in layer_comms["bwd_ag"]:
+            next_layer = layer_id + 1
+            if next_layer < n_layers and regions[next_layer]["bwd_dense"]:
+                _add_move(
+                    ag_launch,
+                    _ag_wait,
+                    regions[next_layer]["bwd_dense"],
+                    f"bwd AG layer {layer_id} -> dense_bwd layer {next_layer}",
+                )
+        for rs_launch, _rs_wait in layer_comms["bwd_rs"]:
+            prev = layer_id - 1
+            if prev >= 0 and regions[prev]["bwd_dense"]:
+                _add_move(
+                    rs_launch,
+                    _rs_wait,
+                    regions[prev]["bwd_dense"],
+                    f"bwd RS layer {layer_id} -> dense_bwd layer {prev}",
+                )
+
+    for comm in all_comms:
+        if comm.logical_index != n_layers:
+            continue
+        if comm.kind == "ag" and comm.direction == "fwd" and n_layers > 0:
+            _add_move(
+                comm.launch,
+                comm.wait,
+                regions[n_layers - 1]["fwd_dense"],
+                "fwd AG top-level bucket -> dense_fwd last transformer block",
+            )
+        elif comm.kind == "rs" and comm.direction == "bwd" and n_layers > 0:
+            _add_move(
+                comm.launch,
+                comm.wait,
+                regions[n_layers - 1]["bwd_dense"],
+                "bwd RS top-level bucket -> dense_bwd last transformer block",
+            )
+
+    if n_layers > 0 and top_regions["bwd_dense"]:
+        for ag_launch, ag_wait in comms.get(n_layers - 1, {}).get("bwd_ag", []):
+            _add_move(
+                ag_launch,
+                ag_wait,
+                top_regions["bwd_dense"],
+                "bwd AG last transformer block -> top-level backward dense",
+            )
+
+    if blockers and strict:
+        raise ValueError(
+            "Could not schedule all interior FSDP comm launches to dense regions:\n"
+            + "\n".join(f"- {blocker}" for blocker in blockers)
+        )
+
+    failed_moves: list[str] = []
+    for comm in all_comms:
+        if comm.kind != "rs":
+            continue
+        moved_wait, reason = _sink_output_only_wait_closure(comm.wait)
+        wait_closures_sunk += int(moved_wait)
+        if not moved_wait and strict:
+            failed_moves.append(
+                f"RS wait sink for {comm.plan_fqns!r} {comm.wait.name}: {reason}"
+            )
+
+    for launch, _wait, target, description in moves:
+        # Recompute order before each move to account for prior moves.
+        order = {node: i for i, node in enumerate(gm.graph.nodes)}
+        moved_chain, reasons = _move_chain_before(launch, target)
+        if moved_chain:
+            moved += 1
+        elif strict:
+            reason = (
+                "; ".join(reasons[:3]) if reasons else "no movable launch chain nodes"
+            )
+            failed_moves.append(f"{description}: {reason}")
+
+    if failed_moves:
+        raise ValueError(
+            "Could not move FSDP comm launches to selected dense targets:\n"
+            + "\n".join(f"- {move}" for move in failed_moves)
+        )
+
+    if moved or wait_closures_sunk:
+        gm.graph.lint()
+        gm.recompile()
+    logger.info("schedule_fsdp_comms_to_dense_regions: moved %d comm chains", moved)
+    return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -31,7 +31,10 @@ from collections.abc import Callable
 
 import torch
 
-from torchtitan.experiments.graph_trainer.configs import validate_ep_overlap_config
+from torchtitan.experiments.graph_trainer.configs import (
+    MOE_BLOCK_FQN,
+    validate_ep_overlap_config,
+)
 
 from torchtitan.experiments.graph_trainer.cpu_offload import apply_cpu_offload_pass
 from torchtitan.experiments.graph_trainer.cudagraph import (
@@ -50,13 +53,21 @@ from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
 from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
     populate_eager_chunk_metadata_pass,
 )
+from torchtitan.experiments.graph_trainer.ep_overlap_pass import (
+    ep_overlap_schedule_pass,
+)
 from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     concretize_ep_chunk_symbolic_shapes_pass,
 )
+from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
+    isolate_ep_process_group_pass,
+)
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     get_fsdp_param_module_order,
+    get_transformer_block_bucket_counts,
     joint_transformer_block_bucketing_reordering_pass,
     reassign_collective_pgs_pass,
+    schedule_fsdp_comms_to_dense_regions_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
@@ -129,6 +140,7 @@ def compile_time_passes(
     config: "GraphTrainer.Config",
     *,
     use_cudagraph: bool = False,
+    parallel_dims=None,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -153,63 +165,56 @@ def compile_time_passes(
     n_layers = len(config.model_spec.model.layers)
     loss_config = getattr(config, "loss", None)
     uses_chunked_loss = isinstance(loss_config, ChunkedCELoss.Config)
+    moe_layer_ids = frozenset(
+        i
+        for i, layer_cfg in enumerate(config.model_spec.model.layers)
+        if getattr(layer_cfg, "moe", None) is not None
+    )
+    ep_overlap_enabled = config.compile.ep_overlap.enabled
+    if parallel_dims is not None and hasattr(parallel_dims, "get_optional_mesh"):
+        efsdp_mesh = parallel_dims.get_optional_mesh("efsdp")
+        efsdp_degree = 1 if efsdp_mesh is None else efsdp_mesh.size()
+    else:
+        dp_shard = max(1, getattr(config.parallelism, "data_parallel_shard_degree", 1))
+        cp_degree = getattr(config.parallelism, "context_parallel_degree", 1)
+        tp_degree = getattr(config.parallelism, "tensor_parallel_degree", 1)
+        ep_degree = max(1, getattr(config.parallelism, "expert_parallel_degree", 1))
+        efsdp_degree = max(1, (dp_shard * cp_degree * tp_degree) // ep_degree)
+    module_bucket_plans = get_default_transformer_block_buckets(
+        n_layers,
+        chunked_loss_enabled=uses_chunked_loss,
+        moe_layer_ids=moe_layer_ids,
+        split_moe_expert_buckets=efsdp_degree > 1,
+    )
+
     passes: list[Callable] = [
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
     ]
     ep_overlap_chunk_passes: list[Callable] = []
-    if config.compile.ep_overlap.enabled:
-        overlap_dim, chunk_strategy, module_fqn = validate_ep_overlap_config(
-            config.compile.ep_overlap
-        )
+    ep_overlap_module_fqn: str | None = None
+    ep_overlap_chunk_strategy: str | None = None
+    if ep_overlap_enabled:
+        (
+            overlap_dim,
+            ep_overlap_chunk_strategy,
+            ep_overlap_module_fqn,
+        ) = validate_ep_overlap_config(config.compile.ep_overlap)
         if (
-            chunk_strategy == "graph"
-            and overlap_dim == "seq"
-            and _tensor_parallel_degree(config) > 1
+            ep_overlap_chunk_strategy == "graph"
+            and _tensor_parallel_degree(config, parallel_dims) > 1
         ):
-            # TODO: Support graph EP chunking with TP after the MoE TP/SP
-            # boundary has a placement-aware contract.  Today, after DTensor
-            # lowering, the FX graph contains physical TP-local tensors.  For
-            # MoE sequence chunking, splitting a local ``Shard(1)`` sequence
-            # shard chunks ``u0 // tp_degree`` tokens per rank instead of the
-            # logical ``u0`` sequence.  The desired TP+EP MoE contract is for
-            # the MoE wrapper to own the TP/SP layout transition:
-            #
-            #   prologue: Shard(1) -> Replicate
-            #   body:     logical full-sequence chunks with EP collectives only
-            #   epilogue: Partial/Replicate -> Shard(1)
-            #
-            # With that contract, the chunk planner can move live-ins forward
-            # through the pure layout prologue until the chunked axis has the
-            # full symbolic dim, and move live-outs backward through the
-            # inverse epilogue before chunking.  The walk must be guarded: only
-            # cross allowlisted view/slice/cat and known non-EP c10d layout
-            # redistributes; require a unique dominance-safe chain; stop before
-            # router/top-k/groupedMM/shared-expert/dense compute; and validate
-            # that the final chunk body contains no non-EP collectives.
-            #
-            # This also avoids redundant inner MoE TP collectives: router can
-            # slice the replicated boundary input to its owned tokens, while
-            # shared experts can reuse that replicated input instead of issuing
-            # their own input all-gathers and leave the final reduction to the
-            # MoE boundary epilogue.
-            #
-            # Batch graph chunking with TP is temporarily allowed so we can
-            # root-cause it separately. The current lowering is not proven
-            # correct there either: DTensor TP/SP layout helper tensors can
-            # encode both batch and sequence structure in flattened index maps,
-            # so naive selected-symbol rewriting may split the layout map
-            # differently from eager chunking.
+            # After DTensor lowering, the FX graph contains physical TP-local
+            # tensors and TP/SP layout helpers. Splitting those values is not
+            # proven equivalent to eager DTensor-level chunking.
             raise ValueError(
-                "Graph EP seq chunking does not support tensor_parallel_degree > 1. "
-                "After DTensor lowering, the FX graph contains TP-local sequence "
-                "shards; splitting those local tensors is not equivalent to eager "
-                "DTensor-level chunking. Use tensor_parallel_degree=1, eager "
-                "chunking, or a non-seq overlap dimension for this configuration."
+                "Graph EP chunking does not support tensor_parallel_degree > 1. "
+                "Use tensor_parallel_degree=1 or eager chunking for this "
+                "configuration."
             )
-        if chunk_strategy == "eager":
+        if ep_overlap_chunk_strategy == "eager":
             ep_overlap_chunk_passes.append(populate_eager_chunk_metadata_pass)
-        else:
+        if ep_overlap_chunk_strategy == "graph":
             ep_overlap_chunk_passes.extend(
                 [
                     functools.partial(
@@ -219,7 +224,7 @@ def compile_time_passes(
                     functools.partial(
                         ep_overlap_chunk_pass,
                         mode=overlap_dim,
-                        module_pattern=module_fqn,
+                        module_pattern=ep_overlap_module_fqn,
                         num_static_inputs=traced_result.num_static_inputs,
                         optimize_grad_live_out=not (
                             config.compile.ep_overlap.disable_early_grad_accumulation
@@ -230,6 +235,7 @@ def compile_time_passes(
                     ),
                 ]
             )
+
     passes.extend(
         [
             functools.partial(
@@ -244,50 +250,91 @@ def compile_time_passes(
             selective_activation_remat_pass,
         ]
     )
-    if ep_overlap_chunk_passes:
+    if ep_overlap_enabled:
         passes.extend(ep_overlap_chunk_passes)
+        passes.append(isolate_ep_process_group_pass)
         passes.append(eliminate_dead_code_pass)
-    passes.extend(
-        [
-            # Run before bucketing so bucketed collectives inherit the dedicated PG.
-            reassign_collective_pgs_pass,
-            functools.partial(
-                joint_transformer_block_bucketing_reordering_pass,
-                module_bucket_plans=get_default_transformer_block_buckets(
-                    n_layers,
-                    chunked_loss_enabled=uses_chunked_loss,
-                ),
-                # FSDP2 packs buckets in managed parameter order. The traced state
-                # FQNs preserve that registration order, unlike graph execution order.
-                fsdp_param_module_order=get_fsdp_param_module_order(
-                    traced_result.state_fqns
-                ),
+
+    if config.compile.enable_fsdp_ag_rs_overlap:
+        passes.append(reassign_collective_pgs_pass)
+    passes.append(
+        functools.partial(
+            joint_transformer_block_bucketing_reordering_pass,
+            module_bucket_plans=module_bucket_plans,
+            # FSDP2 packs buckets in managed parameter order. The traced state
+            # FQNs preserve that registration order, unlike graph execution order.
+            fsdp_param_module_order=get_fsdp_param_module_order(
+                traced_result.state_fqns
             ),
-        ]
+        )
     )
-    if ep_overlap_chunk_passes:
+
+    if ep_overlap_enabled:
+        assert ep_overlap_module_fqn is not None
+        passes.append(
+            functools.partial(
+                ep_overlap_schedule_pass,
+                module_pattern=ep_overlap_module_fqn,
+                require_all_to_all=(
+                    getattr(config.parallelism, "expert_parallel_degree", 1) > 1
+                ),
+                pair_first_token_exchange=ep_overlap_module_fqn == MOE_BLOCK_FQN,
+            )
+        )
         passes.append(concretize_ep_chunk_symbolic_shapes_pass)
+
+    enable_fsdp_dense_region_overlap = config.compile.enable_fsdp_dense_region_overlap
+    if (
+        enable_fsdp_dense_region_overlap
+        and ep_overlap_enabled
+        and (
+            ep_overlap_module_fqn != MOE_BLOCK_FQN
+            or ep_overlap_chunk_strategy != "graph"
+        )
+    ):
+        warnings.warn(
+            "--compile.enable_fsdp_dense_region_overlap is ignored when "
+            "--compile.ep_overlap.enabled is set unless graph chunking is "
+            "applied to layers.*.moe. The dense FSDP scheduler can be used "
+            "standalone when ep_overlap is disabled.",
+            stacklevel=2,
+        )
+        enable_fsdp_dense_region_overlap = False
+
+    if enable_fsdp_dense_region_overlap:
+        # Move FSDP comm launches into neighboring transformer dense regions.
+        # This is useful both as an EP-overlap companion and as a standalone
+        # FSDP scheduling ablation, so it is controlled by its explicit flag.
+        passes.append(
+            functools.partial(
+                schedule_fsdp_comms_to_dense_regions_pass,
+                moe_layer_ids=moe_layer_ids,
+                n_layers=n_layers,
+                transformer_bucket_counts_by_layer=get_transformer_block_bucket_counts(
+                    module_bucket_plans,
+                    n_layers=n_layers,
+                ),
+                strict=True,
+            )
+        )
+
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
     inductor_compilation = config.compile.inductor_compilation
     if inductor_compilation == "full":
-        # Compile the entire graph into optimized Triton kernels. Must
-        # be terminal — the FX graph is no longer authoritative after
-        # this pass, so insert_kernel_annotations_pass cannot follow.
+        # Compile the entire graph into optimized Triton kernels. Must be
+        # terminal; the FX graph is no longer authoritative after this pass.
         passes.append(full_inductor_compilation_pass)
     if inductor_compilation == "regional":
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
-        # When left uncompiled, flex_attention still runs correctly but
-        # produces different numerical results.
         passes.append(
             functools.partial(
                 annotate_flex_attention_for_regional_inductor_pass,
                 flex_compile_config=FlexAttention.inductor_configs,
             )
         )
-        # Performance passes that may change numerics.
         if config.compile.numerics_changing_optim:
             from torchtitan.experiments.graph_trainer.performance_passes import (
                 annotate_rmsnorm_for_regional_inductor_pass,
@@ -296,7 +343,6 @@ def compile_time_passes(
             passes.append(annotate_rmsnorm_for_regional_inductor_pass)
         passes.append(regional_inductor_pass)
         if use_cudagraph:
-            # Must run before cudagraph_pass (which replaces forward()).
             passes.append(insert_kernel_annotations_pass)
     return passes
 
@@ -304,6 +350,8 @@ def compile_time_passes(
 def construct_default_graph_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
+    *,
+    parallel_dims=None,
 ) -> list[Callable]:
     """Build the pass list for the aot_fx_trace path.
 
@@ -320,7 +368,12 @@ def construct_default_graph_passes(
     passes: list[Callable] = []
     if not has_precompile_artifact:
         passes.extend(
-            compile_time_passes(traced_result, config, use_cudagraph=want_cudagraph)
+            compile_time_passes(
+                traced_result,
+                config,
+                use_cudagraph=want_cudagraph,
+                parallel_dims=parallel_dims,
+            )
         )
 
     if want_cudagraph:
@@ -390,13 +443,17 @@ def apply_graph_passes(
     logger.info(f"Applying {len(passes)} graph passes:\n  {pass_list}")
     all_passes_start = time.perf_counter()
     tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
+    # Some passes intentionally change placeholder shape metadata. Keep the
+    # pass-local fake inputs in sync so later compiler passes see the same
+    # static/dynamic contract as the FX graph.
+    pass_example_inputs = list(example_inputs)
     for pass_fn in passes:
         pass_name = _get_pass_name(pass_fn)
         if debug:
             tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}", debug=debug)
             before_snapshot = snapshot_graph(gm)
             start = time.perf_counter()
-        gm = pass_fn(gm, example_inputs)
+        gm = pass_fn(gm, pass_example_inputs)
         assert isinstance(
             gm, torch.fx.GraphModule
         ), f"Pass {pass_name} returned {type(gm).__name__}, expected GraphModule"

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -302,7 +302,7 @@ def _precompile_aot_fx_trace(
         compile_time_passes,
     )
 
-    passes = compile_time_passes(traced_result, config)
+    passes = compile_time_passes(traced_result, config, parallel_dims=parallel_dims)
 
     traced_result.gm = apply_graph_passes(
         traced_result.gm, traced_result.example_inputs, passes

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -243,13 +243,13 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
                     "--module graph_trainer.llama3",
                     "--config graph_trainer_llama3_debugmodel",
                     "--compile.mode aot_fx_trace",
-                    "--compile.inductor_compilation full",
+                    "--compile.inductor_compilation regional",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
                 ],
             ],
-            "aot_fx_trace llama3 FSDP+TP+full_inductor",
-            "aot_fx_trace_llama3_fsdp_tp_full_inductor",
+            "aot_fx_trace llama3 FSDP+TP+regional_inductor",
+            "aot_fx_trace_llama3_fsdp_tp_regional_inductor",
             ngpu=8,
         ),
     ]
@@ -257,6 +257,52 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
 
 def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
     """DeepSeek-v3-based integration tests (require H100 machines)."""
+    ep_overlap_flex_tests = [
+        (
+            "regional",
+            "batch",
+            "layers.*",
+            "transformer_batch",
+        ),
+        (
+            "regional",
+            "batch",
+            "layers.*.moe",
+            "moe_batch",
+        ),
+        (
+            "regional",
+            "seq",
+            "layers.*.moe",
+            "moe_seq",
+        ),
+        (
+            "full",
+            "batch",
+            "layers.*",
+            "transformer_batch",
+        ),
+        (
+            "full",
+            "batch",
+            "layers.*.moe",
+            "moe_batch",
+        ),
+        (
+            "full",
+            "seq",
+            "layers.*.moe",
+            "moe_seq",
+        ),
+    ]
+
+    def ep_overlap_parallelism() -> list[str]:
+        return [
+            "--parallelism.data_parallel_shard_degree 8",
+            "--parallelism.tensor_parallel_degree 1",
+            "--parallelism.expert_parallel_degree 4",
+        ]
+
     return [
         # === JIT mode tests ===
         OverrideDefinitions(
@@ -357,16 +403,42 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--module graph_trainer.deepseek_v3",
                     "--config graph_trainer_deepseek_v3_debugmodel",
                     "--compile.mode aot_fx_trace",
-                    "--compile.inductor_compilation full",
+                    "--compile.inductor_compilation regional",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.expert_parallel_degree 4",
                 ],
             ],
-            "aot_fx_trace deepseek_v3 FSDP+TP+EP+full_inductor",
-            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_full_inductor",
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP+regional_inductor",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_regional_inductor",
             ngpu=8,
         ),
+        *[
+            OverrideDefinitions(
+                [
+                    [
+                        "--module graph_trainer.deepseek_v3",
+                        "--config graph_trainer_deepseek_v3_debugmodel",
+                        "--compile.mode aot_fx_trace",
+                        f"--compile.inductor_compilation {inductor_compilation}",
+                        "--compile.ep_overlap.enabled",
+                        "--compile.ep_overlap.strategy graph",
+                        f"--compile.ep_overlap.chunk_dim {mode}",
+                        f"--compile.ep_overlap.module_fqn {modules}",
+                        *(
+                            ["--compile.enable_fsdp_dense_region_overlap"]
+                            if modules == "layers.*.moe"
+                            else []
+                        ),
+                        *ep_overlap_parallelism(),
+                    ],
+                ],
+                f"aot_fx_trace deepseek_v3 FlexAttn {inductor_compilation}_inductor ep_overlap {variant}",
+                f"aot_fx_trace_deepseek_v3_flexattn_{inductor_compilation}_inductor_ep_overlap_{variant}",
+                ngpu=8,
+            )
+            for inductor_compilation, mode, modules, variant in ep_overlap_flex_tests
+        ],
         OverrideDefinitions(
             [
                 [

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 import operator
 import sys
 from types import SimpleNamespace
@@ -25,9 +26,14 @@ from torch.utils.checkpoint import checkpoint, CheckpointPolicy
 
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _EP_TOKEN_COUNT_EXCHANGE,
+    _EP_TOKEN_COUNT_SYNC,
     _EP_TOKEN_EXCHANGE,
+    _EP_TOKEN_EXCHANGE_WAIT,
     _MODULE_FQN,
     annotate_module_fqns,
+    annotate_moe_ep_regions,
+    get_default_transformer_block_buckets,
 )
 from torchtitan.experiments.graph_trainer.configs import (
     EpOverlapConfig,
@@ -54,15 +60,26 @@ from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
     maybe_apply_ep_overlap_eager_chunking,
     populate_eager_chunk_metadata_pass,
 )
+from torchtitan.experiments.graph_trainer.ep_overlap_pass import (
+    _apply_schedule,
+    _schedule_ep_overlap_regions,
+    _ScheduledRegion,
+)
 from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     CHUNK_SYMBOL_HINTS_META,
+    ChunkBody,
+    ChunkedRegion,
+    ChunkOwner,
     concretize_ep_chunk_symbolic_shapes_pass,
 )
 from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    _FSDP_BUCKET_META,
+    get_transformer_block_bucket_counts,
     reassign_collective_pgs_pass,
+    schedule_fsdp_comms_to_dense_regions_pass,
 )
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
@@ -223,6 +240,15 @@ class TestReassignCollectivePgsPass(FSDPTest):
                 count += 1
         return count
 
+    def _count_rs_nodes_with_pg(self, gm, pg_name):
+        return sum(
+            1
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+            and node.args[3] == pg_name
+        )
+
     def _count_ep_a2a_nodes_with_pg(self, gm, pg_name):
         return sum(
             1
@@ -376,6 +402,773 @@ class TestReassignCollectivePgsPass(FSDPTest):
         self.assertNotEqual(fsdp_extra_pg, ep_extra_pg)
         self.assertEqual(self._count_ag_nodes_with_pg(gm, fsdp_extra_pg), 1)
         self.assertEqual(self._count_ep_a2a_nodes_with_pg(gm, ep_extra_pg), 1)
+
+
+class TestFsdpDenseSchedulerPass(TestCase):
+    """Pure FX tests for FSDP dense scheduling; no process group required."""
+
+    def _tag_fsdp_schedule_node(self, node, fqn, *, backward=False):
+        node.meta["custom"] = {_MODULE_FQN: fqn}
+        if backward:
+            node.meta["autograd_backward"] = True
+        return node
+
+    def _tag_fsdp_bucket(self, node, plan_fqns, direction):
+        node.meta[_FSDP_BUCKET_META] = {
+            "plan_fqns": tuple(plan_fqns),
+            "direction": direction,
+        }
+        if direction == "bwd":
+            node.meta["autograd_backward"] = True
+        return node
+
+    def _node_order(self, gm):
+        return {node: i for i, node in enumerate(gm.graph.nodes)}
+
+    def test_transformer_block_bucket_counts_follow_bucket_plan(self):
+        counts = get_transformer_block_bucket_counts(
+            [
+                "tok_embeddings",
+                "layers.0",
+                [
+                    "layers.1.attention_norm",
+                    "layers.1.attention",
+                    "layers.1.ffn_norm",
+                    "layers.1.moe.router",
+                    "layers.1.moe.shared_experts",
+                ],
+                "layers.1.moe.experts",
+                ["norm", "lm_head"],
+            ],
+            n_layers=2,
+        )
+
+        self.assertEqual(counts, {0: 1, 1: 2})
+
+    def test_fsdp_dense_scheduler_accepts_expected_bucket_counts(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        fwd_ag0 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        fwd_ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(fwd_ag0,))
+        fwd0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(fwd_ag0_wait,)),
+            "layers.0.attention",
+        )
+        bwd_ag0 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        bwd_ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(bwd_ag0,))
+        bwd0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(bwd_ag0_wait,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        rs0 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(bwd0, "sum", 0, "pg")
+            ),
+            "layers.0",
+            backward=True,
+        )
+        rs0_wait = graph.call_function(c10d.wait_tensor.default, args=(rs0,))
+        graph.output((fwd0, rs0_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm,
+            moe_layer_ids=frozenset(),
+            n_layers=1,
+            transformer_bucket_counts_by_layer={0: 1},
+            strict=True,
+        )
+
+        gm.graph.lint()
+
+    def test_fsdp_dense_scheduler_validates_transformer_bucket_counts(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        ag0 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(ag0,))
+        fwd0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(ag0_wait,)),
+            "layers.0.attention",
+        )
+        bwd0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(fwd0,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        graph.output(bwd0)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with self.assertRaisesRegex(ValueError, "layer 0"):
+            schedule_fsdp_comms_to_dense_regions_pass(
+                gm,
+                moe_layer_ids=frozenset(),
+                n_layers=1,
+                transformer_bucket_counts_by_layer={0: 1},
+            )
+
+    def test_fsdp_dense_scheduler_ignores_non_transformer_buckets(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        ag = graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg"))
+        ag_wait = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.wait_tensor.default, args=(ag,)),
+            "norm",
+        )
+        rs = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(ag_wait, "sum", 0, "pg")
+            ),
+            "lm_head",
+            backward=True,
+        )
+        rs_wait = graph.call_function(c10d.wait_tensor.default, args=(rs,))
+        graph.output(rs_wait)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with self.assertRaisesRegex(ValueError, "layer 0"):
+            schedule_fsdp_comms_to_dense_regions_pass(
+                gm,
+                moe_layer_ids=frozenset(),
+                n_layers=1,
+                transformer_bucket_counts_by_layer={0: 1},
+            )
+
+    def test_fsdp_dense_scheduler_skips_transformer_edge_buckets(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.0.attention",
+        )
+        fwd_ag0 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        fwd_ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(fwd_ag0,))
+        fwd_ag0_use = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(fwd_ag0_wait,)),
+            "layers.0.attention",
+        )
+        bwd_dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(fwd_ag0_use,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        bwd_ag2 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        bwd_ag2_wait = graph.call_function(c10d.wait_tensor.default, args=(bwd_ag2,))
+        bwd_ag2_use = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(bwd_ag2_wait,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        rs0 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(bwd_ag2_use, "sum", 0, "pg")
+            ),
+            "layers.0",
+            backward=True,
+        )
+        rs0_wait = graph.call_function(c10d.wait_tensor.default, args=(rs0,))
+        graph.output((dense0, bwd_dense2, rs0_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[dense0], order[fwd_ag0])
+        self.assertLess(order[bwd_dense2], order[bwd_ag2])
+        self.assertLess(order[bwd_ag2_use], order[rs0])
+
+    def test_fsdp_dense_scheduler_places_top_level_edge_buckets(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.0.attention",
+        )
+        top_ag = self._tag_fsdp_bucket(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            ["norm", "lm_head"],
+            "fwd",
+        )
+        top_ag_wait = graph.call_function(c10d.wait_tensor.default, args=(top_ag,))
+        top_fwd = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(top_ag_wait,)),
+            "norm",
+        )
+        top_bwd = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(top_fwd,)),
+            "lm_head",
+            backward=True,
+        )
+        bwd_ag0 = self._tag_fsdp_bucket(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            ["layers.0.attention"],
+            "bwd",
+        )
+        bwd_ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(bwd_ag0,))
+        bwd0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(bwd_ag0_wait,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        top_rs = self._tag_fsdp_bucket(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(top_bwd, "sum", 0, "pg")
+            ),
+            ["norm", "lm_head"],
+            "bwd",
+        )
+        top_rs_wait = graph.call_function(c10d.wait_tensor.default, args=(top_rs,))
+        graph.output((dense0, bwd0, top_rs_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=1, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[top_ag], order[dense0])
+        self.assertLess(order[dense0], order[top_ag_wait])
+        self.assertLess(order[bwd_ag0], order[top_bwd])
+        self.assertLess(order[top_bwd], order[bwd_ag0_wait])
+        self.assertLess(order[top_bwd], order[top_rs])
+        self.assertLess(order[top_rs], order[bwd0])
+        self.assertGreater(order[top_rs_wait], order[bwd0])
+
+    def test_fsdp_dense_scheduler_places_backward_ag_before_rs(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        ag0 = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            "",
+        )
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(ag0,))
+        ag0_wait_user = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(ag0_wait,)),
+            "layers.0",
+            backward=True,
+        )
+        rs2 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(dense2, "sum", 0, "pg")
+            ),
+            "layers.2",
+            backward=True,
+        )
+        rs2_wait = graph.call_function(c10d.wait_tensor.default, args=(rs2,))
+        graph.output((dense0, ag0_wait_user, rs2_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[dense2], order[ag0])
+        self.assertLess(order[ag0], order[rs2])
+        self.assertLess(order[rs2], order[dense1])
+        self.assertLess(order[dense1], order[dense0])
+        self.assertGreater(order[ag0_wait], order[dense0])
+        self.assertGreater(order[rs2_wait], order[dense0])
+
+    def test_fsdp_dense_scheduler_keeps_forward_ag_with_backward_descendants(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.0.attention",
+        )
+        ag1 = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            "",
+        )
+        ag1_wait = graph.call_function(c10d.wait_tensor.default, args=(ag1,))
+        fwd_use = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(ag1_wait,)),
+            "layers.1.attention",
+        )
+        bwd2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(fwd_use,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        bwd1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(bwd2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        graph.output((dense0, fwd_use, bwd1))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[ag1], order[dense0])
+        self.assertLess(order[dense0], order[ag1_wait])
+
+    def test_fsdp_dense_scheduler_uses_compute_not_fsdp_unpack_as_anchor(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        ag0 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        wait0 = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.wait_tensor.default, args=(ag0,)),
+            "layers.0.attention_norm",
+        )
+        unpack0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.view.default, args=(wait0, [1])),
+            "layers.0.attention_norm",
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(unpack0,)),
+            "layers.0.attention",
+        )
+        ag1 = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, "pg")
+        )
+        ag1_wait = graph.call_function(c10d.wait_tensor.default, args=(ag1,))
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(ag1_wait,)),
+            "layers.1.attention",
+        )
+        graph.output((dense0, dense1))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=2, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[wait0], order[ag1])
+        self.assertLess(order[unpack0], order[ag1])
+        self.assertLess(order[ag1], order[dense0])
+        self.assertLess(order[dense0], order[ag1_wait])
+
+    def test_fsdp_dense_scheduler_treats_recomputed_ag_use_as_backward(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        ag0 = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            "",
+        )
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        ag0_wait = graph.call_function(c10d.wait_tensor.default, args=(ag0,))
+        view = graph.call_function(torch.ops.aten.view.default, args=(ag0_wait, [1]))
+        recomputed = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(view,)),
+            "layers.0.ffn_norm",
+        )
+        recomputed.name = "relu_recomputed"
+        graph.output((dense0, recomputed))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[dense2], order[ag0])
+        self.assertLess(order[ag0], order[dense1])
+        self.assertLess(order[ag0_wait], order[recomputed])
+
+    def test_fsdp_dense_scheduler_keeps_rs_after_gradient_producer(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        dense1a = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        grad_cast = graph.call_function(
+            torch.ops.aten._to_copy.default,
+            args=(dense1a,),
+            kwargs={"dtype": torch.float32},
+        )
+        dense1b = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(grad_cast,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1b,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        rs2 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(grad_cast, "sum", 0, "pg")
+            ),
+            "layers.2",
+            backward=True,
+        )
+        rs2_wait = graph.call_function(c10d.wait_tensor.default, args=(rs2,))
+        graph.output((dense0, rs2_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[dense1a], order[grad_cast])
+        self.assertLess(order[grad_cast], order[rs2])
+        self.assertLess(order[rs2], order[dense1b])
+
+    def test_fsdp_dense_scheduler_sinks_output_only_rs_wait(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        rs2 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(dense2, "sum", 0, "pg")
+            ),
+            "layers.2",
+            backward=True,
+        )
+        rs2_wait = graph.call_function(c10d.wait_tensor.default, args=(rs2,))
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        graph.output((dense0, rs2_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[rs2], order[dense1])
+        self.assertGreater(order[rs2_wait], order[dense0])
+
+    def test_fsdp_dense_scheduler_sinks_unscheduled_rs_wait(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        rs0 = self._tag_fsdp_bucket(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(x, "sum", 0, "pg")
+            ),
+            ["layers.0"],
+            "bwd",
+        )
+        rs0_wait = graph.call_function(c10d.wait_tensor.default, args=(rs0,))
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        graph.output((dense0, rs0_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=1, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[rs0], order[dense0])
+        self.assertGreater(order[rs0_wait], order[dense0])
+
+    def test_fsdp_dense_scheduler_sinks_rs_wait_output_unpack(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        rs2 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(dense2, "sum", 0, "pg")
+            ),
+            "layers.2",
+            backward=True,
+        )
+        rs2_wait = graph.call_function(c10d.wait_tensor.default, args=(rs2,))
+        split = graph.call_function(
+            torch.ops.aten.split_with_sizes.default, args=(rs2_wait, [1])
+        )
+        shard = graph.call_function(operator.getitem, args=(split, 0))
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        graph.output((dense0, shard))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[rs2], order[dense1])
+        self.assertGreater(order[rs2_wait], order[dense0])
+        self.assertGreater(order[split], order[dense0])
+        self.assertGreater(order[shard], order[dense0])
+
+    def test_fsdp_dense_scheduler_sinks_rs_wait_grad_accum_chain(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        rs_a = self._tag_fsdp_bucket(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(dense2, "sum", 0, "pg")
+            ),
+            ["loss"],
+            "bwd",
+        )
+        wait_a = graph.call_function(c10d.wait_tensor.default, args=(rs_a,))
+        detached = graph.call_function(torch.ops.aten.detach.default, args=(wait_a,))
+        rs_b = self._tag_fsdp_bucket(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default, args=(dense2, "sum", 0, "pg")
+            ),
+            ["loss"],
+            "bwd",
+        )
+        wait_b = graph.call_function(c10d.wait_tensor.default, args=(rs_b,))
+        accum = graph.call_function(torch.ops.aten.add_.Tensor, args=(detached, wait_b))
+        grad_out = graph.call_function(torch.ops.aten.detach.default, args=(accum,))
+        dense1 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1.attention",
+            backward=True,
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense1,)),
+            "layers.0.attention",
+            backward=True,
+        )
+        graph.output((dense0, grad_out))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset(), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[dense0], order[wait_a])
+        self.assertLess(order[dense0], order[wait_b])
+        self.assertLess(order[wait_a], order[detached])
+        self.assertLess(order[detached], order[accum])
+        self.assertLess(order[wait_b], order[accum])
+        self.assertLess(order[accum], order[grad_out])
+
+    def test_fsdp_dense_scheduler_places_rs_after_moe_backward(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        dense2 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.2.attention",
+            backward=True,
+        )
+        layer1_boundary = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(dense2,)),
+            "layers.1",
+            backward=True,
+        )
+        ffn_norm = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(layer1_boundary,)),
+            "layers.1.ffn_norm",
+            backward=True,
+        )
+        moe_dispatch = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(ffn_norm, [], [], "ep_pg"),
+            ),
+            "layers.1.moe.experts",
+            backward=True,
+        )
+        moe_dispatch_wait = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.wait_tensor.default, args=(moe_dispatch,)),
+            "layers.1.moe.experts",
+            backward=True,
+        )
+        dense1_attention = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                torch.ops.aten.relu.default,
+                args=(moe_dispatch_wait,),
+            ),
+            "layers.1.attention",
+            backward=True,
+        )
+        rs2 = self._tag_fsdp_schedule_node(
+            graph.call_function(
+                c10d.reduce_scatter_tensor.default,
+                args=(dense2, "sum", 0, "pg"),
+            ),
+            "layers.2",
+            backward=True,
+        )
+        rs2_wait = graph.call_function(c10d.wait_tensor.default, args=(rs2,))
+        graph.output((dense1_attention, rs2_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset({1}), n_layers=3, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[layer1_boundary], order[moe_dispatch])
+        self.assertLess(order[moe_dispatch], order[moe_dispatch_wait])
+        self.assertLess(order[moe_dispatch_wait], order[rs2])
+        self.assertLess(order[rs2], order[dense1_attention])
+
+    def test_fsdp_dense_scheduler_excludes_moe_nodes_from_dense_region(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        moe_node = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(x,)),
+            "layers.0.moe.router",
+        )
+        dense0 = self._tag_fsdp_schedule_node(
+            graph.call_function(torch.ops.aten.relu.default, args=(moe_node,)),
+            "layers.0.attention",
+        )
+        ag1 = self._tag_fsdp_schedule_node(
+            graph.call_function(c10d.all_gather_into_tensor.default, args=(x, 1, "pg")),
+            "layers.1",
+        )
+        ag1_wait = graph.call_function(c10d.wait_tensor.default, args=(ag1,))
+        graph.output((dense0, ag1_wait))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        schedule_fsdp_comms_to_dense_regions_pass(
+            gm, moe_layer_ids=frozenset({0}), n_layers=2, strict=True
+        )
+
+        order = self._node_order(gm)
+        self.assertLess(order[moe_node], order[ag1])
+        self.assertLess(order[ag1], order[dense0])
+
+
+class TestOverlapPgIsolationPass(FSDPTest):
+    def _setup(self):
+        self.parallel_dims = ParallelDims(
+            dp_shard=-1,
+            dp_replicate=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            world_size=self.world_size,
+        )
+
+    def _get_fsdp_pg_name(self):
+        fsdp_mesh = self.parallel_dims.get_mesh("fsdp")
+        return fsdp_mesh.get_group().group_name
+
+    def _count_all_ag_nodes(self, gm):
+        return sum(1 for node in gm.graph.nodes if is_all_gather(node))
+
+    def _count_ep_a2a_nodes_with_pg(self, gm, pg_name):
+        return sum(
+            1
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and "all_to_all_single" in str(node.target)
+            and node.args[3] == pg_name
+        )
 
     def test_overlap_preserves_distinct_ep_pg_with_same_fsdp_ranks(self):
         import torch.distributed as dist
@@ -1504,6 +2297,196 @@ class TestChunkPasses(TestCase):
             "full_consumer": full_consumer_node,
         }
 
+    def _build_ep_overlap_schedule_gm(self, *, backward: bool = False):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        outputs = []
+        for chunk_id in (1, 0) if backward else (0, 1):
+            pre = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            first_launch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(pre, [], [], "ep"),
+            )
+            first_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(first_launch,)
+            )
+            compute = graph.call_function(
+                torch.ops.aten.neg.default, args=(first_wait,)
+            )
+            second_launch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(compute, [], [], "ep"),
+            )
+            second_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(second_launch,)
+            )
+            tail = graph.call_function(torch.ops.aten.neg.default, args=(second_wait,))
+            outputs.append(tail)
+
+            first_ep = "combine" if backward else "dispatch"
+            second_ep = "dispatch" if backward else "combine"
+            self._mark_chunk_body(
+                pre, chunk_id=chunk_id, backward=backward, ep=first_ep
+            )
+            self._mark_chunk_body(
+                first_launch,
+                chunk_id=chunk_id,
+                backward=backward,
+                ep=first_ep,
+                token_exchange=True,
+            )
+            self._mark_chunk_body(
+                first_wait, chunk_id=chunk_id, backward=backward, ep=first_ep
+            )
+            self._mark_chunk_body(compute, chunk_id=chunk_id, backward=backward)
+            self._mark_chunk_body(
+                second_launch,
+                chunk_id=chunk_id,
+                backward=backward,
+                ep=second_ep,
+                token_exchange=True,
+            )
+            self._mark_chunk_body(
+                second_wait, chunk_id=chunk_id, backward=backward, ep=second_ep
+            )
+            self._mark_chunk_body(tail, chunk_id=chunk_id, backward=backward)
+
+        graph.output(tuple(outputs))
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def _schedule_ep_overlap_and_order(
+        self,
+        gm,
+        *,
+        module_pattern: str = "layers.*.moe",
+        pair_first_token_exchange: bool = True,
+    ):
+        _schedule_ep_overlap_regions(
+            gm,
+            module_pattern=module_pattern,
+            require_all_to_all=True,
+            pair_first_token_exchange=pair_first_token_exchange,
+        )
+        return {node: idx for idx, node in enumerate(gm.graph.nodes)}
+
+    def _assert_nodes_in_order(self, order, nodes):
+        for before, after in zip(nodes, nodes[1:]):
+            self.assertLess(order[before], order[after])
+
+    def _build_ep_sync_copy_schedule_gm(
+        self,
+        *,
+        fqn: str = "layers.0.moe",
+        copies_per_chunk: int = 2,
+        cpu_destination: bool = True,
+    ):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        refs = {}
+        for chunk_id in (0, 1):
+            router = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            count = graph.call_function(
+                c10d.all_to_all_single.default, args=(router, [], [], "ep")
+            )
+            body_nodes = [router, count]
+            copies = []
+            consumers = []
+            consumer_value = None
+            for copy_idx in range(copies_per_chunk):
+                producer = count
+                if copy_idx:
+                    producer = graph.call_function(
+                        torch.ops.aten.neg.default, args=(count,)
+                    )
+                    body_nodes.append(producer)
+
+                copy_kwargs = {"non_blocking": False}
+                if cpu_destination:
+                    copy_kwargs["device"] = torch.device("cpu")
+                copy = graph.call_function(
+                    torch.ops.aten._to_copy.default,
+                    args=(producer,),
+                    kwargs=copy_kwargs,
+                )
+                if cpu_destination:
+                    copy.meta["val"] = torch.empty(2, device="cpu")
+                consumer = graph.call_function(
+                    torch.ops.aten._local_scalar_dense.default, args=(copy,)
+                )
+                copies.append(copy)
+                consumers.append(consumer)
+                body_nodes.extend((copy, consumer))
+                consumer_value = (
+                    consumer
+                    if consumer_value is None
+                    else graph.call_function(
+                        torch.ops.aten.add.Tensor, args=(consumer_value, consumer)
+                    )
+                )
+                if consumer_value is not consumer:
+                    body_nodes.append(consumer_value)
+
+            if consumer_value is None:
+                consumer_value = count
+            dispatch = graph.call_function(
+                c10d.all_to_all_single.default, args=(consumer_value, [], [], "ep")
+            )
+            wait = graph.call_function(c10d.wait_tensor.default, args=(dispatch,))
+            body_nodes.extend((dispatch, wait))
+            for node in body_nodes:
+                self._mark_chunk_body(
+                    node,
+                    fqn=fqn,
+                    chunk_id=chunk_id,
+                    ep="dispatch",
+                    token_exchange=node is dispatch,
+                )
+            for copy in copies:
+                copy.meta["custom"][_EP_TOKEN_COUNT_SYNC] = "dispatch"
+            refs[chunk_id] = {
+                "copies": tuple(copies),
+                "consumers": tuple(consumers),
+                "dispatch": dispatch,
+                "wait": wait,
+            }
+
+        graph.output((refs[0]["wait"], refs[1]["wait"]))
+        return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+    def _build_hidden_boundary_dep_schedule_gm(
+        self, *, producer: str, boundary_role: str | None = None
+    ):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        outputs = []
+        for chunk_id in (0, 1):
+            hidden = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            boundary = graph.call_function(torch.ops.aten.clone.default, args=(hidden,))
+            if boundary_role is not None:
+                boundary.meta["chunked_region_producer"] = "graph"
+                boundary.meta["chunked_region_role"] = boundary_role
+            launch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(boundary, [], [], "ep"),
+            )
+            wait = graph.call_function(c10d.wait_tensor.default, args=(launch,))
+            outputs.append(wait)
+
+            for node in (hidden, launch, wait):
+                self._mark_chunk_body(
+                    node,
+                    chunk_id=chunk_id,
+                    ep="dispatch" if node is launch else None,
+                    token_exchange=node is launch,
+                    producer=producer,
+                )
+
+        graph.output(tuple(outputs))
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
     def _build_dense_then_moe_gm(self, *, include_all_to_all: bool = True):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
@@ -2238,6 +3221,28 @@ class TestChunkPasses(TestCase):
         by_chunk = {node.meta.get("chunk_id"): node for node in add_mutations}
         self.assertIs(by_chunk[1].args[0], by_chunk[0])
 
+    def test_chunk_batch_rejects_non_ep_collective_in_body(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        all_reduce = graph.call_function(
+            torch.ops._c10d_functional.all_reduce.default,
+            args=(relu, "sum", "dp"),
+        )
+        graph.output(all_reduce)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fake_mode, sym_batch = self._symbolic_batch_fake_mode()
+        with fake_mode:
+            val = torch.empty(sym_batch, 3)
+        x.meta["val"] = val
+        for node in (relu, all_reduce):
+            node.meta["val"] = val
+            node.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+
+        with self.assertRaisesRegex(ValueError, "only EP collectives"):
+            self._chunk_batch(gm, module_patterns=["layers.*.moe"])
+
     def test_ep_overlap_chunk_accepts_moe_module_pattern(self):
         self._chunk_batch(
             self._build_linear_region_gm(fqn="layers.0.moe"),
@@ -2273,27 +3278,34 @@ class TestChunkPasses(TestCase):
                 inductor_compilation="full",
                 numerics_changing_optim=False,
                 enable_fsdp_ag_rs_overlap=False,
+                enable_fsdp_dense_region_overlap=False,
+                precompile_artifact_dir="",
             ),
         )
         return traced_result, config
 
-    def test_ep_overlap_pass_pipeline_order(self):
-        traced_result, config = self._compile_config_for_ep_overlap_test()
-
+    def _compile_pass_names(self, traced_result, config):
         def pass_name(pass_fn):
             return (
                 pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
             )
 
-        names = [
+        return [
             pass_name(pass_fn)
             for pass_fn in compile_time_passes(
                 traced_result, config, use_cudagraph=False
             )
         ]
+
+    def test_ep_overlap_pass_pipeline_order(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        names = self._compile_pass_names(traced_result, config)
         dead_code_indices = [
             i for i, name in enumerate(names) if name == "eliminate_dead_code_pass"
         ]
+        chunk_pass_idx = names.index("ep_overlap_chunk_pass")
+        post_chunk_dce = min(i for i in dead_code_indices if i > chunk_pass_idx)
+
         self.assertLess(
             names.index("canonicalize_graph_pass"),
             names.index("tag_with_memory_policy_pass"),
@@ -2306,20 +3318,22 @@ class TestChunkPasses(TestCase):
             names.index("selective_activation_remat_pass"),
             names.index("populate_chunk_dim_metadata_pass"),
         )
+        self.assertLess(names.index("populate_chunk_dim_metadata_pass"), chunk_pass_idx)
+        self.assertLess(chunk_pass_idx, names.index("isolate_ep_process_group_pass"))
         self.assertLess(
-            names.index("populate_chunk_dim_metadata_pass"),
-            names.index("ep_overlap_chunk_pass"),
+            names.index("isolate_ep_process_group_pass"),
+            post_chunk_dce,
         )
         self.assertLess(
-            names.index("ep_overlap_chunk_pass"),
-            dead_code_indices[-1],
-        )
-        self.assertLess(
-            dead_code_indices[-1],
+            post_chunk_dce,
             names.index("joint_transformer_block_bucketing_reordering_pass"),
         )
         self.assertLess(
             names.index("joint_transformer_block_bucketing_reordering_pass"),
+            names.index("ep_overlap_schedule_pass"),
+        )
+        self.assertLess(
+            names.index("ep_overlap_schedule_pass"),
             names.index("concretize_ep_chunk_symbolic_shapes_pass"),
         )
         self.assertLess(
@@ -2327,25 +3341,99 @@ class TestChunkPasses(TestCase):
             names.index("full_inductor_compilation_pass"),
         )
 
-    def test_graph_ep_seq_chunking_rejects_tensor_parallel(self):
-        traced_result, config = self._compile_config_for_ep_overlap_test()
-        config.compile.ep_overlap.chunk_dim = "seq"
-        config.compile.ep_overlap.module_fqn = "layers.*.moe"
-        config.parallelism.tensor_parallel_degree = 2
+    def test_graph_ep_chunking_rejects_tensor_parallel(self):
+        cases = (
+            ("seq", "layers.*.moe"),
+            ("batch", "layers.*"),
+        )
+        for chunk_dim, module_fqn in cases:
+            with self.subTest(chunk_dim=chunk_dim):
+                traced_result, config = self._compile_config_for_ep_overlap_test()
+                config.compile.ep_overlap.chunk_dim = chunk_dim
+                config.compile.ep_overlap.module_fqn = module_fqn
+                config.parallelism.tensor_parallel_degree = 2
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "Graph EP seq chunking does not support tensor_parallel_degree > 1",
-        ):
-            compile_time_passes(traced_result, config, use_cudagraph=False)
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Graph EP chunking does not support tensor_parallel_degree > 1",
+                ):
+                    compile_time_passes(traced_result, config, use_cudagraph=False)
 
-    def test_graph_ep_batch_chunking_allows_tensor_parallel_guard(self):
-        traced_result, config = self._compile_config_for_ep_overlap_test()
-        config.compile.ep_overlap.chunk_dim = "batch"
-        config.compile.ep_overlap.module_fqn = "layers.*"
-        config.parallelism.tensor_parallel_degree = 2
+    def test_fsdp_dense_region_scheduler_pass_gating(self):
+        def transformer_batch_default(config):
+            pass
 
-        compile_time_passes(traced_result, config, use_cudagraph=False)
+        def transformer_batch_explicit(config):
+            config.compile.enable_fsdp_dense_region_overlap = True
+
+        def moe_ep_default(config):
+            config.compile.ep_overlap.module_fqn = "layers.*.moe"
+
+        def moe_ep_explicit(config):
+            config.compile.ep_overlap.module_fqn = "layers.*.moe"
+            config.compile.enable_fsdp_dense_region_overlap = True
+
+        def fsdp_dense_without_ep(config):
+            config.compile.ep_overlap.enabled = False
+            config.compile.enable_fsdp_dense_region_overlap = True
+
+        cases = (
+            ("transformer_batch_default", transformer_batch_default, True, False, None),
+            (
+                "transformer_batch_explicit",
+                transformer_batch_explicit,
+                True,
+                False,
+                "graph chunking.*layers.*.moe",
+            ),
+            ("moe_ep_default", moe_ep_default, True, False, None),
+            ("moe_ep_explicit", moe_ep_explicit, True, True, None),
+            ("fsdp_dense_without_ep", fsdp_dense_without_ep, False, True, None),
+        )
+        for (
+            name,
+            configure,
+            expects_ep_schedule,
+            expects_fsdp_schedule,
+            warning,
+        ) in cases:
+            with self.subTest(name=name):
+                traced_result, config = self._compile_config_for_ep_overlap_test()
+                configure(config)
+                if warning is None:
+                    names = self._compile_pass_names(traced_result, config)
+                else:
+                    with self.assertWarnsRegex(UserWarning, warning):
+                        names = self._compile_pass_names(traced_result, config)
+
+                self.assertEqual(
+                    "ep_overlap_schedule_pass" in names,
+                    expects_ep_schedule,
+                )
+                self.assertEqual(
+                    "schedule_fsdp_comms_to_dense_regions_pass" in names,
+                    expects_fsdp_schedule,
+                )
+
+    def test_moe_efsdp_bucket_plan_splits_expert_buckets(self):
+        buckets = get_default_transformer_block_buckets(
+            3,
+            moe_layer_ids=frozenset({1}),
+            split_moe_expert_buckets=True,
+        )
+
+        self.assertIn(
+            [
+                "layers.1.attention_norm",
+                "layers.1.attention",
+                "layers.1.ffn_norm",
+                "layers.1.moe.router",
+                "layers.1.moe.shared_experts",
+            ],
+            buckets,
+        )
+        self.assertIn("layers.1.moe.experts", buckets)
+        self.assertNotIn("layers.1", buckets)
 
     def test_prepare_ep_overlap_trace_inputs_marks_batch_dims(self):
         _traced_result, config = self._compile_config_for_ep_overlap_test()
@@ -2464,6 +3552,991 @@ class TestChunkPasses(TestCase):
         seq_len = positions.shape[1]
         self.assertEqual(rebound_mask.seq_lengths[0].node.expr, seq_len.node.expr)
         self.assertEqual(rebound_mask.seq_lengths[1].node.expr, seq_len.node.expr)
+
+    def test_moe_ep_annotations_cover_all_to_all_dispatcher(self):
+        from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
+
+        annotate_moe_ep_regions()
+
+        expected_annotations = [
+            (AllToAllTokenDispatcher.dispatch, {"EP": "dispatch"}),
+            (
+                AllToAllTokenDispatcher._token_count_exchange,
+                {_EP_TOKEN_COUNT_EXCHANGE: "dispatch"},
+            ),
+            (
+                AllToAllTokenDispatcher._sync_token_count_exchange,
+                {_EP_TOKEN_COUNT_SYNC: "dispatch"},
+            ),
+            (
+                AllToAllTokenDispatcher._dispatch_token_exchange,
+                {_EP_TOKEN_EXCHANGE: "dispatch"},
+            ),
+            (
+                AllToAllTokenDispatcher._combine_token_exchange,
+                {_EP_TOKEN_EXCHANGE: "combine"},
+            ),
+            (AllToAllTokenDispatcher.combine, {"EP": "combine"}),
+        ]
+        for method, annotation in expected_annotations:
+            self.assertEqual(
+                inspect.getclosurevars(method).nonlocals["annotation_dict"],
+                annotation,
+            )
+
+    def test_ep_overlap_reorders_forward_and_backward_token_exchange_blocks(self):
+        for backward, first_chunk in ((False, 0), (True, 1)):
+            with self.subTest(backward=backward):
+                gm = self._build_ep_overlap_schedule_gm(backward=backward)
+                order = self._schedule_ep_overlap_and_order(gm)
+                nodes = list(gm.graph.nodes)
+
+                def named(chunk_id, target, ep=None):
+                    matches = [
+                        node
+                        for node in nodes
+                        if node.meta.get("chunk_id") == chunk_id
+                        and node.target == target
+                        and (
+                            ep is None
+                            or node.meta.get("custom", {}).get(_EP_TOKEN_EXCHANGE) == ep
+                            or node.meta.get("custom", {}).get("EP") == ep
+                        )
+                    ]
+                    self.assertEqual(len(matches), 1)
+                    return matches[0]
+
+                second_chunk = 1 - first_chunk
+                c10d = torch.ops._c10d_functional
+                first_dispatch_launch = named(
+                    first_chunk,
+                    c10d.all_to_all_single.default,
+                    ep="dispatch",
+                )
+                second_dispatch_launch = named(
+                    second_chunk,
+                    c10d.all_to_all_single.default,
+                    ep="dispatch",
+                )
+                first_dispatch_wait = next(iter(first_dispatch_launch.users))
+                first_combine_launch = named(
+                    first_chunk,
+                    c10d.all_to_all_single.default,
+                    ep="combine",
+                )
+                second_combine_launch = named(
+                    second_chunk,
+                    c10d.all_to_all_single.default,
+                    ep="combine",
+                )
+
+                self.assertLess(
+                    order[first_dispatch_launch], order[second_dispatch_launch]
+                )
+                self.assertLess(
+                    order[second_dispatch_launch], order[first_dispatch_wait]
+                )
+                self.assertLess(
+                    order[first_combine_launch], order[second_combine_launch]
+                )
+                if not backward:
+                    self.assertLess(
+                        order[first_combine_launch],
+                        order[next(iter(second_dispatch_launch.users))],
+                    )
+                else:
+                    self.assertLess(
+                        order[second_dispatch_launch],
+                        order[next(iter(first_dispatch_launch.users))],
+                    )
+
+    def test_ep_overlap_schedules_moe_shaped_forward_and_backward_order(self):
+        c10d = torch.ops._c10d_functional
+
+        def build_forward_gm():
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            refs = {}
+            for chunk_id in (0, 1):
+                router = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+                count = graph.call_function(
+                    c10d.all_to_all_single.default, args=(router, [], [], "ep")
+                )
+                sync = graph.call_function(
+                    torch.ops.aten._local_scalar_dense.default, args=(count,)
+                )
+                dispatch = graph.call_function(
+                    c10d.all_to_all_single.default, args=(sync, [], [], "ep")
+                )
+                shared = graph.call_function(torch.ops.aten.neg.default, args=(x,))
+                dispatch_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(dispatch,)
+                )
+                grouped_mm = graph.call_function(
+                    torch.ops.aten.relu.default, args=(dispatch_wait,)
+                )
+                combine = graph.call_function(
+                    c10d.all_to_all_single.default, args=(grouped_mm, [], [], "ep")
+                )
+                combine_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(combine,)
+                )
+                refs[chunk_id] = {
+                    "router": router,
+                    "count": count,
+                    "sync": sync,
+                    "dispatch": dispatch,
+                    "shared": shared,
+                    "dispatch_wait": dispatch_wait,
+                    "grouped_mm": grouped_mm,
+                    "combine": combine,
+                    "combine_wait": combine_wait,
+                }
+                for node in (router, count, sync, dispatch, dispatch_wait):
+                    self._mark_chunk_body(
+                        node,
+                        chunk_id=chunk_id,
+                        ep="dispatch",
+                        token_exchange=node is dispatch,
+                    )
+                for node in (shared, grouped_mm):
+                    self._mark_chunk_body(node, chunk_id=chunk_id)
+                for node in (combine, combine_wait):
+                    self._mark_chunk_body(
+                        node,
+                        chunk_id=chunk_id,
+                        ep="combine",
+                        token_exchange=node is combine,
+                    )
+            graph.output((refs[0]["combine_wait"], refs[1]["combine_wait"]))
+            return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+        def build_backward_gm():
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            refs = {}
+            for chunk_id in (0, 1):
+                combine = graph.call_function(
+                    c10d.all_to_all_single.default, args=(x, [], [], "ep")
+                )
+                remat_grouped_mm = graph.call_function(
+                    torch.ops.aten.neg.default, args=(x,)
+                )
+                combine_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(combine,)
+                )
+                input_grad = graph.call_function(
+                    torch.ops.aten.relu.default, args=(combine_wait,)
+                )
+                dispatch = graph.call_function(
+                    c10d.all_to_all_single.default, args=(input_grad, [], [], "ep")
+                )
+                wgrad = graph.call_function(
+                    torch.ops.aten.neg.default, args=(dispatch,)
+                )
+                dispatch_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(dispatch,)
+                )
+                refs[chunk_id] = {
+                    "combine": combine,
+                    "remat_grouped_mm": remat_grouped_mm,
+                    "combine_wait": combine_wait,
+                    "input_grad": input_grad,
+                    "dispatch": dispatch,
+                    "wgrad": wgrad,
+                    "dispatch_wait": dispatch_wait,
+                }
+                for node in (combine, combine_wait):
+                    self._mark_chunk_body(
+                        node,
+                        chunk_id=chunk_id,
+                        backward=True,
+                        ep="combine",
+                        token_exchange=node is combine,
+                    )
+                for node in (remat_grouped_mm, input_grad, wgrad):
+                    self._mark_chunk_body(node, chunk_id=chunk_id, backward=True)
+                for node in (dispatch, dispatch_wait):
+                    self._mark_chunk_body(
+                        node,
+                        chunk_id=chunk_id,
+                        backward=True,
+                        ep="dispatch",
+                        token_exchange=node is dispatch,
+                    )
+            graph.output((refs[1]["dispatch_wait"], refs[0]["dispatch_wait"]))
+            return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+        fwd_gm, fwd = build_forward_gm()
+        fwd_order = self._schedule_ep_overlap_and_order(fwd_gm)
+        self._assert_nodes_in_order(
+            fwd_order,
+            [
+                fwd[0]["router"],
+                fwd[0]["count"],
+                fwd[0]["sync"],
+                fwd[1]["router"],
+                fwd[1]["count"],
+                fwd[1]["sync"],
+                fwd[0]["dispatch"],
+                fwd[1]["dispatch"],
+                fwd[0]["shared"],
+                fwd[1]["shared"],
+                fwd[0]["dispatch_wait"],
+                fwd[0]["grouped_mm"],
+                fwd[0]["combine"],
+                fwd[1]["dispatch_wait"],
+                fwd[1]["grouped_mm"],
+                fwd[1]["combine"],
+                fwd[0]["combine_wait"],
+                fwd[1]["combine_wait"],
+            ],
+        )
+
+        bwd_gm, bwd = build_backward_gm()
+        bwd_order = self._schedule_ep_overlap_and_order(bwd_gm)
+        self._assert_nodes_in_order(
+            bwd_order,
+            [
+                bwd[1]["combine"],
+                bwd[0]["combine"],
+                bwd[1]["remat_grouped_mm"],
+                bwd[0]["remat_grouped_mm"],
+                bwd[1]["combine_wait"],
+                bwd[1]["input_grad"],
+                bwd[1]["dispatch"],
+                bwd[0]["combine_wait"],
+                bwd[0]["input_grad"],
+                bwd[0]["dispatch"],
+                bwd[1]["wgrad"],
+                bwd[0]["wgrad"],
+                bwd[1]["dispatch_wait"],
+                bwd[0]["dispatch_wait"],
+            ],
+        )
+
+    def test_ep_overlap_keeps_transformer_batch_first_marker_wait_gated(self):
+        c10d = torch.ops._c10d_functional
+
+        def build_forward_gm():
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            refs = {}
+            for chunk_id in (0, 1):
+                dense_prefix = graph.call_function(
+                    torch.ops.aten.relu.default, args=(x,)
+                )
+                router = graph.call_function(
+                    torch.ops.aten.neg.default, args=(dense_prefix,)
+                )
+                count = graph.call_function(
+                    c10d.all_to_all_single.default, args=(router, [], [], "ep")
+                )
+                sync = graph.call_function(
+                    torch.ops.aten._local_scalar_dense.default, args=(count,)
+                )
+                dispatch = graph.call_function(
+                    c10d.all_to_all_single.default, args=(sync, [], [], "ep")
+                )
+                dispatch_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(dispatch,)
+                )
+                grouped_mm = graph.call_function(
+                    torch.ops.aten.relu.default, args=(dispatch_wait,)
+                )
+                combine = graph.call_function(
+                    c10d.all_to_all_single.default, args=(grouped_mm, [], [], "ep")
+                )
+                combine_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(combine,)
+                )
+                refs[chunk_id] = {
+                    "dense_prefix": dense_prefix,
+                    "router": router,
+                    "count": count,
+                    "sync": sync,
+                    "dispatch": dispatch,
+                    "dispatch_wait": dispatch_wait,
+                    "grouped_mm": grouped_mm,
+                    "combine": combine,
+                    "combine_wait": combine_wait,
+                }
+                for node in (dense_prefix, router, count, sync, dispatch):
+                    self._mark_chunk_body(
+                        node,
+                        fqn="layers.0",
+                        chunk_id=chunk_id,
+                        ep="dispatch",
+                        token_exchange=node is dispatch,
+                    )
+                for node in (dispatch_wait, grouped_mm, combine, combine_wait):
+                    self._mark_chunk_body(
+                        node,
+                        fqn="layers.0",
+                        chunk_id=chunk_id,
+                        ep="combine",
+                        token_exchange=node is combine,
+                    )
+            graph.output((refs[0]["combine_wait"], refs[1]["combine_wait"]))
+            return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+        def build_backward_gm():
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            refs = {}
+            for chunk_id in (0, 1):
+                remat_prefix = graph.call_function(
+                    torch.ops.aten.relu.default, args=(x,)
+                )
+                combine = graph.call_function(
+                    c10d.all_to_all_single.default, args=(remat_prefix, [], [], "ep")
+                )
+                combine_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(combine,)
+                )
+                input_grad = graph.call_function(
+                    torch.ops.aten.relu.default, args=(combine_wait,)
+                )
+                dispatch = graph.call_function(
+                    c10d.all_to_all_single.default, args=(input_grad, [], [], "ep")
+                )
+                dispatch_wait = graph.call_function(
+                    c10d.wait_tensor.default, args=(dispatch,)
+                )
+                refs[chunk_id] = {
+                    "remat_prefix": remat_prefix,
+                    "combine": combine,
+                    "combine_wait": combine_wait,
+                    "input_grad": input_grad,
+                    "dispatch": dispatch,
+                    "dispatch_wait": dispatch_wait,
+                }
+                for node in (remat_prefix, combine, combine_wait):
+                    self._mark_chunk_body(
+                        node,
+                        fqn="layers.0",
+                        chunk_id=chunk_id,
+                        backward=True,
+                        ep="combine",
+                        token_exchange=node is combine,
+                    )
+                for node in (input_grad, dispatch, dispatch_wait):
+                    self._mark_chunk_body(
+                        node,
+                        fqn="layers.0",
+                        chunk_id=chunk_id,
+                        backward=True,
+                        ep="dispatch",
+                        token_exchange=node is dispatch,
+                    )
+            graph.output((refs[1]["dispatch_wait"], refs[0]["dispatch_wait"]))
+            return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+        fwd_gm, fwd = build_forward_gm()
+        fwd_order = self._schedule_ep_overlap_and_order(
+            fwd_gm,
+            module_pattern="layers.*",
+            pair_first_token_exchange=False,
+        )
+        self._assert_nodes_in_order(
+            fwd_order,
+            [
+                fwd[0]["dense_prefix"],
+                fwd[0]["dispatch"],
+                fwd[1]["dense_prefix"],
+                fwd[1]["dispatch"],
+                fwd[0]["dispatch_wait"],
+                fwd[0]["combine"],
+                fwd[1]["dispatch_wait"],
+                fwd[1]["combine"],
+            ],
+        )
+
+        bwd_gm, bwd = build_backward_gm()
+        bwd_order = self._schedule_ep_overlap_and_order(
+            bwd_gm,
+            module_pattern="layers.*",
+            pair_first_token_exchange=False,
+        )
+        self._assert_nodes_in_order(
+            bwd_order,
+            [
+                bwd[1]["remat_prefix"],
+                bwd[1]["combine"],
+                bwd[0]["remat_prefix"],
+                bwd[0]["combine"],
+                bwd[1]["combine_wait"],
+                bwd[1]["dispatch"],
+                bwd[0]["combine_wait"],
+                bwd[0]["dispatch"],
+                bwd[1]["dispatch_wait"],
+                bwd[0]["dispatch_wait"],
+            ],
+        )
+
+    def test_ep_overlap_pairs_token_count_sync_cpu_copies_before_consumers(self):
+        gm, refs = self._build_ep_sync_copy_schedule_gm()
+
+        order = self._schedule_ep_overlap_and_order(gm)
+
+        copies = refs[0]["copies"] + refs[1]["copies"]
+        consumers = refs[0]["consumers"] + refs[1]["consumers"]
+        self.assertEqual(
+            [copy.kwargs["non_blocking"] for copy in copies],
+            [True, True, True, False],
+        )
+        self.assertLess(
+            max(order[copy] for copy in copies),
+            min(order[consumer] for consumer in consumers),
+        )
+        self.assertLess(
+            max(order[consumer] for consumer in consumers),
+            min(order[refs[chunk_id]["dispatch"]] for chunk_id in (0, 1)),
+        )
+
+    def test_ep_overlap_hoists_token_count_sync_cpu_copies_per_chunk(self):
+        gm, refs = self._build_ep_sync_copy_schedule_gm(fqn="layers.0")
+
+        order = self._schedule_ep_overlap_and_order(
+            gm,
+            module_pattern="layers.*",
+            pair_first_token_exchange=False,
+        )
+
+        for chunk_id in (0, 1):
+            self.assertEqual(
+                [copy.kwargs["non_blocking"] for copy in refs[chunk_id]["copies"]],
+                [True, False],
+            )
+            self.assertLess(
+                max(order[copy] for copy in refs[chunk_id]["copies"]),
+                min(order[consumer] for consumer in refs[chunk_id]["consumers"]),
+            )
+            self.assertLess(
+                max(order[consumer] for consumer in refs[chunk_id]["consumers"]),
+                order[refs[chunk_id]["dispatch"]],
+            )
+        self.assertLess(order[refs[0]["dispatch"]], order[refs[1]["copies"][0]])
+
+    def test_ep_overlap_rejects_malformed_token_count_sync_copy_count(self):
+        gm, _refs = self._build_ep_sync_copy_schedule_gm(copies_per_chunk=1)
+
+        with self.assertRaisesRegex(ValueError, "exactly two token-count sync"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_rejects_ambiguous_token_count_sync_copy_destination(self):
+        gm, _refs = self._build_ep_sync_copy_schedule_gm(cpu_destination=False)
+
+        with self.assertRaisesRegex(ValueError, "CPU _to_copy destinations"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_rejects_unannotated_all_to_all_markers(self):
+        gm = self._build_ep_overlap_schedule_gm()
+        c10d = torch.ops._c10d_functional
+        launches = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target == c10d.all_to_all_single.default
+        ]
+        for node in launches:
+            custom = dict(node.meta.get("custom", {}))
+            custom.pop(_EP_TOKEN_EXCHANGE, None)
+            node.meta["custom"] = custom
+
+        with self.assertRaises(ValueError, msg="did not find any chunked EP"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_rejects_token_exchange_metadata_on_compute(self):
+        gm = self._build_ep_overlap_schedule_gm()
+        compute = next(
+            node
+            for node in gm.graph.nodes
+            if node.target == torch.ops.aten.neg.default
+            and node.meta.get("chunked_region_role") == "body"
+        )
+        compute.meta.setdefault("custom", {})[_EP_TOKEN_EXCHANGE] = "dispatch"
+
+        with self.assertRaisesRegex(ValueError, "non-marker node"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_rejects_mismatched_token_exchange_labels(self):
+        gm = self._build_ep_overlap_schedule_gm()
+        launch = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target == torch.ops._c10d_functional.all_to_all_single.default
+            and node.meta.get("chunk_id") == 0
+            and node.meta.get("custom", {}).get(_EP_TOKEN_EXCHANGE) == "dispatch"
+        )
+        launch.meta["custom"][_EP_TOKEN_EXCHANGE] = "combine"
+
+        with self.assertRaisesRegex(ValueError, "matching token-exchange labels"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_rejects_wait_before_token_exchange_launch(self):
+        gm = self._build_ep_overlap_schedule_gm()
+        launch = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target == torch.ops._c10d_functional.all_to_all_single.default
+            and node.meta.get("custom", {}).get(_EP_TOKEN_EXCHANGE) == "dispatch"
+        )
+        wait = next(
+            user
+            for user in launch.users
+            if user.target == torch.ops._c10d_functional.wait_tensor.default
+        )
+        launch.prepend(wait)
+
+        with self.assertRaisesRegex(ValueError, "wait to appear after its launch"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_uses_future_closure_prefix_before_wait(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        refs = {}
+
+        # Build the graph in the opposite order from the desired backward
+        # schedule. This catches accidental sorting by original graph order when
+        # a ready filler phase intentionally contains chunk1 work before chunk0.
+        for chunk_id in (0, 1):
+            combine_pre = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            combine = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(combine_pre, [], [], "ep"),
+            )
+            dispatch_prefix = graph.call_function(torch.ops.aten.neg.default, args=(x,))
+            combine_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(combine,)
+            )
+            dispatch_pre = graph.call_function(
+                torch.ops.aten.add.Tensor, args=(dispatch_prefix, combine_wait)
+            )
+            dispatch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(dispatch_pre, [], [], "ep"),
+            )
+            dispatch_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(dispatch,)
+            )
+            tail = graph.call_function(
+                torch.ops.aten.relu.default, args=(dispatch_wait,)
+            )
+            refs[chunk_id] = {
+                "combine": combine,
+                "dispatch_prefix": dispatch_prefix,
+                "combine_wait": combine_wait,
+                "dispatch_pre": dispatch_pre,
+                "dispatch": dispatch,
+                "dispatch_wait": dispatch_wait,
+                "tail": tail,
+            }
+
+            for node in (combine_pre, combine, combine_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+            combine.meta["custom"][_EP_TOKEN_EXCHANGE] = "combine"
+            dispatch_prefix.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            dispatch_pre.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in (dispatch, dispatch_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+            dispatch.meta["custom"][_EP_TOKEN_EXCHANGE] = "dispatch"
+            tail.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in (
+                combine_pre,
+                combine,
+                dispatch_prefix,
+                combine_wait,
+                dispatch_pre,
+                dispatch,
+                dispatch_wait,
+                tail,
+            ):
+                node.meta["chunk_id"] = chunk_id
+                node.meta["chunked_region_fqn"] = "layers.0.moe"
+                node.meta["chunked_region_role"] = "body"
+                node.meta["autograd_backward"] = True
+
+        graph.output((refs[1]["tail"], refs[0]["tail"]))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        order = self._schedule_ep_overlap_and_order(gm)
+
+        self.assertEqual(
+            refs[1]["combine_wait"].meta["custom"][_EP_TOKEN_EXCHANGE_WAIT],
+            "combine",
+        )
+        self.assertLess(order[refs[1]["combine"]], order[refs[0]["combine"]])
+        self.assertLess(order[refs[0]["combine"]], order[refs[1]["dispatch_prefix"]])
+        self.assertLess(
+            order[refs[1]["dispatch_prefix"]],
+            order[refs[0]["dispatch_prefix"]],
+        )
+        self.assertLess(
+            order[refs[0]["dispatch_prefix"]], order[refs[1]["combine_wait"]]
+        )
+        self.assertLess(order[refs[1]["combine_wait"]], order[refs[1]["dispatch"]])
+        self.assertLess(order[refs[1]["dispatch"]], order[refs[0]["combine_wait"]])
+        self.assertLess(order[refs[0]["combine_wait"]], order[refs[0]["dispatch"]])
+        self.assertLess(order[refs[0]["dispatch"]], order[refs[1]["dispatch_wait"]])
+        self.assertLess(order[refs[1]["dispatch_wait"]], order[refs[1]["tail"]])
+        self.assertLess(order[refs[1]["tail"]], order[refs[0]["dispatch_wait"]])
+        self.assertLess(order[refs[0]["dispatch_wait"]], order[refs[0]["tail"]])
+
+    def test_ep_overlap_does_not_hoist_non_token_collectives_as_filler(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        refs = {}
+
+        for chunk_id in (0, 1):
+            dispatch_pre = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            dispatch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(dispatch_pre, [], [], "ep"),
+            )
+            dispatch_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(dispatch,)
+            )
+            all_reduce = graph.call_function(
+                c10d.all_reduce.default, args=(x, "sum", "dp")
+            )
+            combine_pre = graph.call_function(
+                torch.ops.aten.add.Tensor, args=(dispatch_wait, all_reduce)
+            )
+            combine = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(combine_pre, [], [], "ep"),
+            )
+            combine_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(combine,)
+            )
+            refs[chunk_id] = {
+                "dispatch": dispatch,
+                "dispatch_wait": dispatch_wait,
+                "all_reduce": all_reduce,
+                "combine": combine,
+                "combine_wait": combine_wait,
+            }
+
+            for node in (dispatch_pre, dispatch, dispatch_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+            dispatch.meta["custom"][_EP_TOKEN_EXCHANGE] = "dispatch"
+            all_reduce.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            combine_pre.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in (combine, combine_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+            combine.meta["custom"][_EP_TOKEN_EXCHANGE] = "combine"
+
+            for node in (
+                dispatch_pre,
+                dispatch,
+                dispatch_wait,
+                all_reduce,
+                combine_pre,
+                combine,
+                combine_wait,
+            ):
+                node.meta["chunk_id"] = chunk_id
+                node.meta["chunked_region_fqn"] = "layers.0.moe"
+                node.meta["chunked_region_role"] = "body"
+
+        graph.output((refs[0]["combine_wait"], refs[1]["combine_wait"]))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        order = self._schedule_ep_overlap_and_order(gm)
+
+        self.assertLess(order[refs[0]["dispatch"]], order[refs[1]["dispatch"]])
+        self.assertLess(order[refs[1]["dispatch"]], order[refs[0]["dispatch_wait"]])
+        for chunk_id in (0, 1):
+            self.assertLess(
+                order[refs[chunk_id]["dispatch_wait"]],
+                order[refs[chunk_id]["all_reduce"]],
+            )
+            self.assertLess(
+                order[refs[chunk_id]["all_reduce"]],
+                order[refs[chunk_id]["combine"]],
+            )
+
+    def test_ep_overlap_rejects_mismatched_all_to_all_count(self):
+        gm = self._build_ep_overlap_schedule_gm(backward=True)
+        c10d = torch.ops._c10d_functional
+        for node in gm.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target == c10d.all_to_all_single.default
+                and node.meta.get("chunk_id") == 0
+            ):
+                node.target = c10d.all_reduce.default
+                node.args = (node.args[0], "sum", "ep")
+                node.meta["custom"].pop(_EP_TOKEN_EXCHANGE, None)
+                break
+        with self.assertRaisesRegex(ValueError, "matching EP all-to-all counts"):
+            _schedule_ep_overlap_regions(
+                gm,
+                module_pattern="layers.*.moe",
+                require_all_to_all=True,
+                pair_first_token_exchange=True,
+            )
+
+    def test_ep_overlap_schedules_arbitrary_matching_token_exchange_sequence(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        outputs = []
+        launches = {}
+        exchange_kinds = ("combine", "dispatch", "combine")
+        for chunk_id in (1, 0):
+            value = x
+            body_nodes = []
+            for idx, kind in enumerate(exchange_kinds):
+                pre = graph.call_function(torch.ops.aten.relu.default, args=(value,))
+                launch = graph.call_function(
+                    c10d.all_to_all_single.default,
+                    args=(pre, [], [], "ep"),
+                )
+                wait = graph.call_function(c10d.wait_tensor.default, args=(launch,))
+                launches[(chunk_id, idx)] = launch
+                for node in (pre, launch, wait):
+                    node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": kind}
+                launch.meta["custom"][_EP_TOKEN_EXCHANGE] = kind
+                value = graph.call_function(torch.ops.aten.neg.default, args=(wait,))
+                value.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+                body_nodes.extend((pre, launch, wait, value))
+            outputs.append(value)
+            for node in body_nodes:
+                node.meta["chunk_id"] = chunk_id
+                node.meta["chunked_region_fqn"] = "layers.0.moe"
+                node.meta["chunked_region_role"] = "body"
+                node.meta["autograd_backward"] = True
+
+        graph.output(tuple(outputs))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        order = self._schedule_ep_overlap_and_order(gm)
+        for idx in range(len(exchange_kinds)):
+            self.assertLess(order[launches[(1, idx)]], order[launches[(0, idx)]])
+            if idx + 1 < len(exchange_kinds):
+                self.assertLess(
+                    order[launches[(0, idx)]], order[launches[(1, idx + 1)]]
+                )
+
+    def test_ep_overlap_reorders_non_body_setup_dependencies(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        outputs = []
+        setup_nodes = {}
+        first_waits = {}
+        for chunk_id in (0, 1):
+            setup = graph.call_function(torch.ops.aten.clone.default, args=(x,))
+            pre = graph.call_function(torch.ops.aten.relu.default, args=(setup,))
+            dispatch = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(pre, [], [], "ep"),
+            )
+            dispatch_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(dispatch,)
+            )
+            compute = graph.call_function(
+                torch.ops.aten.neg.default, args=(dispatch_wait,)
+            )
+            combine = graph.call_function(
+                c10d.all_to_all_single.default,
+                args=(compute, [], [], "ep"),
+            )
+            combine_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(combine,)
+            )
+            outputs.append(combine_wait)
+            setup_nodes[chunk_id] = setup
+            first_waits[chunk_id] = dispatch_wait
+
+            setup.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in (pre, dispatch, dispatch_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+            dispatch.meta["custom"][_EP_TOKEN_EXCHANGE] = "dispatch"
+            compute.meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in (combine, combine_wait):
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+            combine.meta["custom"][_EP_TOKEN_EXCHANGE] = "combine"
+            for node in (pre, dispatch, dispatch_wait, compute, combine, combine_wait):
+                node.meta["chunk_id"] = chunk_id
+                node.meta["chunked_region_fqn"] = "layers.0.moe"
+                node.meta["chunked_region_role"] = "body"
+
+        graph.output(tuple(outputs))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        order = self._schedule_ep_overlap_and_order(gm)
+
+        self.assertLess(order[setup_nodes[1]], order[first_waits[0]])
+        self.assertLess(order[first_waits[0]], order[first_waits[1]])
+
+    def test_ep_overlap_apply_schedule_interleaves_cross_region_boundaries(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        region0_start = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        region1_start = graph.call_function(
+            torch.ops.aten.neg.default, args=(region0_start,)
+        )
+        boundary = graph.call_function(
+            torch.ops.aten.clone.default, args=(region1_start,)
+        )
+        region0_tail = graph.call_function(
+            torch.ops.aten.relu.default, args=(boundary,)
+        )
+        region1_tail = graph.call_function(
+            torch.ops.aten.add.Tensor, args=(region1_start, region0_tail)
+        )
+        graph.output(region1_tail)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        def scheduled_region(
+            root_fqn: str,
+            phases: tuple[tuple[torch.fx.Node, ...], ...],
+        ) -> _ScheduledRegion:
+            bodies = {
+                idx: ChunkBody(
+                    owner=ChunkOwner(root_fqn, False, idx),
+                    nodes=(),
+                    node_set=frozenset(),
+                    live_ins=frozenset(),
+                    producer="graph",
+                )
+                for idx in (0, 1)
+            }
+            return _ScheduledRegion(
+                region=ChunkedRegion(root_fqn, False, bodies),
+                phases=phases,
+            )
+
+        _apply_schedule(
+            gm,
+            [
+                scheduled_region("layers.0", ((region0_start,), (region0_tail,))),
+                scheduled_region("layers.1", ((region1_start,), (region1_tail,))),
+            ],
+        )
+
+        order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
+        self.assertLess(order[region0_start], order[region0_tail])
+        self.assertLess(order[region1_start], order[region1_tail])
+        self.assertLess(order[region1_start], order[boundary])
+        self.assertLess(order[boundary], order[region0_tail])
+        self.assertLess(order[region0_tail], order[region1_tail])
+
+    def test_ep_overlap_moves_owned_remat_with_chunk_body(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+
+        c0_pre = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        c0_dispatch = graph.call_function(
+            c10d.all_to_all_single.default, args=(c0_pre, [], [], "ep")
+        )
+        c0_dispatch_wait = graph.call_function(
+            c10d.wait_tensor.default, args=(c0_dispatch,)
+        )
+        c0_compute = graph.call_function(
+            torch.ops.aten.neg.default, args=(c0_dispatch_wait,)
+        )
+        c0_combine = graph.call_function(
+            c10d.all_to_all_single.default, args=(c0_compute, [], [], "ep")
+        )
+        c0_combine_wait = graph.call_function(
+            c10d.wait_tensor.default, args=(c0_combine,)
+        )
+
+        c1_setup = graph.call_function(torch.ops.aten.clone.default, args=(x,))
+        c1_setup.meta["autograd_backward"] = True
+        c1_setup.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+        c1_pre = graph.call_function(torch.ops.aten.relu.default, args=(c1_setup,))
+        c1_dispatch = graph.call_function(
+            c10d.all_to_all_single.default, args=(c1_pre, [], [], "ep")
+        )
+        c1_dispatch_wait = graph.call_function(
+            c10d.wait_tensor.default, args=(c1_dispatch,)
+        )
+        c1_compute = graph.call_function(
+            torch.ops.aten.neg.default, args=(c1_dispatch_wait,)
+        )
+        c1_combine = graph.call_function(
+            c10d.all_to_all_single.default, args=(c1_compute, [], [], "ep")
+        )
+        c1_combine_wait = graph.call_function(
+            c10d.wait_tensor.default, args=(c1_combine,)
+        )
+        graph.output((c0_combine_wait, c1_combine_wait))
+
+        for chunk_id, nodes in {
+            0: (
+                c0_pre,
+                c0_dispatch,
+                c0_dispatch_wait,
+                c0_compute,
+                c0_combine,
+                c0_combine_wait,
+            ),
+            1: (
+                c1_setup,
+                c1_pre,
+                c1_dispatch,
+                c1_dispatch_wait,
+                c1_compute,
+                c1_combine,
+                c1_combine_wait,
+            ),
+        }.items():
+            for node in nodes:
+                node.meta["chunk_id"] = chunk_id
+                node.meta["chunked_region_fqn"] = "layers.0.moe"
+                node.meta["chunked_region_role"] = "body"
+                node.meta["autograd_backward"] = True
+            ep_nodes = nodes[1:] if chunk_id == 1 else nodes
+            for node in ep_nodes[:3]:
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+            ep_nodes[1].meta["custom"][_EP_TOKEN_EXCHANGE] = "combine"
+            ep_nodes[3].meta["custom"] = {_MODULE_FQN: "layers.0.moe"}
+            for node in ep_nodes[4:]:
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+            ep_nodes[4].meta["custom"][_EP_TOKEN_EXCHANGE] = "dispatch"
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        order = self._schedule_ep_overlap_and_order(gm)
+        self.assertLess(order[c1_setup], order[c1_pre])
+        self.assertLess(order[c1_dispatch], order[c0_dispatch_wait])
 
     def test_eager_chunking_traces_overlap_metadata(self):
         class Block(torch.nn.Module):

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -17,6 +17,7 @@ from torchtitan.experiments.graph_trainer.chunked_loss import (
     ChunkedCELossWithParamGrads,
 )
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _maybe_materialize_grad_for_param_layout,
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
@@ -28,9 +29,6 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
 )
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
-)
-from torchtitan.experiments.graph_trainer.trainer import (
-    _materialize_grad_for_param_layout,
 )
 
 
@@ -356,16 +354,16 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
             )
         )
 
-    def test_materialize_grad_for_param_layout_restores_param_strides(self):
+    def test_maybe_materialize_grad_for_param_layout_restores_param_strides(self):
         param = torch.empty_strided((2, 3), (1, 2))
         grad = torch.arange(6.0).reshape(2, 3)
 
-        materialized = _materialize_grad_for_param_layout(param, grad)
+        materialized = _maybe_materialize_grad_for_param_layout(param, grad)
 
         self.assertEqual(materialized.stride(), param.stride())
         self.assertTrue(torch.equal(materialized, grad))
         self.assertIs(
-            _materialize_grad_for_param_layout(param, materialized),
+            _maybe_materialize_grad_for_param_layout(param, materialized),
             materialized,
         )
 

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from torch.fx.traceback import annotate_fn
 
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _maybe_materialize_grad_for_param_layout,
     _MODULE_FQN,
     log_timer,
     maybe_register_blockmask_pytree_node,
@@ -93,32 +94,6 @@ def make_fwd_bwd_step(model, loss_fn):
         return [loss] + list(grads)
 
     return fwd_bwd_step
-
-
-def _materialize_grad_for_param_layout(
-    param: torch.Tensor, grad: torch.Tensor
-) -> torch.Tensor:
-    """Return ``grad`` with the same layout contract as ``param`` when needed.
-
-    ``aot_fx_trace`` computes gradients with ``torch.autograd.grad`` and then
-    assigns them to ``param.grad`` manually. That bypasses AccumulateGrad's
-    normal layout-contract handling. Full Inductor may return dense gradients
-    with padded local strides, which are legal graph outputs but can violate
-    fused optimizer requirements that params, grads, and optimizer states share
-    matching strides. Materializing through ``empty_like(param).copy_(grad)``
-    restores the same layout eager autograd would expose at the ``.grad``
-    boundary while preserving DTensor placements.
-    """
-
-    if grad.stride() == param.stride():
-        grad_local = grad.to_local() if hasattr(grad, "to_local") else grad
-        param_local = param.to_local() if hasattr(param, "to_local") else param
-        if grad_local.stride() == param_local.stride():
-            return grad
-
-    materialized_grad = torch.empty_like(param)
-    materialized_grad.copy_(grad)
-    return materialized_grad
 
 
 class GraphTrainer(Trainer):
@@ -249,7 +224,11 @@ class GraphTrainer(Trainer):
                     self.config.compile.pass_pipeline,
                     construct_default_graph_passes,
                 )
-                passes = pipeline_fn(self._traced_step, self.config)
+                passes = pipeline_fn(
+                    self._traced_step,
+                    self.config,
+                    parallel_dims=self.parallel_dims,
+                )
 
                 self._traced_step.gm = apply_graph_passes(
                     self._traced_step.gm,
@@ -268,7 +247,7 @@ class GraphTrainer(Trainer):
         grads = outputs[1:]
 
         for param, grad in zip(params, grads, strict=True):
-            grad = _materialize_grad_for_param_layout(param, grad)
+            grad = _maybe_materialize_grad_for_param_layout(param, grad)
             if param.grad is None:
                 param.grad = grad
             else:

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -254,6 +254,130 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
     def __init__(self, config: Config):
         super().__init__(config)
 
+    def _token_count_exchange(
+        self,
+        num_local_tokens_per_expert_E: torch.Tensor,
+        pg,
+        ep_size: int,
+    ) -> torch.Tensor:
+        """Exchange per-rank expert token counts before the data all-to-all.
+
+        This method is separate from ``dispatch`` so graph passes can annotate
+        the count exchange independently from the true token-exchange
+        scheduling markers.
+        """
+        if (
+            torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
+        ) and get_spmd_backend() != "spmd_types":
+            return all_to_all_single(
+                num_local_tokens_per_expert_E.view(ep_size, -1),
+                None,
+                None,
+                group=self.ep_mesh,
+            )
+
+        return spmd.all_to_all(
+            num_local_tokens_per_expert_E.view(ep_size, -1),
+            pg,
+            src=spmd.V,
+            dst=spmd.V,
+        )
+
+    def _sync_token_count_exchange(
+        self,
+        num_local_tokens_per_expert_E: torch.Tensor,
+        num_global_tokens_per_local_expert_EP_e: torch.Tensor,
+        ep_size: int,
+    ) -> tuple[torch.Tensor, list[int], list[int]]:
+        """Wait for token counts and materialize CPU split lists.
+
+        Local input splits can copy to CPU non-blocking; remote output splits
+        must be ready before launching the variable-size data all-to-all.
+        """
+        # Need to wait explicitly because it is used by a triton kernel later
+        # which doesn't realize that AsyncCollectiveTensor needs unwrapping
+        num_global_tokens_per_local_expert_EP_e = (
+            torch.ops._c10d_functional.wait_tensor(
+                num_global_tokens_per_local_expert_EP_e
+            )
+        )
+        num_global_tokens_per_local_expert_E = (
+            num_global_tokens_per_local_expert_EP_e.reshape(-1)
+        )
+        input_splits = (
+            num_local_tokens_per_expert_E.view(ep_size, -1)
+            .sum(dim=1)
+            .to(torch.device("cpu"), non_blocking=True)
+        )
+        # NOTE: this would incur a device-to-host sync
+        output_splits = (
+            num_global_tokens_per_local_expert_E.view(ep_size, -1)
+            .sum(dim=1)
+            .to(torch.device("cpu"), non_blocking=False)
+        )
+        input_splits_list = input_splits.tolist()
+        output_splits_list = output_splits.tolist()
+
+        return (
+            num_global_tokens_per_local_expert_E,
+            input_splits_list,
+            output_splits_list,
+        )
+
+    def _dispatch_token_exchange(
+        self,
+        routed_input_ND: torch.Tensor,
+        pg,
+        output_splits: list[int],
+        input_splits: list[int],
+    ) -> torch.Tensor:
+        """Launch the dispatch all-to-all that moves routed tokens to experts."""
+        if (
+            torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
+        ) and get_spmd_backend() != "spmd_types":
+            return all_to_all_single(
+                routed_input_ND,
+                output_splits,
+                input_splits,
+                self.ep_mesh,
+            )
+
+        return spmd.all_to_all(
+            routed_input_ND,
+            pg,
+            src=spmd.V,
+            dst=spmd.V,
+            output_split_sizes=output_splits,
+            input_split_sizes=input_splits,
+        )
+
+    def _combine_token_exchange(
+        self,
+        routed_output_RD: torch.Tensor,
+        pg,
+        input_splits: list[int],
+        output_splits: list[int],
+    ) -> torch.Tensor:
+        """Launch the combine all-to-all that returns expert outputs to tokens."""
+        if (
+            torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
+        ) and get_spmd_backend() != "spmd_types":
+            return all_to_all_single(
+                routed_output_RD,
+                input_splits,
+                output_splits,
+                self.ep_mesh,
+            )
+
+        return spmd.all_to_all(
+            routed_output_RD,
+            pg,
+            src=spmd.V,
+            dst=spmd.V,
+            output_split_sizes=input_splits,
+            input_split_sizes=output_splits,
+        )
+
     # pyrefly: ignore [bad-override]
     def dispatch(
         self,
@@ -330,60 +454,27 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 )
 
             with torch.no_grad():
-                if torch.compiler.is_compiling() and get_spmd_backend() != "spmd_types":
-                    num_global_tokens_per_local_expert_EP_e = all_to_all_single(
-                        num_local_tokens_per_expert_E.view(ep_size, -1),
-                        None,
-                        None,
-                        group=self.ep_mesh,
-                    )
-                else:
-                    num_global_tokens_per_local_expert_EP_e = spmd.all_to_all(
-                        num_local_tokens_per_expert_E.view(ep_size, -1),
-                        pg,
-                        src=spmd.V,
-                        dst=spmd.V,
-                    )
-                # Need to wait explicitly because it is used by a triton kernel later
-                # which doesn't realize that AsyncCollectiveTensor needs unwrapping
-                num_global_tokens_per_local_expert_EP_e = (
-                    torch.ops._c10d_functional.wait_tensor(
-                        num_global_tokens_per_local_expert_EP_e
-                    )
-                )
-                num_global_tokens_per_local_expert_E = (
-                    num_global_tokens_per_local_expert_EP_e.reshape(-1)
-                )
-                input_splits = (
-                    num_local_tokens_per_expert_E.view(ep_size, -1)
-                    .sum(dim=1)
-                    .to(torch.device("cpu"), non_blocking=True)
-                )
-                # NOTE: this would incur a device-to-host sync
-                output_splits = (
-                    num_global_tokens_per_local_expert_E.view(ep_size, -1)
-                    .sum(dim=1)
-                    .to(torch.device("cpu"), non_blocking=False)
-                )
-                input_splits_list = input_splits.tolist()
-                output_splits_list = output_splits.tolist()
-
-            if torch.compiler.is_compiling() and get_spmd_backend() != "spmd_types":
-                routed_input_RD = all_to_all_single(
-                    routed_input_ND,
-                    output_splits_list,
-                    input_splits_list,
-                    self.ep_mesh,
-                )
-            else:
-                routed_input_RD = spmd.all_to_all(
-                    routed_input_ND,
+                num_global_tokens_per_local_expert_EP_e = self._token_count_exchange(
+                    num_local_tokens_per_expert_E,
                     pg,
-                    src=spmd.V,
-                    dst=spmd.V,
-                    output_split_sizes=output_splits_list,
-                    input_split_sizes=input_splits_list,
+                    ep_size,
                 )
+                (
+                    num_global_tokens_per_local_expert_E,
+                    input_splits_list,
+                    output_splits_list,
+                ) = self._sync_token_count_exchange(
+                    num_local_tokens_per_expert_E,
+                    num_global_tokens_per_local_expert_EP_e,
+                    ep_size,
+                )
+
+            routed_input_RD = self._dispatch_token_exchange(
+                routed_input_ND,
+                pg,
+                output_splits_list,
+                input_splits_list,
+            )
             # Reorder from rank-major to expert-major via _permute.
             #
             # num_global_tokens_per_local_expert_E layout after all-to-all
@@ -530,22 +621,12 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
             )
             # All-to-all combine: returns AsyncCollectiveTensor — the a2a runs
             # on the NCCL stream and won't block until the tensor is accessed.
-            if torch.compiler.is_compiling() and get_spmd_backend() != "spmd_types":
-                routed_output_RD = all_to_all_single(
-                    routed_output_RD,
-                    metadata.input_splits,
-                    metadata.output_splits,
-                    self.ep_mesh,
-                )
-            else:
-                routed_output_RD = spmd.all_to_all(
-                    routed_output_RD,
-                    pg,
-                    src=spmd.V,
-                    dst=spmd.V,
-                    output_split_sizes=metadata.input_splits,
-                    input_split_sizes=metadata.output_splits,
-                )
+            routed_output_RD = self._combine_token_exchange(
+                routed_output_RD,
+                pg,
+                metadata.input_splits,
+                metadata.output_splits,
+            )
 
         if get_spmd_backend() == "spmd_types":
             if spmd.is_type_checking():  # dense mesh reinterpret


### PR DESCRIPTION
Stacked PRs:
 * __->__#3328
 * #3325
 * #3363


--- --- ---

### [graph_trainer] Add EP overlap scheduling pass


Add the EP overlap scheduler, process-group isolation, FSDP dense-region scheduling, and the scheduling metadata needed to pair EP token exchanges with chunked compute regions.

Split MoE token-dispatcher collectives into annotated helper methods so the graph scheduler can distinguish token-count sync, dispatch, and combine boundaries while preserving the existing non-blocking input split copy behavior.

Test Plan:
- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_passes.py::TestFsdpDenseSchedulerPass torchtitan/experiments/graph_trainer/tests/test_passes.py::TestChunkPasses torchtitan/experiments/graph_trainer/tests/test_precompile.py::TestConfigFingerprint torchtitan/experiments/graph_trainer/tests/test_passes.py::TestEagerChunking
- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py torchtitan/experiments/graph_trainer/tests/test_precompile.py::TestPrecompileLossSetup torchtitan/experiments/graph_trainer/tests/test_trace_module.py::TestTraceModule::test_chunked_ce_loss_train_step tests/unit_tests/test_loss.py::TestGradAccumulator tests/unit_tests/test_loss.py::TestGradAccumulatorDTensor tests/unit_tests/test_loss.py::TestChunkedCELoss tests/unit_tests/test_loss.py::TestChunkedCELossSPMD
- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py::TestDSv3FlexAttnBitwiseDeterministic::test_ep_chunk_matches_eager_chunking_bitwise
- conda run -n pt-dev python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics::test_moe_dsv3_ep_overlap_aot_fx_trace_vs_eager_chunked torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics::test_moe_dsv3_ep_overlap_moe_seq_aot_fx_trace_vs_eager_chunked torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics::test_moe_dsv3_ep_overlap_moe_batch_aot_fx_trace_vs_eager_chunked
- python torchtitan/experiments/graph_trainer/tests/integration_tests.py <out> --test_suite graph_trainer_h100 --test_name <each ep_overlap entry> --ngpu 8
- SKIP=pyrefly-check conda run -n pt-dev pre-commit run --files <stack files>
- conda run -n pt-dev pyrefly check --project-excludes=agent_space --project-excludes=torchtitan/experiments --project-excludes='**/tests/**' --output-format omit-errors
