### PR TITLE
Fix imports for latest DeepEP

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -18,9 +18,7 @@ from torch.distributed import ProcessGroup
 from torch.utils._python_dispatch import _disable_current_modes
 
 try:
-    from deep_ep import Buffer
-
-    from deep_ep.utils import EventHandle, EventOverlap
+    from deep_ep import Buffer, EventHandle, EventOverlap
 except ImportError as e:
     raise ImportError(
         "DeepEP is required for this module. "


### PR DESCRIPTION
With DeepEP HEAD, the imports from `deep_ep.utils` fail. According to the current DeepEP Readme (https://github.com/deepseek-ai/deepep#example-use-in-model-training-or-inference-prefilling), all three classes can be imported from the main `deep_ep` package. This PR fixes the imports accordingly.