### PR TITLE
Fix memory snapshot pickle protocol for compatibility with memory visualizers

### DIFF
--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -87,6 +87,7 @@ class MemoryProfiler:
             curr_snapshot_dir, MEMORY_FILE.format(rank=self._rank, step=curr_step)
         )
         with open(output_file, "wb") as output:
+            # Protocol 4 for compatibility with pytorch.org/memory_viz JS parser
             pickle.dump(device_module.memory._snapshot(), output, protocol=4)
         logger.info(
             f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds"

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -87,7 +87,7 @@ class MemoryProfiler:
             curr_snapshot_dir, MEMORY_FILE.format(rank=self._rank, step=curr_step)
         )
         with open(output_file, "wb") as output:
-            pickle.dump(device_module.memory._snapshot(), output)
+            pickle.dump(device_module.memory._snapshot(), output, protocol=4)
         logger.info(
             f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds"
         )


### PR DESCRIPTION
The memory snapshots saved by MemoryProfiler are unusable in pytorch.org/memory_viz and docs.pytorch.org memory_viz: the pages load but display nothing.

Root cause: pickle.dump is called without an explicit protocol, so Python picks the default for the running interpreter. Python 3.14 defaults to protocol 5 (https://docs.python.org/3/library/pickle.html), but the JavaScript pickle parser embedded in MemoryViz.js it seems not to handle it properly

Fix: Pass protocol=4 explicitly to pickle.dump in MemoryProfiler.step().