### PR TITLE
[MoE][5/n] Refactor MoE to clean DTensor boundaries for shared/routed experts

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -5,9 +5,68 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import dataclasses
 import os
 
 from tests.integration_tests import OverrideDefinitions
+
+
+def _is_pp_only(variant: tuple[str, ...], ngpu: int) -> bool:
+    """True when the variant has PP > 1 and no other SPMD parallelism > 1.
+
+    full_dtensor requires at least one SPMD axis > 1; PP-only runs collapse
+    every dense SPMD axis to size 1 and trip DTensor's reshape / flatten
+    rejection of Shard-on-degenerate-axis. Detected by parsing the explicit
+    ``--parallelism.*_degree`` flags and back-computing ``dp_shard`` (default
+    -1, "fill remaining").
+    """
+    degrees = {
+        "pipeline_parallel_degree": 1,
+        "data_parallel_replicate_degree": 1,
+        "data_parallel_shard_degree": -1,
+        "tensor_parallel_degree": 1,
+        "context_parallel_degree": 1,
+        "expert_parallel_degree": 1,
+    }
+    for arg in variant:
+        for key in degrees:
+            if key in arg:
+                try:
+                    degrees[key] = int(arg.split()[-1])
+                except ValueError:
+                    pass
+                break
+    if degrees["data_parallel_shard_degree"] == -1:
+        denom = (
+            degrees["pipeline_parallel_degree"]
+            * degrees["data_parallel_replicate_degree"]
+            * degrees["context_parallel_degree"]
+            * degrees["tensor_parallel_degree"]
+        )
+        degrees["data_parallel_shard_degree"] = max(1, ngpu // denom)
+    return degrees["pipeline_parallel_degree"] > 1 and all(
+        v <= 1 for k, v in degrees.items() if k != "pipeline_parallel_degree"
+    )
+
+
+def _enable_full_dtensor(t: OverrideDefinitions) -> OverrideDefinitions:
+    """Inject ``--parallelism.full_dtensor`` into every variant.
+
+    All features.py tests run under full_dtensor except PP-only variants
+    (see ``_is_pp_only``); legacy non-full_dtensor coverage lives in
+    models.py. CP variants also switch to FlexAttention config because
+    full_dtensor + CP is not supported with SDPA / Varlen.
+    """
+    new_args = []
+    for variant in t.override_args:
+        prefix: list[str] = []
+        if not _is_pp_only(variant, t.ngpu):
+            prefix.append("--parallelism.full_dtensor")
+        if any("context_parallel_degree" in arg for arg in variant):
+            prefix.append("--module llama3 --config llama3_debugmodel_flex_attn")
+        new_args.append(tuple(prefix) + tuple(variant))
+    return dataclasses.replace(t, override_args=tuple(new_args))
+
 
 # Use RUNNER_TEMP if defined (GitHub Actions variable), else fallback to old path
 runner_temp = os.getenv("RUNNER_TEMP")
@@ -639,4 +698,4 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         ),
     ]
 
-    return integration_tests_flavors
+    return [_enable_full_dtensor(t) for t in integration_tests_flavors]

--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -7,7 +7,6 @@
 import unittest
 
 import torch
-import torch.nn.functional as F
 
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 
@@ -140,51 +139,6 @@ class TestPermute(unittest.TestCase):
             set(permuted_indices.tolist()),
             set(range(total)),
         )
