### PR TITLE
[graph_trainer] Re-enable FlexAttention tests after upstream fix

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -197,11 +197,6 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             skip_rocm_test=True,
         ),
         # async_tp test lives in graph_trainer_h100 suite (needs NVLink).
-        # TODO: Disabled due to upstream PyTorch nightly regression in
-        # dev20260508. TransformGetItemToIndex mode has no dispatch for
-        # torch.ops.higher_order.flex_attention, causing TypeError in
-        # gather_node_runtime_estimations during overlap scheduling.
-        # Re-enable once the upstream fix lands.
         OverrideDefinitions(
             [
                 [
@@ -215,7 +210,6 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace llama3 FSDP+TP+FlexAttn",
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
-            disabled=True,
         ),
         # TODO: Disabled due to upstream PyTorch cuDNN regression in nightly
         # dev20260506. _scaled_dot_product_cudnn_attention fails with
@@ -325,11 +319,6 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_deepseek_v3_fsdp_tp_cp_ep",
             ngpu=8,
         ),
-        # TODO: Disabled due to upstream PyTorch nightly regression in
-        # dev20260508. TransformGetItemToIndex mode has no dispatch for
-        # torch.ops.higher_order.flex_attention, causing TypeError in
-        # gather_node_runtime_estimations during overlap scheduling.
-        # Re-enable once the upstream fix lands.
         OverrideDefinitions(
             [
                 [
@@ -344,7 +333,6 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
             ngpu=8,
-            disabled=True,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -431,11 +431,6 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
         self._assert_runs_match(run_a, run_b, "numerics_changing_optim run-to-run: ")
 
 
-# TODO: All FlexAttn bitwise deterministic tests disabled due to upstream
-# PyTorch nightly regression in dev20260508. TransformGetItemToIndex mode
-# has no dispatch for torch.ops.higher_order.flex_attention.
-# Re-enable once the upstream fix lands.
-@unittest.skip("upstream TransformGetItemToIndex flex_attention regression")
 class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for Llama3 with FlexAttention (debugmodel_flex_attn).
 
@@ -498,7 +493,6 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         self._assert_runs_match(run_a, run_b, "numerics_changing_optim run-to-run: ")
 
 
-@unittest.skip("upstream TransformGetItemToIndex flex_attention regression")
 class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for DSv3 with FlexAttention (debugmodel_flex_attn).
 
@@ -635,7 +629,6 @@ class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
         self._assert_runs_match(run_a, run_b, "numerics_changing_optim run-to-run: ")
 
 
-@unittest.skip("upstream TransformGetItemToIndex flex_attention regression")
 class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     """Bitwise determinism tests for Qwen3 MoE with FlexAttention.
 

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -470,6 +470,7 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
+    @unittest.skip("FlexAttention graphs contain unpicklable code objects")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
@@ -538,11 +539,7 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
-    # TODO: FlexAttention compilation exceeds resource limits on pre-Hopper GPUs.
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0),
-        "flex_attention compilation exceeds resource limits on pre-Hopper GPUs",
-    )
+    @unittest.skip("FlexAttention graphs contain unpicklable code objects")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
@@ -668,6 +665,7 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)
         self._assert_runs_match(run_eager, run_traced, "eager vs aot_fx_trace: ")
 
+    @unittest.skip("FlexAttention graphs contain unpicklable code objects")
     def test_precompile_vs_trace(self):
         """Precompiled aot_fx_trace (save/load roundtrip) matches direct trace."""
         run_traced = self._run_steps(copy.deepcopy(self.model), GraphTrainer)


### PR DESCRIPTION
## Summary
- Re-enable FlexAttention tests that were disabled due to the upstream `TransformGetItemToIndex` regression (no dispatch for `torch.ops.higher_order.flex_attention`)
- The fix landed upstream in pytorch/pytorch#182992 (merged 2026-05-12), which is included in our current PyTorch nightly
- Re-enables 3 bitwise deterministic test classes (Llama3, DSv3, Qwen3 FlexAttn) and 2 integration tests

## Test plan
- [ ] CI passes for `test_bitwise_deterministic.py` FlexAttn tests
- [ ] CI passes for `integration_tests.py` FlexAttn tests (`aot_fx_trace_llama3_fsdp_tp_flexattn`, `aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn`)