### PR TITLE
[graph_trainer] Defer cudagraph compatibility check to pass execution…

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -531,6 +531,13 @@ def cudagraph_pass(
             f"GraphModule (e.g. full_inductor_compilation)."
         )
 
+    if not is_cudagraph_compatible(gm):
+        logger.warning(
+            "Skipping cudagraph: graph is not compatible after all preceding "
+            "passes. Use --compile.disable_passes cudagraph_pass to silence."
+        )
+        return gm
+
     if static_input_indices is None:
         static_input_indices = get_static_input_indices(gm, is_forward)
     gm.forward = CUDAGraphWrapper(

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -230,21 +230,17 @@ def construct_default_graph_passes(
     When ``precompile_artifact_dir`` is set, the artifact has graph
     transformed during precompile phase, so only cudagraph is returned.
     """
-    from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
-
-    cudagraph_disabled = "cudagraph_pass" in config.compile.disable_passes
-    use_cudagraph = not cudagraph_disabled and is_cudagraph_compatible(traced_result.gm)
+    want_cudagraph = "cudagraph_pass" not in config.compile.disable_passes
 
     has_precompile_artifact = bool(config.compile.precompile_artifact_dir)
 
     passes: list[Callable] = []
     if not has_precompile_artifact:
         passes.extend(
-            compile_time_passes(traced_result, config, use_cudagraph=use_cudagraph)
+            compile_time_passes(traced_result, config, use_cudagraph=want_cudagraph)
         )
 
-    # cudagraph should be the last pass.
-    if use_cudagraph:
+    if want_cudagraph:
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(


### PR DESCRIPTION
… time

Previously, `construct_default_graph_passes` checked `is_cudagraph_compatible` on the pre-compilation graph to decide whether to include `cudagraph_pass` in the pipeline. This eagerly rejected graphs containing flex_attention higher-order ops, even when `regional_inductor` (which runs earlier in the pipeline) would compile those ops away before cudagraph capture.

Move the compatibility check into `cudagraph_pass` itself so it runs on the final graph state after all preceding passes. This separates user intent ("I want cudagraph" via config) from graph capability ("is the graph compatible" checked at runtime), and naturally handles any future pass that transforms incompatible ops before cudagraph.

The change is two parts:
- `cudagraph_pass`: validate the graph at the top; if incompatible, warn and return unchanged (no-op).
- `construct_default_graph_passes`: always plan for cudagraph when the user hasn't disabled it. Remove the eager `is_cudagraph_compatible` gate.

Tested locally: 8B Llama3 with flex_attention + regional_inductor + cudagraph completes 3 training steps at 25.3% MFU. Without this fix, cudagraph was silently skipped for this configuration.

Authored by Claude.