### PR TITLE
[graph_trainer] Rework full_inductor_compilation_pass via regional_inductor + CPU attr migration

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -326,6 +326,17 @@ def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
       The expected workflow is to apply regional_inductor first to compile
       flex_attention regions, then apply cudagraph.
     """
+    # ``full_inductor_compilation_pass`` collapses the FX graph into one
+    # opaque ``standalone_compile_inner`` node, hiding ops the per-node
+    # scan below would otherwise catch. That pass stashes its pre-collapse
+    # verdict in ``gm.meta``; honor it.
+    if gm.meta.get("cudagraph_compatible") is False:
+        logger.warning(
+            "Skipping cudagraph: gm.meta['cudagraph_compatible'] is False "
+            "(set by full_inductor_compilation_pass before the collapse)."
+        )
+        return False
+
     for node in gm.graph.nodes:
         if node.op != "call_function":
             continue

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -14,7 +14,6 @@ regional_inductor.
 from __future__ import annotations
 
 import torch
-from torch._inductor.compile_fx import compile_fx_inner
 from torch.fx.passes.regional_inductor import regional_inductor
 
 from torchtitan.tools.logging import logger
@@ -200,56 +199,66 @@ def annotate_flex_attention_for_regional_inductor_pass(
     return gm
 
 
+def _migrate_cpu_get_attrs_to_cuda(gm: torch.fx.GraphModule) -> None:
+    """Move CPU constant tensor get_attrs to CUDA so cudagraph capture works."""
+    from torch.fx.graph_module import _assign_attr, _get_attr
+
+    for module in gm.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in module.graph.find_nodes(op="get_attr"):
+            attr = _get_attr(module, node.target)
+            if isinstance(attr, torch.Tensor) and attr.device.type == "cpu":
+                _assign_attr(attr.cuda(), module, node.target)
+
+
 def full_inductor_compilation_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple
 ) -> torch.fx.GraphModule:
-    """Apply full Inductor compilation with code generation.
+    """Apply full Inductor compilation by tagging every node and delegating
+    to :func:`regional_inductor_pass`.
 
-    Applies inductor decompositions (e.g. ``aten.t`` → ``aten.permute``),
-    then compiles the graph into optimized Triton/C++ kernels via
-    ``compile_fx_inner`` and replaces the GraphModule's ``forward``
-    with the compiled callable.
+    Marks every non-placeholder/output node with the ``compile_with_inductor``
+    custom metadata key so ``regional_inductor`` scoops the entire graph as
+    one compiled region. This reuses the regional path (which goes through
+    ``standalone_compile`` and gets c10d functionalization, PG unboxing,
+    decompositions, and caching for free) instead of duplicating that prep
+    around a direct ``compile_fx_inner`` call.
+
+    The collapse hides cudagraph-incompatible ops (unpinned D2H copies,
+    sm<10 ``_grouped_mm``) inside the opaque ``standalone_compile_inner``
+    node, so the later :func:`is_cudagraph_compatible` scan can't see
+    them. Snapshot the verdict on the pre-collapse gm and stash it on
+    the result so the downstream scan can honor it.
 
     Must be the **terminal** pass — no FX-graph-level passes (e.g.
     ``custom_codegen_pass``, ``insert_kernel_annotations_pass``) can
     run after this because the FX graph is no longer authoritative.
     """
+    import torch._inductor.config as ic
 
-    def _apply_decompositions(
-        gm: torch.fx.GraphModule, example_inputs: tuple
-    ) -> torch.fx.GraphModule:
-        """Retrace with ``select_decomp_table()`` so that ops like ``aten.t``
-        are decomposed before ``compile_fx_inner``."""
-        from torch._inductor.decomposition import select_decomp_table
-        from torch._subclasses.fake_tensor import FakeTensor
-        from torch.fx.experimental.proxy_tensor import make_fx
+    from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
-        decomp_table = select_decomp_table()
+    pre_collapse_cudagraph_compatible = is_cudagraph_compatible(gm)
 
