### PR TITLE
[NOT READY][Varlen CP] PTRR load balancer for Varlen attention

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -452,6 +452,33 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.context_parallel_degree=2",
+                    "--parallelism.context_parallel_load_balancer=ptrr",
+                ]
+            ],
+            "Full DTensor CP + PTRR (Varlen)",
+            "full_dtensor_cp_varlen_ptrr",
+            ngpu=2,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.context_parallel_degree=2",
+                    "--parallelism.context_parallel_load_balancer=ptrr",
+                    "--parallelism.data_parallel_shard_degree=2",
+                ]
+            ],
+            "Full DTensor CP + FSDP + PTRR (Varlen)",
+            "full_dtensor_cp_fsdp_varlen_ptrr",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--parallelism.context_parallel_degree=4",
                     "--parallelism.context_parallel_rotate_method='allgather'",
                 ]

--- a/tests/unit_tests/test_varlen_cp.py
+++ b/tests/unit_tests/test_varlen_cp.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Pure-logic CPU tests for ``CPVarlenMetadata.from_global``.
+"""Pure-logic CPU tests for ``CPVarlenMetadata.from_global`` and
+``_VarlenPTRRLoadBalancer``.
 
 These do not require a real distributed environment; we mock the
 ``DeviceMesh`` with ``_MockMesh`` and iterate over ranks manually.
@@ -14,7 +15,7 @@ import torch
 from torch.distributed.tensor.experimental._attention import _HeadTailLoadBalancer
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-from torchtitan.distributed.varlen_cp import CPVarlenMetadata
+from torchtitan.distributed.varlen_cp import _VarlenPTRRLoadBalancer, CPVarlenMetadata
 from torchtitan.models.common.attention import VarlenMetadata
 
 
@@ -253,15 +254,16 @@ class TestCPVarlenMetadata(TestCase):
             )
 
     def test_seq_len_divisibility_with_load_balancer(self) -> None:
-        # With a load balancer, each shard is split into 2 halves, so
-        # seq_length must be divisible by 2 * cp_world_size, not just
-        # cp_world_size. seq_length=6, CP=2 satisfies CP but not 2*CP.
-        # The LB itself is never invoked because divisibility fires first.
+        # With a load balancer, seq_length must be divisible by
+        # 2 * cp_world_size (the extra divisibility comes from the way
+        # CP load balancers chunk each shard). seq_length=6, CP=2
+        # satisfies CP but not 2*CP. The LB itself is never invoked
+        # because divisibility fires first.
         meta = _build_varlen_meta([0, 6], B=1, seq_len=6)
         lb = _HeadTailLoadBalancer(
             seq_length=8, world_size=2, device=torch.device("cpu")
         )
-        with self.assertRaisesRegex(ValueError, "load balancers chunk"):
+        with self.assertRaisesRegex(ValueError, "extra divisibility"):
             CPVarlenMetadata.from_global(
                 meta,
                 device_mesh=_MockMesh(2, 0),
@@ -293,6 +295,214 @@ class TestCPVarlenMetadata(TestCase):
             CPVarlenMetadata.from_global(
                 sharded, device_mesh=_MockMesh(2, 0), batch_size=1, seq_length=32
             )
+
+
+def _synthetic_doc_lengths(seq_len: int, kind: str, seed: int = 0) -> list[int]:
+    """Generate doc lengths summing to seq_len.
+
+    ``kind="mixture"`` (deterministic, hand-checkable):
+        ~30 short docs U(16,64), 2 medium docs U(200,320), 1 long doc =
+        remainder. Long doc placed mid-sequence (worst for headtail).
+    """
+    rng = torch.Generator().manual_seed(seed)
+    if kind == "mixture":
+        short_lens = [
+            int(torch.randint(16, 65, (1,), generator=rng).item()) for _ in range(30)
+        ]
+        medium_lens = [
+            int(torch.randint(200, 321, (1,), generator=rng).item()) for _ in range(2)
+        ]
+        used = sum(short_lens) + sum(medium_lens)
+        if used >= seq_len:
+            raise ValueError("mixture overflows seq_len; bump seq_len")
+        long_len = seq_len - used
+        mid = len(short_lens) // 2
+        return short_lens[:mid] + medium_lens + [long_len] + short_lens[mid:]
+    else:
+        raise ValueError(f"unknown kind {kind!r}")
+
+
+def _build_varlen_meta_from_doc_lens(
+    doc_lens: list[int], B: int, seq_len: int
+) -> VarlenMetadata:
+    if sum(doc_lens) != seq_len:
+        raise ValueError("doc_lens must sum to seq_len")
+    cum = [0]
+    for length in doc_lens:
+        cum.append(cum[-1] + length)
+    return _build_varlen_meta(cum, B=B, seq_len=seq_len)
+
+
+def _per_rank_total_work(
+    indices: torch.Tensor, cu_seq_q: torch.Tensor, B: int, S: int, W: int
+) -> torch.Tensor:
+    """Sum of visible-K-token-counts per rank for a given (B, S) permutation."""
+    cu = cu_seq_q.to(torch.long)
+    positions = torch.arange(B * S, dtype=torch.long)
+    doc_id = torch.searchsorted(cu, positions, right=True) - 1
+    work_per_token = positions - cu[doc_id] + 1
+    work_per_token_2d = work_per_token.view(B, S)
+    work_rearr = torch.gather(work_per_token_2d, 1, indices.to(torch.long))
+    shard = S // W
+    return work_rearr.view(B, W, shard).sum(dim=(0, 2))
+
+
+class TestVarlenPTRRLoadBalancer(TestCase):
+    @staticmethod
+    def _check_perm(indices: torch.Tensor) -> None:
+        B, S = indices.shape
+        for b in range(B):
+            torch.testing.assert_close(
+                torch.sort(indices[b]).values,
+                torch.arange(S, dtype=indices.dtype),
+            )
+
+    @staticmethod
+    def _check_restore(lb: _VarlenPTRRLoadBalancer) -> None:
+        fwd = lb._generate_indices(restore=False).to(torch.long)
+        rev = lb._generate_indices(restore=True).to(torch.long)
+        for b in range(fwd.shape[0]):
+            roundtrip = fwd[b][rev[b]]
+            torch.testing.assert_close(
+                roundtrip, torch.arange(fwd.shape[1], dtype=torch.long)
+            )
+
+    def test_single_doc_hand_balance(self) -> None:
+        # B=1, W=2, S=128, BS=32. One full-seq doc.
+        # PTRR pairs heaviest with lightest: blocks should sum to
+        # 528+3600 and 1552+2576 -- both 4128.
+        S, BS, W = 128, 32, 2
+        meta = _build_varlen_meta_from_doc_lens([S], B=1, seq_len=S)
+        lb = _VarlenPTRRLoadBalancer(
+            meta.cu_seq_q,
+            batch_size=1,
+            seq_length=S,
+            world_size=W,
+            block_size=BS,
+        )
+        idx = lb._generate_indices(restore=False)
+        self._check_perm(idx)
+        self._check_restore(lb)
+        per_rank = _per_rank_total_work(idx, meta.cu_seq_q, B=1, S=S, W=W)
+        torch.testing.assert_close(
+            per_rank, torch.tensor([4128, 4128], dtype=per_rank.dtype)
+        )
+
+    def test_multi_batch_different_doc_structures(self) -> None:
+        BS, W = 32, 2
+        # batch 0: one doc of 128; batch 1: two docs of 64+64.
+        cu = torch.tensor([0, 128, 192, 256], dtype=torch.int32)
+        lb = _VarlenPTRRLoadBalancer(
+            cu,
+            batch_size=2,
+            seq_length=128,
+            world_size=W,
+            block_size=BS,
+        )
+        idx = lb._generate_indices(restore=False)
+        self._check_perm(idx)
+        self._check_restore(lb)
+
+    def test_balance_quality_beats_headtail(self) -> None:
+        # On a skewed mixture, PTRR's per-rank-work spread should be
+        # < 0.5x headtail's.
+        S, BS, W = 4096, 128, 2
+        doc_lens = _synthetic_doc_lengths(S, kind="mixture", seed=0)
+        meta = _build_varlen_meta_from_doc_lens(doc_lens, B=1, seq_len=S)
+
+        ptrr = _VarlenPTRRLoadBalancer(
+            meta.cu_seq_q,
+            batch_size=1,
+            seq_length=S,
+            world_size=W,
+            block_size=BS,
+        )
+        ht = _HeadTailLoadBalancer(S, W, torch.device("cpu"))
+
+        ptrr_work = _per_rank_total_work(
+            ptrr._generate_indices(restore=False),
+            meta.cu_seq_q,
+            B=1,
+            S=S,
+            W=W,
+        )
+        ht_work = _per_rank_total_work(
+            ht._generate_indices(restore=False),
+            meta.cu_seq_q,
+            B=1,
+            S=S,
+            W=W,
+        )
+        ptrr_spread = (ptrr_work.max() - ptrr_work.min()).item()
+        ht_spread = (ht_work.max() - ht_work.min()).item()
+        self.assertLess(
+            ptrr_spread,
+            0.5 * ht_spread,
+            msg=(
+                f"PTRR spread {ptrr_spread} should be < 0.5 * "
+                f"headtail spread {ht_spread}"
+            ),
+        )
+
+    def test_num_blocks_equals_world_size(self) -> None:
+        S, BS, W = 64, 32, 2
+        meta = _build_varlen_meta_from_doc_lens([S], B=1, seq_len=S)
+        lb = _VarlenPTRRLoadBalancer(
+            meta.cu_seq_q,
+            batch_size=1,
+            seq_length=S,
+            world_size=W,
+            block_size=BS,
+        )
+        idx = lb._generate_indices(restore=False)
+        self._check_perm(idx)
+
+    def test_block_size_divisibility_error(self) -> None:
+        meta = _build_varlen_meta_from_doc_lens([128], B=1, seq_len=128)
+        with self.assertRaisesRegex(ValueError, "divisible by block_size"):
+            _VarlenPTRRLoadBalancer(
+                meta.cu_seq_q,
+                batch_size=1,
+                seq_length=128,
+                world_size=2,
+                block_size=100,
+            )
+
+    def test_world_size_divisibility_error(self) -> None:
+        meta = _build_varlen_meta_from_doc_lens([192], B=1, seq_len=192)
+        with self.assertRaisesRegex(ValueError, "must be divisible by world_size"):
+            _VarlenPTRRLoadBalancer(
+                meta.cu_seq_q,
+                batch_size=1,
+                seq_length=192,
+                world_size=4,
+                block_size=32,
+            )
+
+    def test_through_cpvarlen_metadata_builder(self) -> None:
+        # End-to-end: _VarlenPTRRLoadBalancer returns (B, S) indices,
+        # which CPVarlenMetadata.from_global must accept (the per-row
+        # argsort branch). Guards against the (1, S)-only regression.
+        S, BS, W = 64, 32, 2
+        meta = _build_varlen_meta_from_doc_lens([S], B=2, seq_len=S)
+        lb = _VarlenPTRRLoadBalancer(
+            meta.cu_seq_q,
+            batch_size=2,
+            seq_length=S,
+            world_size=W,
+            block_size=BS,
+        )
+        # Should construct without raising; sanity-check per-rank shapes.
+        for rank in range(W):
+            per_rank = CPVarlenMetadata.from_global(
+                meta,
+                device_mesh=_MockMesh(W, rank),
+                batch_size=2,
+                seq_length=S,
+                load_balancer=lb,
+            )
+            # Q is sharded into B * shard_len positions.
+            self.assertEqual(int(per_rank.cu_seq_q[-1].item()), 2 * (S // W))
 
 
 if __name__ == "__main__":

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -200,9 +200,24 @@ class ParallelismConfig:
     context_parallel_load_balancer: str | None = "headtail"
     """
     Load balancer type for context parallelism. Options:
