### PR TITLE
[graph_trainer] Fix H100 CI failure from DeepEP compilation break

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -71,10 +71,13 @@ jobs:
         # Pinned to a known-good commit on the hybrid-ep branch to avoid
         # breakage from upstream changes. Update the commit hash when
         # upgrading to a newer DeepEP version.
+        # Non-fatal: DeepEP may fail to compile against newer PyTorch
+        # nightlies (ABI changes). HybridEP tests are skipped when
+        # DeepEP is unavailable.
         DEEPEP_COMMIT=1b8f467
         git clone --branch hybrid-ep https://github.com/deepseek-ai/deepep.git /tmp/deepep
         pushd /tmp/deepep && git checkout $DEEPEP_COMMIT
-        CUDA_HOME=/usr/local/cuda TORCH_CUDA_ARCH_LIST="9.0" pip install --no-build-isolation -e .
+        CUDA_HOME=/usr/local/cuda TORCH_CUDA_ARCH_LIST="9.0" pip install --no-build-isolation -e . || echo "WARNING: DeepEP installation failed; HybridEP tests will be skipped"
         popd
 
         # Disable Nvlink Sharp. The CI machine seems to be in unstable state to support

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import importlib
 import os
 
 from tests.integration_tests import OverrideDefinitions
@@ -15,6 +16,8 @@ from tests.integration_tests.run_tests import run_tests
 # triggered by the full DTensor change (#2149). Re-enable once the
 # partitioner issue is resolved.
 _JIT_DISABLED = True
+
+_DEEPEP_AVAILABLE = importlib.util.find_spec("deep_ep") is not None
 
 
 def _build_llama3_tests() -> list[OverrideDefinitions]:
@@ -373,6 +376,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+HybridEP",
             "aot_fx_trace_deepseek_v3_hybridep",
             ngpu=4,
+            disabled=not _DEEPEP_AVAILABLE,
         ),
     ]
 


### PR DESCRIPTION
## Summary
- DeepEP (pinned at commit `1b8f467`) fails to compile against the latest PyTorch nightly due to an ABI break in `ATen/core/stack.h` (`torch::jit::push` and `TuplePacker` removed/renamed). Since the H100 CI script uses `set -eux`, the `pip install` failure aborts the entire workflow — no tests run at all.
- Made the DeepEP installation non-fatal (`|| echo WARNING`) so the remaining H100 tests (DeepSeek-v3 EP, Qwen3, async TP, numerics, precompile, bitwise deterministic) still run.
- Disabled the `aot_fx_trace_deepseek_v3_hybridep` integration test until DeepEP is updated to be compatible with the latest PyTorch nightly.

## Test plan
- [ ] Verify H100 CI workflow passes with DeepEP install failure (HybridEP test skipped, all other tests run)
- [ ] Re-enable HybridEP test once DeepEP publishes a fix for the `ATen/core/stack.h` ABI change