### PR TITLE
[graph_trainer] Fix fsdp_passes compat with BitsetAncestors from pytorch passes

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -348,7 +348,13 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
     ) -> None:
         if last_compute is None or not picked:
             return
-        if OrderedSet(picked) & OrderedSet(self.node_ancestors[last_compute]):
+        ancestors = self.node_ancestors
+        # TODO(ivankobzarev): remove OrderedSet fallback after nightly picks up BitsetAncestors
+        if hasattr(ancestors, "is_ancestor"):
+            blocked = any(ancestors.is_ancestor(ag, last_compute) for ag in picked)
+        else:
+            blocked = bool(OrderedSet(picked) & OrderedSet(ancestors[last_compute]))
+        if blocked:
             return
         for ag in picked:
             overlap_deps[last_compute].add(ag)


### PR DESCRIPTION
…rch#183559

pytorch#183559 changed `node_ancestors` from `dict[Node, OrderedSet[Node]]` to `BitsetAncestors` in the overlap scheduler. The `_apply_trailing_block` method in `JointManualOverlapScheduler` used `OrderedSet(self.node_ancestors[node])` which breaks with the new API.

Use `is_ancestor()` when available, with an `OrderedSet` fallback for pytorch builds that predate the change.

Authored by Claude.