### PR TITLE
Add experimental Helion RMSNorm and Q/K RoPE kernels

### DIFF
--- a/tests/unit_tests/test_helion_qk_rmsnorm_rope.py
+++ b/tests/unit_tests/test_helion_qk_rmsnorm_rope.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib.util
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
+
+
+_HAS_HELION = importlib.util.find_spec("helion") is not None
+
+if _HAS_HELION:
+    from torchtitan.experiments.helion_kernels.rope import (
+        apply_qk_rmsnorm_rotary_emb_cos_sin_helion,
+    )
+
+
+def _reference(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xq = F.rms_norm(xq, (xq.shape[-1],), q_weight, eps)
+    xk = F.rms_norm(xk, (xk.shape[-1],), k_weight, eps)
+    return apply_rotary_emb_cos_sin(xq, xk, rope_cache, positions)
+
+
+@unittest.skipUnless(_HAS_HELION, "requires Helion")
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestQKRMSNormRoPEHelion(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    def _make_inputs(
+        self,
+        *,
+        batch_size: int = 1,
+        seq_len: int = 16,
+        n_heads: int = 4,
+        n_kv_heads: int = 2,
+        head_dim: int = 128,
+    ) -> tuple[torch.Tensor, ...]:
+        xq = torch.randn(
+            batch_size,
+            seq_len,
+            n_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        xk = torch.randn(
+            batch_size,
+            seq_len,
+            n_kv_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        q_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+        k_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+        rope_cache = torch.randn(
+            seq_len * 2,
+            head_dim * 2,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        positions = torch.arange(seq_len, device="cuda", dtype=torch.int32).repeat(
+            batch_size, 1
+        )
+        return xq, xk, q_weight, k_weight, rope_cache, positions
+
+    def test_forward_matches_pytorch_reference(self):
+        for seq_len in (1, 16, 192):
+            with self.subTest(seq_len=seq_len):
+                args = self._make_inputs(seq_len=seq_len)
+                with torch.inference_mode():
+                    actual = apply_qk_rmsnorm_rotary_emb_cos_sin_helion(*args)
+                    expected = _reference(*args, eps=1e-5)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=1e-2, atol=7e-2)
+                torch.testing.assert_close(actual[1], expected[1], rtol=1e-2, atol=7e-2)
+
+    def test_training_falls_back_to_autograd_safe_pytorch_path(self):
+        args = list(self._make_inputs(seq_len=8))
+        for tensor in args[:4]:
+            tensor.requires_grad_(True)
+
+        actual = apply_qk_rmsnorm_rotary_emb_cos_sin_helion(*args)
+        expected = _reference(*args, eps=1e-5)
+        torch.testing.assert_close(actual[0], expected[0], rtol=1e-2, atol=7e-2)
+        torch.testing.assert_close(actual[1], expected[1], rtol=1e-2, atol=7e-2)
+
+        (actual[0].sum() + actual[1].sum()).backward()
+        for tensor in args[:4]:
+            self.assertIsNotNone(tensor.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_helion_rmsnorm.py
+++ b/tests/unit_tests/test_helion_rmsnorm.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib.util
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+
+_HAS_HELION = importlib.util.find_spec("helion") is not None
+
+if _HAS_HELION:
+    from torchtitan.experiments.helion_kernels.rmsnorm import (
+        rms_norm_helion,
+        rms_norm_helion_raw,
+    )
+
+
+@unittest.skipUnless(_HAS_HELION, "requires Helion")
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestRMSNormHelion(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    def _assert_matches_reference(self, shape: tuple[int, ...]) -> None:
+        x = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn(shape[-1], device="cuda", dtype=torch.bfloat16)
+
+        with torch.inference_mode():
+            expected = F.rms_norm(x, (shape[-1],), weight, 1e-5)
+            actual = rms_norm_helion(x, weight, 1e-5)
+            raw = rms_norm_helion_raw(x, weight, 1e-5)
+
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(raw, expected, rtol=1e-2, atol=1e-2)
+
+    def test_forward_matches_pytorch_reference_for_qwen_shapes(self):
+        for shape in (
+            (1, 1, 5120),
+            (1, 192, 5120),
+            (1, 1088, 5120),
+            (1, 8, 128),
+            (1088, 8, 128),
+        ):
+            with self.subTest(shape=shape):
+                self._assert_matches_reference(shape)
+
+    def test_training_falls_back_to_autograd_safe_pytorch_path(self):
+        x = torch.randn(2, 4, 128, device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn(128, device="cuda", dtype=torch.bfloat16)
+        x.requires_grad_(True)
+        weight.requires_grad_(True)
+
+        actual = rms_norm_helion(x, weight, 1e-5)
+        expected = F.rms_norm(x, (128,), weight, 1e-5)
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+        actual.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(weight.grad)
+
+    def test_unsupported_no_weight_case_falls_back(self):
+        x = torch.randn(2, 4, 128, device="cuda", dtype=torch.bfloat16)
+
+        actual = rms_norm_helion(x, None, 1e-5)
+        expected = F.rms_norm(x, (128,), None, 1e-5)
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_helion_rope.py
+++ b/tests/unit_tests/test_helion_rope.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib.util
+import unittest
+
+import torch
+
+
+_HAS_HELION = importlib.util.find_spec("helion") is not None
+
+if _HAS_HELION:
+    from torchtitan.experiments.helion_kernels.rope import (
+        apply_rotary_emb_cos_sin_helion,
+    )
+
+
+def _apply_rotary_emb_cos_sin_reference(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    head_dim = xq.shape[-1]
+    rope_cache = rope_cache[None, :, None, :].expand(xq.shape[0], -1, -1, -1)
+    rope_cache = torch.gather(
+        rope_cache,
+        dim=1,
+        index=positions.view(xq.shape[0], xq.shape[1], 1, 1).expand(
+            xq.shape[0], xq.shape[1], 1, head_dim * 2
+        ),
+    )
+    cos = rope_cache[..., :head_dim]
+    sin = rope_cache[..., head_dim:]
+
+    def rotate_half(x: torch.Tensor) -> torch.Tensor:
+        half = x.shape[-1] // 2
+        return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+    xq_out = (xq.float() * cos) + (rotate_half(xq.float()) * sin)
+    xk_out = (xk.float() * cos) + (rotate_half(xk.float()) * sin)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+@unittest.skipUnless(_HAS_HELION, "requires Helion")
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestApplyRotaryEmbCosSinHelion(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.bsz = 2
+        self.seqlen = 16
+        self.n_heads = 4
+        self.n_kv_heads = 2
+        self.head_dim = 64
+        self.xq = torch.randn(
+            self.bsz,
+            self.seqlen,
+            self.n_heads,
+            self.head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        self.xk = torch.randn(
+            self.bsz,
+            self.seqlen,
+            self.n_kv_heads,
+            self.head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        self.rope_cache = torch.randn(
+            self.seqlen * 2,
+            self.head_dim * 2,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        self.positions = torch.arange(
+            self.seqlen, device="cuda", dtype=torch.int32
+        ).repeat(self.bsz, 1)
+
+    def test_forward_matches_pytorch_reference(self):
+        xq_out, xk_out = apply_rotary_emb_cos_sin_helion(
+            self.xq, self.xk, self.rope_cache, self.positions
+        )
+        xq_ref, xk_ref = _apply_rotary_emb_cos_sin_reference(
+            self.xq, self.xk, self.rope_cache, self.positions
+        )
+
+        torch.testing.assert_close(xq_out, xq_ref, rtol=0, atol=1e-5)
+        torch.testing.assert_close(xk_out, xk_ref, rtol=0, atol=1e-5)
+
+    def test_backward_matches_pytorch_reference(self):
+        xq = self.xq.detach().clone().requires_grad_(True)
+        xk = self.xk.detach().clone().requires_grad_(True)
+        xq_ref = self.xq.detach().clone().requires_grad_(True)
+        xk_ref = self.xk.detach().clone().requires_grad_(True)
+
+        grad_xq = torch.randn_like(xq)
+        grad_xk = torch.randn_like(xk)
+
+        xq_out, xk_out = apply_rotary_emb_cos_sin_helion(
+            xq, xk, self.rope_cache, self.positions
+        )
+        torch.autograd.backward((xq_out, xk_out), (grad_xq, grad_xk))
+
+        xq_ref_out, xk_ref_out = _apply_rotary_emb_cos_sin_reference(
+            xq_ref, xk_ref, self.rope_cache, self.positions
+        )
+        torch.autograd.backward((xq_ref_out, xk_ref_out), (grad_xq, grad_xk))
+
+        torch.testing.assert_close(xq.grad, xq_ref.grad, rtol=0, atol=1e-5)
+        torch.testing.assert_close(xk.grad, xk_ref.grad, rtol=0, atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/helion_kernels/README.md
+++ b/torchtitan/experiments/helion_kernels/README.md
@@ -1,0 +1,94 @@
+# Experimental Helion Kernels
+
+This experiment hosts prototype Helion kernels for TorchTitan model hotspots.
+Nothing in core TorchTitan depends on this package.
+
+## RoPE Candidates
+
+The first target is the cos/sin RoPE path used by Qwen3, GPT-OSS, and Qwen3-VL.
+The current core implementation materializes the broadcasted/gathered RoPE cache,
+casts Q and K to fp32, builds `rotate_half` with `torch.cat`, then computes Q and K
+rotations. A Helion kernel can fuse the position lookup, rotation, fp32 math, and
+cast-back into one GPU kernel for both Q and K.
+
+Implemented prototype:
+
+```python
+from torchtitan.experiments.helion_kernels.rope import (
+    apply_rotary_emb_cos_sin_helion,
+)
+```
+
+Supported fast path:
+
+- `xq` and `xk`: contiguous CUDA tensors shaped `(batch, seq_len, heads, head_dim)`
+- `rope_cache`: contiguous CUDA tensor shaped `(max_seq_len, head_dim * 2)`
+- `positions`: contiguous CUDA tensor shaped `(batch, seq_len)`
+
+Other cases fall back to `torchtitan.models.common.rope.apply_rotary_emb_cos_sin`.
+
+## RMSNorm Candidate
+
+Standalone RMSNorm now has an experimental forward-only Helion path:
+
+```python
+from torchtitan.experiments.helion_kernels.rmsnorm import rms_norm_helion
+```
+
+Supported fast path:
+
+- contiguous CUDA tensors with affine `weight`
+- input dtype and weight dtype in `{float16, bfloat16, float32}`
+- inference/no-grad execution
+
+The public wrapper is selective for the current B200 Qwen3 sweep: it uses
+Helion for short hidden-size norms `(num_rows <= 256, dim=5120)` and the
+largest Q/K norm rows `(num_rows >= 4096, dim=128)`, and falls back to
+`torch.nn.functional.rms_norm` elsewhere. Use `rms_norm_helion_raw` to
+benchmark the raw Helion kernel without this routing.
+
+Benchmark the pasted Qwen3 shape/count sweep with:
+
+```bash
+python -m torchtitan.experiments.helion_kernels.bench_rmsnorm \
+  --backends aten helion helion_raw compile
+```
+
+## Q/K RMSNorm + RoPE Fusion
+
+Qwen-style Q/K normalization can be fused with the cos/sin RoPE application:
+
+```python
+from torchtitan.experiments.helion_kernels.rope import (
+    apply_qk_rmsnorm_rotary_emb_cos_sin_helion,
+)
+```
+
+Supported fast path:
+
+- `xq` and `xk`: contiguous CUDA tensors shaped `(batch, seq_len, heads, head_dim)`
+- `q_weight` and `k_weight`: contiguous CUDA tensors shaped `(head_dim,)`
+- `rope_cache`: contiguous CUDA tensor shaped `(max_seq_len, head_dim * 2)`
+- `positions`: contiguous CUDA tensor shaped `(batch, seq_len)`
+- inference/no-grad execution
+
+Other cases fall back to `F.rms_norm` followed by
+`torchtitan.models.common.rope.apply_rotary_emb_cos_sin`.
+
+Benchmark with:
+
+```bash
+python -m torchtitan.experiments.helion_kernels.bench_qk_rmsnorm_rope
+```
+
+Sweep Helion row-tile and warp configs with:
+
+```bash
+python -m torchtitan.experiments.helion_kernels.bench_qk_rmsnorm_rope --sweep
+```
+
+Next candidates:
+
+- A real-valued replacement for complex RoPE, since Helion currently does not support
+  complex tensors directly.
+- MRoPE/Qwen3-VL support for pre-broadcast 4D cos/sin caches.

--- a/torchtitan/experiments/helion_kernels/__init__.py
+++ b/torchtitan/experiments/helion_kernels/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Experimental Helion kernels for TorchTitan."""

--- a/torchtitan/experiments/helion_kernels/_helion_aot_rmsnorm_cuda_sm100.py
+++ b/torchtitan/experiments/helion_kernels/_helion_aot_rmsnorm_cuda_sm100.py
@@ -1,0 +1,226 @@
+"""
+Auto-generated heuristic for kernels in rmsnorm.py.
+Backend: decision_tree
+
+Provides:
+- key_rms_norm_helion_fwd_2d(*args): Returns config index (cache key)
+- autotune_rms_norm_helion_fwd_2d(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_rms_norm_helion_fwd_2d(*args) -> int:
+    """Select config index for the given arguments."""
+    _arg0_dim0 = (
+        int(args[0].shape[0])
+        if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0
+        else 0
+    )
+    _arg0_dim1 = (
+        int(args[0].shape[1])
+        if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1
+        else 0
+    )
+    if _arg0_dim1 <= 3072.0:
+        if _arg0_dim0 <= 2048.0:
+            if _arg0_dim1 <= 2047.0:
+                if _arg0_dim1 <= 96.0:
+                    if _arg0_dim1 <= 48.0:
+                        return 0
+                    else:
+                        return 2
+                else:
+                    return 0
+            else:
+                if _arg0_dim1 <= 2048.0:
+                    return 3
+                else:
+                    return 0
+        else:
+            return 2
+    else:
+        if _arg0_dim1 <= 6144.0:
+            if _arg0_dim0 <= 2048.0:
+                return 5
+            else:
+                if _arg0_dim1 <= 4096.0:
+                    return 5
+                else:
+                    return 1
+        else:
+            if _arg0_dim1 <= 8192.0:
+                return 1
+            else:
+                if _arg0_dim0 <= 2048.0:
+                    return 4
+                else:
+                    return 6
+
+
+def autotune_rms_norm_helion_fwd_2d(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    configs = [
+        {
+            "block_sizes": [2],
+            "reduction_loops": [None],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["last", "first", "first", "", ""],
+            "num_warps": 4,
+            "num_stages": 6,
+            "indexing": [
+                "pointer",
+                "pointer",
+                "pointer",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "pointer",
+                "pointer",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [1],
+            "reduction_loops": [None],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["first", "last", "last", "", "last"],
+            "num_warps": 16,
+            "num_stages": 4,
+            "indexing": [
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+                "pointer",
+                "pointer",
+                "pointer",
+                "pointer",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [4],
+            "reduction_loops": [None],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["first", "last", "", "first", ""],
+            "num_warps": 2,
+            "num_stages": 3,
+            "indexing": [
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [2],
+            "reduction_loops": [2048],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["last", "first", "last", "first", "first"],
+            "num_warps": 2,
+            "num_stages": 1,
+            "indexing": [
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [1],
+            "reduction_loops": [8192],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["", "first", "last", "", ""],
+            "num_warps": 8,
+            "num_stages": 3,
+            "indexing": [
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+                "pointer",
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [1],
+            "reduction_loops": [None],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["", "last", "last", "first", ""],
+            "num_warps": 8,
+            "num_stages": 2,
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "pointer",
+                "pointer",
+                "tensor_descriptor",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+        {
+            "block_sizes": [1],
+            "reduction_loops": [2048],
+            "range_unroll_factors": [0],
+            "range_warp_specializes": [None],
+            "range_num_stages": [0],
+            "range_multi_buffers": [None],
+            "range_flattens": [None],
+            "load_eviction_policies": ["", "first", "last", "first", "last"],
+            "num_warps": 8,
+            "num_stages": 8,
+            "indexing": [
+                "pointer",
+                "pointer",
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+            ],
+            "atomic_indexing": [],
+            "pid_type": "flat",
+        },
+    ]
+    return configs[key_rms_norm_helion_fwd_2d(*args)]

--- a/torchtitan/experiments/helion_kernels/bench_qk_rmsnorm_rope.py
+++ b/torchtitan/experiments/helion_kernels/bench_qk_rmsnorm_rope.py
@@ -1,0 +1,405 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+from dataclasses import dataclass
+import itertools
+
+import helion
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+from torchtitan.experiments.helion_kernels.rope import (
+    _qk_rmsnorm_rope_cos_sin_fwd_positions,
+    apply_qk_rmsnorm_rotary_emb_cos_sin_helion,
+    apply_rotary_emb_cos_sin_helion,
+)
+from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
+
+
+@dataclass(frozen=True)
+class _SweepResult:
+    config: helion.Config
+    ms: float | None
+    error: str | None = None
+
+
+def _make_inputs(
+    *,
+    batch_size: int,
+    seq_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    xq = torch.randn(
+        batch_size,
+        seq_len,
+        n_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    xk = torch.randn(
+        batch_size,
+        seq_len,
+        n_kv_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    q_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    k_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    rope_cache = torch.randn(
+        seq_len + 16,
+        head_dim * 2,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    positions = torch.arange(seq_len, device="cuda", dtype=torch.int32).repeat(
+        batch_size, 1
+    )
+    return xq, xk, q_weight, k_weight, rope_cache, positions
+
+
+def _separate_core(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xq = F.rms_norm(xq, (xq.shape[-1],), q_weight, eps)
+    xk = F.rms_norm(xk, (xk.shape[-1],), k_weight, eps)
+    return apply_rotary_emb_cos_sin(xq, xk, rope_cache, positions)
+
+
+def _separate_helion_rope(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xq = F.rms_norm(xq, (xq.shape[-1],), q_weight, eps)
+    xk = F.rms_norm(xk, (xk.shape[-1],), k_weight, eps)
+    return apply_rotary_emb_cos_sin_helion(xq, xk, rope_cache, positions)
+
+
+def _bench_shape(
+    *,
+    batch_size: int,
+    seq_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+    warmup: int,
+    iters: int,
+    eps: float,
+) -> tuple[float, float, float, float]:
+    xq, xk, q_weight, k_weight, rope_cache, positions = _make_inputs(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        head_dim=head_dim,
+    )
+
+    def fused() -> tuple[torch.Tensor, torch.Tensor]:
+        return apply_qk_rmsnorm_rotary_emb_cos_sin_helion(
+            xq, xk, q_weight, k_weight, rope_cache, positions, eps
+        )
+
+    def separate_core() -> tuple[torch.Tensor, torch.Tensor]:
+        return _separate_core(xq, xk, q_weight, k_weight, rope_cache, positions, eps)
+
+    def separate_helion_rope() -> tuple[torch.Tensor, torch.Tensor]:
+        return _separate_helion_rope(
+            xq, xk, q_weight, k_weight, rope_cache, positions, eps
+        )
+
+    compiled_separate = torch.compile(_separate_core, fullgraph=True)
+
+    def separate_compile() -> tuple[torch.Tensor, torch.Tensor]:
+        return compiled_separate(xq, xk, q_weight, k_weight, rope_cache, positions, eps)
+
+    expected = separate_core()
+    actual = fused()
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-2, atol=7e-2)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-2, atol=7e-2)
+    separate_compile()
+    torch.cuda.synchronize()
+
+    fused_ms = tt.do_bench(
+        fused,
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+    separate_core_ms = tt.do_bench(
+        separate_core,
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+    separate_helion_rope_ms = tt.do_bench(
+        separate_helion_rope,
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+    separate_compile_ms = tt.do_bench(
+        separate_compile,
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+    return fused_ms, separate_core_ms, separate_helion_rope_ms, separate_compile_ms
+
+
+def _make_sweep_configs(
+    q_row_tiles: Iterable[int],
+    k_row_tiles: Iterable[int],
+    num_warps: Iterable[int],
+    *,
+    split_qk_tiles: bool,
+) -> list[helion.Config]:
+    if split_qk_tiles:
+        tile_pairs = itertools.product(q_row_tiles, k_row_tiles)
+    else:
+        tile_pairs = ((tile, tile) for tile in q_row_tiles)
+    return [
+        helion.Config(block_sizes=[q_tile, k_tile], num_warps=warps)
+        for q_tile, k_tile in tile_pairs
+        for warps in num_warps
+    ]
+
+
+def _format_config(config: helion.Config) -> str:
+    q_tile, k_tile = config.block_sizes
+    return f"q={q_tile}, k={k_tile}, warps={config.config.get('num_warps', 'default')}"
+
+
+def _first_error_line(exc: Exception) -> str:
+    return str(exc).splitlines()[0] or type(exc).__name__
+
+
+def _sweep_shape(
+    *,
+    configs: list[helion.Config],
+    batch_size: int,
+    seq_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+    warmup: int,
+    iters: int,
+    eps: float,
+) -> list[_SweepResult]:
+    xq, xk, q_weight, k_weight, rope_cache, positions = _make_inputs(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        head_dim=head_dim,
+    )
+    expected = _separate_core(xq, xk, q_weight, k_weight, rope_cache, positions, eps)
+    kernel_args = _qk_rmsnorm_rope_cos_sin_fwd_positions.normalize_args(
+        xq, xk, q_weight, k_weight, rope_cache, positions, eps
+    )
+    bound_kernel = _qk_rmsnorm_rope_cos_sin_fwd_positions.bind(kernel_args)
+
+    results: list[_SweepResult] = []
+    for config in configs:
+        try:
+            bound_kernel.set_config(config)
+            actual = bound_kernel(*kernel_args)
+            torch.testing.assert_close(actual[0], expected[0], rtol=1e-2, atol=7e-2)
+            torch.testing.assert_close(actual[1], expected[1], rtol=1e-2, atol=7e-2)
+            torch.cuda.synchronize()
+            ms = tt.do_bench(
+                lambda: bound_kernel(*kernel_args),
+                warmup=warmup,
+                rep=iters,
+                return_mode="median",
+            )
+            results.append(_SweepResult(config=config, ms=ms))
+        except Exception as exc:
+            results.append(
+                _SweepResult(config=config, ms=None, error=_first_error_line(exc))
+            )
+    return results
+
+
+def _print_sweep_results(
+    *,
+    seq_len: int,
+    results: list[_SweepResult],
+    top_k: int,
+) -> None:
+    valid = sorted(
+        (result for result in results if result.ms is not None),
+        key=lambda result: result.ms if result.ms is not None else float("inf"),
+    )
+    failed = [result for result in results if result.ms is None]
+    print()
+    print(f"S={seq_len}: swept {len(results)} configs, {len(failed)} failed")
+    print(f"{'rank':>4s} {'time (us)':>10s}  config")
+    print(f"{'----':>4s} {'----------':>10s}  {'-' * 30}")
+    for rank, result in enumerate(valid[:top_k], start=1):
+        assert result.ms is not None
+        print(f"{rank:>4d} {result.ms * 1000:>10.2f}  {_format_config(result.config)}")
+    if failed:
+        first_failed = failed[0]
+        print(
+            f"failed examples: {_format_config(first_failed.config)} "
+            f"({first_failed.error})"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark fused Q/K RMSNorm + RoPE")
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-lens", nargs="+", type=int, default=[1, 192, 1088])
+    parser.add_argument("--n-heads", type=int, default=8)
+    parser.add_argument("--n-kv-heads", type=int, default=1)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--eps", type=float, default=1e-5)
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="Sweep Helion configs for the fused kernel after the baseline benchmark.",
+    )
+    parser.add_argument(
+        "--sweep-q-row-tiles",
+        nargs="+",
+        type=int,
+        default=[1, 2, 4, 8, 16],
+        help="Q row tile sizes to sweep.",
+    )
+    parser.add_argument(
+        "--sweep-k-row-tiles",
+        nargs="+",
+        type=int,
+        default=[1, 2, 4, 8, 16],
+        help="K row tile sizes to sweep when --sweep-split-qk-tiles is set.",
+    )
+    parser.add_argument(
+        "--sweep-warps",
+        nargs="+",
+        type=int,
+        default=[1, 2, 4, 8],
+        help="num_warps values to sweep.",
+    )
+    parser.add_argument(
+        "--sweep-split-qk-tiles",
+        action="store_true",
+        help="Sweep the cross product of Q and K row tiles.",
+    )
+    parser.add_argument(
+        "--sweep-top-k",
+        type=int,
+        default=5,
+        help="Number of fastest configs to print per shape.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"B={args.batch_size}, Hq={args.n_heads}, Hkv={args.n_kv_heads}, "
+        f"D={args.head_dim}, dtype=bfloat16"
+    )
+    print(
+        f"{'S':>6s} {'fused (us)':>12s} {'separate (us)':>14s} "
+        f"{'sep+helion rope':>16s} {'compiled sep':>13s} {'speedup':>9s}"
+    )
+    print("-" * 80)
+
+    with torch.inference_mode():
+        for seq_len in args.seq_lens:
+            (
+                fused_ms,
+                separate_core_ms,
+                separate_helion_rope_ms,
+                separate_compile_ms,
+            ) = _bench_shape(
+                batch_size=args.batch_size,
+                seq_len=seq_len,
+                n_heads=args.n_heads,
+                n_kv_heads=args.n_kv_heads,
+                head_dim=args.head_dim,
+                warmup=args.warmup,
+                iters=args.iters,
+                eps=args.eps,
+            )
+            speedup = separate_core_ms / fused_ms
+            print(
+                f"{seq_len:>6d} {fused_ms * 1000:>12.2f} "
+                f"{separate_core_ms * 1000:>14.2f} "
+                f"{separate_helion_rope_ms * 1000:>16.2f} "
+                f"{separate_compile_ms * 1000:>13.2f} "
+                f"{speedup:>8.2f}x"
+            )
+
+        if args.sweep:
+            configs = _make_sweep_configs(
+                args.sweep_q_row_tiles,
+                args.sweep_k_row_tiles,
+                args.sweep_warps,
+                split_qk_tiles=args.sweep_split_qk_tiles,
+            )
+            print()
+            print(
+                "Sweep config space: "
+                f"{len(configs)} configs "
+                f"(q tiles={args.sweep_q_row_tiles}, "
+                f"k tiles={args.sweep_k_row_tiles if args.sweep_split_qk_tiles else args.sweep_q_row_tiles}, "
+                f"warps={args.sweep_warps})"
+            )
+            for seq_len in args.seq_lens:
+                results = _sweep_shape(
+                    configs=configs,
+                    batch_size=args.batch_size,
+                    seq_len=seq_len,
+                    n_heads=args.n_heads,
+                    n_kv_heads=args.n_kv_heads,
+                    head_dim=args.head_dim,
+                    warmup=args.warmup,
+                    iters=args.iters,
+                    eps=args.eps,
+                )
+                _print_sweep_results(
+                    seq_len=seq_len,
+                    results=results,
+                    top_k=args.sweep_top_k,
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/helion_kernels/bench_rmsnorm.py
+++ b/torchtitan/experiments/helion_kernels/bench_rmsnorm.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 import triton.testing as tt
 
 from torchtitan.experiments.helion_kernels.rmsnorm import (
+    _rms_norm_helion_bwd_2d_with_config,
     rms_norm_helion,
     rms_norm_helion_raw,
 )
@@ -21,6 +22,10 @@ from torchtitan.experiments.helion_kernels.rmsnorm import (
 
 BackendFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 BackendFactory = Callable[[int, float], BackendFn | None]
+BwdFn = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor],
+]
 
 
 def _parse_shape(shape_spec: str) -> tuple[tuple[int, ...], int]:
@@ -117,6 +122,64 @@ _BACKENDS: dict[str, BackendFactory] = {
 }
 
 
+def _aten_bwd_fn(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_out: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out = F.rms_norm(x, (x.shape[-1],), weight, eps)
+    grad_x, grad_weight = torch.autograd.grad(out, (x, weight), grad_out)
+    return grad_x, grad_weight
+
+
+def _make_bwd_fn(name: str, normalized_shape: int, eps: float) -> BwdFn | None:
+    if name == "compile":
+        torch._dynamo.config.trace_autograd_ops = True
+
+        def fn(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            grad_out: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return _aten_bwd_fn(x, weight, grad_out, eps)
+
+        return torch.compile(fn, fullgraph=True)
+
+    if name == "helion_raw":
+
+        def fn(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            grad_out: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            grad_x_2d, grad_weight = _rms_norm_helion_bwd_2d_with_config(
+                grad_out.reshape(-1, normalized_shape),
+                x.reshape(-1, normalized_shape),
+                weight,
+                eps,
+            )
+            return grad_x_2d.reshape_as(x), grad_weight
+
+        return fn
+
+    factory = _BACKENDS[name]
+    fwd_fn = factory(normalized_shape, eps)
+    if fwd_fn is None:
+        return None
+
+    def fn(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        grad_out: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        out = fwd_fn(x, weight)
+        grad_x, grad_weight = torch.autograd.grad(out, (x, weight), grad_out)
+        return grad_x, grad_weight
+
+    return fn
+
+
 def _benchmark_fn(
     fn: BackendFn,
     x: torch.Tensor,
@@ -133,13 +196,30 @@ def _benchmark_fn(
     )
 
 
+def _benchmark_bwd_fn(
+    fn: BwdFn,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_out: torch.Tensor,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    return tt.do_bench(
+        lambda: fn(x, weight, grad_out),
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+
+
 def _available_backends(
     backend_names: list[str],
     dtype: torch.dtype,
     eps: float,
 ) -> dict[str, BackendFactory]:
     available: dict[str, BackendFactory] = {}
-    test_x = torch.randn(2, 128, dtype=dtype, device="cuda")
+    test_x = torch.randn(1, 128, dtype=dtype, device="cuda")
     test_weight = torch.randn(128, dtype=dtype, device="cuda")
     for name in backend_names:
         factory = _BACKENDS[name]
@@ -158,13 +238,207 @@ def _available_backends(
     return available
 
 
+def _available_bwd_backends(
+    backend_names: list[str],
+    dtype: torch.dtype,
+    eps: float,
+) -> dict[str, Callable[[int, float], BwdFn | None]]:
+    available: dict[str, Callable[[int, float], BwdFn | None]] = {}
+    test_x = torch.randn(1, 128, dtype=dtype, device="cuda", requires_grad=True)
+    test_weight = torch.randn(128, dtype=dtype, device="cuda", requires_grad=True)
+    test_grad_out = torch.randn_like(test_x)
+    for name in backend_names:
+        try:
+            fn = _make_bwd_fn(name, 128, eps)
+            if fn is None:
+                print(f"  {name}: not available")
+                continue
+            out = fn(test_x, test_weight, test_grad_out)
+            if out[0].shape != test_x.shape or out[1].shape != test_weight.shape:
+                raise ValueError(
+                    f"unexpected grad shapes {out[0].shape}, {out[1].shape}"
+                )
+            available[name] = lambda normalized_shape, eps, name=name: _make_bwd_fn(
+                name, normalized_shape, eps
+            )
+            print(f"  {name}: available")
+        except Exception as exc:
+            print(f"  {name}: not available ({exc})")
+    return available
+
+
+def _print_table_header(title: str, backend_names: list[str]) -> None:
+    print()
+    print(f"=== {title} ===")
+    header = "  ".join(f"{name:>11s}" for name in backend_names)
+    print(f"{'shape':>16s} {'cnt':>5s}  {header}")
+    print(f"{'':>16s} {'':>5s}  {'  '.join(['-----------'] * len(backend_names))}")
+
+
+def _print_totals(
+    rows: list[dict[str, float | int | str | None]],
+    totals: dict[str, float],
+    backend_names: list[str],
+) -> None:
+    print()
+    print(f"{'weighted total':>16s} {'':>5s}  ", end="")
+    total_values = []
+    for name in backend_names:
+        if all(row.get(name) is not None for row in rows):
+            total_values.append(f"{totals[name]:>10.3f}ms")
+        else:
+            total_values.append(f"{'N/A':>11s}")
+    print("  ".join(total_values))
+
+    if "aten" in backend_names and all(row.get("aten") is not None for row in rows):
+        aten_total = totals["aten"]
+        print(f"{'speedup vs aten':>16s} {'':>5s}  ", end="")
+        speedups = []
+        for name in backend_names:
+            if all(row.get(name) is not None for row in rows):
+                speedups.append(f"{aten_total / totals[name]:>10.2f}x")
+            else:
+                speedups.append(f"{'N/A':>11s}")
+        print("  ".join(speedups))
+
+
+def benchmark_forward(
+    shape_specs: list[str],
+    backend_names: list[str],
+    dtype: torch.dtype,
+    eps: float,
+    warmup: int,
+    iters: int,
+) -> None:
+    print("Forward backend availability:")
+    available = _available_backends(backend_names, dtype, eps)
+    if not available:
+        raise RuntimeError("No requested RMSNorm forward backends are available")
+
+    names = list(available)
+    _print_table_header("RMSNorm forward", names)
+    totals = {name: 0.0 for name in names}
+    rows: list[dict[str, float | int | str | None]] = []
+    with torch.inference_mode():
+        for shape_spec in shape_specs:
+            shape, count = _parse_shape(shape_spec)
+            normalized_shape = shape[-1]
+            x = torch.randn(*shape, dtype=dtype, device="cuda")
+            weight = torch.randn(normalized_shape, dtype=dtype, device="cuda")
+            reference = F.rms_norm(x, (normalized_shape,), weight, eps)
+
+            row: dict[str, float | int | str | None] = {
+                "shape": "x".join(str(dim) for dim in shape),
+                "count": count,
+            }
+            values = []
+            for name, factory in available.items():
+                fn = factory(normalized_shape, eps)
+                assert fn is not None
+                try:
+                    actual = fn(x, weight)
+                    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
+                    ms = _benchmark_fn(
+                        fn,
+                        x,
+                        weight,
+                        warmup=warmup,
+                        iters=iters,
+                    )
+                    row[name] = ms
+                    totals[name] += ms * count
+                    values.append(f"{ms * 1000:>10.2f}us")
+                except Exception as exc:
+                    row[name] = None
+                    values.append(f"{'ERR':>11s}")
+                    print(f"    {name} error for {shape_spec}: {exc}")
+            rows.append(row)
+            count_str = f"x{count}" if count > 1 else ""
+            print(f"{row['shape']:>16s} {count_str:>5s}  {'  '.join(values)}")
+
+    _print_totals(rows, totals, names)
+
+
+def benchmark_backward(
+    shape_specs: list[str],
+    backend_names: list[str],
+    dtype: torch.dtype,
+    eps: float,
+    warmup: int,
+    iters: int,
+) -> None:
+    print()
+    print("Backward backend availability:")
+    available = _available_bwd_backends(backend_names, dtype, eps)
+    if not available:
+        raise RuntimeError("No requested RMSNorm backward backends are available")
+
+    names = list(available)
+    _print_table_header("RMSNorm backward", names)
+    totals = {name: 0.0 for name in names}
+    rows: list[dict[str, float | int | str | None]] = []
+    for shape_spec in shape_specs:
+        shape, count = _parse_shape(shape_spec)
+        normalized_shape = shape[-1]
+        x = torch.randn(*shape, dtype=dtype, device="cuda", requires_grad=True)
+        weight = torch.randn(
+            normalized_shape, dtype=dtype, device="cuda", requires_grad=True
+        )
+        grad_out = torch.randn_like(x)
+        reference = _aten_bwd_fn(x, weight, grad_out, eps)
+
+        row = {
+            "shape": "x".join(str(dim) for dim in shape),
+            "count": count,
+        }
+        values = []
+        for name, factory in available.items():
+            fn = factory(normalized_shape, eps)
+            assert fn is not None
+            try:
+                actual = fn(x, weight, grad_out)
+                torch.testing.assert_close(
+                    actual[0], reference[0], rtol=2e-2, atol=2e-2
+                )
+                torch.testing.assert_close(
+                    actual[1], reference[1], rtol=2e-2, atol=2e-2
+                )
+                ms = _benchmark_bwd_fn(
+                    fn,
+                    x,
+                    weight,
+                    grad_out,
+                    warmup=warmup,
+                    iters=iters,
+                )
+                row[name] = ms
+                totals[name] += ms * count
+                values.append(f"{ms * 1000:>10.2f}us")
+            except Exception as exc:
+                row[name] = None
+                values.append(f"{'ERR':>11s}")
+                print(f"    {name} error for {shape_spec}: {exc}")
+        rows.append(row)
+        count_str = f"x{count}" if count > 1 else ""
+        print(f"{row['shape']:>16s} {count_str:>5s}  {'  '.join(values)}")
+
+    _print_totals(rows, totals, names)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Benchmark RMSNorm implementations")
     parser.add_argument(
         "--backends",
         nargs="+",
-        default=["aten", "helion", "helion_raw", "compile"],
+        default=["aten", "compile", "helion_raw"],
         choices=sorted(_BACKENDS),
+    )
+    parser.add_argument(
+        "--directions",
+        nargs="+",
+        default=["fwd", "bwd"],
+        choices=["fwd", "bwd"],
+        help="Benchmark forward, backward, or both.",
     )
     parser.add_argument(
         "--shapes",
@@ -199,78 +473,34 @@ def main() -> None:
         raise RuntimeError("CUDA is required")
 
     dtype = getattr(torch, args.dtype)
+    torch._dynamo.config.trace_autograd_ops = True
     print(f"GPU: {torch.cuda.get_device_name()}")
     print(f"dtype: {args.dtype}, eps: {args.eps}")
     print()
 
-    available = _available_backends(args.backends, dtype, args.eps)
-    if not available:
-        raise RuntimeError("No requested RMSNorm backends are available")
-    print()
-
-    header = "  ".join(f"{name:>11s}" for name in available)
-    print(f"{'shape':>16s} {'cnt':>5s}  {header}")
-    print(f"{'':>16s} {'':>5s}  {'  '.join(['-----------'] * len(available))}")
-
-    totals = {name: 0.0 for name in available}
-    rows: list[dict[str, float | int | str | None]] = []
-    with torch.inference_mode():
-        for shape_spec in args.shapes:
-            shape, count = _parse_shape(shape_spec)
-            normalized_shape = shape[-1]
-            x = torch.randn(*shape, dtype=dtype, device="cuda")
-            weight = torch.randn(normalized_shape, dtype=dtype, device="cuda")
-
-            row: dict[str, float | int | str | None] = {
-                "shape": "x".join(str(dim) for dim in shape),
-                "count": count,
-            }
-            values = []
-            reference = F.rms_norm(x, (normalized_shape,), weight, args.eps)
-            for name, factory in available.items():
-                fn = factory(normalized_shape, args.eps)
-                assert fn is not None
-                try:
-                    actual = fn(x, weight)
-                    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
-                    ms = _benchmark_fn(
-                        fn,
-                        x,
-                        weight,
-                        warmup=args.warmup,
-                        iters=args.iters,
-                    )
-                    row[name] = ms
-                    totals[name] += ms * count
-                    values.append(f"{ms * 1000:>10.2f}us")
-                except Exception as exc:
-                    row[name] = None
-                    values.append(f"{'ERR':>11s}")
-                    print(f"    {name} error for {shape_spec}: {exc}")
-            rows.append(row)
-            count_str = f"x{count}" if count > 1 else ""
-            print(f"{row['shape']:>16s} {count_str:>5s}  {'  '.join(values)}")
-
-    print()
-    print(f"{'weighted total':>16s} {'':>5s}  ", end="")
-    total_values = []
-    for name in available:
-        if all(row.get(name) is not None for row in rows):
-            total_values.append(f"{totals[name]:>10.3f}ms")
-        else:
-            total_values.append(f"{'N/A':>11s}")
-    print("  ".join(total_values))
-
-    if "aten" in available and all(row.get("aten") is not None for row in rows):
-        aten_total = totals["aten"]
-        print(f"{'speedup vs aten':>16s} {'':>5s}  ", end="")
-        speedups = []
-        for name in available:
-            if all(row.get(name) is not None for row in rows):
-                speedups.append(f"{aten_total / totals[name]:>10.2f}x")
-            else:
-                speedups.append(f"{'N/A':>11s}")
-        print("  ".join(speedups))
+    if "fwd" in args.directions:
+        benchmark_forward(
+            args.shapes,
+            args.backends,
+            dtype,
+            args.eps,
+            args.warmup,
+            args.iters,
+        )
+    if "bwd" in args.directions:
+        print()
+        print(
+            "Backward timings use autograd for aten/compile and direct Helion "
+            "backward kernels for Helion backends."
+        )
+        benchmark_backward(
+            args.shapes,
+            args.backends,
+            dtype,
+            args.eps,
+            args.warmup,
+            args.iters,
+        )
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/helion_kernels/bench_rmsnorm.py
+++ b/torchtitan/experiments/helion_kernels/bench_rmsnorm.py
@@ -1,0 +1,277 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+from torchtitan.experiments.helion_kernels.rmsnorm import (
+    rms_norm_helion,
+    rms_norm_helion_raw,
+)
+
+
+BackendFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+BackendFactory = Callable[[int, float], BackendFn | None]
+
+
+def _parse_shape(shape_spec: str) -> tuple[tuple[int, ...], int]:
+    shape_str, sep, count_str = shape_spec.partition(":")
+    count = int(count_str) if sep else 1
+    return tuple(int(dim) for dim in shape_str.split("x")), count
+
+
+def _make_aten_fn(normalized_shape: int, eps: float) -> BackendFn:
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return F.rms_norm(x, (normalized_shape,), weight, eps)
+
+    return fn
+
+
+def _make_compile_fn(normalized_shape: int, eps: float) -> BackendFn:
+    return torch.compile(_make_aten_fn(normalized_shape, eps), fullgraph=True)
+
+
+def _make_helion_fn(normalized_shape: int, eps: float) -> BackendFn:
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return rms_norm_helion(x, weight, eps)
+
+    return fn
+
+
+def _make_helion_raw_fn(normalized_shape: int, eps: float) -> BackendFn:
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return rms_norm_helion_raw(x, weight, eps)
+
+    return fn
+
+
+def _make_vllm_fn(normalized_shape: int, eps: float) -> BackendFn | None:
+    try:
+        from vllm._custom_ops import rms_norm
+    except ImportError:
+        return None
+
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        rms_norm(out, x, weight, eps)
+        return out
+
+    return fn
+
+
+def _make_quack_fn(normalized_shape: int, eps: float) -> BackendFn | None:
+    try:
+        from quack import rmsnorm as quack_rmsnorm
+    except ImportError:
+        return None
+
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return quack_rmsnorm(x, weight=weight, eps=eps)
+
+    return fn
+
+
+def _make_sixlib_fn(normalized_shape: int, eps: float) -> BackendFn | None:
+    try:
+        from ops.interfaces.norm.rms_norm import rmsnorm_op
+    except ImportError:
+        return None
+
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return rmsnorm_op(x, weight, eps=eps, backend="triton")
+
+    return fn
+
+
+def _make_llama4x_fn(normalized_shape: int, eps: float) -> BackendFn | None:
+    try:
+        from llama4x.ops.triton.rms_norm import rmsnorm_fwd
+    except ImportError:
+        return None
+
+    def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        y, _rstd = rmsnorm_fwd(x, weight, eps)
+        return y
+
+    return fn
+
+
+_BACKENDS: dict[str, BackendFactory] = {
+    "aten": _make_aten_fn,
+    "compile": _make_compile_fn,
+    "helion": _make_helion_fn,
+    "helion_raw": _make_helion_raw_fn,
+    "vllm": _make_vllm_fn,
+    "quack": _make_quack_fn,
+    "sixlib": _make_sixlib_fn,
+    "llama4x": _make_llama4x_fn,
+}
+
+
+def _benchmark_fn(
+    fn: BackendFn,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    return tt.do_bench(
+        lambda: fn(x, weight),
+        warmup=warmup,
+        rep=iters,
+        return_mode="median",
+    )
+
+
+def _available_backends(
+    backend_names: list[str],
+    dtype: torch.dtype,
+    eps: float,
+) -> dict[str, BackendFactory]:
+    available: dict[str, BackendFactory] = {}
+    test_x = torch.randn(2, 128, dtype=dtype, device="cuda")
+    test_weight = torch.randn(128, dtype=dtype, device="cuda")
+    for name in backend_names:
+        factory = _BACKENDS[name]
+        fn = factory(128, eps)
+        if fn is None:
+            print(f"  {name}: not available")
+            continue
+        try:
+            out = fn(test_x, test_weight)
+            if out.shape != test_x.shape:
+                raise ValueError(f"unexpected output shape {out.shape}")
+            available[name] = factory
+            print(f"  {name}: available")
+        except Exception as exc:
+            print(f"  {name}: not available ({exc})")
+    return available
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark RMSNorm implementations")
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=["aten", "helion", "helion_raw", "compile"],
+        choices=sorted(_BACKENDS),
+    )
+    parser.add_argument(
+        "--shapes",
+        nargs="+",
+        default=[
+            "1x1x5120:129",
+            "1x8x128:64",
+            "1x1x128:64",
+            "1x192x5120:129",
+            "192x8x128:64",
+            "1x192x128:64",
+            "1x1088x5120:129",
+            "1088x8x128:64",
+            "1x1088x128:64",
+        ],
+        help="Input shapes as MxN or BxSxN, with optional :COUNT suffix.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["float16", "bfloat16", "float32"],
+    )
+    parser.add_argument("--eps", type=float, default=1e-5)
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iters", type=int, default=100)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    dtype = getattr(torch, args.dtype)
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"dtype: {args.dtype}, eps: {args.eps}")
+    print()
+
+    available = _available_backends(args.backends, dtype, args.eps)
+    if not available:
+        raise RuntimeError("No requested RMSNorm backends are available")
+    print()
+
+    header = "  ".join(f"{name:>11s}" for name in available)
+    print(f"{'shape':>16s} {'cnt':>5s}  {header}")
+    print(f"{'':>16s} {'':>5s}  {'  '.join(['-----------'] * len(available))}")
+
+    totals = {name: 0.0 for name in available}
+    rows: list[dict[str, float | int | str | None]] = []
+    with torch.inference_mode():
+        for shape_spec in args.shapes:
+            shape, count = _parse_shape(shape_spec)
+            normalized_shape = shape[-1]
+            x = torch.randn(*shape, dtype=dtype, device="cuda")
+            weight = torch.randn(normalized_shape, dtype=dtype, device="cuda")
+
+            row: dict[str, float | int | str | None] = {
+                "shape": "x".join(str(dim) for dim in shape),
+                "count": count,
+            }
+            values = []
+            reference = F.rms_norm(x, (normalized_shape,), weight, args.eps)
+            for name, factory in available.items():
+                fn = factory(normalized_shape, args.eps)
+                assert fn is not None
+                try:
+                    actual = fn(x, weight)
+                    torch.testing.assert_close(actual, reference, rtol=1e-2, atol=1e-2)
+                    ms = _benchmark_fn(
+                        fn,
+                        x,
+                        weight,
+                        warmup=args.warmup,
+                        iters=args.iters,
+                    )
+                    row[name] = ms
+                    totals[name] += ms * count
+                    values.append(f"{ms * 1000:>10.2f}us")
+                except Exception as exc:
+                    row[name] = None
+                    values.append(f"{'ERR':>11s}")
+                    print(f"    {name} error for {shape_spec}: {exc}")
+            rows.append(row)
+            count_str = f"x{count}" if count > 1 else ""
+            print(f"{row['shape']:>16s} {count_str:>5s}  {'  '.join(values)}")
+
+    print()
+    print(f"{'weighted total':>16s} {'':>5s}  ", end="")
+    total_values = []
+    for name in available:
+        if all(row.get(name) is not None for row in rows):
+            total_values.append(f"{totals[name]:>10.3f}ms")
+        else:
+            total_values.append(f"{'N/A':>11s}")
+    print("  ".join(total_values))
+
+    if "aten" in available and all(row.get("aten") is not None for row in rows):
+        aten_total = totals["aten"]
+        print(f"{'speedup vs aten':>16s} {'':>5s}  ", end="")
+        speedups = []
+        for name in available:
+            if all(row.get(name) is not None for row in rows):
+                speedups.append(f"{aten_total / totals[name]:>10.2f}x")
+            else:
+                speedups.append(f"{'N/A':>11s}")
+        print("  ".join(speedups))
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/helion_kernels/bench_rope.py
+++ b/torchtitan/experiments/helion_kernels/bench_rope.py
@@ -1,0 +1,129 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+
+import torch
+import triton.testing as tt
+
+from torchtitan.experiments.helion_kernels.rope import (
+    apply_rotary_emb_cos_sin_helion,
+)
+
+
+def apply_rotary_emb_cos_sin_reference(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    head_dim = xq.shape[-1]
+    rope_cache = rope_cache[None, :, None, :].expand(xq.shape[0], -1, -1, -1)
+    rope_cache = torch.gather(
+        rope_cache,
+        dim=1,
+        index=positions.view(xq.shape[0], xq.shape[1], 1, 1).expand(
+            xq.shape[0], xq.shape[1], 1, head_dim * 2
+        ),
+    )
+    cos = rope_cache[..., :head_dim]
+    sin = rope_cache[..., head_dim:]
+
+    def rotate_half(x: torch.Tensor) -> torch.Tensor:
+        half = x.shape[-1] // 2
+        return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+    xq_out = (xq.float() * cos) + (rotate_half(xq.float()) * sin)
+    xk_out = (xk.float() * cos) + (rotate_half(xk.float()) * sin)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def bench_shape(
+    batch_size: int,
+    seq_len: int,
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+) -> float:
+    xq = torch.randn(
+        batch_size,
+        seq_len,
+        n_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    xk = torch.randn(
+        batch_size,
+        seq_len,
+        n_kv_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    rope_cache = torch.randn(
+        seq_len,
+        head_dim * 2,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    positions = torch.arange(seq_len, device="cuda", dtype=torch.int32).repeat(
+        batch_size, 1
+    )
+
+    apply_rotary_emb_cos_sin_helion(xq, xk, rope_cache, positions)
+    apply_rotary_emb_cos_sin_reference(xq, xk, rope_cache, positions)
+    torch.cuda.synchronize()
+
+    helion_ms = tt.do_bench(
+        lambda: apply_rotary_emb_cos_sin_helion(xq, xk, rope_cache, positions),
+        warmup=25,
+        rep=100,
+        return_mode="median",
+    )
+    torch_ms = tt.do_bench(
+        lambda: apply_rotary_emb_cos_sin_reference(xq, xk, rope_cache, positions),
+        warmup=25,
+        rep=100,
+        return_mode="median",
+    )
+    speedup = torch_ms / helion_ms if helion_ms > 0 else float("nan")
+    print(
+        f"{batch_size:>3d} {seq_len:>5d} {n_heads:>3d} {n_kv_heads:>3d} "
+        f"{head_dim:>4d} {helion_ms * 1000:>12.2f} "
+        f"{torch_ms * 1000:>12.2f} {speedup:>8.3f}x"
+    )
+    return speedup
+
+
+def main() -> None:
+    assert torch.cuda.is_available(), "CUDA is required"
+    shapes = [
+        (1, 2048, 32, 8, 128),
+        (2, 2048, 32, 8, 128),
+        (4, 2048, 32, 8, 128),
+        (1, 4096, 32, 8, 128),
+        (2, 4096, 32, 8, 128),
+        (1, 8192, 32, 8, 128),
+    ]
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'B':>3s} {'S':>5s} {'HQ':>3s} {'HK':>3s} {'D':>4s} "
+        f"{'helion (us)':>12s} {'torch (us)':>12s} {'speedup':>8s}"
+    )
+    print("-" * 65)
+    speedups = [bench_shape(*shape) for shape in shapes]
+    geomean = math.exp(
+        sum(math.log(speedup) for speedup in speedups if speedup > 0)
+        / max(len(speedups), 1)
+    )
+    print(f"SUMMARY: geomean={geomean:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/helion_kernels/bench_rope.py
+++ b/torchtitan/experiments/helion_kernels/bench_rope.py
@@ -6,14 +6,33 @@
 
 from __future__ import annotations
 
-import math
+import argparse
+from collections.abc import Callable
 
 import torch
 import triton.testing as tt
 
 from torchtitan.experiments.helion_kernels.rope import (
+    _rope_cos_sin_bwd_positions_with_config,
     apply_rotary_emb_cos_sin_helion,
 )
+
+
+FwdFn = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor],
+]
+BwdFn = Callable[
+    [
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    tuple[torch.Tensor, torch.Tensor],
+]
 
 
 def apply_rotary_emb_cos_sin_reference(
@@ -43,86 +62,357 @@ def apply_rotary_emb_cos_sin_reference(
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
-def bench_shape(
-    batch_size: int,
-    seq_len: int,
-    n_heads: int,
-    n_kv_heads: int,
-    head_dim: int,
-) -> float:
-    xq = torch.randn(
-        batch_size,
-        seq_len,
-        n_heads,
-        head_dim,
-        device="cuda",
-        dtype=torch.bfloat16,
+def _parse_shape(shape_spec: str) -> tuple[tuple[int, ...], tuple[int, ...], int]:
+    shape_pair, sep, count_str = shape_spec.partition(":")
+    count = int(count_str) if sep else 1
+    xq_shape_str, pair_sep, xk_shape_str = shape_pair.partition("/")
+    if not pair_sep:
+        raise ValueError(
+            "RoPE shapes must use XQ_SHAPE/XK_SHAPE with optional :COUNT suffix"
+        )
+    xq_shape = tuple(int(dim) for dim in xq_shape_str.split("x"))
+    xk_shape = tuple(int(dim) for dim in xk_shape_str.split("x"))
+    if len(xq_shape) != 4 or len(xk_shape) != 4:
+        raise ValueError(f"RoPE shapes must be 4D, got {shape_spec}")
+    if xq_shape[0] != xk_shape[0] or xq_shape[1] != xk_shape[1]:
+        raise ValueError(f"Q/K batch and sequence must match, got {shape_spec}")
+    if xq_shape[-1] != xk_shape[-1]:
+        raise ValueError(f"Q/K head_dim must match, got {shape_spec}")
+    return xq_shape, xk_shape, count
+
+
+def _make_inputs(
+    xq_shape: tuple[int, ...],
+    xk_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    *,
+    requires_grad: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    xq = torch.randn(*xq_shape, device="cuda", dtype=dtype).requires_grad_(
+        requires_grad
     )
-    xk = torch.randn(
-        batch_size,
-        seq_len,
-        n_kv_heads,
-        head_dim,
-        device="cuda",
-        dtype=torch.bfloat16,
+    xk = torch.randn(*xk_shape, device="cuda", dtype=dtype).requires_grad_(
+        requires_grad
     )
+    seq_len = xq_shape[1]
+    head_dim = xq_shape[-1]
     rope_cache = torch.randn(
-        seq_len,
+        seq_len + 16,
         head_dim * 2,
         device="cuda",
         dtype=torch.float32,
     )
     positions = torch.arange(seq_len, device="cuda", dtype=torch.int32).repeat(
-        batch_size, 1
+        xq_shape[0], 1
     )
+    return xq, xk, rope_cache, positions
 
-    apply_rotary_emb_cos_sin_helion(xq, xk, rope_cache, positions)
-    apply_rotary_emb_cos_sin_reference(xq, xk, rope_cache, positions)
-    torch.cuda.synchronize()
 
-    helion_ms = tt.do_bench(
-        lambda: apply_rotary_emb_cos_sin_helion(xq, xk, rope_cache, positions),
-        warmup=25,
-        rep=100,
+def _aten_bwd_fn(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    grad_xq_out: torch.Tensor,
+    grad_xk_out: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xq_out, xk_out = apply_rotary_emb_cos_sin_reference(
+        xq, xk, rope_cache, positions
+    )
+    grad_xq, grad_xk = torch.autograd.grad(
+        (xq_out, xk_out),
+        (xq, xk),
+        (grad_xq_out, grad_xk_out),
+    )
+    return grad_xq, grad_xk
+
+
+def _make_fwd_fn(name: str) -> FwdFn:
+    if name == "aten":
+        return apply_rotary_emb_cos_sin_reference
+    if name == "compile":
+        return torch.compile(apply_rotary_emb_cos_sin_reference, fullgraph=True)
+    if name == "helion":
+        return apply_rotary_emb_cos_sin_helion
+    raise ValueError(f"unknown backend {name}")
+
+
+def _make_bwd_fn(name: str) -> BwdFn:
+    if name == "aten":
+        return _aten_bwd_fn
+    if name == "compile":
+        torch._dynamo.config.trace_autograd_ops = True
+        return torch.compile(_aten_bwd_fn, fullgraph=True)
+    if name == "helion":
+
+        def fn(
+            xq: torch.Tensor,
+            xk: torch.Tensor,
+            rope_cache: torch.Tensor,
+            positions: torch.Tensor,
+            grad_xq_out: torch.Tensor,
+            grad_xk_out: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return _rope_cos_sin_bwd_positions_with_config(
+                grad_xq_out,
+                grad_xk_out,
+                rope_cache,
+                positions,
+            )
+
+        return fn
+    raise ValueError(f"unknown backend {name}")
+
+
+def _benchmark_fwd(
+    fn: FwdFn,
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    return tt.do_bench(
+        lambda: fn(xq, xk, rope_cache, positions),
+        warmup=warmup,
+        rep=iters,
         return_mode="median",
     )
-    torch_ms = tt.do_bench(
-        lambda: apply_rotary_emb_cos_sin_reference(xq, xk, rope_cache, positions),
-        warmup=25,
-        rep=100,
+
+
+def _benchmark_bwd(
+    fn: BwdFn,
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    grad_xq_out: torch.Tensor,
+    grad_xk_out: torch.Tensor,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    return tt.do_bench(
+        lambda: fn(xq, xk, rope_cache, positions, grad_xq_out, grad_xk_out),
+        warmup=warmup,
+        rep=iters,
         return_mode="median",
     )
-    speedup = torch_ms / helion_ms if helion_ms > 0 else float("nan")
-    print(
-        f"{batch_size:>3d} {seq_len:>5d} {n_heads:>3d} {n_kv_heads:>3d} "
-        f"{head_dim:>4d} {helion_ms * 1000:>12.2f} "
-        f"{torch_ms * 1000:>12.2f} {speedup:>8.3f}x"
+
+
+def _assert_close_pair(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+    *,
+    rtol: float,
+    atol: float,
+) -> None:
+    torch.testing.assert_close(actual[0], expected[0], rtol=rtol, atol=atol)
+    torch.testing.assert_close(actual[1], expected[1], rtol=rtol, atol=atol)
+
+
+def _print_totals(
+    rows: list[dict[str, float | int | str | None]],
+    totals: dict[str, float],
+    backend_names: list[str],
+) -> None:
+    print()
+    print(f"{'weighted total':>33s} {'':>5s}  ", end="")
+    total_values = []
+    for name in backend_names:
+        if all(row.get(name) is not None for row in rows):
+            total_values.append(f"{totals[name]:>10.3f}ms")
+        else:
+            total_values.append(f"{'N/A':>11s}")
+    print("  ".join(total_values))
+
+    if "aten" in backend_names and all(row.get("aten") is not None for row in rows):
+        aten_total = totals["aten"]
+        print(f"{'speedup vs aten':>33s} {'':>5s}  ", end="")
+        speedups = []
+        for name in backend_names:
+            if all(row.get(name) is not None for row in rows):
+                speedups.append(f"{aten_total / totals[name]:>10.2f}x")
+            else:
+                speedups.append(f"{'N/A':>11s}")
+        print("  ".join(speedups))
+
+
+def benchmark_forward(
+    shape_specs: list[str],
+    backend_names: list[str],
+    dtype: torch.dtype,
+    warmup: int,
+    iters: int,
+) -> None:
+    print()
+    print("=== RoPE forward ===")
+    header = "  ".join(f"{name:>11s}" for name in backend_names)
+    print(f"{'xq / xk shape':>33s} {'cnt':>5s}  {header}")
+    print(f"{'':>33s} {'':>5s}  {'  '.join(['-----------'] * len(backend_names))}")
+
+    fns = {name: _make_fwd_fn(name) for name in backend_names}
+    totals = {name: 0.0 for name in backend_names}
+    rows: list[dict[str, float | int | str | None]] = []
+    with torch.inference_mode():
+        for shape_spec in shape_specs:
+            xq_shape, xk_shape, count = _parse_shape(shape_spec)
+            xq, xk, rope_cache, positions = _make_inputs(
+                xq_shape, xk_shape, dtype, requires_grad=False
+            )
+            reference = apply_rotary_emb_cos_sin_reference(
+                xq, xk, rope_cache, positions
+            )
+            row: dict[str, float | int | str | None] = {
+                "shape": f"{'x'.join(map(str, xq_shape))}/"
+                f"{'x'.join(map(str, xk_shape))}",
+                "count": count,
+            }
+            values = []
+            for name, fn in fns.items():
+                try:
+                    actual = fn(xq, xk, rope_cache, positions)
+                    _assert_close_pair(actual, reference, rtol=1e-2, atol=1e-2)
+                    ms = _benchmark_fwd(
+                        fn,
+                        xq,
+                        xk,
+                        rope_cache,
+                        positions,
+                        warmup=warmup,
+                        iters=iters,
+                    )
+                    row[name] = ms
+                    totals[name] += ms * count
+                    values.append(f"{ms * 1000:>10.2f}us")
+                except Exception as exc:
+                    row[name] = None
+                    values.append(f"{'ERR':>11s}")
+                    print(f"    {name} error for {shape_spec}: {exc}")
+            rows.append(row)
+            count_str = f"x{count}" if count > 1 else ""
+            print(f"{row['shape']:>33s} {count_str:>5s}  {'  '.join(values)}")
+
+    _print_totals(rows, totals, backend_names)
+
+
+def benchmark_backward(
+    shape_specs: list[str],
+    backend_names: list[str],
+    dtype: torch.dtype,
+    warmup: int,
+    iters: int,
+) -> None:
+    print()
+    print("=== RoPE backward ===")
+    header = "  ".join(f"{name:>11s}" for name in backend_names)
+    print(f"{'xq / xk shape':>33s} {'cnt':>5s}  {header}")
+    print(f"{'':>33s} {'':>5s}  {'  '.join(['-----------'] * len(backend_names))}")
+
+    fns = {name: _make_bwd_fn(name) for name in backend_names}
+    totals = {name: 0.0 for name in backend_names}
+    rows: list[dict[str, float | int | str | None]] = []
+    for shape_spec in shape_specs:
+        xq_shape, xk_shape, count = _parse_shape(shape_spec)
+        xq, xk, rope_cache, positions = _make_inputs(
+            xq_shape, xk_shape, dtype, requires_grad=True
+        )
+        grad_xq_out = torch.randn_like(xq)
+        grad_xk_out = torch.randn_like(xk)
+        reference = _aten_bwd_fn(
+            xq, xk, rope_cache, positions, grad_xq_out, grad_xk_out
+        )
+        row = {
+            "shape": f"{'x'.join(map(str, xq_shape))}/"
+            f"{'x'.join(map(str, xk_shape))}",
+            "count": count,
+        }
+        values = []
+        for name, fn in fns.items():
+            try:
+                actual = fn(xq, xk, rope_cache, positions, grad_xq_out, grad_xk_out)
+                _assert_close_pair(actual, reference, rtol=3e-2, atol=3e-2)
+                ms = _benchmark_bwd(
+                    fn,
+                    xq,
+                    xk,
+                    rope_cache,
+                    positions,
+                    grad_xq_out,
+                    grad_xk_out,
+                    warmup=warmup,
+                    iters=iters,
+                )
+                row[name] = ms
+                totals[name] += ms * count
+                values.append(f"{ms * 1000:>10.2f}us")
+            except Exception as exc:
+                row[name] = None
+                values.append(f"{'ERR':>11s}")
+                print(f"    {name} error for {shape_spec}: {exc}")
+        rows.append(row)
+        count_str = f"x{count}" if count > 1 else ""
+        print(f"{row['shape']:>33s} {count_str:>5s}  {'  '.join(values)}")
+
+    _print_totals(rows, totals, backend_names)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark RoPE implementations")
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=["aten", "compile", "helion"],
+        choices=["aten", "compile", "helion"],
     )
-    return speedup
+    parser.add_argument(
+        "--shapes",
+        nargs="+",
+        default=[
+            "1x1x8x128/1x1x1x128:64",
+            "1x192x8x128/1x192x1x128:64",
+            "1x1088x8x128/1x1088x1x128:64",
+        ],
+        help="Shapes as XQ_SHAPE/XK_SHAPE with optional :COUNT suffix.",
+    )
+    parser.add_argument(
+        "--directions",
+        nargs="+",
+        default=["fwd", "bwd"],
+        choices=["fwd", "bwd"],
+        help="Benchmark forward, backward, or both.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["float16", "bfloat16", "float32"],
+    )
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iters", type=int, default=100)
+    return parser.parse_args()
 
 
 def main() -> None:
-    assert torch.cuda.is_available(), "CUDA is required"
-    shapes = [
-        (1, 2048, 32, 8, 128),
-        (2, 2048, 32, 8, 128),
-        (4, 2048, 32, 8, 128),
-        (1, 4096, 32, 8, 128),
-        (2, 4096, 32, 8, 128),
-        (1, 8192, 32, 8, 128),
-    ]
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    torch._dynamo.config.trace_autograd_ops = True
+    dtype = getattr(torch, args.dtype)
     print(f"GPU: {torch.cuda.get_device_name()}")
-    print(
-        f"{'B':>3s} {'S':>5s} {'HQ':>3s} {'HK':>3s} {'D':>4s} "
-        f"{'helion (us)':>12s} {'torch (us)':>12s} {'speedup':>8s}"
-    )
-    print("-" * 65)
-    speedups = [bench_shape(*shape) for shape in shapes]
-    geomean = math.exp(
-        sum(math.log(speedup) for speedup in speedups if speedup > 0)
-        / max(len(speedups), 1)
-    )
-    print(f"SUMMARY: geomean={geomean:.4f}")
+    print(f"dtype: {args.dtype}")
+
+    if "fwd" in args.directions:
+        benchmark_forward(args.shapes, args.backends, dtype, args.warmup, args.iters)
+    if "bwd" in args.directions:
+        print()
+        print(
+            "Backward timings use autograd for aten/compile and the direct "
+            "Helion backward kernel for Helion."
+        )
+        benchmark_backward(args.shapes, args.backends, dtype, args.warmup, args.iters)
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/helion_kernels/rmsnorm.py
+++ b/torchtitan/experiments/helion_kernels/rmsnorm.py
@@ -6,14 +6,16 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 import torch.nn.functional as F
 
-import helion.experimental
+import helion
 import helion.language as hl
 
 
-@helion.experimental.aot_kernel()
+@helion.kernel()
 def rms_norm_helion_fwd_2d(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -33,6 +35,230 @@ def rms_norm_helion_fwd_2d(
     return out
 
 
+@helion.kernel(ignore_warnings=[helion.exc.TensorOperationInWrapper])
+def rms_norm_helion_bwd_2d(
+    grad_out: torch.Tensor,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-5,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = x.size()
+    assert grad_out.size(0) == m, f"grad_out rows mismatch {grad_out.size(0)} != {m}"
+    assert grad_out.size(1) == n, f"grad_out cols mismatch {grad_out.size(1)} != {n}"
+    assert weight.size(0) == n, f"weight size mismatch {weight.size(0)} != {n}"
+
+    m_block = hl.register_block_size(m)
+    grad_x = torch.empty_like(x)
+    grad_weight_partials = torch.empty(
+        [(m + m_block - 1) // m_block, n],
+        dtype=torch.float32,
+        device=x.device,
+    )
+    n_static = hl.specialize(n)
+
+    for tile_m_block in hl.tile(m, block_size=m_block):
+        grad_weight_acc = weight.new_zeros(n_static, dtype=torch.float32)
+        for tile_m in hl.tile(tile_m_block.begin, tile_m_block.end):
+            x_tile = x[tile_m, :].to(torch.float32)
+            grad_out_tile = grad_out[tile_m, :].to(torch.float32)
+            weight_tile = weight[None, :].to(torch.float32)
+
+            variance = torch.sum(x_tile * x_tile, dim=-1) / n_static
+            inv_rms = torch.rsqrt(variance + eps)
+            grad_weighted = grad_out_tile * weight_tile
+            dot_mean = torch.sum(grad_weighted * x_tile, dim=-1) / n_static
+
+            grad_x[tile_m, :] = (
+                grad_weighted * inv_rms[:, None]
+                - x_tile * (inv_rms[:, None] ** 3) * dot_mean[:, None]
+            ).to(x.dtype)
+            grad_weight_acc += (grad_out_tile * x_tile * inv_rms[:, None]).sum(0)
+
+        grad_weight_partials[tile_m_block.id, :] = grad_weight_acc
+
+    return grad_x, grad_weight_partials.sum(0).to(weight.dtype)
+
+
+def _nearest_power_of_2_bucket(value: int) -> int:
+    assert value > 0
+    lower = 1 << (value.bit_length() - 1)
+    upper = lower << 1
+    return lower if value - lower < upper - value else upper
+
+
+def _config(
+    block_sizes: list[int],
+    *,
+    num_warps: int,
+    num_stages: int,
+    pid_type: str = "flat",
+    indexing: list[str] | None = None,
+    load_eviction_policies: list[str] | None = None,
+    maxnreg: int | None = None,
+    num_sm_multiplier: int | None = None,
+    reduction_loops: list[int | None] | None = None,
+) -> helion.Config:
+    kwargs: dict[str, Any] = {
+        "block_sizes": block_sizes,
+        "num_stages": num_stages,
+        "num_warps": num_warps,
+        "pid_type": pid_type,
+    }
+    if indexing is not None:
+        kwargs["indexing"] = indexing
+    if load_eviction_policies is not None:
+        kwargs["load_eviction_policies"] = load_eviction_policies
+    if maxnreg is not None:
+        kwargs["maxnreg"] = maxnreg
+    if num_sm_multiplier is not None:
+        kwargs["num_sm_multiplier"] = num_sm_multiplier
+    if reduction_loops is not None:
+        kwargs["reduction_loops"] = reduction_loops
+    return helion.Config(**kwargs)
+
+
+_RMS_NORM_HELION_CONFIGS_BY_BUCKET: dict[tuple[int, int], helion.Config] = {
+    # (normalized dim, nearest power-of-two row bucket)
+    (5120, 1): _config(
+        [1],
+        num_warps=16,
+        num_stages=8,
+        pid_type="persistent_blocked",
+        maxnreg=128,
+        num_sm_multiplier=8,
+        reduction_loops=[None],
+    ),
+    (5120, 256): _config(
+        [1],
+        num_warps=16,
+        num_stages=8,
+        reduction_loops=[None],
+    ),
+    (5120, 1024): _config(
+        [1],
+        num_warps=4,
+        num_stages=4,
+        pid_type="persistent_interleaved",
+        maxnreg=128,
+        num_sm_multiplier=16,
+        reduction_loops=[1024],
+    ),
+    (128, 1): _config(
+        [1],
+        num_warps=1,
+        num_stages=2,
+        reduction_loops=[None],
+    ),
+    (128, 8): _config(
+        [4],
+        num_warps=4,
+        num_stages=6,
+        reduction_loops=[None],
+    ),
+    (128, 256): _config(
+        [4],
+        num_warps=4,
+        num_stages=2,
+        reduction_loops=[None],
+    ),
+    (128, 1024): _config(
+        [16],
+        num_warps=8,
+        num_stages=1,
+        reduction_loops=[None],
+    ),
+    (128, 2048): _config(
+        [16],
+        num_warps=8,
+        num_stages=1,
+        reduction_loops=[None],
+    ),
+    (128, 8192): _config(
+        [32],
+        num_warps=16,
+        num_stages=7,
+        reduction_loops=[None],
+    ),
+}
+
+
+_RMS_NORM_HELION_BWD_CONFIGS_BY_BUCKET: dict[tuple[int, int], helion.Config] = {
+    # (normalized dim, nearest power-of-two row bucket)
+    (5120, 1): _config([1, 1], num_warps=8, num_stages=6),
+    (5120, 256): _config(
+        [2, 8],
+        num_warps=8,
+        num_stages=3,
+        pid_type="persistent_interleaved",
+        maxnreg=256,
+        num_sm_multiplier=1,
+    ),
+    (5120, 1024): _config([8, 1], num_warps=8, num_stages=3),
+    (128, 1): _config([1, 1], num_warps=1, num_stages=1),
+    (128, 8): _config(
+        [2, 2],
+        num_warps=8,
+        num_stages=6,
+        pid_type="persistent_blocked",
+        maxnreg=256,
+        num_sm_multiplier=4,
+    ),
+    (128, 256): _config([2, 2], num_warps=1, num_stages=4),
+    (128, 1024): _config(
+        [16, 32],
+        num_warps=8,
+        num_stages=1,
+        pid_type="persistent_interleaved",
+        num_sm_multiplier=1,
+    ),
+    (128, 2048): _config([16, 16], num_warps=8, num_stages=6),
+    (128, 8192): _config([128, 128], num_warps=8, num_stages=8),
+}
+
+
+def _rms_norm_helion_config(x_2d: torch.Tensor) -> helion.Config | None:
+    rows, dim = x_2d.shape
+    row_bucket = _nearest_power_of_2_bucket(rows)
+    return _RMS_NORM_HELION_CONFIGS_BY_BUCKET.get((dim, row_bucket))
+
+
+def _rms_norm_helion_bwd_config(x_2d: torch.Tensor) -> helion.Config | None:
+    rows, dim = x_2d.shape
+    row_bucket = _nearest_power_of_2_bucket(rows)
+    return _RMS_NORM_HELION_BWD_CONFIGS_BY_BUCKET.get((dim, row_bucket))
+
+
+def _rms_norm_helion_fwd_2d_with_config(
+    x_2d: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    config = _rms_norm_helion_config(x_2d)
+    if config is None:
+        return rms_norm_helion_fwd_2d(x_2d, weight, eps)
+
+    bound_kernel = rms_norm_helion_fwd_2d.bind((x_2d, weight, eps))
+    if getattr(bound_kernel, "_config", None) != config:
+        bound_kernel.set_config(config)
+    return bound_kernel(x_2d, weight, eps)
+
+
+def _rms_norm_helion_bwd_2d_with_config(
+    grad_out_2d: torch.Tensor,
+    x_2d: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    config = _rms_norm_helion_bwd_config(x_2d)
+    if config is None:
+        return rms_norm_helion_bwd_2d(grad_out_2d, x_2d, weight, eps)
+
+    bound_kernel = rms_norm_helion_bwd_2d.bind((grad_out_2d, x_2d, weight, eps))
+    if getattr(bound_kernel, "_config", None) != config:
+        bound_kernel.set_config(config)
+    return bound_kernel(grad_out_2d, x_2d, weight, eps)
+
+
 def _can_use_helion_rmsnorm(
     x: torch.Tensor,
     weight: torch.Tensor | None,
@@ -48,7 +274,6 @@ def _can_use_helion_rmsnorm(
         and weight.is_contiguous()
         and x.dtype in (torch.float16, torch.bfloat16, torch.float32)
         and weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
-        and not (torch.is_grad_enabled() and (x.requires_grad or weight.requires_grad))
     )
 
 
@@ -71,9 +296,48 @@ def rms_norm_helion_raw(
         return F.rms_norm(x, normalized_shape, weight, eps)
 
     assert weight is not None
+    if torch.is_grad_enabled() and (x.requires_grad or weight.requires_grad):
+        return _RMSNormHelionFunction.apply(x, weight, eps)
+
     x_2d = x.reshape(-1, x.shape[-1])
-    out = rms_norm_helion_fwd_2d(x_2d, weight, eps)
+    out = _rms_norm_helion_fwd_2d_with_config(x_2d, weight, eps)
     return out.reshape_as(x)
+
+
+class _RMSNormHelionFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float,
+    ) -> torch.Tensor:
+        x_2d = x.reshape(-1, x.shape[-1])
+        out = _rms_norm_helion_fwd_2d_with_config(x_2d, weight, eps).reshape_as(x)
+        ctx.x_shape = x.shape
+        ctx.eps = eps
+        ctx.save_for_backward(x, weight)
+        return out
+
+    @staticmethod
+    def backward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        grad_out: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, None]:
+        x, weight = ctx.saved_tensors
+        grad_x, grad_weight = _rms_norm_helion_bwd_2d_with_config(
+            grad_out.contiguous().reshape(-1, x.shape[-1]),
+            x.reshape(-1, x.shape[-1]),
+            weight,
+            ctx.eps,
+        )
+        if not ctx.needs_input_grad[0]:
+            grad_x = None
+        else:
+            grad_x = grad_x.reshape(ctx.x_shape)
+        if not ctx.needs_input_grad[1]:
+            grad_weight = None
+        return grad_x, grad_weight, None
 
 
 def rms_norm_helion(
@@ -81,12 +345,12 @@ def rms_norm_helion(
     weight: torch.Tensor | None,
     eps: float = 1e-5,
 ) -> torch.Tensor:
-    """Apply RMSNorm with an experimental Helion forward kernel.
+    """Apply RMSNorm with experimental Helion kernels for selected shapes.
 
     The public wrapper is deliberately selective: on B200, standalone Helion
     is faster for the short Qwen3 hidden-size norms and the largest Q/K norm
-    rows from the current sweep, but ATen is still better for other RMSNorm
-    shapes. Unsupported layouts and training cases also fall back to PyTorch.
+    rows from the current sweep, but ATen is still better for other forward
+    RMSNorm shapes. Unsupported layouts fall back to PyTorch.
     """
     normalized_shape = (x.shape[-1],)
     if not _can_use_helion_rmsnorm(x, weight):

--- a/torchtitan/experiments/helion_kernels/rmsnorm.py
+++ b/torchtitan/experiments/helion_kernels/rmsnorm.py
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel()
+def rms_norm_helion_fwd_2d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    m, n = x.size()
+    assert weight.size(0) == n, f"weight size mismatch {weight.size(0)} != {n}"
+
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        acc = x[tile_m, :].to(torch.float32)
+        variance = torch.mean(acc * acc, dim=-1)
+        inv_rms = torch.rsqrt(variance + eps)
+        out[tile_m, :] = (acc * inv_rms[:, None] * weight[:].to(torch.float32)).to(
+            x.dtype
+        )
+    return out
+
+
+def _can_use_helion_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor | None,
+) -> bool:
+    return (
+        weight is not None
+        and x.ndim >= 1
+        and weight.ndim == 1
+        and x.shape[-1] == weight.shape[0]
+        and x.is_cuda
+        and weight.is_cuda
+        and x.is_contiguous()
+        and weight.is_contiguous()
+        and x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and not (torch.is_grad_enabled() and (x.requires_grad or weight.requires_grad))
+    )
+
+
+def _is_qwen3_b200_fast_shape(x: torch.Tensor, weight: torch.Tensor) -> bool:
+    normalized_shape = weight.shape[0]
+    num_rows = x.numel() // normalized_shape
+
+    return (normalized_shape == 5120 and num_rows <= 256) or (
+        normalized_shape == 128 and num_rows >= 4096
+    )
+
+
+def rms_norm_helion_raw(
+    x: torch.Tensor,
+    weight: torch.Tensor | None,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    normalized_shape = (x.shape[-1],)
+    if not _can_use_helion_rmsnorm(x, weight):
+        return F.rms_norm(x, normalized_shape, weight, eps)
+
+    assert weight is not None
+    x_2d = x.reshape(-1, x.shape[-1])
+    out = rms_norm_helion_fwd_2d(x_2d, weight, eps)
+    return out.reshape_as(x)
+
+
+def rms_norm_helion(
+    x: torch.Tensor,
+    weight: torch.Tensor | None,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    """Apply RMSNorm with an experimental Helion forward kernel.
+
+    The public wrapper is deliberately selective: on B200, standalone Helion
+    is faster for the short Qwen3 hidden-size norms and the largest Q/K norm
+    rows from the current sweep, but ATen is still better for other RMSNorm
+    shapes. Unsupported layouts and training cases also fall back to PyTorch.
+    """
+    normalized_shape = (x.shape[-1],)
+    if not _can_use_helion_rmsnorm(x, weight):
+        return F.rms_norm(x, normalized_shape, weight, eps)
+
+    assert weight is not None
+    if not _is_qwen3_b200_fast_shape(x, weight):
+        return F.rms_norm(x, normalized_shape, weight, eps)
+
+    return rms_norm_helion_raw(x, weight, eps)

--- a/torchtitan/experiments/helion_kernels/rope.py
+++ b/torchtitan/experiments/helion_kernels/rope.py
@@ -1,0 +1,475 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+import helion
+import helion.language as hl
+
+
+@helion.kernel(
+    config=helion.Config(block_sizes=[512, 512], num_warps=4),
+    static_shapes=True,
+)
+def _rope_cos_sin_fwd_positions(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _, seqlen, n_heads, head_dim = xq.size()
+    _, _, n_kv_heads, _ = xk.size()
+
+    xq_out = torch.empty_like(xq)
+    xk_out = torch.empty_like(xk)
+
+    xq_flat = xq.view(-1)
+    xk_flat = xk.view(-1)
+    xq_out_flat = xq_out.view(-1)
+    xk_out_flat = xk_out.view(-1)
+    rope_cache_flat = rope_cache.view(-1)
+    positions_flat = positions.view(-1)
+
+    half_head_dim = head_dim // 2
+    rope_cache_stride = head_dim * 2
+
+    for tile_q in hl.tile(xq.numel()):
+        idx_q = tile_q.index
+        head_dim_idx_q = idx_q % head_dim
+        seq_idx_q = (idx_q // (head_dim * n_heads)) % seqlen
+        batch_idx_q = idx_q // (head_dim * n_heads * seqlen)
+
+        position_q = positions_flat[batch_idx_q * seqlen + seq_idx_q]
+        rotated_idx_q = torch.where(
+            head_dim_idx_q < half_head_dim,
+            idx_q + half_head_dim,
+            idx_q - half_head_dim,
+        )
+        rotated_sign_q = torch.where(head_dim_idx_q < half_head_dim, -1.0, 1.0).to(
+            torch.float32
+        )
+
+        xq_val = xq_flat[idx_q].to(torch.float32)
+        xq_rotated = xq_flat[rotated_idx_q].to(torch.float32) * rotated_sign_q
+        cos_q = rope_cache_flat[position_q * rope_cache_stride + head_dim_idx_q].to(
+            torch.float32
+        )
+        sin_q = rope_cache_flat[
+            position_q * rope_cache_stride + head_dim + head_dim_idx_q
+        ].to(torch.float32)
+        xq_out_flat[idx_q] = (xq_val * cos_q + xq_rotated * sin_q).to(xq.dtype)
+
+    for tile_k in hl.tile(xk.numel()):
+        idx_k = tile_k.index
+        head_dim_idx_k = idx_k % head_dim
+        seq_idx_k = (idx_k // (head_dim * n_kv_heads)) % seqlen
+        batch_idx_k = idx_k // (head_dim * n_kv_heads * seqlen)
+
+        position_k = positions_flat[batch_idx_k * seqlen + seq_idx_k]
+        rotated_idx_k = torch.where(
+            head_dim_idx_k < half_head_dim,
+            idx_k + half_head_dim,
+            idx_k - half_head_dim,
+        )
+        rotated_sign_k = torch.where(head_dim_idx_k < half_head_dim, -1.0, 1.0).to(
+            torch.float32
+        )
+
+        xk_val = xk_flat[idx_k].to(torch.float32)
+        xk_rotated = xk_flat[rotated_idx_k].to(torch.float32) * rotated_sign_k
+        cos_k = rope_cache_flat[position_k * rope_cache_stride + head_dim_idx_k].to(
+            torch.float32
+        )
+        sin_k = rope_cache_flat[
+            position_k * rope_cache_stride + head_dim + head_dim_idx_k
+        ].to(torch.float32)
+        xk_out_flat[idx_k] = (xk_val * cos_k + xk_rotated * sin_k).to(xk.dtype)
+
+    return xq_out, xk_out
+
+
+@helion.kernel(
+    config=helion.Config(block_sizes=[512, 512], num_warps=4),
+    static_shapes=True,
+)
+def _rope_cos_sin_bwd_positions(
+    grad_xq_out: torch.Tensor,
+    grad_xk_out: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _, seqlen, n_heads, head_dim = grad_xq_out.size()
+    _, _, n_kv_heads, _ = grad_xk_out.size()
+
+    grad_xq = torch.empty_like(grad_xq_out)
+    grad_xk = torch.empty_like(grad_xk_out)
+
+    grad_xq_out_flat = grad_xq_out.view(-1)
+    grad_xk_out_flat = grad_xk_out.view(-1)
+    grad_xq_flat = grad_xq.view(-1)
+    grad_xk_flat = grad_xk.view(-1)
+    rope_cache_flat = rope_cache.view(-1)
+    positions_flat = positions.view(-1)
+
+    half_head_dim = head_dim // 2
+    rope_cache_stride = head_dim * 2
+
+    for tile_q in hl.tile(grad_xq_out.numel()):
+        idx_q = tile_q.index
+        head_dim_idx_q = idx_q % head_dim
+        seq_idx_q = (idx_q // (head_dim * n_heads)) % seqlen
+        batch_idx_q = idx_q // (head_dim * n_heads * seqlen)
+
+        position_q = positions_flat[batch_idx_q * seqlen + seq_idx_q]
+        paired_idx_q = torch.where(
+            head_dim_idx_q < half_head_dim,
+            idx_q + half_head_dim,
+            idx_q - half_head_dim,
+        )
+        paired_head_dim_idx_q = torch.where(
+            head_dim_idx_q < half_head_dim,
+            head_dim_idx_q + half_head_dim,
+            head_dim_idx_q - half_head_dim,
+        )
+        paired_sign_q = torch.where(head_dim_idx_q < half_head_dim, 1.0, -1.0).to(
+            torch.float32
+        )
+
+        grad_self_q = grad_xq_out_flat[idx_q].to(torch.float32)
+        grad_pair_q = grad_xq_out_flat[paired_idx_q].to(torch.float32)
+        cos_q = rope_cache_flat[position_q * rope_cache_stride + head_dim_idx_q].to(
+            torch.float32
+        )
+        sin_pair_q = rope_cache_flat[
+            position_q * rope_cache_stride + head_dim + paired_head_dim_idx_q
+        ].to(torch.float32)
+        grad_self_term_q = (grad_self_q * cos_q).to(grad_xq.dtype)
+        grad_pair_term_q = (grad_pair_q * sin_pair_q * paired_sign_q).to(grad_xq.dtype)
+        grad_xq_flat[idx_q] = grad_self_term_q + grad_pair_term_q
+
+    for tile_k in hl.tile(grad_xk_out.numel()):
+        idx_k = tile_k.index
+        head_dim_idx_k = idx_k % head_dim
+        seq_idx_k = (idx_k // (head_dim * n_kv_heads)) % seqlen
+        batch_idx_k = idx_k // (head_dim * n_kv_heads * seqlen)
+
+        position_k = positions_flat[batch_idx_k * seqlen + seq_idx_k]
+        paired_idx_k = torch.where(
+            head_dim_idx_k < half_head_dim,
+            idx_k + half_head_dim,
+            idx_k - half_head_dim,
+        )
+        paired_head_dim_idx_k = torch.where(
+            head_dim_idx_k < half_head_dim,
+            head_dim_idx_k + half_head_dim,
+            head_dim_idx_k - half_head_dim,
+        )
+        paired_sign_k = torch.where(head_dim_idx_k < half_head_dim, 1.0, -1.0).to(
+            torch.float32
+        )
+
+        grad_self_k = grad_xk_out_flat[idx_k].to(torch.float32)
+        grad_pair_k = grad_xk_out_flat[paired_idx_k].to(torch.float32)
+        cos_k = rope_cache_flat[position_k * rope_cache_stride + head_dim_idx_k].to(
+            torch.float32
+        )
+        sin_pair_k = rope_cache_flat[
+            position_k * rope_cache_stride + head_dim + paired_head_dim_idx_k
+        ].to(torch.float32)
+        grad_self_term_k = (grad_self_k * cos_k).to(grad_xk.dtype)
+        grad_pair_term_k = (grad_pair_k * sin_pair_k * paired_sign_k).to(grad_xk.dtype)
+        grad_xk_flat[idx_k] = grad_self_term_k + grad_pair_term_k
+
+    return grad_xq, grad_xk
+
+
+@helion.kernel(
+    config=helion.Config(block_sizes=[8, 8], num_warps=1),
+    static_shapes=True,
+)
+def _qk_rmsnorm_rope_cos_sin_fwd_positions(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float = 1e-5,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    bsz, seqlen, n_heads, head_dim = xq.size()
+    _, _, n_kv_heads, _ = xk.size()
+    head_dim = hl.specialize(head_dim)
+
+    xq_2d = xq.reshape(-1, head_dim)
+    xk_2d = xk.reshape(-1, head_dim)
+    xq_out = torch.empty_like(xq)
+    xk_out = torch.empty_like(xk)
+    xq_out_2d = xq_out.reshape(-1, head_dim)
+    xk_out_2d = xk_out.reshape(-1, head_dim)
+    positions_flat = positions.view(-1)
+
+    q_rows = xq_2d.size(0)
+    k_rows = xk_2d.size(0)
+
+    for tile_q in hl.tile(q_rows):
+        row_q = tile_q.index
+        seq_idx_q = (row_q // n_heads) % seqlen
+        batch_idx_q = row_q // (n_heads * seqlen)
+        position_q = positions_flat[batch_idx_q * seqlen + seq_idx_q]
+
+        xq_tile = xq_2d[tile_q, :].to(torch.float32)
+        q_variance = torch.mean(xq_tile * xq_tile, dim=-1)
+        q_inv_rms = torch.rsqrt(q_variance + eps)
+        xq_norm = xq_tile * q_inv_rms[:, None] * q_weight[None, :].to(torch.float32)
+        rope_q = rope_cache[position_q, :].to(torch.float32)
+        cos_q, sin_q = hl.split(rope_q.reshape([tile_q, 2, head_dim]).permute(0, 2, 1))
+        xq_norm_lo, xq_norm_hi = hl.split(
+            xq_norm.reshape([tile_q, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+        cos_q_lo, cos_q_hi = hl.split(
+            cos_q.reshape([tile_q, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+        sin_q_lo, sin_q_hi = hl.split(
+            sin_q.reshape([tile_q, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+
+        xq_out_lo = xq_norm_lo * cos_q_lo - xq_norm_hi * sin_q_lo
+        xq_out_hi = xq_norm_hi * cos_q_hi + xq_norm_lo * sin_q_hi
+        xq_out_2d[tile_q, :] = (
+            hl.join(xq_out_lo, xq_out_hi)
+            .permute(0, 2, 1)
+            .reshape([tile_q, head_dim])
+            .to(xq.dtype)
+        )
+
+    for tile_k in hl.tile(k_rows):
+        row_k = tile_k.index
+        seq_idx_k = (row_k // n_kv_heads) % seqlen
+        batch_idx_k = row_k // (n_kv_heads * seqlen)
+        position_k = positions_flat[batch_idx_k * seqlen + seq_idx_k]
+
+        xk_tile = xk_2d[tile_k, :].to(torch.float32)
+        k_variance = torch.mean(xk_tile * xk_tile, dim=-1)
+        k_inv_rms = torch.rsqrt(k_variance + eps)
+        xk_norm = xk_tile * k_inv_rms[:, None] * k_weight[None, :].to(torch.float32)
+        rope_k = rope_cache[position_k, :].to(torch.float32)
+        cos_k, sin_k = hl.split(rope_k.reshape([tile_k, 2, head_dim]).permute(0, 2, 1))
+        xk_norm_lo, xk_norm_hi = hl.split(
+            xk_norm.reshape([tile_k, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+        cos_k_lo, cos_k_hi = hl.split(
+            cos_k.reshape([tile_k, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+        sin_k_lo, sin_k_hi = hl.split(
+            sin_k.reshape([tile_k, 2, head_dim // 2]).permute(0, 2, 1)
+        )
+
+        xk_out_lo = xk_norm_lo * cos_k_lo - xk_norm_hi * sin_k_lo
+        xk_out_hi = xk_norm_hi * cos_k_hi + xk_norm_lo * sin_k_hi
+        xk_out_2d[tile_k, :] = (
+            hl.join(xk_out_lo, xk_out_hi)
+            .permute(0, 2, 1)
+            .reshape([tile_k, head_dim])
+            .to(xk.dtype)
+        )
+
+    return xq_out, xk_out
+
+
+class _ApplyRotaryEmbCosSinHelion(torch.autograd.Function):
+    @staticmethod
+    def forward(  # pyrefly: ignore [bad-override]
+        ctx: Any,
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ctx.xq_shape = xq.shape
+        ctx.xk_shape = xk.shape
+        ctx.save_for_backward(rope_cache, positions)
+        return _rope_cos_sin_fwd_positions(xq, xk, rope_cache, positions)
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        grad_xq_out: torch.Tensor | None,
+        grad_xk_out: torch.Tensor | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, None, None]:
+        rope_cache, positions = ctx.saved_tensors
+        if grad_xq_out is None:
+            assert grad_xk_out is not None
+            grad_xq_out = torch.zeros(
+                ctx.xq_shape,
+                device=grad_xk_out.device,
+                dtype=grad_xk_out.dtype,
+            )
+        if grad_xk_out is None:
+            grad_xk_out = torch.zeros(
+                ctx.xk_shape,
+                device=grad_xq_out.device,
+                dtype=grad_xq_out.dtype,
+            )
+
+        grad_xq, grad_xk = _rope_cos_sin_bwd_positions(
+            grad_xq_out.contiguous(),
+            grad_xk_out.contiguous(),
+            rope_cache,
+            positions,
+        )
+        if not ctx.needs_input_grad[0]:
+            grad_xq = None
+        if not ctx.needs_input_grad[1]:
+            grad_xk = None
+        return grad_xq, grad_xk, None, None
+
+
+def _can_use_helion_rope(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None,
+) -> bool:
+    return (
+        positions is not None
+        and rope_cache.ndim == 2
+        and positions.ndim == 2
+        and positions.shape == (xq.shape[0], xq.shape[1])
+        and xq.is_cuda
+        and xk.is_cuda
+        and rope_cache.is_cuda
+        and positions.is_cuda
+        and xq.is_contiguous()
+        and xk.is_contiguous()
+        and rope_cache.is_contiguous()
+        and positions.is_contiguous()
+        and xq.shape[-1] == xk.shape[-1]
+        and xq.shape[-1] % 2 == 0
+    )
+
+
+def _can_use_helion_qk_rmsnorm_rope(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None,
+) -> bool:
+    return (
+        positions is not None
+        and xq.ndim == 4
+        and xk.ndim == 4
+        and q_weight.ndim == 1
+        and k_weight.ndim == 1
+        and rope_cache.ndim == 2
+        and positions.ndim == 2
+        and positions.shape == (xq.shape[0], xq.shape[1])
+        and xq.shape[0] == xk.shape[0]
+        and xq.shape[1] == xk.shape[1]
+        and xq.shape[-1] == xk.shape[-1]
+        and xq.shape[-1] == q_weight.shape[0]
+        and xk.shape[-1] == k_weight.shape[0]
+        and rope_cache.shape[-1] == xq.shape[-1] * 2
+        and xq.shape[-1] % 2 == 0
+        and xq.is_cuda
+        and xk.is_cuda
+        and q_weight.is_cuda
+        and k_weight.is_cuda
+        and rope_cache.is_cuda
+        and positions.is_cuda
+        and xq.is_contiguous()
+        and xk.is_contiguous()
+        and q_weight.is_contiguous()
+        and k_weight.is_contiguous()
+        and rope_cache.is_contiguous()
+        and positions.is_contiguous()
+        and xq.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and xk.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and q_weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and k_weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and not (
+            torch.is_grad_enabled()
+            and (
+                xq.requires_grad
+                or xk.requires_grad
+                or q_weight.requires_grad
+                or k_weight.requires_grad
+            )
+        )
+    )
+
+
+def _qk_rmsnorm_rope_cos_sin_reference(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
+
+    xq = F.rms_norm(xq, (xq.shape[-1],), q_weight, eps)
+    xk = F.rms_norm(xk, (xk.shape[-1],), k_weight, eps)
+    return apply_rotary_emb_cos_sin(xq, xk, rope_cache, positions)
+
+
+def apply_rotary_emb_cos_sin_helion(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply cos/sin RoPE with an experimental Helion fused kernel.
+
+    The Helion fast path currently targets the common training case:
+    contiguous CUDA ``xq``/``xk`` tensors, a 2D cos/sin cache, and batched
+    position IDs of shape ``(batch, seq_len)``. Other cases fall back to the
+    core PyTorch implementation.
+    """
+    if not _can_use_helion_rope(xq, xk, rope_cache, positions):
+        from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
+
+        return apply_rotary_emb_cos_sin(xq, xk, rope_cache, positions)
+
+    assert positions is not None
+    return _ApplyRotaryEmbCosSinHelion.apply(xq, xk, rope_cache, positions)
+
+
+def apply_qk_rmsnorm_rotary_emb_cos_sin_helion(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None = None,
+    eps: float = 1e-5,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse Q/K RMSNorm and cos/sin RoPE with an experimental Helion kernel.
+
+    The fast path is forward-only and targets inference-style contiguous CUDA
+    tensors shaped ``(batch, seq_len, heads, head_dim)`` with a 2D cos/sin RoPE
+    cache and batched position IDs. Other cases fall back to the PyTorch
+    composition.
+    """
+    if not _can_use_helion_qk_rmsnorm_rope(
+        xq, xk, q_weight, k_weight, rope_cache, positions
+    ):
+        return _qk_rmsnorm_rope_cos_sin_reference(
+            xq, xk, q_weight, k_weight, rope_cache, positions, eps
+        )
+
+    assert positions is not None
+    return _qk_rmsnorm_rope_cos_sin_fwd_positions(
+        xq, xk, q_weight, k_weight, rope_cache, positions, eps
+    )

--- a/torchtitan/experiments/helion_kernels/rope.py
+++ b/torchtitan/experiments/helion_kernels/rope.py
@@ -96,6 +96,149 @@ def _rope_cos_sin_fwd_positions(
     return xq_out, xk_out
 
 
+def _nearest_power_of_2_bucket(value: int) -> int:
+    assert value > 0
+    lower = 1 << (value.bit_length() - 1)
+    upper = lower << 1
+    return lower if value - lower < upper - value else upper
+
+
+def _config(
+    block_sizes: list[int],
+    *,
+    num_warps: int,
+    num_stages: int,
+    pid_type: str = "flat",
+    indexing: list[str] | None = None,
+    load_eviction_policies: list[str] | None = None,
+    maxnreg: int | None = None,
+    num_sm_multiplier: int | None = None,
+) -> helion.Config:
+    kwargs: dict[str, Any] = {
+        "block_sizes": block_sizes,
+        "num_stages": num_stages,
+        "num_warps": num_warps,
+        "pid_type": pid_type,
+    }
+    if indexing is not None:
+        kwargs["indexing"] = indexing
+    if load_eviction_policies is not None:
+        kwargs["load_eviction_policies"] = load_eviction_policies
+    if maxnreg is not None:
+        kwargs["maxnreg"] = maxnreg
+    if num_sm_multiplier is not None:
+        kwargs["num_sm_multiplier"] = num_sm_multiplier
+    return helion.Config(**kwargs)
+
+
+_ROPE_HELION_CONFIGS_BY_SEQ_BUCKET: dict[int, helion.Config] = {
+    1: _config(
+        [512, 128],
+        num_warps=16,
+        num_stages=5,
+        pid_type="persistent_blocked",
+        maxnreg=128,
+        num_sm_multiplier=1,
+    ),
+    256: _config(
+        [1024, 128],
+        num_warps=8,
+        num_stages=4,
+    ),
+    1024: _config(
+        [512, 256],
+        num_warps=8,
+        num_stages=2,
+    ),
+}
+
+
+_ROPE_HELION_BWD_CONFIGS_BY_SEQ_BUCKET: dict[int, helion.Config] = {
+    1: _config([128, 16], num_warps=4, num_stages=3),
+    256: _config([1024, 512], num_warps=16, num_stages=6),
+    1024: _config([1024, 512], num_warps=8, num_stages=7),
+}
+
+
+def _rope_cos_sin_config(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+) -> helion.Config | None:
+    batch, seq_len, n_heads, head_dim = xq.shape
+    _, k_seq_len, n_kv_heads, k_head_dim = xk.shape
+    # These configs were tuned only for the Qwen3-32B TP=8 inference shapes:
+    # xq=[1, S, 8, 128], xk=[1, S, 1, 128], S in {1, 192, 1088}.
+    if (
+        batch != 1
+        or seq_len != k_seq_len
+        or n_heads != 8
+        or n_kv_heads != 1
+        or head_dim != 128
+        or k_head_dim != 128
+    ):
+        return None
+
+    seq_bucket = _nearest_power_of_2_bucket(seq_len)
+    return _ROPE_HELION_CONFIGS_BY_SEQ_BUCKET.get(seq_bucket)
+
+
+def _rope_cos_sin_bwd_config(
+    grad_xq_out: torch.Tensor,
+    grad_xk_out: torch.Tensor,
+) -> helion.Config | None:
+    batch, seq_len, n_heads, head_dim = grad_xq_out.shape
+    _, k_seq_len, n_kv_heads, k_head_dim = grad_xk_out.shape
+    # These configs were tuned only for the Qwen3-32B TP=8 inference shapes:
+    # grad_xq=[1, S, 8, 128], grad_xk=[1, S, 1, 128], S in {1, 192, 1088}.
+    if (
+        batch != 1
+        or seq_len != k_seq_len
+        or n_heads != 8
+        or n_kv_heads != 1
+        or head_dim != 128
+        or k_head_dim != 128
+    ):
+        return None
+
+    seq_bucket = _nearest_power_of_2_bucket(seq_len)
+    return _ROPE_HELION_BWD_CONFIGS_BY_SEQ_BUCKET.get(seq_bucket)
+
+
+def _rope_cos_sin_fwd_positions_with_config(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    config = _rope_cos_sin_config(xq, xk)
+    if config is None:
+        return _rope_cos_sin_fwd_positions(xq, xk, rope_cache, positions)
+
+    bound_kernel = _rope_cos_sin_fwd_positions.bind((xq, xk, rope_cache, positions))
+    if getattr(bound_kernel, "_config", None) != config:
+        bound_kernel.set_config(config)
+    return bound_kernel(xq, xk, rope_cache, positions)
+
+
+def _rope_cos_sin_bwd_positions_with_config(
+    grad_xq_out: torch.Tensor,
+    grad_xk_out: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    config = _rope_cos_sin_bwd_config(grad_xq_out, grad_xk_out)
+    if config is None:
+        return _rope_cos_sin_bwd_positions(
+            grad_xq_out, grad_xk_out, rope_cache, positions
+        )
+
+    args = (grad_xq_out, grad_xk_out, rope_cache, positions)
+    bound_kernel = _rope_cos_sin_bwd_positions.bind(args)
+    if getattr(bound_kernel, "_config", None) != config:
+        bound_kernel.set_config(config)
+    return bound_kernel(*args)
+
+
 @helion.kernel(
     config=helion.Config(block_sizes=[512, 512], num_warps=4),
     static_shapes=True,
@@ -296,7 +439,9 @@ class _ApplyRotaryEmbCosSinHelion(torch.autograd.Function):
         ctx.xq_shape = xq.shape
         ctx.xk_shape = xk.shape
         ctx.save_for_backward(rope_cache, positions)
-        return _rope_cos_sin_fwd_positions(xq, xk, rope_cache, positions)
+        return _rope_cos_sin_fwd_positions_with_config(
+            xq, xk, rope_cache, positions
+        )
 
     @staticmethod
     def backward(
@@ -319,7 +464,7 @@ class _ApplyRotaryEmbCosSinHelion(torch.autograd.Function):
                 dtype=grad_xq_out.dtype,
             )
 
-        grad_xq, grad_xk = _rope_cos_sin_bwd_positions(
+        grad_xq, grad_xk = _rope_cos_sin_bwd_positions_with_config(
             grad_xq_out.contiguous(),
             grad_xk_out.contiguous(),
             rope_cache,


### PR DESCRIPTION

Add experimental Helion kernels, benchmarks, and unit tests for standalone RMSNorm, cos/sin RoPE, and fused Q/K RMSNorm + RoPE.

B200 bf16 perf:

| Benchmark | Baseline | Helion | Speedup |
| --- | ---: | ---: | ---: |
| RMSNorm paste-equivalent weighted total | 8.444ms ATen | 7.883ms Helion | 1.07x |
| Fused Q/K RMSNorm + RoPE, S=1 | 113.95us eager separate | 20.42us fused | 5.58x |
| Fused Q/K RMSNorm + RoPE, S=192 | 112.61us eager separate | 21.22us fused | 5.31x |
| Fused Q/K RMSNorm + RoPE, S=1088 | 112.70us eager separate | 21.06us fused | 5.35x |