### PR TITLE
[MoE][5/n] Refactor MoE to clean DTensor boundaries for shared/routed experts

### DIFF
--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -7,7 +7,6 @@
 import unittest
 
 import torch
-import torch.nn.functional as F
 
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 
@@ -140,51 +139,6 @@ class TestPermute(unittest.TestCase):
             set(permuted_indices.tolist()),
             set(range(total)),
         )
-
-
-class TestSPPaddingRoundTrip(unittest.TestCase):
-    """Verify AllToAllTokenDispatcher's SP padding/unpadding recovers the
-    original tokens for an uneven ``bs * slen`` (not divisible by ``sp_size``).
-
-    See docs/moe_sp_padding.md. Like TestPermute above, this runs on CPU by
-    only exercising the pure-tensor helper ``_split_along_sp`` rather than
-    going through dispatch()/combine() (which need CUDA + a real EP mesh).
-    """
-
-    def test_round_trip_recovers_original(self):
-        original_num_tokens = 7  # not divisible by sp_size=4
-        sp_size = 4
-        dim = 3
-
-        cfg = AllToAllTokenDispatcher.Config(
-            num_experts=4, top_k=1, score_before_experts=True
-        )
-        dispatcher = AllToAllTokenDispatcher(cfg)
-        dispatcher.sp_size = sp_size
-
-        x = torch.randn(original_num_tokens, dim)
-
-        # Pad (matches what dispatch() does on entry).
-        pad = (-original_num_tokens) % sp_size
-        x_padded = F.pad(x, (0, 0, 0, pad))
-        self.assertEqual(x_padded.shape, (8, dim))
-
-        # Split per rank, then reassemble (this is what the EP all-to-all
-        # gathers back in real distributed training).
-        local_num_tokens = x_padded.shape[0] // sp_size
-        per_rank_slices = []
-        for rank in range(sp_size):
-            dispatcher.sp_rank = rank
-            (slice_,) = dispatcher._split_along_sp(x_padded)
-            torch.testing.assert_close(
-                slice_,
-                x_padded[rank * local_num_tokens : (rank + 1) * local_num_tokens],
-            )
-            per_rank_slices.append(slice_)
-        reassembled = torch.cat(per_rank_slices, dim=0)
-
-        # Unpad to recover original prefix bitwise.
-        torch.testing.assert_close(reassembled[:original_num_tokens], x)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -14,7 +14,7 @@ import torch._inductor.config
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import distribute_module, DTensor, Replicate
-from torch.distributed.tensor.parallel import ColwiseParallel, ParallelStyle
+from torch.distributed.tensor.parallel import ParallelStyle
 from torch.distributed.tensor.placement_types import Placement
 
 from torchtitan.config import CompileConfig, ParallelismConfig
@@ -102,89 +102,6 @@ class NoParallel(ParallelStyle):
                 self._prepare_output_fn,  # pyrefly: ignore [bad-argument-type]
                 self.output_layout,
                 self.local_output_grad_placements,
