### PR TITLE
[graph_trainer] Fix TP crash by eliminating dead code from make_fx trace

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -565,6 +565,8 @@ def minimal_fx_tracer(
         _copy_fwd_metadata_to_bw_nodes(traced)
 
         _remove_cpu_shadow_chains(traced)
+        traced.graph.eliminate_dead_code()
+        traced.recompile()
         if _insert_runtime_asserts:
             _insert_runtime_asserts_pass(traced, fake_mode)
 


### PR DESCRIPTION
make_fx tracing through DTensor produces dead "shadow" nodes for every DTensor op. This happens because proxy_call in proxy_tensor.py records an FX node at the DTensor wrapper level (global shape, backed by empty_strided placeholder tensors), and then DTensor's __torch_dispatch__ records a second node at the local tensor level (shard shape, the real computation). Since the tracer returns local tensors (result._local_tensor), the wrapper-level nodes have no downstream consumers and are dead.

These dead nodes are harmless for most ops (they operate on empty_strided placeholders that just waste compute), but for ops with bounds checking like aten.embedding, the empty_strided index tensor contains uninitialized values that trigger out-of-bounds access on the TP-sharded embedding weight, crashing with "device-side assert triggered".

The fix adds eliminate_dead_code() + recompile() right after tracing completes, in the same cleanup section as _copy_fwd_metadata_to_bw_nodes and _remove_cpu_shadow_chains. This is the standard FX graph cleanup that removes all nodes with no downstream users.

For the Llama3 debugmodel (6 layers, TP=2), DCE removes 245 dead nodes: 111 empty_strided wrapper allocations, 30 backward zero-inits, 19 multi-output unpacks, and 85 shadow compute ops (mm, t, view, silu, nll_loss, etc.) -- one shadow chain for every op in the full fwd+bwd.

Note: _remove_cpu_shadow_chains already handles a subset of this (dead CPU-device chains from DTensor metadata bookkeeping), but does not catch dead GPU-device chains. DCE is the general solution. A proper fix in PyTorch core would suppress proxy_call from emitting the wrapper-level node when DTensor dispatch will handle tracing internally, but that requires changes to proxy_tensor.py.

Without this fix, any graph_trainer config with tensor_parallel_degree > 1 crashes at runtime. The existing CI test
aot_fx_trace_llama3_fsdp_tp_flexattn (TP=2, FSDP=4, FlexAttention, regional inductor) exercises this path.

Test Plan:
Verified on 8x H100 with debugmodel (TP=2, TP=8) and Llama3-8B (TP=8, 128K vocab, sharded embedding). All ranks produce identical loss values, training converges.

```
NGPU=8 ./run_train.sh \
  --module graph_trainer.llama3 \
  --config graph_trainer_llama3_debugmodel_flex_attn \
  --compile.mode aot_fx_trace \
  --parallelism.data_parallel_shard_degree 4 \
  --parallelism.tensor_parallel_degree 2 \
  --training.steps 5 \
  --checkpoint.interval 0 \
  --profiler.no_enable_profiling
```

Authored by Claude.