### PR TITLE
Add grouped RaggedShard bucket layout

### DIFF
--- a/torchtitan/experiments/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/__init__.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from .flex_shard import (
+    BucketParamStorageLayout,
     BucketSpec,
+    BucketStorageLayout,
     flex_shard,
     get_global_shape,
     get_placements,
@@ -19,7 +21,9 @@ from .flex_shard import (
 
 
 __all__ = [
+    "BucketParamStorageLayout",
     "BucketSpec",
+    "BucketStorageLayout",
     "flex_shard",
     "get_global_shape",
     "get_placements",

--- a/torchtitan/experiments/flex_shard/example/__init__.py
+++ b/torchtitan/experiments/flex_shard/example/__init__.py
@@ -6,6 +6,8 @@
 
 from .owned import Owned, param_boundary_placements
 from .ragged_shard import (
+    GroupedRaggedShard,
+    make_grouped_ragged_placement_fn,
     make_ragged_placement_fn,
     per_param_ragged_placements,
     RaggedShard,
@@ -13,6 +15,8 @@ from .ragged_shard import (
 from .shard import per_param_placements, Shard
 
 __all__ = [
+    "GroupedRaggedShard",
+    "make_grouped_ragged_placement_fn",
     "make_ragged_placement_fn",
     "Owned",
     "param_boundary_placements",

--- a/torchtitan/experiments/flex_shard/example/ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/example/ragged_shard.py
@@ -13,10 +13,11 @@ from typing import Any, TYPE_CHECKING
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch._prims_common import make_contiguous_strides_for
 from typing_extensions import override
 
 from ..flex_shard.placement_contract import (
+    BucketParamStorageLayout,
+    BucketStorageLayout,
     Placement,
     PlacementPreparedReduceGrad,
     PlacementPreparedUnshard,
@@ -453,10 +454,6 @@ class GroupedRaggedShard(RaggedShard):
             "GroupedRaggedShard(" f"dims={self.dims}, local_units={self.local_units})"
         )
 
-    @override
-    def uses_bucket_param_infos(self) -> bool:
-        return True
-
     def _bucket_layout(self, info: ParamInfo) -> BucketLayout:
         layout = info.bucket_layout
         if layout is None:
@@ -478,7 +475,7 @@ class GroupedRaggedShard(RaggedShard):
     ) -> torch.Size:
         raise NotImplementedError(
             "GroupedRaggedShard computes local shapes from the whole bucket. "
-            "Use create_bucket_param_infos() instead."
+            "Use bucket_storage_layout() instead."
         )
 
     @override
@@ -553,20 +550,16 @@ class GroupedRaggedShard(RaggedShard):
         return torch.Size([local_numel // suffix_numel, *suffix_shape])
 
     @override
-    def create_bucket_param_infos(
+    def bucket_storage_layout(
         self,
         named_params: list[tuple[str, nn.Parameter]],
         param_placements: dict[str, tuple[Placement, ...]],
         mesh: DeviceMesh,
-    ) -> tuple[dict[str, ParamInfo], int] | None:
-        from ..flex_shard.bucket_storage import (
-            BucketLayout,
-            BucketParamLayout,
-            ParamInfo,
-        )
+    ) -> BucketStorageLayout:
+        from ..flex_shard.bucket_storage import BucketLayout, BucketParamLayout
 
         if not named_params:
-            return {}, 0
+            return BucketStorageLayout(param_layouts={}, total_bytes=0)
         if len(self.local_units) != mesh.size():
             raise ValueError(
                 "GroupedRaggedShard local_units length must match world size: "
@@ -627,22 +620,14 @@ class GroupedRaggedShard(RaggedShard):
             rank_numels=rank_numels,
             param_layouts=param_layouts,
         )
-        param_infos: dict[str, ParamInfo] = {}
-        for fqn, param in named_params:
-            placements = param_placements[fqn]
+        storage_layouts: dict[str, BucketParamStorageLayout] = {}
+        for fqn, _ in named_params:
             local_shape, local_numel, byte_offset = local_metadata[fqn]
-            param_infos[fqn] = ParamInfo(
-                fqn=fqn,
-                global_shape=param.shape,
-                global_stride=tuple(make_contiguous_strides_for(param.shape)),
-                dtype=dtype,
-                requires_grad=param.requires_grad,
-                placements=placements,
+            storage_layouts[fqn] = BucketParamStorageLayout(
                 local_shape=local_shape,
                 local_numel=local_numel,
                 byte_offset=byte_offset,
                 storage_nbytes=local_numel * dtype.itemsize,
-                global_numel=param.numel(),
                 bucket_layout=bucket_layout,
             )
 
@@ -653,7 +638,10 @@ class GroupedRaggedShard(RaggedShard):
                 "that assign parameter data to every non-empty rank."
             )
 
-        return param_infos, rank_numels[rank] * dtype.itemsize
+        return BucketStorageLayout(
+            param_layouts=storage_layouts,
+            total_bytes=rank_numels[rank] * dtype.itemsize,
+        )
 
     @override
     def copy_param_to_storage(

--- a/torchtitan/experiments/flex_shard/example/ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/example/ragged_shard.py
@@ -13,6 +13,7 @@ from typing import Any, TYPE_CHECKING
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from torch._prims_common import make_contiguous_strides_for
 from typing_extensions import override
 
 from ..flex_shard.placement_contract import (
@@ -27,7 +28,12 @@ from ..flex_shard.utils import _record_comm_if_eager, _record_function_if_eager
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
 
-    from ..flex_shard.bucket_storage import ParamInfo, PlacementFn
+    from ..flex_shard.bucket_storage import (
+        BucketLayout,
+        BucketParamLayout,
+        ParamInfo,
+        PlacementFn,
+    )
 
 
 class RaggedShard(Placement):
@@ -406,6 +412,494 @@ class RaggedShard(Placement):
         return PlacementReduceGradResult(sharded_grads, [recv_buf])
 
 
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"Expected positive alignment, got {alignment}.")
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+class GroupedRaggedShard(RaggedShard):
+    """Bucket-global RaggedShard with DBuffer-style param-major layout.
+
+    Unlike ``RaggedShard``, this placement plans the whole bucket as one
+    param-major logical buffer, then shards that buffer into rank-local ranges.
+    That makes the all-gather output directly viewable as full parameters.
+    """
+
+    @dataclass(frozen=True)
+    class _UnshardState:
+        infos: list[ParamInfo]
+        pg: Any
+        debug_fqn: str | None
+
+    @dataclass(frozen=True)
+    class _ReduceGradState:
+        infos: list[ParamInfo]
+        rank: int
+        pg: Any
+        debug_fqn: str | None
+        padded_segment_numel: int
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GroupedRaggedShard):
+            return False
+        return self.dims == other.dims and self.local_units == other.local_units
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.dims, self.local_units))
+
+    def __repr__(self) -> str:
+        return (
+            "GroupedRaggedShard(" f"dims={self.dims}, local_units={self.local_units})"
+        )
+
+    @override
+    def uses_bucket_param_infos(self) -> bool:
+        return True
+
+    def _bucket_layout(self, info: ParamInfo) -> BucketLayout:
+        layout = info.bucket_layout
+        if layout is None:
+            raise AssertionError(
+                "Expected GroupedRaggedShard ParamInfo to carry a bucket layout."
+            )
+        return layout
+
+    def _param_layout(self, info: ParamInfo) -> BucketParamLayout:
+        layout = self._bucket_layout(info)
+        return layout.param_layouts[info.fqn]
+
+    @override
+    def compute_local_shape(
+        self,
+        global_shape: torch.Size,
+        rank: int,
+        world_size: int,
+    ) -> torch.Size:
+        raise NotImplementedError(
+            "GroupedRaggedShard computes local shapes from the whole bucket. "
+            "Use create_bucket_param_infos() instead."
+        )
+
+    @override
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError(
+            "GroupedRaggedShard extracts local shards from bucket-global ranges. "
+            "Use bucket storage views instead."
+        )
+
+    def _param_alignment_numel(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+    ) -> int:
+        alignment = 1
+        for _, param in named_params:
+            self._prefix_numel(param.shape)
+            suffix_numel = self._suffix_numel(param.shape)
+            alignment = math.lcm(alignment, suffix_numel)
+        return alignment
+
+    def _bucket_param_offsets(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        alignment_numel: int,
+    ) -> tuple[dict[str, int], int]:
+        offsets: dict[str, int] = {}
+        current_offset = 0
+        for fqn, param in named_params:
+            current_offset = _align_up(current_offset, alignment_numel)
+            offsets[fqn] = current_offset
+            current_offset += param.numel()
+        return offsets, current_offset
+
+    def _bucket_rank_layout(
+        self,
+        unpadded_global_numel: int,
+        alignment_numel: int,
+    ) -> tuple[int, tuple[int, ...], tuple[int, ...]]:
+        total_units = sum(self.local_units)
+        padded_global_numel = _align_up(
+            unpadded_global_numel,
+            alignment_numel * total_units,
+        )
+        elements_per_unit = padded_global_numel // total_units
+        offsets: list[int] = []
+        numels: list[int] = []
+        offset = 0
+        for units in self.local_units:
+            offsets.append(offset)
+            numel = units * elements_per_unit
+            numels.append(numel)
+            offset += numel
+        return padded_global_numel, tuple(offsets), tuple(numels)
+
+    def _local_shape_from_numel(
+        self,
+        global_shape: torch.Size,
+        local_numel: int,
+    ) -> torch.Size:
+        suffix_shape = self._suffix_shape(global_shape)
+        suffix_numel = math.prod(suffix_shape)
+        if local_numel % suffix_numel != 0:
+            raise ValueError(
+                "GroupedRaggedShard bucket split produced a shard that is not "
+                f"aligned to flattened prefix rows for shape {tuple(global_shape)}."
+            )
+        return torch.Size([local_numel // suffix_numel, *suffix_shape])
+
+    @override
+    def create_bucket_param_infos(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> tuple[dict[str, ParamInfo], int] | None:
+        from ..flex_shard.bucket_storage import (
+            BucketLayout,
+            BucketParamLayout,
+            ParamInfo,
+        )
+
+        if not named_params:
+            return {}, 0
+        if len(self.local_units) != mesh.size():
+            raise ValueError(
+                "GroupedRaggedShard local_units length must match world size: "
+                f"got {len(self.local_units)} local units for world size "
+                f"{mesh.size()}."
+            )
+
+        rank = mesh.get_local_rank()
+        dtype = named_params[0][1].dtype
+        alignment_numel = self._param_alignment_numel(named_params)
+        param_offsets, unpadded_global_numel = self._bucket_param_offsets(
+            named_params,
+            alignment_numel,
+        )
+        (
+            padded_global_numel,
+            rank_offsets,
+            rank_numels,
+        ) = self._bucket_rank_layout(unpadded_global_numel, alignment_numel)
+        rank_start = rank_offsets[rank]
+        rank_end = rank_start + rank_numels[rank]
+
+        local_metadata: dict[str, tuple[torch.Size, int, int]] = {}
+        param_layouts: dict[str, BucketParamLayout] = {}
+        has_local_param_data = False
+        for fqn, param in named_params:
+            if param.dtype != dtype:
+                raise ValueError(
+                    "GroupedRaggedShard requires one dtype per bucket: "
+                    f"{named_params[0][0]!r} uses {dtype} but {fqn!r} uses "
+                    f"{param.dtype}."
+                )
+            placements = param_placements[fqn]
+            if placements != (self,):
+                raise ValueError(
+                    "GroupedRaggedShard requires the same placement instance "
+                    f"for every parameter in a bucket; {fqn!r} uses {placements!r}."
+                )
+            param_start = param_offsets[fqn]
+            param_end = param_start + param.numel()
+            local_start = max(rank_start, param_start)
+            local_end = min(rank_end, param_end)
+            local_numel = max(0, local_end - local_start)
+            if local_numel > 0:
+                has_local_param_data = True
+            local_shape = self._local_shape_from_numel(param.shape, local_numel)
+            byte_offset = (local_start - rank_start) * dtype.itemsize
+            local_metadata[fqn] = (local_shape, local_numel, byte_offset)
+            param_layouts[fqn] = BucketParamLayout(
+                param_offset=param_start,
+                local_global_offset=local_start,
+            )
+
+        bucket_layout = BucketLayout(
+            global_numel=padded_global_numel,
+            local_numel=rank_numels[rank],
+            rank_offsets=rank_offsets,
+            rank_numels=rank_numels,
+            param_layouts=param_layouts,
+        )
+        param_infos: dict[str, ParamInfo] = {}
+        for fqn, param in named_params:
+            placements = param_placements[fqn]
+            local_shape, local_numel, byte_offset = local_metadata[fqn]
+            param_infos[fqn] = ParamInfo(
+                fqn=fqn,
+                global_shape=param.shape,
+                global_stride=tuple(make_contiguous_strides_for(param.shape)),
+                dtype=dtype,
+                requires_grad=param.requires_grad,
+                placements=placements,
+                local_shape=local_shape,
+                local_numel=local_numel,
+                byte_offset=byte_offset,
+                storage_nbytes=local_numel * dtype.itemsize,
+                global_numel=param.numel(),
+                bucket_layout=bucket_layout,
+            )
+
+        if rank_numels[rank] > 0 and not has_local_param_data:
+            raise ValueError(
+                "GroupedRaggedShard planned a rank-local bucket range that "
+                "contains only padding. Split the bucket or choose local_units "
+                "that assign parameter data to every non-empty rank."
+            )
+
+        return param_infos, rank_numels[rank] * dtype.itemsize
+
+    @override
+    def copy_param_to_storage(
+        self,
+        byte_storage: torch.Tensor,
+        info: ParamInfo,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        param_data = param.detach()
+        if param_data.device.type == "meta" or info.local_numel == 0:
+            return
+        param_layout = self._param_layout(info)
+        param_offset = param_layout.local_global_offset - param_layout.param_offset
+        shard = param_data.contiguous().view(-1)[
+            param_offset : param_offset + info.local_numel
+        ]
+        nbytes = shard.numel() * shard.element_size()
+        byte_storage[info.byte_offset : info.byte_offset + nbytes].copy_(
+            shard.view(torch.uint8)
+        )
+
+    def _make_local_bucket_view(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+    ) -> torch.Tensor:
+        bucket_layout = self._bucket_layout(infos[0])
+        local_bucket_numel = bucket_layout.local_numel
+        if local_bucket_numel == 0:
+            return tensors[0].new_empty(0)
+
+        bucket_storage: torch.UntypedStorage | None = None
+        bucket_start_ptr: int | None = None
+        bucket_tensor: torch.Tensor | None = None
+        for tensor, info in zip(tensors, infos, strict=True):
+            if tensor.numel() == 0:
+                continue
+            storage = tensor.untyped_storage()
+            storage_start_ptr = tensor.data_ptr() - info.byte_offset
+            if bucket_storage is None:
+                bucket_storage = storage
+                bucket_start_ptr = storage_start_ptr
+                bucket_tensor = tensor
+            elif (
+                storage.data_ptr() != bucket_storage.data_ptr()
+                or storage_start_ptr != bucket_start_ptr
+            ):
+                raise ValueError(
+                    "GroupedRaggedShard expected local tensors to share one "
+                    "bucket storage allocation."
+                )
+            storage_offset_bytes = storage_start_ptr - storage.data_ptr()
+            if storage_offset_bytes % tensor.element_size() != 0:
+                raise AssertionError(
+                    "GroupedRaggedShard local bucket storage is not dtype-aligned."
+                )
+
+        if bucket_storage is None or bucket_start_ptr is None or bucket_tensor is None:
+            raise ValueError(
+                "GroupedRaggedShard cannot create a view-in send buffer because "
+                "this rank has no parameter tensor covering its non-empty bucket "
+                "range."
+            )
+        storage_offset_bytes = bucket_start_ptr - bucket_storage.data_ptr()
+        storage_offset = storage_offset_bytes // bucket_tensor.element_size()
+        return bucket_tensor.new_empty(0).set_(
+            bucket_storage,
+            storage_offset,
+            (local_bucket_numel,),
+            (1,),
+        )
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        send_buf = self._make_local_bucket_view(tensors, infos)
+        bucket_layout = self._bucket_layout(infos[0])
+        gathered_bucket = torch.empty(
+            bucket_layout.global_numel,
+            dtype=dtype,
+            device=device,
+        )
+        gathered_views = [
+            gathered_bucket[offset : offset + numel]
+            for offset, numel in zip(
+                bucket_layout.rank_offsets,
+                bucket_layout.rank_numels,
+                strict=True,
+            )
+        ]
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[send_buf, gathered_bucket, *gathered_views],
+            placement_state=GroupedRaggedShard._UnshardState(
+                infos=infos,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        if not isinstance(prepared.placement_state, GroupedRaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        send_buf = prepared.buffers[0]
+        gathered_views = prepared.buffers[2:]
+        with _record_comm_if_eager(
+            "FlexShard::all_gather",
+            prepared.placement_state.debug_fqn,
+        ):
+            dist.all_gather(gathered_views, send_buf, group=prepared.placement_state.pg)
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        if not isinstance(prepared.placement_state, GroupedRaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        gathered_bucket = prepared.buffers[1]
+        full_params: list[torch.Tensor] = []
+        for info in prepared.placement_state.infos:
+            param_offset = self._param_layout(info).param_offset
+            full_params.append(
+                gathered_bucket[param_offset : param_offset + info.global_numel].view(
+                    info.global_shape
+                )
+            )
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+    @override
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        world_size = mesh.size()
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        bucket_layout = self._bucket_layout(infos[0])
+        padded_segment_numel = max(bucket_layout.rank_numels)
+        with _record_function_if_eager("FlexShard::reduce_scatter_copy_in", debug_fqn):
+            global_grad_bucket = torch.zeros(
+                bucket_layout.global_numel,
+                dtype=dtype,
+                device=device,
+            )
+            for tensor, info in zip(tensors, infos, strict=True):
+                param_layout = self._param_layout(info)
+                global_grad_bucket[
+                    param_layout.param_offset : param_layout.param_offset
+                    + info.global_numel
+                ].copy_(tensor.reshape(-1))
+
+            send_buf = torch.zeros(
+                world_size * padded_segment_numel,
+                dtype=dtype,
+                device=device,
+            )
+            send_buf_by_rank = send_buf.view(world_size, padded_segment_numel)
+            for rank, (offset, numel) in enumerate(
+                zip(
+                    bucket_layout.rank_offsets,
+                    bucket_layout.rank_numels,
+                    strict=True,
+                )
+            ):
+                send_buf_by_rank[rank, :numel].copy_(
+                    global_grad_bucket[offset : offset + numel]
+                )
+
+        return PlacementPreparedReduceGrad(
+            placement=self,
+            buffers=[send_buf],
+            placement_state=GroupedRaggedShard._ReduceGradState(
+                infos=infos,
+                rank=mesh.get_local_rank(),
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                padded_segment_numel=padded_segment_numel,
+            ),
+        )
+
+    @override
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        if not isinstance(
+            prepared.placement_state, GroupedRaggedShard._ReduceGradState
+        ):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._ReduceGradState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        state = prepared.placement_state
+        send_buf = prepared.buffers[0]
+        recv_buf = torch.empty(
+            state.padded_segment_numel,
+            dtype=send_buf.dtype,
+            device=send_buf.device,
+        )
+        with _record_comm_if_eager(
+            "FlexShard::reduce_scatter",
+            state.debug_fqn,
+        ):
+            dist.reduce_scatter_tensor(
+                output=recv_buf,
+                input=send_buf,
+                op=dist.ReduceOp.AVG,
+                group=state.pg,
+            )
+
+        with _record_function_if_eager(
+            "FlexShard::reduce_scatter_copy_out",
+            state.debug_fqn,
+        ):
+            sharded_grads = [
+                recv_buf[
+                    info.byte_offset
+                    // info.dtype.itemsize : info.byte_offset
+                    // info.dtype.itemsize
+                    + info.local_numel
+                ].view(info.local_shape)
+                for info in state.infos
+            ]
+        return PlacementReduceGradResult(sharded_grads, [recv_buf])
+
+
 def make_ragged_placement_fn(
     *,
     dims: tuple[int, ...],
@@ -428,6 +922,28 @@ def make_ragged_placement_fn(
     return ragged_placements
 
 
+def make_grouped_ragged_placement_fn(
+    *,
+    dims: tuple[int, ...],
+    local_units: tuple[int, ...],
+) -> PlacementFn:
+    """Return a placement function assigning one grouped RaggedShard per bucket."""
+
+    def grouped_ragged_placements(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        if len(local_units) != mesh.size():
+            raise ValueError(
+                "GroupedRaggedShard local_units length must match mesh size: "
+                f"got {len(local_units)} local units for mesh size {mesh.size()}."
+            )
+        placement = GroupedRaggedShard(dims=dims, local_units=local_units)
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return grouped_ragged_placements
+
+
 def per_param_ragged_placements(
     named_params: list[tuple[str, nn.Parameter]],
     mesh: DeviceMesh,
@@ -440,6 +956,8 @@ def per_param_ragged_placements(
 
 
 __all__ = [
+    "GroupedRaggedShard",
+    "make_grouped_ragged_placement_fn",
     "make_ragged_placement_fn",
     "per_param_ragged_placements",
     "RaggedShard",

--- a/torchtitan/experiments/flex_shard/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/__init__.py
@@ -6,11 +6,18 @@
 
 from .bucket_storage import BucketSpec, MixedPrecisionPolicy, OffloadPolicy, PlacementFn
 from .flex_shard import flex_shard
-from .placement_contract import LocalStorageLayout, Placement
+from .placement_contract import (
+    BucketParamStorageLayout,
+    BucketStorageLayout,
+    LocalStorageLayout,
+    Placement,
+)
 from .sharded_param import get_global_shape, get_placements, is_flex_shard_param
 
 __all__ = [
+    "BucketParamStorageLayout",
     "BucketSpec",
+    "BucketStorageLayout",
     "flex_shard",
     "get_global_shape",
     "get_placements",

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
@@ -99,6 +99,25 @@ class BucketSpec:
     reshard_after_forward: bool = True
 
 
+@dataclass(frozen=True)
+class BucketParamLayout:
+    """Bucket-global layout metadata for one parameter."""
+
+    param_offset: int
+    local_global_offset: int
+
+
+@dataclass(frozen=True)
+class BucketLayout:
+    """Bucket-global storage layout shared by parameters in one bucket."""
+
+    global_numel: int
+    local_numel: int
+    rank_offsets: tuple[int, ...]
+    rank_numels: tuple[int, ...]
+    param_layouts: dict[str, BucketParamLayout]
+
+
 @dataclass
 class ParamInfo:
     """Metadata for a parameter in chunked storage."""
@@ -114,6 +133,7 @@ class ParamInfo:
     byte_offset: int = 0  # byte offset into the sharded storage
     storage_nbytes: int = 0  # bytes reserved for this param's local storage
     global_numel: int = 0  # total elements in unsharded param
+    bucket_layout: BucketLayout | None = None
 
     @property
     def placement(self) -> Placement:
@@ -223,6 +243,17 @@ class ShardedBucketStorage:
         uniform dtype. Each placement owns its per-parameter local storage layout;
         bucket storage only places those layouts sequentially in the byte buffer.
         """
+        if named_params:
+            first_fqn = named_params[0][0]
+            placement = _get_single_placement(param_placements[first_fqn])
+            maybe_bucket_infos = placement.create_bucket_param_infos(
+                named_params,
+                param_placements,
+                mesh,
+            )
+            if maybe_bucket_infos is not None:
+                return maybe_bucket_infos
+
         param_infos: dict[str, ParamInfo] = {}
         current_byte_offset = 0
 

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
@@ -21,7 +21,7 @@ from .utils import _get_single_placement, _set_param_on_module
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
 
-    from .placement_contract import Placement
+    from .placement_contract import BucketStorageLayout, LocalStorageLayout, Placement
     from .reshard_after_forward import _ReshardAfterForwardRecomputeState
 
 
@@ -216,19 +216,6 @@ class ShardedBucketStorage:
         bucket_storage.install_sharded_params(expected_param_device)
         return bucket_storage
 
-    @staticmethod
-    def _compute_local_storage_layout(
-        global_shape: torch.Size,
-        dtype: torch.dtype,
-        mesh: DeviceMesh,
-        placements: tuple[Placement, ...],
-    ):
-        """Compute the placement-owned local storage layout."""
-        rank = mesh.get_local_rank()
-        world_size = mesh.size()
-        placement = _get_single_placement(placements)
-        return placement.local_storage_layout(global_shape, dtype, rank, world_size)
-
     @classmethod
     def create_param_infos(
         cls,
@@ -243,52 +230,199 @@ class ShardedBucketStorage:
         uniform dtype. Each placement owns its per-parameter local storage layout;
         bucket storage only places those layouts sequentially in the byte buffer.
         """
-        if named_params:
-            first_fqn = named_params[0][0]
-            placement = _get_single_placement(param_placements[first_fqn])
-            maybe_bucket_infos = placement.create_bucket_param_infos(
+        if not named_params:
+            return {}, 0
+
+        first_fqn = named_params[0][0]
+        placement = _get_single_placement(param_placements[first_fqn])
+        bucket_layout = placement.bucket_storage_layout(
+            named_params,
+            param_placements,
+            mesh,
+        )
+        if bucket_layout is not None:
+            return cls._create_param_infos_from_bucket_layout(
                 named_params,
                 param_placements,
-                mesh,
+                bucket_layout,
             )
-            if maybe_bucket_infos is not None:
-                return maybe_bucket_infos
+        return cls._create_param_infos_from_local_layouts(
+            named_params,
+            mesh,
+            param_placements,
+        )
 
+    @classmethod
+    def _create_param_infos_from_local_layouts(
+        cls,
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+        param_placements: dict[str, tuple[Placement, ...]],
+    ) -> tuple[dict[str, ParamInfo], int]:
+        rank = mesh.get_local_rank()
+        world_size = mesh.size()
         param_infos: dict[str, ParamInfo] = {}
         current_byte_offset = 0
-
         for fqn, param in named_params:
             placements = param_placements[fqn]
-            global_shape = param.shape
-            global_stride = make_contiguous_strides_for(global_shape)
-            dtype = param.dtype
+            placement = _get_single_placement(placements)
             local_storage_layout = cls._compute_local_storage_layout(
-                global_shape, dtype, mesh, placements
+                fqn,
+                param,
+                placement,
+                rank,
+                world_size,
             )
-            global_numel = param.numel()
-
             if local_storage_layout.storage_nbytes > 0:
                 byte_offset = current_byte_offset
                 current_byte_offset += local_storage_layout.storage_nbytes
             else:
                 byte_offset = 0
 
-            info = ParamInfo(
+            param_infos[fqn] = cls._create_param_info(
                 fqn=fqn,
-                global_shape=global_shape,
-                global_stride=tuple(global_stride),
-                dtype=dtype,
-                requires_grad=param.requires_grad,
+                param=param,
                 placements=placements,
                 local_shape=local_storage_layout.local_shape,
                 local_numel=local_storage_layout.local_numel,
                 byte_offset=byte_offset,
                 storage_nbytes=local_storage_layout.storage_nbytes,
-                global_numel=global_numel,
             )
-            param_infos[fqn] = info
 
         return param_infos, current_byte_offset
+
+    @staticmethod
+    def _compute_local_storage_layout(
+        fqn: str,
+        param: nn.Parameter,
+        placement: Placement,
+        rank: int,
+        world_size: int,
+    ) -> LocalStorageLayout:
+        try:
+            local_storage_layout = placement.local_storage_layout(
+                param.shape,
+                param.dtype,
+                rank,
+                world_size,
+            )
+        except NotImplementedError as exc:
+            raise TypeError(
+                f"Placement {placement!r} for parameter {fqn!r} must implement "
+                "the FlexShard storage layout contract."
+            ) from exc
+        except Exception as exc:
+            raise ValueError(
+                f"Placement {placement!r} is invalid for parameter {fqn!r} "
+                f"with shape {tuple(param.shape)}: {exc}"
+            ) from exc
+
+        if local_storage_layout.local_numel < 0:
+            raise ValueError(
+                f"Placement {placement!r} returned negative local_numel "
+                f"for parameter {fqn!r}."
+            )
+        if local_storage_layout.storage_nbytes < 0:
+            raise ValueError(
+                f"Placement {placement!r} returned negative storage_nbytes "
+                f"for parameter {fqn!r}."
+            )
+        return local_storage_layout
+
+    @classmethod
+    def _create_param_infos_from_bucket_layout(
+        cls,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        bucket_layout: BucketStorageLayout,
+    ) -> tuple[dict[str, ParamInfo], int]:
+        expected_fqns = {fqn for fqn, _ in named_params}
+        actual_fqns = set(bucket_layout.param_layouts)
+        if actual_fqns != expected_fqns:
+            msg_parts = []
+            missing_fqns = expected_fqns - actual_fqns
+            extra_fqns = actual_fqns - expected_fqns
+            if missing_fqns:
+                msg_parts.append(f"missing layouts for {sorted(missing_fqns)}")
+            if extra_fqns:
+                msg_parts.append(f"unexpected layouts for {sorted(extra_fqns)}")
+            raise ValueError(
+                "Placement bucket_storage_layout() must return layouts for "
+                f"exactly the provided parameters; {', '.join(msg_parts)}."
+            )
+        if bucket_layout.total_bytes < 0:
+            raise ValueError(
+                "Placement bucket_storage_layout() returned negative total_bytes."
+            )
+
+        param_infos: dict[str, ParamInfo] = {}
+        for fqn, param in named_params:
+            placements = param_placements[fqn]
+            layout = bucket_layout.param_layouts[fqn]
+            if layout.local_numel < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"local_numel for parameter {fqn!r}."
+                )
+            if layout.byte_offset < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"byte_offset for parameter {fqn!r}."
+                )
+            if layout.storage_nbytes < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"storage_nbytes for parameter {fqn!r}."
+                )
+            if (
+                layout.storage_nbytes > 0
+                and layout.byte_offset + layout.storage_nbytes
+                > bucket_layout.total_bytes
+            ):
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned storage for "
+                    f"parameter {fqn!r} outside the bucket byte range."
+                )
+
+            param_infos[fqn] = cls._create_param_info(
+                fqn=fqn,
+                param=param,
+                placements=placements,
+                local_shape=layout.local_shape,
+                local_numel=layout.local_numel,
+                byte_offset=layout.byte_offset,
+                storage_nbytes=layout.storage_nbytes,
+                bucket_layout=layout.bucket_layout,
+            )
+
+        return param_infos, bucket_layout.total_bytes
+
+    @staticmethod
+    def _create_param_info(
+        *,
+        fqn: str,
+        param: nn.Parameter,
+        placements: tuple[Placement, ...],
+        local_shape: torch.Size,
+        local_numel: int,
+        byte_offset: int,
+        storage_nbytes: int,
+        bucket_layout: BucketLayout | None = None,
+    ) -> ParamInfo:
+        return ParamInfo(
+            fqn=fqn,
+            global_shape=param.shape,
+            global_stride=tuple(make_contiguous_strides_for(param.shape)),
+            dtype=param.dtype,
+            requires_grad=param.requires_grad,
+            placements=placements,
+            local_shape=local_shape,
+            local_numel=local_numel,
+            byte_offset=byte_offset,
+            storage_nbytes=storage_nbytes,
+            global_numel=param.numel(),
+            bucket_layout=bucket_layout,
+        )
 
     def copy_params_from(
         self,

--- a/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
@@ -29,6 +29,25 @@ class LocalStorageLayout:
     storage_nbytes: int
 
 
+@dataclass(frozen=True)
+class BucketParamStorageLayout:
+    """Placement-owned bucket storage layout for one parameter."""
+
+    local_shape: torch.Size
+    local_numel: int
+    byte_offset: int
+    storage_nbytes: int
+    bucket_layout: Any | None = None
+
+
+@dataclass(frozen=True)
+class BucketStorageLayout:
+    """Placement-owned storage layout for a whole bucket."""
+
+    param_layouts: dict[str, BucketParamStorageLayout]
+    total_bytes: int
+
+
 class Placement(ABC):
     """Base class for FlexShard placement strategies.
 
@@ -97,6 +116,19 @@ class Placement(ABC):
             storage_nbytes=local_numel * dtype.itemsize,
         )
 
+    def bucket_storage_layout(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> BucketStorageLayout | None:
+        """Return an optional bucket-global storage layout.
+
+        Returning None asks ShardedBucketStorage to use the default sequential
+        per-parameter layout derived from local_storage_layout().
+        """
+        return None
+
     def copy_param_to_storage(
         self,
         byte_storage: torch.Tensor,
@@ -133,23 +165,6 @@ class Placement(ABC):
         nbytes = info.local_numel * info.dtype.itemsize
         byte_view = byte_storage[info.byte_offset : info.byte_offset + nbytes]
         return byte_view.view(info.dtype).view(info.local_shape)
-
-    def uses_bucket_param_infos(self) -> bool:
-        """Return whether this placement needs bucket-level storage planning."""
-        return False
-
-    def create_bucket_param_infos(
-        self,
-        named_params: list[tuple[str, nn.Parameter]],
-        param_placements: dict[str, tuple[Placement, ...]],
-        mesh: DeviceMesh,
-    ) -> tuple[dict[str, ParamInfo], int] | None:
-        """Optionally create ParamInfo for a whole bucket at once.
-
-        Placements with bucket-global storage requirements can override this
-        method. Returning ``None`` keeps the default per-parameter storage path.
-        """
-        return None
 
     def prepare_unshard_bucket(
         self,
@@ -238,6 +253,8 @@ class PlacementReduceGradResult:
 
 
 __all__ = [
+    "BucketParamStorageLayout",
+    "BucketStorageLayout",
     "LocalStorageLayout",
     "Placement",
     "PlacementPreparedUnshard",

--- a/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
@@ -14,6 +14,7 @@ from typing import Any, TYPE_CHECKING
 import torch
 
 if TYPE_CHECKING:
+    import torch.nn as nn
     from torch.distributed.device_mesh import DeviceMesh
 
     from .bucket_storage import ParamInfo
@@ -132,6 +133,23 @@ class Placement(ABC):
         nbytes = info.local_numel * info.dtype.itemsize
         byte_view = byte_storage[info.byte_offset : info.byte_offset + nbytes]
         return byte_view.view(info.dtype).view(info.local_shape)
+
+    def uses_bucket_param_infos(self) -> bool:
+        """Return whether this placement needs bucket-level storage planning."""
+        return False
+
+    def create_bucket_param_infos(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> tuple[dict[str, ParamInfo], int] | None:
+        """Optionally create ParamInfo for a whole bucket at once.
+
+        Placements with bucket-global storage requirements can override this
+        method. Returning ``None`` keeps the default per-parameter storage path.
+        """
+        return None
 
     def prepare_unshard_bucket(
         self,

--- a/torchtitan/experiments/flex_shard/flex_shard/utils.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/utils.py
@@ -246,6 +246,8 @@ def _validate_placements(
                 f"{fqn!r} uses {type(placement).__name__}."
             )
         param = param_dict[fqn]
+        if placement.uses_bucket_param_infos():
+            continue
         try:
             layout = placement.local_storage_layout(
                 param.shape,

--- a/torchtitan/experiments/flex_shard/flex_shard/utils.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/utils.py
@@ -234,8 +234,6 @@ def _validate_placements(
             f"provided parameters; {', '.join(msg_parts)}."
         )
 
-    rank = mesh.get_local_rank()
-    world_size = mesh.size()
     from .placement_contract import Placement
 
     for fqn, placements in param_placements.items():
@@ -244,31 +242,6 @@ def _validate_placements(
             raise TypeError(
                 "BucketSpec.placement_fn must return Placement instances, but "
                 f"{fqn!r} uses {type(placement).__name__}."
-            )
-        param = param_dict[fqn]
-        if placement.uses_bucket_param_infos():
-            continue
-        try:
-            layout = placement.local_storage_layout(
-                param.shape,
-                param.dtype,
-                rank,
-                world_size,
-            )
-        except NotImplementedError as exc:
-            raise TypeError(
-                f"Placement {placement!r} for parameter {fqn!r} must implement "
-                "the FlexShard storage layout contract."
-            ) from exc
-        except Exception as exc:
-            raise ValueError(
-                f"Placement {placement!r} is invalid for parameter {fqn!r} "
-                f"with shape {tuple(param.shape)}: {exc}"
-            ) from exc
-        if layout.local_numel < 0 or layout.storage_nbytes < 0:
-            raise ValueError(
-                f"Placement {placement!r} returned negative storage layout "
-                f"values for parameter {fqn!r}."
             )
 
 

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
@@ -370,20 +370,16 @@ class TestBucketPlacementValidation(TestCase):
 
     def test_rejects_incomplete_placement_contract(self):
         """Placement subclasses must implement the storage layout contract."""
-        from torchtitan.experiments.flex_shard.flex_shard.utils import (
-            _validate_placements,
-        )
-
         with single_rank_cpu_mesh() as mesh:
             named_params = self._named_params()
             with self.assertRaisesRegex(TypeError, "storage layout contract"):
-                _validate_placements(
+                ShardedBucketStorage.create_param_infos(
+                    named_params,
+                    mesh,
                     {
                         "a.weight": (_IncompletePlacement(),),
                         "b.weight": (_IncompletePlacement(),),
                     },
-                    named_params,
-                    mesh,
                 )
 
     def test_accepts_valid_placement_subclasses(self):
@@ -454,31 +450,24 @@ class TestBucketPlacementValidation(TestCase):
         self.assertEqual(copied, local_payload.contiguous())
 
     def test_rejects_shard_dim_out_of_range(self):
-        """Placement layout validation is front-loaded."""
-        from torchtitan.experiments.flex_shard.flex_shard.utils import (
-            _validate_placements,
-        )
+        """Placement layout validation happens during bucket storage planning."""
 
         with single_rank_cpu_mesh() as mesh:
             with self.assertRaisesRegex(ValueError, "invalid for parameter"):
-                _validate_placements(
-                    {"scalar": (Shard(0),)},
+                ShardedBucketStorage.create_param_infos(
                     [("scalar", nn.Parameter(torch.empty(())))],
                     mesh,
+                    {"scalar": (Shard(0),)},
                 )
 
     def test_rejects_owned_owner_rank_out_of_range(self):
         """Owned placement owner_rank must be valid for the mesh."""
-        from torchtitan.experiments.flex_shard.flex_shard.utils import (
-            _validate_placements,
-        )
-
         with single_rank_cpu_mesh() as mesh:
             with self.assertRaisesRegex(ValueError, "owner_rank"):
-                _validate_placements(
-                    {"weight": (Owned(1),)},
+                ShardedBucketStorage.create_param_infos(
                     [("weight", nn.Parameter(torch.empty(2, 2)))],
                     mesh,
+                    {"weight": (Owned(1),)},
                 )
 
     def test_owned_reduce_grad_single_rank(self):

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py
@@ -21,6 +21,8 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torchtitan.experiments.flex_shard import BucketSpec, flex_shard
 from torchtitan.experiments.flex_shard.example import (
+    GroupedRaggedShard,
+    make_grouped_ragged_placement_fn,
     make_ragged_placement_fn,
     per_param_ragged_placements,
     RaggedShard,
@@ -55,6 +57,17 @@ def _make_param_info(
         local_numel=local_numel,
         storage_nbytes=local_numel * tensor.dtype.itemsize,
         global_numel=tensor.numel(),
+    )
+
+
+def _expected_grouped_local(tensor: torch.Tensor, info: ParamInfo) -> torch.Tensor:
+    assert info.bucket_layout is not None
+    param_layout = info.bucket_layout.param_layouts[info.fqn]
+    start = param_layout.local_global_offset - param_layout.param_offset
+    return (
+        tensor.contiguous()
+        .view(-1)[start : start + info.local_numel]
+        .view(info.local_shape)
     )
 
 
@@ -325,6 +338,202 @@ class TestRaggedShardDistributed(FSDPTestMultiThread):
         self.assertEqual(full_param, weight)
         self.assertEqual(local_grad, local_shard)
 
+    def test_grouped_ragged_bucket_materializes_bucket_global_local_views(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(8, dtype=torch.float32).view(4, 2)
+                )
+                self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        original_params = {fqn: param.detach().clone() for fqn, param in named_params}
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            reshard_after_forward=False,
+        )
+
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+
+        current_params = dict(model.named_parameters())
+        infos = bucket_storage.param_infos
+        for fqn, info in infos.items():
+            expected = _expected_grouped_local(original_params[fqn], info)
+            self.assertEqual(current_params[fqn], expected)
+            self.assertEqual(bucket_storage.get_local_view(fqn), expected)
+            if expected.numel() > 0:
+                self.assertEqual(
+                    current_params[fqn].untyped_storage().data_ptr(),
+                    bucket_storage.byte_storage.untyped_storage().data_ptr(),
+                )
+
+    def test_grouped_ragged_rejects_padding_only_local_bucket_range(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 1))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(4, dtype=torch.float32).view(1, 4)
+                )
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 1),
+            ),
+            reshard_after_forward=False,
+        )
+
+        if self.rank == 0:
+            bucket_storage = ShardedBucketStorage.from_bucket(
+                model,
+                named_params,
+                placements,
+                mesh,
+                torch.device("cpu"),
+                bucket_spec,
+            )
+            self.assertEqual(bucket_storage.total_bytes, 4 * torch.float32.itemsize)
+        else:
+            with self.assertRaisesRegex(ValueError, "contains only padding"):
+                ShardedBucketStorage.from_bucket(
+                    model,
+                    named_params,
+                    placements,
+                    mesh,
+                    torch.device("cpu"),
+                    bucket_spec,
+                )
+
+    def test_grouped_ragged_unshard_is_view_in_and_view_out(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(8, dtype=torch.float32).view(4, 2)
+                )
+                self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        original_params = {fqn: param.detach().clone() for fqn, param in named_params}
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            reshard_after_forward=False,
+        )
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+        infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+        local_shards = [bucket_storage.get_local_view(fqn) for fqn, _ in named_params]
+
+        prepared = placement.prepare_unshard_bucket(local_shards, infos, mesh, None)
+        send_buf = prepared.buffers[0]
+        self.assertEqual(
+            send_buf.untyped_storage().data_ptr(),
+            bucket_storage.byte_storage.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(send_buf.data_ptr(), bucket_storage.byte_storage.data_ptr())
+
+        placement.run_prepared_unshard(prepared)
+        result = placement.finish_prepared_unshard(prepared).full_params
+        gathered_bucket = prepared.buffers[1]
+
+        for full_param, (fqn, original_param) in zip(
+            result,
+            named_params,
+            strict=True,
+        ):
+            self.assertEqual(full_param, original_params[fqn])
+            self.assertEqual(
+                full_param.untyped_storage().data_ptr(),
+                gathered_bucket.untyped_storage().data_ptr(),
+            )
+            self.assertNotEqual(full_param.data_ptr(), original_param.data_ptr())
+
+    def test_grouped_ragged_reduce_scatter_returns_local_grad_views(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.empty(4, 2))
+                self.bias = nn.Parameter(torch.empty(4))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            reshard_after_forward=False,
+        )
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+        weight_grad = torch.arange(8, dtype=torch.float32).view(4, 2)
+        bias_grad = torch.arange(4, dtype=torch.float32)
+        grads = [weight_grad, bias_grad]
+        infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+
+        prepared = placement.prepare_reduce_grad(grads, infos, mesh, None)
+        reduce_result = placement.reduce_prepared_grad(prepared)
+        sharded_grads = reduce_result.sharded_grads
+        recv_buf = reduce_result.buffers[0]
+
+        for grad, sharded_grad, info in zip(grads, sharded_grads, infos, strict=True):
+            self.assertEqual(sharded_grad, _expected_grouped_local(grad, info))
+            if sharded_grad.numel() > 0:
+                self.assertEqual(
+                    sharded_grad.untyped_storage().data_ptr(),
+                    recv_buf.untyped_storage().data_ptr(),
+                )
+
 
 class TestRaggedShardRuntime(FSDPTest):
     @property
@@ -394,6 +603,62 @@ class TestRaggedShardRuntime(FSDPTest):
                 self.rank,
                 self.world_size,
             )
+            self.assertEqual(param_grad.detach(), expected_grad)
+
+    @skip_if_lt_x_gpu(2)
+    def test_grouped_ragged_flex_shard_forward_backward_on_cuda_mesh(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+        reference = _TinyRaggedModule(device_type.type)
+        model = _TinyRaggedModule(device_type.type)
+        for param in [*reference.parameters(), *model.parameters()]:
+            dist.broadcast(param.data, src=0)
+        x = torch.arange(8, dtype=torch.float32, device=device_type).view(2, 4)
+        dist.broadcast(x, src=0)
+
+        ref_output = reference(x)
+        ref_output.sum().backward()
+        for param in reference.parameters():
+            if param.grad is not None:
+                dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+        original_params = {
+            fqn: param.detach().clone() for fqn, param in model.named_parameters()
+        }
+
+        flex_shard(
+            model,
+            mesh,
+            buckets=[
+                BucketSpec(
+                    ["*"],
+                    placement_fn=make_grouped_ragged_placement_fn(
+                        dims=(0,),
+                        local_units=(1, 3),
+                    ),
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+        output = model(x)
+        output.sum().backward()
+
+        self.assertEqual(output, ref_output.detach())
+        bucket_storage = model.sharded_bucket_storages[0]
+        reference_params = dict(reference.named_parameters())
+        for fqn, param in model.named_parameters():
+            info = bucket_storage.param_infos[fqn]
+            expected_param = _expected_grouped_local(original_params[fqn], info)
+            self.assertEqual(param.detach(), expected_param)
+            param_grad = param.grad
+            ref_grad = reference_params[fqn].grad
+            self.assertIsNotNone(param_grad)
+            self.assertIsNotNone(ref_grad)
+            assert param_grad is not None
+            assert ref_grad is not None
+            expected_grad = _expected_grouped_local(ref_grad.detach(), info)
             self.assertEqual(param_grad.detach(), expected_grad)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #3537
* #3502
* __->__ #3407
* #3317
* #3239

Introduce an explicit bucket-level layout contract for placements that need grouped planning, and add GroupedRaggedShard with param-major gathered storage for view-in/view-out unshard.

Tests: python -m pytest -q torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py; python -m pytest -q torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py