### PR TITLE
[rl] Add TITO generator and gen metrics

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -24,6 +24,7 @@ from torchtitan.experiments.rl.models.vllm_registry import (
     registry_to_vllm,
     TORCHTITAN_CONFIG_FORMAT,
 )
+from torchtitan.experiments.rl.observability import metrics as m
 from torchtitan.experiments.rl.types import Completion
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
@@ -32,10 +33,69 @@ from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig, CompilationConfig
 from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_generation_request_metrics(
+    output: RequestOutput, *, prefix: str
+) -> list[m.Metric]:
+    """Prepare vLLM metrics from a RequestOutput.
+
+    For `[num_prompts]` submitted prompts, vLLM returns `[num_prompts]`
+    per parent `RequestOutput`s (one per `add_request` call), each carrying
+    a single `RequestStateStats` on `.metrics`.
+
+    Caveat under `SamplingParams.n > 1`: vLLM stores one `RequestStateStats`
+    per child request; the parent output exposes the **last-finishing**
+    child's timeline. `arrival_time` is shared across siblings, but
+    [`queued_ts`, `scheduled_ts`, `first_token_ts`, `last_token_ts`,
+    `num_generation_tokens`] describe one specific child — not an aggregate,
+    not the first sibling's. The other `n-1` siblings' stats are dropped by
+    vLLM at ``output_processor._finish_request``.
+    """
+
+    # TODO: Per-request fields here come from RequestOutput.metrics
+    # (RequestStateStats). Engine-aggregate stats, such as KV-cache usage,
+    # prefix-cache hit rate, preemptions, and batch occupancy, live in
+    # SchedulerStats / IterationStats and require registering a
+    # vllm.v1.metrics.loggers.StatLoggerBase via
+    # LLMEngine.from_engine_args(..., stat_loggers=[...]).
+
+    metric_values: dict[str, float] = {}
+    if output.num_cached_tokens is not None:
+        metric_values[f"{prefix}/num_cached_tokens"] = output.num_cached_tokens
+
+    stats = output.metrics
+    if stats is not None:
+        metric_values[f"{prefix}/queue_time_ms"] = (
+            stats.scheduled_ts - stats.queued_ts
+        ) * 1000
+
+        if stats.num_generation_tokens > 0:
+            metric_values[f"{prefix}/time_to_first_token_ms"] = (
+                stats.first_token_latency * 1000
+            )
+            metric_values[f"{prefix}/prefill_time_ms"] = (
+                stats.first_token_ts - stats.scheduled_ts
+            ) * 1000
+
+        if stats.num_generation_tokens > 1:
+            first_to_last_token_ms = (stats.last_token_ts - stats.first_token_ts) * 1000
+            metric_values[f"{prefix}/decode_time_ms"] = first_to_last_token_ms
+            metric_values[
+                f"{prefix}/inter_token_latency_ms"
+            ] = first_to_last_token_ms / (stats.num_generation_tokens - 1)
+
+    # Emit each value with both Mean and Max aggregators.
+    return [
+        metric
+        for key, value in metric_values.items()
+        for metric in (m.Metric(key, m.Mean(value)), m.Metric(key, m.Max(value)))
+    ]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -259,7 +319,8 @@ class VLLMGenerator(Actor, Configurable):
             attention_config=AttentionConfig(
                 backend=AttentionBackendEnum.CUSTOM,
             ),
-            disable_log_stats=True,
+            # Enables RequestOutput.metrics, so generator metrics can be returned
+            disable_log_stats=False,
         )
         engine_kwargs["max_num_seqs"] = self._max_num_seqs
         # FA2 requires block_size to be a multiple of 256
@@ -316,21 +377,25 @@ class VLLMGenerator(Actor, Configurable):
     @sl.log_trace_span("generate")
     async def generate(
         self,
-        prompts: list[str],
+        tokenized_prompts: list[list[int]],
         *,
         sampling_config: SamplingConfig | None = None,
-    ) -> list[Completion]:
-        """Generate completions for the given prompts.
+        metrics_prefix: str = "generator",
+    ) -> tuple[list[Completion], list[m.Metric]]:
+        """Generate completions and generator metrics for tokenized prompts.
 
-        Returns a flat list of length ``len(prompts) * sampling.n``
-        ordered by ``prompt_idx``, with ``sampling.n`` consecutive
-        completions per prompt.
+        Takes ``tokenized_prompts`` as ``[num_prompts][prompt_tokens]``.
+        Returns completions as ``[num_prompts * n]`` plus generator metrics,
+        where ``n`` is the resolved ``SamplingConfig.n`` completions per prompt.
 
         Args:
