### PR TITLE
[graph_trainer] Support multiple FSDP PGs in overlap_fsdp_ag_rs_pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -166,41 +166,41 @@ def overlap_fsdp_ag_rs_pass(
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
     """
-    Reassign FSDP all-gather nodes to an extra NCCL process group for
+    Reassign FSDP all-gather nodes to extra NCCL process groups for
     AG/RS overlap in backward.
 
-    Discovers the FSDP PG by inspecting the graph, creates an extra
-    NCCL PG over the same ranks (giving it a separate CUDA stream),
-    and rewrites every all-gather using that source PG to the extra PG.
-    This separates all-gathers from reduce-scatters onto different streams,
-    enabling AG/RS overlap in backward.
+    Discovers all distinct FSDP PGs by inspecting the graph (e.g. one for
+    FSDP, another for expert-FSDP), creates an extra NCCL PG over the same
+    ranks for each (giving it a separate CUDA stream), and rewrites every
+    all-gather to the corresponding extra PG. This separates all-gathers
+    from reduce-scatters onto different streams, enabling AG/RS overlap in
+    backward.
 
     No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
     bucketing passes so bucketed all-gathers inherit the new PG name.
     """
-    source_pg_name: str | None = None
+    source_pg_names: OrderedSet[str] = OrderedSet()
     for node in gm.graph.nodes:
         if is_wait_tensor_from_fsdp(node):
             ag_node = node.args[0]
-            source_pg_name = ag_node.args[2]
-            break
+            source_pg_names.add(ag_node.args[2])
 
-    if source_pg_name is None:
+    if not source_pg_names:
         return gm
 
-    target_pg_name = _get_or_create_extra_fsdp_pg(source_pg_name)
+    pg_mapping: dict[str, str] = {
+        pg: _get_or_create_extra_fsdp_pg(pg) for pg in source_pg_names
+    }
 
     count = 0
     for node in gm.graph.nodes:
-        if is_all_gather(node) and node.args[2] == source_pg_name:
+        if is_all_gather(node) and node.args[2] in pg_mapping:
             # AG args: (input_tensor, group_size, group_name)
-            node.args = (node.args[0], node.args[1], target_pg_name)
+            node.args = (node.args[0], node.args[1], pg_mapping[node.args[2]])
             count += 1
     if count > 0:
-        logger.info(
-            f"Rewrote {count} all-gather node(s) from PG {source_pg_name} "
-            f"to PG {target_pg_name}"
-        )
+        for source, target in pg_mapping.items():
+            logger.info(f"Rewrote all-gather node(s) from PG {source} to PG {target}")
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -193,6 +193,62 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
 
         self.assertEqual(total_before, total_after)
 
+    def test_overlap_rewrites_multiple_pgs(self):
+        """When the graph has AG nodes from multiple FSDP PGs (e.g. FSDP +
+        expert-FSDP), each source PG should be mapped to its own extra PG."""
+        import torch.distributed as dist
+
+        from torchtitan.experiments.graph_trainer.fsdp_passes import (
+            _EXTRA_FSDP_PG_REGISTRY,
+        )
+
+        self._setup()
+        model = self._make_fsdp_model()
+        inputs = torch.randn(4, 16).cuda()
+        fsdp_pg_name = self._get_fsdp_pg_name()
+
+        bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
+
+        # Create a second PG to simulate expert-FSDP
+        second_pg = dist.new_group(
+            ranks=list(range(self.world_size)),
+            use_local_synchronization=True,
+        )
+        second_pg_name = second_pg.group_name
+
+        # Rewrite half the AG nodes to use the second PG
+        ag_nodes = [n for n in bw_gm.graph.nodes if is_all_gather(n)]
+        self.assertGreater(len(ag_nodes), 1)
+        half = len(ag_nodes) // 2
+        for node in ag_nodes[:half]:
+            node.args = (node.args[0], node.args[1], second_pg_name)
+
+        ag_pg1_before = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
+        ag_pg2_before = self._count_ag_nodes_with_pg(bw_gm, second_pg_name)
+        self.assertGreater(ag_pg1_before, 0)
+        self.assertGreater(ag_pg2_before, 0)
+
+        _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
+        _EXTRA_FSDP_PG_REGISTRY.pop(second_pg_name, None)
+        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
+
+        # Both source PGs should have their own extra PG
+        self.assertIn(fsdp_pg_name, _EXTRA_FSDP_PG_REGISTRY)
+        self.assertIn(second_pg_name, _EXTRA_FSDP_PG_REGISTRY)
+        extra_pg1 = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
+        extra_pg2 = _EXTRA_FSDP_PG_REGISTRY[second_pg_name]
+        self.assertNotEqual(
+            extra_pg1, extra_pg2, "Each source PG must map to a distinct extra PG"
+        )
+
+        # No AG nodes should still use original PGs
+        self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name), 0)
+        self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, second_pg_name), 0)
+
+        # All AG nodes should use their respective extra PGs
+        self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg1), ag_pg1_before)
+        self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg2), ag_pg2_before)
+
     def test_overlap_is_noop_when_no_fsdp_ag(self):
         """If the graph has no FSDP all-gathers, the pass is a no-op."""
         self._setup()


### PR DESCRIPTION
Needed for dsv3 which has both fsdp and efsdp pgs. 

## Summary
- `overlap_fsdp_ag_rs_pass` previously discovered only the first FSDP process group and rewrote all all-gathers to a single extra PG. Models with multiple FSDP PGs (e.g. one for FSDP, another for expert-FSDP in DeepSeek-v3) need each PG mapped to its own extra PG so AG/RS overlap works on all streams.
- Collect all distinct source PGs, create a separate extra PG for each, and rewrite each all-gather to the corresponding extra PG.
- Add `test_overlap_rewrites_multiple_pgs` integration test that simulates the multi-PG case and verifies each source PG gets its own extra PG with correct AG node rewriting.

## Test plan
- [x] Existing `TestOverlapFsdpAgRsPass` tests pass (single-PG behavior unchanged)
- [x] New `test_overlap_rewrites_multiple_pgs` passes — verifies multi-PG discovery, distinct extra PG creation, and correct per-PG rewriting
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x -k TestOverlapFsdpAgRsPass` — all 4 tests pass