### PR TITLE
Support for Varlen+CP

### DIFF
--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -365,6 +365,8 @@ def cp_shard(
                     else {k: v for k, v in zip(attention_masks.keys(), masks)}
                 ),
             )
+        case None:
+            pass
         case _:
             raise ValueError(
                 f"Unsupported attention_masks type for CP sharding: "

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from typing import Any, cast
 
 import torch
+import dataclasses
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -28,8 +29,61 @@ from torchtitan.models.common.attention import (
     FlexAttention,
     ScaledDotProductAttention,
     VarlenAttention,
+    VarlenMetadata,
 )
 from torchtitan.tools.logging import logger
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class CPVarlenMetadata(VarlenMetadata):
+    """Pre-computed VarlenMetadata for the CP forward pass.
+
+    Slice bounds are plain Python ints computed once per batch in
+    ``_shard_varlen_metadata`` (outside the model loop) to avoid GPU→CPU
+    synchronizations inside ``cp_forward``.
+    """
+    k_slice_start: int  # start index into allgathered global K
+    k_slice_end: int  # end index into allgathered global K
+
+def _shard_varlen_metadata(
+    metadata: VarlenMetadata,
+    cp_mesh: DeviceMesh,
+    seq_len: int,
+    cp_world_size: int,
+) -> CPVarlenMetadata:
+    """Shard VarlenMetadata for this rank's contiguous token range.
+
+    All expensive Python-int extraction (.item() calls) happens here, once per
+    batch, outside the compiled model loop.  The returned ``CPVarlenMetadata``
+    carries plain Python ints so ``cp_forward`` can slice K/V without any
+    GPU→CPU synchronization.
+
+    NOTE: assumes contiguous token assignment (``load_balancer_type=None``).
+    Interleaved sharding (headtail / ptrr) is not compatible with the
+    ``cu_seq`` document-boundary structure.
+    """
+    cp_rank = dist.get_rank(group=cp_mesh.get_group())
+    local_start = cp_rank * seq_len // cp_world_size
+    local_end = (cp_rank + 1) * seq_len // cp_world_size
+
+    local_cu_seq_q, count_cu_seq_q = metadata.cu_seq_q.clamp(local_start, local_end).unique_consecutive(return_counts=True)
+    local_cu_seq_k = metadata.cu_seq_k[count_cu_seq_q[0]-1 : (-count_cu_seq_q[-1]+1) or None]
+    local_max_q = int(local_cu_seq_q.diff().max().item())
+    local_max_k = int(local_cu_seq_k.diff().max().item())
+
+    local_cu_seq_k_start = int(local_cu_seq_k[0].item())
+    local_cu_seq_k_end = int(local_cu_seq_k[-1].item())
+    shifted_local_cu_seq_q = local_cu_seq_q - local_start
+    shifted_local_cu_seq_k = local_cu_seq_k - local_cu_seq_k_start
+
+    return CPVarlenMetadata(
+        cu_seq_q=shifted_local_cu_seq_q,
+        cu_seq_k=shifted_local_cu_seq_k,
+        max_q=local_max_q,
+        max_k=local_max_k,
+        k_slice_start=local_cu_seq_k_start,
+        k_slice_end=local_cu_seq_k_end,
+    )
 
 
 def apply_cp_to_forward(
@@ -95,7 +149,27 @@ def apply_cp_to_forward(
             mod.forward = _make_cp_forward(original_forward, cp_mesh)
 
     elif isinstance(first, VarlenAttention):
-        raise NotImplementedError("Variable-length attention CP is not yet supported")
+        for mod in attention_modules:
+            original_forward = mod.forward
+
+            def _make_cp_forward(orig_fn, mesh):
+                pg_name = dist._get_process_group_name(mesh.get_group())
+
+                def cp_forward(q, k, v, **kwargs):
+                    attn_masks = kwargs.get("attention_masks")
+                    assert isinstance(attn_masks, CPVarlenMetadata), "Expected CPVarlenMetadata in attention_masks"
+                    k = k.contiguous()
+                    v = v.contiguous()
+                    global_k, global_v = flex_cp_allgather(k, v, 1, pg_name)
+                    # k_slice_start / k_slice_end are plain Python ints
+                    # pre-computed in _shard_varlen_metadata — no GPU→CPU sync.
+                    global_k = global_k[:, attn_masks.k_slice_start:attn_masks.k_slice_end]
+                    global_v = global_v[:, attn_masks.k_slice_start:attn_masks.k_slice_end]
+                    return orig_fn(q, global_k, global_v, **kwargs)
+
+                return cp_forward
+
+            mod.forward = _make_cp_forward(original_forward, cp_mesh)
     else:
         raise NotImplementedError(
             f"Context Parallel forward wrapping is not supported for "
@@ -240,26 +314,38 @@ def cp_shard(
     # BlockMask, has shape, [B, H, Q, KV], and we can only shard
     # on the Q seq dimension, not KV.
     MASK_Q_SEQ_DIM = 2
-    if attention_masks is not None:
-        assert isinstance(attention_masks, (BlockMask, dict))
-        masks = (
-            [attention_masks]
-            if isinstance(attention_masks, BlockMask)
-            else list(attention_masks.values())
-        )
-        masks = _context_parallel_shard(
-            mesh=cp_mesh,
-            buffers=masks,
-            seq_dims=(MASK_Q_SEQ_DIM,) * len(masks),
-            load_balancer=load_balancer,
-        )
-        attention_masks = cast(
-            (BlockMask | dict[str, BlockMask]),
-            (
-                masks[0]
+
+    match attention_masks:
+        case VarlenMetadata():
+            assert load_balancer is None, "Load balancer must be disabled for variable-length attention"
+            attention_masks = _shard_varlen_metadata(
+                attention_masks, cp_mesh, seq_len, cp_world_size
+            )
+        case BlockMask() | dict():
+            assert isinstance(attention_masks, (BlockMask, dict))
+            masks = (
+                [attention_masks]
                 if isinstance(attention_masks, BlockMask)
-                else {k: v for k, v in zip(attention_masks.keys(), masks)}
-            ),
-        )
+                else list(attention_masks.values())
+            )
+            masks = _context_parallel_shard(
+                mesh=cp_mesh,
+                buffers=masks,
+                seq_dims=(MASK_Q_SEQ_DIM,) * len(masks),
+                load_balancer=load_balancer,
+            )
+            attention_masks = cast(
+                (BlockMask | dict[str, BlockMask]),
+                (
+                    masks[0]
+                    if isinstance(attention_masks, BlockMask)
+                    else {k: v for k, v in zip(attention_masks.keys(), masks)}
+                ),
+            )
+        case _:
+            raise ValueError(
+                f"Unsupported attention_masks type for CP sharding: "
+                f"{type(attention_masks)}. Must be None, BlockMask, or dict[str, BlockMask]."
+            )
 
     return inputs, attention_masks

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -4,11 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 from collections.abc import Sequence
 from typing import Any, cast
 
 import torch
-import dataclasses
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -301,15 +301,38 @@ def cp_shard(
                     f"Must be one of: 'headtail', 'ptrr', or None"
                 )
 
-    inputs = cast(
-        tuple[torch.Tensor, ...],
-        _context_parallel_shard(
-            mesh=cp_mesh,
-            buffers=inputs,
-            seq_dims=tuple(input_seq_dim for _ in inputs),
-            load_balancer=load_balancer,
-        ),
-    )
+    batch_size = inputs[0].size(0)
+    match attention_masks:
+        case None | BlockMask() | dict():
+            inputs = cast(
+                tuple[torch.Tensor, ...],
+                _context_parallel_shard(
+                    mesh=cp_mesh,
+                    buffers=inputs,
+                    seq_dims=tuple(input_seq_dim for _ in inputs),
+                    load_balancer=load_balancer,
+                ),
+            )
+        case VarlenMetadata():
+            # Instead of sharding directly in the sequence length dimension,
+            # we first reshape to [1, batch_size * seq_len] and shard.
+            # this let us treat the entire batch as a single sequence, which is necessary for
+            # correct sharding with variable-length inputs.
+            inputs = cast(
+                tuple[torch.Tensor, ...],
+                _context_parallel_shard(
+                    mesh=cp_mesh,
+                    buffers=tuple(buf.reshape(1, -1) for buf in inputs),
+                    seq_dims=tuple(input_seq_dim for _ in inputs),
+                    load_balancer=None,  # VarlenMetadata sharding is handled separately in _shard_varlen_metadata
+                ),
+            )
+        case _:
+            raise ValueError(
+                f"Unsupported attention_masks type for CP sharding: "
+                f"{type(attention_masks)}. Must be None, VarlenMetadata, "
+                f"BlockMask, or dict[str, BlockMask]."
+            )
 
     # BlockMask, has shape, [B, H, Q, KV], and we can only shard
     # on the Q seq dimension, not KV.
@@ -319,7 +342,7 @@ def cp_shard(
         case VarlenMetadata():
             assert load_balancer is None, "Load balancer must be disabled for variable-length attention"
             attention_masks = _shard_varlen_metadata(
-                attention_masks, cp_mesh, seq_len, cp_world_size
+                attention_masks, cp_mesh, seq_len * batch_size, cp_world_size
             )
         case BlockMask() | dict():
             assert isinstance(attention_masks, (BlockMask, dict))

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -42,8 +42,10 @@ class CPVarlenMetadata(VarlenMetadata):
     ``_shard_varlen_metadata`` (outside the model loop) to avoid GPU→CPU
     synchronizations inside ``cp_forward``.
     """
+
     k_slice_start: int  # start index into allgathered global K
     k_slice_end: int  # end index into allgathered global K
+
 
 def _shard_varlen_metadata(
     metadata: VarlenMetadata,
@@ -66,8 +68,12 @@ def _shard_varlen_metadata(
     local_start = cp_rank * seq_len // cp_world_size
     local_end = (cp_rank + 1) * seq_len // cp_world_size
 
-    local_cu_seq_q, count_cu_seq_q = metadata.cu_seq_q.clamp(local_start, local_end).unique_consecutive(return_counts=True)
-    local_cu_seq_k = metadata.cu_seq_k[count_cu_seq_q[0]-1 : (-count_cu_seq_q[-1]+1) or None].clamp(max=local_end)
+    local_cu_seq_q, count_cu_seq_q = metadata.cu_seq_q.clamp(
+        local_start, local_end
+    ).unique_consecutive(return_counts=True)
+    local_cu_seq_k = metadata.cu_seq_k[
+        count_cu_seq_q[0] - 1 : (-count_cu_seq_q[-1] + 1) or None
+    ].clamp(max=local_end)
     local_max_q = int(local_cu_seq_q.diff().max().item())
     local_max_k = int(local_cu_seq_k.diff().max().item())
 
@@ -157,14 +163,20 @@ def apply_cp_to_forward(
 
                 def cp_forward(q, k, v, **kwargs):
                     attn_masks = kwargs.get("attention_masks")
-                    assert isinstance(attn_masks, CPVarlenMetadata), "Expected CPVarlenMetadata in attention_masks"
+                    assert isinstance(attn_masks, CPVarlenMetadata), (
+                        "Expected CPVarlenMetadata in attention_masks"
+                    )
                     k = k.contiguous()
                     v = v.contiguous()
                     global_k, global_v = flex_cp_allgather(k, v, 1, pg_name)
                     # k_slice_start / k_slice_end are plain Python ints
                     # pre-computed in _shard_varlen_metadata — no GPU→CPU sync.
-                    global_k = global_k[:, attn_masks.k_slice_start:attn_masks.k_slice_end]
-                    global_v = global_v[:, attn_masks.k_slice_start:attn_masks.k_slice_end]
+                    global_k = global_k[
+                        :, attn_masks.k_slice_start : attn_masks.k_slice_end
+                    ]
+                    global_v = global_v[
+                        :, attn_masks.k_slice_start : attn_masks.k_slice_end
+                    ]
                     return orig_fn(q, global_k, global_v, **kwargs)
 
                 return cp_forward
@@ -314,17 +326,26 @@ def cp_shard(
                 ),
             )
         case VarlenMetadata():
-            # Instead of sharding directly in the sequence length dimension,
-            # we first reshape to [1, batch_size * seq_len] and shard.
-            # this let us treat the entire batch as a single sequence, which is necessary for
-            # correct sharding with variable-length inputs.
+            # Reshape [batch_size, seq_len] → [1, batch_size * seq_len] before
+            # sharding so the entire batch is treated as a single packed sequence.
+            # This preserves document boundaries that span sample boundaries, which
+            # is required for correct varlen sharding.
+            # NOTE: after this reshape the model operates with effective batch_size=1
+            # and a longer sequence. This is safe because the model is batch-invariant,
+            # but requires (batch_size * seq_len) to be divisible by cp_world_size.
+            total_tokens = batch_size * seq_len
+            if total_tokens % cp_world_size != 0:
+                raise ValueError(
+                    f"For VarlenAttention CP, batch_size * seq_len ({total_tokens}) "
+                    f"must be divisible by context_parallel_degree ({cp_world_size})."
+                )
             inputs = cast(
                 tuple[torch.Tensor, ...],
                 _context_parallel_shard(
                     mesh=cp_mesh,
                     buffers=tuple(buf.reshape(1, -1) for buf in inputs),
                     seq_dims=tuple(input_seq_dim for _ in inputs),
-                    load_balancer=None,  # VarlenMetadata sharding is handled separately in _shard_varlen_metadata
+                    load_balancer=None,
                 ),
             )
         case _:
@@ -341,7 +362,10 @@ def cp_shard(
     match attention_masks:
         case VarlenMetadata():
             if load_balancer is not None:
-                raise ValueError("Load balancer must be disabled for variable-length attention")
+                raise ValueError(
+                    "Load balancer must be disabled for VarlenAttention CP. "
+                    "Set --parallelism.context_parallel_load_balancer=none in your config."
+                )
             attention_masks = _shard_varlen_metadata(
                 attention_masks, cp_mesh, seq_len * batch_size, cp_world_size
             )

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -163,9 +163,9 @@ def apply_cp_to_forward(
 
                 def cp_forward(q, k, v, **kwargs):
                     attn_masks = kwargs.get("attention_masks")
-                    assert isinstance(attn_masks, CPVarlenMetadata), (
-                        "Expected CPVarlenMetadata in attention_masks"
-                    )
+                    assert isinstance(
+                        attn_masks, CPVarlenMetadata
+                    ), "Expected CPVarlenMetadata in attention_masks"
                     k = k.contiguous()
                     v = v.contiguous()
                     global_k, global_v = flex_cp_allgather(k, v, 1, pg_name)

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -67,7 +67,7 @@ def _shard_varlen_metadata(
     local_end = (cp_rank + 1) * seq_len // cp_world_size
 
     local_cu_seq_q, count_cu_seq_q = metadata.cu_seq_q.clamp(local_start, local_end).unique_consecutive(return_counts=True)
-    local_cu_seq_k = metadata.cu_seq_k[count_cu_seq_q[0]-1 : (-count_cu_seq_q[-1]+1) or None]
+    local_cu_seq_k = metadata.cu_seq_k[count_cu_seq_q[0]-1 : (-count_cu_seq_q[-1]+1) or None].clamp(max=local_end)
     local_max_q = int(local_cu_seq_q.diff().max().item())
     local_max_k = int(local_cu_seq_k.diff().max().item())
 
@@ -340,7 +340,8 @@ def cp_shard(
 
     match attention_masks:
         case VarlenMetadata():
-            assert load_balancer is None, "Load balancer must be disabled for variable-length attention"
+            if load_balancer is not None:
+                raise ValueError("Load balancer must be disabled for variable-length attention")
             attention_masks = _shard_varlen_metadata(
                 attention_masks, cp_mesh, seq_len * batch_size, cp_world_size
             )

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -6,7 +6,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple
+from typing import ClassVar
 
 import torch
 import torch.nn.functional as F
@@ -108,9 +108,9 @@ class VarlenAttention(Module):
         scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(
-            attention_masks, VarlenMetadata
-        ), f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
+        assert isinstance(attention_masks, VarlenMetadata), (
+            f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
+        )
 
         cu_seq_q = attention_masks.cu_seq_q
         cu_seq_k = attention_masks.cu_seq_k
@@ -224,9 +224,9 @@ class FlexAttention(Module):
         enable_gqa: bool = False,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(
-            attention_masks, (BlockMask, type(None))
-        ), f"attention_masks must be instance of BlockMask or None, got {type(attention_masks)}"
+        assert isinstance(attention_masks, (BlockMask, type(None))), (
+            f"attention_masks must be instance of BlockMask or None, got {type(attention_masks)}"
+        )
 
         # Transpose to (bs, heads, seq, dim) for flex_attention
         q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
@@ -475,7 +475,9 @@ class BaseAttention(Module):
             assert self.mask_type in [
                 "causal",
                 "block_causal",
-            ], f"mask_type must be one of ['causal', 'block_causal'], got {self.mask_type}"
+            ], (
+                f"mask_type must be one of ['causal', 'block_causal'], got {self.mask_type}"
+            )
             if (
                 isinstance(self.inner_attention, ScaledDotProductAttention.Config)
                 and self.mask_type == "block_causal"

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -108,9 +108,9 @@ class VarlenAttention(Module):
         scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(attention_masks, VarlenMetadata), (
-            f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
-        )
+        assert isinstance(
+            attention_masks, VarlenMetadata
+        ), f"attention_masks must be instance of VarlenMetadata but got {type(attention_masks)}"
 
         cu_seq_q = attention_masks.cu_seq_q
         cu_seq_k = attention_masks.cu_seq_k
@@ -224,9 +224,9 @@ class FlexAttention(Module):
         enable_gqa: bool = False,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(attention_masks, (BlockMask, type(None))), (
-            f"attention_masks must be instance of BlockMask or None, got {type(attention_masks)}"
-        )
+        assert isinstance(
+            attention_masks, (BlockMask, type(None))
+        ), f"attention_masks must be instance of BlockMask or None, got {type(attention_masks)}"
 
         # Transpose to (bs, heads, seq, dim) for flex_attention
         q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
@@ -475,9 +475,7 @@ class BaseAttention(Module):
             assert self.mask_type in [
                 "causal",
                 "block_causal",
-            ], (
-                f"mask_type must be one of ['causal', 'block_causal'], got {self.mask_type}"
-            )
+            ], f"mask_type must be one of ['causal', 'block_causal'], got {self.mask_type}"
             if (
                 isinstance(self.inner_attention, ScaledDotProductAttention.Config)
                 and self.mask_type == "block_causal"

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -56,7 +56,8 @@ __all__ = [
 ]
 
 
-class VarlenMetadata(NamedTuple):
+@dataclass(kw_only=True, slots=True)
+class VarlenMetadata:
     """
     Cumulative sequence positions for queries and keys/values.
 
@@ -118,10 +119,12 @@ class VarlenAttention(Module):
 
         batch_size, seq_len, _, head_dim = q.shape
 
-        # varlen attention expects (bs*seqlen, n_heads, head_dim)
+        # varlen attention expects (bs*seqlen, n_heads, head_dim).
+        # K/V may have a different sequence length than Q (e.g. after CP
+        # allgather+slice), so pack them independently.
         xq_packed = q.reshape(batch_size * seq_len, -1, head_dim)
-        xk_packed = k.reshape(batch_size * seq_len, -1, head_dim)
-        xv_packed = v.reshape(batch_size * seq_len, -1, head_dim)
+        xk_packed = k.reshape(k.shape[0] * k.shape[1], -1, head_dim)
+        xv_packed = v.reshape(v.shape[0] * v.shape[1], -1, head_dim)
 
         # Some operators can upcast under AMP, but varlen attention currently only
         # supports bf16/fp16 inputs. If this changes, or fp16 training support

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -85,14 +85,6 @@ class Llama3Model(Decoder):
             # Sync rope max_seq_len
             self.rope = dataclasses.replace(self.rope, max_seq_len=seq_len)
 
-            if parallelism.context_parallel_degree > 1 and isinstance(
-                self.layers[0].attention.inner_attention, VarlenAttention.Config
-            ):
-                raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
-                )
-
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 n_heads = self.layers[0].attention.n_heads

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 
-from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
+from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
 from torchtitan.tools.logging import logger

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     GQAttention,
-    VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
@@ -119,14 +118,6 @@ class Qwen3Model(Decoder):
                         layer_cfg.moe.router._debug_force_load_balance = (
                             debug.moe_force_load_balance
                         )
-
-            if parallelism.context_parallel_degree > 1 and isinstance(
-                self.layers[0].attention.inner_attention, VarlenAttention.Config
-            ):
-                raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
-                )
 
             if self.enable_weight_tying and parallelism.pipeline_parallel_degree > 1:
                 raise NotImplementedError(

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -12,10 +12,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.attention import (
-    AttentionMasksType,
-    GQAttention,
-)
+from torchtitan.models.common.attention import AttentionMasksType, GQAttention
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.tools.logging import logger


### PR DESCRIPTION
## Summary

This PR adds support for varlen attention with Context Parallelism (CP).

### Changes

- Added the sharding and CP-related setup in `context_parallel.py`.
- Updated `VarlenAttention.forward` to handle cases where the query sequence length differs from the key/value sequence length.
- Removed assertions in Llama 3 and Qwen 3 that previously disabled the varlen + CP configuration.

---

## Performance

Compared to `flex + cp + ptrr`, `varlen + cp` provides substantial and consistent throughput improvements.

### Long Sequences (64K, batch size = 2)

The following plot shows TPS improvements for long-sequence workloads:

<img width="1172" height="463" alt="tps" src="https://github.com/user-attachments/assets/cb18c46e-e535-4247-b254-7a0ba02ce2e2" />

### Shorter Sequences (`test_c4`)

For shorter sequences (e.g. the setup used in `test_c4`), varlen still provides meaningful gains, although the improvements are more modest:

<img width="1172" height="469" alt="tps2" src="https://github.com/user-attachments/assets/e5851463-f75b-47d1-9f31-5a709b01a89c" />

---

## Testing

### Output Equivalence

I compared the outputs of:
- `varlen` with `CP=4`
- `varlen` with `CP=1`

using the same checkpoint in both cases to ensure identical weights. The outputs matched exactly across several sequence length variations.

### Training Metrics

I also compared the loss and gradient norm between:
- `llama3 + flex + CP=4`
- `llama3 + varlen + CP=4`

at `seq_len=64K`.

The results match closely:

<img width="1172" height="454" alt="llama3-cp-long-bs1-varlen_vs_flex-loss" src="https://github.com/user-attachments/assets/5e459bb0-b938-46b7-8b47-113ab456fda6" />

<img width="1177" height="468" alt="llama3-cp-long-bs1-varlen_vs_flex-gradnorm" src="https://github.com/user-attachments/assets/b67b80bf-582a-4599-944d-a86c67d5aab4" />
