### PR TITLE
[graph_trainer] Add EP overlap eager chunking scaffolding

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import fnmatch
 import time
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -21,6 +22,7 @@ from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,
 )
+from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.tools.logging import logger
 
 
@@ -71,13 +73,17 @@ def _is_backward_node(node: torch.fx.Node) -> bool:
     return node.meta.get("autograd_backward", False)
 
 
+def _get_module_fqn(node: torch.fx.Node) -> str:
+    return node.meta.get("custom", {}).get(_MODULE_FQN, "")
+
+
 def _get_layer_id(node: torch.fx.Node) -> int:
     """Extract the layer index from the node's module_fqn metadata.
 
     Nodes under ``layers.<N>`` return ``N``.
     All other nodes (tok_embeddings, norm, output) return ``_NOT_IN_LAYERS``.
     """
-    fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+    fqn = _get_module_fqn(node)
     parts = fqn.split(".")
     if parts[0] == "layers" and len(parts) >= 2:
         try:
@@ -99,6 +105,47 @@ def annotate_module_fqns(model: nn.Module) -> None:
     for fqn, submodule in model.named_modules():
         if fqn:  # skip root module
             submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
+
+
+def matches_module_fqn_pattern(pattern: str, fqn: str) -> bool:
+    """Match one module FQN against a component-wise fnmatch pattern."""
+    pattern_parts = pattern.split(".")
+    fqn_parts = fqn.split(".")
+    return len(pattern_parts) == len(fqn_parts) and all(
+        fnmatch.fnmatchcase(fqn_part, pattern_part)
+        for pattern_part, fqn_part in zip(pattern_parts, fqn_parts)
+    )
+
+
+_MOE_EP_REGIONS_ANNOTATED = False
+
+
+def annotate_moe_ep_regions() -> None:
+    """Annotate MoE EP compute, dispatch, and combine regions for FX passes."""
+    global _MOE_EP_REGIONS_ANNOTATED
+    if _MOE_EP_REGIONS_ANNOTATED:
+        return
+
+    from torchtitan.models.common.moe import MoE
+    from torchtitan.models.common.token_dispatcher import (
+        AllToAllTokenDispatcher,
+        LocalTokenDispatcher,
+    )
+
+    LocalTokenDispatcher.dispatch = annotate_fn({"EP": "dispatch"})(
+        LocalTokenDispatcher.dispatch
+    )
+    LocalTokenDispatcher.combine = annotate_fn({"EP": "combine"})(
+        LocalTokenDispatcher.combine
+    )
+    AllToAllTokenDispatcher.dispatch = annotate_fn({"EP": "dispatch"})(
+        AllToAllTokenDispatcher.dispatch
+    )
+    AllToAllTokenDispatcher.combine = annotate_fn({"EP": "combine"})(
+        AllToAllTokenDispatcher.combine
+    )
+    MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
+    _MOE_EP_REGIONS_ANNOTATED = True
 
 
 def parallelize_inputs(parallel_dims, args, kwargs):
@@ -249,7 +296,7 @@ def apply_simple_fsdp(
         reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
     )
 
