### PR TITLE
[RFC] a registry mechanism for in-repo / out-of-repo Module-level overrides

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -577,6 +577,17 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "dataloader_kwargs",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--override.imports torchtitan.overrides.fused_swiglu",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "Override: swap FeedForward with fused SwiGLU (FSDP2 + TP2)",
+            "override_fused_swiglu",
+            ngpu=4,
+        ),
         # NOTE: below are tests which require config change that cannot be done
         #       via CLI overrides, so remain llama3 specific
         OverrideDefinitions(

--- a/tests/unit_tests/test_override.py
+++ b/tests/unit_tests/test_override.py
@@ -1,0 +1,439 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from dataclasses import dataclass, field
+
+from torchtitan.config import (
+    apply_overrides,
+    clear_overrides,
+    Configurable,
+    derive,
+    override,
+    OverrideConfig,
+)
+from torchtitan.config.override import _REGISTRY, Override
+
+# Overrides registered in this module have ``origin_module == __name__``; tests
+# pass ``imports=[__name__]`` so the provenance filter activates them.
+
+
+class ComponentA(Configurable):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        dim: int = 64
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class ComponentB(Configurable):
+    """Replacement for ComponentA."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        dim: int = 64
+        extra: int = 128
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class ParentComponent(Configurable):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        child: ComponentA.Config = field(default_factory=ComponentA.Config)
+        children: list[ComponentA.Config] = field(
+            default_factory=lambda: [
+                ComponentA.Config(dim=32),
+                ComponentA.Config(dim=48),
+            ]
+        )
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class Root(Configurable):
+    """Wrapper so ParentComponent appears as a nested node (for nesting tests)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        block: ParentComponent.Config = field(default_factory=ParentComponent.Config)
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class TwoBlocks(Configurable):
+    """Two independent ParentComponent subtrees (for disjoint-subtree tests)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        a: ParentComponent.Config = field(default_factory=ParentComponent.Config)
+        b: ParentComponent.Config = field(default_factory=ParentComponent.Config)
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class DerivedComponent(ComponentA):
+    """A replacement that subclasses the target Config and adds a field.
+
+    Mirrors the common override shape (e.g. ``TritonRoPE.Config(RoPE.Config)``):
+    it inherits the target's fields, so any field later added to the target is
+    inherited here too and ``derive`` carries it automatically.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ComponentA.Config):  # inherits ``dim``
+        block_size: int = 128
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+def _to_b(cfg: ComponentA.Config) -> ComponentB.Config:
+    return ComponentB.Config(dim=cfg.dim)
+
+
+class TestOverride(unittest.TestCase):
+    def setUp(self):
+        clear_overrides()
+
+    def tearDown(self):
+        clear_overrides()
+
+    def _imports(self) -> OverrideConfig:
+        """OverrideConfig that activates overrides defined in this module."""
+        return OverrideConfig(imports=[__name__])
+
+    def test_register_and_apply(self):
+        @override("test_swap", target=ComponentA.Config, description="test swap")
+        def swap_a_to_b(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=256)
+
+        self.assertIn("test_swap", _REGISTRY)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        # No `where` -> child and both list items are replaced.
+        self.assertEqual(len(replacements), 3)
+        self.assertIsInstance(parent_cfg.child, ComponentB.Config)
+        self.assertEqual(parent_cfg.child.extra, 256)
+        for child_cfg in parent_cfg.children:
+            self.assertIsInstance(child_cfg, ComponentB.Config)
+
+    def test_fqns_glob(self):
+        @override("by_glob", target=ComponentA.Config, fqns=["children.*"])
+        def by_glob(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(len(replacements), 2)
+        self.assertIsInstance(parent_cfg.child, ComponentA.Config)  # "child", skipped
+        for child_cfg in parent_cfg.children:
+            self.assertIsInstance(child_cfg, ComponentB.Config)
+
+    def test_fqns_glob_list(self):
+        @override("by_globs", target=ComponentA.Config, fqns=["child", "nomatch.*"])
+        def by_globs(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(len(replacements), 1)
+        self.assertIsInstance(parent_cfg.child, ComponentB.Config)
+        for child_cfg in parent_cfg.children:
+            self.assertIsInstance(child_cfg, ComponentA.Config)
+
+    def test_same_class_disjoint_fqns_ok(self):
+        # Two overrides of the SAME class, but disjoint FQNs -> no conflict.
+        @override("on_child", target=ComponentA.Config, fqns=["child"])
+        def on_child(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=1)
+
+        @override("on_children", target=ComponentA.Config, fqns=["children.*"])
+        def on_children(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=2)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(len(replacements), 3)
+        self.assertEqual(parent_cfg.child.extra, 1)
+        for child_cfg in parent_cfg.children:
+            self.assertEqual(child_cfg.extra, 2)
+
+    def test_non_configurable_target_raises(self):
+        # `target` must be a Configurable.Config subclass; a plain class (e.g.
+        # ModelSpec) or non-type is rejected at registration.
+        with self.assertRaisesRegex(TypeError, "Configurable.Config subclass"):
+
+            @override("bad_target", target=dict)
+            def bad(cfg):
+                return cfg
+
+    def test_conflict_same_node_raises(self):
+        # Two overrides claim the same nodes (both target ComponentA, no `where`).
+        @override("swap1", target=ComponentA.Config)
+        def swap1(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        @override("swap2", target=ComponentA.Config)
+        def swap2(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        parent_cfg = ParentComponent.Config()
+        with self.assertRaisesRegex(ValueError, "both claim node"):
+            apply_overrides(self._imports(), parent_cfg)
+
+    def test_parent_child_disjoint_subtrees_ok(self):
+        # A targets the parent class on subtree "a"; B targets the child class
+        # on subtree "b". Disjoint nodes -> both apply, no conflict.
+        @override("on_parent", target=ParentComponent.Config, fqns=["a"])
+        def on_parent(cfg: ParentComponent.Config) -> ComponentB.Config:
+            return ComponentB.Config()
+
+        @override("on_child", target=ComponentA.Config, fqns=["b.*"])
+        def on_child(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        root_cfg = TwoBlocks.Config()
+        replacements = apply_overrides(self._imports(), root_cfg)
+
+        self.assertEqual(len(replacements), 4)  # "a" + b.child + b.children[0,1]
+        self.assertIsInstance(root_cfg.a, ComponentB.Config)  # whole parent
+        self.assertIsInstance(root_cfg.b, ParentComponent.Config)  # untouched parent
+        self.assertIsInstance(root_cfg.b.child, ComponentB.Config)
+        for child_cfg in root_cfg.b.children:
+            self.assertIsInstance(child_cfg, ComponentB.Config)
+
+    def test_conflict_nested_node_raises(self):
+        # One override claims an ancestor node of another's node.
+        @override("on_parent", target=ParentComponent.Config)
+        def on_parent(cfg: ParentComponent.Config) -> ComponentB.Config:
+            return ComponentB.Config()  # never built; error is raised first
+
+        @override("on_leaf", target=ComponentA.Config)
+        def on_leaf(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        root_cfg = Root.Config()
+        with self.assertRaisesRegex(ValueError, "ancestor"):
+            apply_overrides(self._imports(), root_cfg)
+
+    def test_provenance_only_listed_modules_apply(self):
+        @override("local", target=ComponentA.Config)
+        def local(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=256)
+
+        # An override registered by a module the user did NOT list. Insert it
+        # directly with a foreign origin (the @override decorator would capture
+        # this module's name).
+        def foreign_factory(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=999)
+
+        _REGISTRY["foreign"] = Override(
+            name="foreign",
+            target_cls=ComponentA.Config,
+            factory=foreign_factory,
+            fqns=None,
+            description="",
+            origin_module="vendor.unlisted",
+        )
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        # Only "local" applied; "foreign" filtered out by provenance (so no
+        # same-node conflict was raised despite both targeting ComponentA).
+        self.assertEqual(parent_cfg.child.extra, 256)
+        self.assertTrue(all("foreign" not in line for line in replacements))
+        self.assertTrue(all("local" in line for line in replacements))
+
+    def test_duplicate_name_raises(self):
+        @override("dup", target=ComponentA.Config)
+        def first(cfg):
+            return _to_b(cfg)
+
+        with self.assertRaisesRegex(ValueError, "already registered"):
+
+            @override("dup", target=ComponentA.Config)
+            def second(cfg):
+                return _to_b(cfg)
+
+    def test_clear_overrides(self):
+        @override("temp", target=ComponentA.Config)
+        def temp(cfg):
+            return _to_b(cfg)
+
+        self.assertEqual(len(_REGISTRY), 1)
+        clear_overrides()
+        self.assertEqual(len(_REGISTRY), 0)
+
+    def test_no_overrides_is_noop(self):
+        parent_cfg = ParentComponent.Config(child=ComponentA.Config(dim=100))
+        replacements = apply_overrides(OverrideConfig(), parent_cfg)
+        self.assertEqual(len(replacements), 0)
+        self.assertEqual(parent_cfg.child.dim, 100)
+
+    def test_unlisted_imports_is_noop(self):
+        # Override exists in the registry but the user lists no imports.
+        @override("present", target=ComponentA.Config)
+        def present(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(OverrideConfig(), parent_cfg)
+        self.assertEqual(len(replacements), 0)
+        self.assertIsInstance(parent_cfg.child, ComponentA.Config)
+
+    def test_bad_module_import_raises(self):
+        override_cfg = OverrideConfig(imports=["nonexistent.module.path"])
+        parent_cfg = ParentComponent.Config()
+        with self.assertRaises(ImportError):
+            apply_overrides(override_cfg, parent_cfg)
+
+    def test_logging_format(self):
+        @override("fmt_test", target=ComponentA.Config, description="format test")
+        def fmt_swap(cfg: ComponentA.Config) -> ComponentB.Config:
+            return _to_b(cfg)
+
+        parent_cfg = ParentComponent.Config()
+        replacements = apply_overrides(self._imports(), parent_cfg)
+        for line in replacements:
+            self.assertIn("[Override]", line)
+            self.assertIn("fmt_test", line)
+            self.assertIn("->", line)
+
+
+class TestDerive(unittest.TestCase):
+    def test_copies_shared_and_applies_deltas(self):
+        src = ComponentA.Config(dim=99)
+        out = derive(src, DerivedComponent.Config, block_size=256)
+        self.assertIsInstance(out, DerivedComponent.Config)
+        self.assertEqual(out.dim, 99)  # shared field copied (not in deltas)
+        self.assertEqual(out.block_size, 256)  # delta
+
+    def test_target_only_field_falls_back_to_default(self):
+        src = ComponentA.Config(dim=7)
+        out = derive(src, DerivedComponent.Config)  # no delta for block_size
+        self.assertEqual(out.dim, 7)
+        self.assertEqual(out.block_size, 128)  # target's declared default
+
+    def test_newly_added_field_carried_without_factory_change(self):
+        # ``dim`` stands in for a field the factory never mentions; derive
+        # carries the caller's value instead of reverting to the default (64).
+        src = ComponentA.Config(dim=4096)
+        out = derive(src, DerivedComponent.Config, block_size=64)
+        self.assertEqual(out.dim, 4096)
+
+    def test_unknown_delta_raises(self):
+        src = ComponentA.Config()
+        with self.assertRaisesRegex(ValueError, "not on"):
+            derive(src, DerivedComponent.Config, nonexistent=1)
+
+    def test_src_only_fields_dropped(self):
+        # ComponentB.Config has {dim, extra}; target ComponentA.Config has {dim}.
+        src = ComponentB.Config(dim=5, extra=999)
+        out = derive(src, ComponentA.Config)
+        self.assertIsInstance(out, ComponentA.Config)
+        self.assertEqual(out.dim, 5)
+        self.assertFalse(hasattr(out, "extra"))  # src-only field dropped
+
+    def test_non_dataclass_target_raises(self):
+        with self.assertRaises(TypeError):
+            derive(ComponentA.Config(), object)
+
+
+class _Model(Configurable):
+    """Stand-in for a model config (a `Configurable.Config` with components)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        block: ComponentA.Config = field(default_factory=ComponentA.Config)
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class _TrainerCfgHolder(Configurable):
+    """Stand-in for Trainer.Config holding a ModelSpec under `model_spec`."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        model_spec: object = None
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+def _make_spec():
+    from torchtitan.protocols.model_spec import ModelSpec
+
+    return ModelSpec(
+        name="m",
+        flavor="f",
+        model=_Model.Config(),
+        parallelize_fn=lambda: None,
+        pipelining_fn=None,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=None,
+    )
+
+
+class TestModelSpecTraversal(unittest.TestCase):
+    """Overrides reach the model via ModelSpec.traverse with full-path FQNs."""
+
+    def setUp(self):
+        clear_overrides()
+
+    def tearDown(self):
+        clear_overrides()
+
+    def test_fqns_are_full_path_from_root(self):
+        root = _TrainerCfgHolder.Config(model_spec=_make_spec())
+        model_fqns = [fqn for fqn, *_ in root.traverse(_Model.Config)]
+        comp_fqns = [fqn for fqn, *_ in root.traverse(ComponentA.Config)]
+        # The model config and its components keep the path from the root.
+        self.assertEqual(model_fqns, ["model_spec.model"])
+        self.assertEqual(comp_fqns, ["model_spec.model.block"])
+
+    def test_component_override_through_model_spec(self):
+        @override("blk", target=ComponentA.Config)
+        def blk(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim)
+
+        spec = _make_spec()
+        root = _TrainerCfgHolder.Config(model_spec=spec)
+        replacements = apply_overrides(OverrideConfig(imports=[__name__]), root)
+        self.assertEqual(len(replacements), 1)
+        self.assertIsInstance(spec.model.block, ComponentB.Config)
+
+    def test_whole_model_vs_component_conflict_detected(self):
+        # Regression: a whole-model override (FQN "model_spec.model") and a
+        # component override ("model_spec.model.block") must be flagged as an
+        # ancestor conflict, not silently lose the component override.
+        @override("whole_model", target=_Model.Config)
+        def whole(cfg: _Model.Config) -> _Model.Config:
+            return _Model.Config()
+
+        @override("blk", target=ComponentA.Config)
+        def blk(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim)
+
+        root = _TrainerCfgHolder.Config(model_spec=_make_spec())
+        with self.assertRaisesRegex(ValueError, "ancestor"):
+            apply_overrides(OverrideConfig(imports=[__name__]), root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/config/OVERRIDE.md
+++ b/torchtitan/config/OVERRIDE.md
@@ -1,0 +1,515 @@
+# Configurable Override Mechanism
+
+Swap any `Configurable` in a torchtitan training config — a model component,
+optimizer, loss, dataloader, and so on — for an alternative implementation
+without editing in-repo code, by importing a module that registers an override.
+This is the reference for how the mechanism works and how to write overrides.
+
+## Motivation
+
+Torchtitan has a config-driven build system: every component defines a nested
+`Config` dataclass and `config.build()` constructs the owning object. Swapping a
+component (e.g. Float8 quantization, LoRA) currently works via
+`ModelConfigConverter`, which traverses the model config tree and replaces
+`Config` nodes during config construction, inside `config_registry.py` functions.
+
+That works well for in-repo, first-class features, but it requires editing the
+repo for *every* alternative implementation. The override mechanism removes that
+requirement for three classes of work:
+
+1. **Hardware-specific kernels.** Efficient Triton/CUDA kernels for rotary
+   embeddings, fused attention, or custom norms that target specific hardware.
+   These are valuable for performance but are (a) hardware-specific, (b) harder
+   to maintain, and (c) reasonably held to a lower code-quality bar than core.
+   We want to offer vendors a clean extension point rather than either lowering
+   the core bar or saying "no".
+
+2. **Larger fused regions.** An efficient MoE may fuse dispatch–compute–combine
+   with custom routing, communication, and quantization. This spans several
+   `Config` nodes and is best expressed as a single replacement at a higher
+   scope (e.g. replace `MoE.Config` wholesale).
+
+3. **Team experimentation.** Trying a non-trivial implementation without
+   threading intrusive changes through core, then keeping or discarding it
+   cheaply.
+
+### In-repo vs. external
+
+The same mechanism serves both in-repo examples (`torchtitan/overrides/`) and
+external packages, and the decision of where an implementation lives maps onto
+the goals above:
+
+- **In-repo (`torchtitan/overrides/`)** — illustrative examples and broadly
+  useful kernels we are willing to maintain at a lower bar than core. They are
+  opt-in and never run unless requested, so they cannot regress default
+  behavior.
+- **External package** — vendor- or hardware-specific code, or anything we do
+  not want to maintain in-tree. It lives in the vendor's namespace and is
+  activated by listing its module path.
+
+**Non-goals.** An operator-override API in TorchTitan. To replace or add an op,
+use PyTorch's custom-operator path and wrap the op in a `Module` — see
+[Custom kernels and `torch.compile`](#custom-kernels-and-torchcompile).
+TorchTitan does not provide an op-level override surface.
+
+## Design Overview
+
+Override authors register a factory against a `Configurable.Config` class. After
+config construction and before any `build()`, the mechanism traverses the config
+tree and replaces matching nodes with the factory's output.
+
+### Core principles
+
+- **Explicit opt-in.** Nothing happens unless the user lists modules in
+  `override.imports`. No auto-detection from hardware or installed packages.
+- **Strictly scoped to the request.** Only overrides *registered by the listed
+  modules* (or their submodules) are applied — not the whole global table. This
+  is enforced by provenance (the module a factory is defined in).
+- **Per-instance targeting, per-node conflicts.** An override selects *which*
+  matched nodes it claims via `fqns` (FQN globs). Two overrides conflict only
+  when they claim the *same node* (or one claims an ancestor of the other's
+  node) — not merely the same Config class. So two vendors' norm kernels on
+  different layers, or A/B-ing a kernel per layer, compose cleanly; genuine
+  collisions error out.
+- **Any `Configurable`.** Overrides apply across the entire `Trainer.Config`
+  tree — model components, optimizer, loss, dataloader, etc. — not just the
+  model.
+- **Minimal surface.** The whole mechanism lives in
+  `torchtitan/config/override.py`, reusing the `Configurable.Config.traverse()` +
+  replace pattern that the Float8/LoRA converters already use.
+
+## How It Works
+
+### Registration
+
+An override module defines a replacement and registers a factory with
+`@override`:
+
+`TritonRoPE` below is **illustrative** (a compact subclass-adds-one-field
+example); no `triton_rope.py` is shipped. It is a valid override: each attention
+module owns a `rope` submodule (a `RoPE.Config`), so swapping in a custom RoPE is
+an ordinary component override.
+
+```python
+from dataclasses import dataclass
+
+from torchtitan.config import derive, override
+from torchtitan.models.common.rope import RoPE
+
+
+class TritonRoPE(RoPE):
+    """RoPE applied with a Triton kernel (illustrative)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(RoPE.Config):
+        block_size: int = 128
+
+    def __init__(self, config: Config): ...
+    def forward(self, query, key, positions=None): ...
+
+
+@override("triton_rope", target=RoPE.Config,
+          description="Triton rotary embedding, ~2x faster on A100+")
+def triton_rope(cfg: RoPE.Config) -> TritonRoPE.Config:
+    # `derive` copies every field shared with RoPE.Config; the factory states
+    # only its deltas. See "Deriving the replacement config" below.
+    return derive(cfg, TritonRoPE.Config, block_size=128)
+```
+
+The factory receives the matched config and returns its replacement. *Which*
+instances it applies to is controlled declaratively by `fqns` (see
+[per-instance targeting](#per-instance-targeting)), not by inspecting fields
+inside the factory.
+
+### Deriving the replacement config
+
+Prefer `derive(cfg, NewConfig, **deltas)` over hand-copying each field. It builds
+`NewConfig` by copying fields shared by name with `cfg`, applying `deltas` on
+top; the factory states only what it actually changes.
+
+This matters for version-robustness. Hand-copying couples a factory to the
+target's field set at the time it was written:
+
+```python
+# Fragile: RoPE.Config has many fields (theta, scaling, rope_factor, beta_fast,
+# ...); hand-copying only some silently drops the rest to their defaults — and a
+# field added later would be dropped too, with no error.
+return TritonRoPE.Config(dim=cfg.dim, max_seq_len=cfg.max_seq_len,
+                         theta=cfg.theta, scaling=cfg.scaling)
+
+# Robust: every RoPE.Config field (including ones added later, inherited by the
+# subclass TritonRoPE.Config) is copied automatically; only block_size is a delta.
+return derive(cfg, TritonRoPE.Config, block_size=128)
+```
+
+Semantics: fields on both `cfg` and `NewConfig` are copied from `cfg`; fields
+only on `NewConfig` come from `deltas` (else their declared default); fields only
+on `cfg` are dropped; a delta naming a field that doesn't exist on `NewConfig`
+raises. Copying is shallow (like `dataclasses.replace`), which is fine because
+the matched node is being replaced and detached. `derive` is most valuable when
+the replacement subclasses the target (the common drop-in case), where new core
+fields are inherited and thus carried over for free.
+
+**Configuration is code.** An override takes no CLI flags (it runs after CLI
+parsing), so the override module *is* its configuration: bake sensible defaults
+into the factory (above, `block_size=128`). A user who wants different values
+imports their own module that registers a factory with their deltas — e.g.
+`derive(cfg, TritonRoPE.Config, block_size=256)`. We deliberately don't add a
+CLI-settable `kwargs` dict (untyped, error-prone) or a typed override-`Config`
+parsed at config-construction time (which would re-couple the config registry to
+the override package, defeating the no-touch goal).
+
+### Activation
+
+```bash
+torchtitan_train --module llama3 --config llama3_8b \
+    --override.imports torchtitan.overrides.fused_swiglu
+```
+
+### Application
+
+In `Trainer.__init__`, after `model_config.update_from_config()` (which sets
+sharding config on the pre-override modules) and before any component is built:
+
+1. Import the listed modules — this triggers their `@override` decorators.
+2. Resolve the *active* set: overrides whose defining module is one of the
+   listed imports (or a submodule of one).
+3. Collect claims: traverse the original tree and record every `(override,
+   node)` pair, filtered by each override's `fqns` selector.
+4. Check for per-node conflicts (two overrides claiming the same node, or one
+   claiming an ancestor of another's node).
+5. Apply: build each replacement and swap it in. Because claims are gathered
+   before any mutation, application is order-independent (replacements are never
+   re-traversed).
+6. Log every replacement.
+
+```
+INFO: [Override] fused_swiglu: model_spec.model.layers.0.feed_forward FeedForward.Config -> FusedSwiGLU.Config
+INFO: [Override] fused_swiglu: model_spec.model.layers.1.feed_forward FeedForward.Config -> FusedSwiGLU.Config
+...
+INFO: Applied 32 override(s)
+```
+
+The model config is reached even though it is nested under a non-`Configurable`
+`ModelSpec`: `ModelSpec.traverse` exposes its `model` entry to the traversal.
+FQNs are kept as full paths from the `Trainer.Config` root — the model config is
+`model_spec.model` and a component is `model_spec.model.layers.0.feed_forward`.
+Preserving the full path (rather than resetting to bare model names) is what lets
+per-node conflict detection recognize a whole-model override as an ancestor of a
+component override. (This differs from converter `filter_fqns`, which are bare
+because converters traverse the model config directly.)
+
+### External packages
+
+```python
+# vendor_x/overrides.py
+from torchtitan.config import override
+from torchtitan.models.common.moe import MoE
+
+
+@override("vendor_x_fused_moe", target=MoE.Config,
+          description="Vendor X fused MoE for XPU")
+def vendor_x_moe(cfg: MoE.Config) -> "VendorXFusedMoE.Config":
+    return VendorXFusedMoE.Config(num_experts=cfg.num_experts, ...)
+```
+
+```bash
+pip install torchtitan-vendor-x
+torchtitan_train --module deepseek_v3 --config dsv3_671B \
+    --override.imports vendor_x.overrides
+```
+
+### Version compatibility
+
+An override depends on the internal `Config` shapes it reads and the modules it
+imports, so external packages should:
+
+- **Pin a torchtitan version range** they have validated against. The override
+  contract is the public `Configurable.Config` fields of the targets; these can
+  change across releases.
+- **Align their pytorch-nightly expectation** with the torchtitan version they
+  pin, since hardware kernels are typically nightly-sensitive. Document the
+  tested torchtitan × pytorch pair in the package.
+
+## Per-instance Targeting
+
+Targeting is first-class, not an afterthought: many motivating cases collide by
+design (two vendors with norm kernels, or A/B-ing a kernel per layer). The
+`fqns` selector on `@override` says *which* matched nodes an override claims,
+declaratively — no field-sniffing inside the factory.
+
+`fqns` is one of:
+
+- `None` (default) — every instance of `target`.
+- a list of FQN globs — `fnmatch` style, where `*` also crosses `.`; a node is
+  claimed if any glob matches its FQN.
+
+The FQN is the full path from the `Trainer.Config` root, e.g. a model component
+is `model_spec.model.layers.0.feed_forward` and the optimizer is `optimizer`.
+Globs with `*` (which crosses `.`) keep selectors readable.
+
+```python
+# NVFP4 on every in-layer linear, leaving the top-level LM head ("...output")
+# untouched (required for NVFP4; useful for MXFP8)
+@override("nvfp4_linear", target=Linear.Config,
+          fqns=["*.layers.*.attention.*", "*.layers.*.feed_forward.*"])
+def nvfp4_linear(cfg: Linear.Config) -> "NVFP4Linear.Config":
+    return NVFP4Linear.Config(in_features=cfg.in_features, ...)
+
+# Fused MoE only on the later layers
+@override("vendor_moe", target=MoE.Config, fqns=["*.layers.1[0-9].moe"])
+def vendor_moe(cfg: MoE.Config) -> "VendorMoE.Config":
+    return VendorMoE.Config(num_experts=cfg.num_experts, ...)
+```
+
+`fqns` accepts globs only. A general predicate selector (`(fqn, cfg) -> bool`),
+which would also enable field/type-based selection (e.g. "skip already-quantized
+linears"), is listed under [Future work](#future-work).
+
+### Per-node conflict detection
+
+Conflicts are detected per *node*, not per *class*. Two overrides may target the
+same Config class freely as long as their claimed nodes are disjoint — so one
+norm kernel on `*.layers.0.*` and another on `*.layers.1.*` coexist, and A/B-ing
+a kernel across layers works. An error is raised only when two different overrides
+claim the **same node**, or when one claims an **ancestor** of another's node
+(nested replacement, which would be order-dependent). The fix in both cases is
+to narrow the `fqns` selectors so the claims are disjoint.
+
+Claims are gathered from the **original** tree before any mutation, and a
+replacement is never re-traversed, so application is order-independent — one
+override can never silently affect what another matches.
+
+#### Parent- and child-class overrides
+
+This same rule answers the parent/child question directly. Say override A
+targets a parent Config (e.g. `MoE.Config`) and override B targets a Config
+nested inside it (e.g. `GroupedExperts.Config`):
+
+- **Disjoint subtrees** (A on `...layers.0.moe`, B on `...layers.1.moe.experts`)
+  — the claimed nodes are unrelated, so both apply.
+- **Overlapping** (A on `...layers.0.moe`, B on `...layers.0.moe.experts`) — B's
+  node is inside A's, the ancestor case above, so we **error**.
+
+We error rather than pick one of the two plausible behaviors implicitly:
+
+1. *Apply the parent, then override a child in the new parent.* Only meaningful
+   if A's replacement still exposes a matching child, and it reintroduces
+   ordering (parent-before-child) and re-traversal — which we deliberately avoid.
+2. *Silently drop the child override* (when A's replacement has a different
+   structure with no such child). A silent no-op is exactly the kind of
+   surprise that hides bugs.
+
+Because claims are collected on the original tree, we can't even tell at
+check time which case a given pair would fall into — so instead of guessing, we
+ask the author to disambiguate: narrow `fqns` so the claims are disjoint, or drop
+one override (e.g. let the parent override subsume the child).
+
+## Scope: any `Configurable`
+
+Overrides traverse the whole `Trainer.Config`, so the optimizer, loss,
+dataloader, and validator configs are overridable too — not only model
+components. For example, an emerging or mixed-precision optimizer can be swapped
+in by targeting `OptimizersContainer.Config` without editing a config registry
+function. The model config is reached via `ModelSpec.traverse` (above); the model
+config itself is a valid target (whole-model swap), while `ModelSpec` is not — a
+`target` must be a `Configurable.Config` subclass, so a plain class like
+`ModelSpec` is rejected at registration.
+
+## Interaction with Converters
+
+In-repo converters (Float8, LoRA via `ModelConfigConverter`) run *first*, inside
+`model_registry()` during config construction; overrides run later in
+`Trainer.__init__` and see the post-converter tree. The order is deliberate: an
+in-repo converter cannot be expected to understand arbitrary external overrides,
+so it runs against the known core configs, and overrides layer on top.
+
+Conversely, converter-style transforms *can* be expressed as overrides (a
+factory that rewrites a `Config`), so external code does not need the converter
+machinery.
+
+| Override Target | Conflicts with a converter? | Notes |
+|-----------------|------------------------------|-------|
+| RoPE / FeedForward / MoE / RMSNorm / inner attention | No | Converters don't touch these |
+| GroupedExperts.Config | Possibly | `Float8GroupedExpertsConverter` rewrites this |
+| Linear.Config | Yes | Float8/LoRA replace these |
+
+Where a converter already rewrote a node, target that node by location with
+`fqns` so the override only claims the instances you intend (e.g. specific
+layers the converter left as plain `Linear.Config`). Field/type-based exclusion
+— "skip instances already turned into `Float8Linear.Config`" — is not expressible
+with FQN globs alone and motivates the future predicate selector.
+
+### Override vs. converter: which to use
+
+Converters are the right home for **core, broadly-applicable transforms that
+preserve a property we guarantee** (e.g. batch-invariance, which is largely
+op-level and must hold across the model). Overrides exist for an *unblocking*
+purpose: swapping in an alternative implementation. By design we make **no
+promise that any core property survives an arbitrary override** — that is the
+override author's responsibility. So features like batch-invariant mode stay
+converters, not overrides.
+
+## Checkpoint Compatibility
+
+An override that changes a module's parameter layout changes its checkpoint
+FQNs. An override checkpoints whatever real parameters it defines, and is
+interoperable with another checkpoint only when the FQNs match. The fused
+example (`fused_swiglu.py`) defines one `w13` parameter, so it saves/loads
+`...feed_forward.w13` — **not** the stock `w1.weight` / `w3.weight`. A fused
+checkpoint round-trips with another fused run; it is *not* a drop-in for stock
+checkpoints (and vice-versa).
+
+**Module-level `state_dict` hooks do NOT bridge this** — neither the low-level
+`_save_to_state_dict` / `_load_from_state_dict` nor the public `state_dict()` /
+`load_state_dict()`. It is tempting to present `w13` as `w1.weight` / `w3.weight`
+that way. It works under plain `nn.Module.load_state_dict`, but torchtitan
+checkpoints via DCP `get_model_state_dict` / `set_model_state_dict`, which read
+the keys from `state_dict()` and then run `_get_fqns()` on every key — resolving
+it back to a *real* module attribute via `getattr` (DCP needs the actual param
+object for DTensor/FSDP metadata and in-place load). A fabricated `w1` key has no
+backing attribute, so both paths raise `'FusedSwiGLU' object has no attribute
+'w1'` regardless of which method produced the key. The one escape `_get_fqns`
+offers, `_fqn_modifiers`, only renames/skips an intermediate attribute name; it
+cannot split one parameter into two keys. Do not use this approach.
+
+**The sanctioned mechanism is a model-level `BaseStateDictAdapter`** — the same
+hook used for HF conversion (`Llama3StateDictAdapter`). An adapter transforms the
+flat key→tensor dict *after* `get_model_state_dict`, so it can split `w13` into
+`w1.weight`/`w3.weight` (and recombine on load) without any attribute-resolution
+problem. The catch: the adapter is set on `ModelSpec` (per model), and the
+override mechanism does not expose a hook for an override to contribute one. So
+layout-changing overrides are self-consistent but not stock-compatible — until
+an override-contributed adapter hook exists (see [Future work](#future-work)),
+treat them as checkpoint-incompatible with stock, or pair them with a model whose
+`state_dict_adapter` performs the mapping.
+
+A candidate design (tracked in
+[#3569](https://github.com/pytorch/torchtitan/issues/3569)) is to add an optional
+`state_dict_translator` argument to `@override` that is plugged into the model's
+existing `from_hf` / `to_hf` conversion. The override would declare the
+fused↔canonical FQN mapping (e.g. `w13` ↔ `w1.weight`/`w3.weight`) alongside its
+factory, and the adapter would apply it on save/load — letting an override use
+its own internal FQNs while still reading/writing checkpoints in the canonical
+format.
+
+## Parallelism
+
+Parallelism is expressed entirely through the `Module` protocol: a replacement
+satisfies `init_states` and declares a `ShardingConfig` for the states and
+activations it wants sharded. `Module.parallelize()` reads that `ShardingConfig`
+exactly as it does for core modules, so an override composes with TP/FSDP by
+declaring its own sharding — nothing model-specific is required, and the
+mechanism deliberately stays config-driven rather than depending on imperative
+per-model parallelization code.
+
+One thing worth stating plainly:
+
+- **Fusion under TP.** Fusing weights can interact subtly with tensor
+  parallelism — the fused tensor's layout must admit a correct shard. A *flat*
+  fused gate+up weight `(2*hidden, dim)` has none (`spmd.S(0)` would hand one rank
+  all of `w1` and another all of `w3`). The fix is a layout whose TP-sharded axis
+  gives each rank matching slices: `fused_swiglu` stores `w13` as
+  `(hidden, 2, dim)` and shards `spmd.S(0)` on `hidden`, so each rank holds
+  `(hidden/tp, 2, dim)` — a slice of both gate and up (the Megatron
+  column-parallel layout). `hidden` is also dim 0, so FSDP shards it cleanly at
+  any degree. The single GEMM is an `einsum` that keeps `hidden` sharded, so it
+  never reshapes across the sharded axis. This composes with FSDP and TP through
+  the ordinary `ShardingConfig`; no model-specific code.
+
+## Custom kernels and `torch.compile`
+
+An override that wraps a custom CUDA or Triton kernel must stay compatible with
+`torch.compile`, because torchtitan compiles the transformer blocks by default
+(`compile.components` includes `"model"`). A raw kernel call is opaque to Dynamo
+and will graph-break or fail to trace. Making it compose is the override
+author's responsibility — the mechanism deliberately adds **no** TorchTitan
+operator-override API. Instead, register the kernel as a first-class PyTorch
+custom operator, which gives `torch.compile` (and export) a concrete contract:
+
+- **`torch.library.custom_op`** — wrap a Python/CUDA-extension kernel as an op
+  with a stable schema and a clear functional/mutation contract.
+- **`torch.library.triton_op`** — register a Triton-kernel-backed op so the
+  kernel is visible to (and traceable by) `torch.compile` rather than a black
+  box.
+- **fake / meta kernel** (`register_fake`) — a shape/dtype-only implementation
+  so tracing, `torch.compile`, and export can propagate metadata without running
+  the kernel.
+- **autograd registration** (`register_autograd`) — supply the backward so the
+  op works in training, not only inference.
+- **`torch.library.opcheck`** — test schema / fake / autograd consistency; a
+  good unit test to ship in the override package.
+
+The override module then wraps the registered op in its replacement `Module`,
+and TorchTitan's mechanism keeps operating purely at the `Configurable` / Module
+level. See PyTorch's "Custom Operators" landing page and the Triton-op tutorial
+for the full recipe.
+
+## Composability Notes
+
+- **Context parallelism** is applied on the Attention module. An override of the
+  attention block (or its inner attention) must remain compatible with that
+  application point; this is a composability surface to respect.
+- **Agentic / automated search.** Making model impls, optimizers, and kernels
+  uniformly swappable at config time is a building block for automated
+  hill-climbing over implementations. This mechanism, the GraphTrainer registries,
+  and kernel-fusion prototypes are complementary; keeping the override surface
+  small and declarative is what makes programmatic swapping tractable.
+
+## Worked Examples
+
+- `torchtitan/overrides/fused_swiglu.py` — **the in-repo example.** A fused
+  SwiGLU feed-forward demonstrating custom `__init__` parametrization (one fused
+  `(hidden, 2, dim)` `w13` weight, one GEMM), `param_init`, and a `sharding_config`
+  that composes with both FSDP and TP (see "Fusion under TP" above). Needs no
+  prerequisite. See "Checkpoint Compatibility" for why it is not interoperable
+  with stock checkpoints.
+
+The `TritonRoPE` snippets above are illustrative — no `triton_rope.py` is
+shipped — but RoPE is a fully valid override target: each attention module owns a
+`rope` submodule (`RoPE.Config`), so a custom RoPE is an ordinary component
+override.
+
+## Code map
+
+| File | Role |
+|------|------|
+| `torchtitan/config/override.py` | The mechanism: `OverrideConfig`, `Override`, `override`, `derive`, `apply_overrides`, `clear_overrides`. |
+| `torchtitan/config/__init__.py` | Re-exports the override API. |
+| `torchtitan/protocols/model_spec.py` | `ModelSpec.traverse` exposes the nested model config to the traversal. |
+| `torchtitan/trainer.py` | Holds the `override` config field; applies overrides after `update_from_config`, before builds. |
+| `torchtitan/overrides/` | In-repo example implementations (`fused_swiglu.py`). |
+| `tests/unit_tests/test_override.py` | Unit tests: registration, provenance, FQN targeting, per-node conflicts, `derive`. |
+
+Overriding a component requires no changes to any model's `config_registry.py`
+or `__init__.py` — that is the point of the design.
+
+## At a Glance
+
+- **Activation.** Explicit opt-in via `override.imports`; only overrides
+  registered by the listed modules (provenance-checked) are applied.
+- **Conflicts.** Per-node, not per-class: overrides may share a target class as
+  long as their claimed nodes are disjoint; same-node or ancestor/descendant
+  claims error.
+- **Per-instance targeting.** Via `fqns` (FQN globs) on `@override`; the factory
+  is pure construction.
+- **Scope.** Any `Configurable` in the `Trainer.Config` tree.
+- **Config construction.** Use `derive(cfg, NewConfig, **deltas)` so factories
+  don't silently drop fields added to the target later.
+- **Override-specific config.** Via a small custom module; no new config surface.
+- **Checkpoint.** Layout-changing overrides checkpoint their own parameters and
+  are not stock-interoperable; module-level `state_dict` hooks do not work (use a
+  model-level `BaseStateDictAdapter`).
+
+## Future Work
+
+- **Override-contributed state-dict adapter**
+  ([#3569](https://github.com/pytorch/torchtitan/issues/3569)). A hook so a
+  layout-changing override can register an FQN translation (split/merge params)
+  that plugs into the model's `BaseStateDictAdapter` (`from_hf`/`to_hf`), making
+  it interoperable with stock checkpoints — e.g. an optional
+  `state_dict_translator` argument on `@override`. Until then, such overrides are
+  checkpoint-incompatible with stock.
+- **Predicate `fqns` selector.** A `(fqn, cfg) -> bool` selector to complement
+  the glob strings, enabling field/type-based selection (e.g. skipping linears a
+  converter already turned into `Float8Linear.Config`).

--- a/torchtitan/config/__init__.py
+++ b/torchtitan/config/__init__.py
@@ -23,6 +23,14 @@ from .configs import (
 from .configurable import Configurable
 from .function import Function
 from .manager import ConfigManager
+from .override import (
+    apply_overrides,
+    clear_overrides,
+    derive,
+    Override,
+    override,
+    OverrideConfig,
+)
 
 __all__ = [
     "ConfigManager",
@@ -36,4 +44,11 @@ __all__ = [
     "CommConfig",
     "TrainingConfig",
     "DebugConfig",
+    # Override mechanism
+    "OverrideConfig",
+    "Override",
+    "override",
+    "derive",
+    "apply_overrides",
+    "clear_overrides",
 ]

--- a/torchtitan/config/override.py
+++ b/torchtitan/config/override.py
@@ -1,0 +1,353 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Configurable override mechanism.
+
+Swaps any ``Configurable`` (model components, optimizer, loss, dataloader, …)
+for an alternative implementation — without modifying config_registry functions
+or any other in-repo code.
+
+An override author writes a Python module that registers a factory via the
+``@override`` decorator, then the user activates it by listing that module in
+``--override.imports``. Overrides are applied to the config tree(s) after config
+construction and before any ``build()``.
+
+Per-instance targeting is first-class: ``@override(..., fqns=[...])`` selects
+*which* matched nodes to replace by FQN glob, and conflict detection is per-node
+— two overrides only collide when they claim the same node, not merely the same
+Config class. This supports e.g. "fused MoE on these layers only" and A/B-ing a
+kernel across layers.
+
+See ``torchtitan/config/OVERRIDE.md`` for the full design document.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field, fields, is_dataclass
+from fnmatch import fnmatch
+from typing import cast, TYPE_CHECKING, TypeVar
+
+from torchtitan.tools.logging import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torchtitan.config.configurable import Configurable
+
+# Precise return type for ``derive``: the constructed ``target_config`` class.
+_ConfigT = TypeVar("_ConfigT", bound="Configurable.Config")
+
+
+@dataclass(kw_only=True, slots=True)
+class OverrideConfig:
+    imports: list[str] = field(default_factory=list)
+    """
+    Python module paths to import for override registration.
+
+    Each module is imported once at startup, triggering any ``@override``
+    decorators it defines. Only overrides registered by these modules (or their
+    submodules) are applied — not the entire global registry.
+
+    Example: ``["torchtitan.overrides.fused_swiglu", "vendor_x.kernels"]``
+
+    See ``torchtitan/config/OVERRIDE.md`` for details.
+    """
+
+
+@dataclass
+class Override:
+    """A single registered override.
+
+    ``factory`` constructs the replacement config from the matched config.
+    ``fqns`` selects which matched nodes the override claims (see
+    :func:`override`).
+    """
+
+    name: str
+    target_cls: type[Configurable.Config]
+    factory: Callable[[Configurable.Config], Configurable.Config]
+    fqns: list[str] | None
+    description: str
+    origin_module: str
+
+    def matches(self, fqn: str) -> bool:
+        """Whether this override claims the node at ``fqn``.
+
+        ``fqns`` is ``None`` (every instance of ``target_cls``) or a list of FQN
+        globs (``fnmatch``; ``*`` also crosses ``.``); a node matches if any glob
+        matches its FQN.
+        """
+        if self.fqns is None:
+            return True
+        return any(fnmatch(fqn, pattern) for pattern in self.fqns)
+
+
+_REGISTRY: dict[str, Override] = {}
+
+
+def override(
+    name: str,
+    *,
+    target: type[Configurable.Config],
+    fqns: list[str] | None = None,
+    description: str = "",
+) -> Callable:
+    """Decorator to register an override factory.
+
+    Args:
+        name: Unique identifier for this override (e.g. ``"triton_rope"``).
+        target: The ``Configurable.Config`` class to replace. Instances of this
+            class (and its subclasses) are candidates; ``fqns`` narrows them.
+        fqns: Per-instance selector. ``None`` (default) claims every instance; a
+            list of FQN globs (``fnmatch`` style, where ``*`` also crosses
+            ``.``) claims instances whose FQN matches any glob. The FQN is the
+            bare module FQN, e.g. ``"layers.0.feed_forward"``. (A general
+            predicate selector may be added later if needed.)
+        description: Human-readable description, surfaced in the override log.
+
+    The decorated function takes the matched config and returns its replacement.
+
+    Example — fuse MoE only on the later layers::
+
+        @override("vendor_moe", target=MoE.Config,
+                  fqns=["layers.1[0-9].moe"],
+                  description="Vendor fused MoE")
+        def _vendor_moe(cfg: MoE.Config) -> VendorMoE.Config:
+            return VendorMoE.Config(num_experts=cfg.num_experts, ...)
+    """
+    # Lazy import avoids a config-package import cycle; safe because override
+    # modules are imported well after the config package is loaded.
+    from torchtitan.config.configurable import Configurable
+
+    if not (isinstance(target, type) and issubclass(target, Configurable.Config)):
+        raise TypeError(
+            f"override('{name}', target=...) must be a Configurable.Config "
+            f"subclass, got {target!r}. Targets like ModelSpec or a plain class "
+            f"are not overridable; pick the component's `.Config`."
+        )
+
+    def decorator(fn: Callable) -> Callable:
+        if name in _REGISTRY:
+            raise ValueError(
+                f"Override '{name}' is already registered (by module "
+                f"'{_REGISTRY[name].origin_module}'). Each override name must be "
+                f"unique across all imported modules."
+            )
+        _REGISTRY[name] = Override(
+            name=name,
+            target_cls=target,
+            factory=fn,
+            fqns=fqns,
+            description=description,
+            origin_module=fn.__module__,
+        )
+        return fn
+
+    return decorator
+
+
+def derive(
+    source: Configurable.Config,
+    target_cls: type[_ConfigT],
+    **deltas: object,
+) -> _ConfigT:
+    """Build ``target_cls`` by copying fields shared with ``source``, then deltas.
+
+    A robust alternative to hand-copying each field in an override factory:
+
+    - fields on both ``source`` and ``target_cls`` → copied by name from ``source``
+    - fields only on ``target_cls`` → from ``deltas``, else the field's default
+    - fields only on ``source`` → dropped
+
+    The point is version-robustness: when the target ``Config`` later gains a
+    field (typically inherited, since replacements usually subclass the target),
+    ``derive`` copies it automatically instead of silently reverting to the
+    default. The factory states only the deltas it genuinely changes.
+
+    Copying is shallow (like ``dataclasses.replace``): nested configs are shared
+    by reference, which is fine because the ``source`` node is being replaced and
+    detached from the tree.
+
+    Args:
+        source: The matched source config (a dataclass instance).
+        target_cls: The replacement ``Configurable.Config`` *class*.
+        deltas: Field values to set/override on the replacement. A key not
+            present on ``target_cls`` raises ``ValueError``.
+
+    Returns:
+        A ``target_cls`` instance.
+
+    Example::
+
+        @override("triton_rope", target=RoPE.Config)
+        def triton_rope(cfg: RoPE.Config) -> TritonRoPE.Config:
+            return derive(cfg, TritonRoPE.Config, block_size=128)
+    """
+    if not (isinstance(target_cls, type) and is_dataclass(target_cls)):
+        raise TypeError(
+            f"derive() target_cls must be a dataclass type, got {target_cls!r}"
+        )
+
+    target_field_names = {f.name for f in fields(target_cls) if f.init}
+    unknown = set(deltas) - target_field_names
+    if unknown:
+        raise ValueError(
+            f"derive() got deltas for fields not on {target_cls.__qualname__}: "
+            f"{sorted(unknown)}"
+        )
+
+    source_field_names = (
+        {f.name for f in fields(source)} if is_dataclass(source) else set()
+    )
+    kwargs = dict(deltas)
+    for name in target_field_names:
+        # Delta wins; otherwise copy a shared field; otherwise leave the
+        # target's own default to apply (do not pass the key).
+        if name not in kwargs and name in source_field_names:
+            kwargs[name] = getattr(source, name)
+    # ``is_dataclass`` narrowed ``target_cls`` to a generic dataclass type,
+    # erasing ``_ConfigT``; cast back so the precise return type is preserved.
+    return cast(_ConfigT, target_cls(**kwargs))
+
+
+def _resolve_active(imports: list[str]) -> list[Override]:
+    """Return overrides registered by the listed import modules (or submodules).
+
+    Provenance is the module where the factory is defined (``fn.__module__``),
+    matched against each listed import by exact name or submodule prefix. This
+    keeps application strictly limited to the user's ``override.imports`` even
+    when other code paths have registered overrides into the global table.
+    """
+    prefixes = tuple(imports)
+    active = []
+    for ov in _REGISTRY.values():
+        origin = ov.origin_module
+        if any(origin == p or origin.startswith(p + ".") for p in prefixes):
+            active.append(ov)
+    return active
+
+
+@dataclass
+class _Claim:
+    """One (override, matched node) pair, collected before any mutation."""
+
+    ov: Override
+    fqn: str
+    cfg: Configurable.Config
+    parent: object
+    attr: str | int
+
+
+def _collect_claims(
+    active: list[Override], config_root: Configurable.Config
+) -> list[_Claim]:
+    """Traverse the original tree and gather every node each override claims.
+
+    Collecting before mutating makes application order-independent: replacements
+    are never re-traversed, so one override cannot affect another's matches.
+    """
+    claims: list[_Claim] = []
+    for ov in active:
+        for fqn, cfg, parent, attr in config_root.traverse(ov.target_cls):
+            if ov.matches(fqn):
+                claims.append(_Claim(ov=ov, fqn=fqn, cfg=cfg, parent=parent, attr=attr))
+    return claims
+
+
+def _check_node_conflicts(claims: list[_Claim]) -> None:
+    """Raise if two *different* overrides claim the same node or nested nodes.
+
+    Per-node, not per-class: two overrides of the same Config class on disjoint
+    FQNs do not conflict. Conflicts are (a) the exact same node claimed twice, or
+    (b) one override claiming an ancestor of another override's node — both make
+    the outcome order-dependent.
+    """
+    # (a) exact same node, identified by container + key.
+    by_node: dict[tuple[int, str | int], str] = {}
+    for c in claims:
+        key = (id(c.parent), c.attr)
+        owner = by_node.get(key)
+        if owner is not None and owner != c.ov.name:
+            raise ValueError(
+                f"Overrides '{owner}' and '{c.ov.name}' both claim node "
+                f"'{c.fqn}'. Narrow their `fqns` selectors so they target "
+                f"disjoint nodes."
+            )
+        by_node[key] = c.ov.name
+
+    # (b) one node is an ancestor of another (nested replacement).
+    for a in claims:
+        for b in claims:
+            if a.ov.name == b.ov.name:
+                continue
+            if b.fqn.startswith(a.fqn + "."):
+                raise ValueError(
+                    f"Override '{a.ov.name}' claims '{a.fqn}', an ancestor of "
+                    f"'{b.fqn}' claimed by '{b.ov.name}'. Nested overrides are "
+                    f"order-dependent; narrow their `fqns` selectors."
+                )
+
+
+def apply_overrides(
+    override_config: OverrideConfig,
+    config_root: Configurable.Config,
+) -> list[str]:
+    """Import override modules and apply active overrides to the config tree.
+
+    Args:
+        override_config: The override settings (which modules to import).
+        config_root: The config tree to traverse and mutate in place. The
+            trainer passes the top-level ``Trainer.Config``; the model config
+            nested under ``ModelSpec`` is reached via ``ModelSpec.traverse``.
+
+    Returns a list of human-readable log lines describing each replacement.
+    """
+    for mod_path in override_config.imports:
+        try:
+            importlib.import_module(mod_path)
+        except ImportError as e:
+            raise ImportError(
+                f"Failed to import override module '{mod_path}': {e}"
+            ) from e
+
+    active = _resolve_active(override_config.imports)
+    claims = _collect_claims(active, config_root)
+    _check_node_conflicts(claims)
+
+    replacements: list[str] = []
+    for c in claims:
+        new_cfg = c.ov.factory(c.cfg)
+        if isinstance(c.parent, list) and isinstance(c.attr, int):
+            c.parent[c.attr] = new_cfg
+        elif isinstance(c.attr, str):
+            setattr(c.parent, c.attr, new_cfg)
+        replacements.append(
+            f"[Override] {c.ov.name}: {c.fqn} "
+            f"{type(c.cfg).__qualname__} -> {type(new_cfg).__qualname__}"
+        )
+
+    if replacements:
+        for line in replacements:
+            logger.info(line)
+        logger.info(f"Applied {len(replacements)} override(s)")
+    elif override_config.imports:
+        # The user asked for overrides but nothing matched — likely a wrong
+        # `target` class, a `fqns` glob that matches no node, or a module that
+        # registered no override. Surface it rather than silently no-op.
+        logger.warning(
+            f"override.imports={override_config.imports} produced no "
+            f"replacements. Check that the imported modules register overrides "
+            f"whose `target` and `fqns` match nodes in the config tree."
+        )
+
+    return replacements
+
+
+def clear_overrides() -> None:
+    """Remove all registered overrides. Intended for testing."""
+    _REGISTRY.clear()

--- a/torchtitan/overrides/__init__.py
+++ b/torchtitan/overrides/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+In-repo override implementations.
+
+Each module here registers one or more overrides via the ``@override``
+decorator from ``torchtitan.config``. These are held to a lower code-quality
+bar than core (they may be hardware-specific or experimental) and are opt-in:
+nothing here runs unless the user lists the module in ``--override.imports``.
+
+External packages (e.g. hardware vendors) follow the same pattern in their own
+namespace; this folder is the in-repo example of the convention.
+
+See ``torchtitan/config/OVERRIDE.md``.
+"""

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Example override: a SwiGLU feed-forward with a single fused gate+up weight.
+
+This is the worked example referenced in ``torchtitan/config/OVERRIDE.md``. It
+demonstrates the pieces a non-trivial fused module needs to plug in via the
+override mechanism, *without touching core*:
+
+1. Custom ``__init__`` parametrization — ``w1`` and ``w3`` of the stock
+   :class:`FeedForward` are fused into one parameter ``w13`` of shape
+   ``(hidden_dim, 2, dim)`` (``w13[:, 0]`` is the gate / stock ``w1``,
+   ``w13[:, 1]`` the up / stock ``w3``). The gate+up projection is a single GEMM.
+2. Weight initialization via the ``Module`` protocol (``param_init``).
+3. A ``sharding_config`` that supports both FSDP and tensor parallelism.
+4. Registration via ``@override`` targeting ``FeedForward.Config``.
+
+Tensor parallelism — the ``(hidden_dim, 2, dim)`` layout is what makes TP work.
+``w13`` is sharded ``Shard(0)`` on the ``hidden_dim`` axis, so each TP rank holds
+``(hidden_dim/tp, 2, dim)`` — a matching slice of *both* the gate and up
+projections (the Megatron column-parallel layout for gated MLPs). A flat
+``(2*hidden, dim)`` weight has no correct TP sharding (``Shard(0)`` there would
+give one rank all of ``w1`` and another all of ``w3``); the explicit ``2`` dim
+fixes that. ``hidden_dim`` is also dim 0, so FSDP shards the large axis cleanly
+at any degree. The layout is contiguous and transpose-free, so it costs nothing
+at compute time: the single GEMM is expressed with ``einsum`` (which contracts
+``dim`` and keeps ``hidden`` sharded), and never reshapes across the sharded axis.
+
+NOTE (checkpoint compatibility) — this module checkpoints its own ``w13``
+parameter (FQN ``...feed_forward.w13``); it is **not** interchangeable with stock
+``FeedForward`` checkpoints (``w1.weight`` / ``w3.weight``). A checkpoint saved
+with this override only loads back into a run that also uses it, and vice-versa.
+torchtitan's checkpointing uses DCP ``get_model_state_dict`` /
+``set_model_state_dict``, which resolve every state-dict key back to a real
+module attribute for DTensor/FSDP handling. A module-level ``state_dict`` hook
+that fabricates ``w1``/``w3`` keys is therefore bypassed and in fact errors
+(``'FusedSwiGLU' object has no attribute 'w1'``). Cross-layout interop with stock
+checkpoints requires a model-level ``BaseStateDictAdapter`` (the same mechanism
+used for HF conversion), which operates on the flat key→tensor dict after
+``get_model_state_dict``. The override mechanism does not yet expose a hook to
+contribute such an adapter; a candidate design (an optional
+``state_dict_translator`` on ``@override`` feeding ``from_hf``/``to_hf``) is
+tracked in https://github.com/pytorch/torchtitan/issues/3569. See ``OVERRIDE.md``
+"Checkpoint Compatibility".
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import spmd_types as spmd
+import torch
+import torch.nn.functional as F
+
+from torchtitan.config import derive, override
+from torchtitan.models.common.decoder_sharding import dense_param_placement
+from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.common.nn_modules import Linear
+from torchtitan.protocols.module import Module
+from torchtitan.protocols.sharding import ShardingConfig
+from torchtitan.tools.logging import logger, warn_once
+
+__all__ = ["FusedSwiGLU"]
+
+
+class FusedSwiGLU(Module):
+    """SwiGLU FFN with the gate and up projections fused into one parameter.
+
+    ``w13`` has shape ``(hidden_dim, 2, dim)``: ``w13[:, 0]`` is the gate
+    projection (the stock ``w1``) and ``w13[:, 1]`` the up projection (the stock
+    ``w3``). A single GEMM computes both; the result is split into gate/up. The
+    down projection ``w2`` is reused as-is from the stock config. ``hidden_dim``
+    is dim 0, so TP shards it (``Shard(0)``, matching gate/up slices per rank) and
+    FSDP shards it cleanly at any degree (see module docstring).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        dim: int
+        hidden_dim: int
+        w2: Linear.Config
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.dim = config.dim
+        self.hidden_dim = config.hidden_dim
+        # Fused gate+up weight, gate=w13[:, 0], up=w13[:, 1] (see class docstring).
+        self.w13 = torch.nn.Parameter(torch.empty(config.hidden_dim, 2, config.dim))
+        self.w2 = config.w2.build()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # One GEMM contracting `dim`; keeps the `hidden` axis (TP-sharded),
+        # without ever reshaping across the sharded axis.
+        gate, up = torch.einsum("...d,hgd->...hg", x, self.w13).unbind(-1)
+        return self.w2(F.silu(gate) * up)
+
+
+@override(
+    "fused_swiglu",
+    target=FeedForward.Config,
+    description="Fuse SwiGLU gate+up into one weight (FSDP + TP).",
+)
+def fused_swiglu(cfg: FeedForward.Config) -> FusedSwiGLU.Config:
+    # Warn once: fused checkpoints (`w13`) are not interchangeable with stock
+    # FeedForward checkpoints (`w1.weight`/`w3.weight`). See module docstring.
+    warn_once(
+        logger,
+        "fused_swiglu override active: the fused module stores a single 'w13' "
+        "parameter, so its checkpoints are NOT interchangeable with stock "
+        "FeedForward checkpoints ('w1.weight'/'w3.weight'). A checkpoint saved "
+        "with this override only loads into a run that also uses it. See "
+        "torchtitan/config/OVERRIDE.md 'Checkpoint Compatibility'.",
+    )
+
+    # Initialize each half of the fused weight with its own initializer:
+    # `w13[:, 0]` is the gate (stock `w1`) and `w13[:, 1]` the up (stock `w3`).
+    # In stock FeedForward these differ — `w1` uses the plain linear init while
+    # `w3` shares `w2`'s depth-scaled init — so applying one to the whole tensor
+    # would mis-initialize the up half. Keyed by the fused param name "w13" for
+    # the Module init protocol.
+    w1_init = (cfg.w1.param_init or {}).get("weight")
+    w3_init = (cfg.w3.param_init or {}).get("weight")
+    param_init = None
+    if w1_init is not None and w3_init is not None:
+        # Rebind to non-Optional locals: type narrowing from the `if` above does
+        # not propagate into the nested closure that captures these.
+        gate_init: Callable = w1_init
+        up_init: Callable = w3_init
+
+        def _init_w13(t: torch.Tensor) -> None:
+            gate_init(t[:, 0, :])  # gate (stock w1)
+            up_init(t[:, 1, :])  # up (stock w3)
+
+        param_init = {"w13": _init_w13}
+
+    # `derive` copies fields shared by name (e.g. `w2`) structurally; only the
+    # genuinely-different fields are passed as deltas.
+    fused = derive(
+        cfg,
+        FusedSwiGLU.Config,
+        dim=cfg.w1.in_features,
+        hidden_dim=cfg.w1.out_features,
+        param_init=param_init,
+    )
+
+    # Shard `w13` on the hidden axis (dim 0) under TP — matching gate/up slices
+    # per rank. Reuse the original FFN's input-activation redistribution (set on
+    # `cfg.sharding_config` by the model's sharding pass) if present; `w2`
+    # carries its stock rowwise sharding (copied by `derive`).
+    base = cfg.sharding_config
+    fused.sharding_config = ShardingConfig(
+        state_shardings={"w13": dense_param_placement(tp=spmd.S(0))},
+        in_src_shardings=base.in_src_shardings if base is not None else None,
+        in_dst_shardings=base.in_dst_shardings if base is not None else None,
+    )
+    return fused

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -4,15 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections.abc import Callable
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
 
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
+
+if TYPE_CHECKING:
+    from torchtitan.config import Configurable
 
 # Type aliases for ModelSpec callables
 ParallelizeFunction: TypeAlias = Callable[..., nn.Module]
@@ -23,6 +28,7 @@ FragmentFunction: TypeAlias = Callable[..., list[nn.Module]]
 PostOptimizerBuildFn: TypeAlias = Callable[..., None]
 
 
+# TODO: deprecate ModelSpec, move fields to model config or trainer config
 @dataclass
 class ModelSpec:
     """Per-model bundle. Contains already-selected arch config + callables."""
@@ -30,8 +36,6 @@ class ModelSpec:
     name: str
     flavor: str
     model: BaseModel.Config
-    # TODO: improve the serializability of ModelSpec by refactoring the following
-    #       fields, e.g. by having their own classes, or hard-coding into trainer
     # NOTE: Callable fields use bare ``Callable`` instead of the parameterised
     # TypeAliases (e.g. ``ParallelizeFunction``) because tyro's type-parameter
     # resolver does not handle ``Callable[..., X]`` (Ellipsis as param spec).
@@ -41,3 +45,22 @@ class ModelSpec:
     pipelining_fn: Callable | None
     post_optimizer_build_fn: Callable | None
     state_dict_adapter: type[BaseStateDictAdapter] | None
+
+    def traverse(
+        self, config_cls: type, *, _prefix: str = ""
+    ) -> Iterator[tuple[str, "Configurable.Config", object, str | int]]:
+        """Expose the nested model config to ``Configurable.Config.traverse``.
+
+        ``ModelSpec`` is a plain dataclass, not a ``Configurable.Config``, so a
+        traversal of ``Trainer.Config`` would otherwise stop here. Implementing
+        ``traverse`` lets the override mechanism reach the model config and its
+        components. Only ``self.model`` is exposed; the callable fields
+        (``parallelize_fn`` etc.) are intentionally not traversable.
+        """
+        model_fqn = f"{_prefix}.model" if _prefix else "model"
+        if isinstance(self.model, config_cls):
+            # The model config itself matches — yield it; mirror the generic
+            # traverse, which does not descend into a matched node.
+            yield model_fqn, self.model, self, "model"
+        else:
+            yield from self.model.traverse(config_cls, _prefix=model_fqn)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -37,6 +37,7 @@ from torchtitan.config.configs import (
     ParallelismConfig,
     TrainingConfig,
 )
+from torchtitan.config.override import apply_overrides, OverrideConfig
 from torchtitan.distributed import full_dtensor, ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 
@@ -97,6 +98,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         comm: CommConfig = field(default_factory=CommConfig)
         validator: Validator.Config = field(default_factory=Validator.Config)
         debug: DebugConfig = field(default_factory=DebugConfig)
+        override: OverrideConfig = field(default_factory=OverrideConfig)
         loss: BaseLoss.Config = field(default_factory=BaseLoss.Config)
 
         def __post_init__(self):
@@ -226,6 +228,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             config=config,
         )
         self.model_config = model_config
+
+        # Apply overrides to the full config tree, before any component is
+        # built. The model config is reached via ModelSpec.traverse. Model
+        # overrides must run after update_from_config above (it sets sharding
+        # config on the pre-override modules); all other components (optimizer,
+        # loss, dataloader, …) are built later in __init__.
+        if config.override.imports:
+            apply_overrides(config.override, config)
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")
 


### PR DESCRIPTION
2026/06/07 update:

Addressed most comments, and aimed for landing, with latest design updated in `torchtitan/config/OVERRIDE.md`

In particular, I created a `FusedSwiGLU` override, but admitted that checkpoint incompatibility between fused and non-fused version. Issue tracked in https://github.com/pytorch/torchtitan/issues/3569.

---------------------------------

With the following main goals

**[GOAL 1]**
Provide users a way to use efficient kernels that are not "native implementations".
- main goal is to provide decent performance on ops that don't have efficient implementations in pytorch core, e.g. [RoPE](https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/common/rope.py) with various context-length extension methods.
- lower bar on code maintainability for kernel code; can iterate fast. Similar gist to how we look at agent tooling https://github.com/pytorch/torchtitan/pull/3323#pullrequestreview-4301364966
- doesn't aim to support all hardware, may start with Triton for H100 (available in CI)
- if the `torchtitan/registry` folder grows too quick / becomes messy, we probably should create a separate repo to host overrides

**[GOAL 2]**
Provide team a way to experiment with and showcase non-trivial implementations, without making intrusive changes to the rest of repo
- e.g. fused quantized MoE (cc @vkuzo @danielvegamyhre)

**[GOAL 3]**
Provide hardware vendors a way to override modules, without touching the main repo.
- addresses https://github.com/pytorch/torchtitan/issues/2183
- e.g. https://github.com/pytorch/torchtitan/pull/3266 could be applied without upstreaming, optionally with its own pip package

**[NO GOAL]**
- op-level overrides: one should consider pytorch native ways, e.g. via `torch.library`
- the proposal is orthogonal to graph capture -- it is override author's responsibility to make sure the registered module can be traced (cc @SherlockNoMad @xmfan @aditvenk)

**Please read torchtitan/registry/DESIGN.md for details.** Feedback is welcome.

Additional notes
- [alternative proposal](https://gist.github.com/syed-ahmed/169d3bf96eedefd51e4a001a02a617b8) from @syed-ahmed