### PR TITLE
RoPE refactor: Using model's max_sequence_length as the upper bound of Training.sequence_length

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_example.py
+++ b/scripts/checkpoint_conversion/numerical_tests_example.py
@@ -67,7 +67,7 @@ def forward_tt(model_name, config_name, checkpoint_path, test_set):
     )
 
     model_config = config.model_spec.model  # pyrefly: ignore [missing-attribute]
-    model_config.update_from_config(trainer_config=config)
+    model_config.update_from_config(config=config)
 
     model = model_config.build()
 

--- a/scripts/generate/test_generate.py
+++ b/scripts/generate/test_generate.py
@@ -111,7 +111,7 @@ def test_generate(
     )
 
     model_config = config.model_spec.model  # pyrefly: ignore [missing-attribute]
-    model_config.update_from_config(trainer_config=config)
+    model_config.update_from_config(config=config)
 
     init_device = "meta" if world_size > 1 else device
     with torch.device(init_device):

--- a/tests/unit_tests/test_module.py
+++ b/tests/unit_tests/test_module.py
@@ -278,7 +278,7 @@ class TestVerifyModuleProtocol(unittest.TestCase):
         class GoodModel(BaseModel):
             @dataclass(kw_only=True, slots=True)
             class Config(BaseModel.Config):
-                def update_from_config(self, *, trainer_config, **kwargs):
+                def update_from_config(self, *, config, **kwargs):
                     pass
 
                 def get_nparams_and_flops(self, model, seq_len):
@@ -299,7 +299,7 @@ class TestVerifyModuleProtocol(unittest.TestCase):
         class BadModel(BaseModel):
             @dataclass(kw_only=True, slots=True)
             class Config(BaseModel.Config):
-                def update_from_config(self, *, trainer_config, **kwargs):
+                def update_from_config(self, *, config, **kwargs):
                     pass
 
                 def get_nparams_and_flops(self, model, seq_len):
@@ -320,7 +320,7 @@ class TestVerifyModuleProtocol(unittest.TestCase):
         class ThirdPartyModel(BaseModel):
             @dataclass(kw_only=True, slots=True)
             class Config(BaseModel.Config):
-                def update_from_config(self, *, trainer_config, **kwargs):
+                def update_from_config(self, *, config, **kwargs):
                     pass
 
                 def get_nparams_and_flops(self, model, seq_len):

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -4,11 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import unittest
 
 import torch
 
-from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
+from torchtitan.models.common.rope import (
+    _maybe_check_max_pos,
+    apply_rotary_emb_complex,
+    apply_rotary_emb_cos_sin,
+    RoPE,
+)
 
 
 class TestApplyRotaryEmbCosSin(unittest.TestCase):
@@ -62,6 +68,129 @@ class TestApplyRotaryEmbCosSin(unittest.TestCase):
 
         self.assertEqual((xq_out - xq_ref).abs().max().item(), 0.0)
         self.assertEqual((xk_out - xk_ref).abs().max().item(), 0.0)
+
+
+class TestMaybeCheckMaxPos(unittest.TestCase):
+    """Tests for the _maybe_check_max_pos bounds check."""
+
+    def test_positions_within_bounds(self):
+        positions = torch.tensor([[0, 1, 2, 3]])
+        _maybe_check_max_pos(positions, max_valid_pos=3)
+
+    def test_positions_at_boundary(self):
+        positions = torch.tensor([[0, 5, 10, 15]])
+        _maybe_check_max_pos(positions, max_valid_pos=15)
+
+    def test_positions_out_of_bounds_raises(self):
+        positions = torch.tensor([[0, 1, 2, 16]])
+        with self.assertRaises(RuntimeError):
+            _maybe_check_max_pos(positions, max_valid_pos=15)
+            torch.cuda.synchronize() if torch.cuda.is_available() else None
+
+
+class TestRoPEPositionBoundsComplex(unittest.TestCase):
+    """RoPE complex-format apply must reject out-of-range positions."""
+
+    def setUp(self):
+        torch.manual_seed(42)
+        self.head_dim = 64
+        self.max_seq_len = 32
+        rope_cfg = RoPE.Config(
+            dim=self.head_dim, max_seq_len=self.max_seq_len, backend="complex"
+        )
+        rope = rope_cfg.build()
+        self.freqs_cis = rope.cache
+
+    def test_valid_positions(self):
+        bsz, seqlen = 2, 8
+        xq = torch.randn(bsz, seqlen, 4, self.head_dim)
+        xk = torch.randn(bsz, seqlen, 4, self.head_dim)
+        positions = torch.arange(seqlen).unsqueeze(0).expand(bsz, -1)
+        apply_rotary_emb_complex(xq, xk, self.freqs_cis, positions)
+
+    def test_out_of_range_positions_raises(self):
+        bsz, seqlen = 1, 4
+        xq = torch.randn(bsz, seqlen, 4, self.head_dim)
+        xk = torch.randn(bsz, seqlen, 4, self.head_dim)
+        positions = torch.tensor([[0, 1, self.max_seq_len, self.max_seq_len + 1]])
+        with self.assertRaises(RuntimeError):
+            apply_rotary_emb_complex(xq, xk, self.freqs_cis, positions)
+
+
+class TestRoPEPositionBoundsCosSin(unittest.TestCase):
+    """RoPE cos/sin-format apply must reject out-of-range positions."""
+
+    def setUp(self):
+        torch.manual_seed(42)
+        self.head_dim = 64
+        self.max_seq_len = 32
+        rope_cfg = RoPE.Config(
+            dim=self.head_dim, max_seq_len=self.max_seq_len, backend="cos_sin"
+        )
+        rope = rope_cfg.build()
+        self.rope_cache = rope.cache
+
+    def test_valid_positions(self):
+        bsz, seqlen = 2, 8
+        xq = torch.randn(bsz, seqlen, 4, self.head_dim)
+        xk = torch.randn(bsz, seqlen, 4, self.head_dim)
+        positions = torch.arange(seqlen).unsqueeze(0).expand(bsz, -1)
+        apply_rotary_emb_cos_sin(xq, xk, self.rope_cache, positions)
+
+    def test_out_of_range_positions_raises(self):
+        bsz, seqlen = 1, 4
+        xq = torch.randn(bsz, seqlen, 4, self.head_dim)
+        xk = torch.randn(bsz, seqlen, 4, self.head_dim)
+        positions = torch.tensor([[0, 1, self.max_seq_len, self.max_seq_len + 1]])
+        with self.assertRaises(RuntimeError):
+            apply_rotary_emb_cos_sin(xq, xk, self.rope_cache, positions)
+
+
+class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
+    """update_from_config must reject seq_len > rope.max_seq_len."""
+
+    def _make_trainer_config(self, seq_len):
+        from types import SimpleNamespace
+
+        from torchtitan.config import ParallelismConfig, TrainingConfig
+
+        return SimpleNamespace(
+            training=dataclasses.replace(TrainingConfig(), seq_len=seq_len),
+            parallelism=ParallelismConfig(),
+        )
+
+    def _make_config(self):
+        """Build a minimal Llama3 debug config."""
+        from torchtitan.models.llama3 import llama3_configs
+
+        return llama3_configs["debugmodel"]("sdpa")
+
+    def test_rejects_oversized_seq_len(self):
+        cfg = self._make_config()
+        rope_max = cfg.rope.max_seq_len
+        with self.assertRaises(ValueError):
+            cfg.update_from_config(
+                trainer_config=self._make_trainer_config(rope_max + 1)
+            )
+
+    def test_accepts_valid_seq_len(self):
+        cfg = self._make_config()
+        rope_max = cfg.rope.max_seq_len
+        cfg.update_from_config(trainer_config=self._make_trainer_config(rope_max))
+        self.assertEqual(cfg.rope.max_seq_len, rope_max)
+
+    def test_training_none_preserves_intrinsic_max(self):
+        """When training is None, rope.max_seq_len stays at the model default."""
+        from types import SimpleNamespace
+
+        from torchtitan.config import ParallelismConfig
+
+        cfg = self._make_config()
+        original_max = cfg.rope.max_seq_len
+        cfg.update_from_config(
+            trainer_config=SimpleNamespace(parallelism=ParallelismConfig())
+        )
+        self.assertEqual(cfg.rope.max_seq_len, original_max)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -152,11 +152,12 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
     def _make_trainer_config(self, seq_len):
         from types import SimpleNamespace
 
-        from torchtitan.config import ParallelismConfig, TrainingConfig
+        from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
 
         return SimpleNamespace(
             training=dataclasses.replace(TrainingConfig(), seq_len=seq_len),
             parallelism=ParallelismConfig(),
+            debug=DebugConfig(),
         )
 
     def _make_config(self):
@@ -179,17 +180,15 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
         cfg.update_from_config(trainer_config=self._make_trainer_config(rope_max))
         self.assertEqual(cfg.rope.max_seq_len, rope_max)
 