-            prompts: List of prompt strings.
+            tokenized_prompts: Tokenized prompts shaped ``[num_prompts][prompt_tokens]``.
             sampling_config: Optional per-call override for the generator's
                 default SamplingConfig. ``seed`` always comes from
                 ``config.debug.seed`` (not part of SamplingConfig).
+            metrics_prefix: Namespace prepended to every returned metric key
+                (default ``"generator"``). Callers that need to keep streams
+                separate, e.g. ``"validation/generator"``, can override it.
         """
         _sampling_config = (
             sampling_config if sampling_config is not None else self.config.sampling
@@ -351,8 +416,19 @@ class VLLMGenerator(Actor, Configurable):
                 output_kind=RequestOutputKind.FINAL_ONLY,
             )
 
-            for i, prompt in enumerate(prompts):
-                self._engine.add_request(str(i), prompt, sampling_params)
+            # render_cmpl is vLLM's input-pipeline entry.
+            # The tokenize step is a no-op for already-tokenized prompts. The
+            # lower-level alternative is vllm.inputs.tokens_input; we use the
+            # high-level API to stay resilient to vLLM internal changes.
+            engine_inputs = self._engine.renderer.render_cmpl(
+                [{"prompt_token_ids": ids} for ids in tokenized_prompts]
+            )
+            for i, engine_input in enumerate(engine_inputs):
+                self._engine.add_request(
+                    request_id=str(i),
+                    prompt=engine_input,
+                    params=sampling_params,
+                )
 
             all_outputs = []
             with sl.log_trace_span("engine_steps"):
@@ -364,30 +440,45 @@ class VLLMGenerator(Actor, Configurable):
             all_outputs.sort(key=lambda o: int(o.request_id))
 
             completions: list[Completion] = []
+            generation_metrics: list[m.Metric] = []
+            output_token_counts: list[int] = []
             for output in all_outputs:
                 prompt_idx = int(output.request_id)
-                prompt_token_ids = output.prompt_token_ids
+                generation_metrics.extend(
+                    _prepare_generation_request_metrics(output, prefix=metrics_prefix)
+                )
                 for sample in output.outputs:
                     per_token_logprobs = [
                         list(logprob_dict.values())[0].logprob
                         for logprob_dict in sample.logprobs
                     ]
+                    output_token_counts.append(len(sample.token_ids))
                     completions.append(
                         Completion(
                             policy_version=self.policy_version,
                             prompt_idx=prompt_idx,
-                            prompt_token_ids=prompt_token_ids,
                             text=sample.text,
                             token_ids=sample.token_ids,
                             token_logprobs=per_token_logprobs,
                             finish_reason=sample.finish_reason,
                         )
                     )
+            generation_metrics.append(
+                m.Metric(
+                    f"{metrics_prefix}/output_tokens",
+                    m.Sum.from_list(output_token_counts),
+                )
+            )
 
         logger.debug(
             f"{os.getpid()=} Generating finish generate (policy v{self.policy_version})..."
         )
-        return completions
+
+        # TODO: consider passing metrics as an arg to Completion and Trajectory,
+        # e.g. Completion(metrics=generation_metrics), so when we log the rollouts
+        # to a json or database,  we can associate each rollout with its metrics
+        # I am keeping like this for now for simplicity.
+        return completions, generation_metrics
 
     @endpoint
     @sl.log_trace_span("pull_model_state_dict")

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -23,6 +23,7 @@ from torchtitan.config import (
 from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.grpo import GRPOLoss, RLTrainer
+from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.sum_digits import SumDigitsEnv
 from torchtitan.models.qwen3 import model_registry
 
@@ -41,6 +42,7 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
         validation_env=SumDigitsEnv.Config(
             seed=99, correctness_reward=1.0, format_reward=0.3
         ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
         trainer=PolicyTrainer.Config(
             optimizer=OptimizersContainer.Config(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(
@@ -94,6 +96,7 @@ def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
         validation_env=SumDigitsEnv.Config(
             seed=99, correctness_reward=1.0, format_reward=0.3
         ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
         trainer=PolicyTrainer.Config(
             optimizer=OptimizersContainer.Config(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(
@@ -148,6 +151,7 @@ def rl_grpo_qwen3_14b() -> RLTrainer.Config:
         validation_env=SumDigitsEnv.Config(
             seed=99, correctness_reward=1.0, format_reward=0.3
         ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
         trainer=PolicyTrainer.Config(
             optimizer=OptimizersContainer.Config(lr=1e-6),
             lr_scheduler=LRSchedulersContainer.Config(
@@ -205,6 +209,7 @@ def rl_grpo_qwen3_0_6b_batch_invariant() -> RLTrainer.Config:
         validation_env=SumDigitsEnv.Config(
             seed=99, correctness_reward=1.0, format_reward=0.3
         ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
         trainer=PolicyTrainer.Config(
             optimizer=OptimizersContainer.Config(lr=2e-6),
             lr_scheduler=LRSchedulersContainer.Config(

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -39,6 +39,7 @@ import torchstore as ts
 from monarch.actor import this_host
 from monarch.spmd import setup_torch_elastic_env_async
 
+from torchtitan.components.tokenizer import HuggingFaceTokenizer
 from torchtitan.config import (
     CompileConfig,
     ConfigManager,
@@ -184,7 +185,7 @@ def _log_samples(items: list[Episode] | list[Completion]) -> None:
         logger.info(f"       A: {item.text[:300].replace(chr(10), ' ').strip()}")
 
 
-def _build_reward_metrics(
+def _prepare_reward_metrics(
     prefix: str,
     trajectories: list[Trajectory],
 ) -> list[m.Metric]:
@@ -193,10 +194,18 @@ def _build_reward_metrics(
     Example::
 
         trajectories = [
-            Trajectory(sample_idx=0, transitions=[(c0, Step(rewards={"correctness": 1.0, "format": 0.5}, done=True))]),
-            Trajectory(sample_idx=1, transitions=[(c1, Step(rewards={"correctness": 0.0},               done=True))]),
+            Trajectory(
+                sample_idx=0,
+                prompt_token_ids=p0,
+                transitions=[(c0, Step(rewards={"correctness": 1.0, "format": 0.5}, done=True))],
+            ),
+            Trajectory(
+                sample_idx=1,
+                prompt_token_ids=p1,
+                transitions=[(c1, Step(rewards={"correctness": 0.0}, done=True))],
+            ),
         ]
-        _build_reward_metrics("reward/component", trajectories)
+        _prepare_reward_metrics("reward/component", trajectories)
         # -> [
         #      Metric("reward/component/correctness", Mean(sum=1.0, count=2)),  # 0.5
         #      Metric("reward/component/format",      Mean(sum=0.5, count=1)),  # 0.5 - "format" only in trajectory 0
@@ -306,6 +315,8 @@ class RLTrainer(Configurable):
             log_dir=config.dump_folder,
             job_config=config.to_dict(),
         )
+        # TODO: Replace this single-turn tokenizer with renderer
+        self.tokenizer = HuggingFaceTokenizer(tokenizer_path=config.hf_assets_path)
 
     async def close(self):
         """Best-effort: tear down actors, close metric backends, then stop proc meshes."""
@@ -563,8 +574,15 @@ class RLTrainer(Configurable):
         envs = [
             self.config.env.build(step=step, group_idx=i) for i in range(num_groups)
         ]
-        completions = self._get_rank_0_value(
-            self.generator.generate.call([env.prompt for env in envs]).get()
+        # TODO: Add a check max_tokens = min(max_tokens, context_window - model_input.length)
+        # and pass max_tokens to the generator call or skip the call if max_tokens<=0.
+        # Do the same for validation.
+        tokenized_prompts = [
+            self.tokenizer.encode(env.prompt, add_bos=True, add_eos=False)
+            for env in envs
+        ]
+        completions, generation_metrics = self._get_rank_0_value(
+            self.generator.generate.call(tokenized_prompts).get()
         )
 
         trajectories: list[Trajectory] = []
@@ -572,11 +590,16 @@ class RLTrainer(Configurable):
             for c in completions:
                 step_result = envs[c.prompt_idx].step(c.text)
                 trajectories.append(
-                    Trajectory(sample_idx=c.prompt_idx, transitions=[(c, step_result)])
+                    Trajectory(
+                        sample_idx=c.prompt_idx,
+                        prompt_token_ids=tokenized_prompts[c.prompt_idx],
+                        transitions=[(c, step_result)],
+                    )
                 )
 
+        # Metrics
         response_lens = [len(c.token_ids) for c in completions]
-        prompt_lens = [len(c.prompt_token_ids) for c in completions]
+        prompt_lens = [len(t.prompt_token_ids) for t in trajectories]
         total_lens = [p + r for p, r in zip(prompt_lens, response_lens, strict=True)]
         truncated = [c.finish_reason == "length" for c in completions]
         rollout_metrics: list[m.Metric] = [
@@ -587,7 +610,8 @@ class RLTrainer(Configurable):
             m.Metric("rollout/total_length", m.Max.from_list(total_lens)),
             m.Metric("rollout/truncation_rate", m.Mean.from_list(truncated)),
         ]
-        rollout_metrics += _build_reward_metrics(
+        rollout_metrics += generation_metrics
+        rollout_metrics += _prepare_reward_metrics(
             prefix="reward/component", trajectories=trajectories
         )
         return trajectories, rollout_metrics
@@ -616,7 +640,7 @@ class RLTrainer(Configurable):
                     Episode(
                         policy_version=c.policy_version,
                         prompt_idx=sample_idx,
-                        prompt_token_ids=c.prompt_token_ids,
+                        prompt_token_ids=t.prompt_token_ids,
                         text=c.text,
                         token_ids=c.token_ids,
                         token_logprobs=c.token_logprobs,
@@ -677,14 +701,25 @@ class RLTrainer(Configurable):
             top_p=1.0,
             max_tokens=self.config.generator.sampling.max_tokens,
         )
-        completions = self._get_rank_0_value(
+
+        tokenized_prompts: list[list[int]] = [
+            self.tokenizer.encode(env.prompt, add_bos=True, add_eos=False)
+            for env in envs
+        ]
+        completions, generation_metrics = self._get_rank_0_value(
             self.generator.generate.call(
-                [env.prompt for env in envs], sampling_config=greedy
+                tokenized_prompts,
+                sampling_config=greedy,
+                metrics_prefix="validation_generator",
             ).get()
         )
 
         trajectories = [
-            Trajectory(sample_idx=i, transitions=[(c, envs[i].step(c.text))])
+            Trajectory(
+                sample_idx=i,
+                prompt_token_ids=tokenized_prompts[i],
+                transitions=[(c, envs[i].step(c.text))],
+            )
             for i, c in enumerate(completions)
         ]
 
@@ -702,7 +737,8 @@ class RLTrainer(Configurable):
             ),
             m.Metric("validation/num_samples", m.NoReduce(float(len(trajectories)))),
         ]
-        validation_metrics += _build_reward_metrics(
+        validation_metrics += generation_metrics
+        validation_metrics += _prepare_reward_metrics(
             prefix="validation/reward/component", trajectories=trajectories
         )
 

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -1,0 +1,190 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for ``VLLMGenerator.generate``.
+
+Exercises the endpoint in isolation by swapping in a fake vLLM engine —
+no Monarch, no GPU, no real model. Covers the token-in / token-out
+contract, the metric payload (timing math, edge cases, prefix override),
+and the completion/metrics separation.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
+from torchtitan.experiments.rl.observability import metrics as m
+
+
+class _FakeRenderer:
+    """Stub for vLLM's Renderer.render_cmpl.
+
+    Mirrors the real shape: takes a list of ``{"prompt_token_ids": ids}``
+    dicts and returns a list of typed ``TokensInput`` EngineInputs with
+    ``type="token"`` plus a stamped ``arrival_time``.
+    """
+
+    def render_cmpl(self, prompts):
+        return [
+            {
+                "type": "token",
+                "prompt_token_ids": p["prompt_token_ids"],
+                "arrival_time": 0.0,
+            }
+            for p in prompts
+        ]
+
+
+class _FakeEngine:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.add_requests = []
+        self._stepped = False
+        self.renderer = _FakeRenderer()
+
+    def add_request(self, *args, **kwargs):
+        self.add_requests.append((args, kwargs))
+
+    def has_unfinished_requests(self):
+        return not self._stepped
+
+    def step(self):
+        self._stepped = True
+        return self.outputs
+
+
+def _sample(*, index=0, token_ids=(10, 11), finish_reason="stop"):
+    return SimpleNamespace(
+        index=index,
+        text="ok",
+        token_ids=list(token_ids),
+        logprobs=[{tok: SimpleNamespace(logprob=-0.1)} for tok in token_ids],
+        finish_reason=finish_reason,
+    )
+
+
+def _request_output(
+    *,
+    request_id="0",
+    prompt_token_ids=(1, 2),
+    outputs=None,
+    num_generation_tokens=4,
+):
+    return SimpleNamespace(
+        request_id=request_id,
+        prompt_token_ids=list(prompt_token_ids),
+        num_cached_tokens=0,
+        metrics=SimpleNamespace(
+            first_token_latency=0.012,
+            queued_ts=1.0,
+            scheduled_ts=1.005,
+            first_token_ts=1.017,
+            last_token_ts=1.047,
+            num_generation_tokens=num_generation_tokens,
+        ),
+        outputs=list(outputs or [_sample()]),
+    )
+
+
+def _generator(outputs):
+    generator = VLLMGenerator.__new__(VLLMGenerator)
+    generator._engine = _FakeEngine(outputs)
+    generator.policy_version = 7
+    generator.config = SimpleNamespace(
+        sampling=SamplingConfig(n=1, temperature=0.0, top_p=1.0, max_tokens=4),
+        debug=SimpleNamespace(seed=None),
+    )
+    return generator
+
+
+def _run_generate(generator, tokenized_prompts, **kwargs):
+    return asyncio.run(
+        VLLMGenerator.generate._method(
+            generator, tokenized_prompts, **kwargs
+        )  # noqa: SLF001
+    )
+
+
+def test_generate_passes_token_prompt_to_vllm():
+    generator = _generator([_request_output(prompt_token_ids=[1, 2, 3])])
+
+    _run_generate(generator, [[1, 2, 3]])
+
+    # add_request is invoked entirely with kwargs. The ``prompt`` kwarg
+    # carries the renderer's output: a typed EngineInput (``type="token"``)
+    # with the prompt token IDs and a stamped ``arrival_time`` — keeping us
+    # off vLLM's deprecated raw-prompt path.
+    (_args, kwargs) = generator._engine.add_requests[0]
+    assert kwargs["request_id"] == "0"
+    assert kwargs["prompt"]["type"] == "token"
+    assert kwargs["prompt"]["prompt_token_ids"] == [1, 2, 3]
+    assert "arrival_time" in kwargs["prompt"]
+
+
+def test_generate_carries_finish_reason_and_metrics():
+    output = _request_output(
+        outputs=[
+            _sample(index=0, token_ids=(10, 11), finish_reason="length"),
+            _sample(index=1, token_ids=(12,), finish_reason="stop"),
+        ]
+    )
+    generator = _generator([output])
+
+    completions, generation_metrics = _run_generate(generator, [[1, 2]])
+
+    assert [c.finish_reason for c in completions] == ["length", "stop"]
+    assert not hasattr(completions[0], "metrics")
+    aggregate = m.MetricsProcessor._aggregate_metrics(generation_metrics)
+    assert aggregate["generator/output_tokens/sum"] == 3
+    assert aggregate["generator/num_cached_tokens/mean"] == 0
+    assert aggregate["generator/num_cached_tokens/max"] == 0
+    assert aggregate["generator/time_to_first_token_ms/mean"] == 12
+    assert aggregate["generator/time_to_first_token_ms/max"] == 12
+    assert aggregate["generator/queue_time_ms/mean"] == pytest.approx(5)
+    assert aggregate["generator/queue_time_ms/max"] == pytest.approx(5)
+    assert aggregate["generator/prefill_time_ms/mean"] == pytest.approx(12)
+    assert aggregate["generator/prefill_time_ms/max"] == pytest.approx(12)
+    assert aggregate["generator/decode_time_ms/mean"] == pytest.approx(30)
+    assert aggregate["generator/decode_time_ms/max"] == pytest.approx(30)
+    assert aggregate["generator/inter_token_latency_ms/mean"] == pytest.approx(10)
+    assert aggregate["generator/inter_token_latency_ms/max"] == pytest.approx(10)
+    assert "generator/e2e_latency_ms/mean" not in aggregate
+
+
+def test_generate_metrics_prefix_override_namespaces_keys():
+    output = _request_output(
+        outputs=[_sample(index=0, token_ids=(10, 11))],
+    )
+    generator = _generator([output])
+
+    _, generation_metrics = _run_generate(
+        generator, [[1, 2]], metrics_prefix="validation/generator"
+    )
+
+    metric_keys = {metric.key for metric in generation_metrics}
+    assert "validation/generator/output_tokens" in metric_keys
+    assert "validation/generator/queue_time_ms" in metric_keys
+    assert all(key.startswith("validation/generator/") for key in metric_keys)
+
+
+def test_decode_metrics_are_absent_for_single_generated_token():
+    generator = _generator(
+        [
+            _request_output(
+                outputs=[_sample(index=0, token_ids=(10,))],
+                num_generation_tokens=1,
+            )
+        ]
+    )
+
+    _, generation_metrics = _run_generate(generator, [[1, 2]])
+
+    metric_keys = {metric.key for metric in generation_metrics}
+    assert "generator/prefill_time_ms" in metric_keys
+    assert "generator/decode_time_ms" not in metric_keys
+    assert "generator/inter_token_latency_ms" not in metric_keys

--- a/torchtitan/experiments/rl/tests/test_grpo_metrics.py
+++ b/torchtitan/experiments/rl/tests/test_grpo_metrics.py
@@ -20,13 +20,13 @@ import pytest
 
 import torch
 
-from torchtitan.experiments.rl.grpo import _build_reward_metrics, GRPOLoss, RLTrainer
+from torchtitan.experiments.rl.grpo import _prepare_reward_metrics, GRPOLoss, RLTrainer
 from torchtitan.experiments.rl.observability import metrics as m
 from torchtitan.experiments.rl.types import Completion, Step, Trajectory
 
 
 # ---------------------------------------------------------------------------
-# _build_reward_metrics
+# _prepare_reward_metrics
 # ---------------------------------------------------------------------------
 
 
@@ -39,13 +39,14 @@ def _reward_trajectory(rewards: dict[str, float], sample_idx: int = 0) -> Trajec
     fake_completion = Completion(
         policy_version=0,
         prompt_idx=sample_idx,
-        prompt_token_ids=[],
         text="",
         token_ids=[],
         token_logprobs=[],
     )
     return Trajectory(
-        sample_idx=sample_idx, transitions=[(fake_completion, _step(rewards))]
+        sample_idx=sample_idx,
+        prompt_token_ids=[],
+        transitions=[(fake_completion, _step(rewards))],
     )
 
 
@@ -55,7 +56,7 @@ class TestBuildRewardMetrics:
             _reward_trajectory({"correctness": 1.0, "format": 0.5}, sample_idx=0),
             _reward_trajectory({"correctness": 0.0, "format": 1.0}, sample_idx=1),
         ]
-        metrics = _build_reward_metrics("reward/component", trajectories)
+        metrics = _prepare_reward_metrics("reward/component", trajectories)
         keys = {entry.key for entry in metrics}
         assert keys == {
             "reward/component/correctness",
@@ -71,17 +72,17 @@ class TestBuildRewardMetrics:
             _reward_trajectory({"correctness": 1.0}, sample_idx=0),
             _reward_trajectory({"format": 0.5}, sample_idx=1),
         ]
-        metrics = _build_reward_metrics("reward/component", trajectories)
+        metrics = _prepare_reward_metrics("reward/component", trajectories)
         agg = m.MetricsProcessor._aggregate_metrics(metrics)
         assert agg["reward/component/correctness/mean"] == 1.0
         assert agg["reward/component/format/mean"] == 0.5
 
     def test_empty_input(self) -> None:
-        assert _build_reward_metrics("reward/component", []) == []
+        assert _prepare_reward_metrics("reward/component", []) == []
 
     def test_prefix_controls_namespace(self) -> None:
         trajectories = [_reward_trajectory({"correctness": 1.0}, sample_idx=0)]
-        metrics = _build_reward_metrics("validation/reward/component", trajectories)
+        metrics = _prepare_reward_metrics("validation/reward/component", trajectories)
         assert metrics[0].key == "validation/reward/component/correctness"
 
 
@@ -92,7 +93,6 @@ class TestBuildRewardMetrics:
 
 def _completion(
     prompt_idx: int,
-    prompt_len: int,
     response_len: int,
     finish_reason: str | None = "stop",
     *,
@@ -101,7 +101,6 @@ def _completion(
     return Completion(
         policy_version=policy_version,
         prompt_idx=prompt_idx,
-        prompt_token_ids=list(range(prompt_len)),
         text="x" * response_len,
         token_ids=list(range(response_len)),
         token_logprobs=[0.0] * response_len,
@@ -112,8 +111,8 @@ def _completion(
 class _FakeEnv:
     """Minimal env stub: step(text) returns a preset reward dict."""
 
-    def __init__(self, rewards: dict[str, float]):
-        self.prompt = "p"
+    def __init__(self, rewards: dict[str, float], prompt: str = "p"):
+        self.prompt = prompt
         self._rewards = rewards
 
     def step(self, text: str) -> Step:
@@ -126,9 +125,9 @@ def _build_collect_rollouts_inputs(self_obj):
     """
 
     completions = [
-        _completion(prompt_idx=0, prompt_len=4, response_len=10),
-        _completion(prompt_idx=0, prompt_len=4, response_len=20),
-        _completion(prompt_idx=1, prompt_len=6, response_len=15),
+        _completion(prompt_idx=0, response_len=10),
+        _completion(prompt_idx=0, response_len=20),
+        _completion(prompt_idx=1, response_len=15),
     ]
 
     class _RewardEnvBuilder:
