### PR TITLE
[graph_trainer] Skip tests broken by upstream PyTorch nightly regressions

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -465,6 +465,9 @@ def _build_async_tp_tests() -> list[OverrideDefinitions]:
 def _build_autoparallel_tests() -> list[OverrideDefinitions]:
     """AutoParallel integration tests for default runners."""
     return [
+        # TODO: disabled due to upstream AutoParallel regression in nightly:
+        # nll_loss assertion failure (t >= 0 && t < n_classes) from incorrect
+        # loss partitioning. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -479,6 +482,7 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
             "autoparallel llama3 FSDP+TP",
             "autoparallel_llama3_fsdp_tp",
             ngpu=4,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -300,6 +300,11 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
         # === aot_fx_trace mode tests ===
         # Note: cudagraph is auto-skipped for DSv3 because MoE load-balancing
         # introduces CUDA→CPU transfers incompatible with CUDA graph capture.
+        #
+        # TODO: aot_fx_trace MoE tests are disabled due to an upstream PyTorch
+        # regression: histc's meta kernel doesn't support int64 inputs,
+        # breaking tracing for all MoE models. Re-enable once the histc
+        # meta kernel is fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -315,6 +320,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+CP+EP",
             "aot_fx_trace_deepseek_v3_fsdp_tp_cp_ep",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -330,6 +336,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -346,6 +353,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+full_inductor",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_full_inductor",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -361,6 +369,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+HybridEP",
             "aot_fx_trace_deepseek_v3_hybridep",
             ngpu=4,
+            disabled=True,
         ),
     ]
 
@@ -383,6 +392,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_qwen3_fsdp_tp_cp",
             ngpu=8,
         ),
+        # TODO: disabled due to upstream histc int64 regression (see DSv3 comment)
         OverrideDefinitions(
             [
                 [
@@ -397,6 +407,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace qwen3 MoE FSDP+TP+EP",
             "aot_fx_trace_qwen3_moe_fsdp_tp_ep",
             ngpu=8,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -177,6 +177,10 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
         ),
         # === aot_fx_trace mode tests ===
         # Note: aot_fx_trace applies cudagraph by default, so skip_rocm_test=True.
+        #
+        # TODO: disabled due to upstream PyTorch cuDNN regression in nightly:
+        # CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH with CUDA graphs + context
+        # parallelism. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -192,8 +196,12 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_cp",
             ngpu=8,
             skip_rocm_test=True,
+            disabled=True,
         ),
         # async_tp test lives in graph_trainer_h100 suite (needs NVLink).
+        # TODO: disabled due to upstream PyTorch FlexAttention regression in
+        # nightly: device-side assert triggered during CUDA graph replay.
+        # Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -207,6 +215,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace llama3 FSDP+TP+FlexAttn",
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
+            disabled=True,
         ),
         # TODO: Disabled due to upstream PyTorch cuDNN regression in nightly
         # dev20260506. _scaled_dot_product_cudnn_attention fails with
@@ -377,6 +386,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
 def _build_qwen3_tests() -> list[OverrideDefinitions]:
     """Qwen3-based integration tests (dense + MoE)."""
     return [
+        # TODO: disabled due to upstream PyTorch cuDNN regression in nightly:
+        # CUDA graphs + context parallelism triggers
+        # CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -391,6 +403,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace qwen3 FSDP+TP+CP",
             "aot_fx_trace_qwen3_fsdp_tp_cp",
             ngpu=8,
+            disabled=True,
         ),
         # TODO: disabled due to upstream histc int64 regression (see DSv3 comment)
         OverrideDefinitions(

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -69,6 +69,8 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_name="aot_fx_trace_llama3_precompile_fsdp_tp",
             ngpu=8,
         ),
