### PR TITLE
[graph_trainer] Fix eager SAC policy mm counter to reset at layer boundaries

### DIFF
--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -67,14 +67,22 @@ def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
 
     Matches the behavior of torchtitan.distributed.activation_checkpoint:
     every second mm/linear op is marked PREFER_RECOMPUTE instead of MUST_SAVE.
+    The mm counter resets at each layer boundary so every layer sees the same
+    alternation pattern, just like eager AC's per-layer checkpoint_wrapper.
     """
     if save_ops is None:
         save_ops = _get_save_ops()
     mm_ops = {torch.ops.aten.mm.default, torch.ops.aten.linear.default}
     mm_count = 0
+    current_layer = None
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
-        nonlocal mm_count
+        nonlocal mm_count, current_layer
+        layer_id = _get_layer_id(node)
+        if layer_id != _NOT_IN_LAYERS and layer_id != current_layer:
+            mm_count = 0
+            current_layer = layer_id
+
         if node.target in mm_ops:
             mm_count += 1
             if node.target in save_ops and mm_count % 2 == 0:


### PR DESCRIPTION
The `_make_eager_memory_policy` used a single global mm counter across the entire traced graph. With 7 mm/linear ops per Llama3 transformer layer (odd count), the alternating SAVE/RECOMPUTE pattern shifted on every odd-numbered layer, diverging from the per-layer behavior of BaseInductor's eager AC (`_apply_op_sac`), which creates a fresh counter per `checkpoint_wrapper`.

This caused odd layers to save 3 mm outputs instead of 4, resulting in asymmetric per-layer activation memory and extra backward recomputation.

Reset the mm counter when crossing a layer boundary so the eager policy produces identical per-layer decisions as BaseInductor's selective AC.

Verified with a node-by-node comparison script on Llama3 debugmodel (6 layers, 7 mm ops/layer): 0 mismatches after the fix (was 21 before, all on odd layers 1, 3, 5).

Authored by Claude.