@@ -138,14 +137,25 @@ def _build_collect_rollouts_inputs(self_obj):
 
     self_obj.config = MagicMock()
     self_obj.config.env = _RewardEnvBuilder
+    self_obj.tokenizer = MagicMock()
+    self_obj.tokenizer.encode.side_effect = lambda prompt, **_: [ord(prompt)]
     self_obj.generator = MagicMock()
     # `_get_rank_0_value` is the layer that strips Monarch's ValueMesh,
     # so just make it return whatever it's handed.
-    self_obj._get_rank_0_value = lambda value, has_gpus=True: completions
+    self_obj._get_rank_0_value = lambda value, has_gpus=True: (completions, [])
     return completions
 
 
 class TestCollectRollouts:
+    def test_passes_token_ids_to_generator(self) -> None:
+        """Controller tokenizes env prompts and hands the IDs (not strings)
+        to ``generator.generate.call``."""
+        controller = RLTrainer.__new__(RLTrainer)
+        _build_collect_rollouts_inputs(controller)
+        controller._collect_rollouts(num_groups=2, step=0)
+        # _FakeEnv.prompt == "p"; encode side_effect returns [ord(prompt)] = [112].
+        controller.generator.generate.call.assert_called_once_with([[112], [112]])
+
     def test_emits_expected_metric_keys(self) -> None:
         controller = RLTrainer.__new__(RLTrainer)
         completions = _build_collect_rollouts_inputs(controller)
