### PR TITLE
[graph_trainer] Add full recompute memory policy

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -43,10 +43,12 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
-    memory_policy: Literal["default", "eager", "sac_and_offload"] = "default"
+    memory_policy: Literal["default", "full", "eager", "sac_and_offload"] = "default"
     """
     Memory optimization policy for activation management (SAC, offload).
         default: SAC — save all compute-intensive ops and FSDP all_gathers.
+        full: full recompute — only layer outputs are saved. Mirrors
+            eager's full AC (checkpoint_wrapper with no context_fn).
         eager: SAC alternating mm ops between save/recompute, matching the
             eager AC policy in torchtitan.distributed.activation_checkpoint.
         sac_and_offload: SAC + CPU offload — apply default SAC first,

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -62,6 +62,32 @@ def _make_default_memory_policy(
     return policy_fn
 
 
+def _make_full_memory_policy() -> Callable:
+    """Full recompute policy: mark everything as MUST_RECOMPUTE.
+
+    The layer boundary pass in tag_sac_policy will force MUST_SAVE on nodes
+    whose output crosses a layer boundary, so only layer outputs are saved.
+    This mirrors eager's full AC (checkpoint_wrapper with no context_fn).
+
+    Two classes of ops are always saved:
+    - RNG ops (dropout etc.): remat pass cannot replay their random state.
+    - Higher-order ops (flex_attention, inductor_compiled_code): they carry
+      GraphModule subgraph arguments that node_copy cannot duplicate.
+    """
+    from torch._ops import HigherOrderOperator
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        if torch.Tag.nondeterministic_seeded in getattr(node.target, "tags", set()):
+            return CheckpointPolicy.MUST_SAVE
+        # TODO: node_copy should support HOPs with subgraph arguments,
+        # removing the need for this workaround.
+        if isinstance(node.target, HigherOrderOperator):
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.MUST_RECOMPUTE
+
+    return policy_fn
+
+
 def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
     """Eager-compatible SAC policy that alternates mm ops between save/recompute.
 