-    - "headtail": Use HeadTailLoadBalancer for SDPA
-    - "ptrr": Use PTRRLoadBalancer for FlexAttention
+    - "headtail": Use HeadTailLoadBalancer (works for SDPA, FlexAttention,
+      and varlen attention)
+    - "ptrr": Use PTRRLoadBalancer (FlexAttention) or
+      _VarlenPTRRLoadBalancer (varlen)
     - None: Disable load balancing
+    """
+
+    context_parallel_ptrr_block_size: int = 128
+    """
+    Block size for the varlen PTRR load balancer
+    (``_VarlenPTRRLoadBalancer``). Ignored unless
+    ``context_parallel_load_balancer='ptrr'`` and varlen attention is in
+    use.  Must divide the per-batch sequence length evenly, and
+    ``(seq_len / block_size)`` must be divisible by
+    ``context_parallel_degree``.  Default 128 matches FlexAttention's
+    default sparse block size.  Smaller values give finer load balance
+    at the cost of more rearrange overhead; larger values are coarser
+    but cheaper.
     """
 
     def __post_init__(self):

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -23,7 +23,7 @@ from torch.distributed.tensor.experimental._context_parallel._attention import (
 )
 from torch.nn.attention.flex_attention import BlockMask
 
-from torchtitan.distributed.varlen_cp import CPVarlenMetadata
+from torchtitan.distributed.varlen_cp import _VarlenPTRRLoadBalancer, CPVarlenMetadata
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     FlexAttention,
@@ -117,6 +117,7 @@ def prepare_context_parallel_input(
     cp_mesh: DeviceMesh,
     device: torch.device,
     load_balancer_type: str | None = "headtail",
+    ptrr_block_size: int = 128,
 ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
     """
     Shard inputs, labels, positions, and attention masks for Context Parallel.