-
-
-class TestSPPaddingRoundTrip(unittest.TestCase):
-    """Verify AllToAllTokenDispatcher's SP padding/unpadding recovers the
-    original tokens for an uneven ``bs * slen`` (not divisible by ``sp_size``).
-
-    See docs/moe_sp_padding.md. Like TestPermute above, this runs on CPU by
-    only exercising the pure-tensor helper ``_split_along_sp`` rather than
-    going through dispatch()/combine() (which need CUDA + a real EP mesh).
-    """
-
-    def test_round_trip_recovers_original(self):
-        original_num_tokens = 7  # not divisible by sp_size=4
-        sp_size = 4
-        dim = 3
-
-        cfg = AllToAllTokenDispatcher.Config(
-            num_experts=4, top_k=1, score_before_experts=True
-        )
-        dispatcher = AllToAllTokenDispatcher(cfg)
-        dispatcher.sp_size = sp_size
-
-        x = torch.randn(original_num_tokens, dim)
-
-        # Pad (matches what dispatch() does on entry).
-        pad = (-original_num_tokens) % sp_size
-        x_padded = F.pad(x, (0, 0, 0, pad))
-        self.assertEqual(x_padded.shape, (8, dim))
-
-        # Split per rank, then reassemble (this is what the EP all-to-all
-        # gathers back in real distributed training).
-        local_num_tokens = x_padded.shape[0] // sp_size
-        per_rank_slices = []
-        for rank in range(sp_size):
-            dispatcher.sp_rank = rank
-            (slice_,) = dispatcher._split_along_sp(x_padded)
-            torch.testing.assert_close(
-                slice_,
-                x_padded[rank * local_num_tokens : (rank + 1) * local_num_tokens],
-            )
-            per_rank_slices.append(slice_)
-        reassembled = torch.cat(per_rank_slices, dim=0)
-
-        # Unpad to recover original prefix bitwise.
-        torch.testing.assert_close(reassembled[:original_num_tokens], x)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_loss_dtensor.py
+++ b/tests/unit_tests/test_loss_dtensor.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import unittest
+
+import torch
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Replicate, Shard
+from torch.distributed.tensor.parallel import loss_parallel
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.components.loss import cross_entropy_loss, IGNORE_INDEX
+
+
+def _reference_ce(pred, labels):
+    return torch.nn.functional.cross_entropy(
+        pred.flatten(0, 1).float(),
+        labels.flatten(0, 1),
+        reduction="sum",
+        ignore_index=IGNORE_INDEX,
+    )
+
+
+class TestCrossEntropyDTensor(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
+    def _run_one(self, *, full_dtensor: bool, tp_shard_v: bool):
+        torch.use_deterministic_algorithms(True, warn_only=False)
+        torch.manual_seed(0)
+        if full_dtensor:
+            mesh = init_device_mesh(
+                self.device_type, (2, 2, 2), mesh_dim_names=("dp_shard", "cp", "tp")
+            )
+            pred_pl = (Shard(0), Shard(1), Shard(2) if tp_shard_v else Replicate())
+            labels_pl = (Shard(0), Shard(1), Replicate())
+        else:
+            mesh = init_device_mesh(self.device_type, (8,), mesh_dim_names=("tp",))
+            pred_pl = (Shard(2) if tp_shard_v else Replicate(),)
+            labels_pl = (Replicate(),)
+
+        B, S, V = 4, 16, 64
+        gen = torch.Generator(device=self.device_type).manual_seed(42)
+        global_pred = torch.randn(B, S, V, device=self.device_type, generator=gen)
+        global_labels = torch.randint(
+            0, V, (B, S), device=self.device_type, dtype=torch.long, generator=gen
+        )
+
+        ref_loss = _reference_ce(global_pred, global_labels)
+
+        pred_dt = distribute_tensor(global_pred.clone(), mesh, pred_pl)
+        labels_dt = distribute_tensor(global_labels.clone(), mesh, labels_pl)
+        pred_dt = pred_dt.detach().requires_grad_(True)
+
+        # V-sharded pred requires the caller to provide loss_parallel; mirrors
+        # how the trainer's train_context wraps the forward step.
+        def _ctx():
+            return loss_parallel() if tp_shard_v else contextlib.nullcontext()
+
+        with _ctx():
+            new_loss_dt = cross_entropy_loss(pred_dt, labels_dt)
+            new_loss = new_loss_dt.full_tensor()
+
+        # tp_shard_v=True routes through loss_parallel's Python decomposition
+        # (differs from the C++ kernel at ULP level); tp_shard_v=False routes
+        # through aten.nll_loss_forward on both paths.
+        rtol, atol = (1e-6, 1e-6) if tp_shard_v else (0, 0)
+        torch.testing.assert_close(new_loss, ref_loss, rtol=rtol, atol=atol)
+
+        ref_pred = global_pred.clone().detach().requires_grad_(True)
+        _reference_ce(ref_pred, global_labels).backward()
+        with _ctx():
+            new_loss_dt.backward()
+        torch.testing.assert_close(
+            pred_dt.grad.full_tensor(), ref_pred.grad, rtol=rtol, atol=atol
+        )
+
+    @with_comms
+    def test_legacy_tp_disable_loss_parallel(self):
+        self._run_one(full_dtensor=False, tp_shard_v=False)
+
+    @with_comms
+    def test_legacy_tp_loss_parallel(self):
+        self._run_one(full_dtensor=False, tp_shard_v=True)
+
+    @with_comms
+    def test_full_dtensor_disable_loss_parallel(self):
+        self._run_one(full_dtensor=True, tp_shard_v=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_parallel_dims.py
+++ b/tests/unit_tests/test_parallel_dims.py
@@ -157,7 +157,7 @@ class TestParallelDimsValidation(unittest.TestCase):
         self.assertTrue(parallel_dims.dp_cp_enabled)
         self.assertTrue(parallel_dims.fsdp_enabled)
 
-        # Test with EP and ETP enabled (EP * ETP must not contribute to world_size)
+        # Test with EP enabled (EP must not contribute to world_size)
         parallel_dims = ParallelDims(
             dp_replicate=1,
             dp_shard=2,
@@ -261,12 +261,12 @@ class TestParallelDimsMeshOperations(unittest.TestCase):
             world_size=1,
         )
         # Don't call build_mesh explicitly
-        self.assertEqual(len(parallel_dims._meshes), 0)
+        self.assertEqual(len(parallel_dims._single_axis_meshes), 0)
 
         # get_optional_mesh should trigger build_mesh
         result = parallel_dims.get_optional_mesh("tp")
         # Result is None because tp has size 1, but build_mesh should have been called
-        self.assertGreater(len(parallel_dims._meshes), 0)
+        self.assertGreater(len(parallel_dims._single_axis_meshes), 0)
 
     @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
     def test_single_rank_mesh_operations(self):
@@ -291,25 +291,25 @@ class TestParallelDimsMeshOperations(unittest.TestCase):
         self.assertEqual(world_mesh.size(), 1)
 
         # Verify all expected meshes are created
-        self.assertIsNotNone(parallel_dims._meshes)
-        self.assertIn("pp", parallel_dims._meshes)
-        self.assertIn("batch", parallel_dims._meshes)
-        self.assertIn("loss", parallel_dims._meshes)
-        self.assertIn("dp_replicate", parallel_dims._meshes)
-        self.assertIn("fsdp", parallel_dims._meshes)
-        self.assertIn("cp", parallel_dims._meshes)
-        self.assertIn("tp", parallel_dims._meshes)
+        self.assertIsNotNone(parallel_dims._single_axis_meshes)
+        self.assertIn("pp", parallel_dims._single_axis_meshes)
+        self.assertIn("batch", parallel_dims._single_axis_meshes)
+        self.assertIn("loss", parallel_dims._single_axis_meshes)
+        self.assertIn("dp_replicate", parallel_dims._single_axis_meshes)
+        self.assertIn("fsdp", parallel_dims._single_axis_meshes)
+        self.assertIn("cp", parallel_dims._single_axis_meshes)
+        self.assertIn("tp", parallel_dims._single_axis_meshes)
 
         # Validate 1D mesh sizes - all should be 1 for single rank
-        self.assertEqual(parallel_dims._meshes["dp_replicate"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["fsdp"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["tp"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["batch"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["loss"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["pp"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["cp"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["ep"].size(), 1)
-        self.assertEqual(parallel_dims._meshes["efsdp"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["dp_replicate"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["fsdp"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["tp"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["batch"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["loss"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["pp"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["cp"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["ep"].size(), 1)
+        self.assertEqual(parallel_dims._single_axis_meshes["efsdp"].size(), 1)
 
         # Validate 2D mesh shapes
         dp_replicate_fsdp_mesh = parallel_dims.get_optional_mesh(
@@ -361,7 +361,7 @@ class TestParallelDimsMeshOperations(unittest.TestCase):
     @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
     def test_expert_parallelism_validation(self):
         """Test expert parallelism configurations."""
-        # EP with ETP = 1 (valid) - world_size = dp_replicate * dp_shard * cp * tp * pp
+        # EP enabled (valid) - world_size = dp_replicate * dp_shard * cp * tp * pp
         parallel_dims = ParallelDims(
             dp_replicate=1,
             dp_shard=2,
@@ -386,6 +386,73 @@ class TestParallelDimsMeshOperations(unittest.TestCase):
         self.assertTrue(parallel_dims.ep_enabled)
         self.assertTrue(parallel_dims.dp_replicate_enabled)
         self.assertTrue(parallel_dims.dp_shard_enabled)
+
+
+class TestSpmdMeshesLegacy(DTensorTestBase):
+    """spmd_meshes() under non-full_dtensor."""
+
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_legacy_spmd_meshes(self):
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            pd = ParallelDims(
+                dp_replicate=2,
+                dp_shard=2,
+                cp=1,
+                tp=2,
+                pp=1,
+                ep=1,
+                world_size=8,
+                full_dtensor=False,
+            )
+            pd.build_mesh()
+
+            # Legacy mode pre-flattens dp_shard+cp into 'fsdp'; dp_shard
+            # never appears as a single-axis mesh, so must not appear in any
+            # SPMD mesh either.
+            meshes = pd.spmd_meshes()
+            flat = {axis for m in meshes for axis in (m.mesh_dim_names or ())}
+            self.assertNotIn("dp_shard", flat)
+            # Dense mesh names ``fsdp`` (the storage axis) instead of
+            # ``dp_shard`` / ``cp`` under legacy.
+            dense = next(m for m in meshes if "tp" in (m.mesh_dim_names or ()))
+            self.assertEqual(set(dense.mesh_dim_names), {"dp_replicate", "fsdp", "tp"})
+
+
+class TestSpmdMeshesFullDTensor(DTensorTestBase):
+    """spmd_meshes() under full_dtensor."""
+
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_full_dtensor_spmd_meshes(self):
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            pd = ParallelDims(
+                dp_replicate=2,
+                dp_shard=2,
+                cp=1,
+                tp=2,
+                pp=1,
+                ep=1,
+                world_size=8,
+                full_dtensor=True,
+            )
+            pd.build_mesh()
+
+            # Dense mesh keeps dp_shard separate (no 'fsdp' flatten), in
+            # canonical outer-to-inner order; cp filtered out (disabled).
+            meshes = pd.spmd_meshes()
+            dense = next(m for m in meshes if "tp" in (m.mesh_dim_names or ()))
+            self.assertEqual(dense.mesh_dim_names, ("dp_replicate", "dp_shard", "tp"))
 
 
 class TestParallelDimsWorld8MeshOperations(DTensorTestBase):
@@ -422,34 +489,36 @@ class TestParallelDimsWorld8MeshOperations(DTensorTestBase):
             self.assertEqual(world_mesh.size(), 8)
 
             # Verify all expected meshes are created
-            self.assertIsNotNone(parallel_dims._meshes)
-            self.assertIn("pp", parallel_dims._meshes)
-            self.assertIn("batch", parallel_dims._meshes)
-            self.assertIn("loss", parallel_dims._meshes)
-            self.assertIn("dp_replicate", parallel_dims._meshes)
-            self.assertIn("fsdp", parallel_dims._meshes)
-            self.assertIn("cp", parallel_dims._meshes)
-            self.assertIn("tp", parallel_dims._meshes)
-            self.assertIn("ep", parallel_dims._meshes)
-            self.assertIn("efsdp", parallel_dims._meshes)
+            self.assertIsNotNone(parallel_dims._single_axis_meshes)
+            self.assertIn("pp", parallel_dims._single_axis_meshes)
+            self.assertIn("batch", parallel_dims._single_axis_meshes)
+            self.assertIn("loss", parallel_dims._single_axis_meshes)
+            self.assertIn("dp_replicate", parallel_dims._single_axis_meshes)
+            self.assertIn("fsdp", parallel_dims._single_axis_meshes)
+            self.assertIn("cp", parallel_dims._single_axis_meshes)
+            self.assertIn("tp", parallel_dims._single_axis_meshes)
+            self.assertIn("ep", parallel_dims._single_axis_meshes)
+            self.assertIn("efsdp", parallel_dims._single_axis_meshes)
 
             # Validate 1D mesh sizes match parallelism configuration
-            self.assertEqual(parallel_dims._meshes["pp"].size(), 1)
+            self.assertEqual(parallel_dims._single_axis_meshes["pp"].size(), 1)
             self.assertEqual(
-                parallel_dims._meshes["batch"].size(), 4
+                parallel_dims._single_axis_meshes["batch"].size(), 4
             )  # dp_replicate * dp_shard = 2 * 2
             self.assertEqual(
-                parallel_dims._meshes["loss"].size(), 4
+                parallel_dims._single_axis_meshes["loss"].size(), 4
             )  # dp_replicate * dp_shard * cp = 2 * 2 * 1
-            self.assertEqual(parallel_dims._meshes["dp_replicate"].size(), 2)
             self.assertEqual(
-                parallel_dims._meshes["fsdp"].size(), 2
+                parallel_dims._single_axis_meshes["dp_replicate"].size(), 2
+            )
+            self.assertEqual(
+                parallel_dims._single_axis_meshes["fsdp"].size(), 2
             )  # dp_shard * cp = 2 * 1
-            self.assertEqual(parallel_dims._meshes["cp"].size(), 1)
-            self.assertEqual(parallel_dims._meshes["tp"].size(), 2)
-            self.assertEqual(parallel_dims._meshes["ep"].size(), 1)
+            self.assertEqual(parallel_dims._single_axis_meshes["cp"].size(), 1)
+            self.assertEqual(parallel_dims._single_axis_meshes["tp"].size(), 2)
+            self.assertEqual(parallel_dims._single_axis_meshes["ep"].size(), 1)
             self.assertEqual(
-                parallel_dims._meshes["efsdp"].size(), 4
+                parallel_dims._single_axis_meshes["efsdp"].size(), 4
             )  # fsdp * tp / ep = 2 * 2 / 1 = 4
 
             # Validate 2D mesh shapes

--- a/tests/unit_tests/test_tp_kv_heads_validation.py
+++ b/tests/unit_tests/test_tp_kv_heads_validation.py
@@ -51,6 +51,7 @@ def _make_trainer_config(tp: int, seq_len: int = 2048):
         pipeline_parallel_degree=1,
         disable_loss_parallel=True,
         enable_sequence_parallel=False,
+        full_dtensor=False,
     )
     return SimpleNamespace(training=training, parallelism=parallelism)
 

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -11,6 +11,9 @@ from typing import TypeAlias
 
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
+from torch.distributed.tensor.experimental import local_map
+
 from torchtitan.config import CompileConfig, Configurable
 from torchtitan.tools.logging import logger
 
@@ -22,12 +25,88 @@ LossFunction: TypeAlias = Callable[..., torch.Tensor]
 
 def cross_entropy_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
     """Cross-entropy loss with sum reduction for token-based normalization."""
+    if isinstance(pred, DTensor) and isinstance(labels, DTensor):
+        return _cross_entropy_via_local_map(pred, labels)
+
     return torch.nn.functional.cross_entropy(
         pred.flatten(0, 1).float(),
         labels.flatten(0, 1),
         reduction="sum",
         ignore_index=IGNORE_INDEX,
     )
+
+
+def _cross_entropy_via_local_map(pred: DTensor, labels: DTensor) -> torch.Tensor:
+    mesh = pred.device_mesh
+    # Labels don't have a vocab dim.
+    expected_labels_placements = tuple(
+        Replicate() if isinstance(p, Shard) and p.dim == 2 else p
+        for p in pred.placements
+    )
+    if labels.placements != expected_labels_placements:
+        raise ValueError(
+            f"cross_entropy_loss: expected labels placements {expected_labels_placements}, "
+            f"got {labels.placements}"
+        )
+
+    # After local flatten(0, 1), tensor dims are [batch*seq, vocab].
+    # Per-axis placement:
+    #   Shard on batch/seq -> Shard(0) (valid because reduction is sum)
+    #   Shard on vocab -> Shard(1)
+    def _flatten_placement(p):
+        if isinstance(p, Shard):
+            return Shard(0 if p.dim == 0 else p.dim - 1)
+        return p
+
+    vocab_sharded = any(isinstance(p, Shard) and p.dim == 2 for p in pred.placements)
+
+    # Per-axis output placement for sum reduction:
+    #   Shard on non-vocab-dim -> Partial
+    #   Shard on vocab-dim -> Replicate
+    out_placements = [
+        Partial() if isinstance(p, Shard) and p.dim != 2 else Replicate()
+        for p in pred.placements
+    ]
+
+    @local_map(
+        out_placements=out_placements,
+        in_placements=(pred.placements, labels.placements),
+        in_grad_placements=(pred.placements, labels.placements),
+        device_mesh=mesh,
+    )
+    def _local_cross_entropy(
+        pred_local: torch.Tensor, labels_local: torch.Tensor
+    ) -> torch.Tensor:
+        flat_pred = pred_local.flatten(0, 1).float()
+        flat_labels = labels_local.flatten(0, 1)
+        if not vocab_sharded:
+            return torch.nn.functional.cross_entropy(
+                flat_pred,
+                flat_labels,
+                reduction="sum",
+                ignore_index=IGNORE_INDEX,
+            )
+
+        # vocab_sharded == True => loss parallel case
+        # TODO: rewrite the entire loss parallel using megatron style.
+        flat_pred_placements = tuple(_flatten_placement(p) for p in pred.placements)
+        flat_labels_placements = tuple(_flatten_placement(p) for p in labels.placements)
+        pred_dtensor = DTensor.from_local(
+            flat_pred, mesh, flat_pred_placements, run_check=False
+        )
+        labels_dtensor = DTensor.from_local(
+            flat_labels, mesh, flat_labels_placements, run_check=False
+        )
+        loss_dtensor = torch.nn.functional.cross_entropy(
+            pred_dtensor,
+            labels_dtensor,
+            reduction="sum",
+            ignore_index=IGNORE_INDEX,
+        )
+        assert isinstance(loss_dtensor, DTensor)
+        return loss_dtensor.to_local()
+
+    return _local_cross_entropy(pred, labels)
 
 
 def mse_loss(pred: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
@@ -264,7 +343,6 @@ class ChunkedCELoss(BaseLoss):
         through the decoder via a custom autograd Function.
         """
         from torch.distributed._composable.fsdp import FSDPModule
-        from torch.distributed.tensor import DTensor, Replicate
 
         hidden_states = pred
         num_chunks = self.num_chunks
@@ -287,19 +365,38 @@ class ChunkedCELoss(BaseLoss):
         # Check if it's training model or validation mode
         requires_grad = hidden_states.requires_grad
 
-        # Split hidden states and labels into chunks along seq dim.
-        # Use .contiguous() to break shared storage from torch.chunk().
-        # TODO: When CP mesh is in DTensor, chunking along dim=1 won't work
-        # directly with Shard(1) on CP. Need local_map to operate on local tensors
-        h_detached = hidden_states.detach().requires_grad_(requires_grad)
+        # Chunking always operates on the *local* view: when ``t`` is a
+        # Shard(1) DTensor, chunking the global view would distribute whole
+        # chunks across ranks (e.g. size=2, num_chunks=8: chunks 0-3 on
+        # rank 0, 4-7 on rank 1), leaving half the per-chunk DTensors with
+        # local seq=0 and breaking GradAccumulator's slice writes.
+        # ``local_map`` runs the chunking body on plain tensors; under the
+        # non-DTensor (eager) path we call ``_chunk_local`` directly.
+        # ``.contiguous()`` breaks shared storage from ``torch.chunk``.
+        def _chunk_local(t):
+            return tuple(c.contiguous() for c in torch.chunk(t, num_chunks, dim=1))
+
+        def _chunk(t):
+            if not isinstance(t, DTensor):
+                return _chunk_local(t)
+            p = t.placements
+            wrapped = local_map(
+                _chunk_local,
+                out_placements=(p,) * num_chunks,
+                in_placements=(p,),
+                device_mesh=t.device_mesh,
+            )
+            return wrapped(t)
+
+        # ``detach`` + ``requires_grad_`` makes each chunk a leaf so it
+        # accumulates ``.grad`` for ``GradAccumulator``.
         h_chunks = [
-            c.contiguous().detach().requires_grad_(requires_grad)
-            for c in torch.chunk(h_detached, num_chunks, dim=1)
+            c.detach().requires_grad_(requires_grad) for c in _chunk(hidden_states)
         ]
-        label_chunks = torch.chunk(labels, num_chunks, dim=1)
+        label_chunks = list(_chunk(labels))
 
         grad_accumulator = GradAccumulator(
-            h_detached,
+            hidden_states,
             num_chunks=num_chunks,
             dtype=torch.float32,
         )

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -131,6 +131,9 @@ class ParallelismConfig:
     enable_sequence_parallel: bool = True
     """Whether to use SequenceParallel as part of tensor parallelism. Enabled by default."""
 
+    full_dtensor: bool = False
+    """Whether to use full DTensor mode."""
+
     pipeline_parallel_degree: int = 1
     """
     Pipeline Parallelism degree, or number of ranks. 1 means disabled.

--- a/torchtitan/distributed/full_dtensor.py
+++ b/torchtitan/distributed/full_dtensor.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Full DTensor infrastructure for SPMD-style parallelization.
+
+When ``parallelism.full_dtensor`` is enabled, all model parameters,
+buffers, and inputs become DTensors on a multi-dimensional SPMD mesh.
+FSDP uses ``DataParallelMeshDims`` to identify which mesh axes
+are data-parallel.
+
+TP, CP, and EP shardings are handled by ``Module.parallelize(parallel_dims)``
+using config-based ``ShardingConfig``.
+"""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import DataParallelMeshDims
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.distributed.tensor.placement_types import Placement
+
+from torchtitan.distributed.parallel_dims import ParallelDims
+
+
+def validate_config(
+    parallel_dims: ParallelDims,
+    model: nn.Module,
+) -> None:
+    """Validate that the current configuration is compatible with full DTensor.
+
+    Walks ``model`` to discover the actual attention modules in use and
+    raises ``NotImplementedError`` with a clear message if incompatible.
+    """
+    from torchtitan.models.common.attention import (
+        ScaledDotProductAttention,
+        VarlenAttention,
+    )
+
+    if parallel_dims.ep_enabled:
+        raise NotImplementedError(
+            "full_dtensor is not supported with Expert Parallel. "
+            "Disable EP or disable full_dtensor."
+        )
+
+    if parallel_dims.cp_enabled:
+        if any(
+            isinstance(m, (ScaledDotProductAttention, VarlenAttention))
+            for m in model.modules()
+        ):
+            raise NotImplementedError(
+                "full_dtensor + CP is not supported with "
+                "ScaledDotProductAttention or VarlenAttention. "
+                "Use FlexAttention + CP or disable CP."
+            )
+
+
+def _get_dp_mesh_axes(parallel_dims: ParallelDims) -> DataParallelMeshDims:
+    """Build ``DataParallelMeshDims`` for dense (non-MoE) parameters.
+
+    ``dp_shard`` is always included (force-kept-alive in the SPMD mesh
+    even at size 1) so FSDP can pick the DP submesh out of the multi-axis
+    SPMD mesh inside ``DeviceMesh._concatenate([dp_mesh, tp_mesh])``.
+    """
+    assert (
+        parallel_dims.full_dtensor
+    ), "_get_dp_mesh_axes is only meaningful under full_dtensor"
+    shard_axes: list[str] = ["dp_shard"]
+    if parallel_dims.cp_enabled:
+        shard_axes.append("cp")
+
+    if len(shard_axes) > 1:
+        shard: str | tuple[str, ...] | None = tuple(shard_axes)
+    elif shard_axes:
+        shard = shard_axes[0]
+    else:
+        shard = None
+
+    replicate = "dp_replicate" if parallel_dims.dp_replicate_enabled else None
+
+    return DataParallelMeshDims(shard=shard, replicate=replicate)
+
+
+_DENSE_SPMD_AXES = ["dp_replicate", "dp_shard", "cp", "tp"]
+
+
+def resolve_fsdp_mesh(
+    parallel_dims: ParallelDims,
+) -> tuple[DeviceMesh, DataParallelMeshDims]:
+    """Select the dense SPMD mesh and DataParallelMeshDims for full_dtensor."""
+    spmd_mesh = parallel_dims.get_activated_mesh(_DENSE_SPMD_AXES)
+    assert spmd_mesh is not None
+    return spmd_mesh, _get_dp_mesh_axes(parallel_dims)
+
+
+def parallelize_inputs(
+    parallel_dims: ParallelDims,
+    inputs: torch.Tensor,
+    labels: torch.Tensor,
+    extra_kwargs: dict[str, Any],
+) -> tuple[DTensor, DTensor, dict[str, Any]]:
+    """Wrap ``inputs``, ``labels``, and tensor ``extra_kwargs`` as DTensors.
+
+    Placements on the dense SPMD mesh: DP -> Shard(0), CP -> Shard(1),
+    TP -> Replicate. Inputs are assumed already sharded; this only
+    re-wraps via ``from_local``.
+    """
+    mesh = parallel_dims.get_activated_mesh(_DENSE_SPMD_AXES)
+    assert mesh is not None
+    assert mesh.mesh_dim_names is not None
+    input_shardings: dict[str, Placement] = {}
+    if parallel_dims.dp_replicate_enabled:
+        input_shardings["dp_replicate"] = Shard(0)
+    if parallel_dims.dp_shard_enabled:
+        input_shardings["dp_shard"] = Shard(0)
+    if parallel_dims.cp_enabled:
+        input_shardings["cp"] = Shard(1)
+    placements: list[Placement] = [
+        input_shardings.get(name, Replicate()) for name in mesh.mesh_dim_names
+    ]
+
+    new_extra_kwargs: dict[str, Any] = {
+        k: (
+            DTensor.from_local(v, mesh, placements)
+            if isinstance(v, torch.Tensor) and not isinstance(v, DTensor)
+            else v
+        )
+        for k, v in extra_kwargs.items()
+    }
+
+    return (
+        DTensor.from_local(inputs, mesh, placements),
+        DTensor.from_local(labels, mesh, placements),
+        new_extra_kwargs,
+    )

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -6,13 +6,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from torchtitan.config.configs import ParallelismConfig
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_type
+
+if TYPE_CHECKING:
+    from torchtitan.protocols.types import MeshAxisName, NamedPlacement
 
 
 __all__ = ["ParallelDims"]
@@ -27,9 +32,13 @@ class ParallelDims:
     pp: int
     ep: int
     world_size: int
-
-    _meshes: dict[str, DeviceMesh] = field(default_factory=dict)
+    full_dtensor: bool = False
+    # Cache by axis name(s); DeviceMesh equality is by identity, so reuse
+    # is required for ``mesh in spmd_meshes()`` checks.
+    _single_axis_meshes: dict[str, DeviceMesh] = field(default_factory=dict)
+    _multi_axis_meshes: dict[tuple[str, ...], DeviceMesh] = field(default_factory=dict)
     _world_mesh: DeviceMesh | None = None
+    _spmd_meshes: list[DeviceMesh] = field(default_factory=list)
 
     @classmethod
     def from_config(
@@ -43,6 +52,7 @@ class ParallelDims:
             pp=parallelism_config.pipeline_parallel_degree,
             ep=parallelism_config.expert_parallel_degree,
             world_size=world_size,
+            full_dtensor=parallelism_config.full_dtensor,
         )
 
     def __post_init__(self):
@@ -75,6 +85,12 @@ class ParallelDims:
             # Always keep fsdp mesh with real backend so fully_shard()
             # can apply MixedPrecisionPolicy even at degree 1.
             return True
+        if name == "dp_shard" and self.full_dtensor:
+            # Under full_dtensor ``dp_shard`` is the DP storage axis (no
+            # flattened ``fsdp``); keep alive at size 1 so ``fully_shard``
+            # can install MixedPrecisionPolicy and FSDP can discriminate
+            # the DP submesh on TP/DDP/PP-only.
+            return True
         if name == "efsdp":
             # We always keep the efsdp if EP is larger than 1 because we need
             # FSDP wrapping to help the MoE layers do mixed precision training.
@@ -103,6 +119,10 @@ class ParallelDims:
             tp:      Tensor Parallelism (TP).
             ep:      Expert Parallelism (EP).
             efsdp:   FSDP in the EP region.
+            grad_norm: 1D ``dp_shard * cp * tp`` mesh used by clip_grad_norm_.
+                     Excludes ``dp_replicate`` since HSDP grads are Replicate
+                     on that axis (each replica group computes the same
+                     answer in parallel).
 
         Note: Most dimensions above are created by unflattening the world mesh, except for loss,
         which is created by flattening the batch and cp dimensions.
@@ -111,6 +131,7 @@ class ParallelDims:
             ["pp", "batch", "cp", "tp"]  # dataloading_mesh
             ["pp", "dp_replicate", "fsdp", "tp"]  # dense_mesh
             ["pp", "dp_replicate", "efsdp", "ep"]  # sparse_mesh
+            ["pp", "dp_replicate", "grad_norm"]
 
         Note: DeviceMesh currently recreates the process group for each dimension.
         It should share the process group for the same dim group to avoid unnecessary
@@ -161,12 +182,27 @@ class ParallelDims:
             (self.pp, batch, self.cp, self.tp),
         )
         loss_mesh = dataloading_mesh["batch", "cp"]._flatten("loss_mesh")
-        dense_mesh = unflatten_mesh(
-            self._world_mesh,
-            ("pp", "dp_replicate", "fsdp", "tp"),
-            (self.pp, self.dp_replicate, fsdp, self.tp),
-        )
-        sparse_mesh = unflatten_mesh(
+        if self.full_dtensor:
+            # Under full_dtensor, ``dp_shard`` and ``cp`` cannot be folded
+            # together: activations carry a ``cp`` dimension, so parameters
+            # need a ``cp`` axis as well. ``fully_shard`` folds ``dp_shard``
+            # and ``cp`` internally at initialization time.
+            candidate_spmd_dense_axes = ["dp_replicate", "dp_shard", "cp", "tp"]
+            full_dense_mesh = unflatten_mesh(
+                self._world_mesh,
+                tuple(["pp"] + candidate_spmd_dense_axes),
+                (self.pp, self.dp_replicate, self.dp_shard, self.cp, self.tp),
+            )
+        else:
+            # Legacy path folds ``dp_shard`` and ``cp`` into ``fsdp``.
+            candidate_spmd_dense_axes = ["dp_replicate", "fsdp", "tp"]
+            full_dense_mesh = unflatten_mesh(
+                self._world_mesh,
+                ("pp", "dp_replicate", "fsdp", "tp"),
+                (self.pp, self.dp_replicate, fsdp, self.tp),
+            )
+
+        full_sparse_mesh = unflatten_mesh(
             self._world_mesh,
             ("pp", "dp_replicate", "efsdp", "ep"),
             (self.pp, self.dp_replicate, efsdp, self.ep),
@@ -175,24 +211,35 @@ class ParallelDims:
         self._global_meshes = {
             "dataloading": dataloading_mesh,
             "loss": loss_mesh,
-            "dense": dense_mesh,
-            "sparse": sparse_mesh,
+            "dense": full_dense_mesh,
+            "sparse": full_sparse_mesh,
         }
 
-        self._meshes = {
+        self._single_axis_meshes = {
             "pp": dataloading_mesh["pp"],
             "batch": dataloading_mesh["batch"],
             "loss": loss_mesh,
-            "dp_replicate": dense_mesh["dp_replicate"],
-            "fsdp": dense_mesh["fsdp"],
+            "dp_replicate": full_dense_mesh["dp_replicate"],
             "cp": dataloading_mesh["cp"],
             "tp": dataloading_mesh["tp"],
-            "ep": sparse_mesh["ep"],
-            "efsdp": sparse_mesh["efsdp"],
+            "ep": full_sparse_mesh["ep"],
+            "efsdp": full_sparse_mesh["efsdp"],
         }
+        if self.full_dtensor:
+            self._single_axis_meshes["dp_shard"] = full_dense_mesh["dp_shard"]
+        else:
+            self._single_axis_meshes["fsdp"] = full_dense_mesh["fsdp"]
 
-        # Validate mesh sizes
         self._validate_meshes()
+
+        candidate_spmd_sparse_axes = ["dp_replicate", "efsdp", "ep"]
+        activated_spmd_dense_mesh = self.get_activated_mesh(candidate_spmd_dense_axes)
+        activated_spmd_sparse_mesh = self.get_activated_mesh(candidate_spmd_sparse_axes)
+        self._spmd_meshes = [
+            m
+            for m in (activated_spmd_dense_mesh, activated_spmd_sparse_mesh)
+            if m is not None
+        ]
 
         logger.info(
             f"Successfully created meshes with active dimensions: "
@@ -208,15 +255,18 @@ class ParallelDims:
             "batch": self.dp_replicate * self.dp_shard,
             "loss": self.dp_replicate * self.dp_shard * self.cp,
             "dp_replicate": self.dp_replicate,
-            "fsdp": self.dp_shard * self.cp,
             "cp": self.cp,
             "tp": self.tp,
             "ep": self.ep,
             "efsdp": self.dp_shard * self.cp * self.tp // self.ep,
         }
+        if self.full_dtensor:
+            expected_sizes["dp_shard"] = self.dp_shard
+        else:
+            expected_sizes["fsdp"] = self.dp_shard * self.cp
 
         for mesh_name, expected_size in expected_sizes.items():
-            actual_size = self._meshes[mesh_name].size()
+            actual_size = self._single_axis_meshes[mesh_name].size()
             assert actual_size == expected_size, (
                 f"Mesh '{mesh_name}' has unexpected size: "
                 f"expected {expected_size}, got {actual_size}"
@@ -240,31 +290,44 @@ class ParallelDims:
         Raises:
             ValueError: If the requested dimension name(s) is not valid.
         """
-        if not self._meshes:
+        if not self._single_axis_meshes:
             self.build_mesh()
 
         if isinstance(dims, str):
             dims = [dims]
 
         for mesh_name in dims:
-            if mesh_name not in self._meshes:
+            if mesh_name not in self._single_axis_meshes:
                 raise ValueError(
                     f"Invalid mesh dim: '{mesh_name}'. "
-                    f"Valid dimensions are: {list(self._meshes.keys())}"
+                    f"Valid dimensions are: {list(self._single_axis_meshes.keys())}"
                 )
 
-        if any(not self._mesh_exist(dim, self._meshes[dim].size()) for dim in dims):
+        if any(
+            not self._mesh_exist(dim, self._single_axis_meshes[dim].size())
+            for dim in dims
+        ):
             return None
 
         if len(dims) == 1:
-            return self._meshes[dims[0]]
-        else:
-            for global_mesh in self._global_meshes.values():
-                assert global_mesh.mesh_dim_names is not None
-                if not set(dims).issubset(set(global_mesh.mesh_dim_names)):
-                    continue
-                return global_mesh[tuple(dims)]
+            return self._single_axis_meshes[dims[0]]
+
+        # Cache to ensure mesh equality by object identity.
+        key = tuple(dims)
+        if key in self._multi_axis_meshes:
+            return self._multi_axis_meshes[key]
+
+        candidates = [
+            (name, global_mesh)
+            for name, global_mesh in self._global_meshes.items()
+            if global_mesh.mesh_dim_names is not None
+            and set(dims).issubset(set(global_mesh.mesh_dim_names))
+        ]
+        if not candidates:
             raise ValueError(f"Invalid mesh name combinations {dims}.")
+        submesh = candidates[0][1][key]
+        self._multi_axis_meshes[key] = submesh
+        return submesh
 
     def get_mesh(self, dims: str | list[str]) -> DeviceMesh:
         """Get a device mesh by dimension name(s), raising if not available.
@@ -292,6 +355,91 @@ class ParallelDims:
             )
         return mesh
 
+    def spmd_meshes(self) -> list[DeviceMesh]:
+        """Valid full-SPMD meshes, restricted to enabled axes.
+
+        Returns the full-SPMD meshes; today we have dense and sparse.
+        """
+        if not self._spmd_meshes:
+            self.build_mesh()
+        return self._spmd_meshes
+
+    def get_activated_mesh(self, axes: list[str]) -> DeviceMesh | None:
+        """Submesh of ``axes`` filtered to those actually enabled in this run.
+
+        Returns a mesh containing the axes in ``axes`` that are enabled. If
+        none of the axes in ``axes`` is enabled, returns ``None``. This
+        differs from ``get_optional_mesh``, which returns ``None`` as soon
+        as any axis in ``axes`` is not enabled.
+        """
+        if not self._single_axis_meshes:
+            self.build_mesh()
+        axes = [
+            axis
+            for axis in axes
+            if axis in self._single_axis_meshes
+            and self.get_optional_mesh(axis) is not None
+        ]
+        return self.get_optional_mesh(axes) if axes else None
+
+    def resolve_mesh(self, axes: Iterable[MeshAxisName | str]) -> DeviceMesh | None:
+        """Resolve the device mesh for a set of mesh axis names.
+
+        Given the axes, query ``parallel_dims`` for the corresponding SPMD
+        mesh (dense or sparse).
+
+        ``axes`` is always a superset of the resolved mesh's axes: we always
+        specify every axis. Under full_dtensor the resolved mesh contains
+        every activated axis; under non-full_dtensor only ``tp`` and ``ep``
+        are kept (DP/CP stay out-of-band).
+
+        Returns ``None`` when no axis is enabled under non-``full_dtensor``.
+        Raises ``ValueError`` under ``full_dtensor`` if the resolved mesh is
+        not one of ``parallel_dims.spmd_meshes()``.
+        """
+        axes_list = list(axes)
+        if not self.full_dtensor:
+            in_band = ("tp", "ep")
+            axes_list = [axis for axis in axes_list if axis in in_band]
+        mesh = self.get_activated_mesh(axes_list)
+        if mesh is None:
+            return None
+        assert mesh.mesh_dim_names is not None, "DeviceMesh must have named axes"
+        if self.full_dtensor and mesh not in self.spmd_meshes():
+            raise ValueError(
+                f"Resolved mesh {list(mesh.mesh_dim_names)} does not match any "
+                f"SPMD mesh. Valid meshes: "
+                f"{[list(m.mesh_dim_names or ()) for m in self.spmd_meshes()]}."
+            )
+        return mesh
+
+    def resolve_shared_mesh(
+        self, placements: Iterable["NamedPlacement | None"]
+    ) -> DeviceMesh | None:
+        """Resolve the mesh shared by a list of NamedPlacements.
+
+        All non-``None`` entries must reference the same axis keys (placement
+        values may differ -- "redistribute on the same mesh" is exactly the
+        case of same axes, different placements). ``None`` entries are
+        skipped (e.g. LocalMapConfig non-tensor args, optional in/dst/grad
+        placements).
+
+        Returns ``None`` when every entry is ``None`` or when ``resolve_mesh``
+        filters every axis out (legacy non-``full_dtensor`` path); callers
+        should treat this as a no-op for the corresponding boundary.
+        """
+        non_none = [p for p in placements if p is not None]
+        if not non_none:
+            return None
+        axes = non_none[0].keys()
+        for p in non_none[1:]:
+            assert p.keys() == axes, (
+                f"Inconsistent mesh axes within a boundary: "
+                f"{sorted(k.value for k in axes)} vs "
+                f"{sorted(k.value for k in p.keys())}"
+            )
+        return self.resolve_mesh(axes)
+
     def get_all_one_dimensional_meshes(self) -> dict[str, DeviceMesh]:
         """Get all enabled one-dimensional device meshes.
 
@@ -314,10 +462,18 @@ class ParallelDims:
             >>> meshes = parallel_dims.get_all_one_dimensional_meshes()
             >>> print(meshes.keys())
             dict_keys(['dp_replicate', 'fsdp', 'tp', 'batch', 'loss', 'efsdp'])
+
+        Note:
+            Under ``full_dtensor=True`` the dense shard axis appears as
+            ``'dp_shard'`` instead of the pre-flattened ``'fsdp'``.
         """
-        if not self._meshes:
+        if not self._single_axis_meshes:
             self.build_mesh()
-        return {k: v for k, v in self._meshes.items() if v.ndim == 1 and v.size() > 1}
+        return {
+            k: v
+            for k, v in self._single_axis_meshes.items()
+            if v.ndim == 1 and v.size() > 1
+        }
 
     @property
     def world_mesh(self) -> DeviceMesh:

--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -14,7 +14,7 @@ import torch._inductor.config
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import distribute_module, DTensor, Replicate
-from torch.distributed.tensor.parallel import ColwiseParallel, ParallelStyle
+from torch.distributed.tensor.parallel import ParallelStyle
 from torch.distributed.tensor.placement_types import Placement
 
 from torchtitan.config import CompileConfig, ParallelismConfig
@@ -102,89 +102,6 @@ class NoParallel(ParallelStyle):
                 self._prepare_output_fn,  # pyrefly: ignore [bad-argument-type]
                 self.output_layout,
                 self.local_output_grad_placements,
-            ),
-        )
-
-
-class ColwiseParallelWithGradPlacement(ColwiseParallel):
-    """ColwiseParallel with explicit control over backward gradient placement.
-
-    By default, ``ColwiseParallel`` with ``input_layouts=Replicate()`` wraps
-    the input via ``from_local(Replicate)``, whose backward all-reduces d_x
-    back to Replicate.  This subclass overrides ``_prepare_input_fn`` to pass
-    ``local_input_grad_placements`` to ``DTensor.from_local``, giving users
-    explicit control over the gradient placement during backward.  When not
-    specified, defaults to ``None`` and the gradient placement follows the
-    default guarantees of ``DTensor.from_local``.
-    """
-
-    def __init__(
-        self,
-        *,
-        input_layouts: Placement | None = None,
-        output_layouts: Placement | None = None,
-        use_local_output: bool = True,
-        local_input_grad_placements: Sequence[Placement] | None = None,
-    ):
-        super().__init__(
-            input_layouts=input_layouts,
-            output_layouts=output_layouts,
-            use_local_output=use_local_output,
-        )
-        self.local_input_grad_placements = local_input_grad_placements
-
-    @staticmethod
-    # pyrefly: ignore [bad-param-name-override]
-    def _prepare_input_fn(
-        input_layouts,
-        desired_input_layouts,
-        local_input_grad_placements,
-        mod,
-        inputs,
-        device_mesh,
-    ):
-        input_tensor = inputs[0]
-        if not isinstance(input_tensor, DTensor):
-            assert local_input_grad_placements is not None, (
-                "local_input_grad_placements must be specified when input is a "
-                "plain tensor. Please think about what you want the from_local(Replicate) backward behavior like."
-            )
-            input_tensor = DTensor.from_local(
-                input_tensor,
-                device_mesh,
-                input_layouts,
-                run_check=False,
-                grad_placements=local_input_grad_placements,
-            )
-
-        if input_layouts != desired_input_layouts:
-            input_tensor = input_tensor.redistribute(
-                placements=desired_input_layouts, async_op=True
-            )
-        return input_tensor
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        if isinstance(module, nn.Linear):
-            partition_fn = self._partition_linear_fn
-        elif isinstance(module, nn.Embedding):
-            partition_fn = self._partition_embedding_fn
-        else:
-            raise NotImplementedError(
-                "ColwiseParallelWithGradPlacement currently only supports nn.Linear and nn.Embedding!"
-            )
-
-        return distribute_module(
-            module,
-            device_mesh,
-            partition_fn,
-            partial(
-                self._prepare_input_fn,  # pyrefly: ignore [bad-argument-type]
-                self.input_layouts,
-                self.desired_input_layouts,
-                self.local_input_grad_placements,
-            ),
-            partial(
-                self._prepare_output_fn, self.output_layouts, self.use_local_output
             ),
         )
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -45,11 +45,12 @@ def _dist_reduce(
             process group, and then the result will be all_reduced for the mesh.
     """
     if isinstance(x, DTensor):
-        # DTensor path: ``full_tensor()`` already performs the mesh reduction
-        # for Partial placements and is a no-op for Replicate. Skipping the
-        # subsequent mesh all-reduce is required to avoid double-counting.
-        # Shard placements are not supported — semantics are undefined since
-        # the reduction target is ambiguous.
+        # loss being a DTensor can be 1) full dtensor or 2) non-full dtensor but
+        # TP is enabled. For the former one, a single `full_tensor()` call is enough
+        # but for the later one, we need to treat it as a plain tensor. Since there
+        # is no robust way to distinguish the two and `full_tensor()` may result in
+        # multiple all_reduce() (one for dp_shard and one for CP), we always use
+        # `to_local()` to ensure loss parity in both cases.
         assert all(p.is_replicate() or p.is_partial() for p in x.placements), (
             f"_dist_reduce received a DTensor with unsupported placements "
             f"{x.placements}; only Replicate/Partial are supported."
@@ -57,11 +58,9 @@ def _dist_reduce(
         if extra_pg is not None:
             raise ValueError(
                 "_dist_reduce does not support DTensor input combined with "
-                "extra_pg: ``full_tensor()`` already reduces over the DTensor's "
-                "mesh, and extra_pg (e.g. the FT replica group) is orthogonal "
-                "to that mesh. Pass a plain tensor when using extra_pg."
+                "extra_pg: pass a plain tensor when using extra_pg."
             )
-        return float(x.full_tensor().item())
+        x = x.to_local()
 
     # Plain tensor path.
     if extra_pg is not None:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -306,7 +306,7 @@ class Trainer(ForgeEngine):
             [p for m in self.model_parts for p in m.parameters()],
             self.config.training.max_norm,
             foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
+            parallel_dims=parallel_dims,
             ep_enabled=parallel_dims.ep_enabled,
         )
         self.checkpointer.maybe_wait_for_staging()

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -415,7 +415,7 @@ class FaultTolerantTrainer(Trainer):
             [p for m in self.model_parts for p in m.parameters()],
             self.config.training.max_norm,
             foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
+            parallel_dims=parallel_dims,
             ep_enabled=parallel_dims.ep_enabled,
         )
         self.checkpointer.maybe_wait_for_staging()

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -13,6 +13,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
     apply_cp_to_attention,
@@ -76,10 +77,10 @@ def parallelize_deepseekv3(
     annotate_deepseekv3(model)
 
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
         # Config-based sharding: ShardingConfig is populated on the model
         # config in Trainer.Config.__post_init__; Module.parallelize applies it.
-        model.parallelize(tp_mesh)
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     # Read comm_backend from the model's token dispatcher config
     # (set by moe_comm_backend in model_registry / config factories).

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -11,6 +11,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
     apply_cp_to_attention,
@@ -60,8 +61,8 @@ def parallelize_llama(
     annotate_llama(model)
 
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
-        model.parallelize(tp_mesh)
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
     # real backend (see ParallelDims._mesh_exist), even at degree 1, so that

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -13,6 +13,7 @@ from torchtitan.config import (
     TrainingConfig,
 )
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
     apply_cp_to_attention,
@@ -78,10 +79,10 @@ def parallelize_qwen3(
     annotate_qwen3(model)
 
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
         # Config-based sharding: ShardingConfig is populated on the model
         # config in Trainer.Config.__post_init__; Module.parallelize applies it.
-        model.parallelize(tp_mesh)
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -64,11 +64,14 @@ def build_minimal_trainer(
                 pipeline_parallel_degree=1,
                 fsdp_reshard_after_forward=fsdp_reshard_after_forward,
                 enable_async_tensor_parallel=False,
+                full_dtensor=False,
             ),
         )
         trainer._fwd_bwd_step_module = None
         trainer._traced_step = None
     else:
-        trainer.config = SimpleNamespace()
+        trainer.config = SimpleNamespace(
+            parallelism=SimpleNamespace(full_dtensor=False),
+        )
 
     return trainer

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -47,7 +47,6 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
             tp=1,
             pp=1,
             ep=1,
-            etp=1,
             world_size=1,
         )
         training = TrainingConfig(

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -351,7 +351,7 @@ class PolicyTrainer(Actor, Configurable):
             [p for m in self.model_parts for p in m.parameters()],
             self.config.training.max_norm,
             foreach=True,
-            pp_mesh=self.parallel_dims.get_optional_mesh("pp"),
+            parallel_dims=self.parallel_dims,
         )
 
         self.optimizers.step()

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -25,12 +25,13 @@ The folder should be organized as follows
     - In post-training, `to_hf()` helps convert a torchtitan model to HF model, which can be used for inference by other frameworks.
   - This is optional for offline exploration.
 - `sharding.py`
-  - Define `set_<model>_sharding_spec(config, *, loss_parallel, enable_sp, ...)` that populates `sharding_spec` on each `Module.Config` in the model config (embeddings, norms, attention, feed-forward, output). TP, SP, and inner-attention `LocalMapConfig` placements are expressed declaratively via `ShardingConfig` instead of a runtime `parallelize_module` plan.
+  - Define `set_<model>_sharding_config(config, *, loss_parallel, enable_sp, ...)` that populates `sharding_config` on each `Module.Config` in the model config (embeddings, norms, attention, feed-forward, output). TP, SP, and inner-attention `LocalMapConfig` placements are expressed declaratively via `ShardingConfig` instead of a runtime `parallelize_module` plan.
   - Call the helper from `Model.Config.update_from_config()` so placements depend on the trainer's `parallelism` settings.
-  - Reuse shared helpers from `torchtitan/models/common/decoder_sharding.py` (`set_decoder_sharding_spec`, `set_dense_ffn_sharding`, `set_gqa_attention_sharding`, `norm_spec`, `dense_param_placement`, `dense_activation_placement`) where possible.
+  - Reuse shared helpers from `torchtitan/models/common/decoder_sharding.py` (`set_decoder_sharding_config`, `set_dense_ffn_sharding`, `set_gqa_attention_sharding`, `norm_config`, `dense_param_placement`, `dense_activation_placement`) where possible.
+  - Under `--training.full_dtensor`, declare the mesh axes in canonical outer-to-inner SPMD order: `(dp_replicate, dp_shard, cp, tp)` for dense (attention/MLP/norm/embed/lm_head) and `(dp_replicate, efsdp, ep)` for sparse (MoE expert weights). `Module.parallelize` resolves the mesh by the declared order and validates it matches one of the SPMD meshes; declaring axes out of order raises `ValueError`.
 - `parallelize.py`
   - apply training techniques in the following order
-    - `model.parallelize(mesh)` — auto-recursive declarative sharding driven by `sharding_spec` (TP, SP, attention `local_map`). Replaces per-model `parallelize_module` plan dicts.
+    - `model.parallelize(parallel_dims)` — auto-recursive declarative sharding driven by `sharding_config` (TP, SP, attention `local_map`). Replaces per-model `parallelize_module` plan dicts.
     - (MoE models) `apply_moe_ep_tp` for expert-parallel + TP on MoE experts (not yet config-based).
     - activation checkpointing
     - `torch.compile`

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -99,9 +99,9 @@ class VarlenAttention(Module):
 
     def forward(
         self,
-        xq: torch.Tensor,
-        xk: torch.Tensor,
-        xv: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
         *,
         attention_masks: VarlenMetadata,
         scale: float | None = None,
@@ -116,12 +116,12 @@ class VarlenAttention(Module):
         max_q = attention_masks.max_q
         max_k = attention_masks.max_k
 
-        batch_size, seq_len, _, head_dim = xq.shape
+        batch_size, seq_len, _, head_dim = q.shape
 
         # varlen attention expects (bs*seqlen, n_heads, head_dim)
-        xq_packed = xq.reshape(batch_size * seq_len, -1, head_dim)
-        xk_packed = xk.reshape(batch_size * seq_len, -1, head_dim)
-        xv_packed = xv.reshape(batch_size * seq_len, -1, head_dim)
+        xq_packed = q.reshape(batch_size * seq_len, -1, head_dim)
+        xk_packed = k.reshape(batch_size * seq_len, -1, head_dim)
+        xv_packed = v.reshape(batch_size * seq_len, -1, head_dim)
 
         # Some operators can upcast under AMP, but varlen attention currently only
         # supports bf16/fp16 inputs. If this changes, or fp16 training support
@@ -162,7 +162,7 @@ class VarlenAttention(Module):
         # Reshape back to the format expected by GQAttention.forward()
         out = out_packed.view(batch_size, seq_len, -1, head_dim)
 
-        return out.to(xq.dtype)
+        return out.to(q.dtype)
 
 
 class FlexAttention(Module):

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributed.tensor import Placement, Replicate, Shard
+from torch.distributed.tensor import Partial, Placement, Replicate, Shard
 
 from torchtitan.models.common.attention import FusedQKVLinear, GQAttention, QKVLinear
 from torchtitan.protocols.sharding import LocalMapConfig, NamedPlacement, ShardingConfig
@@ -158,17 +158,41 @@ def set_gqa_inner_attention_local_map(
     TP-sharded (``Shard(2)``), regardless of SP. ``local_map`` converts them
     to local tensors before the kernel runs, then wraps outputs back.
 
+    Declares placements over the full dense SPMD axis set (DP/CP/TP) so
+    the LocalMap composes under ``full_dtensor`` (where the surrounding
+    mesh is multi-axis); under non-full_dtensor, the (tp,)-only mesh only
+    consumes the ``TP`` placement and the rest are ignored.
+
+    Under ``full_dtensor`` + CP, q stays seq-sharded on the CP axis
+    (``Shard(1)``) while k/v are ``Replicate`` on CP -- DTensor all-gathers
+    k/v at the local_map boundary so the kernel sees full-length keys
+    (matching the BlockMask's kv dimension). Q's local grad is naturally
+    seq-sharded; k/v's local grads accumulate as ``Partial`` on CP and
+    DTensor reduces them on the way out.
+
     ``return_lse=True`` is for kernels that return ``(output, lse)`` (e.g.,
     GPT-OSS's flash attention with ``return_lse=True``); both outputs share
     the same heads-sharded placement.
     """
-    qkv_placements: NamedPlacement = {TP: Shard(2)}
-    num_outputs = 2 if return_lse else 1
+    q_placements: NamedPlacement = dense_activation_placement(tp=Shard(2))
+    kv_placements: NamedPlacement = dense_activation_placement(
+        tp=Shard(2), cp=Replicate()
+    )
+    kv_grad_placements: NamedPlacement = dense_activation_placement(
+        tp=Shard(2), cp=Partial()
+    )
+    out_src: NamedPlacement | tuple[NamedPlacement, ...] = (
+        (q_placements, q_placements) if return_lse else q_placements
+    )
     inner_attention_cfg.sharding_config = ShardingConfig(
+        in_dst_shardings={
+            "q": q_placements,
+            "k": kv_placements,
+            "v": kv_placements,
+        },
+        out_src_shardings=out_src,
         local_map=LocalMapConfig(
-            in_placements=(qkv_placements, qkv_placements, qkv_placements),
-            out_placements=(qkv_placements,) * num_outputs,
-            in_grad_placements=(qkv_placements, qkv_placements, qkv_placements),
+            in_grad_placements=(q_placements, kv_grad_placements, kv_grad_placements),
         ),
     )
 

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -10,14 +10,13 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.distributed.tensor import DTensor, Partial
+from torch.distributed.tensor import DTensor
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
-
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import LocalTokenDispatcher
+from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
 
 
 class GroupedExperts(Module):
@@ -72,7 +71,7 @@ class GroupedExperts(Module):
             x.bfloat16(), w3.bfloat16().transpose(-2, -1), offs=offsets
         )
         return torch._grouped_mm(
-            h, w2.bfloat16().transpose(-2, -1), offs=offsets
+            +h, w2.bfloat16().transpose(-2, -1), offs=offsets
         ).type_as(x)
 
     def forward(
@@ -80,18 +79,27 @@ class GroupedExperts(Module):
         x: torch.Tensor,
         top_scores: torch.Tensor,
         selected_experts_indices: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add.
 
-        shared_experts is passed to combine() where it overlaps with the async
-        combine all-to-all (NCCL stream) or async DeepEP combine.
+        When parallelized, ``local_map`` (from ``sharding_config``) handles
+        DTensor→local conversion on entry and local→DTensor(Partial) wrapping
+        on exit. The forward body operates on plain local tensors.
         """
         routed_input, num_tokens_local, metadata = self.token_dispatcher.dispatch(
             x, top_scores, selected_experts_indices
         )
         routed_output = self._experts_forward(routed_input, num_tokens_local)
-        return self.token_dispatcher.combine(routed_output, metadata, x, shared_experts)
+        return self.token_dispatcher.combine(routed_output, metadata, x)
+
+    def parallelize(self, parallel_dims) -> None:
+        """Parallelize expert weights, then wire EP/TP meshes on the dispatcher
+        so dispatch/combine see the right meshes at runtime."""
+        super().parallelize(parallel_dims)
+        self.token_dispatcher.wire_meshes(
+            ep_mesh=parallel_dims.get_optional_mesh("ep"),
+            tp_mesh=parallel_dims.get_optional_mesh("tp"),
+        )
 
 
 class TokenChoiceTopKRouter(Module):
@@ -258,18 +266,18 @@ class MoE(Module):
     """Mixture of Experts layer.
 
     The forward pass proceeds as:
-    1. Router computes expert assignments
-    2. GroupedExperts.forward() handles:
+    1. Router computes expert assignments (stays on DTensor)
+    2. GroupedExperts.forward() converts DTensor to local, then handles:
        a. dispatch (TokenDispatcher) — reorder tokens by expert assignment.
           With EP, also performs all-to-all communication to send tokens
           to expert-owning ranks.
-       b. expert computation
+       b. expert computation (local tensors)
        c. combine (TokenDispatcher) — reverse the dispatch reordering.
-          With EP, starts async communication (NCCL all-to-all or DeepEP
-          combine), runs shared_experts in parallel, then forces sync
-          (scatter_add for NCCL AllToAll, sync_combine for DeepEP) and
-          produces final output.
-          Without EP (LocalTokenDispatcher), no communication is needed.
+          - LocalTokenDispatcher (no EP): scatter_add only.
+          - AllToAll: all-to-all communication, then scatter_add.
+          - DeepEP/HybridEP: async combine_tokens.
+    3. Shared experts run on DTensor (overlaps with DeepEP async combine).
+    4. Routed and shared expert outputs are summed.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -318,30 +326,14 @@ class MoE(Module):
 
         Returns:
             out (torch.Tensor): Output tensor with shape ``(bs, slen, dim)``.
+
+        Under TP, the MoE wrapper's ``sharding_config`` (set by
+        ``set_moe_sharding_config``) handles input/output redistribution:
+        input is redistributed from sp_layout to desired_input_layouts;
+        output (Partial) is redistributed to sp_layout. MoE.forward()
+        operates on DTensors — the DTensor→local conversion happens at
+        the GroupedExperts boundary.
         """
-        # Convert DTensor to local tensor for MoE-internal computation.
-        # grad_placements=(Partial(),) ensures x.grad is Partial on the tp_mesh
-        # in backward, so gradient reduction (reduce-scatter from Partial to
-        # Shard(1)) happens once at the MoE boundary rather than being
-        # duplicated inside the MoE.
-        #
-        # Why grad(x) is Partial on the tp_mesh across all parallelism:
-        # - TP only / TP+EP with ETP=TP: TP-sharded expert weights (Colwise on
-        #   w1/w3, Rowwise on w2) produce Partial output gradients.
-        # - TP+EP with ETP=1: each TP rank processes a disjoint token subset
-        #   (via sequence-parallel token splitting in AllToAllTokenDispatcher),
-        #   so grad(x) is non-zero only at each rank's token positions (Partial).
-        #
-        # This holds for all MoE components (router.gate, routed experts, shared
-        # experts) and regardless of score_before_experts.
-        if isinstance(x, DTensor):
-            assert (
-                x.device_mesh.ndim == 1
-            ), f"Expected 1D mesh, got {x.device_mesh.ndim}D mesh"
-            assert x.device_mesh.mesh_dim_names == (
-                "tp",
-            ), f"Expected TP mesh, got mesh_dim_names={x.device_mesh.mesh_dim_names}"
-            x = x.to_local(grad_placements=(Partial(),))
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
 
@@ -361,13 +353,21 @@ class MoE(Module):
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert)
 
-        out = self.experts(
-            x,
-            top_scores,
-            selected_experts_indices,
-            shared_experts=self.shared_experts,
-        )
+        out = self.experts(x, top_scores, selected_experts_indices)
 
+        # shared_experts runs in parallel with deepep combine communication.
+        shared_out = self.shared_experts(x) if self.shared_experts is not None else None
+
+        if isinstance(self.experts.token_dispatcher, DeepEPTokenDispatcher):
+            # Sync the combine operation before using routed_output.
+            # This inserts a CUDA stream wait, ensuring combine is complete before
+            # the subsequent addition or reshape operations read routed output.
+            from torchtitan.distributed.deepep.deepep import sync_combine
+
+            sync_combine()
+
+        if shared_out is not None:
+            out = out + shared_out
         return out.reshape(bs, slen, dim)
 
     def _init_self_buffers(self, *, buffer_device: torch.device | None = None) -> None:

--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -1,0 +1,267 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Config-based sharding helpers for MoE submodules."""
+
+from torch.distributed.tensor import Partial, Placement, Replicate, Shard
+
+from torchtitan.models.common.decoder_sharding import (
+    dense_activation_placement,
+    dense_param_placement,
+)
+from torchtitan.protocols.sharding import LocalMapConfig, NamedPlacement, ShardingConfig
+from torchtitan.protocols.types import MeshAxisName
+
+
+DP_REPLICATE = MeshAxisName.DP_REPLICATE
+DP_SHARD = MeshAxisName.DP_SHARD
+CP = MeshAxisName.CP
+TP = MeshAxisName.TP
+EP = MeshAxisName.EP
+EFSDP = MeshAxisName.EFSDP
+
+
+def expert_param_placement_sparse() -> NamedPlacement:
+    """Sparse-family placement for routed-expert weights (EP enabled).
+
+    Insertion order matches canonical mesh order ``DP_REPLICATE -> EFSDP ->
+    EP`` so ``_needed_axes``'s first-insertion axis order resolves
+    to the sparse_mesh.
+
+    DP_REPLICATE / EFSDP are FSDP storage axes: ``Replicate`` at
+    ``distribute_tensor`` time, FSDP reshards ``EFSDP`` post-parallelize.
+    EP always shards on dim 0 (the expert dim of ``(num_experts, *, *)``
+    weights).
+    """
+    return {
+        DP_REPLICATE: Replicate(),
+        EFSDP: Replicate(),
+        EP: Shard(0),
+    }
+
+
+def expert_param_placement_dense(*, tp_placement: Placement) -> NamedPlacement:
+    """Dense-family placement for routed-expert weights (EP disabled, TP > 1).
+
+    Used when expert parallelism is disabled but tensor parallelism shards
+    the experts on the dense TP axis.
+
+    Insertion order matches canonical mesh order. ``tp_placement`` is the
+    placement on the TP axis: ``Shard(1)`` for colwise, ``Shard(2)`` for
+    rowwise, ``Replicate()`` for replicated bias.
+    """
+    return {
+        DP_REPLICATE: Replicate(),
+        DP_SHARD: Replicate(),
+        CP: Replicate(),
+        TP: tp_placement,
+    }
+
+
+def _shared_expert_colwise_config(enable_ep: bool, enable_sp: bool) -> ShardingConfig:
+    """Colwise shared-expert FFN (w1/w3).
+
+    Mirrors ``ColwiseParallel(input_layouts=...)``: input is all-gathered
+    to Replicate for the column-sharded matmul; output is Shard(1).
+    """
+    sp_layout = Shard(1) if enable_sp else Replicate()
+    input_layout = Replicate() if not enable_ep else sp_layout
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=Shard(0)),
+            "bias": dense_param_placement(tp=Shard(0)),
+        },
+        in_src_shardings={"input": dense_activation_placement(tp=input_layout)},
+        in_dst_shardings={"input": dense_activation_placement(tp=Replicate())},
+        out_dst_shardings=dense_activation_placement(tp=Shard(1)),
+    )
+
+
+def _shared_expert_rowwise_config() -> ShardingConfig:
+    """Rowwise shared-expert FFN (w2), output stays DTensor(Partial).
+
+    Mirrors ``RowwiseParallel(output_layouts=Partial(), use_local_output=False)``:
+    input Shard(1) from upstream colwise; rowwise matmul produces Partial;
+    output stays DTensor(Partial) — reduction happens at the MoE boundary.
+    """
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=Shard(1)),
+            # Rowwise bias is replicated (not sharded) -- the rowwise matmul
+            # sums across TP ranks, then the bias add is a per-rank add.
+            "bias": dense_param_placement(tp=Replicate()),
+        },
+        in_src_shardings={"input": dense_activation_placement(tp=Shard(1))},
+        out_dst_shardings=dense_activation_placement(tp=Partial()),
+    )
+
+
+def _router_gate_config(*, enable_ep: bool) -> ShardingConfig:
+    """Router gate: Replicate weights, output stays DTensor.
+
+    EP off: input Replicate, gate computes on all tokens, output DTensor(Replicate).
+    EP on:  input redistributed to Shard(0), gate computes on local shard, output DTensor(Shard(0)).
+    """
+    state = {
+        "weight": dense_param_placement(tp=Replicate()),
+        "bias": dense_param_placement(tp=Replicate()),
+    }
+    if enable_ep:
+        return ShardingConfig(
+            state_shardings=state,
+            in_dst_shardings={"input": dense_activation_placement(tp=Shard(0))},
+            out_dst_shardings=dense_activation_placement(tp=Shard(0)),
+        )
+    else:
+        return ShardingConfig(
+            state_shardings=state,
+            out_dst_shardings=dense_activation_placement(tp=Replicate()),
+        )
+
+
+def _moe_wrapper_sharding_config(*, enable_ep: bool, enable_sp: bool) -> ShardingConfig:
+    """``ShardingConfig`` at the MoE wrapper boundary.
+
+    Mirrors ``PrepareModuleInputOutput``: input arrives at sp_layout,
+    redistributed to desired_input_layouts; output is Partial,
+    redistributed to sp_layout. MoE.forward() operates on DTensors —
+    the DTensor→local conversion happens at GroupedExperts boundary.
+    """
+    sp_layout: Placement = Shard(1) if enable_sp else Replicate()
+    moe_desired_input_layouts = Replicate() if not enable_ep else sp_layout
+
+    return ShardingConfig(
+        state_shardings={
+            "expert_bias": dense_param_placement(tp=Replicate()),
+            "tokens_per_expert": dense_param_placement(
+                tp=Partial() if enable_ep else Replicate()
+            ),
+        },
+        in_src_shardings={"x": dense_activation_placement(tp=sp_layout)},
+        in_dst_shardings={
+            "x": dense_activation_placement(tp=moe_desired_input_layouts)
+        },
+        out_src_shardings=dense_activation_placement(tp=Partial()),
+        out_dst_shardings=dense_activation_placement(tp=sp_layout),
+    )
+
+
+def set_moe_sharding_config(
+    moe_cfg,
+    *,
+    enable_tp: bool,
+    enable_ep: bool,
+    enable_sp: bool,
+    expert_param_layout: dict[str, Placement],
+) -> None:
+    """Populate ``sharding_config`` on every MoE submodule.
+
+    Branches dense vs sparse family per Module:
+
+    - ``moe`` (wrapper): input/output redistribution on ``{TP}``.
+      Always set when ``tp_enabled``.
+    - ``moe.router.gate``: Replicate weights, output stays DTensor.
+    - ``moe.shared_experts.{w1,w2,w3}``: dense-family TP plan with
+      Partial-flow grad annotations (when ``moe_cfg.shared_experts is not
+      None``).
+    - ``moe.experts`` (``GroupedExperts``): sparse-family ``{EP}``
+      placements when EP is enabled; dense-family ``{TP}`` placements
+      when EP is disabled and TP is enabled; no sharding when both are
+      disabled.
+
+    ``expert_param_layout`` maps each routed-expert parameter name to its
+    dense in/out-dim placement (used on the EP-disabled + TP-enabled path):
+    ``Shard(1)`` for colwise, ``Shard(2)`` for rowwise, ``Replicate()`` for
+    replicated bias. The shared ``GroupedExperts`` (qwen3, llama4,
+    deepseek_v3) passes ``{"w1": Shard(1), "w2": Shard(2), "w3": Shard(1)}``;
+    ``GptOssGroupedExperts`` passes its mlp1/mlp2 layout.
+
+    Args:
+        moe_cfg: The ``MoE.Config`` instance to populate.
+        tp_enabled: Whether tensor parallelism is enabled.
+        ep_enabled: Whether expert parallelism is enabled.
+        enable_sp: Whether sequence parallelism is enabled (affects the
+            wrapper's enter/exit TP layout).
+        expert_param_layout: ``{param_name: tp_placement}`` for the
+            routed experts' weight params (used on the EP-disabled +
+            TP-enabled path).
+    """
+    # MoE wrapper boundary. Set whenever TP is enabled (with or without
+    # SP) -- the wrapper still needs to convert DTensor inputs to local.
+    if enable_tp:
+        moe_cfg.sharding_config = _moe_wrapper_sharding_config(
+            enable_ep=enable_ep, enable_sp=enable_sp
+        )
+
+        # Router gate: dense-family TP plan with Partial output grad.
+        moe_cfg.router.gate.sharding_config = _router_gate_config(enable_ep=enable_ep)
+
+        # Shared experts: optional. Use Partial-flow variants so the
+        # Partial->sp_layout reduce only happens once at the MoE boundary.
+        if getattr(moe_cfg, "shared_experts", None) is not None:
+            moe_cfg.shared_experts.w1.sharding_config = _shared_expert_colwise_config(
+                enable_ep=enable_ep, enable_sp=enable_sp
+            )
+            moe_cfg.shared_experts.w2.sharding_config = _shared_expert_rowwise_config()
+            moe_cfg.shared_experts.w3.sharding_config = _shared_expert_colwise_config(
+                enable_ep=enable_ep, enable_sp=enable_sp
+            )
+
+    # Routed experts: local_map converts DTensor inputs to local for
+    # dispatch/compute/combine, then wraps local output as DTensor(Partial).
+    experts_out_layout = dense_activation_placement(tp=Partial())
+    if enable_ep:
+        # Sparse family: {EP}. Expert weights shard on the expert dim.
+        state_shardings: dict[str, NamedPlacement] = {
+            name: expert_param_placement_sparse() for name in expert_param_layout
+        }
+        experts_in_layout = dense_activation_placement(tp=Shard(0))
+        experts_in_grad_layout = dense_activation_placement(tp=Shard(0))
+        moe_cfg.experts.sharding_config = ShardingConfig(
+            state_shardings=state_shardings,
+            in_dst_shardings={
+                "x": experts_in_layout,
+                "top_scores": experts_in_layout,
+                "selected_experts_indices": experts_in_layout,
+            },
+            out_src_shardings=experts_out_layout,
+            out_dst_shardings=experts_out_layout,
+            local_map=LocalMapConfig(
+                in_grad_placements=(
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                ),
+            ),
+        )
+    elif enable_tp:
+        # Dense family: {TP}. EP disabled, TP shards routed-expert weights.
+        state_shardings = {}
+        for name, placement in expert_param_layout.items():
+            state_shardings[name] = expert_param_placement_dense(
+                tp_placement=placement,
+            )
+        experts_in_layout = dense_activation_placement(tp=Replicate())
+        experts_in_grad_layout = dense_activation_placement(tp=Partial())
+        moe_cfg.experts.sharding_config = ShardingConfig(
+            state_shardings=state_shardings,
+            in_dst_shardings={
+                "x": experts_in_layout,
+                "top_scores": experts_in_layout,
+                "selected_experts_indices": experts_in_layout,
+            },
+            out_src_shardings=experts_out_layout,
+            out_dst_shardings=experts_out_layout,
+            local_map=LocalMapConfig(
+                in_grad_placements=(
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                ),
+            ),
+        )
+    # else: EP and TP both disabled -- experts stay plain tensors,
+    # no sharding_config.

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -7,8 +7,6 @@
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
-from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
     all_to_all_single_autograd,
@@ -35,9 +33,6 @@ class AllToAllDispatchMetadata(LocalDispatchMetadata):
     permuted_indices: torch.Tensor  # for _unpermute
     input_splits: list[int]
     output_splits: list[int]
-    # Pre-pad token count. dispatch() rounds bs*slen up to a multiple of
-    # sp_size when sp_size > 1; combine() slices pad rows off using this.
-    original_num_tokens: int
 
 
 class LocalTokenDispatcher(Configurable):
@@ -59,6 +54,15 @@ class LocalTokenDispatcher(Configurable):
         self.num_experts = config.num_experts
         self.top_k = config.top_k
         self.score_before_experts = config.score_before_experts
+
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """No-op for the EP=1 dispatcher. Subclasses override."""
+        del ep_mesh, tp_mesh
 
     def dispatch(
         self,
@@ -119,24 +123,18 @@ class LocalTokenDispatcher(Configurable):
         routed_output: torch.Tensor,
         metadata: LocalDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
-        """Score, scatter_add, and optionally overlap shared_experts.
-
-        For EP=1, no communication is needed. shared_experts runs before
-        scatter_add (no async overlap benefit here, but keeps the interface
-        uniform with AllToAllTokenDispatcher).
+        """Score and scatter_add routed expert outputs.
 
         Args:
             routed_output: (num_tokens * top_k, dim) expert outputs
             metadata: LocalDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        out = torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -159,7 +157,9 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
     Handles the full token routing lifecycle:
     dispatch (reorder + EP all-to-all) and combine (reverse).
 
-    ep_mesh is set by the parallelization code after construction.
+    ``ep_mesh`` and the ``sp_size`` / ``sp_rank`` SP coordinates are wired
+    by the owning ``GroupedExperts.parallelize`` override via
+    ``wire_meshes``.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -170,31 +170,32 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         super().__init__(config)
         # DeviceMesh (not ProcessGroup) so that CooR precompile can use
         # torch.ops._dtensor.mesh_get_process_group to keep the FX graph
-        # rank-agnostic. Set by ExpertParallel._partition_fn().
+        # rank-agnostic. None when EP=1 so dispatch falls back to the
+        # LocalTokenDispatcher path.
         self.ep_mesh: DeviceMesh | None = None
-        # TODO: these should be set at config time
-        # Set at runtime by apply_moe_ep_tp. Uses _sym_get_coordinate
-        # so the rank is a SymInt under CooR precompile.
+        # Sequence-parallel split coordinates derived from tp_mesh.
+        # ``sp_rank`` uses ``DeviceMesh._sym_get_coordinate`` so it is a
+        # ``SymInt`` under CooR precompile, keeping the FX graph
+        # rank-agnostic. Defaults are the TP=1 values.
         self.sp_size: int = 1
-        self.sp_rank: int | torch.SymInt = -1
+        self.sp_rank: int | torch.SymInt = 0
 
-    def _split_along_sp(self, *tensors: torch.Tensor) -> list[torch.Tensor]:
-        """Split tensors along the first dim across EP ranks for sequence parallel."""
-        sp_size = self.sp_size
-        sp_rank = self.sp_rank
-        results = []
-        for t in tensors:
-            assert t.is_contiguous()
-            num_tokens = t.shape[0]
-            if num_tokens % sp_size != 0:
-                raise ValueError(
-                    "Uneven split of tokens is not supported yet. "
-                    "Requires EP degree dividing batch size * seq len."
-                )
-            local_num_tokens = num_tokens // sp_size
-            offset = sp_rank * local_num_tokens
-            results.append(t[offset : offset + local_num_tokens])
-        return results
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """Install the EP mesh and SP coordinates used by dispatch / combine.
+
+        Both arguments may be ``None`` when the corresponding parallelism
+        dimension is disabled; ``dispatch`` / ``combine`` handle the
+        disabled cases internally.
+        """
+        self.ep_mesh = ep_mesh
+        if tp_mesh is not None:
+            self.sp_size = tp_mesh.size()
+            self.sp_rank = tp_mesh._sym_get_coordinate(0)
 
     def dispatch(
         self,
@@ -209,13 +210,13 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         When ep_mesh is None (EP=1), falls back to local dispatch — no
         all-to-all communication, just local token reordering with padding.
 
-        When sp_size > 1 (sequence parallel), inputs are first split along
-        the token dim so each EP rank processes a disjoint subset.
+        With SP, x/top_scores/selected_experts_indices are already the local
+        SP shard (from DTensor Shard to_local via LocalMapConfig).
 
         Args:
-            x: (num_tokens, dim) all input tokens (global if sp_size > 1)
-            top_scores: (num_tokens, top_k) routing scores
-            selected_experts_indices: (num_tokens, top_k) expert indices per token
+            x: (num_local_tokens, dim) local token shard
+            top_scores: (num_local_tokens, top_k) routing scores
+            selected_experts_indices: (num_local_tokens, top_k) expert indices
 
         Returns:
             routed_input: (R, dim) tokens in expert-major order for local experts
@@ -227,25 +228,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             return super().dispatch(x, top_scores, selected_experts_indices)
 
         ep_size = self.ep_mesh.size()
-        original_num_tokens = x.shape[0]
-
-        if self.sp_size > 1:
-            assert self.sp_rank >= 0, (
-                "sp_rank must be set before use. "
-                "apply_moe_ep_tp() should set it from tp_mesh._sym_get_coordinate()."
-            )
-            # Round bs*slen up to a multiple of sp_size. Pad rows route to
-            # expert 0 with zero scores -> zero contribution to scatter_add.
-            pad = (-original_num_tokens) % self.sp_size
-            if pad > 0:
-                x = F.pad(x, (0, 0, 0, pad))
-                top_scores = F.pad(top_scores, (0, 0, 0, pad))
-                selected_experts_indices = F.pad(
-                    selected_experts_indices, (0, 0, 0, pad)
-                )
-            x, top_scores, selected_experts_indices = self._split_along_sp(
-                x, top_scores, selected_experts_indices
-            )
 
         # TODO: Extract this local reordering block (histc, argsort, score
         # application) into a shared helper — it's duplicated in
@@ -342,7 +324,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
-            original_num_tokens=original_num_tokens,
         )
         return routed_input, num_tokens_per_expert_group, metadata
 
@@ -401,34 +382,30 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: AllToAllDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Reverse the dispatch: unpermute + all-to-all + score + scatter_add.
 
-        shared_experts overlaps with the async all-to-all combine — it runs
-        while the a2a is in flight on the NCCL stream. scatter_add forces sync.
-
-        When sp_size > 1 (sequence parallel), dispatch uses local token
-        indices. Combine offsets them to global positions so scatter_add
+        When sp_size > 1, dispatch uses local token indices.
+        Combine offsets them to global positions so scatter_add
         into full x is correct.
 
         Args:
             routed_output: (R, dim) expert outputs in expert-major order
             metadata: AllToAllDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
         # EP=1: fall back to local combine (no all-to-all needed)
         if self.ep_mesh is None:
-            return super().combine(routed_output, metadata, x, shared_experts)
+            return super().combine(routed_output, metadata, x)
 
         # Reverse expert-major reordering
         routed_output = self._unpermute(
             routed_output, metadata.input_shape, metadata.permuted_indices
         )
+
         # All-to-all combine: returns AsyncCollectiveTensor — the a2a runs
         # on the NCCL stream and won't block until the tensor is accessed.
         routed_output = all_to_all_single_autograd(
@@ -438,9 +415,11 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
-        # shared_experts overlaps with the async a2a (NCCL stream).
-        # Score application + scatter_add forces the a2a to sync.
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        # With SP, x is the local shard. Create full-size buffer for scatter_add
+        # so routed results from all SP ranks can be placed at global positions.
+        out = torch.zeros(
+            x.shape[0] * self.sp_size, x.shape[-1], device=x.device, dtype=x.dtype
+        )
 
         if not self.score_before_experts:
             routed_output = (
@@ -448,31 +427,19 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
                 * metadata.top_scores_experts_sorted.reshape(-1, 1)
             ).to(routed_output.dtype)
 
-        # When sequence_parallel is active, dispatch splits tokens to a local
-        # shard, so token_indices_experts_sorted are 0-based local indices.
-        # Offset them to global positions so scatter_add into full x is correct.
-        original_num_tokens = metadata.original_num_tokens
+        # With SP, token indices are 0-based within the local shard.
+        # Offset to global positions for the full-size scatter buffer.
         if self.sp_size > 1:
-            padded_num_tokens = original_num_tokens + (
-                (-original_num_tokens) % self.sp_size
-            )
-            local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
-                metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
+                metadata.token_indices_experts_sorted + x.shape[0] * self.sp_rank
             )
-            assert isinstance(token_indices_experts_sorted, torch.Tensor)
-            # Drop pad-row entries: their global indices fall in
-            # [original_num_tokens, padded_num_tokens), out of `out`'s range.
-            # scatter_add itself is not padded; `out` matches x's shape.
-            if padded_num_tokens != original_num_tokens:
-                mask = token_indices_experts_sorted < original_num_tokens
-                token_indices_experts_sorted = token_indices_experts_sorted[mask]
-                routed_output = routed_output[mask]
         else:
             token_indices_experts_sorted = metadata.token_indices_experts_sorted
+
+        assert isinstance(token_indices_experts_sorted, torch.Tensor)
         out = deterministic_scatter_add(
             out,
-            token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
+            token_indices_experts_sorted.reshape(-1, 1).expand(-1, out.shape[-1]),
             routed_output,
         )
         return out
@@ -606,7 +573,7 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
         self.comm_backend = config.comm_backend
         self.non_blocking_capacity_factor = config.non_blocking_capacity_factor
         self.pad_multiple = config.pad_multiple
-        # Set by ExpertParallel._partition_fn()
+        # Wired by GroupedExperts.parallelize via wire_meshes.
         self.ep_mesh: DeviceMesh | None = None
 
         # Import to register custom ops so SAC saves communication outputs
@@ -615,6 +582,20 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
             from torchtitan.distributed.deepep import hybridep  # noqa: F401
         else:
             from torchtitan.distributed.deepep import deepep  # noqa: F401
+
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """Install the EP mesh used by DeepEP dispatch / combine.
+
+        ``tp_mesh`` is ignored — DeepEP does not use SP token splitting.
+        Accepted for API parity with ``AllToAllTokenDispatcher.wire_meshes``.
+        """
+        del tp_mesh
+        self.ep_mesh = ep_mesh
 
     # pyrefly: ignore [bad-override]
     def dispatch(
@@ -665,7 +646,6 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: DeepEPDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Combine tokens via DeepEP/HybridEP, overlapping shared_experts.
 
@@ -685,18 +665,4 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
 
             # pyrefly: ignore [bad-argument-type]
             routed_output = combine_tokens(routed_output, metadata.state)
-
-        # shared_experts runs in parallel with combine communication.
-        # This is the key optimization - we overlap compute with communication.
-        shared_out = shared_experts(x) if shared_experts is not None else None
-
-        # Sync the combine operation before using routed_output.
-        # This inserts a CUDA stream wait, ensuring combine is complete before
-        # the subsequent addition or reshape operations read routed_output.
-        from torchtitan.distributed.deepep.deepep import sync_combine
-
-        sync_combine()
-
-        if shared_out is not None:
-            routed_output = routed_output + shared_out
         return routed_output

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -39,6 +39,9 @@ def parallelize_deepseekv3(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
+    if parallelism.full_dtensor:
+        raise NotImplementedError("full_dtensor is not supported yet.")
+
     # CP: wrap inner attention forward BEFORE parallelize() so CP logic
     # runs inside the local_map boundary on local tensors.
     if parallel_dims.cp_enabled:
@@ -49,9 +52,8 @@ def parallelize_deepseekv3(
         )
 
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
-        model.parallelize(tp_mesh)
-        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(

--- a/torchtitan/models/flux/parallelize.py
+++ b/torchtitan/models/flux/parallelize.py
@@ -47,8 +47,8 @@ def parallelize_flux(
     if compile_config.enable and "model" in compile_config.components:
         apply_compile(model, compile_config)
 
-    names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    dp_mesh = parallel_dims.get_mesh(names)
+    dp_mesh = parallel_dims.get_activated_mesh(["dp_replicate", "fsdp"])
+    assert dp_mesh is not None
     apply_fsdp(
         model,
         dp_mesh,
@@ -207,8 +207,8 @@ def parallelize_encoders(
         reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
     )
 
-    names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    dp_mesh = parallel_dims.get_mesh(names)
+    dp_mesh = parallel_dims.get_activated_mesh(["dp_replicate", "fsdp"])
+    assert dp_mesh is not None
     fsdp_config: dict[str, Any] = {
         "mesh": dp_mesh,
         "mp_policy": mp_policy,

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -283,7 +283,7 @@ class FluxTrainer(Trainer):
             [p for m in self.model_parts for p in m.parameters()],
             self.config.training.max_norm,
             foreach=True,
-            pp_mesh=parallel_dims.get_optional_mesh("pp"),
+            parallel_dims=parallel_dims,
             ep_enabled=parallel_dims.ep_enabled,
         )
         self.checkpointer.maybe_wait_for_staging()

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -10,7 +10,12 @@
 import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
+from torch.distributed.fsdp import (
+    CPUOffloadPolicy,
+    DataParallelMeshDims,
+    fully_shard,
+    MixedPrecisionPolicy,
+)
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -27,6 +32,7 @@ from torchtitan.distributed.fsdp import (
     disable_fsdp_gradient_division,
     get_fsdp_reshard_after_forward_policy,
 )
+from torchtitan.distributed.full_dtensor import resolve_fsdp_mesh, validate_config
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.models.llama3.model import Llama3Model
 from torchtitan.tools.logging import logger
@@ -56,22 +62,20 @@ def parallelize_llama(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
-    # CP: wrap inner attention forward BEFORE parallelize() so CP logic
-    # runs inside the local_map boundary on local tensors.
-    if parallel_dims.cp_enabled:
-        apply_cp_to_forward(
-            # pyrefly: ignore [missing-attribute]
-            [block.attention.inner_attention for block in model.layers.values()],
-            parallel_dims.get_mesh("cp"),
-        )
-
-    # TODO: We pass tp_mesh here because TP is the only parallelism
-    # using DTensor currently. Once we move to full DTensor (e.g.,
-    # FSDP via DTensor, CP via DTensor), pass the full SPMD mesh instead.
+    if parallelism.full_dtensor:
+        validate_config(parallel_dims, model)
+        model.parallelize(parallel_dims)
+    else:
+        if parallel_dims.cp_enabled:
+            apply_cp_to_forward(
+                # pyrefly: ignore [missing-attribute, not-callable]
+                [block.attention.inner_attention for block in model.layers.values()],
+                parallel_dims.get_mesh("cp"),
+            )
+        if parallel_dims.tp_enabled:
+            model.parallelize(parallel_dims)
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
-        model.parallelize(tp_mesh)
-        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
@@ -89,8 +93,17 @@ def parallelize_llama(
     if model_compile_enabled:
         apply_compile(model, compile_config)
 
-    names = ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    dp_mesh = parallel_dims.get_mesh(names)
+    # Always run apply_fsdp -- with shard_degree=1 it is a no-op for the
+    # all-gather but still installs the MixedPrecisionPolicy.
+    if parallelism.full_dtensor:
+        dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
+    else:
+        names = (
+            ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
+        )
+        dp_mesh = parallel_dims.get_mesh(names)
+        dp_mesh_dims = None
+
     apply_fsdp(
         model,
         dp_mesh,
@@ -99,6 +112,7 @@ def parallelize_llama(
         pp_enabled=parallel_dims.pp_enabled,
         cpu_offload=training.enable_cpu_offload,
         reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
+        dp_mesh_dims=dp_mesh_dims,
     )
 
     if parallel_dims.dp_replicate_enabled:
@@ -120,6 +134,7 @@ def apply_fsdp(
     pp_enabled: bool,
     cpu_offload: bool = False,
     reshard_after_forward_policy: str = "default",
+    dp_mesh_dims: "DataParallelMeshDims | None" = None,
 ):
     """
     Apply data parallelism (via FSDP2) to the model.
@@ -136,7 +151,14 @@ def apply_fsdp(
             - "default" applies default resharding behavior, implementing "smart defaults" for known optimal scenarios.
             - "always" will enable `reshard_after_forward` for all forward passes.
             - "never" will disable `reshard_after_forward` for all forward passes.
-
+        dp_mesh_dims: Under full_dtensor, ``fully_shard`` must flatten
+            ``dp_shard`` and ``cp`` into a single FSDP shard dim, so it
+            needs to know which axes of the multi-D SPMD mesh are
+            data-parallel. We pass this explicitly via ``dp_mesh_dims``
+            rather than letting FSDP infer it from mesh axis names: the
+            naming contract between ``fully_shard`` and torchtitan is not
+            strong enough to infer safely, and an explicit declaration
+            avoids silent miscategorization when new mesh axes appear.
     """
     mp_policy = MixedPrecisionPolicy(
         param_dtype=param_dtype,
@@ -144,6 +166,9 @@ def apply_fsdp(
         cast_forward_inputs=False,
     )
     fsdp_config = {"mesh": dp_mesh, "mp_policy": mp_policy}
+    if dp_mesh_dims is not None:
+        # pyrefly: ignore[bad-typed-dict-key]
+        fsdp_config["dp_mesh_dims"] = dp_mesh_dims
     if cpu_offload:
         # pyrefly: ignore[bad-typed-dict-key]
         fsdp_config["offload_policy"] = CPUOffloadPolicy()

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -178,6 +178,8 @@ class Llama4Model(Decoder):
                 self,
                 loss_parallel=not parallelism.disable_loss_parallel,
                 enable_sp=parallelism.enable_sequence_parallel,
+                enable_tp=parallelism.tensor_parallel_degree > 1,
+                enable_ep=parallelism.expert_parallel_degree > 1,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -10,12 +10,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
-from torch.distributed.tensor import Partial, Replicate, Shard
-from torch.distributed.tensor.parallel import (
-    parallelize_module,
-    PrepareModuleInputOutput,
-    RowwiseParallel,
-)
+from torch.distributed.tensor import Shard
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -28,17 +23,11 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_forward
-from torchtitan.distributed.expert_parallel import ExpertParallel, TensorParallel
 from torchtitan.distributed.fsdp import (
     disable_fsdp_gradient_division,
     get_fsdp_reshard_after_forward_policy,
 )
-from torchtitan.distributed.tensor_parallel import (
-    ColwiseParallelWithGradPlacement,
-    maybe_enable_async_tp,
-    NoParallel,
-)
-from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.models.llama4.model import Llama4Model
 from torchtitan.tools.logging import logger
 
@@ -67,6 +56,9 @@ def parallelize_llama(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
+    if parallelism.full_dtensor:
+        raise NotImplementedError("full_dtensor is not supported yet.")
+
     # CP: wrap inner attention forward BEFORE parallelize() so CP logic
     # runs inside the local_map boundary on local tensors.
     if parallel_dims.cp_enabled:
@@ -76,20 +68,12 @@ def parallelize_llama(
             parallel_dims.get_mesh("cp"),
         )
 
-    tp_mesh = None
-    if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
-        model.parallelize(tp_mesh)
-        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
-
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
-        apply_moe_ep_tp(
-            model,
-            tp_mesh=parallel_dims.get_optional_mesh("tp"),
-            ep_mesh=parallel_dims.get_optional_mesh("ep"),
-            enable_sp=True,
-        )
+        model.parallelize(parallel_dims)
+    if parallel_dims.tp_enabled:
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
+    # Set SP size/rank on EP dispatchers for sequence-parallel token splitting.
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
@@ -361,108 +345,3 @@ def apply_fsdp(
         elif model.tok_embeddings is not None:
             # pyrefly: ignore [missing-attribute]
             transformer_block.set_modules_to_backward_prefetch([model.tok_embeddings])
-
-
-def apply_moe_ep_tp(
-    model: nn.Module,
-    tp_mesh: DeviceMesh | None,
-    ep_mesh: DeviceMesh | None,
-    enable_sp: bool = True,
-):
-    """
-    Apply MoE expert/tensor parallelism plans to MoE-enabled transformer blocks.
-
-    Args:
-        model: Model containing transformer blocks.
-        tp_mesh: Tensor-parallel device mesh.
-        ep_mesh: Expert-parallel device mesh.
-        enable_sp: Whether sequence parallelism is enabled.
-    """
-    assert ep_mesh is not None or tp_mesh is not None
-
-    sp_layout = Shard(1) if enable_sp else Replicate()
-
-    # pyrefly: ignore [not-callable]
-    for transformer_block in model.layers.values():
-        # pyrefly: ignore [missing-attribute]
-        if not transformer_block.moe_enabled:
-            continue
-
-        if tp_mesh is not None:
-            moe_layer_plan = {
-                # With SP: all-gather (Shard→Replicate) for input,
-                # reduce-scatter (Partial→Shard) for output.
-                # Without SP: input is already Replicate,
-                # all-reduce (Partial→Replicate) for output.
-                "moe": PrepareModuleInputOutput(
-                    input_layouts=(sp_layout,),
-                    desired_input_layouts=(Replicate(),),
-                    use_local_input=False,
-                    output_layouts=(Partial(),),
-                    desired_output_layouts=(sp_layout,),
-                    # Keep MoE output as DTensor so the residual add
-                    # ``h + self.moe(...)`` composes with config-based
-                    # attention (which flows DTensors).
-                    use_local_output=False,
-                ),
-                # replicate computation for the router
-                "moe.router.gate": NoParallel(
-                    local_output_grad_placements=(Partial(),),
-                ),
-            }
-            # pyrefly: ignore [missing-attribute]
-            if transformer_block.moe.shared_experts is not None:
-                # Use ColwiseParallelWithGradPlacement to keep d_x as Partial in
-                # backward (avoids the all-reduce that from_local(Replicate)
-                # would otherwise trigger). For w2, output_layouts=Partial()
-                # skips the Partial→Replicate all-reduce in forward. The
-                # reduction happens once at the MoE output boundary
-                # (PrepareModuleInputOutput).
-                # pyrefly: ignore [no-matching-overload]
-                moe_layer_plan.update(
-                    {
-                        "moe.shared_experts.w1": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
-                        ),
-                        "moe.shared_experts.w2": RowwiseParallel(
-                            output_layouts=Partial(),
-                        ),
-                        "moe.shared_experts.w3": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
-                        ),
-                    }
-                )
-            parallelize_module(
-                # pyrefly: ignore [bad-argument-type]
-                module=transformer_block,
-                device_mesh=tp_mesh,
-                # pyrefly: ignore [bad-argument-type]
-                parallelize_plan=moe_layer_plan,
-            )
-
-        experts_mesh, experts_plan = None, None
-        # EP disabled: shard routed expert weights across TP mesh (input Replicate, produces Partial output reduced at MoE boundary)
-        if ep_mesh is None:
-            experts_mesh = tp_mesh
-            experts_plan = TensorParallel()
-        else:
-            experts_mesh = ep_mesh
-            experts_plan = ExpertParallel()
-            # pyrefly: ignore [missing-attribute]
-            dispatcher = transformer_block.moe.experts.token_dispatcher
-            if tp_mesh is not None:
-                if isinstance(dispatcher, AllToAllTokenDispatcher):
-                    # sp_size and sp_rank are set for sequence-parallel token splitting
-                    # when EP borrows from TP.
-                    dispatcher.sp_size = tp_mesh.size()
-                    # Use _sym_get_coordinate so the rank is a SymInt
-                    # under CooR precompile instead of a concrete int
-                    # that gets baked into the FX graph.
-                    dispatcher.sp_rank = tp_mesh._sym_get_coordinate(0)
-
-        parallelize_module(
-            # pyrefly: ignore [missing-attribute]
-            module=transformer_block.moe.experts,
-            device_mesh=experts_mesh,
-            parallelize_plan=experts_plan,
-        )

--- a/torchtitan/models/llama4/sharding.py
+++ b/torchtitan/models/llama4/sharding.py
@@ -15,9 +15,17 @@ from torchtitan.models.common.decoder_sharding import (
     set_gqa_attention_sharding,
     set_gqa_inner_attention_local_map,
 )
+from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 
 if TYPE_CHECKING:
     from torchtitan.models.llama4.model import Llama4Model, Llama4TransformerBlock
+
+# Routed-expert layout for the shared ``GroupedExperts`` (w1/w2/w3).
+_GROUPED_EXPERTS_PARAM_LAYOUT: dict[str, Placement] = {
+    "w1": Shard(1),
+    "w2": Shard(2),
+    "w3": Shard(1),
+}
 
 
 def set_llama4_sharding_config(
@@ -25,27 +33,40 @@ def set_llama4_sharding_config(
     *,
     loss_parallel: bool,
     enable_sp: bool,
+    enable_tp: bool,
+    enable_ep: bool,
 ) -> None:
     """Fill ``sharding_config`` on all Llama4 sub-configs.
 
-    No-op when TP is not enabled.
+    Dense sub-configs (attention, norms, dense FFN) are populated
+    unconditionally — ``Module.parallelize`` filters disabled axes
+    at runtime.
+
+    MoE sub-configs (router, shared experts, routed experts) are
+    populated when TP or EP is enabled.
     """
 
     set_decoder_sharding_config(
         config, loss_parallel=loss_parallel, enable_sp=enable_sp
     )
     for layer_cfg in config.layers:
-        _set_llama4_layer_sharding(layer_cfg, enable_sp=enable_sp)
+        _set_llama4_layer_sharding(
+            layer_cfg, enable_sp=enable_sp, enable_tp=enable_tp, enable_ep=enable_ep
+        )
 
 
 def _set_llama4_layer_sharding(
-    layer_cfg: "Llama4TransformerBlock.Config", *, enable_sp: bool
+    layer_cfg: "Llama4TransformerBlock.Config",
+    *,
+    enable_sp: bool,
+    enable_tp: bool,
+    enable_ep: bool,
 ) -> None:
     """Set sharding on one Llama4 transformer layer.
 
     Attention and norms are sharded on all blocks (MoE and non-MoE).
-    Dense FFN is only sharded on non-MoE blocks — MoE FFN stays
-    under apply_moe_ep_tp.
+    Dense FFN is only sharded on non-MoE blocks; MoE FFN is routed
+    through ``set_moe_sharding_config``.
     """
     norm = norm_config(enable_sp=enable_sp)
     layer_cfg.attention_norm.sharding_config = norm
@@ -61,4 +82,14 @@ def _set_llama4_layer_sharding(
             layer_cfg.feed_forward,
             attn_x_placement=attn_x_placement,
             enable_sp=enable_sp,
+        )
+
+    # MoE FFN (MoE-enabled layers only).
+    if layer_cfg.moe is not None and (enable_tp or enable_ep):
+        set_moe_sharding_config(
+            layer_cfg.moe,
+            enable_tp=enable_tp,
+            enable_ep=enable_ep,
+            enable_sp=enable_sp,
+            expert_param_layout=_GROUPED_EXPERTS_PARAM_LAYOUT,
         )

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -42,6 +42,9 @@ def parallelize_qwen3(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
+    if parallelism.full_dtensor:
+        raise NotImplementedError("full_dtensor is not supported yet.")
+
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
@@ -56,9 +59,8 @@ def parallelize_qwen3(
         )
 
     if parallel_dims.tp_enabled:
-        tp_mesh = parallel_dims.get_mesh("tp")
-        model.parallelize(tp_mesh)
-        maybe_enable_async_tp(parallelism, compile_config, tp_mesh)
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -11,11 +11,14 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from torch.distributed.tensor import DeviceMesh, distribute_tensor, DTensor
+from torch.distributed.tensor import distribute_tensor, DTensor
 from torch.distributed.tensor.experimental import local_map
+from torch.distributed.tensor.placement_types import Placement
 
 from torchtitan.config import Configurable
+from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.protocols.sharding import resolve_placements, ShardingConfig
+from torchtitan.protocols.types import NamedPlacement
 
 
 # Cache: maps nn.Module subclass -> created Module wrapper class.
@@ -38,6 +41,7 @@ class Module(nn.Module, Configurable):
     _param_init: dict[str, Callable] | None = None
     _sharding_config: ShardingConfig | None = None
     _pos_arg_list: list[str] | None = None
+    _parallelized: bool = False
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
@@ -169,47 +173,85 @@ class Module(nn.Module, Configurable):
         ]
         return self._pos_arg_list
 
-    def parallelize(self, mesh: DeviceMesh) -> None:
+    def parallelize(self, parallel_dims: ParallelDims) -> None:
         """Parallelize this module and all Module children recursively.
 
         For each module with a ``sharding_config``:
 
-        1. ``distribute_tensor`` on params and buffers per ``state_shardings``.
-        2. Wrap ``self.forward`` with redistribution (+ ``local_map`` if needed).
+        1. Shard states (parameters and buffers).
+        2. Wrap the forward with:
+            ``reshard inputs -> [optional local_map] forward -> reshard outputs``.
 
-        The wrapping order is:
-            ``reshard inputs -> [optional local_map] fn -> reshard outputs``.
+        ``fully_shard`` hooks on ``__call__`` fire around the wrapped ``forward``.
 
-        fully_shard hooks on ``__call__`` fire around the wrapped ``forward``.
-
-        CP (applied before ``parallelize``) is captured inside ``local_map``.
+        Each ``ShardingConfig`` field resolves its mesh independently via
+        ``resolve_mesh()`` and resolves its placements independently via
+        ``resolve_placements()``.
         """
-        # Recurse children first
+        if self._parallelized:
+            raise ValueError(
+                f"{type(self).__name__} has already been parallelized. "
+                "Module.parallelize() must be called at most once per instance."
+            )
+        self._parallelized = True
+
         queue = list(self.children())
         while queue:
             child = queue.pop()
             if isinstance(child, Module):
-                child.parallelize(mesh)
+                child.parallelize(parallel_dims)
             else:
-                # Look through non-Module wrappers, e.g., CheckpointWrapper
+                # Look through non-Module wrappers, e.g., CheckpointWrapper.
                 queue.extend(child.children())
 
-        sharding_config = self._sharding_config
-        if sharding_config is None:
+        # TODO(fegin): Change to assert once ALL Models are migrated to use _sharding_config.
+        if self._sharding_config is None:
             return
 
-        assert mesh.mesh_dim_names is not None, "DeviceMesh must have named axes"
-        mesh_axis_names = mesh.mesh_dim_names
+        self._shard_states(parallel_dims)
+        self._cache_pos_arg_names()
+        fn = self._maybe_wrap_with_local_map(self.forward, parallel_dims)
 
-        # Distribute parameters and buffers per state_shardings. Every sharding_config
-        # must declare a placement for every mesh axis; ``resolve_placements``
-        # raises otherwise.
+        def forward_with_redistribution(*args, **kwargs):
+            args, kwargs = self._redistribute_inputs(parallel_dims, args, kwargs)
+            outputs = fn(*args, **kwargs)
+            return self._redistribute_outputs(parallel_dims, outputs)
+
+        self.forward = forward_with_redistribution
+
+    def _shard_states(self, parallel_dims: ParallelDims) -> None:
+        """Distribute params and buffers per ``state_shardings``.
+
+        Each entry resolves its own mesh via ``resolve_mesh``, so different
+        params on the same Module may live on different meshes. An
+        already-DTensor param/buffer indicates it was distributed by a
+        sibling (e.g. weight tying); skip but verify placements agree.
+        """
+        sharding_config = self._sharding_config
+        assert sharding_config is not None
+
         for name, param in self.named_parameters(recurse=False):
-            if name not in sharding_config.state_shardings:
+            named_placements = sharding_config.state_shardings.get(name)
+            if named_placements is None:
+                raise ValueError(
+                    f"{type(self).__name__}.{name} has no placement declared "
+                    "in sharding_config.state_shardings."
+                )
+            axes = named_placements.keys()
+            mesh = parallel_dims.resolve_mesh(axes)
+            if mesh is None:
                 continue
-            placements = resolve_placements(
-                sharding_config.state_shardings[name], mesh_axis_names
-            )
+            placements = resolve_placements(named_placements, mesh)
+            if isinstance(param, DTensor):
+                if tuple(param.placements) != tuple(placements):
+                    raise ValueError(
+                        f"{type(self).__name__}.{name} is already a DTensor with "
+                        f"placements {param.placements}, but its sharding_config "
+                        f"expects {placements}. This usually means a tied parameter "
+                        "is referenced by two modules with conflicting sharding "
+                        "configs."
+                    )
+                continue
             self.register_parameter(
                 name,
                 nn.Parameter(
@@ -219,11 +261,21 @@ class Module(nn.Module, Configurable):
             )
 
         for name, buffer in self.named_buffers(recurse=False):
-            if name not in sharding_config.state_shardings or buffer is None:
+            named_placements = sharding_config.state_shardings.get(name)
+            if named_placements is None:
+                raise ValueError(
+                    f"{type(self).__name__}.{name} (buffer) has no placement "
+                    "declared in sharding_config.state_shardings."
+                )
+            if buffer is None:
+                # ``register_buffer(name, None)`` reserves a slot to be filled
+                # by ``init_states`` later; nothing to distribute yet.
                 continue
-            placements = resolve_placements(
-                sharding_config.state_shardings[name], mesh_axis_names
-            )
+            axes = named_placements.keys()
+            mesh = parallel_dims.resolve_mesh(axes)
+            if mesh is None:
+                continue
+            placements = resolve_placements(named_placements, mesh)
             persistent = name not in self._non_persistent_buffers_set
             self.register_buffer(
                 name,
@@ -231,51 +283,83 @@ class Module(nn.Module, Configurable):
                 persistent=persistent,
             )
 
-        # Cache positional arg names of the original forward so _shard_inputs
-        # can read them from the cache instead of calling inspect every forward.
-        self._cache_pos_arg_names()
-
-        fn = self.forward
-        if sharding_config.local_map is not None:
-            # Resolve each NamedPlacement to a positional tuple for the
-            # current mesh.
-            lm = sharding_config.local_map
-            in_placements = tuple(
-                resolve_placements(p, mesh_axis_names) for p in lm.in_placements
-            )
-            out_placements = tuple(
-                resolve_placements(p, mesh_axis_names) for p in lm.out_placements
-            )
-            in_grad_placements = tuple(
-                resolve_placements(p, mesh_axis_names) for p in lm.in_grad_placements
-            )
-            fn = local_map(
-                fn,
-                in_placements=in_placements,
-                out_placements=out_placements,
-                in_grad_placements=in_grad_placements,
-                device_mesh=mesh,
-            )
-
-        def with_redistribution(*args, **kwargs):
-            args, kwargs = self._shard_inputs(mesh, args, kwargs)
-            outputs = fn(*args, **kwargs)
-            return self._shard_outputs(mesh, outputs)
-
-        self.forward = with_redistribution
-
-    def _shard_inputs(
+    def _maybe_wrap_with_local_map(
         self,
-        mesh: DeviceMesh,
+        fn: Callable,
+        parallel_dims: ParallelDims,
+    ) -> Callable:
+        """Wrap ``fn`` with ``local_map`` if ``sharding_config.local_map`` is set.
+
+        Input placements come from ``in_dst_shardings`` (the same dict
+        ``_redistribute_inputs`` uses to pre-align inputs); output placements
+        from ``out_src_shardings``; only ``in_grad_placements`` lives on
+        ``LocalMapConfig``. ``local_map`` takes a single ``device_mesh``, so
+        all NamedPlacements must resolve to the same mesh.
+        """
+        sharding_config = self._sharding_config
+        assert sharding_config is not None
+        if sharding_config.local_map is None:
+            return fn
+
+        lm = sharding_config.local_map
+        in_dst = sharding_config.in_dst_shardings or {}
+        pos_args = self._cache_pos_arg_names()
+        out_src = sharding_config.out_src_shardings
+        if out_src is None:
+            raise AssertionError(
+                f"{type(self).__name__}: local_map is set but "
+                "out_src_shardings is None."
+            )
+        if isinstance(out_src, tuple):
+            out_src_list: list[NamedPlacement] = [p for p in out_src if p is not None]
+        else:
+            out_src_list = [out_src]
+
+        missing_in = [name for name in pos_args if name not in in_dst]
+        if missing_in:
+            raise AssertionError(
+                f"{type(self).__name__}: local_map is set but in_dst_shardings "
+                f"is missing entries for: {missing_in}"
+            )
+        in_named: list[NamedPlacement] = [in_dst[name] for name in pos_args]
+        out_named: list[NamedPlacement] = out_src_list
+        # in_grad_placements may contain None for non-tensor args; filter
+        # them out for mesh resolution -- local_map passes None through.
+        grad_named: list[NamedPlacement | None] = list(lm.in_grad_placements)
+
+        resolved_mesh = parallel_dims.resolve_shared_mesh(
+            in_named + out_named + grad_named
+        )
+        if resolved_mesh is None:
+            return fn
+
+        out_placements: tuple[tuple[Placement, ...], ...] = tuple(
+            resolve_placements(p, resolved_mesh) for p in out_named
+        )
+        return local_map(
+            fn,
+            in_placements=tuple(resolve_placements(p, resolved_mesh) for p in in_named),
+            out_placements=out_placements,
+            in_grad_placements=tuple(
+                resolve_placements(p, resolved_mesh) if p is not None else None
+                for p in grad_named
+            ),
+            device_mesh=resolved_mesh,
+        )
+
+    def _redistribute_inputs(
+        self,
+        parallel_dims: ParallelDims,
         args: tuple,
         kwargs: dict,
     ) -> tuple[tuple, dict]:
         """Redistribute inputs to desired placements.
 
-        Two-step process per input:
-        1. If plain tensor, wrap as DTensor using ``in_src_shardings``
-           (declares the source placement of the incoming tensor).
-        2. If DTensor placements != ``in_dst_shardings``, redistribute.
+        Per input present in ``in_src_shardings`` / ``in_dst_shardings``:
+        resolve a mesh from that input's NamedPlacements, then:
+        1. If plain tensor and ``in_src_shardings`` declared, wrap as
+           DTensor via ``DTensor.from_local`` on that mesh.
+        2. If ``in_dst_shardings`` declared, redistribute on the same mesh.
         """
         sharding_config = self._sharding_config
         assert sharding_config is not None
@@ -286,31 +370,40 @@ class Module(nn.Module, Configurable):
         ):
             return args, kwargs
 
-        # Use pre-cached positional arg names (populated in parallelize()) to
-        # merge positional args into a unified kwargs dict.
         pos_arg_names = [
             name for name in self._cache_pos_arg_names() if name not in kwargs
         ]
         new_kwargs = dict(zip(pos_arg_names, args))
         new_kwargs.update(kwargs)
 
-        assert mesh.mesh_dim_names is not None
-        mesh_axis_names = mesh.mesh_dim_names
         in_dst_shardings = sharding_config.in_dst_shardings or {}
         in_src_shardings = sharding_config.in_src_shardings or {}
 
         for name, value in new_kwargs.items():
             if not isinstance(value, torch.Tensor):
                 continue
+            src_named_placements = in_src_shardings.get(name)
+            dst_named_placements = in_dst_shardings.get(name)
+            mesh = parallel_dims.resolve_shared_mesh(
+                [src_named_placements, dst_named_placements]
+            )
+            if mesh is None:
+                continue
 
-            # Step 1: Annotate plain tensor as DTensor using in_src_shardings.
-            if not isinstance(value, DTensor) and name in in_src_shardings:
-                layout = resolve_placements(in_src_shardings[name], mesh_axis_names)
-                value = DTensor.from_local(value, mesh, layout, run_check=False)
+            if not isinstance(value, DTensor) and parallel_dims.full_dtensor:
+                raise ValueError("Got a plain Tensor under the full_dtensor mode.")
 
-            # Step 2: Redistribute to desired placement if needed.
-            if name in in_dst_shardings and isinstance(value, DTensor):
-                desired = resolve_placements(in_dst_shardings[name], mesh_axis_names)
+            if not isinstance(value, DTensor) and src_named_placements is not None:
+                layout = resolve_placements(src_named_placements, mesh)
+                value = DTensor.from_local(
+                    value,
+                    mesh,
+                    layout,
+                    run_check=False,
+                )
+
+            if dst_named_placements is not None and isinstance(value, DTensor):
+                desired = resolve_placements(dst_named_placements, mesh)
                 if value.placements != desired:
                     value = value.redistribute(placements=desired, async_op=True)
 
@@ -319,30 +412,39 @@ class Module(nn.Module, Configurable):
         new_args = tuple(new_kwargs.pop(name) for name in pos_arg_names)
         return new_args, new_kwargs
 
-    def _shard_outputs(
-        self,
-        mesh: DeviceMesh,
-        outputs: Any,
-    ) -> Any:
+    def _redistribute_outputs(self, parallel_dims: ParallelDims, outputs: Any) -> Any:
         """Redistribute output to desired placement.
 
         TODO: Currently only handles a single DTensor output. Extend to
         support nested outputs (tuples, dicts) when models with
-        multi-tensor forward returns (e.g., Flux, MoE) adopt
-        config-based sharding. out_dst_shardings would also need to become
-        a nested structure.
+        multi-tensor forward returns (e.g., Flux, MoE) adopt config-based
+        sharding. ``out_dst_shardings`` would also need to become a nested
+        structure.
         """
         sharding_config = self._sharding_config
         assert sharding_config is not None
 
-        if sharding_config.out_dst_shardings is None:
-            return outputs
-        assert mesh.mesh_dim_names is not None
-        desired = resolve_placements(
-            sharding_config.out_dst_shardings, mesh.mesh_dim_names
+        out_named_placements = sharding_config.out_dst_shardings
+        out_grad_named_placements = sharding_config.local_output_grad_placements
+        mesh = parallel_dims.resolve_shared_mesh(
+            [out_named_placements, out_grad_named_placements]
         )
-        if isinstance(outputs, DTensor) and outputs.placements != desired:
-            outputs = outputs.redistribute(placements=desired, async_op=True)
+        if mesh is None:
+            return outputs
+
+        if out_named_placements is not None:
+            desired = resolve_placements(out_named_placements, mesh)
+            if isinstance(outputs, DTensor) and outputs.placements != desired:
+                outputs = outputs.redistribute(placements=desired, async_op=True)
+
+        # Unwrap DTensor output to local tensor with the declared backward
+        # gradient placement. Mirrors NoParallel(local_output_grad_placements
+        # =...): the module returns a local tensor; in backward, the
+        # upstream local d_output is wrapped back as a DTensor with the
+        # declared placement (e.g. Partial to skip a downstream all-reduce).
+        if out_grad_named_placements is not None and isinstance(outputs, DTensor):
+            grad_placements = resolve_placements(out_grad_named_placements, mesh)
+            outputs = outputs.to_local(grad_placements=grad_placements)
         return outputs
 
     @classmethod

--- a/torchtitan/protocols/sharding.py
+++ b/torchtitan/protocols/sharding.py
@@ -7,29 +7,31 @@
 """Sharding types for config-based parallelization.
 
 ``ShardingConfig`` is set on ``Module.Config`` by ``set_sharding_config()``
-and read by ``Module.parallelize(mesh)``.  All placements use
+and read by ``Module.parallelize(parallel_dims)``.  All placements use
 ``NamedPlacement`` (dict keyed by ``MeshAxisName``) so they are
 self-documenting and support multi-dimensional meshes.
 """
 
 from dataclasses import dataclass, field
 
-from torch.distributed.tensor import Placement
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Placement, Replicate, Shard
 
-from torchtitan.protocols.types import MeshAxisName
+from torchtitan.protocols.types import MeshAxisName, NamedPlacement
 
 
-# Placement per mesh axis, keyed by MeshAxisName.
-# Example: {MeshAxisName.TP: Shard(0), MeshAxisName.DP_SHARD: Replicate()}
-# Every sharding_config must declare a placement for every mesh axis it will be applied
-# against; ``resolve_placements`` errors otherwise.
-#
+__all__ = [
+    "LocalMapConfig",
+    "NamedPlacement",
+    "ShardingConfig",
+    "resolve_placements",
+]
+
 # Shard order: we implicitly assume the trivial outer -> inner order matching
 # the mesh axis order. The only non-trivial case is FSDP + TP both sharding on
 # tensor dim 0, but it doesn't need to be annotated today.
 # TODO: integrate with global spmd types (e.g., ``TP: V`` + ``PartitionSpec``
 # carrying explicit shard-order info) once that lands.
-NamedPlacement = dict[MeshAxisName, Placement]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -39,18 +41,17 @@ class LocalMapConfig:
     Wraps forward with ``local_map()``: DTensor -> local before forward,
     local -> DTensor after forward.
 
-    Placements are ``NamedPlacement`` (keyed by mesh axis name). At
-    parallelize time they are resolved to positional tuples matching the
-    runtime mesh's axis order.
+    Input placements come from ``ShardingConfig.in_dst_shardings``
+    (already aligned by ``_redistribute_inputs``); output placements from
+    ``ShardingConfig.out_src_shardings``. ``LocalMapConfig`` only carries
+    ``in_grad_placements`` since there's no equivalent slot on
+    ``ShardingConfig`` today.
 
     Attributes:
-        in_placements: Per-input NamedPlacements (positional: q, k, v).
-        out_placements: Per-output NamedPlacements.
-        in_grad_placements: Per-input-gradient NamedPlacements.
+        in_grad_placements: Per-input-gradient NamedPlacements (positional,
+            ordered by ``forward`` args).
     """
 
-    in_placements: tuple[NamedPlacement, ...]
-    out_placements: tuple[NamedPlacement, ...]
     in_grad_placements: tuple[NamedPlacement, ...]
 
     def to_dict(self) -> dict:
@@ -89,20 +90,39 @@ class ShardingConfig:
             keyed by ``forward()`` arg name.
             e.g. ``{"x": {TP: Replicate()}}`` for all-gather.
             ``None`` means no input redistribution.
+        out_src_shardings: Source placement of the forward's output as a
+            DTensor. When ``local_map`` is set this also tells ``local_map``
+            what to wrap the local output back to. Accepts a single
+            ``NamedPlacement`` (single-output case) or a tuple (multi-
+            output case, e.g. attention with ``return_lse=True``). ``None``
+            means "infer from the output" (it's already a DTensor at the
+            right placement, or there's no local_map to drive).
+            e.g. ``{TP: Partial()}`` for the MoE wrapper.
         out_dst_shardings: Desired output placement after redistribution.
             e.g. ``{TP: Shard(1)}`` for reduce-scatter to sequence-parallel.
             ``None`` means no output redistribution.
-        local_map: If set, wraps forward with ``local_map()``.
-
-    TODO: add ``out_src_shardings`` to declare the output's source placement
-    when integrating with spmd_type (erased types), which requires both src
-    and dst for every redistribute.
+        local_output_grad_placements: ``NamedPlacement`` declaring the
+            placement of the **output gradient** when the DTensor output is
+            unwrapped via ``to_local(grad_placements=...)`` at the output
+            boundary. When set, the module's effective return type becomes
+            a local tensor (the wrapper calls ``to_local`` after any
+            ``out_dst_shardings`` redistribute). Mirrors
+            ``NoParallel(local_output_grad_placements=...)``.
+            e.g. ``{TP: Partial()}`` to receive the upstream local d_output
+            as Partial on TP in backward.
+            ``None`` leaves the output as DTensor.
+        local_map: If set, wraps forward with ``local_map()``. Input and
+            output placements come from ``in_dst_shardings`` and
+            ``out_src_shardings``; ``LocalMapConfig`` only carries
+            ``in_grad_placements``.
     """
 
     state_shardings: dict[str, NamedPlacement] = field(default_factory=dict)
     in_src_shardings: dict[str, NamedPlacement] | None = None
     in_dst_shardings: dict[str, NamedPlacement] | None = None
+    out_src_shardings: NamedPlacement | tuple[NamedPlacement, ...] | None = None
     out_dst_shardings: NamedPlacement | None = None
+    local_output_grad_placements: NamedPlacement | None = None
     local_map: LocalMapConfig | None = None
 
     def to_dict(self) -> dict:
@@ -112,23 +132,35 @@ class ShardingConfig:
 
 def resolve_placements(
     named: NamedPlacement,
-    mesh_axis_names: tuple[str, ...],
+    mesh: DeviceMesh,
 ) -> tuple[Placement, ...]:
     """Resolve NamedPlacement against a mesh in axis order.
 
     Every sharding_config must explicitly declare a placement for every mesh axis
     it will be applied against. Missing declarations raise ``ValueError``;
     extra declarations (axes not in the mesh) are ignored.
+
+    ``Shard(d)`` on a size-1 mesh axis is normalized to ``Replicate()`` --
+    the two are operationally identical on a 1-rank axis, but DTensor's op
+    rules (placement-equality, view/reshape strict mode, ...) treat them
+    as distinct and reject ``Shard`` in places where ``Replicate`` would
+    work.
     """
+    # TODO(fegin): remove the ``Shard(d)`` on a size-1 mesh to ``Replicate()``
+    # conversion once FlexShard replaces ``fully_shard``.
+    assert mesh.mesh_dim_names is not None, "DeviceMesh must have named axes"
     result = []
-    for axis_name in mesh_axis_names:
+    for i, axis_name in enumerate(mesh.mesh_dim_names):
         key = MeshAxisName(axis_name)
         if key not in named:
             raise ValueError(
-                f"Sharding sharding_config does not declare a placement for mesh axis "
+                f"ShardingConfig does not declare a placement for mesh axis "
                 f"{axis_name!r}. Declared: "
                 f"{sorted(k.value for k in named)}; "
-                f"required: {list(mesh_axis_names)}."
+                f"required: {list(mesh.mesh_dim_names)}."
             )
-        result.append(named[key])
+        p = named[key]
+        if isinstance(p, Shard) and mesh.size(i) == 1:
+            p = Replicate()
+        result.append(p)
     return tuple(result)

--- a/torchtitan/protocols/types.py
+++ b/torchtitan/protocols/types.py
@@ -12,6 +12,8 @@ so individual protocol modules don't grow their own copies.
 
 from enum import Enum
 
+from torch.distributed.tensor import Placement
+
 
 class StrEnum(str, Enum):
     """str + Enum for Python < 3.11 compatibility."""
@@ -41,3 +43,9 @@ class MeshAxisName(StrEnum):
     PP = "pp"
     EP = "ep"
     EFSDP = "efsdp"
+
+
+# Placement per mesh axis, keyed by MeshAxisName.
+# Every sharding_config must declare a placement for every mesh axis it
+# will be applied against; ``resolve_placements`` errors otherwise.
+NamedPlacement = dict[MeshAxisName, Placement]

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -17,6 +17,7 @@ import torch
 import torch.distributed.checkpoint.stateful
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.dataloader import BaseDataLoader, DataloaderExhaustedError
@@ -39,7 +40,7 @@ from torchtitan.config.configs import (
     ParallelismConfig,
     TrainingConfig,
 )
-from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.distributed import full_dtensor, ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
@@ -628,6 +629,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # unique tokens this rank processes (not the full pre-split sequence).
         self.ntokens_seen += labels.numel()
 
+        if self.config.parallelism.full_dtensor:
+            inputs, labels, extra_kwargs = full_dtensor.parallelize_inputs(
+                self.parallel_dims, inputs, labels, extra_kwargs
+            )
+
         return inputs, labels, extra_inputs, extra_kwargs
 
     @sl.log_trace_span("fwd_bwd")
@@ -684,6 +690,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             assert len(model_parts) == 1
             with self.train_context():
                 pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
+                # Under non-full_dtensor, labels stay as plain tensors. See
+                # ``cross_entropy_loss`` for why pred must also be plain.
+                # Remove once non-full_dtensor is no longer supported.
+                if (
+                    isinstance(pred, DTensor)
+                    and not self.config.parallelism.full_dtensor
+                    and self.config.parallelism.disable_loss_parallel
+                ):
+                    pred = pred.to_local()
                 loss = self.loss_fn(pred, labels, global_valid_tokens)
                 del pred
                 loss.backward()


### PR DESCRIPTION
**Copying major part from @fegin's PR https://github.com/pytorch/torchtitan/pull/3160** 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3381
* __->__ #3382

<img width="463" height="665" alt="image" src="https://github.com/user-attachments/assets/39a2e880-62da-4e20-ab7c-0f36fd0bccc5" />

https://excalidraw.com/#json=2abKr0m2s26fc6lyoF9Qq,MqMzUIoXWYJIfckHNOB7Sw

## Summary

Refactor MoE parallelization to establish clean DTensor boundaries:
- **Router**: gate weights Replicate, input all-gathered to Replicate (via `NoParallel`), compute on DTensor, output converted to local via `to_local(grad_placements=Partial)`
- **Shared experts**: weights TP-sharded (via `ColwiseParallel`/`RowwiseParallel`), input all-gathered to Replicate inside `ColwiseParallel`, compute on DTensor, output local via `to_local` (Partial placement, `use_local_output=True`)
- **Routed experts**: input converted to local via `to_local` at `GroupedExperts` boundary, EP-partitioned weights on local tensors, dispatch/compute/combine all local

Key changes:
- Move `shared_experts` computation from inside `TokenDispatcher.combine()` to `MoE.forward()`
- Move `to_local` from `MoE.forward()` into `GroupedExperts.forward()`, with proper `grad_placements` based on placement type (Shard vs Replicate)
- Replace `ColwiseParallelWithGradPlacement` with standard `ColwiseParallel` using `input_layouts`
- Remove `shared_experts` parameter from all token dispatchers, replace with `initial_output` buffer
- For EP+SP, keep `Shard(1)` as desired MoE input layout (avoid redundant all-gather at MoE boundary); for TP-only, keep `Replicate()` (required for TP-sharded expert weight reduction)

### Trade-offs
- Removes async overlap between `shared_experts` and the all-to-all combine. Previously `shared_experts` ran while the combine A2A was in flight on the NCCL stream. A follow-up can restore overlap using CUDA streams.

## Test plan
- [X] TP=1 EP=1 runs, losses different than main starting step1. 
- [X] TP=2 EP=1 runs, losses different than main starting step1.  
- [X] TP=1 EP=2 runs, losses different than main starting step1. 
- [X] TP=2 EP=2 runs, losses different than main starting step1. 

Loss is expected to diverge compared to main due to different reduction pattern, and shared expert computation changes place.

single run
```
NCCL_NVLS_ENABLE=0 NGPU=4 MODULE='llama4' CONFIG='llama4_debugmodel' ./run_train.sh \
    --parallelism.pipeline_parallel_degree 1 \
    --parallelism.data_parallel_shard_degree 2 \
    --parallelism.tensor_parallel_degree 2 \
    --parallelism.expert_parallel_degree 2 \
    --debug.deterministic --debug.seed=42
```
Compare loss
```
NCCL_NVLS_ENABLE=0 python scripts/loss_compare.py . main --baseline-module='llama4' --baseline-config='llama4_debugmodel' --baseline-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2" --baseline-ngpus=4 --test-module='llama4' --test-config='llama4_debugmodel' --test-options="--parallelism.pipeline_parallel_degree 1 --parallelism.data_parallel_shard_degree 2 --parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 2" --test-ngpus=4 --assert-equal --no-seed-checkpoint
```