### PR TITLE
[graph_trainer] Fix full_inductor_compilation_pass on graphs with c10d collectives

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -14,6 +14,10 @@ regional_inductor.
 from __future__ import annotations
 
 import torch
+from torch._inductor._functionalize_collectives import (
+    _functionalize_inplace_collectives,
+    _unbox_process_group_torchbinds,
+)
 from torch._inductor.compile_fx import compile_fx_inner
 from torch.fx.passes.regional_inductor import regional_inductor
 
@@ -241,6 +245,24 @@ def full_inductor_compilation_pass(
 
         return gm
 
+    # ``make_fx`` traces ``dist.*`` collectives as raw ``c10d.{op}_`` inplace
+    # ops with a torchbind ``ProcessGroup`` baked in as a graph attr. Inductor
+    # only recognizes the ``_c10d_functional.{op}`` + ``wait_tensor`` form,
+    # and downstream caching (FakeTensor dispatch cache during the decomp
+    # retrace, and ``compile_fx_inner``'s own cache) calls ``__eq__`` on the
+    # PG — not implemented on the torchbind. Mirror ``standalone_compile``'s
+    # pre-compile prep before retracing: rewrite to functional form and unbox
+    # the PG.
+    #
+    # Separately: see https://github.com/pytorch/pytorch/issues/183469,
+    # discovered when trying to use ``standalone_compile``. TorchTitan also
+    # runs Inductor's bucketing pass (intended for the post-joint graph) on
+    # the traced graph, which inserts ``_out`` variant c10d ops like
+    #   torch.ops._c10d_functional.all_gather_into_tensor_out.default(
+    #       input, GROUP_SIZE, GROUP_NAME, out=out)
+    # that AOTAutograd doesn't handle.
+    gm = _functionalize_inplace_collectives(gm)
+    gm = _unbox_process_group_torchbinds(gm)
     gm = _apply_decompositions(gm, example_inputs)
     output_code = compile_fx_inner(gm, example_inputs)
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -818,6 +818,33 @@ class TestTraceDTensor(unittest.TestCase):
         for gr, gt in zip(grads_ref, grads_tr, strict=True):
             self.assertTrue(torch.equal(gr.full_tensor(), gt.full_tensor()))
 
+    def test_full_inductor_pass_on_collective(self):
+        # ``make_fx`` traces ``dist.*`` collectives as raw ``c10d.{op}_``
+        # inplace ops with a torchbind ``ProcessGroup`` baked in as a graph
+        # attr. ``full_inductor_compilation_pass`` must functionalize the
+        # collective and unbox the PG before ``compile_fx_inner`` — otherwise
+        # the cache key calls ``__eq__`` on the torchbind and crashes.
+        import torch.distributed as dist
+
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            full_inductor_compilation_pass,
+        )
+
+        def f(_state, t):
+            t = t.clone()
+            dist.all_reduce(t)
+            return t + 1
+
+        traced = minimal_fx_tracer(f)({}, torch.ones(4, device=self.DEVICE))
+        compiled_gm = full_inductor_compilation_pass(traced.gm, traced.example_inputs)
+
+        real_input = torch.ones(4, device=self.DEVICE)
+        expected = f({}, real_input.clone())
+        actual = compiled_gm(real_input.clone())
+        if isinstance(actual, (list, tuple)):
+            actual = actual[0]
+        torch.testing.assert_close(actual, expected)
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestMetadataPropagation(unittest.TestCase):


### PR DESCRIPTION

Summary:
``make_fx`` traces ``dist.*`` collectives as raw ``c10d.{op}_`` inplace ops with a torchbind ``ProcessGroup`` baked in as a graph attr. Inductor only recognizes the ``_c10d_functional.{op}`` + ``wait_tensor`` form, and the FakeTensor / compile_fx_inner cache key calls ``__eq__`` on the PG which is not implemented on the torchbind. Mirror ``standalone_compile``'s prep: functionalize the inplace collectives and unbox the PG before retracing with decompositions.

Test Plan:
New test ``test_full_inductor_pass_on_collective`` in test_trace_module.py runs the pass on a graph containing ``dist.all_reduce`` and asserts the compiled output matches eager.