### PR TITLE
[graph_trainer] Add bucketing ops to precompile serialization filter

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -36,6 +36,7 @@ def _ops_filter_with_distributed(name: str) -> bool:
             "torch.ops._c10d_functional",
             "torch.ops._dtensor",
             "torch.ops.device_mesh",
+            "torch.ops.bucketing",
         )
     )
 


### PR DESCRIPTION
Add ``torch.ops.bucketing`` to ``_ops_filter_with_distributed`` so that GraphPickler accepts the custom bucketing ops introduced by ``joint_transformer_block_bucketing_reordering_pass``. Without this, CooR precompile with regional_inductor fails with:

    BypassFxGraphCache: Unable to pickle non-standard op:
    torch.ops.bucketing._pre_bucket_reduce_scatter.default

Authored by Claude.