### PR TITLE
[rl] switch to vllm v2 engine

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -206,6 +206,7 @@ class VLLMGenerator(Actor, Configurable):
 
         # Set vLLM environment variables from config before any vLLM initialization
         os.environ["VLLM_ATTENTION_BACKEND"] = "CUSTOM"
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
 
         set_batch_invariance(config.debug.batch_invariant)
 


### PR DESCRIPTION
vllm v2 engine is inner engine optimization, which should be invisible to users like us: https://docs.google.com/document/d/1gFqtDkcoqhy9j-X0ndshzbhapX1uNey1-wBENwGPI80/edit?tab=t.b0q43s8q2hje#heading=h.nzt0yzryf4am 

vllm is developing v2 Engine, and we might want switching to v2 engine. 

Pros: 
- Find any incompatible issue earlier. 

Cons: 
- v2 development might bread our RL stack as we depend on vllm nightly 