### PR TITLE
to_local() for ChunkedCELoss + no LP

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -11,6 +11,7 @@ from typing import TypeAlias
 
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import DTensor, Replicate
 from torchtitan.config import CompileConfig, Configurable
 from torchtitan.tools.logging import logger
 
@@ -22,6 +23,13 @@ LossFunction: TypeAlias = Callable[..., torch.Tensor]
 
 def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
     """Cross-entropy loss with sum reduction for token-based normalization."""
+    if isinstance(pred, DTensor) and not isinstance(labels, DTensor):
+        mesh_axis_names = pred.device_mesh.mesh_dim_names
+        if mesh_axis_names is not None and "tp" in mesh_axis_names:
+            tp_axis = mesh_axis_names.index("tp")
+            if isinstance(pred.placements[tp_axis], Replicate):
+                pred = pred.to_local()
+
     return torch.nn.functional.cross_entropy(
         pred.flatten(0, 1).float(),
         labels.flatten(0, 1),


### PR DESCRIPTION
Fixes mixed tensor-DTensor error when running TP w/ no SP, no loss parallel: `NGPU=4 ./run_train.sh --module llama3 --config llama3_debugmodel --parallelism.tensor_parallel_degree=4 --activation_checkpoint.mode=none --training.steps=10 --parallelism.no_enable_sequence_parallel --parallelism.disable_loss_parallel --debug.deterministic --debug.seed 42`

I believe https://github.com/pytorch/torchtitan/pull/2937 calls lm_head with a R@TP sharding config, and calls plain `cross_entropy_loss` with plain tensor labels, if loss parallel is off. However the logits remain in DTensor form (a `use_local_output=True` flag is appropriate but we don't have that).

The fix is asserting they're R@TP (sharded on DP/CP axes should be fine?) and extracting local tensor for loss calculation.