-    if parallel_dims.ep_enabled and hasattr(model, "layers"):
+    if parallel_dims.ep_enabled and isinstance(model, Decoder):
         edp_mesh_names = (
             ["dp_replicate", "efsdp"]
             if parallel_dims.dp_replicate_enabled
@@ -259,18 +306,17 @@ def apply_simple_fsdp(
         assert edp_mesh is not None
 
         for _, transformer_block in model.layers.items():
-            if not getattr(transformer_block, "moe_enabled", False):
+            if not isinstance(transformer_block, TransformerBlock):
                 continue
-            assert hasattr(transformer_block, "moe")
+            moe = getattr(transformer_block, "moe", None)
+            if moe is None:
+                continue
             experts_shard_dim = 0
-            if (
-                edp_mesh["efsdp"].size() * parallel_dims.ep
-                > transformer_block.moe.experts.num_experts
-            ):
+            if edp_mesh["efsdp"].size() * parallel_dims.ep > moe.experts.num_experts:
                 experts_shard_dim = 1
 
-            transformer_block.moe.experts = data_parallel(
-                transformer_block.moe.experts,
+            moe.experts = data_parallel(
+                moe.experts,
                 edp_mesh,
                 dp_mode,
                 mp_policy=mp_policy,

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -17,6 +17,44 @@ from torchtitan.experiments.graph_trainer.chunked_loss import (
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
 
+EpOverlapChunkDim = Literal["batch", "seq"]
+EpOverlapChunkStrategy = Literal["eager", "graph"]
+
+TRANSFORMER_BLOCK_FQN = "layers.*"
+MOE_BLOCK_FQN = "layers.*.moe"
+SUPPORTED_EP_OVERLAP_MODULE_FQNS = frozenset({TRANSFORMER_BLOCK_FQN, MOE_BLOCK_FQN})
+
+
+@dataclass(kw_only=True, slots=True)
+class EpOverlapConfig:
+    enabled: bool = False
+    """Enable EP-overlap support for the selected chunking and scheduling mode."""
+
+    chunk_dim: EpOverlapChunkDim = "batch"
+    """Logical input dimension to split for EP-overlap chunking.
+
+    Sequence chunking is only supported for MoE block roots because attention
+    requires full K/V context.
+    """
+
+    strategy: EpOverlapChunkStrategy = "graph"
+    """How selected EP-overlap regions are chunked before scheduling.
+
+    ``eager`` wraps module forwards before tracing. ``graph`` traces the
+    unmodified model and chunks selected regions with an FX graph pass.
+    """
+
+    module_fqn: str = TRANSFORMER_BLOCK_FQN
+    """Single module FQN pattern chunked for EP overlap.
+
+    v1 supports all transformer blocks (``layers.*``) or all MoE blocks
+    (``layers.*.moe``). The overlap scheduler consumes the common chunk metadata
+    produced by either eager or graph chunking.
+    """
+
+    disable_early_grad_accumulation: bool = False
+    """Disable the scheduler optimization that accumulates chunk gradients early."""
+
 
 @dataclass(kw_only=True, slots=True)
 class GraphTrainerCompileConfig(CompileConfig):
@@ -31,7 +69,7 @@ class GraphTrainerCompileConfig(CompileConfig):
 
     passes: list[str] = field(default_factory=list)
     """
-    Compiler pass names to apply.
+    Additional compiler pass names to apply.
     In JIT mode: applied as graph passes (e.g., auto_bucketing, transformer_block_bucketing)
     """
 
@@ -95,6 +133,9 @@ class GraphTrainerCompileConfig(CompileConfig):
     two collectives can overlap. It is a no-op when the graph contains no
     FSDP all-gathers."""
 
+    ep_overlap: EpOverlapConfig = field(default_factory=EpOverlapConfig)
+    """Configuration for EP-overlap chunking and scheduling."""
+
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:
@@ -116,6 +157,53 @@ def validate_autoparallel_config(
             "AutoParallel graph_trainer integration only supports "
             "--compile.mode aot_fx_trace"
         )
+
+
+def validate_ep_overlap_config(
+    ep_overlap_config: EpOverlapConfig,
+) -> tuple[EpOverlapChunkDim, EpOverlapChunkStrategy, str]:
+    chunk_dim = ep_overlap_config.chunk_dim
+    if chunk_dim not in ("batch", "seq"):
+        raise ValueError(
+            "--compile.ep_overlap.chunk_dim must be 'batch' or 'seq' when "
+            "--compile.ep_overlap.enabled is set"
+        )
+
+    chunk_strategy = ep_overlap_config.strategy
+    if chunk_strategy not in ("eager", "graph"):
+        raise ValueError(
+            "--compile.ep_overlap.strategy must be 'eager' or 'graph' when "
+            "--compile.ep_overlap.enabled is set"
+        )
+
+    module_fqn = ep_overlap_config.module_fqn
+    if module_fqn not in SUPPORTED_EP_OVERLAP_MODULE_FQNS:
+        raise ValueError(
+            "--compile.ep_overlap.module_fqn must be either 'layers.*' "
+            "or 'layers.*.moe' for ep_overlap"
+        )
+    if chunk_dim == "seq" and module_fqn != MOE_BLOCK_FQN:
+        raise ValueError(
+            "--compile.ep_overlap.chunk_dim seq is only supported with "
+            "--compile.ep_overlap.module_fqn layers.*.moe"
+        )
+
+    return chunk_dim, chunk_strategy, module_fqn
+
+
+def trace_input_preparer_keys(
+    compile_config: GraphTrainerCompileConfig,
+) -> list[str]:
+    """Return feature names whose trace-input hooks should run.
+
+    ``compile.passes`` remains the escape hatch for standalone graph passes.
+    EP overlap has structured config because enabling it also controls eager
+    module wrapping and later scheduling behavior.
+    """
+    names = list(compile_config.passes)
+    if compile_config.ep_overlap.enabled:
+        names.append("ep_overlap")
+    return list(dict.fromkeys(names))
 
 
 def to_graph_trainer_config(

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -4,20 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.fx.traceback import annotate_fn
-
-from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.config import ParallelismConfig, TrainingConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    annotate_moe_ep_regions,
     apply_cp_to_attention,
     apply_simple_fsdp,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
+)
+from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
+    maybe_apply_ep_overlap_eager_chunking,
 )
 from torchtitan.tools.logging import logger
 
@@ -31,17 +34,7 @@ def annotate_deepseekv3(model: GraphTrainerDeepSeekV3Model) -> None:
       fully-qualified name for downstream passes (bucketing, SAC region
       boundaries, etc.).
     """
-    from torchtitan.models.common.moe import MoE
-    from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher
-
-    LocalTokenDispatcher.dispatch = annotate_fn({"EP": "dispatch"})(
-        LocalTokenDispatcher.dispatch
-    )
-    LocalTokenDispatcher.combine = annotate_fn({"EP": "combine"})(
-        LocalTokenDispatcher.combine
-    )
-    MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
-
+    annotate_moe_ep_regions()
     annotate_module_fqns(model)
 
 
@@ -51,7 +44,7 @@ def parallelize_deepseekv3(
     parallel_dims: ParallelDims,
     training: TrainingConfig,
     parallelism: ParallelismConfig,
-    compile_config: CompileConfig,
+    compile_config: GraphTrainerCompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ):
@@ -92,6 +85,7 @@ def parallelize_deepseekv3(
     # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
     # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
     model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+    maybe_apply_ep_overlap_eager_chunking(model, compile_config)
 
     # TODO: HybridEP applies to other sparse models (e.g. Qwen3). Refactor
     # the common HybridEP buffer init into a shared utility.

--- a/torchtitan/experiments/graph_trainer/ep_eager_chunk.py
+++ b/torchtitan/experiments/graph_trainer/ep_eager_chunk.py
@@ -1,0 +1,423 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Eager producer for the EP-overlap chunk metadata contract.
+
+Eager chunking is intentionally narrow: it supports the model input contracts
+used by ``layers.*`` TransformerBlock roots and ``layers.*.moe`` MoE roots, and
+fails loudly if those upstream forward signatures drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.fx.traceback import annotate_fn
+
+from torchtitan.experiments.graph_trainer.common_utils import matches_module_fqn_pattern
+from torchtitan.experiments.graph_trainer.configs import (
+    EpOverlapChunkDim,
+    GraphTrainerCompileConfig,
+    MOE_BLOCK_FQN,
+    TRANSFORMER_BLOCK_FQN,
+    validate_ep_overlap_config,
+)
+from torchtitan.models.common.decoder import TransformerBlock
+from torchtitan.tools.logging import logger
+
+
+def _chunk_dim_index(mode: EpOverlapChunkDim) -> int:
+    """Map logical EP chunk mode to the tensor dimension used by eager wrappers."""
+    return 0 if mode == "batch" else 1
+
+
+def _cat_chunked_outputs(outputs: list[Any], dim: int, root_fqn: str) -> Any:
+    """Recursively cat Tensor outputs while preserving tuple/list structure."""
+    first = outputs[0]
+    if isinstance(first, torch.Tensor):
+        return torch.cat(outputs, dim=dim)
+    if isinstance(first, tuple):
+        if any(
+            not isinstance(output, tuple) or len(output) != len(first)
+            for output in outputs
+        ):
+            raise TypeError(
+                "ep_overlap eager chunking expected matching tuple outputs "
+                f"for {root_fqn!r}"
+            )
+        return tuple(
+            _cat_chunked_outputs([output[i] for output in outputs], dim, root_fqn)
+            for i in range(len(first))
+        )
+    if isinstance(first, list):
+        if any(
+            not isinstance(output, list) or len(output) != len(first)
+            for output in outputs
+        ):
+            raise TypeError(
+                "ep_overlap eager chunking expected matching list outputs "
+                f"for {root_fqn!r}"
+            )
+        return [
+            _cat_chunked_outputs([output[i] for output in outputs], dim, root_fqn)
+            for i in range(len(first))
+        ]
+    raise TypeError(
+        "ep_overlap eager chunking only supports Tensor, tuple, or list outputs "
+        f"for {root_fqn!r}; got {type(first).__name__}"
+    )
+
+
+def _describe_value(value: Any) -> str:
+    if isinstance(value, torch.Tensor):
+        return (
+            f"Tensor(shape={tuple(value.shape)}, dtype={value.dtype}, "
+            f"device={value.device})"
+        )
+    if isinstance(value, dict):
+        items = ", ".join(
+            f"{key!r}: {_describe_value(item)}" for key, item in value.items()
+        )
+        return f"dict({{{items}}})"
+    return type(value).__name__
+
+
+def _describe_inputs(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    arg_desc = ", ".join(_describe_value(arg) for arg in args)
+    kwarg_desc = ", ".join(
+        f"{key}={_describe_value(value)}" for key, value in kwargs.items()
+    )
+    return f"args=[{arg_desc}], kwargs={{{kwarg_desc}}}"
+
+
+def _expected_contract(root_kind: str) -> str:
+    if root_kind == "moe":
+        return "MoE.forward(x_BLD: Tensor[B, L, D])"
+    return (
+        "TransformerBlock.forward(x: Tensor[B, L, D], "
+        "attention_masks: BlockMask|dict[BlockMask]|None, "
+        "positions: Tensor[B, L]|None)"
+    )
+
+
+def _contract_error(
+    *,
+    root_fqn: str,
+    root_kind: str,
+    chunk_dim: EpOverlapChunkDim,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    reason: str,
+) -> ValueError:
+    return ValueError(
+        "ep_overlap eager chunking only supports the current "
+        f"{_expected_contract(root_kind)} contract for root {root_fqn!r} "
+        f"with chunk_dim={chunk_dim!r}. {reason}. Observed "
+        f"{_describe_inputs(args, kwargs)}. If this is a real model path, "
+        "the upstream MoE.forward or TransformerBlock.forward contract likely "
+        "changed and the eager EP chunking wrapper must be updated."
+    )
+
+
+class _EagerChunkedForward:
+    def __init__(
+        self,
+        inner_forward: Callable[..., Any],
+        *,
+        root_fqn: str,
+        chunk_dim: EpOverlapChunkDim,
+        root_kind: str,
+    ) -> None:
+        self.inner_forward = inner_forward
+        self.root_fqn = root_fqn
+        self.chunk_dim = chunk_dim
+        self.root_kind = root_kind
+        self.dim = _chunk_dim_index(chunk_dim)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        def split_block_mask(value: Any) -> list[Any] | None:
+            from torch.nn.attention.flex_attention import BlockMask
+
+            if isinstance(value, BlockMask):
+                from torch.distributed.pipelining.microbatch import _split_block_mask
+
+                # Pipeline microbatching owns the BlockMask metadata splitting
+                # logic, including batch-index offsetting inside mask_mod.
+                return _split_block_mask(value, 2)
+            if isinstance(value, dict) and any(
+                isinstance(item, BlockMask) for item in value.values()
+            ):
+                split_items = {
+                    key: split_block_mask(item) or [item, item]
+                    for key, item in value.items()
+                }
+                return [
+                    {key: chunks[chunk_id] for key, chunks in split_items.items()}
+                    for chunk_id in (0, 1)
+                ]
+            return None
+
+        def split_tensor(
+            value: torch.Tensor, *, logical_name: str
+        ) -> list[torch.Tensor]:
+            if value.dim() <= self.dim:
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason=(
+                        f"{logical_name} rank must include selected dim {self.dim}"
+                    ),
+                )
+            full_extent = value.shape[self.dim]
+            torch._check(
+                full_extent % 2 == 0,
+                lambda: (
+                    f"ep_overlap eager chunking requires an even {self.chunk_dim} "
+                    f"extent for {logical_name} in {self.root_fqn!r}, "
+                    f"got {full_extent}"
+                ),
+            )
+            chunk_extent = full_extent // 2
+            split = annotate_fn(
+                {
+                    "chunked_region_fqn": self.root_fqn,
+                    "chunked_region_role": "split_boundary",
+                }
+            )(torch.split)
+            # MoE blocks flatten activations with view(); seq chunks are
+            # non-contiguous views, so materialize the chunk boundary.
+            return [
+                chunk.contiguous()
+                for chunk in split(value, [chunk_extent, chunk_extent], dim=self.dim)
+            ]
+
+        def split_moe_inputs() -> tuple[list[list[Any]], dict[str, list[Any]]]:
+            if len(args) != 1 or kwargs or not isinstance(args[0], torch.Tensor):
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="expected exactly one positional activation tensor",
+                )
+            return [split_tensor(args[0], logical_name="x_BLD")], {}
+
+        def split_transformer_block_inputs() -> tuple[
+            list[list[Any]], dict[str, list[Any]]
+        ]:
+            if self.chunk_dim != "batch":
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="TransformerBlock eager chunking only supports batch chunking",
+                )
+            if not args or len(args) > 3 or not isinstance(args[0], torch.Tensor):
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason=(
+                        "expected positional x tensor followed by optional "
+                        "attention_masks and positions"
+                    ),
+                )
+            if any(key not in ("attention_masks", "positions") for key in kwargs):
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="unexpected keyword argument",
+                )
+            if len(args) > 1 and "attention_masks" in kwargs:
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="attention_masks was passed both positionally and by keyword",
+                )
+            if len(args) > 2 and "positions" in kwargs:
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="positions was passed both positionally and by keyword",
+                )
+
+            def split_attention_masks(value: Any) -> list[Any]:
+                if value is None:
+                    return [None, None]
+                chunks = split_block_mask(value)
+                if chunks is not None:
+                    return chunks
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason=(
+                        "attention_masks must be None, BlockMask, or dict "
+                        "containing BlockMask"
+                    ),
+                )
+
+            def split_positions(value: Any) -> list[Any]:
+                if value is None:
+                    return [None, None]
+                if isinstance(value, torch.Tensor):
+                    return split_tensor(value, logical_name="positions")
+                raise _contract_error(
+                    root_fqn=self.root_fqn,
+                    root_kind=self.root_kind,
+                    chunk_dim=self.chunk_dim,
+                    args=args,
+                    kwargs=kwargs,
+                    reason="positions must be None or a tensor",
+                )
+
+            split_args = [split_tensor(args[0], logical_name="x")]
+            if len(args) > 1:
+                split_args.append(split_attention_masks(args[1]))
+            if len(args) > 2:
+                split_args.append(split_positions(args[2]))
+            split_kwargs = {
+                key: (
+                    split_attention_masks(value)
+                    if key == "attention_masks"
+                    else split_positions(value)
+                )
+                for key, value in kwargs.items()
+            }
+            return split_args, split_kwargs
+
+        if self.root_kind == "moe":
+            split_args, split_kwargs = split_moe_inputs()
+        else:
+            split_args, split_kwargs = split_transformer_block_inputs()
+
+        outputs = []
+        for chunk_id in (0, 1):
+            body = annotate_fn(
+                {
+                    "chunk_id": chunk_id,
+                    "chunked_region_fqn": self.root_fqn,
+                    "chunked_region_role": "body",
+                }
+            )(self.inner_forward)
+            outputs.append(
+                body(
+                    *(chunks[chunk_id] for chunks in split_args),
+                    **{key: chunks[chunk_id] for key, chunks in split_kwargs.items()},
+                )
+            )
+
+        materialize = annotate_fn(
+            {
+                "chunked_region_fqn": self.root_fqn,
+                "chunked_region_role": "materialization",
+            }
+        )(_cat_chunked_outputs)
+        return materialize(outputs, self.dim, self.root_fqn)
+
+
+def _wrap_forward_with_eager_chunking(
+    module: nn.Module,
+    *,
+    root_fqn: str,
+    chunk_dim: EpOverlapChunkDim,
+    root_kind: str,
+) -> None:
+    """Install an idempotent two-chunk forward wrapper on ``module``."""
+    if isinstance(module.forward, _EagerChunkedForward):
+        return
+
+    module.forward = _EagerChunkedForward(
+        module.forward,
+        root_fqn=root_fqn,
+        chunk_dim=chunk_dim,
+        root_kind=root_kind,
+    )
+    logger.debug("Installed eager EP chunk wrapper on %s", root_fqn)
+
+
+def maybe_apply_ep_overlap_eager_chunking(
+    model: nn.Module,
+    compile_config: GraphTrainerCompileConfig,
+) -> None:
+    """Wrap selected module forwards so tracing observes eager chunking."""
+    if not compile_config.enable or not compile_config.ep_overlap.enabled:
+        return
+    chunk_dim, chunk_strategy, module_fqn = validate_ep_overlap_config(
+        compile_config.ep_overlap
+    )
+    if chunk_strategy != "eager":
+        return
+
+    root_kind = "moe" if module_fqn == MOE_BLOCK_FQN else "transformer_block"
+    matched: list[str] = []
+    for fqn, module in model.named_modules():
+        if matches_module_fqn_pattern(module_fqn, fqn):
+            if (
+                module_fqn == TRANSFORMER_BLOCK_FQN
+                and isinstance(module, TransformerBlock)
+                and getattr(module, "moe", None) is None
+            ):
+                continue
+            _wrap_forward_with_eager_chunking(
+                module,
+                root_fqn=fqn,
+                chunk_dim=chunk_dim,
+                root_kind=root_kind,
+            )
+            matched.append(fqn)
+    if not matched:
+        raise ValueError(f"ep_overlap eager chunking matched no modules: {module_fqn}")
+    logger.info(
+        "Applied eager EP chunking to %d module(s): pattern=%s, chunk_dim=%s",
+        len(matched),
+        module_fqn,
+        chunk_dim,
+    )
+
+
+def populate_eager_chunk_metadata_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+) -> torch.fx.GraphModule:
+    """Promote eager traceback chunk annotations into pass metadata."""
+    del example_inputs
+    imported = 0
+    for node in gm.graph.nodes:
+        custom = node.meta.get("custom")
+        if not isinstance(custom, dict):
+            continue
+        for key in ("chunk_id", "chunked_region_fqn", "chunked_region_role"):
+            if key in custom:
+                node.meta[key] = custom[key]
+        if "chunked_region_role" in node.meta:
+            node.meta["chunked_region_producer"] = "eager"
+            imported += 1
+    if imported:
+        logger.debug("Populated eager EP chunk metadata for %d node(s)", imported)
+    return gm

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -336,6 +336,12 @@ def minimal_fx_tracer(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
+    prepare_inputs: Callable[[tuple[Any, ...], dict[str, Any]], None] | None = None,
+    prepare_call_inputs: Callable[
+        [tuple[Any, ...], dict[str, Any]],
+        tuple[tuple[Any, ...], dict[str, Any]] | None,
+    ]
+    | None = None,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
     """Return a tracer that captures ``fn`` with implicit module/optimizer state.
@@ -377,6 +383,9 @@ def minimal_fx_tracer(
     _check_optimizer_has_module(module, optimizer)
 
     def _trace_with_args(*args: Any, **kwargs: Any) -> TracedResult:
+        if prepare_inputs is not None:
+            prepare_inputs(args, kwargs)
+
         model_state, optim_state = extract_train_state(module, optimizer)
         state_fqns = list(model_state.keys())
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -31,6 +31,8 @@ from collections.abc import Callable
 
 import torch
 
+from torchtitan.experiments.graph_trainer.configs import validate_ep_overlap_config
+
 from torchtitan.experiments.graph_trainer.cpu_offload import apply_cpu_offload_pass
 from torchtitan.experiments.graph_trainer.cudagraph import (
     cudagraph_pass,
@@ -40,6 +42,9 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
     snapshot_graph,
     tlparse_log_graph_pass,
+)
+from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
+    populate_eager_chunk_metadata_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     get_fsdp_param_module_order,
@@ -137,31 +142,41 @@ def compile_time_passes(
     passes: list[Callable] = [
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
-        functools.partial(
-            tag_with_memory_policy_pass,
-            config=config,
-        ),
-        functools.partial(
-            apply_cpu_offload_pass,
-            prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
-            defer_n_layers=config.compile.cpu_offload_defer_n_layers,
-        ),
-        selective_activation_remat_pass,
-        # Run before bucketing so bucketed collectives inherit the dedicated PG.
-        reassign_collective_pgs_pass,
-        functools.partial(
-            joint_transformer_block_bucketing_reordering_pass,
-            module_bucket_plans=get_default_transformer_block_buckets(
-                n_layers,
-                chunked_loss_enabled=uses_chunked_loss,
-            ),
-            # FSDP2 packs buckets in managed parameter order. The traced state
-            # FQNs preserve that registration order, unlike graph execution order.
-            fsdp_param_module_order=get_fsdp_param_module_order(
-                traced_result.state_fqns
-            ),
-        ),
     ]
+    if config.compile.ep_overlap.enabled:
+        _overlap_dim, chunk_strategy, _module_fqn = validate_ep_overlap_config(
+            config.compile.ep_overlap
+        )
+        if chunk_strategy == "eager":
+            passes.append(populate_eager_chunk_metadata_pass)
+    passes.extend(
+        [
+            functools.partial(
+                tag_with_memory_policy_pass,
+                config=config,
+            ),
+            functools.partial(
+                apply_cpu_offload_pass,
+                prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
+                defer_n_layers=config.compile.cpu_offload_defer_n_layers,
+            ),
+            selective_activation_remat_pass,
+            # Run before bucketing so bucketed collectives inherit the dedicated PG.
+            reassign_collective_pgs_pass,
+            functools.partial(
+                joint_transformer_block_bucketing_reordering_pass,
+                module_bucket_plans=get_default_transformer_block_buckets(
+                    n_layers,
+                    chunked_loss_enabled=uses_chunked_loss,
+                ),
+                # FSDP2 packs buckets in managed parameter order. The traced state
+                # FQNs preserve that registration order, unlike graph execution order.
+                fsdp_param_module_order=get_fsdp_param_module_order(
+                    traced_result.state_fqns
+                ),
+            ),
+        ]
+    )
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -54,6 +54,23 @@ def compute_config_fingerprint(
     h.update(f"compile:mode:{compile_config.mode}\n".encode())
     h.update(f"compile:backend:{compile_config.backend}\n".encode())
     h.update(f"compile:passes:{list(compile_config.passes)}\n".encode())
+    h.update(
+        f"compile:ep_overlap:enabled:{compile_config.ep_overlap.enabled}\n".encode()
+    )
+    h.update(
+        f"compile:ep_overlap:chunk_dim:{compile_config.ep_overlap.chunk_dim}\n".encode()
+    )
+    h.update(
+        "compile:ep_overlap:strategy:"
+        f"{compile_config.ep_overlap.strategy}\n".encode()
+    )
+    h.update(
+        f"compile:ep_overlap:module_fqn:{compile_config.ep_overlap.module_fqn}\n".encode()
+    )
+    h.update(
+        "compile:ep_overlap:disable_early_grad_accumulation:"
+        f"{compile_config.ep_overlap.disable_early_grad_accumulation}\n".encode()
+    )
 
     h.update(f"torch_version:{torch.__version__}\n".encode())
 

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -4,18 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.fx.traceback import annotate_fn
-
-from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.config import ParallelismConfig, TrainingConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
+    annotate_moe_ep_regions,
     apply_cp_to_attention,
     apply_simple_fsdp,
 )
 from torchtitan.experiments.graph_trainer.compile import apply_compile
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
+    maybe_apply_ep_overlap_eager_chunking,
+)
 from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
 
 
@@ -30,16 +33,7 @@ def annotate_qwen3(model: GraphTrainerQwen3Model) -> None:
     """
     # Annotate MoE EP regions if any layer has MoE enabled
     if any(layer.moe is not None for layer in model.config.layers):
-        from torchtitan.models.common.moe import MoE
-        from torchtitan.models.common.token_dispatcher import LocalTokenDispatcher
-
-        LocalTokenDispatcher.dispatch = annotate_fn({"EP": "dispatch"})(
-            LocalTokenDispatcher.dispatch
-        )
-        LocalTokenDispatcher.combine = annotate_fn({"EP": "combine"})(
-            LocalTokenDispatcher.combine
-        )
-        MoE.forward = annotate_fn({"EP": "compute"})(MoE.forward)
+        annotate_moe_ep_regions()
 
     annotate_module_fqns(model)
 
@@ -50,7 +44,7 @@ def parallelize_qwen3(
     parallel_dims: ParallelDims,
     training: TrainingConfig,
     parallelism: ParallelismConfig,
-    compile_config: CompileConfig,
+    compile_config: GraphTrainerCompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ):
@@ -83,6 +77,7 @@ def parallelize_qwen3(
     # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
     # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.
     model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+    maybe_apply_ep_overlap_eager_chunking(model, compile_config)
 
     # Apply compilation based on mode
     model = apply_compile(

--- a/torchtitan/experiments/graph_trainer/registry.py
+++ b/torchtitan/experiments/graph_trainer/registry.py
@@ -42,8 +42,10 @@ MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
 PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
 POST_INIT_HOOKS: dict[str, Callable] = {}
 PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
+TRACE_INPUT_PREPARERS: dict[str, Callable] = {}
 
 register_memory_policy = _make_registry_decorator(MEMORY_POLICY_REGISTRY)
 register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
 register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
 register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)
+register_trace_input_preparer = _make_registry_decorator(TRACE_INPUT_PREPARERS)

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -12,6 +12,10 @@ import torch.nn as nn
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.distributed.utils import get_train_context
+from torchtitan.experiments.graph_trainer.configs import (
+    EpOverlapConfig,
+    GraphTrainerCompileConfig,
+)
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.trainer import Trainer
 
@@ -24,6 +28,13 @@ def build_minimal_trainer(
     activation_checkpoint_mode: str = "none",
     compile_enable_passes: bool = True,
     compile_passes: list[str] | None = None,
+    compile_ep_overlap_enabled: bool = False,
+    compile_ep_overlap_chunk_dim: str = "batch",
+    compile_ep_overlap_chunk_strategy: str = "graph",
+    compile_ep_overlap_module_fqn: str = "layers.*",
+    compile_ep_overlap_disable_early_grad_accumulation: bool = False,
+    compile_inductor_compilation: str = "regional",
+    compile_disable_passes: list[str] | None = None,
     compile_numerics_changing_optim: bool = False,
     tokenizer=None,
     fsdp_reshard_after_forward: str = "default",
@@ -41,20 +52,27 @@ def build_minimal_trainer(
 
     if trainer_cls is GraphTrainer:
         trainer.config = SimpleNamespace(
-            compile=SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                enable=True,
                 mode="aot_fx_trace",
                 enable_passes=compile_enable_passes,
                 passes=[] if compile_passes is None else list(compile_passes),
-                precompile_artifact_dir="",
-                memory_policy="default",
-                pass_pipeline="default",
-                inductor_compilation="regional",
+                disable_passes=(
+                    []
+                    if compile_disable_passes is None
+                    else list(compile_disable_passes)
+                ),
+                inductor_compilation=compile_inductor_compilation,
                 numerics_changing_optim=compile_numerics_changing_optim,
-                disable_passes=[],
-                debug_graph_passes=False,
-                cpu_offload_prefetch_n_layers=1,
-                cpu_offload_defer_n_layers=1,
-                cpu_offload_budget_gb=100.0,
+                ep_overlap=EpOverlapConfig(
+                    enabled=compile_ep_overlap_enabled,
+                    chunk_dim=compile_ep_overlap_chunk_dim,
+                    strategy=compile_ep_overlap_chunk_strategy,
+                    module_fqn=compile_ep_overlap_module_fqn,
+                    disable_early_grad_accumulation=(
+                        compile_ep_overlap_disable_early_grad_accumulation
+                    ),
+                ),
             ),
             model_spec=SimpleNamespace(model=model_config),
             activation_checkpoint={

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -28,10 +28,18 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
     annotate_module_fqns,
 )
+from torchtitan.experiments.graph_trainer.configs import (
+    EpOverlapConfig,
+    GraphTrainerCompileConfig,
+)
 from torchtitan.experiments.graph_trainer.cudagraph import (
     insert_kernel_annotations_pass,
     is_cudagraphable,
     is_full_cudagraphable,
+)
+from torchtitan.experiments.graph_trainer.ep_eager_chunk import (
+    maybe_apply_ep_overlap_eager_chunking,
+    populate_eager_chunk_metadata_pass,
 )
 from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
@@ -2405,6 +2413,276 @@ class TestIsFullCudagraphable(TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), g)
         self.assertFalse(is_cudagraphable(s))
         self.assertFalse(is_full_cudagraphable(gm))
+
+
+class TestEagerChunking(TestCase):
+    def _config(
+        self,
+        *,
+        chunk_dim: str = "batch",
+        module_fqn: str = "layers.*",
+    ) -> GraphTrainerCompileConfig:
+        return GraphTrainerCompileConfig(
+            enable=True,
+            ep_overlap=EpOverlapConfig(
+                enabled=True,
+                strategy="eager",
+                chunk_dim=chunk_dim,
+                module_fqn=module_fqn,
+            ),
+        )
+
+    def test_eager_chunking_is_idempotent(self):
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                return x.sin()
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = Model()
+        config = self._config()
+        maybe_apply_ep_overlap_eager_chunking(model, config)
+        wrapped_forward = model.layers[0].forward
+        maybe_apply_ep_overlap_eager_chunking(model, config)
+
+        self.assertIs(model.layers[0].forward, wrapped_forward)
+
+    def test_eager_chunking_compile_disabled_is_noop(self):
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                return x.sin()
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = Model()
+        forward = model.layers[0].forward
+        config = self._config()
+        config.enable = False
+
+        maybe_apply_ep_overlap_eager_chunking(model, config)
+
+        self.assertIs(model.layers[0].forward.__func__, forward.__func__)
+
+    def test_eager_chunking_rejects_unsupported_output_type(self):
+        class Block(torch.nn.Module):
+            def forward(self, x):
+                return {"x": x}
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(model, self._config())
+
+        with self.assertRaisesRegex(TypeError, "layers.0.*dict"):
+            model(torch.randn(4, 3))
+
+    def test_transformer_batch_chunking_splits_positions_by_batch(self):
+        seen_positions = []
+
+        class Block(torch.nn.Module):
+            def forward(self, x, attention_masks=None, positions=None):
+                seen_positions.append(positions)
+                return x
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x, positions):
+                return self.layers[0](x, None, positions)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(model, self._config())
+        x = torch.randn(4, 4, 2)
+        positions = torch.arange(16).view(4, 4)
+
+        self.assertEqual(model(x, positions), x)
+        self.assertEqual([tuple(pos.shape) for pos in seen_positions], [(2, 4), (2, 4)])
+        self.assertEqual(seen_positions[0], positions[:2])
+        self.assertEqual(seen_positions[1], positions[2:])
+
+    def test_transformer_batch_chunking_rejects_same_extent_tensor_mask(self):
+        class Block(torch.nn.Module):
+            def forward(self, x, attention_masks):
+                return x + attention_masks
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x, attention_masks):
+                return self.layers[0](x, attention_masks)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(model, self._config())
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "attention_masks must be None, BlockMask.*upstream .*TransformerBlock",
+        ):
+            model(torch.randn(4, 3), torch.randn(4, 3))
+
+    def test_moe_chunking_splits_activation_only(self):
+        seen_shapes = []
+
+        class Moe(torch.nn.Module):
+            def forward(self, x):
+                seen_shapes.append(tuple(x.shape))
+                return x
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([torch.nn.Module()])
+                self.layers[0].moe = Moe()
+
+            def forward(self, x):
+                return self.layers[0].moe(x)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(
+            model,
+            self._config(chunk_dim="seq", module_fqn="layers.*.moe"),
+        )
+        x = torch.randn(2, 4, 3)
+
+        self.assertEqual(model(x), x)
+        self.assertEqual(seen_shapes, [(2, 2, 3), (2, 2, 3)])
+
+    def test_moe_chunking_rejects_extra_tensor_input(self):
+        class Moe(torch.nn.Module):
+            def forward(self, x, aux):
+                return x + aux
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([torch.nn.Module()])
+                self.layers[0].moe = Moe()
+
+            def forward(self, x, aux):
+                return self.layers[0].moe(x, aux)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(
+            model,
+            self._config(module_fqn="layers.*.moe"),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "expected exactly one positional activation tensor.*upstream MoE.forward",
+        ):
+            model(torch.randn(4, 3), torch.randn(4, 3))
+
+    def test_eager_chunking_traces_overlap_metadata(self):
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x):
+                return self.layers[0](x)
+
+        model = Model()
+        annotate_module_fqns(model)
+        maybe_apply_ep_overlap_eager_chunking(model, self._config())
+
+        traced = minimal_fx_tracer(lambda inputs: model(inputs), module=model)(
+            torch.randn(4, 3)
+        )
+        gm = populate_eager_chunk_metadata_pass(traced.gm)
+
+        body_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_role") == "body"
+        ]
+        roles = {
+            node.meta.get("chunked_region_role")
+            for node in gm.graph.nodes
+            if node.meta.get("chunked_region_fqn") == "layers.0"
+        }
+        self.assertEqual({node.meta.get("chunk_id") for node in body_nodes}, {0, 1})
+        self.assertEqual(
+            {node.meta.get("chunked_region_fqn") for node in body_nodes},
+            {"layers.0"},
+        )
+        self.assertIn("split_boundary", roles)
+        self.assertIn("materialization", roles)
+
+    def test_eager_chunking_splits_block_mask_batch_metadata(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        seen_masks = []
+
+        def mask_mod(b, h, q_idx, kv_idx):
+            return (b == 2) & (q_idx >= kv_idx)
+
+        class Block(torch.nn.Module):
+            def forward(self, x, attention_masks, positions):
+                seen_masks.append(attention_masks)
+                return x
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block()])
+
+            def forward(self, x, attention_masks, positions):
+                return self.layers[0](x, attention_masks, positions)
+
+        model = Model()
+        maybe_apply_ep_overlap_eager_chunking(model, self._config())
+        block_mask = create_block_mask(
+            mask_mod,
+            B=4,
+            H=None,
+            Q_LEN=128,
+            KV_LEN=128,
+            device="cpu",
+        )
+        x = torch.randn(4, 128, 8)
+        positions = torch.arange(128).repeat(4, 1)
+
+        self.assertEqual(model(x, block_mask, positions).shape, x.shape)
+        self.assertEqual(len(seen_masks), 2)
+        self.assertEqual([mask.kv_num_blocks.size(0) for mask in seen_masks], [2, 2])
+
+        b = torch.tensor(0)
+        h = torch.tensor(0)
+        q_idx = torch.tensor(1)
+        kv_idx = torch.tensor(0)
+        self.assertFalse(seen_masks[0].mask_mod(b, h, q_idx, kv_idx).item())
+        self.assertTrue(seen_masks[1].mask_mod(b, h, q_idx, kv_idx).item())
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
+from torchtitan.experiments.graph_trainer.configs import EpOverlapConfig
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 
 
