### PR TITLE
[loss] Fix ChunkedCELoss + TP gradient placement mismatch

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -7,7 +7,10 @@
 import unittest
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Partial, Replicate
 from torchtitan.components.loss import (
     ChunkedCELoss,
     cross_entropy_loss,
@@ -190,6 +193,71 @@ class TestGradAccumulator(unittest.TestCase):
         acc.add(torch.randn(2, 4, 16))
         with self.assertRaises(ValueError):
             acc.add(torch.randn(2, 4, 16))
+
+
+class TestGradAccumulatorDTensor(unittest.TestCase):
+    """Regression tests for the DTensor path.
+
+    These pin down the contract that prevented the TP gradient-placement bug:
+    result() must label the buffer with the placement of the chunks that were
+    actually added (e.g. Partial(sum) for a loss-parallel ColwiseParallel
+    lm_head), not the placement of the reference activation.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo",
+                init_method="tcp://localhost:12358",
+                world_size=1,
+                rank=0,
+            )
+        cls._mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _make_chunk(self, shape, placement):
+        return DTensor.from_local(
+            torch.randn(*shape), self._mesh, (placement,), run_check=False
+        )
+
+    def test_result_takes_placement_from_first_chunk(self):
+        """result() wraps the buffer with chunk_grad's placement.
+
+        The pre-fix code wrapped with the reference activation's placement
+        (Replicate) even when chunks were Partial(sum), which silently dropped
+        the implied all-reduce and corrupted TP training.
+        """
+        B, L, D = 2, 8, 16
+        num_chunks = 4
+        reference = DTensor.from_local(
+            torch.zeros(B, L, D), self._mesh, (Replicate(),), run_check=False
+        )
+
+        acc = GradAccumulator(reference, num_chunks=num_chunks, dtype=torch.float32)
+        for _ in range(num_chunks):
+            acc.add(self._make_chunk((B, L // num_chunks, D), Partial()))
+
+        result = acc.result()
+        self.assertIsInstance(result, DTensor)
+        self.assertEqual(result.placements, (Partial(),))
+
+    def test_placement_mismatch_raises(self):
+        """A chunk whose placement disagrees with the first one is a bug."""
+        B, L, D = 2, 8, 16
+        num_chunks = 2
+        reference = DTensor.from_local(
+            torch.zeros(B, L, D), self._mesh, (Replicate(),), run_check=False
+        )
+
+        acc = GradAccumulator(reference, num_chunks=num_chunks, dtype=torch.float32)
+        acc.add(self._make_chunk((B, L // num_chunks, D), Partial()))
+        with self.assertRaisesRegex(ValueError, "does not match first chunk"):
+            acc.add(self._make_chunk((B, L // num_chunks, D), Replicate()))
 
 
 class _FakeDecoder(nn.Module):

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -186,8 +186,13 @@ class GradAccumulator:
     this uses a pre-allocated buffer with in-place copies for better memory efficiency.
 
     Args:
-        reference: Reference tensor to derive shape, device, and DTensor metadata.
-            If a DTensor, result() returns a DTensor with matching placements.
+        reference: Reference tensor for shape, device, and DTensor-ness. If a
+            DTensor, only its device mesh is reused; the placement of the
+            returned DTensor is taken from the first added chunk (see add()),
+            not from this reference, so the buffer is labeled with the actual
+            gradient placement (e.g. Partial(sum) on the TP axis when the
+            forward used a Replicate input with a Shard(0) weight, as in
+            ColwiseParallel lm_head) rather than the activation placement.
         num_chunks: Number of chunks that will be added.
         seq_dim: The sequence dimension along which chunks are accumulated.
         dtype: Dtype for the buffer.
@@ -214,12 +219,11 @@ class GradAccumulator:
         self.seq_dim = seq_dim
         self._next_idx = 0
         self._device_mesh: DeviceMesh | None = None
+        # Captured from the first added chunk; see __init__ docstring.
         self._placements: tuple[Placement, ...] | None = None
 
-        # Track DTensor metadata for transparent wrap-back in result()
         if isinstance(reference, DTensor):
             self._device_mesh = reference.device_mesh
-            self._placements = reference.placements
             local = reference.to_local()
         else:
             local = reference
@@ -236,9 +240,25 @@ class GradAccumulator:
         if self._next_idx >= self.num_chunks:
             raise ValueError(f"Already added {self.num_chunks} chunks, cannot add more")
 
-        # Extract local tensor if DTensor
         if isinstance(chunk_grad, DTensor):
+            if self._placements is None:
+                self._placements = chunk_grad.placements
+            elif chunk_grad.placements != self._placements:
+                # All chunks come from the same op chain and must share a
+                # placement. Otherwise the buffer mixes frames and result()
+                # would mislabel them.
+                raise ValueError(
+                    f"chunk_grad placement {chunk_grad.placements} does not "
+                    f"match first chunk's placement {self._placements}"
+                )
             chunk_grad = chunk_grad.to_local()
+        elif self._placements is not None:
+            # Earlier chunks were DTensor but this one is a plain tensor;
+            # mixing the two would silently drop the implied reduction.
+            raise ValueError(
+                "chunk_grad is a plain tensor but earlier chunks were "
+                f"DTensor with placement {self._placements}"
+            )
 
         if chunk_grad.dtype != self._buffer.dtype:
             chunk_grad = chunk_grad.to(self._buffer.dtype)
@@ -254,10 +274,21 @@ class GradAccumulator:
         self._next_idx += 1
 
     def result(self) -> torch.Tensor:
-        """Return the accumulated gradient tensor, wrapped as DTensor if needed."""
+        """Return the accumulated gradient tensor, wrapped as DTensor if needed.
+
+        When the chunks were Partial(sum), the returned DTensor is also
+        Partial(sum); autograd performs the implied reduction once when this
+        gradient lands on the decoder-side leaf.
+        """
         from torch.distributed.tensor import DTensor
 
         if self._device_mesh is not None:
+            if self._placements is None:
+                raise ValueError(
+                    "No DTensor chunk was added; cannot wrap the buffer as "
+                    "DTensor without a known placement. Either pass DTensor "
+                    "chunks to add(), or use a plain reference tensor."
+                )
             return DTensor.from_local(
                 self._buffer,
                 device_mesh=self._device_mesh,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3418

GradAccumulator was wrapping the buffer with the reference activation's placement, which on the TP axis is Replicate after ChunkedCELoss's upstream redistribute. But the buffer actually held the local values of chunk_grad, which on the TP axis comes back as Partial(sum) from the lm_head backward: with a Replicate input and a Shard(0) weight (the ColwiseParallel pattern, independent of whether loss_parallel is enabled), the backward matmul contracts along the sharded vocab dim and emits a per-rank partial sum. to_local() then returns each rank's partial slice without an all-reduce. Labeling that partial slice as Replicate made downstream autograd treat it as the already-summed value, poisoning the decoder backward and pushing the loss curve well above the single-GPU baseline.

Capture _placements from the first added chunk_grad instead of from the reference activation, and wrap result() with that placement. The single implied reduction now happens once at the autograd boundary instead of N times inside the chunk loop, matching the cost of the non-chunked TP path. Raise on a mid-loop placement mismatch since all chunks should share a placement, and raise when DTensor and plain-tensor chunks are mixed across calls.

Validated via scripts/loss_compare.py on llama3 debugmodel + global batch size 8 + 500 steps + seed checkpoint + --debug.seed=42 --debug.deterministic.

| Config              | Step 1 loss | Step 500 loss |
|---------------------|-------------|---------------|
| Single GPU          |    8.054873 |      2.342949 |
| TP8 before this fix |    8.054862 |      2.727362 |
| TP8 after this fix  |    8.054862 |      2.353253 |

Step 1 matches across the three (same init via seed checkpoint), confirming the divergence comes from the gradient path. By step 500, TP8 before the fix drifts +0.384 above the single-GPU baseline; after the fix it lands within +0.010 of the baseline, matching the non-chunked CrossEntropyLoss + TP8 control.