### PR TITLE
[graph_trainer] Make JointManualOverlapScheduler standalone with direct node moves

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -170,41 +170,41 @@ def overlap_fsdp_ag_rs_pass(
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
     """
-    Reassign FSDP all-gather nodes to extra NCCL process groups for
+    Reassign FSDP all-gather nodes to an extra NCCL process group for
     AG/RS overlap in backward.
 
-    Discovers all distinct FSDP PGs by inspecting the graph (e.g. one for
-    FSDP, another for expert-FSDP), creates an extra NCCL PG over the same
-    ranks for each (giving it a separate CUDA stream), and rewrites every
-    all-gather to the corresponding extra PG. This separates all-gathers
-    from reduce-scatters onto different streams, enabling AG/RS overlap in
-    backward.
+    Discovers the FSDP PG by inspecting the graph, creates an extra
+    NCCL PG over the same ranks (giving it a separate CUDA stream),
+    and rewrites every all-gather using that source PG to the extra PG.
+    This separates all-gathers from reduce-scatters onto different streams,
+    enabling AG/RS overlap in backward.
 
     No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
     bucketing passes so bucketed all-gathers inherit the new PG name.
     """
-    source_pg_names: OrderedSet[str] = OrderedSet()
+    source_pg_name: str | None = None
     for node in gm.graph.nodes:
         if is_wait_tensor_from_fsdp(node):
             ag_node = node.args[0]
-            source_pg_names.add(ag_node.args[2])
+            source_pg_name = ag_node.args[2]
+            break
 
-    if not source_pg_names:
+    if source_pg_name is None:
         return gm
 
-    pg_mapping: dict[str, str] = {
-        pg: _get_or_create_extra_fsdp_pg(pg) for pg in source_pg_names
-    }
+    target_pg_name = _get_or_create_extra_fsdp_pg(source_pg_name)
 
     count = 0
     for node in gm.graph.nodes:
-        if is_all_gather(node) and node.args[2] in pg_mapping:
+        if is_all_gather(node) and node.args[2] == source_pg_name:
             # AG args: (input_tensor, group_size, group_name)
-            node.args = (node.args[0], node.args[1], pg_mapping[node.args[2]])
+            node.args = (node.args[0], node.args[1], target_pg_name)
             count += 1
     if count > 0:
-        for source, target in pg_mapping.items():
-            logger.info(f"Rewrote all-gather node(s) from PG {source} to PG {target}")
+        logger.info(
+            f"Rewrote {count} all-gather node(s) from PG {source_pg_name} "
+            f"to PG {target_pg_name}"
+        )
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -263,7 +263,6 @@ class JointManualOverlapScheduler:
         self,
         gm: fx.GraphModule,
         module_bucket_plans: list[list[str] | str],
-        insert_overlap_deps: bool,
         *,
         is_backward_fn: Callable[[fx.Node], bool],
         module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]],
@@ -271,7 +270,6 @@ class JointManualOverlapScheduler:
     ) -> None:
         self.gm = gm
         self.graph = gm.graph
-        self.insert_overlap_deps = insert_overlap_deps
         self.module_bucket_plans = module_bucket_plans
         self.module_stack_fn = module_stack_fn
         self._is_backward_fn = is_backward_fn
@@ -405,13 +403,6 @@ class JointManualOverlapScheduler:
         self._execute_direct_moves(overlap_deps)
         self._tlparse_dump("after_reorder_graph_move_pass")
         self.graph.lint()
