### PR TITLE
[MoE] Move shared_experts out of combine() for clean DTensor boundaries

### DIFF
--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -7,7 +7,6 @@
 import unittest
 
 import torch
-import torch.nn.functional as F
 
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 
@@ -140,51 +139,6 @@ class TestPermute(unittest.TestCase):
             set(permuted_indices.tolist()),
             set(range(total)),
         )
-
-
-class TestSPPaddingRoundTrip(unittest.TestCase):
-    """Verify AllToAllTokenDispatcher's SP padding/unpadding recovers the
-    original tokens for an uneven ``bs * slen`` (not divisible by ``sp_size``).
-
-    See docs/moe_sp_padding.md. Like TestPermute above, this runs on CPU by
-    only exercising the pure-tensor helper ``_split_along_sp`` rather than
-    going through dispatch()/combine() (which need CUDA + a real EP mesh).
-    """
-
-    def test_round_trip_recovers_original(self):
-        original_num_tokens = 7  # not divisible by sp_size=4
-        sp_size = 4
-        dim = 3
-
-        cfg = AllToAllTokenDispatcher.Config(
-            num_experts=4, top_k=1, score_before_experts=True
-        )
-        dispatcher = AllToAllTokenDispatcher(cfg)
-        dispatcher.sp_size = sp_size
-
-        x = torch.randn(original_num_tokens, dim)
-
-        # Pad (matches what dispatch() does on entry).
-        pad = (-original_num_tokens) % sp_size
-        x_padded = F.pad(x, (0, 0, 0, pad))
-        self.assertEqual(x_padded.shape, (8, dim))
-
-        # Split per rank, then reassemble (this is what the EP all-to-all
-        # gathers back in real distributed training).
-        local_num_tokens = x_padded.shape[0] // sp_size
-        per_rank_slices = []
-        for rank in range(sp_size):
-            dispatcher.sp_rank = rank
-            (slice_,) = dispatcher._split_along_sp(x_padded)
-            torch.testing.assert_close(
-                slice_,
-                x_padded[rank * local_num_tokens : (rank + 1) * local_num_tokens],
-            )
-            per_rank_slices.append(slice_)
-        reassembled = torch.cat(per_rank_slices, dim=0)
-
-        # Unpad to recover original prefix bitwise.
-        torch.testing.assert_close(reassembled[:original_num_tokens], x)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -14,7 +14,7 @@ import torch._inductor.config
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import distribute_module, DTensor, Replicate
-from torch.distributed.tensor.parallel import ColwiseParallel, ParallelStyle
+from torch.distributed.tensor.parallel import ParallelStyle
 from torch.distributed.tensor.placement_types import Placement
 
 from torchtitan.config import CompileConfig, ParallelismConfig
@@ -102,89 +102,6 @@ class NoParallel(ParallelStyle):
                 self._prepare_output_fn,  # pyrefly: ignore [bad-argument-type]
                 self.output_layout,
                 self.local_output_grad_placements,
-            ),
-        )
-
-
-class ColwiseParallelWithGradPlacement(ColwiseParallel):
-    """ColwiseParallel with explicit control over backward gradient placement.
-
-    By default, ``ColwiseParallel`` with ``input_layouts=Replicate()`` wraps
-    the input via ``from_local(Replicate)``, whose backward all-reduces d_x
-    back to Replicate.  This subclass overrides ``_prepare_input_fn`` to pass
-    ``local_input_grad_placements`` to ``DTensor.from_local``, giving users
-    explicit control over the gradient placement during backward.  When not
-    specified, defaults to ``None`` and the gradient placement follows the
-    default guarantees of ``DTensor.from_local``.
-    """
-
-    def __init__(
-        self,
-        *,
-        input_layouts: Placement | None = None,
-        output_layouts: Placement | None = None,
-        use_local_output: bool = True,
-        local_input_grad_placements: Sequence[Placement] | None = None,
-    ):
-        super().__init__(
-            input_layouts=input_layouts,
-            output_layouts=output_layouts,
-            use_local_output=use_local_output,
-        )
-        self.local_input_grad_placements = local_input_grad_placements
-
-    @staticmethod
-    # pyrefly: ignore [bad-param-name-override]
-    def _prepare_input_fn(
-        input_layouts,
-        desired_input_layouts,
-        local_input_grad_placements,
-        mod,
-        inputs,
-        device_mesh,
-    ):
-        input_tensor = inputs[0]
-        if not isinstance(input_tensor, DTensor):
-            assert local_input_grad_placements is not None, (
-                "local_input_grad_placements must be specified when input is a "
-                "plain tensor. Please think about what you want the from_local(Replicate) backward behavior like."
-            )
-            input_tensor = DTensor.from_local(
-                input_tensor,
-                device_mesh,
-                input_layouts,
-                run_check=False,
-                grad_placements=local_input_grad_placements,
-            )
-
-        if input_layouts != desired_input_layouts:
-            input_tensor = input_tensor.redistribute(
-                placements=desired_input_layouts, async_op=True
-            )
-        return input_tensor
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        if isinstance(module, nn.Linear):
-            partition_fn = self._partition_linear_fn
-        elif isinstance(module, nn.Embedding):
-            partition_fn = self._partition_embedding_fn
-        else:
-            raise NotImplementedError(
-                "ColwiseParallelWithGradPlacement currently only supports nn.Linear and nn.Embedding!"
-            )
-
-        return distribute_module(
-            module,
-            device_mesh,
-            partition_fn,
-            partial(
-                self._prepare_input_fn,  # pyrefly: ignore [bad-argument-type]
-                self.input_layouts,
-                self.desired_input_layouts,
-                self.local_input_grad_placements,
-            ),
-            partial(
-                self._prepare_output_fn, self.output_layouts, self.use_local_output
             ),
         )
 

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -10,14 +10,13 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.distributed.tensor import DTensor, Partial
+from torch.distributed.tensor import DTensor
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
-
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import LocalTokenDispatcher
+from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
 
 
 class GroupedExperts(Module):
