### PR TITLE
[graph_trainer] Use separate EP process groups for overlap

### DIFF
--- a/torchtitan/experiments/graph_trainer/ep_process_group_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_process_group_pass.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""EP process-group isolation for graph_trainer.
+
+Algorithm:
+1. Scan collectives and separate EP all-to-alls from all other collectives.
+2. If an EP all-to-all resolves to the same process-group object as a non-EP
+   collective, create one extra PG with the same ranks for EP traffic.
+3. Rewrite the EP all-to-all PG argument. Other collectives keep their original
+   PGs and ordering.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.fx as fx
+from torch.utils._ordered_set import OrderedSet
+
+from torchtitan.tools.logging import logger
+
+c10d = torch.ops._c10d_functional
+_EXTRA_EP_PG_REGISTRY: dict[str, str] = {}
+
+
+def _is_ep_all_to_all(node: fx.Node) -> bool:
+    """Return whether ``node`` is a traced all-to-all using the EP PG slot."""
+    return (
+        node.op == "call_function"
+        and node.target == c10d.all_to_all_single.default
+        and len(node.args) > 3
+    )
+
+
+def _collective_pg_name(node: fx.Node) -> str | None:
+    """Return the process-group name argument for supported c10d collectives."""
+    if node.op != "call_function":
+        return None
+    if node.target == c10d.all_gather_into_tensor.default and len(node.args) > 2:
+        return node.args[2]
+    if node.target == c10d.reduce_scatter_tensor.default and len(node.args) > 3:
+        return node.args[3]
+    if node.target == c10d.all_reduce.default and len(node.args) > 2:
+        return node.args[2]
+    if node.target == c10d.all_to_all_single.default and len(node.args) > 3:
+        return node.args[3]
+    return None
+
+
+def _pg_rank_set(pg_name: str) -> frozenset[int]:
+    """Resolve ``pg_name`` and return its rank set."""
+    import torch.distributed as dist
+
+    pg = dist.distributed_c10d._resolve_process_group(pg_name)
+    return frozenset(dist.get_process_group_ranks(pg))
+
+
+def _same_process_group(lhs_pg_name: str, rhs_pg_name: str) -> bool:
+    """Compare process-group object identity after resolving graph PG names."""
+    import torch.distributed as dist
+
+    lhs_pg = dist.distributed_c10d._resolve_process_group(lhs_pg_name)
+    rhs_pg = dist.distributed_c10d._resolve_process_group(rhs_pg_name)
+    return lhs_pg is rhs_pg
+
+
+def _shares_process_group_with(
+    pg_name: str, candidate_pg_names: OrderedSet[str]
+) -> bool:
+    """Return whether ``pg_name`` resolves to any candidate PG object."""
+    for candidate_pg_name in candidate_pg_names:
+        if _same_process_group(pg_name, candidate_pg_name):
+            if _pg_rank_set(pg_name) != _pg_rank_set(candidate_pg_name):
+                raise ValueError(
+                    "Resolved the same process group with different rank sets: "
+                    f"{pg_name} and {candidate_pg_name}"
+                )
+            return True
+    return False
+
+
+def _get_or_create_extra_ep_pg(source_pg_name: str) -> str:
+    """Create or reuse an EP-only PG with the same ranks as ``source_pg_name``."""
+    import torch.distributed as dist
+
+    if source_pg_name in _EXTRA_EP_PG_REGISTRY:
+        return _EXTRA_EP_PG_REGISTRY[source_pg_name]
+
+    source_pg = dist.distributed_c10d._resolve_process_group(source_pg_name)
+    ranks = dist.get_process_group_ranks(source_pg)
+    pg_options = (
+        dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+        if hasattr(dist, "ProcessGroupNCCL")
+        else None
+    )
+    extra_pg = dist.new_group(
+        ranks=ranks,
+        backend="nccl" if pg_options is not None else None,
+        pg_options=pg_options,
+        group_desc="ep_extra",
+        use_local_synchronization=True,
+    )
+    _EXTRA_EP_PG_REGISTRY[source_pg_name] = extra_pg.group_name
+    logger.info(
+        "Created extra EP PG (source: %s, extra: %s, high_priority=%s)",
+        source_pg_name,
+        extra_pg.group_name,
+        pg_options is not None,
+    )
+    return extra_pg.group_name
+
+
+def isolate_ep_process_group_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> fx.GraphModule:
+    """Move EP all-to-alls off any non-EP collective PG they share by object."""
+    del example_inputs
+    # Step 1: classify process groups by the collectives that use them.
+    ep_pg_names: OrderedSet[str] = OrderedSet()
+    non_ep_pg_names: OrderedSet[str] = OrderedSet()
+    for node in gm.graph.nodes:
+        pg_name = _collective_pg_name(node)
+        if pg_name is None:
+            continue
+        if _is_ep_all_to_all(node):
+            ep_pg_names.add(pg_name)
+        else:
+            non_ep_pg_names.add(pg_name)
+
+    logger.debug(
+        "EP PG isolation scan: ep_pgs=%s non_ep_pgs=%s",
+        list(ep_pg_names),
+        list(non_ep_pg_names),
+    )
+
+    # Step 2: create replacement PGs only for object-identical sharing. Rank
+    # equality alone is not sufficient because distinct PGs can share ranks.
+    pg_mapping = {
+        pg_name: _get_or_create_extra_ep_pg(pg_name)
+        for pg_name in ep_pg_names
+        if _shares_process_group_with(pg_name, non_ep_pg_names)
+    }
+    if not pg_mapping:
+        return gm
+
+    # Step 3: rewrite the EP all-to-all PG operand.
+    rewrite_counts = {source: 0 for source in pg_mapping}
+    for node in gm.graph.nodes:
+        if _is_ep_all_to_all(node) and node.args[3] in pg_mapping:
+            source = node.args[3]
+            node.args = (*node.args[:3], pg_mapping[source], *node.args[4:])
+            rewrite_counts[source] += 1
+    for source, target in pg_mapping.items():
+        logger.info(
+            "Rewrote %d EP all-to-all node(s) from PG %s to PG %s",
+            rewrite_counts[source],
+            source,
+            target,
+        )
+    gm.recompile()
+    return gm

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -64,28 +64,47 @@ def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
 _EXTRA_FSDP_PG_REGISTRY: dict[str, str] = {}
 
 