-    def test_training_none_preserves_intrinsic_max(self):
-        """When training is None, rope.max_seq_len stays at the model default."""
-        from types import SimpleNamespace
+    def test_intrinsic_max_preserved_when_seq_len_equals_max(self):
+        """Passing seq_len=rope.max_seq_len preserves the intrinsic max.
 
-        from torchtitan.config import ParallelismConfig
-
+        This is the pattern used by the vLLM wrapper to avoid shrinking the
+        RoPE cache below the model's intrinsic maximum.
+        """
         cfg = self._make_config()
         original_max = cfg.rope.max_seq_len
-        cfg.update_from_config(
-            trainer_config=SimpleNamespace(parallelism=ParallelismConfig())
-        )
+        cfg.update_from_config(trainer_config=self._make_trainer_config(original_max))
         self.assertEqual(cfg.rope.max_seq_len, original_max)
 
 

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -180,15 +180,21 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
         cfg.update_from_config(trainer_config=self._make_trainer_config(rope_max))
         self.assertEqual(cfg.rope.max_seq_len, rope_max)
 
-    def test_intrinsic_max_preserved_when_seq_len_equals_max(self):
-        """Passing seq_len=rope.max_seq_len preserves the intrinsic max.
+    def test_training_omitted_preserves_intrinsic_max(self):
+        """When training is omitted, rope.max_seq_len stays at the model default.
 
-        This is the pattern used by the vLLM wrapper to avoid shrinking the
-        RoPE cache below the model's intrinsic maximum.
+        This is the pattern used by the vLLM wrapper: it only passes
+        parallelism, so the model's intrinsic rope.max_seq_len is preserved.
         """
+        from types import SimpleNamespace
+
+        from torchtitan.config import ParallelismConfig
+
         cfg = self._make_config()
         original_max = cfg.rope.max_seq_len
-        cfg.update_from_config(trainer_config=self._make_trainer_config(original_max))
+        cfg.update_from_config(
+            trainer_config=SimpleNamespace(parallelism=ParallelismConfig())
+        )
         self.assertEqual(cfg.rope.max_seq_len, original_max)
 
 

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -150,11 +150,10 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
     """update_from_config must reject seq_len > rope.max_seq_len."""
 
     def _make_trainer_config(self, seq_len):
-        from types import SimpleNamespace
-
         from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
+        from torchtitan.trainer import Trainer
 
-        return SimpleNamespace(
+        return Trainer.Config(
             training=dataclasses.replace(TrainingConfig(), seq_len=seq_len),
             parallelism=ParallelismConfig(),
             debug=DebugConfig(),
@@ -170,14 +169,12 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
         cfg = self._make_config()
         rope_max = cfg.rope.max_seq_len
         with self.assertRaises(ValueError):
-            cfg.update_from_config(
-                trainer_config=self._make_trainer_config(rope_max + 1)
-            )
+            cfg.update_from_config(config=self._make_trainer_config(rope_max + 1))
 
     def test_accepts_valid_seq_len(self):
         cfg = self._make_config()
         rope_max = cfg.rope.max_seq_len
-        cfg.update_from_config(trainer_config=self._make_trainer_config(rope_max))
+        cfg.update_from_config(config=self._make_trainer_config(rope_max))
         self.assertEqual(cfg.rope.max_seq_len, rope_max)
 
     def test_vllm_max_model_len_as_seq_len(self):
@@ -188,7 +185,7 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
         """
         cfg = self._make_config()
         original_max = cfg.rope.max_seq_len
-        cfg.update_from_config(trainer_config=self._make_trainer_config(original_max))
+        cfg.update_from_config(config=self._make_trainer_config(original_max))
         self.assertEqual(cfg.rope.max_seq_len, original_max)
 
 

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -180,21 +180,15 @@ class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):
         cfg.update_from_config(trainer_config=self._make_trainer_config(rope_max))
         self.assertEqual(cfg.rope.max_seq_len, rope_max)
 
-    def test_training_omitted_preserves_intrinsic_max(self):
-        """When training is omitted, rope.max_seq_len stays at the model default.
+    def test_vllm_max_model_len_as_seq_len(self):
+        """vLLM wrapper translates max_model_len to TrainingConfig.seq_len.
 