-            ),
-        )
-
-
-class ColwiseParallelWithGradPlacement(ColwiseParallel):
-    """ColwiseParallel with explicit control over backward gradient placement.
-
-    By default, ``ColwiseParallel`` with ``input_layouts=Replicate()`` wraps
-    the input via ``from_local(Replicate)``, whose backward all-reduces d_x
-    back to Replicate.  This subclass overrides ``_prepare_input_fn`` to pass
-    ``local_input_grad_placements`` to ``DTensor.from_local``, giving users
-    explicit control over the gradient placement during backward.  When not
-    specified, defaults to ``None`` and the gradient placement follows the
-    default guarantees of ``DTensor.from_local``.
-    """
-
-    def __init__(
-        self,
-        *,
-        input_layouts: Placement | None = None,
-        output_layouts: Placement | None = None,
-        use_local_output: bool = True,
-        local_input_grad_placements: Sequence[Placement] | None = None,
-    ):
-        super().__init__(
-            input_layouts=input_layouts,
-            output_layouts=output_layouts,
-            use_local_output=use_local_output,
-        )
-        self.local_input_grad_placements = local_input_grad_placements
-
-    @staticmethod
-    # pyrefly: ignore [bad-param-name-override]
-    def _prepare_input_fn(
-        input_layouts,
-        desired_input_layouts,
-        local_input_grad_placements,
-        mod,
-        inputs,
-        device_mesh,
-    ):
-        input_tensor = inputs[0]
-        if not isinstance(input_tensor, DTensor):
-            assert local_input_grad_placements is not None, (
-                "local_input_grad_placements must be specified when input is a "
-                "plain tensor. Please think about what you want the from_local(Replicate) backward behavior like."
-            )
-            input_tensor = DTensor.from_local(
-                input_tensor,
-                device_mesh,
-                input_layouts,
-                run_check=False,
-                grad_placements=local_input_grad_placements,
-            )
-
-        if input_layouts != desired_input_layouts:
-            input_tensor = input_tensor.redistribute(
-                placements=desired_input_layouts, async_op=True
-            )
-        return input_tensor
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        if isinstance(module, nn.Linear):
-            partition_fn = self._partition_linear_fn
-        elif isinstance(module, nn.Embedding):
-            partition_fn = self._partition_embedding_fn
-        else:
-            raise NotImplementedError(
-                "ColwiseParallelWithGradPlacement currently only supports nn.Linear and nn.Embedding!"
-            )
-
-        return distribute_module(
-            module,
-            device_mesh,
-            partition_fn,
-            partial(
-                self._prepare_input_fn,  # pyrefly: ignore [bad-argument-type]
-                self.input_layouts,
-                self.desired_input_layouts,
-                self.local_input_grad_placements,
-            ),
-            partial(
-                self._prepare_output_fn, self.output_layouts, self.use_local_output
             ),
         )
 

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -10,14 +10,13 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.distributed.tensor import DTensor, Partial
+from torch.distributed.tensor import DTensor, Partial, Replicate
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
-
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import LocalTokenDispatcher
+from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
 
 
 class GroupedExperts(Module):
@@ -80,18 +79,25 @@ class GroupedExperts(Module):
         x: torch.Tensor,
         top_scores: torch.Tensor,
         selected_experts_indices: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
-        """Dispatch tokens to experts, compute, combine, and scatter_add.
+        """Dispatch tokens to experts, compute, combine, and scatter_add."""
+        # Convert to local for routed expert dispatch/compute.
+        # Replicate x → Partial grad; Shard x → grad unchanged.
+        if isinstance(x, DTensor):
+            grad_placements = (
+                (Partial(),) if x.placements[0].is_replicate() else x.placements
+            )
+            x = x.to_local(grad_placements=grad_placements)
+        if isinstance(top_scores, DTensor):
+            assert isinstance(selected_experts_indices, DTensor)
+            top_scores = top_scores.to_local()
+            selected_experts_indices = selected_experts_indices.to_local()
 
-        shared_experts is passed to combine() where it overlaps with the async
-        combine all-to-all (NCCL stream) or async DeepEP combine.
-        """
         routed_input, num_tokens_local, metadata = self.token_dispatcher.dispatch(
             x, top_scores, selected_experts_indices
         )
         routed_output = self._experts_forward(routed_input, num_tokens_local)
-        return self.token_dispatcher.combine(routed_output, metadata, x, shared_experts)
+        return self.token_dispatcher.combine(routed_output, metadata, x)
 
 
 class TokenChoiceTopKRouter(Module):
@@ -218,6 +224,14 @@ class TokenChoiceTopKRouter(Module):
         else:
             raise NotImplementedError(f"Unknown score function {self.score_func}")
 
+        if (
+            expert_bias is not None
+            and isinstance(scores, DTensor)
+            and not isinstance(expert_bias, DTensor)
+        ):
+            expert_bias = DTensor.from_local(
+                expert_bias, scores.device_mesh, (Replicate(),), run_check=False
+            )
         scores_for_choice = scores if expert_bias is None else scores + expert_bias
         # Apply node-limited routing if configured
         if self.num_expert_groups is not None:
@@ -243,9 +257,15 @@ class TokenChoiceTopKRouter(Module):
             top_scores = top_scores / denominator
         top_scores = top_scores * self.route_scale
 