-def _get_or_create_extra_fsdp_pg(source_pg_name: str) -> str:
-    """Return the extra PG name for ``source_pg_name``, creating it once.
-
-    The extra PG is a new NCCL process group with the same ranks as the source
-    FSDP PG but a different communicator (and therefore a different CUDA stream).
-    """
+def _get_or_create_extra_pg(
+    source_pg_name: str,
+    registry: dict[str, str],
+    *,
+    group_desc: str,
+    high_priority: bool = False,
+) -> str:
     import torch.distributed as dist
 
-    if source_pg_name in _EXTRA_FSDP_PG_REGISTRY:
-        return _EXTRA_FSDP_PG_REGISTRY[source_pg_name]
+    if source_pg_name in registry:
+        return registry[source_pg_name]
 
     source_pg = dist.distributed_c10d._resolve_process_group(source_pg_name)
     ranks = dist.get_process_group_ranks(source_pg)
-    extra_pg = dist.new_group(
-        ranks=ranks, group_desc="fsdp_extra", use_local_synchronization=True
+    pg_options = (
+        dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+        if high_priority and hasattr(dist, "ProcessGroupNCCL")
+        else None
     )
-    _EXTRA_FSDP_PG_REGISTRY[source_pg_name] = extra_pg.group_name
+    extra_pg = dist.new_group(
+        ranks=ranks,
+        backend="nccl" if pg_options is not None else None,
+        pg_options=pg_options,
+        group_desc=group_desc,
+        use_local_synchronization=True,
+    )
+    registry[source_pg_name] = extra_pg.group_name
     logger.info(
-        f"Created extra FSDP PG (source: {source_pg_name}, "
-        f"extra: {extra_pg.group_name})"
+        f"Created extra {group_desc} PG (source: {source_pg_name}, "
+        f"extra: {extra_pg.group_name}, high_priority={high_priority})"
     )
     return extra_pg.group_name
+
+
+def _get_or_create_extra_fsdp_pg(source_pg_name: str) -> str:
+    """Return an extra FSDP PG with the same ranks and a distinct NCCL stream."""
+    return _get_or_create_extra_pg(
+        source_pg_name,
+        _EXTRA_FSDP_PG_REGISTRY,
+        group_desc="fsdp_extra",
+    )
 
 
 def overlap_fsdp_ag_rs_pass(
@@ -93,15 +112,15 @@ def overlap_fsdp_ag_rs_pass(
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
     """
-    Reassign FSDP all-gather nodes to extra NCCL process groups for
-    AG/RS overlap in backward.
+    Reassign FSDP all-gathers to extra NCCL process groups.
 
     Discovers all distinct FSDP PGs by inspecting the graph (e.g. one for
     FSDP, another for expert-FSDP), creates an extra NCCL PG over the same
     ranks for each (giving it a separate CUDA stream), and rewrites every
     all-gather to the corresponding extra PG. This separates all-gathers
     from reduce-scatters onto different streams, enabling AG/RS overlap in
-    backward.
+    backward. EP communicator isolation is handled by
+    ``isolate_ep_process_group_pass``.
 
     No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
     bucketing passes so bucketed all-gathers inherit the new PG name.
@@ -119,13 +138,13 @@ def overlap_fsdp_ag_rs_pass(
         pg: _get_or_create_extra_fsdp_pg(pg) for pg in source_pg_names
     }
 
-    count = 0
+    ag_count = 0
     for node in gm.graph.nodes:
         if is_all_gather(node) and node.args[2] in pg_mapping:
             # AG args: (input_tensor, group_size, group_name)
             node.args = (node.args[0], node.args[1], pg_mapping[node.args[2]])
-            count += 1
-    if count > 0:
+            ag_count += 1
+    if ag_count > 0:
         for source, target in pg_mapping.items():
             logger.info(f"Rewrote all-gather node(s) from PG {source} to PG {target}")
     gm.recompile()

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -29,6 +29,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.cudagraph import (
     insert_kernel_annotations_pass,
 )
+from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
+    isolate_ep_process_group_pass,
+)
 from torchtitan.experiments.graph_trainer.fsdp_passes import overlap_fsdp_ag_rs_pass
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
@@ -144,6 +147,15 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
                 count += 1
         return count
 
+    def _count_ep_a2a_nodes_with_pg(self, gm, pg_name):
+        return sum(
+            1
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and "all_to_all_single" in str(node.target)
+            and node.args[3] == pg_name
+        )
+
     def test_overlap_rewrites_ag_nodes(self):
         """Apply overlap_fsdp_ag_rs_pass on the real backward graph and verify
         that FSDP AG nodes are rewritten to the auto-created extra PG."""
@@ -245,6 +257,125 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
         # All AG nodes should use their respective extra PGs
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg1), ag_pg1_before)
         self.assertEqual(self._count_ag_nodes_with_pg(bw_gm, extra_pg2), ag_pg2_before)
+
+    def test_overlap_rewrites_ep_a2a_on_fsdp_pg_to_separate_pg(self):
+        from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
+            _EXTRA_EP_PG_REGISTRY,
+        )
+        from torchtitan.experiments.graph_trainer.fsdp_passes import (
+            _EXTRA_FSDP_PG_REGISTRY,
+        )
+
+        self._setup()
+        fsdp_pg_name = self._get_fsdp_pg_name()
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        ag = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, fsdp_pg_name)
+        )
+        wait = graph.call_function(c10d.wait_tensor.default, args=(ag,))
+        rs = graph.call_function(
+            c10d.reduce_scatter_tensor.default, args=(x, "sum", 1, fsdp_pg_name)
+        )
+        rs_wait = graph.call_function(c10d.wait_tensor.default, args=(rs,))
+        a2a = graph.call_function(
+            c10d.all_to_all_single.default, args=(x, [], [], fsdp_pg_name)
+        )
+        a2a.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "dispatch"}
+        graph.output((wait, rs_wait, a2a))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
+        _EXTRA_EP_PG_REGISTRY.pop(fsdp_pg_name, None)
+        overlap_fsdp_ag_rs_pass(gm, ())
+        isolate_ep_process_group_pass(gm, ())
+
+        fsdp_extra_pg = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
+        ep_extra_pg = _EXTRA_EP_PG_REGISTRY[fsdp_pg_name]
+        self.assertNotEqual(fsdp_extra_pg, ep_extra_pg)
+        self.assertEqual(self._count_ag_nodes_with_pg(gm, fsdp_extra_pg), 1)
+        self.assertEqual(self._count_ep_a2a_nodes_with_pg(gm, ep_extra_pg), 1)
+
+    def test_overlap_preserves_distinct_ep_pg_with_same_fsdp_ranks(self):
+        import torch.distributed as dist
+
+        from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
+            _EXTRA_EP_PG_REGISTRY,
+        )
+        from torchtitan.experiments.graph_trainer.fsdp_passes import (
+            _EXTRA_FSDP_PG_REGISTRY,
+        )
+
+        self._setup()
+        fsdp_pg_name = self._get_fsdp_pg_name()
+        ep_pg = dist.new_group(
+            ranks=list(range(self.world_size)),
+            use_local_synchronization=True,
+        )
+        ep_pg_name = ep_pg.group_name
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        ag = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, fsdp_pg_name)
+        )
+        wait = graph.call_function(c10d.wait_tensor.default, args=(ag,))
+        rs = graph.call_function(
+            c10d.reduce_scatter_tensor.default, args=(x, "sum", 1, fsdp_pg_name)
+        )
+        rs_wait = graph.call_function(c10d.wait_tensor.default, args=(rs,))
+        a2a = graph.call_function(
+            c10d.all_to_all_single.default, args=(x, [], [], ep_pg_name)
+        )
+        a2a.meta["custom"] = {_MODULE_FQN: "layers.0.moe", "EP": "combine"}
+        graph.output((wait, rs_wait, a2a))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
+        _EXTRA_EP_PG_REGISTRY.pop(ep_pg_name, None)
+        overlap_fsdp_ag_rs_pass(gm, ())
+        isolate_ep_process_group_pass(gm, ())
+
+        self.assertNotIn(ep_pg_name, _EXTRA_EP_PG_REGISTRY)
+        self.assertEqual(self._count_ep_a2a_nodes_with_pg(gm, ep_pg_name), 1)
+
+    def test_ep_pg_pass_rewrites_all_ep_a2a_on_tp_pg_to_separate_pg(self):
+        from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
+            _EXTRA_EP_PG_REGISTRY,
+        )
+
+        self._setup()
+        tp_pg_name = self._get_fsdp_pg_name()
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        c10d = torch.ops._c10d_functional
+        ag = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(x, 1, tp_pg_name)
+        )
+        a2a = graph.call_function(
+            c10d.all_to_all_single.default, args=(x, [], [], tp_pg_name)
+        )
+        a2a.meta["custom"] = {
+            _MODULE_FQN: "layers.0.moe",
+            "EP": "dispatch",
+        }
+        generic_ep_a2a = graph.call_function(
+            c10d.all_to_all_single.default, args=(x, [], [], tp_pg_name)
+        )
+        generic_ep_a2a.meta["custom"] = {
+            _MODULE_FQN: "layers.0.moe",
+            "EP": "combine",
+        }
+        graph.output((ag, a2a, generic_ep_a2a))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        _EXTRA_EP_PG_REGISTRY.pop(tp_pg_name, None)
+        isolate_ep_process_group_pass(gm, ())
+
+        ep_extra_pg = _EXTRA_EP_PG_REGISTRY[tp_pg_name]
+        self.assertEqual(self._count_ep_a2a_nodes_with_pg(gm, ep_extra_pg), 2)
 
     def test_overlap_is_noop_when_no_fsdp_ag(self):
         """If the graph has no FSDP all-gathers, the pass is a no-op."""


### PR DESCRIPTION
Stacked PRs:
 * #3328
 * #3325
 * #3363
 * #3362
 * __->__#3369


--- --- ---

### [graph_trainer] Use separate EP process groups for overlap


When EP all-to-alls use the same process group object as FSDP or TP collectives, they share a NCCL communicator/stream and can serialize communication that the EP overlap schedule is trying to expose.

Add isolate_ep_process_group_pass as a dedicated EP pass instead of mixing this policy into FSDP bucketing. The pass scans traced collectives, identifies EP process-group users by _c10d_functional.all_to_all_single.default nodes, and compares the resolved process-group object identity against non-EP collective process groups. If an EP process group is object-identical to a non-EP collective group, the pass creates one high-priority EP-only process group over the same EP ranks and rewrites all traced EP all-to-all calls that used the shared source group.

The matching contract is intentionally process-group based because graph-level metadata does not carry DeviceMesh objects. Rank-set equality is only a validator: two distinct process groups may have the same ranks but already have separate NCCL communicators, so rank-set equality alone is not a sufficient reason to rewrite EP. The replacement communicator is always constructed from the EP process group itself, preserving the EP group rank order used by all-to-all split semantics.

FSDP all-gathers continue to use the existing extra FSDP group from overlap_fsdp_ag_rs_pass. Generic MoE dispatch/combine traceback metadata and EP_token_exchange scheduling metadata are not required for EP process-group isolation; the scheduling pass still owns token-exchange wait ordering.

Test Plan:
- pytest -q torchtitan/experiments/graph_trainer/tests/test_passes.py::TestOverlapFsdpAgRsPass