-        This is the pattern used by the vLLM wrapper: it only passes
-        parallelism, so the model's intrinsic rope.max_seq_len is preserved.
+        When seq_len equals rope.max_seq_len, the RoPE cache stays at
+        the model's intrinsic maximum.
         """
-        from types import SimpleNamespace
-
-        from torchtitan.config import ParallelismConfig
-
         cfg = self._make_config()
         original_max = cfg.rope.max_seq_len
-        cfg.update_from_config(
-            trainer_config=SimpleNamespace(parallelism=ParallelismConfig())
-        )
+        cfg.update_from_config(trainer_config=self._make_trainer_config(original_max))
         self.assertEqual(cfg.rope.max_seq_len, original_max)
 
 

--- a/tests/unit_tests/test_tp_kv_heads_validation.py
+++ b/tests/unit_tests/test_tp_kv_heads_validation.py
@@ -24,6 +24,7 @@ try:
         sys.modules["triton"] = MagicMock()
         sys.modules["triton.language"] = MagicMock()
 
+    from torchtitan.config import ParallelismConfig
     from torchtitan.models.common import (
         compute_ffn_hidden_dim,
         Embedding,
@@ -43,15 +44,11 @@ _VOCAB_SIZE = 2048
 
 
 def _make_trainer_config(tp: int, seq_len: int = 2048):
-    """Minimal trainer_config stub with just the fields update_from_config reads."""
+    """Minimal config stub with just the fields update_from_config reads."""
     training = SimpleNamespace(seq_len=seq_len)
-    parallelism = SimpleNamespace(
+    parallelism = ParallelismConfig(
         tensor_parallel_degree=tp,
-        context_parallel_degree=1,
-        pipeline_parallel_degree=1,
         disable_loss_parallel=True,
-        enable_sequence_parallel=False,
-        full_dtensor=False,
     )
     return SimpleNamespace(training=training, parallelism=parallelism)
 
@@ -120,7 +117,7 @@ class TestTPKVHeadsValidation(unittest.TestCase):
         """n_kv_heads=2, tp=4 → fractional KV heads per rank → ValueError."""
         cfg = _make_llama3_config(n_heads=8, n_kv_heads=2)
         with self.assertRaises(ValueError):
-            cfg.update_from_config(trainer_config=_make_trainer_config(tp=4))
+            cfg.update_from_config(config=_make_trainer_config(tp=4))
 
     # ------------------------------------------------------------------
     # n_heads not divisible by TP  →  should raise
@@ -130,7 +127,7 @@ class TestTPKVHeadsValidation(unittest.TestCase):
         """n_heads=6, tp=4 → fractional Q heads per rank → ValueError."""
         cfg = _make_llama3_config(n_heads=6, n_kv_heads=6)
         with self.assertRaises(ValueError):
-            cfg.update_from_config(trainer_config=_make_trainer_config(tp=4))
+            cfg.update_from_config(config=_make_trainer_config(tp=4))
 
     # ------------------------------------------------------------------
     # Valid configs  →  should not raise
@@ -139,17 +136,17 @@ class TestTPKVHeadsValidation(unittest.TestCase):
     def test_llama3_valid_gqa_does_not_raise(self):
         """n_kv_heads=8, n_heads=16, tp=4 → both divisible → no error."""
         cfg = _make_llama3_config(n_heads=16, n_kv_heads=8)
-        cfg.update_from_config(trainer_config=_make_trainer_config(tp=4))
+        cfg.update_from_config(config=_make_trainer_config(tp=4))
 
     def test_llama3_mha_none_kv_heads_does_not_raise(self):
         """n_kv_heads=None (MHA, falls back to n_heads=16), tp=4 → no error."""
         cfg = _make_llama3_config(n_heads=16, n_kv_heads=None)
-        cfg.update_from_config(trainer_config=_make_trainer_config(tp=4))
+        cfg.update_from_config(config=_make_trainer_config(tp=4))
 
     def test_llama3_tp1_skips_check(self):
         """tp=1 → check skipped even with indivisible n_kv_heads."""
         cfg = _make_llama3_config(n_heads=8, n_kv_heads=3)
-        cfg.update_from_config(trainer_config=_make_trainer_config(tp=1))
+        cfg.update_from_config(config=_make_trainer_config(tp=1))
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -22,7 +22,7 @@ class FakeModel(BaseModel):
     class Config(BaseModel.Config):
         hidden: int = 8
 
-        def update_from_config(self, *, trainer_config, **kwargs):
+        def update_from_config(self, *, config, **kwargs):
             pass
 
         def get_nparams_and_flops(self, model, seq_len):

--- a/tests/unit_tests/test_weight_tying.py
+++ b/tests/unit_tests/test_weight_tying.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from types import SimpleNamespace
 
 import torch.nn as nn
 
+from torchtitan.config import ParallelismConfig
 from torchtitan.models.common.param_init import skip_param_init
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.model import Llama3Model
@@ -76,33 +78,25 @@ class TestLlama3WeightTying(unittest.TestCase):
 
     def test_pp_guard_raises_when_weight_tying_and_pp_enabled(self):
         """update_from_config must raise NotImplementedError when PP > 1 and weight tying is on."""
-        from unittest.mock import MagicMock
-
         config = _make_config(enable_weight_tying=True)
 
-        trainer_config = MagicMock()
-        trainer_config.training.seq_len = 512
-        trainer_config.parallelism.pipeline_parallel_degree = 2
-        trainer_config.parallelism.context_parallel_degree = 1
-        trainer_config.parallelism.tensor_parallel_degree = 1
+        runtime_config = SimpleNamespace(
+            parallelism=ParallelismConfig(pipeline_parallel_degree=2)
+        )
 
         with self.assertRaises(NotImplementedError):
-            config.update_from_config(trainer_config=trainer_config)
+            config.update_from_config(config=runtime_config)
 
     def test_pp_guard_does_not_raise_without_weight_tying(self):
         """update_from_config must NOT raise when PP > 1 and weight tying is off."""
-        from unittest.mock import MagicMock
-
         config = _make_config(enable_weight_tying=False)
 
-        trainer_config = MagicMock()
-        trainer_config.training.seq_len = 512
-        trainer_config.parallelism.pipeline_parallel_degree = 2
-        trainer_config.parallelism.context_parallel_degree = 1
-        trainer_config.parallelism.tensor_parallel_degree = 1
+        runtime_config = SimpleNamespace(
+            parallelism=ParallelismConfig(pipeline_parallel_degree=2)
+        )
 
         # Should not raise
-        config.update_from_config(trainer_config=trainer_config)
+        config.update_from_config(config=runtime_config)
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -254,6 +254,7 @@ def set_batch_invariance(enable: bool) -> None:
 
     # Register batch-invariant ATen overrides via upstream package
     # https://github.com/thinking-machines-lab/batch_invariant_ops
+    # pyrefly: ignore[missing-import]
     from batch_invariant_ops import enable_batch_invariant_mode as _upstream_enable
 
     _upstream_enable()
@@ -420,6 +421,7 @@ def init_distributed(
     device_id: torch.device | None = None
     if comm_config.mode == "torchcomms":
         try:
+            # pyrefly: ignore[missing-import]
             import torchcomms  # noqa: F401
         except ImportError as err:
             raise ImportError(

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -254,9 +254,7 @@ def set_batch_invariance(enable: bool) -> None:
 
     # Register batch-invariant ATen overrides via upstream package
     # https://github.com/thinking-machines-lab/batch_invariant_ops
-    from batch_invariant_ops import (  # pyrefly: ignore [missing-import]
-        enable_batch_invariant_mode as _upstream_enable,
-    )
+    from batch_invariant_ops import enable_batch_invariant_mode as _upstream_enable
 
     _upstream_enable()
 
@@ -422,7 +420,7 @@ def init_distributed(
     device_id: torch.device | None = None
     if comm_config.mode == "torchcomms":
         try:
-            import torchcomms  # noqa: F401  # pyrefly: ignore [missing-import]
+            import torchcomms  # noqa: F401
         except ImportError as err:
             raise ImportError(
                 "torchcomms package is required for --comm.mode=torchcomms."

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -138,7 +138,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.model_config = model_config = self.train_spec.model
         # set the model args from training configs
         model_config.update_from_config(
-            trainer_config=config,
+            config=config,
         )
 
         with (

--- a/torchtitan/experiments/ft/trainer.py
+++ b/torchtitan/experiments/ft/trainer.py
@@ -100,7 +100,7 @@ class FaultTolerantTrainer(Trainer):
         model_config = model_spec.model
         # set the model args from training job configs
         model_config.update_from_config(
-            trainer_config=config,
+            config=config,
         )
         self.model_config = model_config
 

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -113,7 +113,7 @@ def _common_setup(config):
     # TODO: Factor the model setup below with the training path so precompile
     # and training share a single implementation of build/parallelize/init.
     model_config = model_spec.model
-    model_config.update_from_config(trainer_config=config)
+    model_config.update_from_config(config=config)
 
     logger.info(f"Building {model_spec.name} {model_spec.flavor} on meta device")
     with (

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -321,6 +321,7 @@ class VLLMGenerator(Actor, Configurable):
             # Enables RequestOutput.metrics, so generator metrics can be returned
             disable_log_stats=False,
         )
+        engine_kwargs["max_model_len"] = model_spec.model.rope.max_seq_len
         engine_kwargs["max_num_seqs"] = self._max_num_seqs
         # FA2 requires block_size to be a multiple of 256
         if not has_cuda_capability(9, 0):

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -234,7 +234,7 @@ class PolicyTrainer(Actor, Configurable):
         # Fill sharding configs on the config BEFORE build via the
         # model-agnostic `update_from_config` hook (RL's trainer bypasses
         # `torchtitan.Trainer's` call, so we invoke it directly).
-        model_spec.model.update_from_config(trainer_config=config)
+        model_spec.model.update_from_config(config=config)
 
         with torch.device("meta"):
             with utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]):

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -22,7 +22,6 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
-    DebugConfig,
     ParallelismConfig,
     TrainingConfig,
 )
@@ -184,21 +183,13 @@ class VLLMModelWrapper(Module):
         # Fill sharding configs on the config BEFORE build so every sub-module
         # is constructed with its ShardingConfig attached (required by the
         # declarative model.parallelize() API).
-        # NOTE: We pass seq_len=rope.max_seq_len so the RoPE cache stays at
-        # the model's intrinsic maximum. Using the default TrainingConfig()
-        # would shrink it to 2048, which is wrong for inference — vLLM can
-        # generate positions up to max_model_len (derived from the model's
-        # max_position_embeddings).
-        # TODO: Refactor update_from_config to separate parallelism setup
-        # from training-specific config (rope resize, debug flags).
+        # Only ``parallelism`` is passed; ``training`` is omitted so the
+        # model's intrinsic ``rope.max_seq_len`` is preserved (the inference
+        # path must not shrink the RoPE cache to a training seq_len).
         from types import SimpleNamespace
 
         self.config.update_from_config(
-            trainer_config=SimpleNamespace(
-                training=TrainingConfig(seq_len=self.config.rope.max_seq_len),
-                parallelism=parallelism,
-                debug=DebugConfig(),
-            )
+            trainer_config=SimpleNamespace(parallelism=parallelism)
         )
 
         # Enforce that vLLM's max_model_len does not exceed the model's

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -22,6 +22,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
+    DebugConfig,
     ParallelismConfig,
     TrainingConfig,
 )
@@ -183,14 +184,21 @@ class VLLMModelWrapper(Module):
         # Fill sharding configs on the config BEFORE build so every sub-module
         # is constructed with its ShardingConfig attached (required by the
         # declarative model.parallelize() API).
-        # Only ``parallelism`` is needed here; ``training`` is intentionally
-        # omitted so the model's intrinsic ``rope.max_seq_len`` is preserved
-        # (the vLLM inference path must not shrink the RoPE cache to the
-        # trainer's default seq_len).
+        # NOTE: We pass seq_len=rope.max_seq_len so the RoPE cache stays at
+        # the model's intrinsic maximum. Using the default TrainingConfig()
+        # would shrink it to 2048, which is wrong for inference — vLLM can
+        # generate positions up to max_model_len (derived from the model's
+        # max_position_embeddings).
+        # TODO: Refactor update_from_config to separate parallelism setup
+        # from training-specific config (rope resize, debug flags).
         from types import SimpleNamespace
 
         self.config.update_from_config(
-            trainer_config=SimpleNamespace(parallelism=parallelism)
+            trainer_config=SimpleNamespace(
+                training=TrainingConfig(seq_len=self.config.rope.max_seq_len),
+                parallelism=parallelism,
+                debug=DebugConfig(),
+            )
         )
 
         # Enforce that vLLM's max_model_len does not exceed the model's

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -22,7 +22,6 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
-    DebugConfig,
     ParallelismConfig,
     TrainingConfig,
 )
@@ -184,23 +183,30 @@ class VLLMModelWrapper(Module):
         # Fill sharding configs on the config BEFORE build so every sub-module
         # is constructed with its ShardingConfig attached (required by the
         # declarative model.parallelize() API).
-        # TODO: Refactor update_from_config to accept ParallelismConfig
-        # directly instead of requiring a trainer_config wrapper.
+        # Only ``parallelism`` is needed here; ``training`` is intentionally
+        # omitted so the model's intrinsic ``rope.max_seq_len`` is preserved
+        # (the vLLM inference path must not shrink the RoPE cache to the
+        # trainer's default seq_len).
         from types import SimpleNamespace
 
         self.config.update_from_config(
-            trainer_config=SimpleNamespace(
-                training=TrainingConfig(),
-                parallelism=parallelism,
-                debug=DebugConfig(),
-            )
+            trainer_config=SimpleNamespace(parallelism=parallelism)
         )
+
+        # Enforce that vLLM's max_model_len does not exceed the model's
+        # intrinsic max_seq_len -- positions beyond this are invalid.
+        max_model_len = vllm_config.model_config.max_model_len
+        rope_max_seq_len = self.config.rope.max_seq_len
+        if max_model_len > rope_max_seq_len:
+            raise ValueError(
+                f"vLLM max_model_len ({max_model_len}) exceeds the model's "
+                f"maximum supported sequence length ({rope_max_seq_len}). "
+                f"Set max_model_len <= {rope_max_seq_len} in EngineArgs or "
+                f"use a model with a larger rope.max_seq_len."
+            )
 
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()
-
-        # RoPE config from model for cache extension
-        self.rope_config = self.config.rope
 
         # With TP, collectives may return AsyncCollectiveTensor (overlap
         # path) or plain Tensor (sync path) depending on timing.  Dynamo
@@ -222,62 +228,9 @@ class VLLMModelWrapper(Module):
             skip_dp=True,
         )
 
-        # Pre-extend RoPE cache to cover vLLM's max model length (profiling
-        # may use up to 2x max_seq_len, so use max_model_len which already
-        # accounts for this). This avoids data-dependent control flow in
-        # forward() which is incompatible with torch.compile.
-        max_model_len = vllm_config.model_config.max_model_len
-        if self.model.freqs_cis.shape[0] < max_model_len:
-            self.model.freqs_cis = self._extend_rope_cache(
-                self.model.freqs_cis, max_model_len
-            )
-
         # Load initial weights based on checkpoint config.
         self._checkpoint_config = checkpoint_config
         self._maybe_initial_load_weights()
-
-    def _extend_rope_cache(
-        self, rope_cache: torch.Tensor, required_len: int
-    ) -> torch.Tensor:
-        """
-        Build an extended RoPE cache of at least ``required_len`` positions.
-
-        Args:
-            rope_cache: Current RoPE cache tensor
-            required_len: Minimum number of positions the cache must cover
-
-        Returns:
-            Extended RoPE cache tensor
-        """
-        # Handle DTensor case
-        is_dtensor = isinstance(rope_cache, DTensor)
-        if is_dtensor:
-            device_mesh = rope_cache.device_mesh
-            local_rope_cache = rope_cache.to_local()
-            device = local_rope_cache.device
-            dtype = local_rope_cache.dtype
-        else:
-            device = rope_cache.device
-            dtype = rope_cache.dtype
-
-        # Build a new RoPE module with extended max_seq_len
-        extended_rope_config = dataclasses.replace(
-            self.rope_config, max_seq_len=required_len
-        )
-        extended_rope = extended_rope_config.build()
-        extended_cache = extended_rope.cache.to(device=device, dtype=dtype)
-
-        # Convert back to DTensor if needed
-        if is_dtensor:
-            rope_cache = DTensor.from_local(
-                extended_cache,
-                device_mesh=device_mesh,
-                placements=[Replicate()],
-            )
-        else:
-            rope_cache = extended_cache
-
-        return rope_cache
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         """vLLM required API.

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -185,14 +185,14 @@ class VLLMModelWrapper(Module):
         # is constructed with its ShardingConfig attached (required by the
         # declarative model.parallelize() API). Need to be called after Attention
         # module replacement.