-        fake_mode = None
-        for inp in example_inputs:
-            if isinstance(inp, FakeTensor):
-                fake_mode = inp.fake_mode
-                break
+    _migrate_cpu_get_attrs_to_cuda(gm)
+    for module in gm.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in module.graph.nodes:
+            if node.op in ("placeholder", "output"):
+                continue
+            node.meta.setdefault("custom", {}).setdefault(
+                "compile_with_inductor", {"inductor_configs": {}}
+            )
+    # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
+    # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
+    # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.
+    with ic.patch(reorder_for_peak_memory=True):
+        result = regional_inductor_pass(gm, example_inputs)
 
-        if fake_mode is not None:
-            with fake_mode:
-                gm = make_fx(
-                    gm,
-                    decomposition_table=decomp_table,
-                    _allow_non_fake_inputs=True,
-                )(*example_inputs)
-
-        return gm
-
-    gm = _apply_decompositions(gm, example_inputs)
-    output_code = compile_fx_inner(gm, example_inputs)
-
-    # compile_fx_inner returns OutputCode with boxed calling convention
-    # (single list arg). Adapt to positional args so the graph trainer's
-    # execution path (gm(*flat_inputs)) works unchanged.
-    def _compiled_forward(*args):
-        return output_code(list(args))
-
-    gm.forward = _compiled_forward
-    return gm
+    # Carry the pre-collapse cudagraph verdict forward via gm.meta. The
+    # collapse is information-destroying; this is how downstream passes
+    # know whether the artifact contains hidden cudagraph-incompatible ops.
+    result.meta["cudagraph_compatible"] = pre_collapse_cudagraph_compatible
+    return result

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -878,6 +878,76 @@ class TestTraceDTensor(unittest.TestCase):
         for gr, gt in zip(grads_ref, grads_tr, strict=True):
             self.assertTrue(torch.equal(gr.full_tensor(), gt.full_tensor()))
 
+    def test_full_inductor_pass_on_collective(self):
+        # ``make_fx`` traces ``dist.*`` collectives as raw ``c10d.{op}_``
+        # inplace ops with a torchbind ``ProcessGroup`` baked in as a graph
+        # attr. ``full_inductor_compilation_pass`` must functionalize the
+        # collective and unbox the PG before ``compile_fx_inner`` — otherwise
+        # the cache key calls ``__eq__`` on the torchbind and crashes.
+        import torch.distributed as dist
+
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            full_inductor_compilation_pass,
+        )
+
+        def f(_state, t):
+            t = t.clone()
+            dist.all_reduce(t)
+            return t + 1
+
+        traced = minimal_fx_tracer(f)({}, torch.ones(4, device=self.DEVICE))
+        compiled_gm = full_inductor_compilation_pass(traced.gm, traced.example_inputs)
+
+        real_input = torch.ones(4, device=self.DEVICE)
+        expected = f({}, real_input.clone())
+        actual = compiled_gm(real_input.clone())
+        if isinstance(actual, (list, tuple)):
+            actual = actual[0]
+        torch.testing.assert_close(actual, expected)
+
+    def test_full_inductor_pass_migrates_cpu_attrs(self):
+        from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_pass
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            full_inductor_compilation_pass,
+        )
+
+        def f(_state, x):
+            pad = torch.tensor(-1, dtype=torch.int64)
+            fill = torch.tensor(0, dtype=torch.bfloat16)
+            scale = torch.tensor(1.0, dtype=torch.float32)
+            return x + pad.to(x.dtype) + fill.to(x.dtype) + scale.to(x.dtype)
+
+        traced = minimal_fx_tracer(f)(
+            {}, torch.zeros(4, dtype=torch.float32, device=self.DEVICE)
+        )
+
+        cpu_attr_names = [
+            n.target
+            for n in traced.gm.graph.find_nodes(op="get_attr")
+            if isinstance(getattr(traced.gm, n.target, None), torch.Tensor)
+            and getattr(traced.gm, n.target).device.type == "cpu"
+        ]
+
+        gm = full_inductor_compilation_pass(traced.gm, traced.example_inputs)
+
+        for name in cpu_attr_names:
+            attr = getattr(traced.gm, name, None)
+            self.assertIsInstance(attr, torch.Tensor)
+            self.assertEqual(
+                attr.device.type,
+                "cuda",
+                f"{name} should have been migrated to CUDA",
+            )
+
+        gm = cudagraph_pass(gm, traced.example_inputs, is_forward=True)
+        real_x = torch.zeros(4, dtype=torch.float32, device=self.DEVICE)
+        expected = f({}, real_x.clone())
+        for _ in range(3):
+            actual = gm(real_x.clone())
+            if isinstance(actual, (list, tuple)):
+                actual = actual[0]
+            torch.testing.assert_close(actual, expected)
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestMetadataPropagation(unittest.TestCase):