@@ -227,6 +253,17 @@ def _default_memory_policy_pass(
     return gm
 
 
+@register_memory_policy("full")
+def _full_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """Full recompute: only layer outputs are saved."""
+    tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+    return gm
+
+
 @register_memory_policy("eager")
 def _eager_memory_policy_pass(
     gm: torch.fx.GraphModule,
@@ -262,6 +299,7 @@ def tag_with_memory_policy_pass(
 
     The ``config.compile.memory_policy`` selects the tagging strategy:
         default: SAC with all compute-intensive ops saved.
+        full: full recompute — only layer outputs are saved.
         eager: SAC alternating mm ops between save/recompute.
         sac_and_offload: SAC + CPU offload within budget.
 

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -67,21 +67,22 @@ def _make_full_memory_policy() -> Callable:
 
     The layer boundary pass in tag_sac_policy will force MUST_SAVE on nodes
     whose output crosses a layer boundary, so only layer outputs are saved.
-    This mirrors eager's full AC (checkpoint_wrapper with no context_fn).
+    This mirrors eager's full AC (checkpoint_wrapper with no context_fn),
+    which recomputes the entire block — including attention — in backward.
 
-    Two classes of ops are always saved:
-    - RNG ops (dropout etc.): remat pass cannot replay their random state.
-    - Higher-order ops (flex_attention, inductor_compiled_code): they carry
-      GraphModule subgraph arguments that node_copy cannot duplicate.
+    RNG ops (dropout etc.) are the one class that is always saved: the remat
+    pass cannot replay their random state, and ``has_recomputable_rng_ops``
+    would otherwise raise. Eager full AC recomputes them by forking the RNG
+    state (``preserve_rng_state=True``); the graph path lacks that, so it
+    saves them instead.
+
+    Higher-order ops (e.g. flex_attention) ARE recomputed: ``node_copy``
+    duplicates them together with their ``get_attr`` subgraph references, and
+    the subsequent regional_inductor pass compiles the duplicate as well.
     """
-    from torch._ops import HigherOrderOperator
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         if torch.Tag.nondeterministic_seeded in getattr(node.target, "tags", set()):
-            return CheckpointPolicy.MUST_SAVE
-        # TODO: node_copy should support HOPs with subgraph arguments,
-        # removing the need for this workaround.
-        if isinstance(node.target, HigherOrderOperator):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.MUST_RECOMPUTE
 
@@ -150,10 +151,6 @@ def tag_sac_policy(
     if policy_fn is None:
         policy_fn = _make_default_memory_policy()
 
-    layer_stats: dict[int, dict[str, int]] = defaultdict(
-        lambda: {"save": 0, "recompute": 0}
-    )
-
     # Pass 1: Tag each forward node with a recompute policy.
     for node in gm.graph.nodes:
         if node.op != "call_function":
@@ -183,18 +180,10 @@ def tag_sac_policy(
                 node.meta["recompute"] = parent.meta["recompute"]
             continue
 
-        layer_id = _get_layer_id(node)
-
         # NOTE: The eager SAC policy (activation_checkpoint.py) alternates
         # mm ops between MUST_SAVE and PREFER_RECOMPUTE. We omit that here
         # because the alternating heuristic is arbitrary.
         node.meta["recompute"] = policy_fn(node)
-        key = (
-            "save"
-            if node.meta["recompute"] == CheckpointPolicy.MUST_SAVE
-            else "recompute"
-        )
-        layer_stats[layer_id][key] += 1
 
     # Pass 2: Force MUST_SAVE at layer boundaries. If a recomputable node
     # feeds into a node in a higher layer, saving it is cheaper than
@@ -221,6 +210,27 @@ def tag_sac_policy(
                 break
 
     gm.recompile()
+
+    # Per-layer summary from the FINAL policy (after boundary forcing). Counts
+    # every forward node carrying a recompute decision — primary policy-tagged
+    # ops plus getitem/wait_tensor (which inherit a parent's tag) plus any node
+    # the boundary pass forced to MUST_SAVE — so the per-layer MUST_SAVE counts
+    # account for boundary saves wherever they land (including on getitem /
+    # wait_tensor). The recompute count covers both PREFER_RECOMPUTE and
+    # MUST_RECOMPUTE, so the column is labelled generically as RECOMPUTE.
+    layer_stats: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"save": 0, "recompute": 0}
+    )
+    for node in gm.graph.nodes:
+        if "recompute" not in node.meta:
+            continue
+        key = (
+            "save"
+            if node.meta["recompute"] == CheckpointPolicy.MUST_SAVE
+            else "recompute"
+        )
+        layer_stats[_get_layer_id(node)][key] += 1
+
     logger.info("Applied selective activation checkpointing (SAC) graph pass.")
     if boundary_saves:
         logger.info(f"  Forced {boundary_saves} nodes to MUST_SAVE at layer boundaries")
@@ -230,7 +240,7 @@ def tag_sac_policy(
         logger.info(
             f"  Layer {label}: "
             f"{stats['save']} MUST_SAVE, "
-            f"{stats['recompute']} PREFER_RECOMPUTE"
+            f"{stats['recompute']} RECOMPUTE"
         )
     return gm
 

--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -271,6 +271,34 @@ def selective_activation_remat_pass(
             return bwd_wait
         return x
 
+    def duplicate_subgraph_get_attrs(
+        fwd_node: fx.Node, bwd_target: fx.Node
+    ) -> dict[fx.Node, fx.Node]:
+        """Give a recompute dup private copies of its subgraph get_attr inputs.
+
+        HOPs like ``flex_attention`` reference their ``score_mod`` / ``mask_mod``
+        subgraphs through ``get_attr`` nodes. If the dup shared the original's
+        get_attr, the later ``regional_inductor`` pass — which partitions the
+        annotated flex node together with its subgraph get_attrs — could only
+        place that shared get_attr in one flex region's partition, leaving the
+        other flex with the subgraph passed as a raw ``GraphModule`` arg (which
+        fails to compile). Fresh get_attr nodes (same target, same submodule)
+        keep each flex region self-contained. Plain-tensor get_attrs are left
+        shared: they are never annotated, so they stay cross-region inputs for
+        both the original and the dup, exactly as before.
+        """
+        dups: dict[fx.Node, fx.Node] = {}
+        for arg in fwd_node.all_input_nodes:
+            if arg.op != "get_attr":
+                continue
+            if not isinstance(getattr(gm, arg.target, None), fx.GraphModule):
+                continue
+            with gm.graph.inserting_before(bwd_target):
+                dup_attr = gm.graph.get_attr(arg.target)
+            dup_attr.meta.update(arg.meta)
+            dups[arg] = dup_attr
+        return dups
+
     # Iterate the claimed must_recompute fwd nodes in graph order so that
     # each dup's upstream deps are already duped (and visible via
     # ``recomputed_nodes``) by the time we copy a downstream node.
@@ -283,8 +311,17 @@ def selective_activation_remat_pass(
             bwd_wait = offloaded_fwd_to_bwd_wait.get(arg)
             if bwd_wait is not None:
                 ensure_offload_chain_before(bwd_wait, bwd_target)
+        # HOP subgraph get_attrs must be private to each recompute dup so
+        # regional_inductor can partition each flex region independently.
+        get_attr_dups = duplicate_subgraph_get_attrs(fwd_node, bwd_target)
+
+        def remat_and_dup_get_attr(x: object, _dups=get_attr_dups) -> object:
+            if isinstance(x, fx.Node) and x in _dups:
+                return _dups[x]
+            return remat_input(x)
+
         with gm.graph.inserting_before(bwd_target):
-            dup = gm.graph.node_copy(fwd_node, remat_input)
+            dup = gm.graph.node_copy(fwd_node, remat_and_dup_get_attr)
         dup.name = fwd_node.name + "_recomputed"
         dup.meta["autograd_backward"] = True
         recomputed_nodes[fwd_node] = dup

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -610,7 +610,7 @@ class TestFullMemoryPolicy(TestCase):
             )
 
     def test_save_ops_also_recomputed(self):
-        """Even compute-intensive ops (SDPA, linear) are recomputed under full."""
+        """Compute-intensive ops (linear, max) are recomputed under full."""
         gm = self._build_gm(
             [
                 torch.ops.aten.linear.default,
@@ -623,6 +623,22 @@ class TestFullMemoryPolicy(TestCase):
                 node.meta["recompute"],
                 CheckpointPolicy.MUST_RECOMPUTE,
             )
+
+    def test_rng_ops_saved(self):
+        """RNG ops (nondeterministic_seeded) are saved: the remat pass cannot
+        replay their random state, unlike eager AC's preserve_rng_state."""
+        policy_fn = _make_full_memory_policy()
+        gm = self._build_gm([torch.ops.aten.native_dropout.default])
+        node = self._get_call_function_nodes(gm)[0]
+        self.assertEqual(policy_fn(node), CheckpointPolicy.MUST_SAVE)
+
+    def test_higher_order_ops_recomputed(self):
+        """Higher-order ops (flex_attention) are recomputed, not saved: the
+        remat pass duplicates the HOP together with its subgraph get_attrs."""
+        policy_fn = _make_full_memory_policy()
+        gm = self._build_gm([torch.ops.higher_order.flex_attention])
+        node = self._get_call_function_nodes(gm)[0]
+        self.assertEqual(policy_fn(node), CheckpointPolicy.MUST_RECOMPUTE)
 
     def test_layer_boundary_forced_to_must_save(self):
         """Nodes at layer boundaries should still be forced to MUST_SAVE."""
@@ -1819,6 +1835,69 @@ class TestSelectiveActivationRematPass(TestCase):
         )
         for inp_node in fwd_use_node.all_input_nodes:
             self.assertEqual(inp_node.name, a_name)
+
+    def test_subgraph_get_attr_duplicated_for_recompute(self):
+        """A recomputed node with a subgraph (GraphModule) get_attr input gets
+        a PRIVATE copy of that get_attr, pointing at the same submodule.
+
+        This mirrors how ``flex_attention`` references its score_mod / mask_mod
+        subgraphs via get_attr nodes. Without private copies, the later
+        regional_inductor pass — which partitions each flex node together with
+        its subgraph get_attrs — would place a shared get_attr in only one
+        region, leaving the other flex with the subgraph passed as a raw
+        GraphModule arg (which fails to compile).
+
+            sub = get_attr("subgraph")     # GraphModule attribute
+            a   = some_op(inp, sub)        # must_recompute (HOP-like)
+            bwd = a + a                    # autograd_backward consumer
+
+        Plain-tensor get_attrs are left shared (they are never region-annotated),
+        so this only fires for GraphModule-valued attributes.
+        """
+        from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+            selective_activation_remat_pass,
+        )
+
+        # A trivial GraphModule used as the subgraph attribute, plus a plain
+        # tensor constant attribute that must stay shared (not duplicated).
+        sub_graph = torch.fx.Graph()
+        sub_graph.output(sub_graph.placeholder("x"))
+        root = torch.nn.Module()
+        root.subgraph = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+        root.const = torch.nn.Buffer(torch.zeros(1))
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        sub = graph.get_attr("subgraph")
+        const = graph.get_attr("const")
+        a = graph.call_function(torch.ops.aten.add.Tensor, args=(inp, sub))
+        a.kwargs = {"const": const}
+        bwd = graph.call_function(torch.ops.aten.add.Tensor, args=(a, a))
+        graph.output(bwd)
+        a.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        bwd.meta["autograd_backward"] = True
+
+        gm = torch.fx.GraphModule(root, graph)
+        result = selective_activation_remat_pass(gm)
+
+        dups = [n for n in result.graph.nodes if n.name.endswith("_recomputed")]
+        self.assertEqual(len(dups), 1)
+        dup = dups[0]
+
+        dup_subgraph_attrs = [
+            n
+            for n in dup.all_input_nodes
+            if n.op == "get_attr" and n.target == "subgraph"
+        ]
+        self.assertEqual(len(dup_subgraph_attrs), 1)
+        # Private copy: a distinct node from the original, same submodule target.
+        self.assertIsNot(dup_subgraph_attrs[0], sub)
+
+        # The plain-tensor const get_attr is shared, not duplicated.
+        const_attrs = [
+            n for n in result.graph.nodes if n.op == "get_attr" and n.target == "const"
+        ]
+        self.assertEqual(len(const_attrs), 1)
 
     def test_offload_reload_chain_hoisted(self):
         """Mirrors the graph the CPU-offload pass produces: a forward

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -37,6 +37,7 @@ from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
 from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_default_memory_policy,
+    _make_full_memory_policy,
     tag_sac_policy,
 )
 from torchtitan.experiments.graph_trainer.passes import (
@@ -565,6 +566,106 @@ class TestApplySACPass(TestCase):
         ]
         self.assertEqual(len(recomputed_nodes), 1)
         self.assertTrue(recomputed_nodes[0].meta["autograd_backward"])
+
+
+class TestFullMemoryPolicy(TestCase):
+    """Unit tests for the full recompute memory policy."""
+
+    def _build_gm(self, op_targets, layer_fqns=None):
+        """Build a GraphModule with call_function nodes and optional layer FQNs."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        last = x
+        nodes = []
+        for target in op_targets:
+            last = graph.call_function(target, args=(last, y))
+            nodes.append(last)
+        graph.output(last)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        if layer_fqns:
+            for node, fqn in zip(nodes, layer_fqns):
+                if fqn is not None:
+                    node.meta["custom"] = {_MODULE_FQN: fqn}
+        return gm
+
+    def _get_call_function_nodes(self, gm):
+        return [n for n in gm.graph.nodes if n.op == "call_function"]
+
+    def test_all_ops_marked_recompute(self):
+        """All ops should be marked MUST_RECOMPUTE with full policy."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.mm.default,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ]
+        )
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        for node in self._get_call_function_nodes(gm):
+            self.assertEqual(
+                node.meta["recompute"],
+                CheckpointPolicy.MUST_RECOMPUTE,
+                f"node {node.name} should be MUST_RECOMPUTE",
+            )
+
+    def test_save_ops_also_recomputed(self):
+        """Even compute-intensive ops (SDPA, linear) are recomputed under full."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.linear.default,
+                torch.ops.aten.max.default,
+            ]
+        )
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        for node in self._get_call_function_nodes(gm):
+            self.assertEqual(
+                node.meta["recompute"],
+                CheckpointPolicy.MUST_RECOMPUTE,
+            )
+
+    def test_layer_boundary_forced_to_must_save(self):
+        """Nodes at layer boundaries should still be forced to MUST_SAVE."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ],
+            layer_fqns=[
+                "layers.0.feed_forward",
+                "layers.1.attention",
+            ],
+        )
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        nodes = self._get_call_function_nodes(gm)
+        # add crosses from layer 0 to layer 1 — forced to MUST_SAVE
+        self.assertEqual(nodes[0].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        # relu has no higher-layer consumer — stays MUST_RECOMPUTE
+        self.assertEqual(nodes[1].meta["recompute"], CheckpointPolicy.MUST_RECOMPUTE)
+
+    def test_same_layer_nodes_all_recomputed(self):
+        """Within a single layer, all ops should be recomputed."""
+        gm = self._build_gm(
+            [
+                torch.ops.aten.mm.default,
+                torch.ops.aten.linear.default,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.relu.default,
+            ],
+            layer_fqns=[
+                "layers.0.attention",
+                "layers.0.attention",
+                "layers.0.feed_forward",
+                "layers.0.feed_forward",
+            ],
+        )
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        for node in self._get_call_function_nodes(gm):
+            self.assertEqual(
+                node.meta["recompute"],
+                CheckpointPolicy.MUST_RECOMPUTE,
+                f"node {node.name} in single layer should be MUST_RECOMPUTE",
+            )
 
 
 class TestBucketingPrefetchOrder(FSDPTest):

--- a/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
@@ -159,6 +159,82 @@ class TestGraphSACPeakMemory(unittest.TestCase):
             f"ratio={active_ratio:.3f}",
         )
 
+    def test_llama3_debugmodel_full_ac_saves_memory_vs_default(self):
+        """Full recompute uses less peak memory than the default SAC policy."""
+        default_model = _build_model(DEBUGMODEL)
+        default_model.load_state_dict(copy.deepcopy(self.state_dict))
+        default_trainer = build_minimal_trainer(
+            default_model,
+            llama3_registry(DEBUGMODEL).model,
+            GraphTrainer,
+            activation_checkpoint_mode="selective",
+        )
+        default_trainer.config.compile.memory_policy = "default"
+
+        full_model = _build_model(DEBUGMODEL)
+        full_model.load_state_dict(copy.deepcopy(self.state_dict))
+        full_trainer = build_minimal_trainer(
+            full_model,
+            llama3_registry(DEBUGMODEL).model,
+            GraphTrainer,
+            activation_checkpoint_mode="selective",
+        )
+        full_trainer.config.compile.memory_policy = "full"
+
+        _measure_step(default_trainer, self.tokens, self.labels)
+        _measure_step(full_trainer, self.tokens, self.labels)
+        torch.cuda.empty_cache()
+
+        default = _measure_step(default_trainer, self.tokens, self.labels)
+        full = _measure_step(full_trainer, self.tokens, self.labels)
+
+        self.assertLessEqual(
+            full.active_gib,
+            default.active_gib,
+            "full recompute should use less peak memory than default SAC: "
+            f"full={full.active_gib:.3f} GiB, "
+            f"default={default.active_gib:.3f} GiB",
+        )
+
+    def test_llama3_debugmodel_full_ac_numerics_match_eager(self):
+        """Graph full recompute produces bitwise-identical loss and grads vs eager."""
+        eager_model = _build_model(DEBUGMODEL)
+        eager_model.load_state_dict(copy.deepcopy(self.state_dict))
+        apply_ac(eager_model, ActivationCheckpointConfig(mode="full"))
+        eager_trainer = build_minimal_trainer(
+            eager_model,
+            llama3_registry(DEBUGMODEL).model,
+            Trainer,
+        )
+
+        traced_model = _build_model(DEBUGMODEL)
+        traced_model.load_state_dict(copy.deepcopy(self.state_dict))
+        traced_trainer = build_minimal_trainer(
+            traced_model,
+            llama3_registry(DEBUGMODEL).model,
+            GraphTrainer,
+            activation_checkpoint_mode="selective",
+        )
+        traced_trainer.config.compile.memory_policy = "full"
+
+        _measure_step(eager_trainer, self.tokens, self.labels)
+        _measure_step(traced_trainer, self.tokens, self.labels)
+        torch.cuda.empty_cache()
+
+        eager = _measure_step(eager_trainer, self.tokens, self.labels)
+        traced = _measure_step(traced_trainer, self.tokens, self.labels)
+
+        self.assertTrue(
+            torch.equal(eager.loss, traced.loss),
+            f"loss mismatch: eager={eager.loss.item()} traced={traced.loss.item()}",
+        )
+        for idx, (eager_grad, traced_grad) in enumerate(
+            zip(eager.grads, traced.grads, strict=True)
+        ):
+            self.assertTrue(
+                torch.equal(eager_grad, traced_grad), f"grad[{idx}] mismatch"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a `"full"` memory policy for graph_trainer that marks all ops as `PREFER_RECOMPUTE`, saving only layer boundary outputs, RNG ops (dropout), and higher-order ops (flex_attention, inductor_compiled_code whose GraphModule subgraph arguments can't be duplicated by node_copy). This mirrors eager mode's `_apply_full_ac` (`checkpoint_wrapper` with no `context_fn`).
- Useful for memory-constrained scenarios: larger batch sizes, longer sequences, or bigger models where trading ~10% throughput for ~35-39% memory savings is worthwhile.
- Usage: `--compile.memory_policy full`

## Llama3 8B benchmarks (8×H100, 20 steps, c4_test)

### FSDP4 + TP2
| Metric       | `default`         | `full`            | Delta     |
|--------------|-------------------|-------------------|-----------|
| Peak memory  | 30.92 GiB (33%)   | 20.70 GiB (22%)   | **-33.0%** |
| TPS (step20) | 6,607             | 5,933             | -10.2%    |
| MFU (step20) | 38.69%            | 34.74%            | -10.2%    |

### FSDP8 + TP1
| Metric       | `default`         | `full`            | Delta     |
|--------------|-------------------|-------------------|-----------|
| Peak memory  | 52.44 GiB (55%)   | 32.07 GiB (34%)   | **-38.8%** |
| TPS (step20) | 7,890             | 7,006             | -11.2%    |
| MFU (step20) | 46.20%            | 41.02%            | -11.2%    |

## DeepSeek-v3 16B benchmarks (8×H100, FSDP8+EP8, 20 steps, c4_test)

| Metric       | `default`         | `full`            | Delta     |
|--------------|-------------------|-------------------|-----------|
| Peak memory  | 84.78 GiB (89%)   | 52.02 GiB (55%)   | **-38.6%** |
| TPS (step20) | 8,325             | 7,444             | -10.6%    |
| MFU (step20) | 15.24%            | 13.63%            | -10.6%    |

## Test plan

- [x] `TestFullMemoryPolicy` (4 unit tests): all ops marked recompute, save ops also recomputed, layer boundaries forced to MUST_SAVE, same-layer nodes all recomputed
- [x] `TestApplySACPass` (8 existing tests): no regressions
- [x] `test_llama3_debugmodel_full_ac_saves_memory_vs_default`: full uses less peak memory than default
- [x] `test_llama3_debugmodel_full_ac_numerics_match_eager`: bitwise-identical loss and grads vs eager full AC
- [x] `test_llama3_debugmodel_peak_memory_matches_eager_selective_ac`: existing test still passes
- [x] Llama3 8B FSDP4+TP2, FSDP8+TP1 benchmarks
- [x] DeepSeek-v3 16B FSDP8+EP8 benchmark