-        # Matches the shape of trainer_config (has .parallelism) so
+        # Provides the generic config shape (has .parallelism) so
         # update_from_config can extract parallelism uniformly.
         @dataclass(kw_only=True, slots=True)
         class _InferenceConfig:
             parallelism: ParallelismConfig
 
         self.config.update_from_config(
-            trainer_config=_InferenceConfig(parallelism=parallelism)
+            config=_InferenceConfig(parallelism=parallelism)
         )
 
         # TODO: Check if it's possible to apply meta init

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -183,26 +183,19 @@ class VLLMModelWrapper(Module):
         # Fill sharding configs on the config BEFORE build so every sub-module
         # is constructed with its ShardingConfig attached (required by the
         # declarative model.parallelize() API).
-        # Only ``parallelism`` is passed; ``training`` is omitted so the
-        # model's intrinsic ``rope.max_seq_len`` is preserved (the inference
-        # path must not shrink the RoPE cache to a training seq_len).
+        # Translate vLLM's max_model_len to TrainingConfig.seq_len so the
+        # RoPE cache is sized to exactly what vLLM needs. The seq_len >
+        # rope.max_seq_len check in update_from_config will catch invalid
+        # configs (max_model_len exceeding the model's intrinsic maximum).
         from types import SimpleNamespace
 
-        self.config.update_from_config(
-            trainer_config=SimpleNamespace(parallelism=parallelism)
-        )
-
-        # Enforce that vLLM's max_model_len does not exceed the model's
-        # intrinsic max_seq_len -- positions beyond this are invalid.
         max_model_len = vllm_config.model_config.max_model_len
-        rope_max_seq_len = self.config.rope.max_seq_len
-        if max_model_len > rope_max_seq_len:
-            raise ValueError(
-                f"vLLM max_model_len ({max_model_len}) exceeds the model's "
-                f"maximum supported sequence length ({rope_max_seq_len}). "
-                f"Set max_model_len <= {rope_max_seq_len} in EngineArgs or "
-                f"use a model with a larger rope.max_seq_len."
+        self.config.update_from_config(
+            trainer_config=SimpleNamespace(
+                training=TrainingConfig(seq_len=max_model_len),
+                parallelism=parallelism,
             )
+        )
 
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -12,6 +12,7 @@ TorchTitan models for vLLM.
 """
 
 import dataclasses
+from dataclasses import dataclass
 
 import torch
 import torch._dynamo
@@ -182,19 +183,16 @@ class VLLMModelWrapper(Module):
 
         # Fill sharding configs on the config BEFORE build so every sub-module
         # is constructed with its ShardingConfig attached (required by the
-        # declarative model.parallelize() API).
-        # Translate vLLM's max_model_len to TrainingConfig.seq_len so the
-        # RoPE cache is sized to exactly what vLLM needs. The seq_len >
-        # rope.max_seq_len check in update_from_config will catch invalid
-        # configs (max_model_len exceeding the model's intrinsic maximum).
-        from types import SimpleNamespace
+        # declarative model.parallelize() API). Need to be called after Attention
+        # module replacement.
+        # Matches the shape of trainer_config (has .parallelism) so
+        # update_from_config can extract parallelism uniformly.
+        @dataclass(kw_only=True, slots=True)
+        class _InferenceConfig:
+            parallelism: ParallelismConfig
 
-        max_model_len = vllm_config.model_config.max_model_len
         self.config.update_from_config(
-            trainer_config=SimpleNamespace(
-                training=TrainingConfig(seq_len=max_model_len),
-                parallelism=parallelism,
-            )
+            trainer_config=_InferenceConfig(parallelism=parallelism)
         )
 
         # TODO: Check if it's possible to apply meta init

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -191,9 +191,7 @@ class VLLMModelWrapper(Module):
         class _InferenceConfig:
             parallelism: ParallelismConfig
 
-        self.config.update_from_config(
-            config=_InferenceConfig(parallelism=parallelism)
-        )
+        self.config.update_from_config(config=_InferenceConfig(parallelism=parallelism))
 
         # TODO: Check if it's possible to apply meta init
         self.model = self.config.build()

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -197,6 +197,7 @@ def build_inference_engine(config: RLTrainer.Config) -> LLMEngine:
     if not has_cuda_capability(9, 0):
         engine_kwargs["block_size"] = 256  # set blocksize to be 256 to align with FA2
 
+    engine_kwargs["max_model_len"] = config.model_spec.model.rope.max_seq_len
     max_num_seqs = config.num_prompts_per_step * gen_config.sampling.n
     engine_kwargs["max_num_seqs"] = max_num_seqs
     vllm_compilation_config = gen_config.cudagraph.get_vllm_compilation_config(

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -112,7 +112,7 @@ def build_trainer_model(
     # so each Module is constructed with its ShardingConfig / LocalMapConfig.
     # Without this the trainer side would run un-parallelized while the vLLM
     # generator runs fully TP-parallelized, breaking trainer-vs-vLLM parity.
-    model_spec.model.update_from_config(trainer_config=config.trainer)
+    model_spec.model.update_from_config(config=config.trainer)
 
     # Build on meta device, parallelize, then materialize
     with torch.device("meta"):

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -219,14 +219,14 @@ class HFTransformerModel(BaseModel):
         def update_from_config(
             self,
             *,
-            trainer_config=None,
+            config=None,
             **kwargs,
         ):
-            training = trainer_config.training
-            parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            # Extract HF model ID from the extended trainer_config
-            hf_model_id = getattr(trainer_config, "hf_model", "")
+            training = config.training
+            parallelism = config.parallelism
+            debug = config.debug
+            # Extract HF model ID from the extended config
+            hf_model_id = getattr(config, "hf_model", "")
             # Load HF config (overwrites our HF attributes)
             hf_model_config = AutoConfig.from_pretrained(
                 hf_model_id,

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 from dataclasses import dataclass
 
 import torch
@@ -79,6 +80,32 @@ class Decoder(BaseModel):
         # https://github.com/pytorch/torchtitan/pull/2785#discussion_r3033849265
         # and fix the typing here
         layers: list  # list[TransformerBlock.Config] or subclass configs
+
+        def update_from_config(
+            self,
+            *,
+            trainer_config,
+            **kwargs,
+        ) -> None:
+            """Apply trainer config to model config.
+
+            ``training`` is optional: callers that only need parallelism
+            setup (e.g. the vLLM inference wrapper) may omit it.  When
+            present, ``training.seq_len`` is validated against the model's
+            intrinsic ``rope.max_seq_len`` and the RoPE cache is resized.
+            """
+            training = getattr(trainer_config, "training", None)
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}."
+                    )
+                self.rope = dataclasses.replace(
+                    self.rope, max_seq_len=seq_len
+                )
 
     # Set by the trainer when ChunkedCELoss is used, so lm_head is applied
     # per-chunk inside the loss function instead of in forward().

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -89,23 +89,29 @@ class Decoder(BaseModel):
         ) -> None:
             """Apply trainer config to model config.
 
-            ``training`` is optional: callers that only need parallelism
-            setup (e.g. the vLLM inference wrapper) may omit it.  When
-            present, ``training.seq_len`` is validated against the model's
-            intrinsic ``rope.max_seq_len`` and the RoPE cache is resized.
+            Validates ``training.seq_len`` against the model's intrinsic
+            ``rope.max_seq_len`` and resizes the RoPE cache.
+
+            ``debug`` is optional: callers that only need parallelism and
+            training setup (e.g. the vLLM inference wrapper) may omit it.
             """
-            training = getattr(trainer_config, "training", None)
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}."
-                    )
-                self.rope = dataclasses.replace(
-                    self.rope, max_seq_len=seq_len
+            training = trainer_config.training
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds "
+                    f"model's maximum supported sequence length "
+                    f"{self.rope.max_seq_len}."
                 )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+
+            debug = getattr(trainer_config, "debug", None)
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
     # Set by the trainer when ChunkedCELoss is used, so lm_head is applied
     # per-chunk inside the loss function instead of in forward().

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -98,9 +98,26 @@ class Decoder(BaseModel):
             """
             from torchtitan.trainer import Trainer
 
+            parallelism = trainer_config.parallelism
+            tp = parallelism.tensor_parallel_degree
+            if tp > 1:
+                n_heads = self.layers[0].attention.n_heads
+                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
+                if n_heads % tp != 0:
+                    raise ValueError(
+                        f"tensor_parallel_degree ({tp}) must divide "
+                        f"n_heads ({n_heads})."
+                    )
+                if n_kv_heads % tp != 0:
+                    raise ValueError(
+                        f"tensor_parallel_degree ({tp}) must divide "
+                        f"n_kv_heads ({n_kv_heads})."
+                    )
+
             if isinstance(trainer_config, Trainer.Config):
-                training = trainer_config.training
-                seq_len = training.seq_len
+                debug = trainer_config.debug
+                seq_len = trainer_config.training.seq_len
+
                 if seq_len > self.rope.max_seq_len:
                     raise ValueError(
                         f"Training sequence length {seq_len} exceeds "
@@ -109,13 +126,11 @@ class Decoder(BaseModel):
                     )
                 self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-                debug = getattr(trainer_config, "debug", None)
-                if debug is not None:
-                    for layer_cfg in self.layers:
-                        if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
-                            layer_cfg.moe.router._debug_force_load_balance = (
-                                debug.moe_force_load_balance
-                            )
+                for layer_cfg in self.layers:
+                    if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
     # Set by the trainer when ChunkedCELoss is used, so lm_head is applied
     # per-chunk inside the loss function instead of in forward().

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -131,9 +131,7 @@ class Decoder(BaseModel):
                         HybridEPTokenDispatcher,
                     )
 
