### PR TITLE
Revert "Avoid repeat_interleave output-size sync (#3274)"

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -348,9 +348,7 @@ def _permute_tokens(
     sort_order = torch.argsort(valid_expert_ids, stable=True)
     permuted_indices = torch.arange(
         len(hidden_states), device=hidden_states.device
-    ).repeat_interleave(mask.sum(dim=1), output_size=valid_expert_ids.shape[0])[
-        sort_order
-    ]
+    ).repeat_interleave(mask.sum(dim=1))[sort_order]
     permuted_hidden_states = hidden_states.index_select(0, permuted_indices)
     permuted_scores = valid_scores[sort_order]
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -355,11 +355,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         Output layout: (e0,r0), (e0,r1), ..., (e1,r0), (e1,r1), ...  (expert-major)
         """
         device = num_tokens_per_expert_group.device
-        # output_size must be host-known. num_tokens_per_expert_group.sum()
-        # is a CUDA scalar, but this unpadded all-to-all path keeps one
-        # routed_input row per received routed token assignment, so its shape
-        # equals the number of routed tokens.
-        total = routed_input.shape[0]
+        total = num_tokens_per_expert_group.sum()
 
         # [R, E] matrix of token counts per (rank, expert)
         t_mat = num_tokens_per_expert_group.view(ep_size, num_local_experts)
@@ -376,7 +372,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # For each output position, find its input position:
         #   output[p] = input[input_starts[seg] + (p - output_starts[seg])]
         seg_ids = torch.arange(segment_lens.shape[0], device=device).repeat_interleave(
-            segment_lens, output_size=total
+            segment_lens
         )
         output_starts = segment_lens.cumsum(0) - segment_lens
         permuted_indices = (


### PR DESCRIPTION
Stacked PRs:
 * __->__#3335


--- --- ---

Revert "Avoid repeat_interleave output-size sync (#3274)"

This reverts commit e917ff4cf993e44f7e2abfcfbf30e0d5e7cc9ae9.

cc @syed-ahmed, who reported it breaks

```
-m torchtitan.train --module torchtitan_configs.deepseek_v3 --config deepseek_v3_671b --profiler.no-enable-profiling --metrics.enable-tensorboard --metrics.save_for_all_ranks --training.steps 50 --training.local_batch_size 16 --training.seq_len 4096 --parallelism.tensor_parallel_degree 1 --parallelism.pipeline_parallel_degree 4 --parallelism.context_parallel_degree 1 --parallelism.expert_parallel_degree 32 --compile.components model,loss --parallelism.data_parallel_shard_degree=64 --activation_checkpoint.mode=full
```

```
[rank0]:[CUDA_KERNEL_ASSERT] /opt/pytorch/pytorch/aten/src/ATen/native/cuda/Repeat.cu:20: compute_cuda_kernel: block: [3,0,0], thread: [416,0,0]: Assertion failed: `result_size == cumsum_ptr[size - 1]`: Invalid input! In `repeat_interleave`, the `output_size` argument (30364) must be the same as the sum of the elements in the `repeats` tensor (30365).
```

Strange issue
routed_input.shape[0] == 30364 # number of 
num_tokens_per_expert_group.sum() == 30365

This would imply the CPU splits used to allocate the all-to-all output disagree with the CUDA count tensor later used for permutation