+        # TODO: disabled due to upstream histc int64 regression breaking
+        # MoE model tracing. Re-enable once fixed upstream.
         PrecompileTestDefinition(
             precompile_command=(
                 "python -m torchtitan.experiments.graph_trainer.precompile_main"
@@ -92,6 +94,7 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_descr="aot_fx_trace deepseek_v3 precompile FSDP+TP+EP",
             test_name="aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep",
             ngpu=8,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -68,6 +68,9 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_descr="aot_fx_trace llama3 precompile FSDP+TP",
             test_name="aot_fx_trace_llama3_precompile_fsdp_tp",
             ngpu=8,
+            # TODO: disabled due to upstream CUDA graph device-side assert
+            # regression in PyTorch nightly. Re-enable once fixed.
+            disabled=True,
         ),
         # TODO: disabled due to upstream histc int64 regression breaking
         # MoE model tracing. Re-enable once fixed upstream.

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -381,9 +381,9 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
-    )
+    # TODO: expected hashes are stale due to upstream PyTorch nightly changes.
+    # Run `EXPECTTEST_ACCEPT=1 pytest <this_file>` on H100 to update.
+    @unittest.skip("DSv3 expected hashes stale after upstream PyTorch changes")
     def test_eager_self_deterministic(self):
         """Eager mode: results match hardcoded expected values.
 
@@ -507,9 +507,9 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
-    )
+    # TODO: expected hashes are stale due to upstream PyTorch nightly changes.
+    # Run `EXPECTTEST_ACCEPT=1 pytest <this_file>` on H100 to update.
+    @unittest.skip("DSv3 FlexAttn expected hashes stale after upstream PyTorch changes")
     def test_eager_self_deterministic(self):
         """Eager results match hardcoded expected values.
 

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -371,6 +371,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 class TestGraphTrainerAutoParallelNumerics(unittest.TestCase):
     """Test graph_trainer AutoParallel numerics equivalence against eager."""
 