@@ -82,6 +83,7 @@ class _StubCompileConfig:
     mode: str = "aot_fx_trace"
     backend: str = "aot_eager"
     passes: list = field(default_factory=list)
+    ep_overlap: EpOverlapConfig = field(default_factory=EpOverlapConfig)
 
 
 @dataclass
@@ -171,6 +173,22 @@ class TestConfigFingerprint(unittest.TestCase):
         fp_a = compute_config_fingerprint(_make_stub_model(), cfg_a, dims)
         fp_b = compute_config_fingerprint(_make_stub_model(), cfg_b, dims)
         self.assertNotEqual(fp_a, fp_b)
+
+        cfg_graph_batch = _StubCompileConfig(ep_overlap=EpOverlapConfig(enabled=True))
+        cfg_graph_seq = _StubCompileConfig(
+            ep_overlap=EpOverlapConfig(
+                enabled=True,
+                chunk_dim="seq",
+                module_fqn="layers.*.moe",
+            ),
+        )
+        fp_graph_batch = compute_config_fingerprint(
+            _make_stub_model(), cfg_graph_batch, dims
+        )
+        fp_graph_seq = compute_config_fingerprint(
+            _make_stub_model(), cfg_graph_seq, dims
+        )
+        self.assertNotEqual(fp_graph_batch, fp_graph_seq)
 
     def test_pass_order_sensitive(self):
         from torchtitan.experiments.graph_trainer.precompile import (

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -17,7 +17,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     log_timer,
     maybe_register_blockmask_pytree_node,
 )
