### PR TITLE
Re-enable compile for gpt-oss integration tests

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -153,8 +153,6 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             ngpu=8,
         ),
         # Integration Test Cases for gpt-oss
-        # TODO: re-enable compile after fixing
-        # https://github.com/pytorch/torchtitan/issues/2776
         OverrideDefinitions(
             [
                 [
@@ -162,7 +160,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.expert_parallel_degree 4",
-                    # "--compile.enable",
+                    "--compile.enable",
                 ],
             ],
             "Gpt-oss FSDP+TP+EP+compile",


### PR DESCRIPTION
Verifies https://github.com/pytorch/torchtitan/issues/2776