### PR TITLE
[forge] bugfix: ForgeEngine broken with `ChunkedCELoss`

### DIFF
--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -13,7 +13,7 @@ import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.checkpoint import CheckpointManager
-from torchtitan.components.loss import LossFunction
+from torchtitan.components.loss import BaseLoss, ChunkedCELoss, LossFunction
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
@@ -54,6 +54,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         compile: CompileConfig = field(default_factory=CompileConfig)
         comm: CommConfig = field(default_factory=CommConfig)
         debug: DebugConfig = field(default_factory=DebugConfig)
+        loss: BaseLoss.Config = field(default_factory=BaseLoss.Config)
 
         def to_dict(self) -> dict[str, Any]:
             return asdict(self)
@@ -161,9 +162,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             init_device = device_type
             buffer_device = None
 
-        self.loss_fn = self.train_spec.loss.build(
-            config.compile, parallel_dims=parallel_dims
-        )
+        self.loss_fn = config.loss.build(compile_config=config.compile)
 
         # verify batch sizes
         global_batch_size = config.training.global_batch_size
@@ -242,6 +241,25 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             self.model_parts = [model]
 
+        # Set lm_head reference for ChunkedCELoss after model construction.
+        # Non-PP: single model part always has lm_head.
+        # PP: only the last stage has lm_head; non-last stages skip this.
+        if isinstance(self.loss_fn, ChunkedCELoss):
+            if parallel_dims.pp_enabled:
+                if self.pp_has_last_stage:
+                    lm_head = self.model_parts[-1].lm_head
+                    assert (
+                        lm_head is not None
+                    ), "Last PP stage must have lm_head for ChunkedCELoss"
+                    self.loss_fn.set_lm_head(lm_head)
+                    self.model_parts[-1]._skip_lm_head = True
+            else:
+                assert len(self.model_parts) == 1
+                lm_head = self.model_parts[0].lm_head
+                assert lm_head is not None, "Model must have lm_head for ChunkedCELoss"
+                self.loss_fn.set_lm_head(lm_head)
+                self.model_parts[0]._skip_lm_head = True
+
         # build optimizer after applying parallelisms to the model
         self.optimizers = config.optimizer.build(
             model_parts=self.model_parts,
@@ -270,7 +288,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
 
         loss_parallel_enabled = (
-            parallel_dims.tp_enabled and not parallelism_config.disable_loss_parallel
+            parallel_dims.tp_enabled and not config.parallelism.disable_loss_parallel
         )
         self.train_context = dist_utils.get_train_context(loss_parallel_enabled)
 


### PR DESCRIPTION
# Summary

`ForgeEngine` is currently broken on main branch. Constructing a Trainer from torchtitan/experiments/forge/example_train.py fails with:

```
    File "/[venv]/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 367, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/[workspace]/torchtitan/torchtitan/experiments/forge/example_train.py", line 47, in __init__
      super().__init__(config)
    File "/[venv]/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 367, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/[workspace]/torchtitan/torchtitan/experiments/forge/engine.py", line 164, in __init__
      self.loss_fn = self.train_spec.loss.build(
                     ^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'ModelSpec' object has no attribute 'loss'
```

This was introduced by #2937. That PR moved the loss config from `ModelSpec.build_loss_fn` to the top-level `Trainer.Config.loss` field and updated torchtitan/trainer.py accordingly, but the sibling change to ForgeEngine was wrong: it became `self.train_spec.loss.build(...)` even though `ModelSpec` no longer has a loss field at all.

# Changes

- Build the loss from the top-level config, matching Trainer: `self.loss_fn = config.loss.build(compile_config=config.compile)`.
- Add a `loss: BaseLoss.Config` field on ForgeEngine.Config so that ForgeEngine can be used standalone (the existing example_train.py path keeps working because it passes the wider Trainer.Config whose loss is populated by the model registry).
- Port the ChunkedCELoss `lm_head` wiring from Trainer. Without this, models whose registry defaults to ChunkedCELoss.Config() (e.g. llama3, qwen3) would crash again during the first forward.
- Fix an unrelated `NameError` introduced by #2822: `parallelism_config.disable_loss_parallel` -> `config.parallelism.disable_loss_parallel`.

No behavior change for torchtitan/trainer.py; this only realigns ForgeEngine with the post-#2937 loss-building contract.