-from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.configs import (
+    GraphTrainerCompileConfig,
+    trace_input_preparer_keys,
+)
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
@@ -32,6 +35,7 @@ from torchtitan.experiments.graph_trainer.registry import (
     PASS_PIPELINE_REGISTRY,
     POST_INIT_HOOKS,
     PRE_TRAIN_STEP_HOOKS,
+    TRACE_INPUT_PREPARERS,
 )
 from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
@@ -227,7 +231,11 @@ class GraphTrainer(Trainer):
             else:
                 fwd_bwd_fn = make_fwd_bwd_step(model, self.loss_fn)
                 with self.train_context(), log_timer("minimal_fx_tracer"):
-                    self._traced_step = minimal_fx_tracer(fwd_bwd_fn, module=model)(
+                    self._traced_step = minimal_fx_tracer(
+                        fwd_bwd_fn,
+                        module=model,
+                        prepare_inputs=self._prepare_trace_inputs,
+                    )(
                         inputs,
                         labels,
                         global_valid_tokens,
@@ -265,6 +273,16 @@ class GraphTrainer(Trainer):
                 param.grad += grad
 
         return loss
+
+    def _prepare_trace_inputs(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        for pass_name in trace_input_preparer_keys(self.config.compile):
+            prepare = TRACE_INPUT_PREPARERS.get(pass_name)
+            if prepare is not None:
+                prepare(self.config.compile, args, kwargs)
 
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]


### PR DESCRIPTION
Stacked PRs:
 * #3328
 * #3325
 * __->__#3363


--- --- ---

### [graph_trainer] Add EP overlap eager chunking scaffolding


Add the public EP-overlap chunking config, eager module wrappers, trace-input preparation, and eager chunk metadata population. The eager path gives graph_trainer a reference chunking implementation before the graph rewrite and scheduling passes are introduced.

Wire the eager wrapper into supported MoE model parallelization and include the EP overlap config in the precompile fingerprint.

Test Plan:\n- Covered by focused graph_trainer pass/precompile tests and the final stack validation.
