### PR TITLE
[graph_trainer] Fix precompile pickle failure with FlexAttention BlockMask

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -145,7 +145,11 @@ class PrecompiledFxTraceArtifact:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int]
-    user_inputs_spec: pytree.TreeSpec
+    # user_inputs_spec is intentionally omitted: it can contain
+    # FlexAttention _MaskModWrapper objects that are not picklable,
+    # and the mask_mod is already compiled into standalone Inductor
+    # HOPs (AOTCompiledArtifact) baked into serialized_gm. The spec
+    # is only used for optional runtime validation in run_traced().
     config_fingerprint: ConfigFingerprint = ConfigFingerprint("")
 
     @classmethod
@@ -185,7 +189,6 @@ class PrecompiledFxTraceArtifact:
             output_subclass_layouts=traced_result.output_subclass_layouts,
             output_spec=traced_result.output_spec,
             tensor_input_indices=traced_result.tensor_input_indices,
-            user_inputs_spec=traced_result.user_inputs_spec,
             config_fingerprint=config_fingerprint or ConfigFingerprint(""),
         )
 
@@ -209,12 +212,16 @@ class PrecompiledFxTraceArtifact:
         gm = GraphPickler.loads(self.serialized_gm, fake_mode)
         gm.recompile()
 
+        # Provide a minimal dummy spec since user_inputs_spec is not
+        # serialized (see comment on the dataclass field above).
+        dummy_spec = pytree.tree_flatten(((), {}))[1]
+
         return TracedResult(
             gm=gm,
             example_inputs=(),
             num_flat_inputs=self.num_flat_inputs,
             input_subclass_layouts=self.input_subclass_layouts,
-            user_inputs_spec=self.user_inputs_spec,
+            user_inputs_spec=dummy_spec,
             tensor_input_indices=self.tensor_input_indices,
             num_flat_outputs=self.num_flat_outputs,
             output_subclass_layouts=self.output_subclass_layouts,

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -205,7 +205,6 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
             output_subclass_layouts={0: SubclassLayout(1, None)},
             output_spec=spec,
             tensor_input_indices=[0, 1, 2, 3],
-            user_inputs_spec=spec,
             config_fingerprint="test_fp_123",
         )
 
@@ -218,6 +217,63 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
         self.assertEqual(len(loaded.input_subclass_layouts), 2)
         self.assertEqual(loaded.num_flat_outputs, 2)
         self.assertEqual(loaded.config_fingerprint, "test_fp_123")
+
+    def test_artifact_pickle_with_blockmask_treespec(self):
+        """Verify artifact pickles when user_inputs_spec contains BlockMask.
+
+        BlockMask's pytree context stores a _MaskModWrapper holding the
+        mask_mod closure, which is not picklable. The artifact must not
+        serialize user_inputs_spec (the mask_mod is already compiled into
+        standalone Inductor HOPs baked into serialized_gm).
+        """
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        from torchtitan.experiments.graph_trainer.common_utils import (
+            maybe_register_blockmask_pytree_node,
+        )
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+        from torchtitan.experiments.graph_trainer.precompile import (
+            PrecompiledFxTraceArtifact,
+        )
+        from torchtitan.models.common.attention import get_causal_mask_mod
+
+        maybe_register_blockmask_pytree_node()
+
+        mask_mod = get_causal_mask_mod()
+        block_mask = create_block_mask(mask_mod, B=1, H=1, Q_LEN=128, KV_LEN=128)
+
+        # Build a user_inputs_spec that includes BlockMask — this is what
+        # minimal_fx_tracer produces when FlexAttention is configured.
+        _, blockmask_spec = torch.utils._pytree.tree_flatten(
+            ((torch.zeros(2),), {"attention_masks": block_mask})
+        )
+
+        # Sanity: the raw TreeSpec itself is NOT picklable (the bug).
+        with self.assertRaises((TypeError, AttributeError)):
+            pickle.dumps(blockmask_spec)
+
+        # Build a TracedResult with the unpicklable spec, then create
+        # the artifact via from_traced_result — this must succeed because
+        # user_inputs_spec is excluded from serialization.
+        gm = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
+        dummy_spec = torch.utils._pytree.tree_flatten(((), {}))[1]
+        traced_result = TracedResult(
+            gm=gm,
+            example_inputs=(),
+            num_flat_inputs=0,
+            input_subclass_layouts={},
+            user_inputs_spec=blockmask_spec,
+            tensor_input_indices=[],
+            num_flat_outputs=0,
+            output_subclass_layouts={},
+            output_spec=dummy_spec,
+            state_fqns=[],
+        )
+
+        artifact = PrecompiledFxTraceArtifact.from_traced_result(traced_result)
+        data = pickle.dumps(artifact)
+        loaded = pickle.loads(data)
+        self.assertEqual(loaded.serialized_gm, artifact.serialized_gm)
 
     def test_fx_trace_save_load_fingerprint_mismatch(self):
         from torchtitan.experiments.graph_trainer.precompile import (
@@ -236,7 +292,6 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
             output_subclass_layouts={},
             output_spec=spec,
             tensor_input_indices=[0, 1],
-            user_inputs_spec=spec,
             config_fingerprint="old_fp",
         )
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Fix `TypeError: cannot pickle code objects` when precompiling models with FlexAttention (e.g. Llama3-70B with `attn_backend="flex"`).

### Root cause

Two PRs combined to create this bug:

1. **#2916** ("Add CooR precompile support for DeepSeek V3") hoisted `BlockMask` into `extra_kwargs["attention_masks"]` so FlexAttention masks flow through `minimal_fx_tracer` as kwargs. This was fine at the time because `user_inputs_spec` was not serialized.

2. **#3262** ("Support kwargs in minimal_fx_tracer") added `user_inputs_spec` to `PrecompiledFxTraceArtifact` for optional runtime validation. This caused `pickle.dumps(artifact)` to serialize the `TreeSpec`, which now contained a `_MaskModWrapper` from the `BlockMask` pytree context. `_MaskModWrapper` holds the `mask_mod` closure (a local function from `get_causal_mask_mod`), which Python's pickle cannot serialize.

Neither PR broke things on its own — #2916 put `BlockMask` in the kwargs, and #3262 started serializing the kwargs' `TreeSpec`.

### Fix

Remove `user_inputs_spec` from `PrecompiledFxTraceArtifact`. The `mask_mod` is already compiled into standalone Inductor HOPs (`AOTCompiledArtifact`) baked into `serialized_gm` by the regional inductor pass, so it does not need to be preserved in the artifact metadata. `user_inputs_spec` is only used for an optional runtime validation check in `run_traced()` (disabled by default), so omitting it is safe.

## Test plan

- [x] New unit test `test_artifact_pickle_with_blockmask_treespec` — creates a `TracedResult` with an unpicklable BlockMask `TreeSpec`, verifies `from_traced_result` + `pickle.dumps` succeeds
- [x] `pytest torchtitan/experiments/graph_trainer/tests/test_precompile.py` — all 20 tests pass