+        # histc doesn't support DTensor — use local tensor for counting.
+        indices_for_histc = (
+            selected_experts_indices._local_tensor
+            if isinstance(selected_experts_indices, DTensor)
+            else selected_experts_indices
+        )
         # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
         num_tokens_per_expert = torch.histc(
-            selected_experts_indices.view(-1),
+            indices_for_histc.view(-1),
             bins=self.num_experts,
             min=0,
             max=self.num_experts,
@@ -258,18 +278,18 @@ class MoE(Module):
     """Mixture of Experts layer.
 
     The forward pass proceeds as:
-    1. Router computes expert assignments
-    2. GroupedExperts.forward() handles:
+    1. Router computes expert assignments (stays on DTensor)
+    2. GroupedExperts.forward() converts DTensor to local, then handles:
        a. dispatch (TokenDispatcher) — reorder tokens by expert assignment.
           With EP, also performs all-to-all communication to send tokens
           to expert-owning ranks.
-       b. expert computation
+       b. expert computation (local tensors)
        c. combine (TokenDispatcher) — reverse the dispatch reordering.
-          With EP, starts async communication (NCCL all-to-all or DeepEP
-          combine), runs shared_experts in parallel, then forces sync
-          (scatter_add for NCCL AllToAll, sync_combine for DeepEP) and
-          produces final output.
-          Without EP (LocalTokenDispatcher), no communication is needed.
+          - LocalTokenDispatcher (no EP): scatter_add only.
+          - AllToAll: all-to-all communication, then scatter_add.
+          - DeepEP/HybridEP: async combine_tokens.
+    3. Shared experts run on DTensor (overlaps with DeepEP async combine).
+    4. Routed and shared expert outputs are summed.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -319,32 +339,8 @@ class MoE(Module):
         Returns:
             out (torch.Tensor): Output tensor with shape ``(bs, slen, dim)``.
         """
-        # Convert DTensor to local tensor for MoE-internal computation.
-        # grad_placements=(Partial(),) ensures x.grad is Partial on the tp_mesh
-        # in backward, so gradient reduction (reduce-scatter from Partial to
-        # Shard(1)) happens once at the MoE boundary rather than being
-        # duplicated inside the MoE.
-        #
-        # Why grad(x) is Partial on the tp_mesh across all parallelism:
-        # - TP only / TP+EP with ETP=TP: TP-sharded expert weights (Colwise on
-        #   w1/w3, Rowwise on w2) produce Partial output gradients.
-        # - TP+EP with ETP=1: each TP rank processes a disjoint token subset
-        #   (via sequence-parallel token splitting in AllToAllTokenDispatcher),
-        #   so grad(x) is non-zero only at each rank's token positions (Partial).
-        #
-        # This holds for all MoE components (router.gate, routed experts, shared
-        # experts) and regardless of score_before_experts.
-        if isinstance(x, DTensor):
-            assert (
-                x.device_mesh.ndim == 1
-            ), f"Expected 1D mesh, got {x.device_mesh.ndim}D mesh"
-            assert x.device_mesh.mesh_dim_names == (
-                "tp",
-            ), f"Expected TP mesh, got mesh_dim_names={x.device_mesh.mesh_dim_names}"
-            x = x.to_local(grad_placements=(Partial(),))
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
-
         # top_scores and selected_experts_indices shape (bs*slen, top_k)
         # num_tokens_per_expert shape (num_experts,)
         (
@@ -361,13 +357,21 @@ class MoE(Module):
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert)
 
-        out = self.experts(
-            x,
-            top_scores,
-            selected_experts_indices,
-            shared_experts=self.shared_experts,
-        )
+        out = self.experts(x, top_scores, selected_experts_indices)
 
+        # shared_experts runs in parallel with deepep combine communication.
+        shared_out = self.shared_experts(x) if self.shared_experts is not None else None
+
+        if isinstance(self.experts.token_dispatcher, DeepEPTokenDispatcher):
+            # Sync the combine operation before using routed_output.
+            # This inserts a CUDA stream wait, ensuring combine is complete before
+            # the subsequent addition or reshape operations read routed output.
+            from torchtitan.distributed.deepep.deepep import sync_combine
+
+            sync_combine()
+
+        if shared_out is not None:
+            out = out + shared_out
         return out.reshape(bs, slen, dim)
 
     def _init_self_buffers(self, *, buffer_device: torch.device | None = None) -> None:

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -7,8 +7,6 @@
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
-from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
     all_to_all_single_autograd,
@@ -35,9 +33,6 @@ class AllToAllDispatchMetadata(LocalDispatchMetadata):
     permuted_indices: torch.Tensor  # for _unpermute
     input_splits: list[int]
     output_splits: list[int]
-    # Pre-pad token count. dispatch() rounds bs*slen up to a multiple of
-    # sp_size when sp_size > 1; combine() slices pad rows off using this.
-    original_num_tokens: int
 
 
 class LocalTokenDispatcher(Configurable):
@@ -119,24 +114,18 @@ class LocalTokenDispatcher(Configurable):
         routed_output: torch.Tensor,
         metadata: LocalDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
-        """Score, scatter_add, and optionally overlap shared_experts.
-
-        For EP=1, no communication is needed. shared_experts runs before
-        scatter_add (no async overlap benefit here, but keeps the interface
-        uniform with AllToAllTokenDispatcher).
+        """Score and scatter_add routed expert outputs.
 
         Args:
             routed_output: (num_tokens * top_k, dim) expert outputs
             metadata: LocalDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        out = torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -178,24 +167,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         self.sp_size: int = 1
         self.sp_rank: int | torch.SymInt = -1
 
-    def _split_along_sp(self, *tensors: torch.Tensor) -> list[torch.Tensor]:
-        """Split tensors along the first dim across EP ranks for sequence parallel."""
-        sp_size = self.sp_size
-        sp_rank = self.sp_rank
-        results = []
-        for t in tensors:
-            assert t.is_contiguous()
-            num_tokens = t.shape[0]
-            if num_tokens % sp_size != 0:
-                raise ValueError(
-                    "Uneven split of tokens is not supported yet. "
-                    "Requires EP degree dividing batch size * seq len."
-                )
-            local_num_tokens = num_tokens // sp_size
-            offset = sp_rank * local_num_tokens
-            results.append(t[offset : offset + local_num_tokens])
-        return results
-
     def dispatch(
         self,
         x: torch.Tensor,
@@ -209,13 +180,13 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         When ep_mesh is None (EP=1), falls back to local dispatch — no
         all-to-all communication, just local token reordering with padding.
 
-        When sp_size > 1 (sequence parallel), inputs are first split along
-        the token dim so each EP rank processes a disjoint subset.
+        With SP, x/top_scores/selected_experts_indices are already the local
+        SP shard (from DTensor Shard to_local in GroupedExperts.forward).
 
         Args:
-            x: (num_tokens, dim) all input tokens (global if sp_size > 1)
-            top_scores: (num_tokens, top_k) routing scores
-            selected_experts_indices: (num_tokens, top_k) expert indices per token
+            x: (num_local_tokens, dim) local token shard
+            top_scores: (num_local_tokens, top_k) routing scores
+            selected_experts_indices: (num_local_tokens, top_k) expert indices
 
         Returns:
             routed_input: (R, dim) tokens in expert-major order for local experts
@@ -227,25 +198,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             return super().dispatch(x, top_scores, selected_experts_indices)
 
         ep_size = self.ep_mesh.size()
-        original_num_tokens = x.shape[0]
-
-        if self.sp_size > 1:
-            assert self.sp_rank >= 0, (
-                "sp_rank must be set before use. "
-                "apply_moe_ep_tp() should set it from tp_mesh._sym_get_coordinate()."
-            )
-            # Round bs*slen up to a multiple of sp_size. Pad rows route to
-            # expert 0 with zero scores -> zero contribution to scatter_add.
-            pad = (-original_num_tokens) % self.sp_size
-            if pad > 0:
-                x = F.pad(x, (0, 0, 0, pad))
-                top_scores = F.pad(top_scores, (0, 0, 0, pad))
-                selected_experts_indices = F.pad(
-                    selected_experts_indices, (0, 0, 0, pad)
-                )
-            x, top_scores, selected_experts_indices = self._split_along_sp(
-                x, top_scores, selected_experts_indices
-            )
 
         # TODO: Extract this local reordering block (histc, argsort, score
         # application) into a shared helper — it's duplicated in
@@ -342,7 +294,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
-            original_num_tokens=original_num_tokens,
         )
         return routed_input, num_tokens_per_expert_group, metadata
 
@@ -401,34 +352,30 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: AllToAllDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Reverse the dispatch: unpermute + all-to-all + score + scatter_add.
 
-        shared_experts overlaps with the async all-to-all combine — it runs
-        while the a2a is in flight on the NCCL stream. scatter_add forces sync.
-
-        When sp_size > 1 (sequence parallel), dispatch uses local token
-        indices. Combine offsets them to global positions so scatter_add
+        When sp_size > 1, dispatch uses local token indices.
+        Combine offsets them to global positions so scatter_add
         into full x is correct.
 
         Args:
             routed_output: (R, dim) expert outputs in expert-major order
             metadata: AllToAllDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
         # EP=1: fall back to local combine (no all-to-all needed)
         if self.ep_mesh is None:
-            return super().combine(routed_output, metadata, x, shared_experts)
+            return super().combine(routed_output, metadata, x)
 
         # Reverse expert-major reordering
         routed_output = self._unpermute(
             routed_output, metadata.input_shape, metadata.permuted_indices
         )
+
         # All-to-all combine: returns AsyncCollectiveTensor — the a2a runs
         # on the NCCL stream and won't block until the tensor is accessed.
         routed_output = all_to_all_single_autograd(
@@ -438,9 +385,11 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
-        # shared_experts overlaps with the async a2a (NCCL stream).
-        # Score application + scatter_add forces the a2a to sync.
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        # With SP, x is the local shard. Create full-size buffer for scatter_add
+        # so routed results from all SP ranks can be placed at global positions.
+        out = torch.zeros(
+            x.shape[0] * self.sp_size, x.shape[-1], device=x.device, dtype=x.dtype
+        )
 
         if not self.score_before_experts:
             routed_output = (
@@ -448,31 +397,19 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
                 * metadata.top_scores_experts_sorted.reshape(-1, 1)
             ).to(routed_output.dtype)
 
-        # When sequence_parallel is active, dispatch splits tokens to a local
-        # shard, so token_indices_experts_sorted are 0-based local indices.
-        # Offset them to global positions so scatter_add into full x is correct.
-        original_num_tokens = metadata.original_num_tokens
+        # With SP, token indices are 0-based within the local shard.
+        # Offset to global positions for the full-size scatter buffer.
         if self.sp_size > 1:
-            padded_num_tokens = original_num_tokens + (
-                (-original_num_tokens) % self.sp_size
-            )
-            local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
-                metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
+                metadata.token_indices_experts_sorted + x.shape[0] * self.sp_rank
             )
-            assert isinstance(token_indices_experts_sorted, torch.Tensor)
-            # Drop pad-row entries: their global indices fall in
-            # [original_num_tokens, padded_num_tokens), out of `out`'s range.
-            # scatter_add itself is not padded; `out` matches x's shape.
-            if padded_num_tokens != original_num_tokens:
-                mask = token_indices_experts_sorted < original_num_tokens
-                token_indices_experts_sorted = token_indices_experts_sorted[mask]
-                routed_output = routed_output[mask]
         else:
             token_indices_experts_sorted = metadata.token_indices_experts_sorted
+
+        assert isinstance(token_indices_experts_sorted, torch.Tensor)
         out = deterministic_scatter_add(
             out,
-            token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
+            token_indices_experts_sorted.reshape(-1, 1).expand(-1, out.shape[-1]),
             routed_output,
         )
         return out
@@ -665,7 +602,6 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: DeepEPDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Combine tokens via DeepEP/HybridEP, overlapping shared_experts.
 
@@ -685,18 +621,4 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
 
             # pyrefly: ignore [bad-argument-type]
             routed_output = combine_tokens(routed_output, metadata.state)
-
-        # shared_experts runs in parallel with combine communication.
-        # This is the key optimization - we overlap compute with communication.
-        shared_out = shared_experts(x) if shared_experts is not None else None
-
-        # Sync the combine operation before using routed_output.
-        # This inserts a CUDA stream wait, ensuring combine is complete before
-        # the subsequent addition or reshape operations read routed_output.
-        from torchtitan.distributed.deepep.deepep import sync_combine
-
-        sync_combine()
-
-        if shared_out is not None:
-            routed_output = routed_output + shared_out
         return routed_output

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Partial
 
 from torchtitan.models.common.moe import GroupedExperts, MoE
 from torchtitan.protocols.module import Module
@@ -143,14 +143,22 @@ class GptOssGroupedExperts(Module):
         x: torch.Tensor,
         top_scores: torch.Tensor,
         selected_experts_indices: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add."""
+        if isinstance(x, DTensor):
+            grad_placements = (
+                (Partial(),) if x.placements[0].is_replicate() else x.placements
+            )
+            x = x.to_local(grad_placements=grad_placements)
+        if isinstance(top_scores, DTensor):
+            assert isinstance(selected_experts_indices, DTensor)
+            top_scores = top_scores.to_local()
+            selected_experts_indices = selected_experts_indices.to_local()
         routed_input, num_tokens_local, metadata = self.token_dispatcher.dispatch(
             x, top_scores, selected_experts_indices
         )
         routed_output = self._experts_forward(routed_input, num_tokens_local)
-        return self.token_dispatcher.combine(routed_output, metadata, x, shared_experts)
+        return self.token_dispatcher.combine(routed_output, metadata, x)
 
 
 class GptOssMoE(MoE):

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -10,6 +10,7 @@ from torch.distributed.tensor import Partial, Replicate, Shard
 from torch.distributed.tensor.parallel import (
     parallelize_module,
     PrepareModuleInputOutput,
+    SequenceParallel,
 )
 
 from torchtitan.config import (
@@ -73,7 +74,7 @@ def parallelize_gptoss(
             model,
             tp_mesh=parallel_dims.get_optional_mesh("tp"),
             ep_mesh=parallel_dims.get_optional_mesh("ep"),
-            enable_sp=True,
+            enable_sp=parallelism.enable_sequence_parallel,
         )
 
     if ac_config.mode != "none":
@@ -132,8 +133,6 @@ def apply_moe_ep_tp(
 ):
     assert ep_mesh is not None or tp_mesh is not None
 
-    sp_layout = Shard(1) if enable_sp else Replicate()
-
     # pyrefly: ignore [not-callable]
     for transformer_block in model.layers.values():
         # pyrefly: ignore [missing-attribute]
@@ -141,26 +140,28 @@ def apply_moe_ep_tp(
             continue
 
         if tp_mesh is not None:
+            sp_layout = Shard(1) if enable_sp else Replicate()
+            moe_desired_input_layouts = (
+                Replicate() if ep_mesh is None else sp_layout
+            )
+
             moe_layer_plan = {
-                # With SP: all-gather (Shard→Replicate) for input,
-                # reduce-scatter (Partial→Shard) for output.
-                # Without SP: input is already Replicate,
-                # all-reduce (Partial→Replicate) for output.
                 "moe": PrepareModuleInputOutput(
                     input_layouts=(sp_layout,),
-                    desired_input_layouts=(Replicate(),),
+                    desired_input_layouts=(moe_desired_input_layouts,),
                     use_local_input=False,
                     output_layouts=(Partial(),),
                     desired_output_layouts=(sp_layout,),
-                    # Keep MoE output as DTensor so the residual add
-                    # ``h + self.moe(...)`` composes with config-based
-                    # attention (which flows DTensors).
                     use_local_output=False,
                 ),
-                # replicate computation for the router
+                # Router gate: Replicate weights.
+                # EP off: input is Replicate, gate computes on all tokens, output local tensor.
+                # EP on:  input is Shard(0), gate computes on local token shard, output stays DTensor.
                 "moe.router.gate": NoParallel(
-                    local_output_grad_placements=(Partial(),),
-                ),
+                    local_output_grad_placements=(Partial(),)
+                )
+                if ep_mesh is None
+                else SequenceParallel(sequence_dim=0, use_local_output=False),
             }
             parallelize_module(
                 # pyrefly: ignore [bad-argument-type]

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -12,9 +12,12 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
 from torch.distributed.tensor import Partial, Replicate, Shard
 from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
     parallelize_module,
     PrepareModuleInputOutput,
+    PrepareModuleOutput,
     RowwiseParallel,
+    SequenceParallel,
 )
 
 from torchtitan.config import (
@@ -33,11 +36,7 @@ from torchtitan.distributed.fsdp import (
     disable_fsdp_gradient_division,
     get_fsdp_reshard_after_forward_policy,
 )
-from torchtitan.distributed.tensor_parallel import (
-    ColwiseParallelWithGradPlacement,
-    maybe_enable_async_tp,
-    NoParallel,
-)
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp, NoParallel
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 from torchtitan.models.llama4.model import Llama4Model
 from torchtitan.tools.logging import logger
@@ -87,7 +86,7 @@ def parallelize_llama(
             model,
             tp_mesh=parallel_dims.get_optional_mesh("tp"),
             ep_mesh=parallel_dims.get_optional_mesh("ep"),
-            enable_sp=True,
+            enable_sp=parallelism.enable_sequence_parallel,
         )
 
     model_compile_enabled = (
@@ -380,8 +379,6 @@ def apply_moe_ep_tp(
     """
     assert ep_mesh is not None or tp_mesh is not None
 
-    sp_layout = Shard(1) if enable_sp else Replicate()
-
     # pyrefly: ignore [not-callable]
     for transformer_block in model.layers.values():
         # pyrefly: ignore [missing-attribute]
@@ -389,46 +386,45 @@ def apply_moe_ep_tp(
             continue
 
         if tp_mesh is not None:
+            sp_layout = Shard(1) if enable_sp else Replicate()
+            moe_desired_input_layouts = Replicate() if ep_mesh is None else sp_layout
+
             moe_layer_plan = {
-                # With SP: all-gather (Shard→Replicate) for input,
-                # reduce-scatter (Partial→Shard) for output.
-                # Without SP: input is already Replicate,
-                # all-reduce (Partial→Replicate) for output.
                 "moe": PrepareModuleInputOutput(
                     input_layouts=(sp_layout,),
-                    desired_input_layouts=(Replicate(),),
+                    desired_input_layouts=(moe_desired_input_layouts,),
                     use_local_input=False,
                     output_layouts=(Partial(),),
                     desired_output_layouts=(sp_layout,),
-                    # Keep MoE output as DTensor so the residual add
-                    # ``h + self.moe(...)`` composes with config-based
-                    # attention (which flows DTensors).
                     use_local_output=False,
                 ),
-                # replicate computation for the router
-                "moe.router.gate": NoParallel(
-                    local_output_grad_placements=(Partial(),),
+                # GroupedExperts output is Partial, reduced at MoE boundary
+                "moe.experts": PrepareModuleOutput(
+                    output_layouts=Partial(),
+                    desired_output_layouts=Partial(),
+                    use_local_output=False,
                 ),
+                # Router gate: Replicate weights.
+                # EP off: input is Replicate, gate computes on all tokens, output local tensor.
+                # EP on:  input is Shard(0), gate computes on local token shard, output stays DTensor.
+                "moe.router.gate": NoParallel(local_output_grad_placements=(Partial(),))
+                if ep_mesh is None
+                else SequenceParallel(sequence_dim=0, use_local_output=False),
             }
             # pyrefly: ignore [missing-attribute]
             if transformer_block.moe.shared_experts is not None:
-                # Use ColwiseParallelWithGradPlacement to keep d_x as Partial in
-                # backward (avoids the all-reduce that from_local(Replicate)
-                # would otherwise trigger). For w2, output_layouts=Partial()
-                # skips the Partial→Replicate all-reduce in forward. The
-                # reduction happens once at the MoE output boundary
-                # (PrepareModuleInputOutput).
                 # pyrefly: ignore [no-matching-overload]
                 moe_layer_plan.update(
                     {
-                        "moe.shared_experts.w1": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
+                        "moe.shared_experts.w1": ColwiseParallel(
+                            input_layouts=moe_desired_input_layouts,
                         ),
                         "moe.shared_experts.w2": RowwiseParallel(
                             output_layouts=Partial(),
+                            use_local_output=False,
                         ),
-                        "moe.shared_experts.w3": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
+                        "moe.shared_experts.w3": ColwiseParallel(
+                            input_layouts=moe_desired_input_layouts,
                         ),
                     }
                 )
@@ -441,7 +437,8 @@ def apply_moe_ep_tp(
             )
 
         experts_mesh, experts_plan = None, None
-        # EP disabled: shard routed expert weights across TP mesh (input Replicate, produces Partial output reduced at MoE boundary)
+        # EP disabled: shard routed expert weights across TP mesh
+        # (input Replicate, produces Partial output reduced at MoE boundary)
         if ep_mesh is None:
             experts_mesh = tp_mesh
             experts_plan = TensorParallel()


### PR DESCRIPTION
**Copying major part from @fegin's PR https://github.com/pytorch/torchtitan/pull/3160** 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3381
* __->__ #3380

<img width="463" height="665" alt="image" src="https://github.com/user-attachments/assets/39a2e880-62da-4e20-ab7c-0f36fd0bccc5" />

https://excalidraw.com/#json=2abKr0m2s26fc6lyoF9Qq,MqMzUIoXWYJIfckHNOB7Sw

## Summary

Refactor MoE parallelization to establish clean DTensor boundaries:
- **Router**: gate weights Replicate, input all-gathered to Replicate (via `NoParallel`), compute on DTensor, output converted to local via `to_local(grad_placements=Partial)`
- **Shared experts**: weights TP-sharded (via `ColwiseParallel`/`RowwiseParallel`), input all-gathered to Replicate inside `ColwiseParallel`, compute on DTensor, output local via `to_local` (Partial placement, `use_local_output=True`)
- **Routed experts**: input converted to local via `to_local` at `GroupedExperts` boundary, EP-partitioned weights on local tensors, dispatch/compute/combine all local

Key changes:
- Move `shared_experts` computation from inside `TokenDispatcher.combine()` to `MoE.forward()`
- Move `to_local` from `MoE.forward()` into `GroupedExperts.forward()`, with proper `grad_placements` based on placement type (Shard vs Replicate)
- Replace `ColwiseParallelWithGradPlacement` with standard `ColwiseParallel` using `input_layouts`
- Remove `shared_experts` parameter from all token dispatchers, replace with `initial_output` buffer
- For EP+SP, keep `Shard(1)` as desired MoE input layout (avoid redundant all-gather at MoE boundary); for TP-only, keep `Replicate()` (required for TP-sharded expert weight reduction)

### Trade-offs
- Removes async overlap between `shared_experts` and the all-to-all combine. Previously `shared_experts` ran while the combine A2A was in flight on the NCCL stream. A follow-up can restore overlap using CUDA streams.

## Test plan
- [X] TP=1 EP=1 runs, losses different than main starting step1. 
- [X] TP=2 EP=1 runs, losses different than main starting step1.  
- [X] TP=1 EP=2 runs, losses different than main starting step1. 
- [X] TP=2 EP=2 runs, losses different than main starting step1. 

Loss is expected to diverge compared to main due to different reduction pattern, and shared expert computation changes place.

single run
```
NCCL_NVLS_ENABLE=0 NGPU=4 MODULE='llama4' CONFIG='llama4_debugmodel' ./run_train.sh \
    --parallelism.pipeline_parallel_degree 1 \
    --parallelism.data_parallel_shard_degree 2 \
    --parallelism.tensor_parallel_degree 2 \
    --parallelism.expert_parallel_degree 2 \
    --debug.deterministic --debug.seed=42
```
Compare loss
```
NCCL_NVLS_ENABLE=0 python scripts/loss_compare.py . main --baseline-module='llama4' --baseline-config='llama4_debugmodel' --baseline-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2" --baseline-ngpus=4 --test-module='llama4' --test-config='llama4_debugmodel' --test-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2" --test-ngpus=4 --assert-equal --no-seed-checkpoint
```