-
-        if self.insert_overlap_deps:
-            from torch._inductor.fx_passes.control_dependencies import (
-                preserve_node_ordering,
-            )
-
-            preserve_node_ordering(self.graph, overlap_deps)
 
     def _execute_direct_moves(
         self, overlap_deps: dict[fx.Node, OrderedSet[fx.Node]]
@@ -635,7 +626,6 @@ def joint_transformer_block_bucketing_reordering_pass(
     example_inputs: tuple | None = None,
     *,
     module_bucket_plans: list[list[str] | str],
-    insert_overlap_deps: bool = False,
     bucket_mode: BucketMode | None = None,
 ) -> torch.fx.GraphModule:
     """Run joint-graph manual bucketing and reordering.
@@ -651,8 +641,6 @@ def joint_transformer_block_bucketing_reordering_pass(
         module_bucket_plans: list of module FQNs (or lists of FQNs); each
             entry defines one bucketing scope whose collectives should be
             merged into a single bucket per direction per collective type.
-        insert_overlap_deps: if ``True``, insert explicit control deps via
-            ``preserve_node_ordering`` after the topological sort.
         bucket_mode: bucket mode forwarded to the underlying bucketer;
             defaults to ``"custom_ops"`` via the parent class.
     """
@@ -666,7 +654,6 @@ def joint_transformer_block_bucketing_reordering_pass(
     overlapped_gm = JointManualOverlapScheduler(
         gm,
         module_bucket_plans,
-        insert_overlap_deps,
         is_backward_fn=_is_backward_node,
         module_stack_fn=_stack_fn,
         bucket_mode=bucket_mode,

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import torch
 import torch.fx as fx
-from torch._dynamo.graph_deduplication import _stable_topological_sort
 from torch._inductor.fx_passes.bucketing import (
     BucketMode,
     is_all_gather_into_tensor as is_all_gather,
@@ -37,8 +36,8 @@ from torch._inductor.fx_passes.overlap_scheduling import (
     CollectiveInfo,
     is_compute_node,
     schedule_overlap_bucketing,
-    stable_topological_sort,
 )
+from torch._logging import trace_structured
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
@@ -279,7 +278,6 @@ class JointManualOverlapScheduler:
 
         bucket_mode = bucket_mode or "custom_ops"
 
-        stable_topological_sort(self.graph)
         self.nodes: list[fx.Node] = list(self.graph.nodes)
         self.node_idx: dict[fx.Node, int] = {n: i for i, n in enumerate(self.nodes)}
         self.node_ancestors: dict[
@@ -363,9 +361,24 @@ class JointManualOverlapScheduler:
         self._manual_reorder_graph()
         return self.gm
 
+    def _tlparse_dump(self, graph_name: str) -> None:
+        trace_structured(
+            "artifact",
+            metadata_fn=lambda: {"name": graph_name, "encoding": "string"},
+            payload_fn=lambda: self.gm.print_readable(
+                print_output=False,
+                include_stride=True,
+                include_device=True,
+                expanded_def=True,
+                additional_meta=["autograd_backward"],
+            ),
+            expect_trace_id=False,
+        )
+
     def _manual_bucket_collectives(self) -> None:
         """Bucket per module, splitting by direction to keep fwd/bwd buckets disjoint."""
         self._obtain_nodes_in_subgraph()
+        self._tlparse_dump("before_manual_bucket_collectives_pass")
         for nodes in self.nodes_in_subgraph:
             fwd_nodes = [n for n in nodes if not self._is_backward_fn(n)]
             bwd_nodes = [n for n in nodes if self._is_backward_fn(n)]
@@ -373,23 +386,30 @@ class JointManualOverlapScheduler:
                 self.bucketer.manual_bucket_collectives(nodes=fwd_nodes)
             if bwd_nodes:
                 self.bucketer.manual_bucket_collectives(nodes=bwd_nodes)
+        self._tlparse_dump("after_manual_bucket_collectives_pass")
 
-        _stable_topological_sort(self.graph, {})
         self.graph.lint()
+
         self.nodes = list(self.graph.nodes)
         self.in_degree = Counter(user for node in self.nodes for user in node.users)
 
     def _manual_reorder_graph(self) -> None:
-        """Reorder pass with separate fwd/bwd buffers so AG pairing never
-        crosses the fwd/bwd boundary. RS pairing is unchanged — RSs only
-        occur in backward and are already direction-scoped.
+        """Reorder pass that directly moves nodes instead of relying on
+        topological sort. AG start chains are moved earlier (prefetch),
+        RS wait chains are moved later (deferred).
+
+        Separate fwd/bwd buffers in ``_schedule_ag_prefetch`` ensure AG
+        pairing never crosses the fwd/bwd boundary. RS pairing is
+        unchanged — RSs only occur in backward.
         """
         overlap_deps: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
 
         self._schedule_rs_prefetch(overlap_deps)
         self._schedule_ag_prefetch(overlap_deps)
 
-        _stable_topological_sort(self.graph, overlap_deps)
+        self._tlparse_dump("before_reorder_graph_move_pass")
+        self._execute_direct_moves(overlap_deps)
+        self._tlparse_dump("after_reorder_graph_move_pass")
         self.graph.lint()
 
         if self.insert_overlap_deps:
@@ -398,6 +418,119 @@ class JointManualOverlapScheduler:
             )
 
             preserve_node_ordering(self.graph, overlap_deps)
+
+    def _execute_direct_moves(
+        self, overlap_deps: dict[fx.Node, OrderedSet[fx.Node]]
+    ) -> None:
+        """Realize overlap_deps by directly moving nodes in the FX graph.
+
+        Classifies each overlap_dep entry by source node type:
+        - ``bucketed_reduce_scatter`` sources → RS defer (move wait chain later)
+        - ``bucketed_all_gather`` sources → AG prefetch (move start chain earlier)
+        """
+        rs_defer: dict[fx.Node, list[fx.Node]] = defaultdict(list)
+        ag_prefetch: dict[fx.Node, list[fx.Node]] = defaultdict(list)
+
+        for target, sources in overlap_deps.items():
+            for source in sources:
+                source_type = self.bucketer.bucketed_node_types.get(source, "")
+                if source_type == "bucketed_reduce_scatter":
+                    rs_defer[target].append(source)
+                elif source_type == "bucketed_all_gather":
+                    ag_prefetch[target].append(source)
+
+        node_positions = {n: i for i, n in enumerate(self.graph.nodes)}
+
+        # RS defer: move each wait chain to right after the latest RS start
+        for rs_wait, rs_starts in rs_defer.items():
+            anchor = max(rs_starts, key=lambda n: node_positions[n])
+            chain = self._collect_forward_chain(rs_wait)
+            logger.info(
+                "RS defer: moving %d nodes (%s …) after %s",
+                len(chain),
+                chain[0].name,
+                anchor.name,
+            )
+            cursor = anchor
+            for node in chain:
+                cursor.append(node)
+                cursor = node
+
+        # AG prefetch: move each start chain to right before the anchor.
+        # Skip if the AG start is already before the anchor (e.g. trailing
+        # block deps that are no-ops in topological sort).
+        for anchor, ag_starts in ag_prefetch.items():
+            anchor_pos = node_positions[anchor]
+            sorted_starts = sorted(ag_starts, key=lambda n: node_positions[n])
+            for ag_start in sorted_starts:
+                if node_positions[ag_start] < anchor_pos:
+                    continue
+                chain = self._collect_ag_chain(ag_start)
+                logger.info(
+                    "AG prefetch: moving %d nodes (… %s) before %s",
+                    len(chain),
+                    chain[-1].name,
+                    anchor.name,
+                )
+                for node in chain:
+                    anchor.prepend(node)
+
+    @staticmethod
+    def _collect_ag_chain(ag_start: fx.Node) -> list[fx.Node]:
+        """Collect the AG chain from ``_pre_bucket_all_gather`` through
+        ``ag_start`` in topological order.
+
+        The bucketed AG pattern is always::
+
+            _pre_bucket_all_gather → slice → all_gather_into_tensor_out
+
+        Walk forward from the ``_pre_bucket_all_gather`` root, collecting
+        every node up to and including ``ag_start``.
+        """
+        root = ag_start
+        while root.op != "placeholder":
+            parents = [inp for inp in root.all_input_nodes if inp.op != "placeholder"]
+            if not parents:
+                break
+            root = parents[0]
+
+        chain: list[fx.Node] = [root]
+        chain_set: set[fx.Node] = {root}
+        i = 0
+        while i < len(chain):
+            for user in chain[i].users:
+                if user not in chain_set and all(
+                    inp in chain_set or inp.op == "placeholder"
+                    for inp in user.all_input_nodes
+                ):
+                    chain_set.add(user)
+                    chain.append(user)
+                    if user is ag_start:
+                        return chain
+            i += 1
+        return chain
+
+    @staticmethod
+    def _collect_forward_chain(start: fx.Node) -> list[fx.Node]:
+        """Collect ``start`` and all transitively dependent nodes whose
+        inputs are all within the chain, in BFS (topological) order.
+
+        For a bucketed RS wait this returns the ``wait_tensor``,
+        ``split_with_sizes``, ``getitem`` and ``view`` nodes — everything
+        in the unpack chain.
+        """
+        chain: list[fx.Node] = [start]
+        chain_set: set[fx.Node] = {start}
+        i = 0
+        while i < len(chain):
+            for user in chain[i].users:
+                if user not in chain_set and all(
+                    inp in chain_set for inp in user.all_input_nodes
+                ):
+                    chain_set.add(user)
+                    chain.append(user)
+            i += 1
+        return chain
 
     def _schedule_rs_prefetch(
         self,

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -170,41 +170,41 @@ def overlap_fsdp_ag_rs_pass(
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
     """
-    Reassign FSDP all-gather nodes to an extra NCCL process group for
+    Reassign FSDP all-gather nodes to extra NCCL process groups for
     AG/RS overlap in backward.
 
-    Discovers the FSDP PG by inspecting the graph, creates an extra
-    NCCL PG over the same ranks (giving it a separate CUDA stream),
-    and rewrites every all-gather using that source PG to the extra PG.
-    This separates all-gathers from reduce-scatters onto different streams,
-    enabling AG/RS overlap in backward.
+    Discovers all distinct FSDP PGs by inspecting the graph (e.g. one for
+    FSDP, another for expert-FSDP), creates an extra NCCL PG over the same
+    ranks for each (giving it a separate CUDA stream), and rewrites every
+    all-gather to the corresponding extra PG. This separates all-gathers
+    from reduce-scatters onto different streams, enabling AG/RS overlap in
+    backward.
 
     No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
     bucketing passes so bucketed all-gathers inherit the new PG name.
     """
-    source_pg_name: str | None = None
+    source_pg_names: OrderedSet[str] = OrderedSet()
     for node in gm.graph.nodes:
         if is_wait_tensor_from_fsdp(node):
             ag_node = node.args[0]
-            source_pg_name = ag_node.args[2]
-            break
+            source_pg_names.add(ag_node.args[2])
 
-    if source_pg_name is None:
+    if not source_pg_names:
         return gm
 
-    target_pg_name = _get_or_create_extra_fsdp_pg(source_pg_name)
+    pg_mapping: dict[str, str] = {
+        pg: _get_or_create_extra_fsdp_pg(pg) for pg in source_pg_names
+    }
 
     count = 0
     for node in gm.graph.nodes:
-        if is_all_gather(node) and node.args[2] == source_pg_name:
+        if is_all_gather(node) and node.args[2] in pg_mapping:
             # AG args: (input_tensor, group_size, group_name)
-            node.args = (node.args[0], node.args[1], target_pg_name)
+            node.args = (node.args[0], node.args[1], pg_mapping[node.args[2]])
             count += 1
     if count > 0:
-        logger.info(
-            f"Rewrote {count} all-gather node(s) from PG {source_pg_name} "
-            f"to PG {target_pg_name}"
-        )
+        for source, target in pg_mapping.items():
+            logger.info(f"Rewrote all-gather node(s) from PG {source} to PG {target}")
     gm.recompile()
     return gm
 

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -279,14 +279,11 @@ class JointManualOverlapScheduler:
         bucket_mode = bucket_mode or "custom_ops"
 
         self.nodes: list[fx.Node] = list(self.graph.nodes)
-        self.node_idx: dict[fx.Node, int] = {n: i for i, n in enumerate(self.nodes)}
         self.node_ancestors: dict[
             fx.Node, OrderedSet[fx.Node]
         ] = self._collect_node_ancestors()
 
         self.collective_info: dict[fx.Node, CollectiveInfo] = {}
-        self.wait_to_start: dict[fx.Node, fx.Node] = {}
-        self.unscheduled_collectives: OrderedSet[fx.Node] = OrderedSet()
         self._identify_collectives()
 
         self.in_degree: Counter[fx.Node] = Counter(
@@ -315,16 +312,13 @@ class JointManualOverlapScheduler:
         for node in self.nodes:
             if _schedulable_wait_node(node):
                 start = node.args[0]
-                info = CollectiveInfo(
+                self.collective_info[start] = CollectiveInfo(
                     start_node=start,
                     wait_node=node,
                     size_bytes=0,
                     estimated_time_ms=0,
                     exposed_time_ms=0,
                 )
-                self.collective_info[start] = info
-                self.wait_to_start[node] = start
-                self.unscheduled_collectives.add(start)
 
     def _obtain_nodes_in_subgraph(self) -> None:
         graph_view = make_graph_view(self.graph, self.module_stack_fn)

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -27,12 +27,17 @@ from torch._inductor.fx_passes.bucketing import (
     is_wait_tensor,
 )
 from torch._inductor.fx_passes.overlap_manual_scheduling import (
+    _schedulable_wait_node,
+    get_subgraph_by_path,
+    make_graph_view,
     manual_overlap_bucketing,
-    ManualOverlapScheduler,
+    ManualOverlapPreservingBucketer,
 )
 from torch._inductor.fx_passes.overlap_scheduling import (
+    CollectiveInfo,
     is_compute_node,
     schedule_overlap_bucketing,
+    stable_topological_sort,
 )
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
@@ -235,21 +240,15 @@ def transformer_block_bucketing_reordering_pass(
     return gm
 
 
-class JointManualOverlapScheduler(ManualOverlapScheduler):
+class JointManualOverlapScheduler:
     """Manual overlap scheduler for joint forward+backward graphs.
 
-    For the aot_fx_trace path we trace a joint forward+backward graph and
-    want to bucket + reorder both directions in a single pass over the
-    graph. This subclass of :class:`ManualOverlapScheduler` produces the
-    same bucketing and prefetch pattern as invoking the upstream
-    ``manual_overlap_bucketing`` twice (once per direction).
-
-    Overrides :meth:`_manual_bucket_collectives` to split each module's
-    collectives by direction before handing them to the bucketer.
-
-    Overrides :meth:`_manual_reorder_graph` to track per-direction state
-    so a single reversed walk emits correct AG prefetch edges for both
-    forward and backward regions.
+    Lightweight, standalone scheduler that buckets and reorders FSDP
+    collectives in a joint forward+backward FX graph.  Unlike the upstream
+    ``ManualOverlapScheduler`` (which inherits from ``OverlapScheduler``),
+    this class does **not** run ``gather_node_runtime_estimations`` or any
+    other expensive/fragile estimation in its constructor.  It only needs
+    the graph structure and collective identification — nothing more.
 
     The caller supplies:
 
@@ -271,14 +270,98 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]],
         bucket_mode: BucketMode | None = None,
     ) -> None:
-        super().__init__(
-            gm,
-            module_bucket_plans,
-            insert_overlap_deps,
-            module_stack_fn=module_stack_fn,
+        self.gm = gm
+        self.graph = gm.graph
+        self.insert_overlap_deps = insert_overlap_deps
+        self.module_bucket_plans = module_bucket_plans
+        self.module_stack_fn = module_stack_fn
+        self._is_backward_fn = is_backward_fn
+
+        bucket_mode = bucket_mode or "custom_ops"
+
+        stable_topological_sort(self.graph)
+        self.nodes: list[fx.Node] = list(self.graph.nodes)
+        self.node_idx: dict[fx.Node, int] = {n: i for i, n in enumerate(self.nodes)}
+        self.node_ancestors: dict[
+            fx.Node, OrderedSet[fx.Node]
+        ] = self._collect_node_ancestors()
+
+        self.collective_info: dict[fx.Node, CollectiveInfo] = {}
+        self.wait_to_start: dict[fx.Node, fx.Node] = {}
+        self.unscheduled_collectives: OrderedSet[fx.Node] = OrderedSet()
+        self._identify_collectives()
+
+        self.in_degree: Counter[fx.Node] = Counter(
+            user for node in self.nodes for user in node.users
+        )
+        self.on_path_ready: list[tuple[int, fx.Node]] = []
+        self.scheduled: OrderedSet[fx.Node] = OrderedSet()
+        self.nodes_in_subgraph: list[list[fx.Node]] = []
+
+        self.bucketer = ManualOverlapPreservingBucketer(
+            graph=self.graph,
+            collective_info=self.collective_info,
+            scheduled=OrderedSet(self.graph.nodes),
             bucket_mode=bucket_mode,
         )
-        self._is_backward_fn = is_backward_fn
+
+    def _collect_node_ancestors(self) -> dict[fx.Node, OrderedSet[fx.Node]]:
+        ancestors: dict[fx.Node, OrderedSet[fx.Node]] = defaultdict(OrderedSet)
+        for node in self.nodes:
+            for input_node in node.all_input_nodes:
+                ancestors[node].add(input_node)
+                ancestors[node] |= ancestors[input_node]
+        return ancestors
+
+    def _identify_collectives(self) -> None:
+        for node in self.nodes:
+            if _schedulable_wait_node(node):
+                start = node.args[0]
+                info = CollectiveInfo(
+                    start_node=start,
+                    wait_node=node,
+                    size_bytes=0,
+                    estimated_time_ms=0,
+                    exposed_time_ms=0,
+                )
+                self.collective_info[start] = info
+                self.wait_to_start[node] = start
+                self.unscheduled_collectives.add(start)
+
+    def _obtain_nodes_in_subgraph(self) -> None:
+        graph_view = make_graph_view(self.graph, self.module_stack_fn)
+        if graph_view is None:
+            return
+        for module in self.module_bucket_plans:
+            subgraph_view = get_subgraph_by_path(graph_view, module)
+            self.nodes_in_subgraph.append(subgraph_view)
+        all_subgraph_nodes = [
+            node for sublist in self.nodes_in_subgraph for node in sublist
+        ]
+        unique_subgraph_nodes = list(OrderedSet(all_subgraph_nodes))
+        assert len(all_subgraph_nodes) <= len(unique_subgraph_nodes), (
+            f"Overlapping FX nodes detected across subgraphs in "
+            f"`module_bucket_plans`. Expected disjoint node sets but found "
+            f"{len(all_subgraph_nodes) - len(unique_subgraph_nodes)} "
+            f"duplicated node(s)."
+        )
+
+    def _add_to_ready_queue(self, node: fx.Node) -> None:
+        heapq.heappush(self.on_path_ready, (self.node_idx[node], node))
+
+    def _schedule(self, node: fx.Node) -> None:
+        assert node not in self.scheduled
+        assert all(n in self.scheduled for n in node.all_input_nodes)
+        self.scheduled.add(node)
+        for user in node.users:
+            self.in_degree[user] -= 1
+            if self.in_degree[user] == 0:
+                self._add_to_ready_queue(user)
+
+    def run(self) -> fx.GraphModule:
+        self._manual_bucket_collectives()
+        self._manual_reorder_graph()
+        return self.gm
 
     def _manual_bucket_collectives(self) -> None:
         """Bucket per module, splitting by direction to keep fwd/bwd buckets disjoint."""
@@ -364,7 +447,7 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
 
         Uses separate fwd/bwd buffers so AG pairing never crosses the
         fwd/bwd boundary. Consumes ``self.scheduled`` produced by
-        :meth:`_emit_rs_prefetch`.
+        :meth:`_schedule_rs_prefetch`.
         """
         self.scheduled = OrderedSet(reversed(list(self.scheduled)))
 
@@ -398,18 +481,11 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
                 picked.clear()
 
             if is_compute_node(node):
-                # Track per-direction last_compute so orphan bwd all-gathers
-                # attach to a bwd-region compute and orphan fwd all-gathers
-                # attach to a fwd-region compute.
                 if is_bwd and node in bwd_scope:
                     bwd_last_compute = node
                 elif not is_bwd and node in fwd_scope:
                     fwd_last_compute = node
 
-        # Trailing block, applied once per direction. Attaches any orphan
-        # AG starts (those whose wait was not matched during the reversed
-        # walk of their direction) to the last compute in that direction,
-        # unless they are already an ancestor of it.
         self._apply_trailing_block(bwd_picked, bwd_last_compute, overlap_deps)
         self._apply_trailing_block(fwd_picked, fwd_last_compute, overlap_deps)
 


### PR DESCRIPTION
## Why
topological_sort is in overlap pass is problematic, it change the graph in a global way, and make it hard to compose with other passes. So I am trying to remove the topological sorts. 

Here's the effect of _manual_reorder_graph. 

Before: many nodes moved via topological sort
https://www.internalfb.com/intern/diffing/?paste_number=2323930952

After: only move what you need 
https://www.internalfb.com/intern/diffing/?paste_number=2324948763


## Summary
- Replace the `ManualOverlapScheduler` → `OverlapScheduler` inheritance chain with a lightweight standalone class that only sets up what it actually uses: graph structure, collective identification, bucketing, and scheduling. The upstream `OverlapScheduler.__init__` runs `gather_node_runtime_estimations` which breaks on `flex_attention` higher-order ops and is never used by the manual bucketing/reordering path.
- Replace `_stable_topological_sort` in `_manual_reorder_graph` with direct FX node moves using `Node.prepend()` and `Node.append()`. AG start chains are moved earlier for prefetch, RS wait chains are moved later for deferral — without re-sorting the entire graph.
- Remove unused attributes (`wait_to_start`, `unscheduled_collectives`, redundant `node_idx`) and the unused `insert_overlap_deps` parameter.
- Add tlparse dumps for before/after bucketing and reordering passes.

## Test plan
- [x] `bash run_graph_trainer_llama3_8b.sh` — DeepSeek-v3 16B compiles and runs step 1 successfully (graph.lint() passes after direct moves)
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x -k TestBucketingPrefetchOrder`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x`