-                    token_dispatcher_cfg = (
-                        layer_cfg.moe.experts.token_dispatcher
-                    )
+                    token_dispatcher_cfg = layer_cfg.moe.experts.token_dispatcher
                     if (
                         isinstance(
                             token_dispatcher_cfg,

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -89,29 +89,33 @@ class Decoder(BaseModel):
         ) -> None:
             """Apply trainer config to model config.
 
-            Validates ``training.seq_len`` against the model's intrinsic
-            ``rope.max_seq_len`` and resizes the RoPE cache.
-
-            ``debug`` is optional: callers that only need parallelism and
-            training setup (e.g. the vLLM inference wrapper) may omit it.
+            When *trainer_config* is a ``Trainer.Config``, validates
+            ``training.seq_len`` against the model's intrinsic
+            ``rope.max_seq_len``, resizes the RoPE cache, and propagates
+            debug flags.  Non-trainer callers (e.g. the vLLM inference
+            wrapper) may pass a ``ParallelismConfig`` directly; in that
+            case the training/debug setup is skipped.
             """
-            training = trainer_config.training
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds "
-                    f"model's maximum supported sequence length "
-                    f"{self.rope.max_seq_len}."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            from torchtitan.trainer import Trainer
 
-            debug = getattr(trainer_config, "debug", None)
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
+            if isinstance(trainer_config, Trainer.Config):
+                training = trainer_config.training
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}."
+                    )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+
+                debug = getattr(trainer_config, "debug", None)
+                if debug is not None:
+                    for layer_cfg in self.layers:
+                        if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
+                            layer_cfg.moe.router._debug_force_load_balance = (
+                                debug.moe_force_load_balance
+                            )
 
     # Set by the trainer when ChunkedCELoss is used, so lm_head is applied
     # per-chunk inside the loss function instead of in forward().

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -84,21 +84,31 @@ class Decoder(BaseModel):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
-            """Apply trainer config to model config.
+            """Apply runtime config to model config.
 
-            When *trainer_config* is a ``Trainer.Config``, validates
+            When *config* is a ``Trainer.Config``, validates
             ``training.seq_len`` against the model's intrinsic
             ``rope.max_seq_len``, resizes the RoPE cache, and propagates
-            debug flags.  Non-trainer callers (e.g. the vLLM inference
-            wrapper) may pass a ``ParallelismConfig`` directly; in that
-            case the training/debug setup is skipped.
+            debug flags. Non-trainer callers may pass any config-like
+            object with a ``ParallelismConfig`` in its ``parallelism``
+            field; in that case the training/debug setup is skipped.
             """
+            from torchtitan.config import ParallelismConfig
             from torchtitan.trainer import Trainer
 
-            parallelism = trainer_config.parallelism
+            assert hasattr(config, "parallelism"), (
+                "config passed to update_from_config must provide "
+                "a parallelism field."
+            )
+            parallelism = config.parallelism
+            assert isinstance(parallelism, ParallelismConfig), (
+                "config.parallelism must be a ParallelismConfig, got "
+                f"{type(parallelism).__name__}."
+            )
+
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads
@@ -140,9 +150,12 @@ class Decoder(BaseModel):
                             "(expert_parallel_degree > 1)."
                         )
 
-            if isinstance(trainer_config, Trainer.Config):
-                debug = trainer_config.debug
-                seq_len = trainer_config.training.seq_len
+            # NOTE: Inference-only callers such as the RL generator skip
+            # training.seq_len sync. Generated sequence length is not known
+            # ahead of time, so keep the RoPE cache at the model's max_seq_len.
+            if isinstance(config, Trainer.Config):
+                debug = config.debug
+                seq_len = config.training.seq_len
 
                 if seq_len > self.rope.max_seq_len:
                     raise ValueError(

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -114,6 +114,32 @@ class Decoder(BaseModel):
                         f"n_kv_heads ({n_kv_heads})."
                     )
 
+            for layer_cfg in self.layers:
+                if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
+                    from torchtitan.models.common.token_dispatcher import (
+                        DeepEPTokenDispatcher,
+                        HybridEPTokenDispatcher,
+                    )
+
+                    token_dispatcher_cfg = (
+                        layer_cfg.moe.experts.token_dispatcher
+                    )
+                    if (
+                        isinstance(
+                            token_dispatcher_cfg,
+                            (
+                                DeepEPTokenDispatcher.Config,
+                                HybridEPTokenDispatcher.Config,
+                            ),
+                        )
+                        and parallelism.expert_parallel_degree == 1
+                    ):
+                        raise ValueError(
+                            f"{type(token_dispatcher_cfg).__qualname__} "
+                            "requires expert parallelism "
+                            "(expert_parallel_degree > 1)."
+                        )
+
             if isinstance(trainer_config, Trainer.Config):
                 debug = trainer_config.debug
                 seq_len = trainer_config.training.seq_len

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -243,8 +243,7 @@ def _reshape_for_broadcast_complex(
         assert freqs_cis.shape == (seqlen, x.shape[-1])
         shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
         return freqs_cis.view(*shape)
-    _maybe_check_max_pos(positions, max_valid_pos=freqs_cis.shape[0] - 1)
-    if positions.size(0) == 1:
+    elif positions.size(0) == 1:
         assert positions.shape == (1, seqlen)
         freqs_cis = freqs_cis[positions.squeeze(0)]
         assert freqs_cis.shape == (seqlen, x.shape[-1])
@@ -281,8 +280,7 @@ def _reshape_for_broadcast_cos_sin(
         assert rope_cache.shape == (seqlen, head_dim * 2)
         shape = [-1, seqlen, 1, head_dim * 2]
         return rope_cache.view(*shape)
-    _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
-    if positions.size(0) == 1:
+    elif positions.size(0) == 1:
         assert positions.shape == (1, seqlen)
         rope_cache = rope_cache[positions.squeeze(0)]
         assert rope_cache.shape == (seqlen, head_dim * 2)
@@ -360,6 +358,8 @@ def apply_rotary_emb_complex(
         positions: optional position indices
     """
     positions = _maybe_wrap_positions(positions, xq)