### PR DESCRIPTION
Summary: Rework ``full_inductor_compilation_pass`` to compile the entire traced graph through the regional inductor path and play nicely with ``cudagraph_pass``.

Three pieces:

1) **Route through ``standalone_compile`` for reliable Inductor work.**
   Calling ``compile_fx_inner`` directly skips a pile of prep that
   Inductor really wants — c10d functionalization
   (``c10d.{op}_`` → ``_c10d_functional.{op}`` + ``wait_tensor``),
   ``ProcessGroup`` torchbind unboxing, general functionalization and decompositions.
   Hand-rolling those in this pass is fragile and``standalone_compile`` (reached via ``regional_inductor``)
   does all of it. So instead of calling `standalone_compile` here, tag every
   non-placeholder/output node with ``compile_with_inductor`` and
   delegate to ``regional_inductor_pass`` — the whole graph becomes
   one big "region" and gets standalone-compiled.

2) **Keep the result a ``GraphModule``.**
3) **Move CPU get_attr tensors to CUDA before delegating
   (``_migrate_cpu_get_attrs_to_cuda``).** ``make_fx`` lifts Python
   scalar literals from some decompositions as get_attr nodes. 
   ``standalone_compile``'s AOT autograd then lifts them as compiled
   inputs; Inductor emits an unpinned H2D copy at the top of the
   compiled artifact, which is fatal under CUDA graph capture
   (cannot copy CPU↔CUDA inside a stream-captured region without
   pinned memory). 


End-to-end:

<img width="953" height="156" alt="Screenshot 2026-05-19 at 2 14 17 PM" src="https://github.com/user-attachments/assets/4ed0e01e-ad9d-4b55-920b-956352ce1d16" />


On llama3 8b model:

  PR:
    step  3: tps=  5891  mfu=34.50%
    step  4: tps=  5867  mfu=34.36%
    step  5: tps=  4199  mfu=24.59%   
    step  6: tps=  5854  mfu=34.28%
    step  7: tps=  5866  mfu=34.35%
    step  8: tps=  5900  mfu=34.55%  ← profiled
    step  9: tps=  4885  mfu=28.61%  
    step 10: tps=  5930  mfu=34.72%

  Main:
    step  3: tps=  5802  mfu=33.97%
    step  4: tps=  5768  mfu=33.78%
    step  5: tps=  4065  mfu=23.80%
    step  6: tps=  5771  mfu=33.79%
    step  7: tps=  5769  mfu=33.78%
    step  8: tps=  5797  mfu=33.95%  ← profiled
    step  9: tps=  4765  mfu=27.90%
    step 10: tps=  5811  mfu=34.03%
    
 We consistently get better tps and mfu (around 1%) 
 
 
<img width="1798" height="960" alt="zoomed_step8" src="https://github.com/user-attachments/assets/c50d4f50-8a2b-4d58-834a-fd33410cad3f" />
The step time comparison between this PR and main, you can see after this PR, we complete the step little earlier. 

Repro command:
```
  NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b LOG_RANK=0 \
      ./run_train.sh \
      --compile.mode aot_fx_trace --compile.inductor_compilation full \
      --parallelism.data_parallel_shard_degree 4 --parallelism.tensor_parallel_degree 2 \
      --dataloader.dataset c4_test --metrics.no-enable_tensorboard \
      --metrics.log_freq 1 \
      --profiler.enable_profiling --profiler.profile_freq 8 \
      --profiler.save-traces-folder /tmp/llama3_8b_profiles_v4/<label>/traces \
      --comm.trace_buf_size=0 --training.steps 10 \
      --hf-assets-path ./tests/assets/tokenizer \
      --debug.seed=42 --debug.deterministic \
      --dump-folder /tmp/llama3_8b_profiles_v4/<label>
```

Authored with Claude