@@ -72,7 +71,7 @@ class GroupedExperts(Module):
             x.bfloat16(), w3.bfloat16().transpose(-2, -1), offs=offsets
         )
         return torch._grouped_mm(
-            h, w2.bfloat16().transpose(-2, -1), offs=offsets
+            +h, w2.bfloat16().transpose(-2, -1), offs=offsets
         ).type_as(x)
 
     def forward(
@@ -80,18 +79,27 @@ class GroupedExperts(Module):
         x: torch.Tensor,
         top_scores: torch.Tensor,
         selected_experts_indices: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add.
 
-        shared_experts is passed to combine() where it overlaps with the async
-        combine all-to-all (NCCL stream) or async DeepEP combine.
+        When parallelized, ``local_map`` (from ``sharding_config``) handles
+        DTensor→local conversion on entry and local→DTensor(Partial) wrapping
+        on exit. The forward body operates on plain local tensors.
         """
         routed_input, num_tokens_local, metadata = self.token_dispatcher.dispatch(
             x, top_scores, selected_experts_indices
         )
         routed_output = self._experts_forward(routed_input, num_tokens_local)
-        return self.token_dispatcher.combine(routed_output, metadata, x, shared_experts)
+        return self.token_dispatcher.combine(routed_output, metadata, x)
+
+    def parallelize(self, parallel_dims) -> None:
+        """Parallelize expert weights, then wire EP/TP meshes on the dispatcher
+        so dispatch/combine see the right meshes at runtime."""
+        super().parallelize(parallel_dims)
+        self.token_dispatcher.wire_meshes(
+            ep_mesh=parallel_dims.get_optional_mesh("ep"),
+            tp_mesh=parallel_dims.get_optional_mesh("tp"),
+        )
 
 
 class TokenChoiceTopKRouter(Module):
@@ -258,18 +266,18 @@ class MoE(Module):
     """Mixture of Experts layer.
 
     The forward pass proceeds as:
-    1. Router computes expert assignments
-    2. GroupedExperts.forward() handles:
+    1. Router computes expert assignments (stays on DTensor)
+    2. GroupedExperts.forward() converts DTensor to local, then handles:
        a. dispatch (TokenDispatcher) — reorder tokens by expert assignment.
           With EP, also performs all-to-all communication to send tokens
           to expert-owning ranks.
-       b. expert computation
+       b. expert computation (local tensors)
        c. combine (TokenDispatcher) — reverse the dispatch reordering.
-          With EP, starts async communication (NCCL all-to-all or DeepEP
-          combine), runs shared_experts in parallel, then forces sync
-          (scatter_add for NCCL AllToAll, sync_combine for DeepEP) and
-          produces final output.
-          Without EP (LocalTokenDispatcher), no communication is needed.
+          - LocalTokenDispatcher (no EP): scatter_add only.
+          - AllToAll: all-to-all communication, then scatter_add.
+          - DeepEP/HybridEP: async combine_tokens.
+    3. Shared experts run on DTensor (overlaps with DeepEP async combine).
+    4. Routed and shared expert outputs are summed.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -318,30 +326,14 @@ class MoE(Module):
 
         Returns:
             out (torch.Tensor): Output tensor with shape ``(bs, slen, dim)``.
+
+        Under TP, the MoE wrapper's ``sharding_config`` (set by
+        ``set_moe_sharding_config``) handles input/output redistribution:
+        input is redistributed from sp_layout to desired_input_layouts;
+        output (Partial) is redistributed to sp_layout. MoE.forward()
+        operates on DTensors — the DTensor→local conversion happens at
+        the GroupedExperts boundary.
         """
-        # Convert DTensor to local tensor for MoE-internal computation.
-        # grad_placements=(Partial(),) ensures x.grad is Partial on the tp_mesh
-        # in backward, so gradient reduction (reduce-scatter from Partial to
-        # Shard(1)) happens once at the MoE boundary rather than being
-        # duplicated inside the MoE.
-        #
-        # Why grad(x) is Partial on the tp_mesh across all parallelism:
-        # - TP only / TP+EP with ETP=TP: TP-sharded expert weights (Colwise on
-        #   w1/w3, Rowwise on w2) produce Partial output gradients.
-        # - TP+EP with ETP=1: each TP rank processes a disjoint token subset
-        #   (via sequence-parallel token splitting in AllToAllTokenDispatcher),
-        #   so grad(x) is non-zero only at each rank's token positions (Partial).
-        #
-        # This holds for all MoE components (router.gate, routed experts, shared
-        # experts) and regardless of score_before_experts.
-        if isinstance(x, DTensor):
-            assert (
-                x.device_mesh.ndim == 1
-            ), f"Expected 1D mesh, got {x.device_mesh.ndim}D mesh"
-            assert x.device_mesh.mesh_dim_names == (
-                "tp",
-            ), f"Expected TP mesh, got mesh_dim_names={x.device_mesh.mesh_dim_names}"
-            x = x.to_local(grad_placements=(Partial(),))
         bs, slen, dim = x.shape
         x = x.view(-1, dim)
 
@@ -361,13 +353,21 @@ class MoE(Module):
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert)
 
-        out = self.experts(
-            x,
-            top_scores,
-            selected_experts_indices,
-            shared_experts=self.shared_experts,
-        )
+        out = self.experts(x, top_scores, selected_experts_indices)
 
+        # shared_experts runs in parallel with deepep combine communication.
+        shared_out = self.shared_experts(x) if self.shared_experts is not None else None
+
+        if isinstance(self.experts.token_dispatcher, DeepEPTokenDispatcher):
+            # Sync the combine operation before using routed_output.
+            # This inserts a CUDA stream wait, ensuring combine is complete before
+            # the subsequent addition or reshape operations read routed output.
+            from torchtitan.distributed.deepep.deepep import sync_combine
+
+            sync_combine()
+
+        if shared_out is not None:
+            out = out + shared_out
         return out.reshape(bs, slen, dim)
 
     def _init_self_buffers(self, *, buffer_device: torch.device | None = None) -> None:

--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -1,0 +1,267 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Config-based sharding helpers for MoE submodules."""
+
+from torch.distributed.tensor import Partial, Placement, Replicate, Shard
+
+from torchtitan.models.common.decoder_sharding import (
+    dense_activation_placement,
+    dense_param_placement,
+)
+from torchtitan.protocols.sharding import LocalMapConfig, NamedPlacement, ShardingConfig
+from torchtitan.protocols.types import MeshAxisName
+
+
+DP_REPLICATE = MeshAxisName.DP_REPLICATE
+DP_SHARD = MeshAxisName.DP_SHARD
+CP = MeshAxisName.CP
+TP = MeshAxisName.TP
+EP = MeshAxisName.EP
+EFSDP = MeshAxisName.EFSDP
+
+
+def expert_param_placement_sparse() -> NamedPlacement:
+    """Sparse-family placement for routed-expert weights (EP enabled).
+
+    Insertion order matches canonical mesh order ``DP_REPLICATE -> EFSDP ->
+    EP`` so ``_needed_axes``'s first-insertion axis order resolves
+    to the sparse_mesh.
+
+    DP_REPLICATE / EFSDP are FSDP storage axes: ``Replicate`` at
+    ``distribute_tensor`` time, FSDP reshards ``EFSDP`` post-parallelize.
+    EP always shards on dim 0 (the expert dim of ``(num_experts, *, *)``
+    weights).
+    """
+    return {
+        DP_REPLICATE: Replicate(),
+        EFSDP: Replicate(),
+        EP: Shard(0),
+    }
+
+
+def expert_param_placement_dense(*, tp_placement: Placement) -> NamedPlacement:
+    """Dense-family placement for routed-expert weights (EP disabled, TP > 1).
+
+    Used when expert parallelism is disabled but tensor parallelism shards
+    the experts on the dense TP axis.
+
+    Insertion order matches canonical mesh order. ``tp_placement`` is the
+    placement on the TP axis: ``Shard(1)`` for colwise, ``Shard(2)`` for
+    rowwise, ``Replicate()`` for replicated bias.
+    """
+    return {
+        DP_REPLICATE: Replicate(),
+        DP_SHARD: Replicate(),
+        CP: Replicate(),
+        TP: tp_placement,
+    }
+
+
+def _shared_expert_colwise_config(enable_ep: bool, enable_sp: bool) -> ShardingConfig:
+    """Colwise shared-expert FFN (w1/w3).
+
+    Mirrors ``ColwiseParallel(input_layouts=...)``: input is all-gathered
+    to Replicate for the column-sharded matmul; output is Shard(1).
+    """
+    sp_layout = Shard(1) if enable_sp else Replicate()
+    input_layout = Replicate() if not enable_ep else sp_layout
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=Shard(0)),
+            "bias": dense_param_placement(tp=Shard(0)),
+        },
+        in_src_shardings={"input": dense_activation_placement(tp=input_layout)},
+        in_dst_shardings={"input": dense_activation_placement(tp=Replicate())},
+        out_dst_shardings=dense_activation_placement(tp=Shard(1)),
+    )
+
+
+def _shared_expert_rowwise_config() -> ShardingConfig:
+    """Rowwise shared-expert FFN (w2), output stays DTensor(Partial).
+
+    Mirrors ``RowwiseParallel(output_layouts=Partial(), use_local_output=False)``:
+    input Shard(1) from upstream colwise; rowwise matmul produces Partial;
+    output stays DTensor(Partial) — reduction happens at the MoE boundary.
+    """
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=Shard(1)),
+            # Rowwise bias is replicated (not sharded) -- the rowwise matmul
+            # sums across TP ranks, then the bias add is a per-rank add.
+            "bias": dense_param_placement(tp=Replicate()),
+        },
+        in_src_shardings={"input": dense_activation_placement(tp=Shard(1))},
+        out_dst_shardings=dense_activation_placement(tp=Partial()),
+    )
+
+
+def _router_gate_config(*, enable_ep: bool) -> ShardingConfig:
+    """Router gate: Replicate weights, output stays DTensor.
+
+    EP off: input Replicate, gate computes on all tokens, output DTensor(Replicate).
+    EP on:  input redistributed to Shard(0), gate computes on local shard, output DTensor(Shard(0)).
+    """
+    state = {
+        "weight": dense_param_placement(tp=Replicate()),
+        "bias": dense_param_placement(tp=Replicate()),
+    }
+    if enable_ep:
+        return ShardingConfig(
+            state_shardings=state,
+            in_dst_shardings={"input": dense_activation_placement(tp=Shard(0))},
+            out_dst_shardings=dense_activation_placement(tp=Shard(0)),
+        )
+    else:
+        return ShardingConfig(
+            state_shardings=state,
+            out_dst_shardings=dense_activation_placement(tp=Replicate()),
+        )
+
+
+def _moe_wrapper_sharding_config(*, enable_ep: bool, enable_sp: bool) -> ShardingConfig:
+    """``ShardingConfig`` at the MoE wrapper boundary.
+
+    Mirrors ``PrepareModuleInputOutput``: input arrives at sp_layout,
+    redistributed to desired_input_layouts; output is Partial,
+    redistributed to sp_layout. MoE.forward() operates on DTensors —
+    the DTensor→local conversion happens at GroupedExperts boundary.
+    """
+    sp_layout: Placement = Shard(1) if enable_sp else Replicate()
+    moe_desired_input_layouts = Replicate() if not enable_ep else sp_layout
+
+    return ShardingConfig(
+        state_shardings={
+            "expert_bias": dense_param_placement(tp=Replicate()),
+            "tokens_per_expert": dense_param_placement(
+                tp=Partial() if enable_ep else Replicate()
+            ),
+        },
+        in_src_shardings={"x": dense_activation_placement(tp=sp_layout)},
+        in_dst_shardings={
+            "x": dense_activation_placement(tp=moe_desired_input_layouts)
+        },
+        out_src_shardings=dense_activation_placement(tp=Partial()),
+        out_dst_shardings=dense_activation_placement(tp=sp_layout),
+    )
+
+
+def set_moe_sharding_config(
+    moe_cfg,
+    *,
+    enable_tp: bool,
+    enable_ep: bool,
+    enable_sp: bool,
+    expert_param_layout: dict[str, Placement],
+) -> None:
+    """Populate ``sharding_config`` on every MoE submodule.
+
+    Branches dense vs sparse family per Module:
+
+    - ``moe`` (wrapper): input/output redistribution on ``{TP}``.
+      Always set when ``tp_enabled``.
+    - ``moe.router.gate``: Replicate weights, output stays DTensor.
+    - ``moe.shared_experts.{w1,w2,w3}``: dense-family TP plan with
+      Partial-flow grad annotations (when ``moe_cfg.shared_experts is not
+      None``).
+    - ``moe.experts`` (``GroupedExperts``): sparse-family ``{EP}``
+      placements when EP is enabled; dense-family ``{TP}`` placements
+      when EP is disabled and TP is enabled; no sharding when both are
+      disabled.
+
+    ``expert_param_layout`` maps each routed-expert parameter name to its
+    dense in/out-dim placement (used on the EP-disabled + TP-enabled path):
+    ``Shard(1)`` for colwise, ``Shard(2)`` for rowwise, ``Replicate()`` for
+    replicated bias. The shared ``GroupedExperts`` (qwen3, llama4,
+    deepseek_v3) passes ``{"w1": Shard(1), "w2": Shard(2), "w3": Shard(1)}``;
+    ``GptOssGroupedExperts`` passes its mlp1/mlp2 layout.
+
+    Args:
+        moe_cfg: The ``MoE.Config`` instance to populate.
+        tp_enabled: Whether tensor parallelism is enabled.
+        ep_enabled: Whether expert parallelism is enabled.
+        enable_sp: Whether sequence parallelism is enabled (affects the
+            wrapper's enter/exit TP layout).
+        expert_param_layout: ``{param_name: tp_placement}`` for the
+            routed experts' weight params (used on the EP-disabled +
+            TP-enabled path).
+    """
+    # MoE wrapper boundary. Set whenever TP is enabled (with or without
+    # SP) -- the wrapper still needs to convert DTensor inputs to local.
+    if enable_tp:
+        moe_cfg.sharding_config = _moe_wrapper_sharding_config(
+            enable_ep=enable_ep, enable_sp=enable_sp
+        )
+
+        # Router gate: dense-family TP plan with Partial output grad.
+        moe_cfg.router.gate.sharding_config = _router_gate_config(enable_ep=enable_ep)
+
+        # Shared experts: optional. Use Partial-flow variants so the
+        # Partial->sp_layout reduce only happens once at the MoE boundary.
+        if getattr(moe_cfg, "shared_experts", None) is not None:
+            moe_cfg.shared_experts.w1.sharding_config = _shared_expert_colwise_config(
+                enable_ep=enable_ep, enable_sp=enable_sp
+            )
+            moe_cfg.shared_experts.w2.sharding_config = _shared_expert_rowwise_config()
+            moe_cfg.shared_experts.w3.sharding_config = _shared_expert_colwise_config(
+                enable_ep=enable_ep, enable_sp=enable_sp
+            )
+
+    # Routed experts: local_map converts DTensor inputs to local for
+    # dispatch/compute/combine, then wraps local output as DTensor(Partial).
+    experts_out_layout = dense_activation_placement(tp=Partial())
+    if enable_ep:
+        # Sparse family: {EP}. Expert weights shard on the expert dim.
+        state_shardings: dict[str, NamedPlacement] = {
+            name: expert_param_placement_sparse() for name in expert_param_layout
+        }
+        experts_in_layout = dense_activation_placement(tp=Shard(0))
+        experts_in_grad_layout = dense_activation_placement(tp=Shard(0))
+        moe_cfg.experts.sharding_config = ShardingConfig(
+            state_shardings=state_shardings,
+            in_dst_shardings={
+                "x": experts_in_layout,
+                "top_scores": experts_in_layout,
+                "selected_experts_indices": experts_in_layout,
+            },
+            out_src_shardings=experts_out_layout,
+            out_dst_shardings=experts_out_layout,
+            local_map=LocalMapConfig(
+                in_grad_placements=(
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                ),
+            ),
+        )
+    elif enable_tp:
+        # Dense family: {TP}. EP disabled, TP shards routed-expert weights.
+        state_shardings = {}
+        for name, placement in expert_param_layout.items():
+            state_shardings[name] = expert_param_placement_dense(
+                tp_placement=placement,
+            )
+        experts_in_layout = dense_activation_placement(tp=Replicate())
+        experts_in_grad_layout = dense_activation_placement(tp=Partial())
+        moe_cfg.experts.sharding_config = ShardingConfig(
+            state_shardings=state_shardings,
+            in_dst_shardings={
+                "x": experts_in_layout,
+                "top_scores": experts_in_layout,
+                "selected_experts_indices": experts_in_layout,
+            },
+            out_src_shardings=experts_out_layout,
+            out_dst_shardings=experts_out_layout,
+            local_map=LocalMapConfig(
+                in_grad_placements=(
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                    experts_in_grad_layout,
+                ),
+            ),
+        )
+    # else: EP and TP both disabled -- experts stay plain tensors,
+    # no sharding_config.

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -7,8 +7,6 @@
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
-from torch import nn
 from torch.distributed._functional_collectives import (
     all_to_all_single,
     all_to_all_single_autograd,
@@ -35,9 +33,6 @@ class AllToAllDispatchMetadata(LocalDispatchMetadata):
     permuted_indices: torch.Tensor  # for _unpermute
     input_splits: list[int]
     output_splits: list[int]
-    # Pre-pad token count. dispatch() rounds bs*slen up to a multiple of
-    # sp_size when sp_size > 1; combine() slices pad rows off using this.
-    original_num_tokens: int
 
 
 class LocalTokenDispatcher(Configurable):
@@ -59,6 +54,15 @@ class LocalTokenDispatcher(Configurable):
         self.num_experts = config.num_experts
         self.top_k = config.top_k
         self.score_before_experts = config.score_before_experts
+
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """No-op for the EP=1 dispatcher. Subclasses override."""
+        del ep_mesh, tp_mesh
 
     def dispatch(
         self,
@@ -119,24 +123,18 @@ class LocalTokenDispatcher(Configurable):
         routed_output: torch.Tensor,
         metadata: LocalDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
-        """Score, scatter_add, and optionally overlap shared_experts.
-
-        For EP=1, no communication is needed. shared_experts runs before
-        scatter_add (no async overlap benefit here, but keeps the interface
-        uniform with AllToAllTokenDispatcher).
+        """Score and scatter_add routed expert outputs.
 
         Args:
             routed_output: (num_tokens * top_k, dim) expert outputs
             metadata: LocalDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        out = torch.zeros_like(x)
 
         if not self.score_before_experts:
             routed_output = (
@@ -159,7 +157,9 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
     Handles the full token routing lifecycle:
     dispatch (reorder + EP all-to-all) and combine (reverse).
 
-    ep_mesh is set by the parallelization code after construction.
+    ``ep_mesh`` and the ``sp_size`` / ``sp_rank`` SP coordinates are wired
+    by the owning ``GroupedExperts.parallelize`` override via
+    ``wire_meshes``.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -170,31 +170,32 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         super().__init__(config)
         # DeviceMesh (not ProcessGroup) so that CooR precompile can use
         # torch.ops._dtensor.mesh_get_process_group to keep the FX graph
-        # rank-agnostic. Set by ExpertParallel._partition_fn().
+        # rank-agnostic. None when EP=1 so dispatch falls back to the
+        # LocalTokenDispatcher path.
         self.ep_mesh: DeviceMesh | None = None
-        # TODO: these should be set at config time
-        # Set at runtime by apply_moe_ep_tp. Uses _sym_get_coordinate
-        # so the rank is a SymInt under CooR precompile.
+        # Sequence-parallel split coordinates derived from tp_mesh.
+        # ``sp_rank`` uses ``DeviceMesh._sym_get_coordinate`` so it is a
+        # ``SymInt`` under CooR precompile, keeping the FX graph
+        # rank-agnostic. Defaults are the TP=1 values.
         self.sp_size: int = 1
-        self.sp_rank: int | torch.SymInt = -1
+        self.sp_rank: int | torch.SymInt = 0
 
-    def _split_along_sp(self, *tensors: torch.Tensor) -> list[torch.Tensor]:
-        """Split tensors along the first dim across EP ranks for sequence parallel."""
-        sp_size = self.sp_size
-        sp_rank = self.sp_rank
-        results = []
-        for t in tensors:
-            assert t.is_contiguous()
-            num_tokens = t.shape[0]
-            if num_tokens % sp_size != 0:
-                raise ValueError(
-                    "Uneven split of tokens is not supported yet. "
-                    "Requires EP degree dividing batch size * seq len."
-                )
-            local_num_tokens = num_tokens // sp_size
-            offset = sp_rank * local_num_tokens
-            results.append(t[offset : offset + local_num_tokens])
-        return results
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """Install the EP mesh and SP coordinates used by dispatch / combine.
+
+        Both arguments may be ``None`` when the corresponding parallelism
+        dimension is disabled; ``dispatch`` / ``combine`` handle the
+        disabled cases internally.
+        """
+        self.ep_mesh = ep_mesh
+        if tp_mesh is not None:
+            self.sp_size = tp_mesh.size()
+            self.sp_rank = tp_mesh._sym_get_coordinate(0)
 
     def dispatch(
         self,
@@ -209,13 +210,13 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         When ep_mesh is None (EP=1), falls back to local dispatch — no
         all-to-all communication, just local token reordering with padding.
 
-        When sp_size > 1 (sequence parallel), inputs are first split along
-        the token dim so each EP rank processes a disjoint subset.
+        With SP, x/top_scores/selected_experts_indices are already the local
+        SP shard (from DTensor Shard to_local via LocalMapConfig).
 
         Args:
-            x: (num_tokens, dim) all input tokens (global if sp_size > 1)
-            top_scores: (num_tokens, top_k) routing scores
-            selected_experts_indices: (num_tokens, top_k) expert indices per token
+            x: (num_local_tokens, dim) local token shard
+            top_scores: (num_local_tokens, top_k) routing scores
+            selected_experts_indices: (num_local_tokens, top_k) expert indices
 
         Returns:
             routed_input: (R, dim) tokens in expert-major order for local experts
@@ -227,25 +228,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             return super().dispatch(x, top_scores, selected_experts_indices)
 
         ep_size = self.ep_mesh.size()
-        original_num_tokens = x.shape[0]
-
-        if self.sp_size > 1:
-            assert self.sp_rank >= 0, (
-                "sp_rank must be set before use. "
-                "apply_moe_ep_tp() should set it from tp_mesh._sym_get_coordinate()."
-            )
-            # Round bs*slen up to a multiple of sp_size. Pad rows route to
-            # expert 0 with zero scores -> zero contribution to scatter_add.
-            pad = (-original_num_tokens) % self.sp_size
-            if pad > 0:
-                x = F.pad(x, (0, 0, 0, pad))
-                top_scores = F.pad(top_scores, (0, 0, 0, pad))
-                selected_experts_indices = F.pad(
-                    selected_experts_indices, (0, 0, 0, pad)
-                )
-            x, top_scores, selected_experts_indices = self._split_along_sp(
-                x, top_scores, selected_experts_indices
-            )
 
         # TODO: Extract this local reordering block (histc, argsort, score
         # application) into a shared helper — it's duplicated in
@@ -342,7 +324,6 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
-            original_num_tokens=original_num_tokens,
         )
         return routed_input, num_tokens_per_expert_group, metadata
 
@@ -401,34 +382,30 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: AllToAllDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Reverse the dispatch: unpermute + all-to-all + score + scatter_add.
 
-        shared_experts overlaps with the async all-to-all combine — it runs
-        while the a2a is in flight on the NCCL stream. scatter_add forces sync.
-
-        When sp_size > 1 (sequence parallel), dispatch uses local token
-        indices. Combine offsets them to global positions so scatter_add
+        When sp_size > 1, dispatch uses local token indices.
+        Combine offsets them to global positions so scatter_add
         into full x is correct.
 
         Args:
             routed_output: (R, dim) expert outputs in expert-major order
             metadata: AllToAllDispatchMetadata from dispatch()
             x: (num_tokens, dim) original input tokens
-            shared_experts: optional shared expert module to overlap
 
         Returns:
-            (num_tokens, dim) combined output with shared_experts added.
+            (num_tokens, dim) combined output.
         """
         # EP=1: fall back to local combine (no all-to-all needed)
         if self.ep_mesh is None:
-            return super().combine(routed_output, metadata, x, shared_experts)
+            return super().combine(routed_output, metadata, x)
 
         # Reverse expert-major reordering
         routed_output = self._unpermute(
             routed_output, metadata.input_shape, metadata.permuted_indices
         )
+
         # All-to-all combine: returns AsyncCollectiveTensor — the a2a runs
         # on the NCCL stream and won't block until the tensor is accessed.
         routed_output = all_to_all_single_autograd(
@@ -438,9 +415,11 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             self.ep_mesh,
         )
 
-        # shared_experts overlaps with the async a2a (NCCL stream).
-        # Score application + scatter_add forces the a2a to sync.
-        out = shared_experts(x) if shared_experts is not None else torch.zeros_like(x)
+        # With SP, x is the local shard. Create full-size buffer for scatter_add
+        # so routed results from all SP ranks can be placed at global positions.
+        out = torch.zeros(
+            x.shape[0] * self.sp_size, x.shape[-1], device=x.device, dtype=x.dtype
+        )
 
         if not self.score_before_experts:
             routed_output = (
@@ -448,31 +427,19 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
                 * metadata.top_scores_experts_sorted.reshape(-1, 1)
             ).to(routed_output.dtype)
 
-        # When sequence_parallel is active, dispatch splits tokens to a local
-        # shard, so token_indices_experts_sorted are 0-based local indices.
-        # Offset them to global positions so scatter_add into full x is correct.
-        original_num_tokens = metadata.original_num_tokens
+        # With SP, token indices are 0-based within the local shard.
+        # Offset to global positions for the full-size scatter buffer.
         if self.sp_size > 1:
-            padded_num_tokens = original_num_tokens + (
-                (-original_num_tokens) % self.sp_size
-            )
-            local_num_tokens = padded_num_tokens // self.sp_size
             token_indices_experts_sorted = (
-                metadata.token_indices_experts_sorted + local_num_tokens * self.sp_rank
+                metadata.token_indices_experts_sorted + x.shape[0] * self.sp_rank
             )
-            assert isinstance(token_indices_experts_sorted, torch.Tensor)
-            # Drop pad-row entries: their global indices fall in
-            # [original_num_tokens, padded_num_tokens), out of `out`'s range.
-            # scatter_add itself is not padded; `out` matches x's shape.
-            if padded_num_tokens != original_num_tokens:
-                mask = token_indices_experts_sorted < original_num_tokens
-                token_indices_experts_sorted = token_indices_experts_sorted[mask]
-                routed_output = routed_output[mask]
         else:
             token_indices_experts_sorted = metadata.token_indices_experts_sorted
+
+        assert isinstance(token_indices_experts_sorted, torch.Tensor)
         out = deterministic_scatter_add(
             out,
-            token_indices_experts_sorted.reshape(-1, 1).expand(-1, x.shape[-1]),
+            token_indices_experts_sorted.reshape(-1, 1).expand(-1, out.shape[-1]),
             routed_output,
         )
         return out
@@ -606,7 +573,7 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
         self.comm_backend = config.comm_backend
         self.non_blocking_capacity_factor = config.non_blocking_capacity_factor
         self.pad_multiple = config.pad_multiple
-        # Set by ExpertParallel._partition_fn()
+        # Wired by GroupedExperts.parallelize via wire_meshes.
         self.ep_mesh: DeviceMesh | None = None
 
         # Import to register custom ops so SAC saves communication outputs
@@ -615,6 +582,20 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
             from torchtitan.distributed.deepep import hybridep  # noqa: F401
         else:
             from torchtitan.distributed.deepep import deepep  # noqa: F401
+
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """Install the EP mesh used by DeepEP dispatch / combine.
+
+        ``tp_mesh`` is ignored — DeepEP does not use SP token splitting.
+        Accepted for API parity with ``AllToAllTokenDispatcher.wire_meshes``.
+        """
+        del tp_mesh
+        self.ep_mesh = ep_mesh
 
     # pyrefly: ignore [bad-override]
     def dispatch(
@@ -665,7 +646,6 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
         routed_output: torch.Tensor,
         metadata: DeepEPDispatchMetadata,
         x: torch.Tensor,
-        shared_experts: nn.Module | None = None,
     ) -> torch.Tensor:
         """Combine tokens via DeepEP/HybridEP, overlapping shared_experts.
 
@@ -685,18 +665,4 @@ class DeepEPTokenDispatcher(LocalTokenDispatcher):
 
             # pyrefly: ignore [bad-argument-type]
             routed_output = combine_tokens(routed_output, metadata.state)
-
-        # shared_experts runs in parallel with combine communication.
-        # This is the key optimization - we overlap compute with communication.
-        shared_out = shared_experts(x) if shared_experts is not None else None
-
-        # Sync the combine operation before using routed_output.
-        # This inserts a CUDA stream wait, ensuring combine is complete before
-        # the subsequent addition or reshape operations read routed_output.
-        from torchtitan.distributed.deepep.deepep import sync_combine
-
-        sync_combine()
-
-        if shared_out is not None:
-            routed_output = routed_output + shared_out
         return routed_output

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -51,9 +51,6 @@ def parallelize_gptoss(
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
 
-    if parallelism.full_dtensor:
-        raise NotImplementedError("full_dtensor is not supported yet.")
-
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
@@ -68,7 +65,8 @@ def parallelize_gptoss(
         )
 
     if parallel_dims.tp_enabled:
-        model.parallelize(parallel_dims)
+        tp_mesh = parallel_dims.get_mesh("tp")
+        model.parallelize(tp_mesh)
 
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         apply_moe_ep_tp(

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -178,6 +178,8 @@ class Llama4Model(Decoder):
                 self,
                 loss_parallel=not parallelism.disable_loss_parallel,
                 enable_sp=parallelism.enable_sequence_parallel,
+                enable_tp=parallelism.tensor_parallel_degree > 1,
+                enable_ep=parallelism.expert_parallel_degree > 1,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/llama4/parallelize.py
+++ b/torchtitan/models/llama4/parallelize.py
@@ -10,12 +10,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
-from torch.distributed.tensor import Partial, Replicate, Shard
-from torch.distributed.tensor.parallel import (
-    parallelize_module,
-    PrepareModuleInputOutput,
-    RowwiseParallel,
-)
+from torch.distributed.tensor import Shard
 
 from torchtitan.config import (
     ActivationCheckpointConfig,
@@ -28,17 +23,11 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_forward
-from torchtitan.distributed.expert_parallel import ExpertParallel, TensorParallel
 from torchtitan.distributed.fsdp import (
     disable_fsdp_gradient_division,
     get_fsdp_reshard_after_forward_policy,
 )
-from torchtitan.distributed.tensor_parallel import (
-    ColwiseParallelWithGradPlacement,
-    maybe_enable_async_tp,
-    NoParallel,
-)
-from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 from torchtitan.models.llama4.model import Llama4Model
 from torchtitan.tools.logging import logger
 
@@ -79,18 +68,12 @@ def parallelize_llama(
             parallel_dims.get_mesh("cp"),
         )
 
-    if parallel_dims.tp_enabled:
+    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         model.parallelize(parallel_dims)
+    if parallel_dims.tp_enabled:
         maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
 
-    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
-        apply_moe_ep_tp(
-            model,
-            tp_mesh=parallel_dims.get_optional_mesh("tp"),
-            ep_mesh=parallel_dims.get_optional_mesh("ep"),
-            enable_sp=True,
-        )
-
+    # Set SP size/rank on EP dispatchers for sequence-parallel token splitting.
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
@@ -362,108 +345,3 @@ def apply_fsdp(
         elif model.tok_embeddings is not None:
             # pyrefly: ignore [missing-attribute]
             transformer_block.set_modules_to_backward_prefetch([model.tok_embeddings])
-
-
-def apply_moe_ep_tp(
-    model: nn.Module,
-    tp_mesh: DeviceMesh | None,
-    ep_mesh: DeviceMesh | None,
-    enable_sp: bool = True,
-):
-    """
-    Apply MoE expert/tensor parallelism plans to MoE-enabled transformer blocks.
-
-    Args:
-        model: Model containing transformer blocks.
-        tp_mesh: Tensor-parallel device mesh.
-        ep_mesh: Expert-parallel device mesh.
-        enable_sp: Whether sequence parallelism is enabled.
-    """
-    assert ep_mesh is not None or tp_mesh is not None
-
-    sp_layout = Shard(1) if enable_sp else Replicate()
-
-    # pyrefly: ignore [not-callable]
-    for transformer_block in model.layers.values():
-        # pyrefly: ignore [missing-attribute]
-        if not transformer_block.moe_enabled:
-            continue
-
-        if tp_mesh is not None:
-            moe_layer_plan = {
-                # With SP: all-gather (Shard→Replicate) for input,
-                # reduce-scatter (Partial→Shard) for output.
-                # Without SP: input is already Replicate,
-                # all-reduce (Partial→Replicate) for output.
-                "moe": PrepareModuleInputOutput(
-                    input_layouts=(sp_layout,),
-                    desired_input_layouts=(Replicate(),),
-                    use_local_input=False,
-                    output_layouts=(Partial(),),
-                    desired_output_layouts=(sp_layout,),
-                    # Keep MoE output as DTensor so the residual add
-                    # ``h + self.moe(...)`` composes with config-based
-                    # attention (which flows DTensors).
-                    use_local_output=False,
-                ),
-                # replicate computation for the router
-                "moe.router.gate": NoParallel(
-                    local_output_grad_placements=(Partial(),),
-                ),
-            }
-            # pyrefly: ignore [missing-attribute]
-            if transformer_block.moe.shared_experts is not None:
-                # Use ColwiseParallelWithGradPlacement to keep d_x as Partial in
-                # backward (avoids the all-reduce that from_local(Replicate)
-                # would otherwise trigger). For w2, output_layouts=Partial()
-                # skips the Partial→Replicate all-reduce in forward. The
-                # reduction happens once at the MoE output boundary
-                # (PrepareModuleInputOutput).
-                # pyrefly: ignore [no-matching-overload]
-                moe_layer_plan.update(
-                    {
-                        "moe.shared_experts.w1": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
-                        ),
-                        "moe.shared_experts.w2": RowwiseParallel(
-                            output_layouts=Partial(),
-                        ),
-                        "moe.shared_experts.w3": ColwiseParallelWithGradPlacement(
-                            local_input_grad_placements=(Partial(),)
-                        ),
-                    }
-                )
-            parallelize_module(
-                # pyrefly: ignore [bad-argument-type]
-                module=transformer_block,
-                device_mesh=tp_mesh,
-                # pyrefly: ignore [bad-argument-type]
-                parallelize_plan=moe_layer_plan,
-            )
-
-        experts_mesh, experts_plan = None, None
-        # EP disabled: shard routed expert weights across TP mesh (input Replicate, produces Partial output reduced at MoE boundary)
-        if ep_mesh is None:
-            experts_mesh = tp_mesh
-            experts_plan = TensorParallel()
-        else:
-            experts_mesh = ep_mesh
-            experts_plan = ExpertParallel()
-            # pyrefly: ignore [missing-attribute]
-            dispatcher = transformer_block.moe.experts.token_dispatcher
-            if tp_mesh is not None:
-                if isinstance(dispatcher, AllToAllTokenDispatcher):
-                    # sp_size and sp_rank are set for sequence-parallel token splitting
-                    # when EP borrows from TP.
-                    dispatcher.sp_size = tp_mesh.size()
-                    # Use _sym_get_coordinate so the rank is a SymInt
-                    # under CooR precompile instead of a concrete int
-                    # that gets baked into the FX graph.
-                    dispatcher.sp_rank = tp_mesh._sym_get_coordinate(0)
-
-        parallelize_module(
-            # pyrefly: ignore [missing-attribute]
-            module=transformer_block.moe.experts,
-            device_mesh=experts_mesh,
-            parallelize_plan=experts_plan,
-        )

--- a/torchtitan/models/llama4/sharding.py
+++ b/torchtitan/models/llama4/sharding.py
@@ -15,9 +15,17 @@ from torchtitan.models.common.decoder_sharding import (
     set_gqa_attention_sharding,
     set_gqa_inner_attention_local_map,
 )
+from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 
 if TYPE_CHECKING:
     from torchtitan.models.llama4.model import Llama4Model, Llama4TransformerBlock
+
+# Routed-expert layout for the shared ``GroupedExperts`` (w1/w2/w3).
+_GROUPED_EXPERTS_PARAM_LAYOUT: dict[str, Placement] = {
+    "w1": Shard(1),
+    "w2": Shard(2),
+    "w3": Shard(1),
+}
 
 
 def set_llama4_sharding_config(
@@ -25,27 +33,40 @@ def set_llama4_sharding_config(
     *,
     loss_parallel: bool,
     enable_sp: bool,
+    enable_tp: bool,
+    enable_ep: bool,
 ) -> None:
     """Fill ``sharding_config`` on all Llama4 sub-configs.
 
-    No-op when TP is not enabled.
+    Dense sub-configs (attention, norms, dense FFN) are populated
+    unconditionally — ``Module.parallelize`` filters disabled axes
+    at runtime.
+
+    MoE sub-configs (router, shared experts, routed experts) are
+    populated when TP or EP is enabled.
     """
 
     set_decoder_sharding_config(
         config, loss_parallel=loss_parallel, enable_sp=enable_sp
     )
     for layer_cfg in config.layers:
-        _set_llama4_layer_sharding(layer_cfg, enable_sp=enable_sp)
+        _set_llama4_layer_sharding(
+            layer_cfg, enable_sp=enable_sp, enable_tp=enable_tp, enable_ep=enable_ep
+        )
 
 
 def _set_llama4_layer_sharding(
-    layer_cfg: "Llama4TransformerBlock.Config", *, enable_sp: bool
+    layer_cfg: "Llama4TransformerBlock.Config",
+    *,
+    enable_sp: bool,
+    enable_tp: bool,
+    enable_ep: bool,
 ) -> None:
     """Set sharding on one Llama4 transformer layer.
 
     Attention and norms are sharded on all blocks (MoE and non-MoE).
-    Dense FFN is only sharded on non-MoE blocks — MoE FFN stays
-    under apply_moe_ep_tp.
+    Dense FFN is only sharded on non-MoE blocks; MoE FFN is routed
+    through ``set_moe_sharding_config``.
     """
     norm = norm_config(enable_sp=enable_sp)
     layer_cfg.attention_norm.sharding_config = norm
@@ -61,4 +82,14 @@ def _set_llama4_layer_sharding(
             layer_cfg.feed_forward,
             attn_x_placement=attn_x_placement,
             enable_sp=enable_sp,
+        )
+
+    # MoE FFN (MoE-enabled layers only).
+    if layer_cfg.moe is not None and (enable_tp or enable_ep):
+        set_moe_sharding_config(
+            layer_cfg.moe,
+            enable_tp=enable_tp,
+            enable_ep=enable_ep,
+            enable_sp=enable_sp,
+            expert_param_layout=_GROUPED_EXPERTS_PARAM_LAYOUT,
         )

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -301,14 +301,6 @@ class Module(nn.Module, Configurable):
         if sharding_config.local_map is None:
             return fn
 
-        if sharding_config.local_input_grad_placements is not None:
-            raise ValueError(
-                f"{type(self).__name__}: local_map and "
-                "local_input_grad_placements cannot coexist. "
-                "Use LocalMapConfig.in_grad_placements for modules "
-                "wrapped with local_map."
-            )
-
         lm = sharding_config.local_map
         in_dst = sharding_config.in_dst_shardings or {}
         pos_args = self._cache_pos_arg_names()
@@ -386,16 +378,14 @@ class Module(nn.Module, Configurable):
 
         in_dst_shardings = sharding_config.in_dst_shardings or {}
         in_src_shardings = sharding_config.in_src_shardings or {}
-        in_grad_shardings = sharding_config.local_input_grad_placements or {}
 
         for name, value in new_kwargs.items():
             if not isinstance(value, torch.Tensor):
                 continue
             src_named_placements = in_src_shardings.get(name)
             dst_named_placements = in_dst_shardings.get(name)
-            grad_named_placements = in_grad_shardings.get(name)
             mesh = parallel_dims.resolve_shared_mesh(
-                [src_named_placements, dst_named_placements, grad_named_placements]
+                [src_named_placements, dst_named_placements]
             )
             if mesh is None:
                 continue
@@ -405,15 +395,11 @@ class Module(nn.Module, Configurable):
 
             if not isinstance(value, DTensor) and src_named_placements is not None:
                 layout = resolve_placements(src_named_placements, mesh)
-                grad_placements: tuple | None = None
-                if grad_named_placements is not None:
-                    grad_placements = resolve_placements(grad_named_placements, mesh)
                 value = DTensor.from_local(
                     value,
                     mesh,
                     layout,
                     run_check=False,
-                    grad_placements=grad_placements,
                 )
 
             if dst_named_placements is not None and isinstance(value, DTensor):

--- a/torchtitan/protocols/sharding.py
+++ b/torchtitan/protocols/sharding.py
@@ -101,16 +101,6 @@ class ShardingConfig:
         out_dst_shardings: Desired output placement after redistribution.
             e.g. ``{TP: Shard(1)}`` for reduce-scatter to sequence-parallel.
             ``None`` means no output redistribution.
-        local_input_grad_placements: Per-input ``NamedPlacement`` declaring
-            the placement of the **input gradient** when the plain input is
-            wrapped via ``DTensor.from_local`` at the input boundary. Keyed
-            by ``forward()`` arg name. Mirrors
-            ``ColwiseParallelWithGradPlacement(local_input_grad_placements=...)``.
-            Only effective for inputs that arrive as plain tensors and have
-            an entry in ``in_src_shardings``.
-            e.g. ``{"x": {TP: Partial()}}`` to keep d_x as Partial in
-            backward instead of all-reducing to Replicate.
-            ``None`` means default ``from_local`` grad behavior.
         local_output_grad_placements: ``NamedPlacement`` declaring the
             placement of the **output gradient** when the DTensor output is
             unwrapped via ``to_local(grad_placements=...)`` at the output
@@ -132,7 +122,6 @@ class ShardingConfig:
     in_dst_shardings: dict[str, NamedPlacement] | None = None
     out_src_shardings: NamedPlacement | tuple[NamedPlacement, ...] | None = None
     out_dst_shardings: NamedPlacement | None = None
-    local_input_grad_placements: dict[str, NamedPlacement] | None = None
     local_output_grad_placements: NamedPlacement | None = None
     local_map: LocalMapConfig | None = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Move shared_experts computation from inside TokenDispatcher.combine()
to MoE.forward(), so that:
- Router stays on DTensor (via NoParallel)
- Shared experts stay on DTensor (via ColwiseParallel/RowwiseParallel)
- Only routed experts convert DTensor→local at GroupedExperts boundary

This removes the DTensor→local→DTensor round-trip that shared experts
previously went through, and simplifies the combine() interface by
removing the shared_experts parameter from all token dispatchers.

Trade-off: this removes the async overlap between shared_experts and
the all-to-all combine communication. Previously shared_experts ran
while the combine a2a was in flight on the NCCL stream. A follow-up
can restore overlap using CUDA streams.