+    if positions is not None:
+        _maybe_check_max_pos(positions, max_valid_pos=freqs_cis.shape[0] - 1)
     xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
     xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
     freqs_cis = _reshape_for_broadcast_complex(freqs_cis, xq_, positions)
@@ -381,6 +381,8 @@ def apply_rotary_emb_single_complex(
         positions: optional position indices
     """
     positions = _maybe_wrap_positions(positions, x)
+    if positions is not None:
+        _maybe_check_max_pos(positions, max_valid_pos=freqs_cis.shape[0] - 1)
     dtype = x.dtype
     x = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))
     freqs_cis = _reshape_for_broadcast_complex(freqs_cis, x, positions)
@@ -404,6 +406,8 @@ def apply_rotary_emb_cos_sin(
         positions: optional position indices
     """
     positions = _maybe_wrap_positions(positions, xq)
+    if positions is not None:
+        _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
     head_dim = xq.shape[-1]
     if rope_cache.ndim != 4:
         rope_cache = _reshape_for_broadcast_cos_sin(rope_cache, xq, positions)

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -21,6 +21,22 @@ __all__ = [
 ]
 
 
+def _maybe_check_max_pos(positions: torch.Tensor, *, max_valid_pos: int) -> None:
+    """Async bounds check: verify all position values <= max_valid_pos.
+
+    Uses ``torch._assert_async`` to avoid a device-host sync while still
+    catching out-of-bounds positions (the assertion failure surfaces at a
+    later kernel launch).  Skipped entirely under ``torch.compile``.
+    """
+    if torch.compiler.is_compiling():
+        return
+    pos_local = positions.to_local() if isinstance(positions, DTensor) else positions
+    torch._assert_async(
+        torch.all(pos_local <= max_valid_pos),
+        f"position_ids exceed {max_valid_pos=}",
+    )
+
+
 class RoPE(Module):
     """Shared Rotary Position Embedding module.
 
@@ -227,7 +243,8 @@ def _reshape_for_broadcast_complex(
         assert freqs_cis.shape == (seqlen, x.shape[-1])
         shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
         return freqs_cis.view(*shape)
-    elif positions.size(0) == 1:
+    _maybe_check_max_pos(positions, max_valid_pos=freqs_cis.shape[0] - 1)
+    if positions.size(0) == 1:
         assert positions.shape == (1, seqlen)
         freqs_cis = freqs_cis[positions.squeeze(0)]
         assert freqs_cis.shape == (seqlen, x.shape[-1])
@@ -264,7 +281,8 @@ def _reshape_for_broadcast_cos_sin(
         assert rope_cache.shape == (seqlen, head_dim * 2)
         shape = [-1, seqlen, 1, head_dim * 2]
         return rope_cache.view(*shape)
-    elif positions.size(0) == 1:
+    _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
+    if positions.size(0) == 1:
         assert positions.shape == (1, seqlen)
         rope_cache = rope_cache[positions.squeeze(0)]
         assert rope_cache.shape == (seqlen, head_dim * 2)

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -194,40 +194,26 @@ class DeepSeekV3Model(Decoder):
             **kwargs,
         ) -> None:
 
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-            debug = getattr(trainer_config, "debug", None)
+            debug = trainer_config.debug
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot "
-                        f"produce valid RoPE embeddings for positions "
-                        f"beyond this limit."
-                    )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
-
-            if training is not None:
-                # Sync rope fields to attention for all layers.
-                # Mutate in-place — simpler than replacing each config
-                # in the list.
-                for layer_cfg in self.layers:
-                    assert isinstance(layer_cfg.attention, Attention.Config)
-                    layer_cfg.attention.rope_max_seq_len = seq_len
-                    layer_cfg.attention.rope_factor = self.rope.rope_factor
-                    layer_cfg.attention.rope_original_seq_len = (
-                        self.rope.original_seq_len
-                    )
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
+            # Sync rope fields to attention for all layers.
+            # Mutate in-place — simpler than replacing each config in the list.
+            for layer_cfg in self.layers:
+                assert isinstance(layer_cfg.attention, Attention.Config)
+                layer_cfg.attention.rope_max_seq_len = seq_len
+                layer_cfg.attention.rope_factor = self.rope.rope_factor
+                layer_cfg.attention.rope_original_seq_len = self.rope.original_seq_len
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -196,15 +196,19 @@ class DeepSeekV3Model(Decoder):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-            training = trainer_config.training
+
+            from torchtitan.trainer import Trainer
 
             # Sync rope fields to attention for all layers.
-            seq_len = training.seq_len
-            for layer_cfg in self.layers:
-                assert isinstance(layer_cfg.attention, Attention.Config)
-                layer_cfg.attention.rope_max_seq_len = seq_len
-                layer_cfg.attention.rope_factor = self.rope.rope_factor
-                layer_cfg.attention.rope_original_seq_len = self.rope.original_seq_len
+            if isinstance(trainer_config, Trainer.Config):
+                seq_len = trainer_config.training.seq_len
+                for layer_cfg in self.layers:
+                    assert isinstance(layer_cfg.attention, Attention.Config)
+                    layer_cfg.attention.rope_max_seq_len = seq_len
+                    layer_cfg.attention.rope_factor = self.rope.rope_factor
+                    layer_cfg.attention.rope_original_seq_len = (
+                        self.rope.original_seq_len
+                    )
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -26,7 +26,6 @@ from torchtitan.models.common.token_dispatcher import (
 )
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 
 class Attention(BaseAttention):
@@ -195,23 +194,40 @@ class DeepSeekV3Model(Decoder):
             **kwargs,
         ) -> None:
 
-            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                logger.warning(
-                    f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            training = getattr(trainer_config, "training", None)
+            debug = getattr(trainer_config, "debug", None)
 
-            # Sync rope fields to attention for all layers.
-            # Mutate in-place — simpler than replacing each config in the list.
-            for layer_cfg in self.layers:
-                assert isinstance(layer_cfg.attention, Attention.Config)
-                layer_cfg.attention.rope_max_seq_len = seq_len
-                layer_cfg.attention.rope_factor = self.rope.rope_factor
-                layer_cfg.attention.rope_original_seq_len = self.rope.original_seq_len
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot "
+                        f"produce valid RoPE embeddings for positions "
+                        f"beyond this limit."
+                    )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+
+            if training is not None:
+                # Sync rope fields to attention for all layers.
+                # Mutate in-place — simpler than replacing each config
+                # in the list.
+                for layer_cfg in self.layers:
+                    assert isinstance(layer_cfg.attention, Attention.Config)
+                    layer_cfg.attention.rope_max_seq_len = seq_len
+                    layer_cfg.attention.rope_factor = self.rope.rope_factor
+                    layer_cfg.attention.rope_original_seq_len = (
+                        self.rope.original_seq_len
+                    )
+
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import dataclasses
 import math
 from dataclasses import dataclass, field
 
@@ -197,19 +196,15 @@ class DeepSeekV3Model(Decoder):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-            debug = getattr(trainer_config, "debug", None)
+            training = trainer_config.training
 
             # Sync rope fields to attention for all layers.
-            if training is not None:
-                seq_len = training.seq_len
-                for layer_cfg in self.layers:
-                    assert isinstance(layer_cfg.attention, Attention.Config)
-                    layer_cfg.attention.rope_max_seq_len = seq_len
-                    layer_cfg.attention.rope_factor = self.rope.rope_factor
-                    layer_cfg.attention.rope_original_seq_len = (
-                        self.rope.original_seq_len
-                    )
+            seq_len = training.seq_len
+            for layer_cfg in self.layers:
+                assert isinstance(layer_cfg.attention, Attention.Config)
+                layer_cfg.attention.rope_max_seq_len = seq_len
+                layer_cfg.attention.rope_factor = self.rope.rope_factor
+                layer_cfg.attention.rope_original_seq_len = self.rope.original_seq_len
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -185,19 +185,19 @@ class DeepSeekV3Model(Decoder):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             from torchtitan.trainer import Trainer
 
             # Sync rope fields to attention for all layers.
-            if isinstance(trainer_config, Trainer.Config):
-                seq_len = trainer_config.training.seq_len
+            if isinstance(config, Trainer.Config):
+                seq_len = config.training.seq_len
                 for layer_cfg in self.layers:
                     assert isinstance(layer_cfg.attention, Attention.Config)
                     layer_cfg.attention.rope_max_seq_len = seq_len

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -188,9 +188,7 @@ class DeepSeekV3Model(Decoder):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             from torchtitan.trainer import Trainer

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -193,27 +193,23 @@ class DeepSeekV3Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            training = getattr(trainer_config, "training", None)
+            debug = getattr(trainer_config, "debug", None)
 
             # Sync rope fields to attention for all layers.
-            # Mutate in-place — simpler than replacing each config in the list.
-            for layer_cfg in self.layers:
-                assert isinstance(layer_cfg.attention, Attention.Config)
-                layer_cfg.attention.rope_max_seq_len = seq_len
-                layer_cfg.attention.rope_factor = self.rope.rope_factor
-                layer_cfg.attention.rope_original_seq_len = self.rope.original_seq_len
+            if training is not None:
+                seq_len = training.seq_len
+                for layer_cfg in self.layers:
+                    assert isinstance(layer_cfg.attention, Attention.Config)
+                    layer_cfg.attention.rope_max_seq_len = seq_len
+                    layer_cfg.attention.rope_factor = self.rope.rope_factor
+                    layer_cfg.attention.rope_original_seq_len = (
+                        self.rope.original_seq_len
+                    )
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -19,10 +19,6 @@ from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rmsnorm import RMSNorm
 from torchtitan.models.common.rope import apply_rotary_emb_single_complex
-from torchtitan.models.common.token_dispatcher import (
-    DeepEPTokenDispatcher,
-    HybridEPTokenDispatcher,
-)
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
@@ -209,27 +205,6 @@ class DeepSeekV3Model(Decoder):
                     layer_cfg.attention.rope_original_seq_len = (
                         self.rope.original_seq_len
                     )
-
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    layer_cfg.moe.router._debug_force_load_balance = (
-                        debug.moe_force_load_balance
-                    )
-                    token_dispatcher_cfg = layer_cfg.moe.experts.token_dispatcher
-                    if (
-                        isinstance(
-                            token_dispatcher_cfg,
-                            (
-                                DeepEPTokenDispatcher.Config,
-                                HybridEPTokenDispatcher.Config,
-                            ),
-                        )
-                        and parallelism.expert_parallel_degree == 1
-                    ):
-                        raise ValueError(
-                            f"{type(token_dispatcher_cfg).__qualname__} requires expert parallelism "
-                            "(expert_parallel_degree > 1)."
-                        )
 
             if parallelism.context_parallel_degree > 1 and not isinstance(
                 self.layers[0].attention.inner_attention,

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -53,7 +53,7 @@ class FluxModel(BaseModel):
         double_blocks: list[DoubleStreamBlock.Config]
         single_blocks: list[SingleStreamBlock.Config]
 
-        def update_from_config(self, *, trainer_config, **kwargs) -> None:
+        def update_from_config(self, *, config, **kwargs) -> None:
             pass
 
         def get_nparams_and_flops(

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -188,20 +188,17 @@ class GptOssModel(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot "
-                        f"produce valid RoPE embeddings for positions "
-                        f"beyond this limit."
-                    )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             tp = parallelism.tensor_parallel_degree
             if tp > 1:

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -188,17 +188,10 @@ class GptOssModel(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             tp = parallelism.tensor_parallel_degree
             if tp > 1:

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -27,7 +27,6 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rope import apply_rotary_emb_cos_sin
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 
 class Attention(BaseAttention):
@@ -189,16 +188,20 @@ class GptOssModel(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                logger.warning(
-                    f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
-                )
+            training = getattr(trainer_config, "training", None)
 
-            # Sync rope max_seq_len
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot "
+                        f"produce valid RoPE embeddings for positions "
+                        f"beyond this limit."
+                    )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             tp = parallelism.tensor_parallel_degree
             if tp > 1:

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -188,9 +188,7 @@ class GptOssModel(Decoder):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             from torchtitan.models.gpt_oss.sharding import set_gpt_oss_sharding_config

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -185,13 +185,13 @@ class GptOssModel(Decoder):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             from torchtitan.models.gpt_oss.sharding import set_gpt_oss_sharding_config
 

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -193,19 +193,6 @@ class GptOssModel(Decoder):
             )
             parallelism = trainer_config.parallelism
 
-            tp = parallelism.tensor_parallel_degree
-            if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_kv_heads ({n_kv_heads})."
-                    )
-
             from torchtitan.models.gpt_oss.sharding import set_gpt_oss_sharding_config
 
             set_gpt_oss_sharding_config(

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -74,20 +74,17 @@ class Llama3Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot "
-                        f"produce valid RoPE embeddings for positions "
-                        f"beyond this limit."
-                    )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -74,17 +74,10 @@ class Llama3Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -15,7 +15,6 @@ from torch import nn
 from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
-from torchtitan.tools.logging import logger
 
 
 class Llama3TransformerBlock(TransformerBlock):
@@ -75,15 +74,20 @@ class Llama3Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                logger.warning(
-                    f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
-                )
-            # Sync rope max_seq_len
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            training = getattr(trainer_config, "training", None)
+
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot "
+                        f"produce valid RoPE embeddings for positions "
+                        f"beyond this limit."
+                    )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -73,9 +73,7 @@ class Llama3Model(Decoder):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1 and isinstance(

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -6,7 +6,6 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-import dataclasses
 from dataclasses import dataclass
 
 import torch

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -70,13 +70,13 @@ class Llama3Model(Decoder):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -86,19 +86,6 @@ class Llama3Model(Decoder):
                     "Varlen attention is not supported with CP."
                 )
 
-            tp = parallelism.tensor_parallel_degree
-            if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_kv_heads ({n_kv_heads})."
-                    )
-
             if self.enable_weight_tying and parallelism.pipeline_parallel_degree > 1:
                 raise NotImplementedError(
                     "Weight tying is not supported with Pipeline Parallel."

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -120,9 +120,7 @@ class Llama4Model(Decoder):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1:

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -156,19 +156,6 @@ class Llama4Model(Decoder):
                     "(Llama4 requires FlexAttention, which is not supported with CP)."
                 )
 
-            tp = parallelism.tensor_parallel_degree
-            if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_kv_heads ({n_kv_heads})."
-                    )
-
             from torchtitan.models.llama4.sharding import set_llama4_sharding_config
 
             set_llama4_sharding_config(

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -117,13 +117,13 @@ class Llama4Model(Decoder):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1:
                 raise NotImplementedError(

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -24,7 +24,6 @@ from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
 )
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
-from torchtitan.tools.logging import logger
 
 
 def compute_moe_hidden_dim(
@@ -127,16 +126,28 @@ class Llama4Model(Decoder):
             **kwargs,
         ) -> None:
 
-            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                logger.warning(
-                    f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
-                )
-            # Sync rope max_seq_len
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            training = getattr(trainer_config, "training", None)
+            debug = getattr(trainer_config, "debug", None)
+
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot "
+                        f"produce valid RoPE embeddings for positions "
+                        f"beyond this limit."
+                    )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -18,10 +18,6 @@ from torchtitan.models.common.attention import (
     get_fixed_block_mask_mod,
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.common.token_dispatcher import (
-    DeepEPTokenDispatcher,
-    HybridEPTokenDispatcher,
-)
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 
 
@@ -128,27 +124,6 @@ class Llama4Model(Decoder):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    layer_cfg.moe.router._debug_force_load_balance = (
-                        debug.moe_force_load_balance
-                    )
-                    token_dispatcher_cfg = layer_cfg.moe.experts.token_dispatcher
-                    if (
-                        isinstance(
-                            token_dispatcher_cfg,
-                            (
-                                DeepEPTokenDispatcher.Config,
-                                HybridEPTokenDispatcher.Config,
-                            ),
-                        )
-                        and parallelism.expert_parallel_degree == 1
-                    ):
-                        raise ValueError(
-                            f"{type(token_dispatcher_cfg).__qualname__} requires expert parallelism "
-                            "(expert_parallel_degree > 1)."
-                        )
 
             if parallelism.context_parallel_degree > 1:
                 raise NotImplementedError(

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import dataclasses
 from dataclasses import dataclass
 
 import torch
@@ -129,7 +128,6 @@ class Llama4Model(Decoder):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-            debug = getattr(trainer_config, "debug", None)
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -125,19 +125,11 @@ class Llama4Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            debug = getattr(trainer_config, "debug", None)
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/llama4/model.py
+++ b/torchtitan/models/llama4/model.py
@@ -126,28 +126,18 @@ class Llama4Model(Decoder):
             **kwargs,
         ) -> None:
 
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-            debug = getattr(trainer_config, "debug", None)
-
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot "
-                        f"produce valid RoPE embeddings for positions "
-                        f"beyond this limit."
-                    )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
+            debug = trainer_config.debug
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             for layer_cfg in self.layers:
                 if layer_cfg.moe is not None:

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -90,25 +90,18 @@ class Qwen3Model(Decoder):
             trainer_config,
             **kwargs,
         ) -> None:
-
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            debug = getattr(trainer_config, "debug", None)
 
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    layer_cfg.moe.router._debug_force_load_balance = (
-                        debug.moe_force_load_balance
-                    )
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -91,36 +91,24 @@ class Qwen3Model(Decoder):
             **kwargs,
         ) -> None:
 
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            # ``training`` and ``debug`` are optional: the RL vLLM generator
-            # passes a minimal trainer_config containing only ``parallelism``
-            # (no RoPE cache extension at this stage; no MoE force-load-balance
-            # at inference time).
+            debug = trainer_config.debug
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-            # TODO: This method is used by more than just training. We should
-            # refactor this method such that the logic and naming are meaningful
-            # for both training and RL use cases.
-            training = getattr(trainer_config, "training", None)
-            debug = getattr(trainer_config, "debug", None)
-
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds model's "
-                        f"maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot produce "
-                        f"valid RoPE embeddings for positions beyond this "
-                        f"limit."
+            for layer_cfg in self.layers:
+                if layer_cfg.moe is not None:
+                    layer_cfg.moe.router._debug_force_load_balance = (
+                        debug.moe_force_load_balance
                     )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -19,7 +19,6 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
-from torchtitan.tools.logging import logger
 
 
 class Qwen3TransformerBlock(TransformerBlock):
@@ -107,10 +106,13 @@ class Qwen3Model(Decoder):
             if training is not None:
                 seq_len = training.seq_len
                 if seq_len > self.rope.max_seq_len:
-                    logger.warning(
-                        f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds model's "
+                        f"maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot produce "
+                        f"valid RoPE embeddings for positions beyond this "
+                        f"limit."
                     )
-                # Sync rope max_seq_len
                 self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
             if debug is not None:

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -107,19 +107,6 @@ class Qwen3Model(Decoder):
                     "Weight tying is not supported with Pipeline Parallel."
                 )
 
-            tp = parallelism.tensor_parallel_degree
-            if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_kv_heads ({n_kv_heads})."
-                    )
-
             from torchtitan.models.qwen3.sharding import set_qwen3_sharding_config
 
             set_qwen3_sharding_config(

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -6,7 +6,6 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-import dataclasses
 from dataclasses import dataclass
 
 import torch
@@ -94,14 +93,6 @@ class Qwen3Model(Decoder):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-            debug = getattr(trainer_config, "debug", None)
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -86,13 +86,13 @@ class Qwen3Model(Decoder):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -89,9 +89,7 @@ class Qwen3Model(Decoder):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             if parallelism.context_parallel_degree > 1 and isinstance(

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -64,24 +64,18 @@ class Qwen3VLModel(Qwen3Model):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
+            Decoder.Config.update_from_config(
+                self, trainer_config=trainer_config, **kwargs
+            )
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                raise ValueError(
-                    f"Training sequence length {seq_len} exceeds model's "
-                    f"maximum supported sequence length "
-                    f"{self.rope.max_seq_len}. The model cannot produce "
-                    f"valid RoPE embeddings for positions beyond this limit."
-                )
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            debug = getattr(trainer_config, "debug", None)
 
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    layer_cfg.moe.router._debug_force_load_balance = (
-                        debug.moe_force_load_balance
-                    )
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config
 

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -60,13 +60,13 @@ class Qwen3VLModel(Qwen3Model):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(
-                self, trainer_config=trainer_config, **kwargs
+                self, config=config, **kwargs
             )
-            parallelism = trainer_config.parallelism
+            parallelism = config.parallelism
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config
 

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import dataclasses
 from dataclasses import dataclass, field
 
 import torch
@@ -68,14 +67,6 @@ class Qwen3VLModel(Qwen3Model):
                 self, trainer_config=trainer_config, **kwargs
             )
             parallelism = trainer_config.parallelism
-            debug = getattr(trainer_config, "debug", None)
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config
 

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -15,7 +15,6 @@ from torch.distributed.tensor import DTensor
 from torchtitan.models.common.attention import AttentionMasksType, GQAttention
 from torchtitan.models.qwen3.model import Qwen3Model
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
-from torchtitan.tools.logging import logger
 
 from .vision_encoder import Qwen3VLVisionEncoder
 
@@ -65,22 +64,28 @@ class Qwen3VLModel(Qwen3Model):
             trainer_config,
             **kwargs,
         ) -> None:
-            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            debug = trainer_config.debug
-            seq_len = training.seq_len
-            if seq_len > self.rope.max_seq_len:
-                logger.warning(
-                    f"Sequence length {seq_len} exceeds original maximum {self.rope.max_seq_len}."
-                )
-            # Sync rope max_seq_len
-            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+            training = getattr(trainer_config, "training", None)
+            debug = getattr(trainer_config, "debug", None)
 
-            for layer_cfg in self.layers:
-                if layer_cfg.moe is not None:
-                    layer_cfg.moe.router._debug_force_load_balance = (
-                        debug.moe_force_load_balance
+            if training is not None:
+                seq_len = training.seq_len
+                if seq_len > self.rope.max_seq_len:
+                    raise ValueError(
+                        f"Training sequence length {seq_len} exceeds "
+                        f"model's maximum supported sequence length "
+                        f"{self.rope.max_seq_len}. The model cannot "
+                        f"produce valid RoPE embeddings for positions "
+                        f"beyond this limit."
                     )
+                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
+
+            if debug is not None:
+                for layer_cfg in self.layers:
+                    if layer_cfg.moe is not None:
+                        layer_cfg.moe.router._debug_force_load_balance = (
+                            debug.moe_force_load_balance
+                        )
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config
 

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -12,6 +12,7 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 
 from torchtitan.models.common.attention import AttentionMasksType, GQAttention
+from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.qwen3.model import Qwen3Model
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 
@@ -63,9 +64,7 @@ class Qwen3VLModel(Qwen3Model):
             config,
             **kwargs,
         ) -> None:
-            Decoder.Config.update_from_config(
-                self, config=config, **kwargs
-            )
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -76,19 +76,6 @@ class Qwen3VLModel(Qwen3Model):
                 enable_ep=parallelism.expert_parallel_degree > 1,
             )
 
-            tp = parallelism.tensor_parallel_degree
-            if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide n_kv_heads ({n_kv_heads})."
-                    )
-
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -64,28 +64,24 @@ class Qwen3VLModel(Qwen3Model):
             trainer_config,
             **kwargs,
         ) -> None:
+            training = trainer_config.training
             parallelism = trainer_config.parallelism
-            training = getattr(trainer_config, "training", None)
-            debug = getattr(trainer_config, "debug", None)
+            debug = trainer_config.debug
+            seq_len = training.seq_len
+            if seq_len > self.rope.max_seq_len:
+                raise ValueError(
+                    f"Training sequence length {seq_len} exceeds model's "
+                    f"maximum supported sequence length "
+                    f"{self.rope.max_seq_len}. The model cannot produce "
+                    f"valid RoPE embeddings for positions beyond this limit."
+                )
+            self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-            if training is not None:
-                seq_len = training.seq_len
-                if seq_len > self.rope.max_seq_len:
-                    raise ValueError(
-                        f"Training sequence length {seq_len} exceeds "
-                        f"model's maximum supported sequence length "
-                        f"{self.rope.max_seq_len}. The model cannot "
-                        f"produce valid RoPE embeddings for positions "
-                        f"beyond this limit."
+            for layer_cfg in self.layers:
+                if layer_cfg.moe is not None:
+                    layer_cfg.moe.router._debug_force_load_balance = (
+                        debug.moe_force_load_balance
                     )
-                self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
-
-            if debug is not None:
-                for layer_cfg in self.layers:
-                    if layer_cfg.moe is not None:
-                        layer_cfg.moe.router._debug_force_load_balance = (
-                            debug.moe_force_load_balance
-                        )
 
             from torchtitan.models.qwen3_vl.sharding import set_qwen3_vl_sharding_config
 

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -83,7 +83,7 @@ class BaseModel(Module):
         def update_from_config(
             self,
             *,
-            trainer_config,
+            config,
             **kwargs,
         ) -> None:
             pass

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -246,7 +246,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         model_config = model_spec.model
         # set the model args from training job configs
         model_config.update_from_config(
-            trainer_config=config,
+            config=config,
         )
         self.model_config = model_config
 


### PR DESCRIPTION
- Make seq_len > rope.max_seq_len a hard error: All models' update_from_config now raise ValueError instead of logging a warning when the training sequence length exceeds the model's intrinsic maximum. The model cannot produce valid RoPE embeddings for positions beyond this limit.
- Fix vLLM wrapper RoPE cache sizing: The wrapper was passing a default TrainingConfig() (with seq_len=2048) to update_from_config, which shrank the RoPE cache from the model's intrinsic max (e.g., 4096 for Qwen3) to 2048. It then had to extend the cache back via _extend_rope_cache because vLLM's max_model_len (derived from the original max_position_embeddings=4096) exceeded the shrunken cache.
    - Fixed by passing TrainingConfig(seq_len=rope.max_seq_len) so the cache stays at the model's intrinsic maximum. Removed _extend_rope_cache and self.rope_config which are no longer needed. Added a max_model_len <= rope.max_seq_len enforcement.

NOTE: In next PR, I plan to change current implementation of all layers share one RoPE cache, to be each layer has one RoPE cache.