### PR TITLE
[graph_trainer] Replace stable_topological_sort with _move_overlap_nodes

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -20,13 +20,13 @@ from typing import Any
 
 import torch
 import torch.fx as fx
-from torch._dynamo.graph_deduplication import _stable_topological_sort
 from torch._inductor.fx_passes.bucketing import (
     BucketMode,
     is_all_gather_into_tensor as is_all_gather,
     is_wait_tensor,
 )
 from torch._inductor.fx_passes.overlap_manual_scheduling import (
+    _move_overlap_nodes,
     manual_overlap_bucketing,
     ManualOverlapScheduler,
 )
@@ -231,7 +231,6 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
             if bwd_nodes:
                 self.bucketer.manual_bucket_collectives(nodes=bwd_nodes)
 
-        _stable_topological_sort(self.graph, {})
         self.graph.lint()
         self.nodes = list(self.graph.nodes)
         self.in_degree = Counter(user for node in self.nodes for user in node.users)
@@ -246,7 +245,7 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         self._schedule_rs_prefetch(overlap_deps)
         self._schedule_ag_prefetch(overlap_deps)
 
-        _stable_topological_sort(self.graph, overlap_deps)
+        _move_overlap_nodes(self.graph, overlap_deps, self.bucketer.bucketed_node_types)
         self.graph.lint()
 
         if self.insert_overlap_deps:


### PR DESCRIPTION
Replace the two `_stable_topological_sort` calls in `JointManualOverlapScheduler` with `_move_overlap_nodes` from upstream pytorch. This surgically moves only the AG/RS chains instead of re-sorting the entire graph, reducing node displacement from ~97% to ~5% and making the pass composable with downstream graph passes.

- `_manual_bucket_collectives`: remove the no-op `_stable_topological_sort(graph, {})` call after bucketing — the graph is already valid after `manual_bucket_collectives`.
- `_manual_reorder_graph`: replace `_stable_topological_sort(graph, overlap_deps)` with `_move_overlap_nodes(graph, overlap_deps, bucketed_node_types)`.

Depends on pytorch PR #184711.
!!! Land only pytorch PR is in nightly

Authored by Claude.


Before vs. After for dsv3_16b
https://www.internalfb.com/intern/diffing/?before_paste_number=2371069081&after_paste_number=2371069207&regex_remove_pattern=&enable_regex_remove=0&strip_empty_lines=0&line_wrap=0&selected_tab=plain_diff