### PR TITLE
[NOT READY][Varlen CP] Enable Varlen attention under Context Parallel + Full DTensor

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -55,17 +55,19 @@ def _enable_full_dtensor(t: OverrideDefinitions) -> OverrideDefinitions:
     All features.py tests run under full_dtensor except PP-only variants
     (see ``_is_pp_only``) and CP + compile variants (upstream symint
     limitation); legacy non-full_dtensor coverage lives in models.py.
-    CP variants also switch to FlexAttention config because
-    full_dtensor + CP is not supported with SDPA / Varlen.
+    CP variants default to FlexAttention (full_dtensor + CP under SDPA is
+    not supported), but variants that already pick their own ``--module``
+    or ``--config`` (e.g. the varlen+CP tests) keep that selection.
     """
     new_args = []
     for variant in t.override_args:
         prefix: list[str] = []
         has_cp = any("context_parallel_degree" in arg for arg in variant)
         has_compile = any("compile.enable" in arg for arg in variant)
+        has_module = any("--module" in arg or "--config" in arg for arg in variant)
         if not _is_pp_only(variant, t.ngpu) and not (has_cp and has_compile):
             prefix.append("--parallelism.full_dtensor")
-        if has_cp:
+        if has_cp and not has_module:
             prefix.append("--module llama3 --config llama3_debugmodel_flex_attn")
         new_args.append(tuple(prefix) + tuple(variant))
     return dataclasses.replace(t, override_args=tuple(new_args))
@@ -407,6 +409,45 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "HSDP",
             "hsdp",
             ngpu=4,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.context_parallel_degree=2",
+                ]
+            ],
+            "Full DTensor CP (Varlen)",
+            "full_dtensor_cp_varlen",
+            ngpu=2,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.context_parallel_degree=2",
+                    "--parallelism.data_parallel_shard_degree=2",
+                ]
+            ],
+            "Full DTensor CP + FSDP (Varlen)",
+            "full_dtensor_cp_fsdp_varlen",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.tensor_parallel_degree=2",
+                    "--parallelism.context_parallel_degree=2",
+                    "--parallelism.data_parallel_shard_degree=2",
+                ]
+            ],
+            "Full DTensor TP + CP + FSDP (Varlen)",
+            "full_dtensor_tp_cp_fsdp_varlen",
+            ngpu=8,
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [

--- a/tests/unit_tests/test_varlen_cp.py
+++ b/tests/unit_tests/test_varlen_cp.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Pure-logic CPU tests for ``CPVarlenMetadata.from_global``.
+
+These do not require a real distributed environment; we mock the
+``DeviceMesh`` with ``_MockMesh`` and iterate over ranks manually.
+"""
+
+import torch
+from torch.distributed.tensor.experimental._attention import _HeadTailLoadBalancer
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.distributed.varlen_cp import CPVarlenMetadata
+from torchtitan.models.common.attention import VarlenMetadata
+
+
+class _MockMesh:
+    """Minimal DeviceMesh stand-in for non-distributed unit tests."""
+
+    ndim = 1
+
+    def __init__(self, world_size: int, rank: int, device_type: str = "cpu") -> None:
+        self._world_size = world_size
+        self._rank = rank
+        self.device_type = device_type
+
+    def size(self) -> int:
+        return self._world_size
+
+    def get_local_rank(self) -> int:
+        return self._rank
+
+
+def _build_varlen_meta(cu_seq_q: list[int], B: int, seq_len: int) -> VarlenMetadata:
+    """Build a global VarlenMetadata from a per-batch cumulative tensor.
+
+    The given ``cu_seq_q`` covers a single batch element ``[0, ..., seq_len]``.
+    It is replicated across ``B`` batches with offsets, matching what
+    ``create_varlen_metadata_for_document`` produces.
+    """
+    if cu_seq_q[0] != 0 or cu_seq_q[-1] != seq_len:
+        raise ValueError("cu_seq_q must start at 0 and end at seq_len")
+    per_batch = torch.tensor(cu_seq_q, dtype=torch.int32)
+    parts = [per_batch[:-1] + b * seq_len for b in range(B)]
+    parts.append(torch.tensor([B * seq_len], dtype=torch.int32))
+    cu = torch.cat(parts)
+    seg_lens = torch.diff(cu)
+    return VarlenMetadata(
+        cu_seq_q=cu,
+        cu_seq_k=cu,
+        max_q=int(seg_lens.max().item()),
+        max_k=int(seg_lens.max().item()),
+    )
+
+
+class TestCPVarlenMetadata(TestCase):
+    def _run(
+        self,
+        global_meta: VarlenMetadata,
+        cp_world_size: int,
+        B: int,
+        seq_len: int,
+        load_balancer_factory=None,
+    ) -> list[CPVarlenMetadata]:
+        results = []
+        for rank in range(cp_world_size):
+            mesh = _MockMesh(cp_world_size, rank)
+            lb = (
+                load_balancer_factory(seq_len, cp_world_size)
+                if load_balancer_factory
+                else None
+            )
+            results.append(
+                CPVarlenMetadata.from_global(
+                    global_meta,
+                    device_mesh=mesh,
+                    batch_size=B,
+                    seq_length=seq_len,
+                    load_balancer=lb,
+                )
+            )
+        return results
+
+    @staticmethod
+    def _seg_lens(meta: VarlenMetadata) -> tuple[list[int], list[int]]:
+        return (
+            torch.diff(meta.cu_seq_q).tolist(),
+            torch.diff(meta.cu_seq_k).tolist(),
+        )
+
+    def test_single_doc_no_loadbalancer(self) -> None:
+        # B=1, one doc spanning [0, 32). CP=2 -> rank 0 gets [0, 16),
+        # rank 1 gets [16, 32). rank 1 is mid-doc so its seqlen_k = 32.
+        meta = _build_varlen_meta([0, 32], B=1, seq_len=32)
+        per_rank = self._run(meta, cp_world_size=2, B=1, seq_len=32)
+        self.assertEqual(self._seg_lens(per_rank[0]), ([16], [16]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([16], [32]))
+        self.assertEqual(per_rank[0].max_q, 16)
+        self.assertEqual(per_rank[1].max_k, 32)
+
+    def test_single_doc_headtail(self) -> None:
+        # seq_len=32, CP=2, headtail chunks=8 -> rearranged
+        # [0..7, 24..31, 8..15, 16..23]. Rank 0 gets [0..7, 24..31] (one
+        # contiguous + one tail chunk -> 2 segments). Rank 1 gets [8..23]
+        # contiguous -> 1 segment.
+        meta = _build_varlen_meta([0, 32], B=1, seq_len=32)
+        per_rank = self._run(
+            meta,
+            cp_world_size=2,
+            B=1,
+            seq_len=32,
+            load_balancer_factory=lambda s, w: _HeadTailLoadBalancer(
+                s, w, torch.device("cpu")
+            ),
+        )
+        self.assertEqual(self._seg_lens(per_rank[0]), ([8, 8], [8, 32]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([16], [24]))
+
+    def test_multi_doc_straddling(self) -> None:
+        # docs [0,10), [10,50), [50,64). CP=2, no LB.
+        # rank 0 has [0..32): doc 0 fully + doc 1 prefix [10..32).
+        # rank 1 has [32..64): doc 1 mid [32..50) + doc 2 fully [50..64).
+        meta = _build_varlen_meta([0, 10, 50, 64], B=1, seq_len=64)
+        per_rank = self._run(meta, cp_world_size=2, B=1, seq_len=64)
+        self.assertEqual(self._seg_lens(per_rank[0]), ([10, 22], [10, 22]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([18, 14], [40, 14]))
+
+    def test_multi_doc_headtail(self) -> None:
+        # Same docs as test_multi_doc_straddling, with headtail balancer
+        # (chunk=16). Forward permutation is [0..16, 48..64, 16..48].
+        meta = _build_varlen_meta([0, 10, 50, 64], B=1, seq_len=64)
+        per_rank = self._run(
+            meta,
+            cp_world_size=2,
+            B=1,
+            seq_len=64,
+            load_balancer_factory=lambda s, w: _HeadTailLoadBalancer(
+                s, w, torch.device("cpu")
+            ),
+        )
+        self.assertEqual(self._seg_lens(per_rank[0]), ([10, 6, 2, 14], [10, 6, 40, 14]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([32], [38]))
+
+        # k_local_indices compose the K-gather with the inverse permutation.
+        # Rank 1 K covers original [10..48) -> [10..16) stays, [16..48) +16.
+        expected_rank1 = torch.tensor(
+            list(range(10, 16)) + list(range(32, 64)), dtype=torch.long
+        )
+        self.assertEqual(per_rank[1].k_local_indices, expected_rank1)
+        # Rank 0 K-gather covers originals [0..10), [10..16), [10..50), [50..64).
+        expected_rank0 = torch.tensor(
+            list(range(10))
+            + list(range(10, 16))
+            + list(range(10, 16))
+            + list(range(32, 64))
+            + [16, 17]
+            + list(range(18, 32)),
+            dtype=torch.long,
+        )
+        self.assertEqual(per_rank[0].k_local_indices, expected_rank0)
+
+    def test_one_token_segment(self) -> None:
+        # 1-token doc + 7-token doc; seq_len=8, CP=2.
+        meta = _build_varlen_meta([0, 1, 8], B=1, seq_len=8)
+        per_rank = self._run(meta, cp_world_size=2, B=1, seq_len=8)
+        self.assertEqual(self._seg_lens(per_rank[0]), ([1, 3], [1, 3]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([4], [7]))
+
+    def test_multi_batch_multi_doc_straddling(self) -> None:
+        # B=2, per-batch docs [10, 22] -> packed cu_seq_q =
+        # [0, 10, 32, 42, 64]. CP=2, shard_len=16.
+        # Rank 0: per-batch [0..16) -> 4 segments; k_local_indices must
+        # pick out [0..10), [10..16), [32..42), [42..48) from packed K.
+        meta = _build_varlen_meta([0, 10, 32], B=2, seq_len=32)
+        per_rank = self._run(meta, cp_world_size=2, B=2, seq_len=32)
+        self.assertEqual(self._seg_lens(per_rank[0]), ([10, 6, 10, 6], [10, 6, 10, 6]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([16, 16], [22, 22]))
+        expected_rank0_k = torch.tensor(
+            list(range(10))
+            + list(range(10, 16))
+            + list(range(32, 42))
+            + list(range(42, 48)),
+            dtype=torch.long,
+        )
+        self.assertEqual(per_rank[0].k_local_indices, expected_rank0_k)
+
+    def test_multi_batch_headtail(self) -> None:
+        # B=2, single doc per batch (cu_seq_q=[0,32,64]). CP=2, headtail
+        # chunk=8 -> per-batch forward perm [0..8, 24..32, 8..16, 16..24].
+        # Exercises the per-batch rearrange + per-batch inverse permutation
+        # composition with B > 1, which is the most error-prone path.
+        meta = _build_varlen_meta([0, 32], B=2, seq_len=32)
+        per_rank = self._run(
+            meta,
+            cp_world_size=2,
+            B=2,
+            seq_len=32,
+            load_balancer_factory=lambda s, w: _HeadTailLoadBalancer(
+                s, w, torch.device("cpu")
+            ),
+        )
+        # Rank 0 owns rearranged [0..8, 24..32] of each batch. In packed
+        # globals those are [0..8, 24..32, 32..40, 56..64], giving 4
+        # segments split by the global-discontinuities and the doc 0/1
+        # boundary at packed position 16.
+        self.assertEqual(self._seg_lens(per_rank[0]), ([8, 8, 8, 8], [8, 32, 8, 32]))
+        expected_rank0_k = torch.tensor(
+            list(range(0, 8))
+            + list(range(0, 8))
+            + list(range(16, 24))
+            + list(range(24, 32))
+            + list(range(8, 16))
+            + list(range(32, 40))
+            + list(range(32, 40))
+            + list(range(48, 56))
+            + list(range(56, 64))
+            + list(range(40, 48)),
+            dtype=torch.long,
+        )
+        self.assertEqual(per_rank[0].k_local_indices, expected_rank0_k)
+        # Rank 1 owns rearranged [8..24] of each batch. The two halves are
+        # contiguous in globals, so each batch contributes one segment.
+        self.assertEqual(self._seg_lens(per_rank[1]), ([16, 16], [24, 24]))
+        expected_rank1_k = torch.tensor(
+            list(range(0, 8))
+            + list(range(16, 24))
+            + list(range(24, 32))
+            + list(range(32, 40))
+            + list(range(48, 56))
+            + list(range(56, 64)),
+            dtype=torch.long,
+        )
+        self.assertEqual(per_rank[1].k_local_indices, expected_rank1_k)
+
+    def test_cp_world_size_4(self) -> None:
+        # CP=4 exercises off-by-one in the per-rank boundary math.
+        meta = _build_varlen_meta([0, 20, 64], B=1, seq_len=64)
+        per_rank = self._run(meta, cp_world_size=4, B=1, seq_len=64)
+        self.assertEqual(self._seg_lens(per_rank[0]), ([16], [16]))
+        self.assertEqual(self._seg_lens(per_rank[1]), ([4, 12], [20, 12]))
+        self.assertEqual(self._seg_lens(per_rank[2]), ([16], [28]))
+        self.assertEqual(self._seg_lens(per_rank[3]), ([16], [44]))
+
+    def test_seq_len_divisibility(self) -> None:
+        meta = _build_varlen_meta([0, 30], B=1, seq_len=30)
+        with self.assertRaisesRegex(ValueError, "divisible"):
+            CPVarlenMetadata.from_global(
+                meta, device_mesh=_MockMesh(4, 0), batch_size=1, seq_length=30
+            )
+
+    def test_seq_len_divisibility_with_load_balancer(self) -> None:
+        # With a load balancer, each shard is split into 2 halves, so
+        # seq_length must be divisible by 2 * cp_world_size, not just
+        # cp_world_size. seq_length=6, CP=2 satisfies CP but not 2*CP.
+        # The LB itself is never invoked because divisibility fires first.
+        meta = _build_varlen_meta([0, 6], B=1, seq_len=6)
+        lb = _HeadTailLoadBalancer(
+            seq_length=8, world_size=2, device=torch.device("cpu")
+        )
+        with self.assertRaisesRegex(ValueError, "load balancers chunk"):
+            CPVarlenMetadata.from_global(
+                meta,
+                device_mesh=_MockMesh(2, 0),
+                batch_size=1,
+                seq_length=6,
+                load_balancer=lb,
+            )
+
+    def test_cross_attention_unsupported(self) -> None:
+        meta = VarlenMetadata(
+            cu_seq_q=torch.tensor([0, 16, 32], dtype=torch.int32),
+            cu_seq_k=torch.tensor([0, 20, 40], dtype=torch.int32),
+            max_q=16,
+            max_k=20,
+        )
+        with self.assertRaisesRegex(ValueError, "self-attention"):
+            CPVarlenMetadata.from_global(
+                meta, device_mesh=_MockMesh(2, 0), batch_size=1, seq_length=32
+            )
+
+    def test_already_sharded_rejected(self) -> None:
+        # Passing a CPVarlenMetadata as if it were a global metadata
+        # should be rejected to prevent double-shard bugs.
+        meta = _build_varlen_meta([0, 32], B=1, seq_len=32)
+        sharded = CPVarlenMetadata.from_global(
+            meta, device_mesh=_MockMesh(2, 0), batch_size=1, seq_length=32
+        )
+        with self.assertRaisesRegex(ValueError, "CPVarlenMetadata"):
+            CPVarlenMetadata.from_global(
+                sharded, device_mesh=_MockMesh(2, 0), batch_size=1, seq_length=32
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -23,11 +23,13 @@ from torch.distributed.tensor.experimental._context_parallel._attention import (
 )
 from torch.nn.attention.flex_attention import BlockMask
 
+from torchtitan.distributed.varlen_cp import CPVarlenMetadata
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     FlexAttention,
     ScaledDotProductAttention,
     VarlenAttention,
+    VarlenMetadata,
 )
 from torchtitan.tools.logging import logger
 
@@ -95,7 +97,10 @@ def apply_cp_to_forward(
             mod.forward = _make_cp_forward(original_forward, cp_mesh)
 
     elif isinstance(first, VarlenAttention):
-        raise NotImplementedError("Variable-length attention CP is not yet supported")
+        raise NotImplementedError(
+            "VarlenAttention CP requires parallelism.full_dtensor=True; "
+            "the legacy forward-wrapping path does not all-gather K/V."
+        )
     else:
         raise NotImplementedError(
             f"Context Parallel forward wrapping is not supported for "
@@ -171,10 +176,12 @@ def cp_shard(
         inputs: Tuple of input tensors to be sharded along the sequence
             dimension
         attention_masks: Attention masks to be sharded. Supports None,
-            BlockMask, or dict[str, BlockMask]
+            BlockMask, dict[str, BlockMask], or VarlenMetadata.
         load_balancer_type: Type of load balancer to use. Options:
-            - "headtail": Use HeadTailLoadBalancer (for SDPA)
-            - "ptrr": Use PTRRLoadBalancer (for FlexAttention)
+            - "headtail": Use HeadTailLoadBalancer (works for SDPA, varlen,
+              and FlexAttention)
+            - "ptrr": Use PTRRLoadBalancer (FlexAttention only; not yet
+              supported for varlen)
             - None: Disable load balancing
             Defaults to "headtail".
         input_seq_dim: Sequence dimension index for sharding. Defaults to 1,
@@ -187,29 +194,49 @@ def cp_shard(
         Tuple of (sharded_inputs, attention_masks) where:
             - sharded_inputs: Tuple of input tensors sharded along the
               sequence dimension
-            - attention_masks: Sharded attention masks (BlockMask or
-              dict[str, BlockMask]) or None
+            - attention_masks: Sharded attention masks (BlockMask,
+              dict[str, BlockMask], or CPVarlenMetadata when the input
+              was a VarlenMetadata) or None
 
     Raises:
         ValueError: If load_balancer_type is "ptrr" and attention_masks
-            is None or a dict
+            is None, a dict, or a VarlenMetadata (PTRR + varlen is not
+            yet supported).
+        ValueError: If attention_masks is a VarlenMetadata and
+            input_seq_dim is not 1 (varlen sharding assumes the
+            (B, S, ...) layout).
+        ValueError: When inputs are inconsistent for varlen sharding
+            (cu_seq_q malformed, cross-attention, divisibility,
+            double-shard, non-1D mesh). See CPVarlenMetadata.from_global
+            for the full list.
     """
+    if cp_mesh.ndim != 1:
+        raise ValueError(f"cp_shard expects a 1-D CP mesh, got ndim={cp_mesh.ndim}.")
+    if isinstance(attention_masks, VarlenMetadata) and input_seq_dim != 1:
+        raise ValueError(
+            "VarlenMetadata sharding assumes inputs are (B, S, ...) "
+            f"with input_seq_dim=1; got input_seq_dim={input_seq_dim}."
+        )
     seq_len = inputs[0].size(input_seq_dim)
-    cp_world_size = cp_mesh.size(0)
+    cp_world_size = cp_mesh.size()
 
     load_balancer = None
     if load_balancer_type:
         match load_balancer_type:
             case "headtail":
-                # For SDPA, we use the _HeadTailLoadBalancer.
                 load_balancer = _HeadTailLoadBalancer(
                     seq_len, cp_world_size, cp_mesh.device_type
                 )
             case "ptrr":
-                # For FlexAttention, we use _PTRRLoadBalancer.
-                # _PTRRLoadBalancer requires attention_masks to be a BlockMask.
-                # For dict[str, BlockMask], _PTRRLoadBalancer currently doesn't
-                # support the case where there are multiple masks.
+                # _PTRRLoadBalancer is FlexAttention-only today: it needs
+                # a BlockMask to compute per-block work. The varlen variant
+                # would share the algorithm but read work from cu_seq_q,
+                # and is not yet implemented.
+                if isinstance(attention_masks, VarlenMetadata):
+                    raise ValueError(
+                        "PTRR load balancer is not yet implemented for "
+                        "varlen attention; use 'headtail' or None."
+                    )
                 if attention_masks is None or isinstance(attention_masks, dict):
                     raise ValueError(
                         "PTRRLoadBalancer requires attention_masks to be a "
@@ -237,29 +264,39 @@ def cp_shard(
         ),
     )
 
-    # BlockMask, has shape, [B, H, Q, KV], and we can only shard
-    # on the Q seq dimension, not KV.
+    # BlockMask path uses the upstream dispatcher (shard Q seq dim only;
+    # KV stays full). VarlenMetadata path uses the local CPVarlenMetadata
+    # builder since the CP-aware varlen logic lives entirely in torchtitan.
     MASK_Q_SEQ_DIM = 2
     if attention_masks is not None:
-        assert isinstance(attention_masks, (BlockMask, dict))
-        masks = (
-            [attention_masks]
-            if isinstance(attention_masks, BlockMask)
-            else list(attention_masks.values())
-        )
-        masks = _context_parallel_shard(
-            mesh=cp_mesh,
-            buffers=masks,
-            seq_dims=(MASK_Q_SEQ_DIM,) * len(masks),
-            load_balancer=load_balancer,
-        )
-        attention_masks = cast(
-            (BlockMask | dict[str, BlockMask]),
-            (
-                masks[0]
+        if isinstance(attention_masks, VarlenMetadata):
+            attention_masks = CPVarlenMetadata.from_global(
+                attention_masks,
+                device_mesh=cp_mesh,
+                batch_size=inputs[0].size(0),
+                seq_length=seq_len,
+                load_balancer=load_balancer,
+            )
+        else:
+            assert isinstance(attention_masks, (BlockMask, dict))
+            masks = (
+                [attention_masks]
                 if isinstance(attention_masks, BlockMask)
-                else {k: v for k, v in zip(attention_masks.keys(), masks)}
-            ),
-        )
+                else list(attention_masks.values())
+            )
+            masks = _context_parallel_shard(
+                mesh=cp_mesh,
+                buffers=masks,
+                seq_dims=(MASK_Q_SEQ_DIM,) * len(masks),
+                load_balancer=load_balancer,
+            )
+            attention_masks = cast(
+                (BlockMask | dict[str, BlockMask]),
+                (
+                    masks[0]
+                    if isinstance(attention_masks, BlockMask)
+                    else {k: v for k, v in zip(attention_masks.keys(), masks)}
+                ),
+            )
 
     return inputs, attention_masks

--- a/torchtitan/distributed/full_dtensor.py
+++ b/torchtitan/distributed/full_dtensor.py
@@ -36,10 +36,7 @@ def validate_config(
     Walks ``model`` to discover the actual attention modules in use and
     raises ``NotImplementedError`` with a clear message if incompatible.
     """
-    from torchtitan.models.common.attention import (
-        ScaledDotProductAttention,
-        VarlenAttention,
-    )
+    from torchtitan.models.common.attention import ScaledDotProductAttention
 
     if parallel_dims.ep_enabled:
         raise NotImplementedError(
@@ -48,14 +45,11 @@ def validate_config(
         )
 
     if parallel_dims.cp_enabled:
-        if any(
-            isinstance(m, (ScaledDotProductAttention, VarlenAttention))
-            for m in model.modules()
-        ):
+        if any(isinstance(m, ScaledDotProductAttention) for m in model.modules()):
             raise NotImplementedError(
                 "full_dtensor + CP is not supported with "
-                "ScaledDotProductAttention or VarlenAttention. "
-                "Use FlexAttention + CP or disable CP."
+                "ScaledDotProductAttention. "
+                "Use FlexAttention or VarlenAttention with CP, or disable CP."
             )
 
 

--- a/torchtitan/distributed/varlen_cp.py
+++ b/torchtitan/distributed/varlen_cp.py
@@ -1,0 +1,286 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context-parallel support for variable-length attention.
+
+Houses :class:`CPVarlenMetadata`, the CP-specific extension of
+:class:`~torchtitan.models.common.attention.VarlenMetadata` that adds
+``k_local_indices`` and the per-rank metadata builder.
+
+Lives under ``torchtitan/distributed/`` because it is model-agnostic
+CP infrastructure; the base :class:`VarlenMetadata` data type stays in
+``models/common/attention.py`` so attention modules don't depend on CP
+internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor.experimental._context_parallel._load_balancer import (
+    _LoadBalancer,
+)
+
+from torchtitan.models.common.attention import VarlenMetadata
+
+
+@dataclass(frozen=True, eq=False)
+class CPVarlenMetadata(VarlenMetadata):
+    """Per-rank :class:`VarlenMetadata` for context-parallel varlen attention.
+
+    A marker subclass produced by :meth:`from_global` whose
+    ``k_local_indices`` field is always populated. The base class
+    declares the field as optional so :class:`VarlenAttention` can
+    consume both CP-built and plain metadata uniformly; this subclass
+    exists to host the CP-specific construction logic and to make the
+    "this came from CP sharding" intent visible at call sites.
+
+    Because CP shards the sequence dim (not the batch), under DTensor
+    Replicate-on-CP the rank-local packed K can have unused gaps between
+    per-segment visible regions when ``B > 1``; ``k_local_indices``
+    picks out just those regions. When a load balancer is active the
+    indices also compose with the per-batch inverse permutation so the
+    gather hits the correct entries in the rearranged K/V.
+    """
+
+    @classmethod
+    def from_global(
+        cls,
+        global_metadata: VarlenMetadata,
+        device_mesh: DeviceMesh,
+        batch_size: int,
+        seq_length: int,
+        load_balancer: _LoadBalancer | None = None,
+    ) -> "CPVarlenMetadata":
+        """Build per-rank :class:`CPVarlenMetadata` from a global metadata.
+
+        ``batch_size`` and ``seq_length`` describe the unpacked input
+        tensor whose packed form is ``global_metadata``; they are used
+        to decompose the rank's shard per-batch and must satisfy
+        ``batch_size * seq_length == cu_seq_q[-1]``.
+
+        Each rank holds a shard of the global Q; K/V are assumed already
+        all-gathered across the CP dim (e.g. via DTensor ``Replicate``).
+        For each (doc, rank) contiguous-Q run the builder emits a varlen
+        segment with ``seqlen_k`` = (global doc-relative offset at the
+        chunk end) + 1, so FA's right-aligned causal reproduces
+        document-causal masking exactly.
+
+        Self-attention only (``cu_seq_q == cu_seq_k``); all segment
+        construction is vectorized.
+
+        Example (segment layout, ``B = 1``):
+            ``seq_len=20, B=1, 3 docs (cu_seq_q=[0,7,13,20]), CP=4``,
+            no load balancer. Rank 2 owns Q rows 10..14 which span the
+            tail of doc 1 and the head of doc 2, giving two segments::
+
+              cu_seq_q        = [0, 3, 5]         (segment lengths 3, 2)
+              cu_seq_k        = [0, 6, 8]         (visible K per segment 6, 2)
+              max_q, max_k    = 3, 6
+              k_local_indices = [7, 8, 9, 10, 11, 12,  13, 14]
+
+        Example (non-contiguous K under ``B > 1``):
+            ``B=2, S=20, CP=4, rank 2``, same docs per batch as above.
+            ``K_packed`` (length ``B*S = 40``) places batch 1 after
+            batch 0, so a rank's visible K per segment lives inside one
+            batch's range; consecutive segments straddle the batch
+            boundary. ``k_local_indices`` (length 16) concatenates the
+            visible slices [7..13), [13..15), [27..33), [33..35).
+        """
+        if isinstance(global_metadata, CPVarlenMetadata):
+            raise ValueError(
+                "from_global received a CPVarlenMetadata; pass the "
+                "unsharded global VarlenMetadata instead."
+            )
+        # Identity check (not torch.equal) to avoid a D2H sync per forward.
+        # create_varlen_metadata_for_document uses the same tensor for both
+        # fields; callers must do the same.
+        if global_metadata.cu_seq_q is not global_metadata.cu_seq_k:
+            raise ValueError(
+                "CP varlen sharding currently supports only self-attention; "
+                "cu_seq_q and cu_seq_k must be the same tensor object."
+            )
+        cu_seq_q_global = global_metadata.cu_seq_q
+        expected_total = batch_size * seq_length
+        if cu_seq_q_global.ndim != 1 or cu_seq_q_global.numel() < 2:
+            raise ValueError(
+                "VarlenMetadata.cu_seq_q must be a 1-D tensor with at least "
+                f"2 entries; got shape {tuple(cu_seq_q_global.shape)}."
+            )
+        if cu_seq_q_global.dtype not in (torch.int32, torch.int64):
+            raise ValueError(
+                "VarlenMetadata.cu_seq_q must be int32 or int64; "
+                f"got {cu_seq_q_global.dtype}."
+            )
+
+        if device_mesh.ndim != 1:
+            raise ValueError(
+                f"CPVarlenMetadata.from_global expects a 1-D CP mesh, "
+                f"got ndim={device_mesh.ndim}."
+            )
+        cp_world_size = device_mesh.size()
+        cp_rank = device_mesh.get_local_rank()
+        required_divisor = (
+            2 * cp_world_size if load_balancer is not None else cp_world_size
+        )
+        if seq_length % required_divisor != 0:
+            reason = (
+                "2 * cp world size (load balancers chunk each shard into 2 halves)"
+                if load_balancer is not None
+                else "cp world size"
+            )
+            raise ValueError(
+                f"seq_length {seq_length} must be divisible by {required_divisor} "
+                f"({reason}); got cp world size {cp_world_size}."
+            )
+        shard_len = seq_length // cp_world_size
+        device = cu_seq_q_global.device
+        dtype = cu_seq_q_global.dtype
+
+        # Per-batch forward / inverse permutation from the load balancer;
+        # ``None`` means no rearrangement.
+        rearrange_per_batch: torch.Tensor | None = None
+        restore_per_batch: torch.Tensor | None = None
+        if load_balancer is not None:
+            # TODO: migrate to a public API when upstream stabilizes one.
+            rearrange_indices = load_balancer._generate_indices(restore=False)
+            if rearrange_indices is not None:
+                # Only same-across-batch indices are reachable today: PTRR
+                # (the lone balancer that can vary per-batch) is rejected
+                # upfront for varlen+CP. Argsort the (1, S) tensor once
+                # then expand both permutations to (batch_size, S).
+                if rearrange_indices.ndim != 2 or rearrange_indices.shape[0] != 1:
+                    raise ValueError(
+                        "load balancer indices must have shape "
+                        f"(1, seq_length); got {tuple(rearrange_indices.shape)}."
+                    )
+                rearrange_1xS = rearrange_indices.to(dtype)
+                restore_1xS = torch.argsort(rearrange_1xS, dim=-1)
+                rearrange_per_batch = rearrange_1xS.expand(batch_size, -1)
+                restore_per_batch = restore_1xS.expand(batch_size, -1)
+
+        # Per-batch local-to-global seq mapping, (batch_size, shard_len)
+        # in [0, seq_length).
+        if rearrange_per_batch is None:
+            rank_q_indices = (
+                torch.arange(
+                    cp_rank * shard_len,
+                    (cp_rank + 1) * shard_len,
+                    device=device,
+                    dtype=dtype,
+                )
+                .unsqueeze(0)
+                .expand(batch_size, -1)
+            )
+        else:
+            rank_q_indices = rearrange_per_batch[
+                :, cp_rank * shard_len : (cp_rank + 1) * shard_len
+            ]
+
+        # Per-batch -> packed global positions, row-major across batch
+        # (matches the rank's local packed Q layout).
+        batch_offsets = (
+            torch.arange(batch_size, device=device, dtype=dtype).unsqueeze(1)
+            * seq_length
+        )
+        packed_local_to_global = (batch_offsets + rank_q_indices).reshape(-1)
+        total_local = batch_size * shard_len
+
+        doc_id = (
+            torch.searchsorted(
+                cu_seq_q_global,
+                packed_local_to_global,
+                right=True,
+                out_int32=(dtype == torch.int32),
+            )
+            - 1
+        )
+
+        # Segment break wherever doc id changes or packed-global positions
+        # are non-consecutive. Batch boundaries are covered by diff_doc
+        # since adjacent batches' docs always have different ids globally.
+        diff_doc = doc_id[1:] != doc_id[:-1]
+        diff_global = packed_local_to_global[1:] != packed_local_to_global[:-1] + 1
+        is_break = diff_doc | diff_global
+        # nonzero() always returns int64; cast back so downstream arithmetic
+        # stays in cu_seq_q_global.dtype (typically int32).
+        seg_starts_inner = (is_break.nonzero(as_tuple=False).squeeze(-1) + 1).to(dtype)
+        seg_starts = torch.cat(
+            [torch.zeros(1, dtype=dtype, device=device), seg_starts_inner]
+        )
+        seg_ends = torch.cat(
+            [seg_starts[1:], torch.tensor([total_local], dtype=dtype, device=device)]
+        )
+
+        seqlen_q = seg_ends - seg_starts
+        # seqlen_k = (last global pos in segment) - (doc global start) + 1.
+        last_local_idx = seg_ends - 1
+        last_global = packed_local_to_global[last_local_idx]
+        seg_doc_id = doc_id[seg_starts]
+        doc_global_start = cu_seq_q_global[seg_doc_id]
+        seqlen_k = last_global - doc_global_start + 1
+
+        cu_seq_q = torch.cat(
+            [
+                torch.zeros(1, dtype=dtype, device=device),
+                seqlen_q.cumsum(0).to(dtype),
+            ]
+        )
+        cu_seq_k = torch.cat(
+            [torch.zeros(1, dtype=dtype, device=device), seqlen_k.cumsum(0).to(dtype)]
+        )
+
+        # Fuse max_q / max_k / total_k and cu_seq_q endpoint validation into
+        # a single D2H transfer to keep one sync point per forward. The
+        # endpoint check below raises before any wrong values escape the
+        # function, so it does not need to gate the work above.
+        max_q, max_k, total_k, first, last = (
+            torch.stack(
+                [
+                    seqlen_q.max(),
+                    seqlen_k.max(),
+                    seqlen_k.sum(),
+                    cu_seq_q_global[0],
+                    cu_seq_q_global[-1],
+                ]
+            )
+            .cpu()
+            .tolist()
+        )
+        if first != 0 or last != expected_total:
+            raise ValueError(
+                "VarlenMetadata.cu_seq_q must start at 0 and end at "
+                f"batch_size * seq_length = {expected_total}; got endpoints "
+                f"({first}, {last})."
+            )
+
+        # Flat gather index (length total_k) over original K coords; per
+        # segment covers [doc_global_start, last_global], built via
+        # repeat_interleave + arange offset.
+        bases = torch.repeat_interleave(doc_global_start, seqlen_k)
+        seg_starts_repeated = torch.repeat_interleave(cu_seq_k[:-1], seqlen_k)
+        within_seg = (
+            torch.arange(total_k, device=device, dtype=dtype) - seg_starts_repeated
+        )
+        k_local_indices = bases + within_seg
+
+        # K is all-gathered in the balancer's shuffling order, so compose the
+        # gather index with the per-batch inverse permutation.
+        if restore_per_batch is not None:
+            b_ids = k_local_indices // seq_length
+            p_orig = k_local_indices % seq_length
+            p_rearr = restore_per_batch[b_ids, p_orig]
+            k_local_indices = b_ids * seq_length + p_rearr
+
+        return cls(
+            cu_seq_q=cu_seq_q,
+            cu_seq_k=cu_seq_k,
+            max_q=max_q,
+            max_k=max_k,
+            k_local_indices=k_local_indices.to(torch.long),
+        )

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -6,7 +6,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple
+from typing import ClassVar
 
 import torch
 import torch.nn.functional as F
@@ -56,16 +56,36 @@ __all__ = [
 ]
 
 
-class VarlenMetadata(NamedTuple):
-    """
-    Cumulative sequence positions for queries and keys/values.
+@dataclass(frozen=True, eq=False)
+class VarlenMetadata:
+    """Metadata for variable-length attention (``varlen_attn``).
 
+    ``cu_seq_q``, ``cu_seq_k``, ``max_q``, ``max_k`` are the standard
+    varlen kernel arguments describing document boundaries within a
+    packed sequence.
+
+    ``k_local_indices`` is an optional 1-D gather index of length
+    ``cu_seq_k[-1]`` over the packed K/V layout. When set (e.g. by
+    :class:`torchtitan.distributed.varlen_cp.CPVarlenMetadata` after CP
+    all-gather), :class:`VarlenAttention` repacks K/V via
+    ``index_select`` before calling the kernel; when ``None`` the
+    kernel sees K/V unchanged.
+
+    For self-attention, ``cu_seq_q`` and ``cu_seq_k`` should be the same
+    tensor object (not just equal-valued); :class:`CPVarlenMetadata`
+    uses an identity check to avoid a per-forward D2H sync.
+
+    Kept as a frozen dataclass with ``eq=False`` because the default
+    dataclass ``__eq__`` would compare tensor fields elementwise (and
+    break identity-based hashing); subclasses such as
+    :class:`CPVarlenMetadata` extend it without adding new fields.
     """
 
     cu_seq_q: torch.Tensor
     cu_seq_k: torch.Tensor
     max_q: int
     max_k: int
+    k_local_indices: torch.Tensor | None = None
 
 
 AttentionMasksType = dict[str, BlockMask] | BlockMask | VarlenMetadata
@@ -107,21 +127,47 @@ class VarlenAttention(Module):
         scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(
-            attention_masks, VarlenMetadata
-        ), f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
+        if not isinstance(attention_masks, VarlenMetadata):
+            raise ValueError(
+                f"attention_masks must be a VarlenMetadata, "
+                f"got {type(attention_masks).__name__}"
+            )
 
         cu_seq_q = attention_masks.cu_seq_q
         cu_seq_k = attention_masks.cu_seq_k
         max_q = attention_masks.max_q
         max_k = attention_masks.max_k
 
-        batch_size, seq_len, _, head_dim = q.shape
+        # Q and K may have different seq lengths under CP: K/V are
+        # all-gathered across the CP dim while Q stays sharded, so K's seq
+        # equals the global seq while Q's is the local shard.
+        batch_size, q_seq_len, _, head_dim = q.shape
+        k_seq_len = k.shape[1]
 
         # varlen attention expects (bs*seqlen, n_heads, head_dim)
-        xq_packed = q.reshape(batch_size * seq_len, -1, head_dim)
-        xk_packed = k.reshape(batch_size * seq_len, -1, head_dim)
-        xv_packed = v.reshape(batch_size * seq_len, -1, head_dim)
+        xq_packed = q.reshape(batch_size * q_seq_len, -1, head_dim)
+        xk_packed = k.reshape(batch_size * k_seq_len, -1, head_dim)
+        xv_packed = v.reshape(batch_size * k_seq_len, -1, head_dim)
+
+        # Under CP, the global K is replicated on each rank but cu_seq_k
+        # describes only the per-segment visible regions, which can be
+        # non-contiguous in the standard packed layout when B > 1 (gaps
+        # between batches). The CP metadata builder ships an index tensor
+        # that gathers the visible K (and V) positions into a contiguous
+        # layout matching cu_seq_k. ``k_local_indices`` defaults to None
+        # for non-CP callers.
+        if attention_masks.k_local_indices is not None:
+            # The CP builder constructs cu_seq_k as a right-aligned causal
+            # window per (doc, rank) chunk, so it is only valid for causal
+            # attention. Non-causal varlen+CP would need a different K shard
+            # layout (full K per doc, not just past-and-current).
+            if self.window_size != (-1, 0):
+                raise ValueError(
+                    "Varlen attention under CP only supports causal masking "
+                    f"(window_size=(-1, 0)); got window_size={self.window_size}."
+                )
+            xk_packed = xk_packed.index_select(0, attention_masks.k_local_indices)
+            xv_packed = xv_packed.index_select(0, attention_masks.k_local_indices)
 
         # Some operators can upcast under AMP, but varlen attention currently only
         # supports bf16/fp16 inputs. If this changes, or fp16 training support
@@ -160,7 +206,7 @@ class VarlenAttention(Module):
         )
         assert isinstance(out_packed, torch.Tensor)
         # Reshape back to the format expected by GQAttention.forward()
-        out = out_packed.view(batch_size, seq_len, -1, head_dim)
+        out = out_packed.view(batch_size, q_seq_len, -1, head_dim)
 
         return out.to(q.dtype)
 

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -85,12 +85,16 @@ class Llama3Model(Decoder):
             # Sync rope max_seq_len
             self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-            if parallelism.context_parallel_degree > 1 and isinstance(
-                self.layers[0].attention.inner_attention, VarlenAttention.Config
+            if (
+                parallelism.context_parallel_degree > 1
+                and isinstance(
+                    self.layers[0].attention.inner_attention, VarlenAttention.Config
+                )
+                and not parallelism.full_dtensor
             ):
                 raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
+                    "Varlen attention with CP requires parallelism.full_dtensor=True; "
+                    "the legacy CP path does not all-gather K/V."
                 )
 
             tp = parallelism.tensor_parallel_degree

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -123,9 +123,10 @@ class Qwen3Model(Decoder):
             if parallelism.context_parallel_degree > 1 and isinstance(
                 self.layers[0].attention.inner_attention, VarlenAttention.Config
             ):
+                # TODO: enable once qwen3 supports parallelism.full_dtensor.
                 raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
+                    "qwen3 does not yet support varlen attention with CP; "
+                    "the required full_dtensor path is not implemented for qwen3."
                 )
 
             if self.enable_weight_tying and parallelism.pipeline_parallel_degree > 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3411
* __->__ #3410

Add varlen-attention support under CP with full_dtensor mode. Q stays sharded on the CP axis while K and V use DTensor Replicate placement so DTensor all-gathers them automatically.

Key design:
- VarlenMetadata is a frozen dataclass in torchtitan/models/common/attention.py with fields cu_seq_q, cu_seq_k, max_q, max_k, plus an optional k_local_indices.
- CPVarlenMetadata in torchtitan/distributed/varlen_cp.py extends VarlenMetadata with k_local_indices always populated and a from_global builder that produces per-rank metadata. For each (doc, rank) contiguous-Q chunk, seqlen_k = (global doc-relative offset at chunk end) + 1.
- cp_shard calls CPVarlenMetadata.from_global directly for varlen masks. Q/K/V tensors and BlockMask still use the upstream _context_parallel_shard dispatcher.
- VarlenAttention.forward re-packs K/V via k_local_indices when present, reading the field directly on VarlenMetadata so the attention module never imports CP infrastructure.

Varlen+CP only works under full_dtensor because without DTensor Replicate placement, K and V are plain local tensors and nothing all-gathers them across CP. The legacy apply_cp_to_forward path raises with a message pointing users to parallelism.full_dtensor=True.

Other changes:
- full_dtensor.validate_config no longer rejects flex/varlen.
- llama3.model.update_from_config requires parallelism.full_dtensor for varlen+CP instead of rejecting the combo.
- qwen3.model.update_from_config error message updated for consistency with the new wording.
- VarlenAttention.forward now rejects non-causal window_size when k_local_indices is set, since the CP builder constructs cu_seq_k as a right-aligned causal window.
- Integration tests: full_dtensor_cp_varlen, full_dtensor_cp_fsdp_varlen, full_dtensor_tp_cp_fsdp_varlen.
- CPU unit tests: multi-doc straddling, headtail rearrangement, multi-batch, CP=4, divisibility (with and without load balancer), cross-attention validation, double-shard rejection.