+    @unittest.skip("upstream AutoParallel nll_loss assertion regression")
     def test_llama3_aot_fx_trace_autoparallel_vs_eager(self):
         self.assertTrue(_run_autoparallel_llama3_loss_compare())
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -765,6 +765,7 @@ class TestReparametrizeOptimizer(unittest.TestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestTraceDTensor(unittest.TestCase):
     DEVICE = "cuda"
     DTYPE = torch.float32
@@ -950,6 +951,7 @@ class TestTraceDTensor(unittest.TestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestMetadataPropagation(unittest.TestCase):
     """Tests for _copy_fwd_metadata_to_bw_nodes."""
 
@@ -1079,6 +1081,7 @@ class TestMetadataPropagation(unittest.TestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestTraceModels(unittest.TestCase):
     DEVICE = "cuda"
     DTYPE = torch.float32
@@ -1486,6 +1489,7 @@ class TestTraceModels(unittest.TestCase):
             )
 
 
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestTraceFSDP(FSDPTest):
     @property
     def world_size(self):
@@ -1668,6 +1672,7 @@ class TestTraceFSDP(FSDPTest):
 
 
 @unittest.skipIf(torch.cuda.device_count() < 2, "CP trace test requires 2 GPUs")
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestTraceContextParallel(FSDPTest):
     @property
     def world_size(self):
@@ -1802,6 +1807,7 @@ class TestTraceContextParallel(FSDPTest):
         )
 
 
+@unittest.skip("upstream DTensor+Embedding device-side assert regression")
 class TestAutogradGradVsBackwardFSDP(FSDPTest):
     """Verify autograd.grad() and loss.backward() have identical peak memory with FSDP."""
 

--- a/torchtitan/models/flux/inference/sampling.py
+++ b/torchtitan/models/flux/inference/sampling.py
@@ -180,11 +180,10 @@ def denoise(
     timesteps = get_schedule(denoising_steps, latent_height * latent_width, shift=True)
 
     if enable_classifier_free_guidance:
+        assert empty_t5_encodings is not None and empty_clip_encodings is not None
         # Double batch size for CFG: [unconditional, conditional]
         latents = torch.cat([latents, latents], dim=0)
-        # pyrefly: ignore [no-matching-overload]
         t5_encodings = torch.cat([empty_t5_encodings, t5_encodings], dim=0)
-        # pyrefly: ignore [no-matching-overload]
         clip_encodings = torch.cat([empty_clip_encodings, clip_encodings], dim=0)
         bsz *= 2
 


### PR DESCRIPTION
## Summary

Graph Trainer CI (both A10G and H100 suites) went red on `main` after several
upstream PyTorch nightly regressions landed. This PR disables the affected
tests so CI is green again, with TODO comments pointing at each upstream cause.
No model or training logic changes — only test skip flags (plus one small
type-narrowing fix to unblock lint).

### Upstream regressions covered

1. **`histc` meta kernel int64** — `histc`'s meta kernel doesn't support int64
   inputs, breaking `make_fx` tracing for all MoE models (expert routing uses
   `histc`).
2. **cuDNN + CUDA graphs** — `CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH` /
   `device-side assert triggered` during CUDA graph replay with cuDNN attention,
   FlexAttention, or DTensor+Embedding. Affects `aot_fx_trace` mode (CUDA graphs
   on by default) with CP, FlexAttention, or DTensor.
3. **AutoParallel loss partitioning** — AutoParallel mis-partitions the loss with
   TP, sending out-of-range indices to `nll_loss`
   (`Assertion t >= 0 && t < n_classes failed`).

### Tests disabled

**Integration (`integration_tests.py`)**
- `aot_fx_trace_llama3_fsdp_tp_cp` — cuDNN+CUDA graphs
- `aot_fx_trace_llama3_fsdp_tp_flexattn` — cuDNN+CUDA graphs
- `aot_fx_trace_qwen3_fsdp_tp_cp` — cuDNN+CUDA graphs
- `autoparallel_llama3_fsdp_tp` — AutoParallel nll_loss
- `aot_fx_trace_deepseek_v3_fsdp_tp_cp_ep` — histc int64
- `aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn` — histc int64
- `aot_fx_trace_deepseek_v3_fsdp_tp_ep_full_inductor` — histc int64
- `aot_fx_trace_deepseek_v3_hybridep` — histc int64
- `aot_fx_trace_qwen3_moe_fsdp_tp_ep` — histc int64

**Precompile (`run_precompile_tests.py`)**
- `aot_fx_trace_llama3_precompile_fsdp_tp` — cuDNN+CUDA graphs
- `aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep` — histc int64

**Unit tests**
- `test_numerics.py::...::test_llama3_aot_fx_trace_autoparallel_vs_eager` — AutoParallel nll_loss
- `test_trace_module.py` — 6 classes (`TestTraceDTensor`, `TestMetadataPropagation`,
  `TestTraceModels`, `TestTraceFSDP`, `TestTraceContextParallel`,
  `TestAutogradGradVsBackwardFSDP`) — cuDNN+CUDA graphs / DTensor
- `test_bitwise_deterministic.py` — DSv3 `test_eager_self_deterministic`
  (eager + FlexAttn) skipped; expected hashes stale after upstream numerics changes

### Lint fix

`torchtitan/models/flux/inference/sampling.py`: the Pyrefly pre-commit hook
auto-removes now-stale `# pyrefly: ignore [no-matching-overload]` suppressions
(an upstream torch type-stub change turned them into `bad-argument-type`),
which surfaces a `list[Tensor | None]` → `torch.cat` type error whenever any
`.py` change triggers Pyrefly's whole-project check. Replaced the suppressions
with an `assert ... is not None` that genuinely narrows the type (the CFG path
already requires these to be non-None at runtime).

## Test plan

- [x] GraphTrainer 8 GPU (A10G) integration CI green
- [x] Lint, CPU unit tests, 8 GPU Model/Feature tests green
- [x] Each disabled test confirmed failing from the stated upstream regression
- [x] Eager (non-graph-trainer) paths unaffected
- [x] Uses existing `disabled=True` / `@unittest.skip` patterns
- [x] `pre-commit run --all-files` passes

Re-enable each test as its upstream fix lands (TODO comments mark all sites).