@@ -170,17 +180,19 @@ class TestCollectRollouts:
         finish_reason == 'length' over completions."""
         controller = RLTrainer.__new__(RLTrainer)
         completions = [
-            _completion(0, 4, 10, finish_reason="length"),
-            _completion(0, 4, 10, finish_reason="stop"),
-            _completion(1, 4, 10, finish_reason="length"),
-            _completion(1, 4, 10, finish_reason="length"),
+            _completion(0, 10, finish_reason="length"),
+            _completion(0, 10, finish_reason="stop"),
+            _completion(1, 10, finish_reason="length"),
+            _completion(1, 10, finish_reason="length"),
         ]
 
         controller.config = MagicMock()
         controller.config.env = MagicMock()
         controller.config.env.build = lambda *, step, group_idx: _FakeEnv({"r": 1.0})
+        controller.tokenizer = MagicMock()
+        controller.tokenizer.encode.side_effect = lambda prompt, **_: [ord(prompt)]
         controller.generator = MagicMock()
-        controller._get_rank_0_value = lambda value, has_gpus=True: completions
+        controller._get_rank_0_value = lambda value, has_gpus=True: (completions, [])
 
         _, rollout_metrics = controller._collect_rollouts(num_groups=2, step=0)
         agg = m.MetricsProcessor._aggregate_metrics(rollout_metrics)
@@ -194,25 +206,37 @@ class TestCollectRollouts:
         controller = RLTrainer.__new__(RLTrainer)
 
         # Carefully chosen so per-side maxes don't align: the longest
-        # prompt has the shortest response, etc.
+        # prompt has the shortest response, etc. The tokenizer mock below
+        # produces token lists of length == len(prompt), so the env prompts
+        # control prompt-side lengths.
+        env_prompts = {0: "x" * 10, 1: "x" * 2, 2: "x" * 5}
         completions = [
-            _completion(prompt_idx=0, prompt_len=10, response_len=2),  # total 12
-            _completion(prompt_idx=1, prompt_len=2, response_len=10),  # total 12
-            _completion(prompt_idx=2, prompt_len=5, response_len=5),  # total 10
+            _completion(prompt_idx=0, response_len=2),  # total 10 + 2 = 12
+            _completion(prompt_idx=1, response_len=10),  # total 2 + 10 = 12
+            _completion(prompt_idx=2, response_len=5),  # total 5 + 5 = 10
         ]
         controller.config = MagicMock()
         controller.config.env = MagicMock()
-        controller.config.env.build = lambda *, step, group_idx: _FakeEnv({"r": 1.0})
+        controller.config.env.build = lambda *, step, group_idx: _FakeEnv(
+            {"r": 1.0}, prompt=env_prompts[group_idx]
+        )
+        controller.tokenizer = MagicMock()
+        controller.tokenizer.encode.side_effect = lambda prompt, **_: list(
+            prompt.encode()
+        )
         controller.generator = MagicMock()
-        controller._get_rank_0_value = lambda value, has_gpus=True: completions
+        controller._get_rank_0_value = lambda value, has_gpus=True: (completions, [])
 
-        _, rollout_metrics = controller._collect_rollouts(num_groups=3, step=0)
+        trajectories, rollout_metrics = controller._collect_rollouts(
+            num_groups=3, step=0
+        )
         agg = m.MetricsProcessor._aggregate_metrics(rollout_metrics)
-        per_side_max_sum = max(c.prompt_token_ids[-1] + 1 for c in completions) + max(
-            c.token_ids[-1] + 1 for c in completions
+        per_side_max_sum = max(len(t.prompt_token_ids) for t in trajectories) + max(
+            len(c.token_ids) for c in completions
         )  # = 10 + 10 = 20
         actual_max = max(
-            len(c.prompt_token_ids) + len(c.token_ids) for c in completions
+            len(t.prompt_token_ids) + len(c.token_ids)
+            for t, c in zip(trajectories, completions, strict=True)
         )  # = 12
         assert agg["rollout/total_length/max"] == actual_max
         assert agg["rollout/total_length/max"] < per_side_max_sum
@@ -226,11 +250,10 @@ def _trajectory(
     *,
     policy_version: int = 0,
 ) -> Trajectory:
-    completion = _completion(
-        sample_idx, prompt_len, response_len, policy_version=policy_version
-    )
+    completion = _completion(sample_idx, response_len, policy_version=policy_version)
     return Trajectory(
         sample_idx=sample_idx,
+        prompt_token_ids=list(range(prompt_len)),
         transitions=[(completion, _step({"r": reward}))],
     )
 
@@ -353,11 +376,11 @@ class TestRLTrainerConfigWiring:
         assert "X" not in fresh.metrics.console_log_keys_train
         assert "Y" not in fresh.metrics.console_log_keys_validation
 
-    def test_metrics_default_wandb_disabled(self) -> None:
+    def test_metrics_default_wandb_enabled(self) -> None:
         from torchtitan.experiments.rl.config_registry import rl_grpo_qwen3_0_6b
 
         cfg = rl_grpo_qwen3_0_6b()
-        assert cfg.metrics.enable_wandb is False
+        assert cfg.metrics.enable_wandb is True
         assert cfg.metrics.enable_tensorboard is False
 
 

--- a/torchtitan/experiments/rl/types.py
+++ b/torchtitan/experiments/rl/types.py
@@ -42,7 +42,6 @@ class Completion:
 
     policy_version: int
     prompt_idx: int
-    prompt_token_ids: list[int]
     text: str
     token_ids: list[int]
     token_logprobs: list[float]
@@ -55,11 +54,12 @@ class Trajectory:
     """One rollout: a sequence of ``(Completion, Step)`` transitions.
 
     Single-turn tasks produce trajectories with one transition. The
