### PR TITLE
[graph_trainer] Remove fsdp_reshard_after_fwd_pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/compile.py
+++ b/torchtitan/experiments/graph_trainer/compile.py
@@ -24,7 +24,6 @@ import torch.nn as nn
 
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed import ParallelDims
-from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.experiments.graph_trainer.common_utils import (
     get_transformer_block_buckets,
 )
@@ -38,13 +37,11 @@ from torchtitan.tools.logging import logger
 def _apply_jit_compile(
     model: nn.Module,
     compile_config: GraphTrainerCompileConfig,
-    fsdp_reshard_after_forward: bool,
 ) -> nn.Module:
     """Apply JIT compilation (torch.compile with custom backend)."""
     transformer_block_buckets = get_transformer_block_buckets(model)
     backend = get_compile_backend_with_passes(
         compile_config,
-        fsdp_reshard_after_forward,
         transformer_block_buckets,
     )
     model.compile(
@@ -92,17 +89,12 @@ def apply_compile(
     torch._inductor.config.reorder_for_peak_memory = False
     torch._dynamo.config.capture_scalar_outputs = True
 
-    fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
-        parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
-    )
-
     if mode == "jit":
         if "model" not in compile_config.components:
             return model
         return _apply_jit_compile(
             model,
             compile_config,
-            fsdp_reshard_after_forward,
         )
     elif mode == "aot_fx_trace":
         # aot_fx_trace traces fwd+loss+bwd together inside forward_backward_step,

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -35,7 +35,6 @@ from torch._inductor.fx_passes.overlap_scheduling import (
     schedule_overlap_bucketing,
 )
 from torch.utils._ordered_set import OrderedSet
-from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
@@ -57,78 +56,6 @@ def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
                 return True
             n = n.all_input_nodes[0]
     return False
-
-
-def annotate_fsdp_all_gather(
-    gm: torch.fx.GraphModule, reshard_after_forward: bool
-) -> None:
-    """
-    Force recompute all_gather nodes from SimpleFSDP in the graph.
-    This pass should be added in torch._inductor.config.joint_custom_post_pass
-    """
-    graph = gm.graph
-
-    def force_recompute_node(node):
-        # Respect MUST_CPU_OFFLOAD set by ``tag_all_offloadable_activations``:
-        # the offload chain already keeps the activation off-GPU between
-        # forward and backward, so re-tagging as MUST_RECOMPUTE/MUST_SAVE
-        # would either undo the offload selection or re-save GPU memory we
-        # just freed.
-        if node.meta.get("recompute") == CheckpointPolicy.MUST_CPU_OFFLOAD:
-            return
-        if reshard_after_forward:
-            node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
-        else:
-            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
-        # ac_graph_id is used in the partitioner to decide
-        # if two nodes which have AC applied come from a different
-        # AC regions. This is needed because nodes in the boundary
-        # of two AC regions are marked as MUST_SAVE. In our case
-        # we just add a large value of ac_graph_id so that
-        # all nodes we tag for recomputation do indeed get recomputed
-        # and are not influenced by other nodes in the graph with
-        # nearby ac_graph_id values
-        node.meta["ac_graph_id"] = 100000
-
-    # Make all-gather nodes (and related nodes) recomputable, to circumvent
-    # https://github.com/pytorch/pytorch/issues/136433
-    for node in graph.nodes:
-        if is_wait_tensor_from_fsdp(node):
-            ag_node = node.args[0]
-            force_recompute_node(ag_node)  # all_gather
-            force_recompute_node(node)  # wait_tensor
-            # Force-recompute slice that comes after wait
-            for user in node.users:
-                if (
-                    user.op == "call_function"
-                    and user.target == torch.ops.aten.slice.Tensor
-                ):
-                    force_recompute_node(user)
-            # Force-recompute potential dtype casts from all_gather
-            if (
-                ag_node.all_input_nodes[0].op == "call_function"
-                and ag_node.args[0].target
-                == torch.ops.prims.convert_element_type.default
-            ):
-                force_recompute_node(ag_node.all_input_nodes[0])
-
-    return gm
-
-
-def fsdp_reshard_after_fwd_pass(
-    gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
-    *,
-    reshard_after_forward: bool,
-) -> torch.fx.GraphModule:
-    # this pass implements simplefsdp's fsdp_reshard_after_forward behavior
-    # when fsdp_reshard_after_forward set to True, it will annotate simple_fsdp AG
-    #   to CheckpointPolicy.MUST_RECOMPUTE.
-    # when fsdp_reshard_after_forward set to False, it will annotate simple_fsdp AG
-    #   to CheckpointPolicy.MUST_SAVE.
-    gm = annotate_fsdp_all_gather(gm, reshard_after_forward)
-    gm.recompile()
-    return gm
 
 
 # Maps an FSDP group_name to an extra group_name created by this pass.

--- a/torchtitan/experiments/graph_trainer/jit_backend.py
+++ b/torchtitan/experiments/graph_trainer/jit_backend.py
@@ -4,32 +4,25 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any
-
 import torch
-import torch._functorch.config as functorch_config
 
 from torchtitan.tools.logging import logger
 
 from .configs import GraphTrainerCompileConfig as CompileConfig
 from .fsdp_passes import (
     autobucketing_reordering_pass,
-    fsdp_reshard_after_fwd_pass,
     transformer_block_bucketing_reordering_pass,
 )
 
 
 def get_compile_backend_with_passes(
     compile_config: CompileConfig,
-    fsdp_reshard_after_forward: bool,
     fsdp_manual_buckets: list[list[str] | str] | None,
 ) -> callable:
     """
     Apply compile backend and additional graph passes.
     Args:
         compile_config: compile configs to apply torch.compile.
-        fsdp_reshard_after_forward: whether to enable reshard_after_forward in SimpleFSDP,
-            which is implemented via a customized AC graph pass.
         fsdp_manual_buckets: used in transformer_block_bucketing to define which modules should be bucketed.
     Returns:
         compile backend with applied graph passes.
@@ -144,17 +137,4 @@ def get_compile_backend_with_passes(
     else:
         logger.info("No bucketing or overlapping pass is applied")
 
-    def joint_ac_pass(
-        gm: torch.fx.GraphModule, example_inputs: Any
-    ) -> torch.fx.GraphModule:
-        return fsdp_reshard_after_fwd_pass(
-            gm, example_inputs, reshard_after_forward=fsdp_reshard_after_forward
-        )
-
-    def graph_trainer_custom_pass(*args, **kwargs):
-        # the ac pass has to operate in a joint graph before partitioner for ac
-        # annotation to take into effect.
-        with functorch_config.patch("joint_custom_pass", joint_ac_pass):
-            return backend(*args, **kwargs)
-
-    return graph_trainer_custom_pass
+    return backend


### PR DESCRIPTION
## Summary
- Removes `fsdp_reshard_after_fwd_pass` and its helper `annotate_fsdp_all_gather` from `fsdp_passes.py`
- Removes the `fsdp_reshard_after_forward` parameter threading through `jit_backend.py` and `compile.py` that only fed into this pass
- Cleans up unused imports (`CheckpointPolicy`, `functorch_config`, `Any`, `get_fsdp_reshard_after_forward_policy`)

The same FSDP all-gather save/recompute behavior is now handled by the memory policy framework (`tag_with_memory_policy_pass` in `memory_policy.py`), making this pass redundant.

## Test plan
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -x`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x`
- [ ] `pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py -x`