### PR TITLE
[graph_trainer] Add DeepSeek V3 16B SDPA config

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -66,6 +66,12 @@ def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_16b_sdpa() -> GraphTrainer.Config:
+    config = graph_trainer_deepseek_v3_16b()
+    config.model_spec = model_registry("16B", attn_backend="sdpa")
+    return config
+
+
 def graph_trainer_deepseek_v3_671b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_671b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)


### PR DESCRIPTION
Stacked PRs:
 * #3328
 * #3325
 * #3363
 * #3362
 * #3369
 * __->__#3361


--- --- ---

### [graph_trainer] Add DeepSeek V3 16B SDPA config


Add a graph_trainer DeepSeek V3 16B config that selects the SDPA attention backend. This complements the existing 16B FlexAttention graph_trainer config and gives performance and validation runs an explicit SDPA entry point.

Test Plan:\n- Not run; registry-only config addition.
