### PR TITLE
[rl] use wandb=False in CI

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -77,6 +77,8 @@ python torchtitan/experiments/rl/grpo.py --module rl --config rl_grpo_qwen3_0_6b
 
 **NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
 
+**Metrics:** W&B is on by default — run `wandb login` first, or pass `--metrics.no-enable-wandb` to disable. TensorBoard is also supported via `--metrics.enable-tensorboard`.
+
 We use a unified model definition from torchtitan for the trainer and generator, ensuring bitwise-identical models to address a class of subtle correctness bugs in RL for LLMs.
 
 ## Reproducibility

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -41,6 +41,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--generator.debug.no_batch_invariant",
                     "--compile.no-enable",
                     "--generator.cudagraph.no-enable",
+                    "--metrics.no-enable-wandb",
                 ],
             ],
             "RL GRPO TP=2 no compile",
@@ -57,6 +58,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--generator.sampling.n 2",
                     "--trainer.debug.no_batch_invariant",
                     "--generator.debug.no_batch_invariant",
+                    "--metrics.no-enable-wandb",
                 ],
             ],
             "RL GRPO TP=2 compile",
@@ -73,6 +75,7 @@ def build_rl_h100_test_list() -> list[OverrideDefinitions]:
                 [
                     "--module rl",
                     "--config rl_grpo_qwen3_0_6b_batch_invariant",
+                    "--metrics.no-enable-wandb",
                 ],
             ],
             "RL GRPO TP=2 batch-invariant + deterministic",


### PR DESCRIPTION
## Summary
- The RL integration configs (`rl_grpo_qwen3_0_6b{,_batch_invariant}`, `rl_grpo_qwen3_1_7b`, `rl_grpo_qwen3_14b`) set `metrics=MetricsProcessor.Config(enable_wandb=True)` since #3391
- CI machines have no W&B credentials; leaving `enable_wandb=True` makes every RL CI launch either fail at W&B init or silently noop.
- Append `--metrics.no-enable-wandb` to every RL integration command (both the 4-GPU default suite and the 8-GPU H100 batch-invariant suite) so CI runs are wandb-free without changing the default that's useful for local/dev runs.
