### PR TITLE
Fix optimizer state and module state coupling

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -310,21 +310,26 @@ def _reparametrize_train_state(
 ):
     """Reparametrize module and optimizer with explicit tensor state for tracing."""
     with contextlib.ExitStack() as stack:
-        if module is not None:
-            stack.enter_context(stateless._reparametrize_module(module, model_state))
         if optimizer is not None:
-            # swap_in_optimizer_params_and_state aligns swapin_parameters values
-            # with optimizer.param_groups by order, so pass only parameters (in
-            # module.named_parameters() order).
+            # swap_in pairs values positionally in optimizer.param_groups flat
+            # order, which differs from named_parameters() order for bucketed
+            # param_groups. Walk param_groups and resolve names by id() against
+            # the originals; must run before _reparametrize_module rebinds them.
+            id_to_name = {
+                id(p): n for n, p in module.named_parameters(remove_duplicate=False)
+            }
             params_for_optim = {
-                name: model_state[name]
-                for name, _ in module.named_parameters(remove_duplicate=False)
+                id_to_name[id(p)]: model_state[id_to_name[id(p)]]
+                for group in optimizer.param_groups
+                for p in group["params"]
             }
             stack.enter_context(
                 torch.optim.swap_in_optimizer_params_and_state(
                     optimizer, params_for_optim, optim_state
                 )
             )
+        if module is not None:
+            stack.enter_context(stateless._reparametrize_module(module, model_state))
         yield
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -6,6 +6,7 @@
 
 import unittest
 from collections import Counter
+from copy import deepcopy
 
 import torch
 import torch.nn as nn
@@ -724,6 +725,43 @@ class TestReparametrizeOptimizer(unittest.TestCase):
         self.assertEqual(list(inner.state.keys()), original_state_keys)
         for orig_ids, group in zip(original_param_ids, inner.param_groups, strict=True):
             self.assertEqual([id(p) for p in group["params"]], orig_ids)
+
+    def test_minimal_fx_tracer_with_bucketed_optimizer(self):
+        torch.manual_seed(0)
+        module = nn.Sequential(nn.Linear(3, 5), nn.ReLU(), nn.Linear(5, 7))
+        weights = [p for n, p in module.named_parameters() if n.endswith("weight")]
+        biases = [p for n, p in module.named_parameters() if n.endswith("bias")]
+        optimizer = torch.optim.AdamW(
+            [{"params": weights, "lr": 0.1}, {"params": biases, "lr": 0.01}]
+        )
+
+        x = torch.randn(2, 3)
+        module(x).sum().backward()
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+
+        def train_step(x):
+            optimizer.zero_grad(set_to_none=True)
+            module(x).sum().backward()
+            optimizer.step()
+            return torch.stack([p.detach().sum() for p in module.parameters()])
+
+        traced = minimal_fx_tracer(train_step, module=module, optimizer=optimizer)(x)
+
+        model_sd = deepcopy(module.state_dict())
+        optim_sd = deepcopy(optimizer.state_dict())
+
+        eager_out = train_step(x)
+        eager_params = [p.detach().clone() for p in module.parameters()]
+
+        module.load_state_dict(model_sd)
+        optimizer.load_state_dict(optim_sd)
+        traced_out = run_traced(traced, module=module, optimizer=optimizer)(x)
+        traced_params = [p.detach().clone() for p in module.parameters()]
+
+        self.assertTrue(torch.equal(eager_out, traced_out))
+        for ep, tp in zip(eager_params, traced_params, strict=True):
+            self.assertTrue(torch.equal(ep, tp))
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")


### PR DESCRIPTION
When we pass in the optimizer that was initialized via param groups, the flat order of optimizer param states don't align with module param orders. This PR fixes it by reordering the user supplied param order according to optimizer param order. 

We don't want to make swapin_optim_state too complicated, hence doing the reordering outside of it. 