@@ -134,6 +135,9 @@ def prepare_context_parallel_input(
         device: Device for the tensors
         load_balancer_type: Type of load balancer to use for sharding.
             Options: "headtail", "ptrr", or None. Defaults to "headtail".
+        ptrr_block_size: Block size used by the varlen PTRR load balancer
+            (only consulted when ``load_balancer_type='ptrr'`` and
+            ``attention_masks`` is a ``VarlenMetadata``).
 
     Returns:
         Tuple of (sharded_inputs, sharded_labels, updated_extra_kwargs) where:
@@ -149,6 +153,7 @@ def prepare_context_parallel_input(
         (inputs, labels, positions),
         attention_masks,
         load_balancer_type,
+        ptrr_block_size=ptrr_block_size,
     )
     extra_kwargs["positions"] = positions
     if attention_masks is not None:
@@ -163,6 +168,7 @@ def cp_shard(
     attention_masks: AttentionMasksType | None,
     load_balancer_type: str | None = "headtail",
     input_seq_dim: int = 1,
+    ptrr_block_size: int = 128,
 ) -> tuple[tuple[torch.Tensor, ...], AttentionMasksType | None]:
     """
     Shard inputs and attention masks across the context parallel mesh.
@@ -180,8 +186,8 @@ def cp_shard(
         load_balancer_type: Type of load balancer to use. Options:
             - "headtail": Use HeadTailLoadBalancer (works for SDPA, varlen,
               and FlexAttention)
-            - "ptrr": Use PTRRLoadBalancer (FlexAttention only; not yet
-              supported for varlen)
+            - "ptrr": Use PTRRLoadBalancer (FlexAttention) or
+              _VarlenPTRRLoadBalancer (varlen)
             - None: Disable load balancing
             Defaults to "headtail".
         input_seq_dim: Sequence dimension index for sharding. Defaults to 1,
@@ -189,6 +195,9 @@ def cp_shard(
             [batch_size, seq_len]. Can be changed by passing a
             different value if your tensors use a different sequence
             dimension layout.
+        ptrr_block_size: Block size used by the varlen PTRR load balancer
+            (only consulted when ``load_balancer_type='ptrr'`` and
+            ``attention_masks`` is a ``VarlenMetadata``).
 
     Returns:
         Tuple of (sharded_inputs, attention_masks) where:
@@ -200,8 +209,8 @@ def cp_shard(
 
     Raises:
         ValueError: If load_balancer_type is "ptrr" and attention_masks
-            is None, a dict, or a VarlenMetadata (PTRR + varlen is not
-            yet supported).
+            is None or a dict (FlexAttention PTRR requires a BlockMask;
+            VarlenMetadata is routed to _VarlenPTRRLoadBalancer).
         ValueError: If attention_masks is a VarlenMetadata and
             input_seq_dim is not 1 (varlen sharding assumes the
             (B, S, ...) layout).
@@ -220,6 +229,11 @@ def cp_shard(
     seq_len = inputs[0].size(input_seq_dim)
     cp_world_size = cp_mesh.size()
 
+    # batch_size is only meaningful for VarlenMetadata branches (varlen
+    # PTRR balancer construction and CPVarlenMetadata.from_global), which
+    # both require the (B, S, ...) layout asserted above.
+    batch_size = inputs[0].size(0)
+
     load_balancer = None
     if load_balancer_type:
         match load_balancer_type:
@@ -228,26 +242,31 @@ def cp_shard(
                     seq_len, cp_world_size, cp_mesh.device_type
                 )
             case "ptrr":
-                # _PTRRLoadBalancer is FlexAttention-only today: it needs
-                # a BlockMask to compute per-block work. The varlen variant
-                # would share the algorithm but read work from cu_seq_q,
-                # and is not yet implemented.
+                # FlexAttention takes a BlockMask; varlen takes the global
+                # cu_seq_q via _VarlenPTRRLoadBalancer. The varlen balancer
+                # assumes document-causal masking, which is the only varlen
+                # path currently in the codebase (VarlenAttention.forward
+                # also rejects non-causal window_size under CP).
                 if isinstance(attention_masks, VarlenMetadata):
-                    raise ValueError(
-                        "PTRR load balancer is not yet implemented for "
-                        "varlen attention; use 'headtail' or None."
+                    load_balancer = _VarlenPTRRLoadBalancer(
+                        attention_masks.cu_seq_q,
+                        batch_size=batch_size,
+                        seq_length=seq_len,
+                        world_size=cp_world_size,
+                        block_size=ptrr_block_size,
                     )
-                if attention_masks is None or isinstance(attention_masks, dict):
-                    raise ValueError(
-                        "PTRRLoadBalancer requires attention_masks to be a "
-                        "BlockMask, but got None or dict[str, BlockMask]"
-                    )
-                if not isinstance(attention_masks, BlockMask):
-                    raise ValueError(
-                        f"PTRRLoadBalancer requires attention_masks to be a "
-                        f"BlockMask, but got {type(attention_masks)}"
-                    )
-                load_balancer = _PTRRLoadBalancer(attention_masks, cp_world_size)
+                else:
+                    if attention_masks is None or isinstance(attention_masks, dict):
+                        raise ValueError(
+                            "PTRRLoadBalancer requires attention_masks to be a "
+                            "BlockMask, but got None or dict[str, BlockMask]"
+                        )
+                    if not isinstance(attention_masks, BlockMask):
+                        raise ValueError(
+                            f"PTRRLoadBalancer requires attention_masks to be a "
+                            f"BlockMask, but got {type(attention_masks)}"
+                        )
+                    load_balancer = _PTRRLoadBalancer(attention_masks, cp_world_size)
             case _:
                 raise ValueError(
                     f"Invalid load_balancer_type '{load_balancer_type}'. "
@@ -273,7 +292,7 @@ def cp_shard(
             attention_masks = CPVarlenMetadata.from_global(
                 attention_masks,
                 device_mesh=cp_mesh,
-                batch_size=inputs[0].size(0),
+                batch_size=batch_size,
                 seq_length=seq_len,
                 load_balancer=load_balancer,
             )

--- a/torchtitan/distributed/varlen_cp.py
+++ b/torchtitan/distributed/varlen_cp.py
@@ -18,12 +18,15 @@ internals.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 import torch
+from torch import Tensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.experimental._context_parallel._load_balancer import (
     _LoadBalancer,
+    _PTRRLoadBalancer,
 )
 
 from torchtitan.models.common.attention import VarlenMetadata
@@ -130,7 +133,8 @@ class CPVarlenMetadata(VarlenMetadata):
         )
         if seq_length % required_divisor != 0:
             reason = (
-                "2 * cp world size (load balancers chunk each shard into 2 halves)"
+                "2 * cp world size (extra divisibility required when a load "
+                "balancer is used)"
                 if load_balancer is not None
                 else "cp world size"
             )
@@ -150,19 +154,28 @@ class CPVarlenMetadata(VarlenMetadata):
             # TODO: migrate to a public API when upstream stabilizes one.
             rearrange_indices = load_balancer._generate_indices(restore=False)
             if rearrange_indices is not None:
-                # Only same-across-batch indices are reachable today: PTRR
-                # (the lone balancer that can vary per-batch) is rejected
-                # upfront for varlen+CP. Argsort the (1, S) tensor once
-                # then expand both permutations to (batch_size, S).
-                if rearrange_indices.ndim != 2 or rearrange_indices.shape[0] != 1:
+                if rearrange_indices.ndim != 2 or rearrange_indices.shape[0] not in (
+                    1,
+                    batch_size,
+                ):
                     raise ValueError(
-                        "load balancer indices must have shape "
-                        f"(1, seq_length); got {tuple(rearrange_indices.shape)}."
+                        "load balancer indices must have shape (1, seq_length) "
+                        "or (batch_size, seq_length); got "
+                        f"{tuple(rearrange_indices.shape)}."
                     )
-                rearrange_1xS = rearrange_indices.to(dtype)
-                restore_1xS = torch.argsort(rearrange_1xS, dim=-1)
-                rearrange_per_batch = rearrange_1xS.expand(batch_size, -1)
-                restore_per_batch = restore_1xS.expand(batch_size, -1)
+                rearrange_indices = rearrange_indices.to(dtype)
+                # (1, S): same permutation across batches (e.g. headtail);
+                # argsort once and expand both permutations.
+                # (B, S): per-batch permutation (e.g. _VarlenPTRRLoadBalancer);
+                # argsort per row.
+                if rearrange_indices.shape[0] == 1:
+                    rearrange_per_batch = rearrange_indices.expand(batch_size, -1)
+                    restore_per_batch = torch.argsort(rearrange_indices, dim=-1).expand(
+                        batch_size, -1
+                    )
+                else:
+                    rearrange_per_batch = rearrange_indices
+                    restore_per_batch = torch.argsort(rearrange_indices, dim=-1)
 
         # Per-batch local-to-global seq mapping, (batch_size, shard_len)
         # in [0, seq_length).
@@ -284,3 +297,112 @@ class CPVarlenMetadata(VarlenMetadata):
             max_k=max_k,
             k_local_indices=k_local_indices.to(torch.long),
         )
+
+
+class _VarlenPTRRLoadBalancer(_LoadBalancer):
+    """Processing-Time based Round-Robin (PTRR) load balancer for
+    **document-causal** varlen attention.
+
+    .. warning::
+        This balancer assumes per-document causal masking. The per-Q-block
+        work estimate is ``t - doc_start[t] + 1`` summed over the block,
+        which is only the correct work estimate under causal masking.
+        Using this balancer with a non-causal varlen mask will produce a
+        valid permutation but a meaningless load balance -- callers are
+        responsible for ensuring the attention mask is causal.
+
+    Estimates per-Q-block work directly from ``cu_seq_q`` (no ``BlockMask``
+    needed). Per-block work is the sum of per-token work over the block.
+    The same scheduling primitive (``_PTRRLoadBalancer.ptrr_scheduling``)
+    is reused.
+
+    Outputs a ``(B, S)`` permutation tensor where each batch element is
+    rearranged independently -- important when documents differ across
+    the batch.
+    """
+
+    def __init__(
+        self,
+        cu_seq_q: Tensor,
+        *,
+        batch_size: int,
+        seq_length: int,
+        world_size: int,
+        block_size: int = 128,
+    ):
+        # cu_seq_q is consumed below by ``torch.searchsorted``, which only
+        # requires 1-D and monotonic non-decreasing input. Monotonicity and
+        # the ``cu_seq_q[-1] == batch_size * seq_length`` endpoint are
+        # already enforced by the same tensor's path through
+        # :meth:`CPVarlenMetadata.from_global` (which builds the balancer);
+        # we skip re-checking here to avoid two extra D2H syncs per forward.
+        if cu_seq_q.dim() != 1:
+            raise ValueError(
+                f"cu_seq_q must be 1-D, got shape {tuple(cu_seq_q.shape)}."
+            )
+        if seq_length % block_size != 0:
+            raise ValueError(
+                f"seq_length {seq_length} must be divisible by block_size {block_size}."
+            )
+        num_blocks = seq_length // block_size
+        if num_blocks % world_size != 0:
+            raise ValueError(
+                f"num_blocks (seq_length / block_size = {num_blocks}) "
+                f"must be divisible by world_size {world_size}."
+            )
+
+        self.cu_seq_q = cu_seq_q
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+        self.world_size = world_size
+        self.block_size = block_size
+
+    def _generate_indices(self, restore: bool = False) -> Tensor:
+        """Compute the per-batch forward or inverse permutation.
+
+        Returns a ``(B, S)`` int64 tensor. When ``restore=False`` the
+        result is the forward permutation: ``indices[b, i]`` is the
+        original token position to be placed at slot ``i`` of batch
+        ``b`` after PTRR rebalancing. When ``restore=True`` the result
+        is its inverse (``argsort`` of the forward permutation).
+
+        Note the ``(B, S)`` output shape, vs upstream
+        :class:`_LoadBalancer`'s ``(1, S)`` or ``(B, S)`` contract:
+        PTRR rebalances every batch independently because document
+        structure can vary across the batch.
+        """
+        B = self.batch_size
+        S = self.seq_length
+        W = self.world_size
+        block_size = self.block_size
+        num_blocks = S // block_size
+
+        device = self.cu_seq_q.device
+        cu = self.cu_seq_q.to(torch.long)
+
+        # Per-token causal work = (token's offset within its doc) + 1.
+        positions = torch.arange(B * S, device=device, dtype=torch.long)
+        doc_id = torch.searchsorted(cu, positions, right=True) - 1
+        work_per_token = positions - cu[doc_id] + 1  # (B*S,)
+
+        # Per-block work: sum of token work within each block, per batch.
+        work_per_block = work_per_token.view(B, num_blocks, block_size).sum(dim=-1)
+        # (B, num_blocks)
+
+        batch_ptrr = torch.vmap(
+            functools.partial(_PTRRLoadBalancer.ptrr_scheduling, group_size=W)
+        )
+        ptrr_blocks = batch_ptrr(work_per_block)  # (B, W, num_blocks_per_rank)
+        ptrr_blocks = ptrr_blocks.reshape(B, -1)  # (B, num_blocks)
+
+        # Expand block indices to token indices.
+        block_indices = torch.arange(num_blocks * block_size, device=device).view(
+            num_blocks, block_size
+        )  # (num_blocks, block_size)
+        indices = block_indices[ptrr_blocks].view(B, -1)  # (B, S)
+
+        if restore:
+            # pyrefly: ignore[missing-argument]
+            indices = torch.vmap(torch.argsort)(indices)
+
+        return indices

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -623,6 +623,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.parallel_dims.get_mesh("cp"),
                 self.device,
                 self.config.parallelism.context_parallel_load_balancer,
+                ptrr_block_size=self.config.parallelism.context_parallel_ptrr_block_size,
             )
 
         # Accumulate after CP sharding so labels.numel() reflects the actual


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3411
* #3410

Add a varlen-aware PTRR load balancer that estimates per-Q-block work directly from cu_seq_q instead of needing a BlockMask. Under document-causal masking, per-token work is (t - doc_start[t] + 1) and per-block work is the sum over the block. The _PTRRLoadBalancer.ptrr_scheduling primitive is reused unchanged. Per-batch rearrangement via vmap balances batches with different doc structures independently.

Changes:
- _VarlenPTRRLoadBalancer lives in torchtitan/distributed/varlen_cp.py alongside the rest of varlen CP code.
- cp_shard plumbs the balancer through the existing "ptrr" branch when attention_masks is a VarlenMetadata. The FlexAttention BlockMask path keeps using upstream _PTRRLoadBalancer.
- New config field: parallelism.context_parallel_ptrr_block_size.
- Integration tests: full_dtensor_cp_varlen_ptrr, full_dtensor_cp_fsdp_varlen_ptrr.
- CPU unit tests: permutation/restore roundtrip, hand-computed single-doc balance, multi-batch with different doc structures, balance quality vs _HeadTailLoadBalancer, constructor validation.