-    Completion carries the generator's token-level metadata; the Step
-    carries the env's reward and done flag.
+    Completion carries the generator's response-side metadata; the Step
+    carries the env's reward and done flag;
     """
 
     sample_idx: int
+    prompt_token_ids: list[int]
     transitions: list[tuple[Completion, Step]]
 
     @property


### PR DESCRIPTION
This PR does three things:
- Changes generator to receive tokens instead of text (token-in/token-out) by encoding prompts in the controller and passing `tokenized_prompts` into the generator. This is the standard in RL training and avoids retokenization of texts, which leads to all sorts of issues.
- Adds generation_metrics to the generation output.
- Sets wandb=True in our configs


### test
<img width="1663" height="539" alt="image" src="https://github.com/user-attachments/assets/12d8a41b-320d-4451-934c-58339da80efd" />

[actor=<root>] ============================================================
[actor=<root>] Validation summary (pre / post):
[actor=<root>]   validation/reward/_max:  +1.300  /  +1.300
[actor=<root>]   validation/reward/_mean:  +0.385  /  +0.700
[actor=<root>]   validation/reward/_min:  +0.000  /  +0.300
[actor=<root>]   validation/reward/_std:  +0.541  /  +0.490
[actor=<root>]   validation/reward/_sum:  +7.700  /  +14.000
[actor=<root>]   validation/reward/component/correctness/mean:  +0.250  /  +0.400
[actor=<root>]   validation/reward/component/format/mean:  +0.135  /  +0.300
[actor=<root>] ============================================================

<img width="1646" height="302" alt="image" src="https://github.com/user-attachments/assets/b6f58769-0110-478e-8ed4-f0644cb8a823" />
