### PR TITLE
[Autoresearch] Run 3: + Production Graph + Refs — +5.21% over production baseline

### DIFF
--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -415,3 +415,21 @@ learn from past experiments and avoid repeating failed approaches.
   rewriting the unpack path to avoid issuing clones in the first place.
 
 ---
+
+## Subgraph descent + second run for clone removal — discard (xxxxxxx, xxxxxxx)
+
+- **Idea**: Investigate if the missing ~290 FSDP weight-unpack clones live
+  in subgraphs (HOPs / get_attr submodules) or are introduced by the
+  auto-bucketer's pre-bucketing rewrite.
+- **Changes**: (a) Extended clone pass to recurse via `named_children()`
+  into nested GraphModules; (b) added a second invocation of the clone
+  pass after `auto_overlap_bucketing_pass`.
+- **Result**: Both experiments found **0 additional clones**. Numerics
+  PASS, perf within noise. No subgraphs exist at this pipeline position;
+  bucketing doesn't introduce new clones.
+- **Lessons**: The missing 290 clones in the original profile are
+  apparently *consumed/eliminated* by `auto_overlap_bucketing_pass`
+  itself (it reorders/fuses the unpack chain), not present as
+  subgraph hidden ops. 68 root-level clones is the actual ceiling here.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -616,3 +616,30 @@ learn from past experiments and avoid repeating failed approaches.
   bug isn't worth fixing in this codebase for these AR sizes.
 
 ---
+
+## RMSNorm Inductor with strict-bitwise Inductor flags — crash (xxxxxxx)
+
+- **Idea**: The performance_passes.py annotation for RMSNorm is gated
+  behind `numerics_changing_optim`. Inductor has commented-out
+  bitwise-alignment flags (`emulate_precision_casts`, `disable_ftz`,
+  `use_pytorch_libdevice`). Enable them, then tag RMSNorm forward+backward
+  for regional_inductor — maybe the strict flags make it bitwise-safe.
+- **Changes**: New pass that sets `ic.emulate_precision_casts = True`,
+  `ic.eager_numerics.disable_ftz = True`,
+  `ic.eager_numerics.use_pytorch_libdevice = True` (in addition to the
+  already-set `division_rounding=True`), then tags `_fused_rms_norm`
+  /  `_fused_rms_norm_backward` + getitem users.
+- **Result**: CRASH on bitwise test. Both `model_hash` and `grad_hash`
+  diverge from eager. Loss matches at printed precision (5 digits) but
+  byte-level fails.
+- **Analysis**: All four known Inductor bitwise-alignment flags TOGETHER
+  are insufficient to make Inductor's RMSNorm match aten's fused
+  `_fused_rms_norm` kernel bit-for-bit. The aten kernel does fused
+  fp32 reduction + scaling internally in a way Inductor's Triton
+  decomposition doesn't replicate exactly.
+- **Lessons**: RMSNorm Inductor compile is a **HARD floor** under
+  strict bitwise — gating it behind `numerics_changing_optim` (as
+  performance_passes.py already does) is correct. ~10-15 ms of unfused
+  RMSNorm time is unrecoverable without relaxing bitwise.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -303,3 +303,35 @@ learn from past experiments and avoid repeating failed approaches.
   pointwise time sits next to matmul/comm that dominates anyway.
 
 ---
+
+## Auto overlap bucketing (schedule_overlap_bucketing) — keep (PENDING)
+
+- **Idea**: Replace the manual `joint_transformer_block_bucketing_reordering_pass`
+  (with 2-layer bucket plan) with upstream
+  `torch._inductor.fx_passes.overlap_scheduling.schedule_overlap_bucketing(collective_bucketing=True, ...)`.
+  Auto-bucketer uses roofline runtime estimates to pick bandwidth-saturating
+  bucket sizes and reorders for maximal compute/comm overlap, respecting
+  a memory budget (`max_memory_increase_gb=2.0`, ratio=0.05).
+- **Changes**: Added `auto_overlap_bucketing_pass`, removed manual 2-layer
+  bucket plan construction. Kept `overlap_fsdp_ag_rs_pass` gated on
+  `config.compile.enable_fsdp_ag_rs_overlap` (default False; the benchmark
+  doesn't set it, so the extra-stream split is OFF for both manual-keep
+  and this experiment).
+- **Result**: 3 runs **7,291 / 7,305 / 7,287** (avg **7,294**, +0.90% vs
+  manual 2-layer, +1.84% vs Run 3 production baseline). mfu 42.72%
+  avg, memory **49.06 GiB** (+1.35 GiB), wall **128 s** (vs 79 s
+  manual — compile overhead from auto-bucketer's roofline estimation).
+  Bitwise numerics PASS.
+- **Analysis**: Auto-bucketer picked finer-grained buckets (131 AG / 163
+  RS buckets, vs manual's 18 in each direction) that better saturate
+  NCCL bandwidth. The +0.90% is just under the strict +1% threshold but
+  consistent across 3 runs (range 7,287–7,305) with the worst run still
+  beating manual 2-layer (avg 7,229). Memory increased 1.35 GiB —
+  expected from larger in-flight buckets, well within the 95 GB H100
+  budget.
+- **Lessons**: Roofline-driven auto-bucketing dominates manual N-layer
+  bucketing here. The compile-time cost (49 s extra) is acceptable.
+  Code is also simpler — no manual bucket plan to maintain. Future
+  experiments should layer on top of this rather than swap it out.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -390,3 +390,28 @@ learn from past experiments and avoid repeating failed approaches.
   largest unattacked bottleneck.
 
 ---
+
+## Remove redundant contiguous clones — keep (PENDING)
+
+- **Idea**: Profile showed 358 `aten.clone(memory_format=contiguous_format)`
+  calls, ~290 from FSDP weight unpack. Many should be no-ops if the input
+  is already contiguous (per FakeTensor stride metadata).
+- **Changes**: Added `remove_redundant_contiguous_clone_pass` — walks the
+  graph, finds `aten.clone.default` nodes (default kwargs → contig
+  format), checks FakeTensor stride against contiguous strides; if
+  already-contiguous, replaces uses with input. Registered before
+  `auto_overlap_bucketing_pass`.
+- **Result**: 68 clones eliminated per step (deterministic across 3
+  runs). 3-run tps **7,321 / 7,323 / 7,312** (avg **7,319**, +0.34% vs
+  7,294). Bitwise numerics PASS. wall 129 s.
+- **Analysis**: 68 of 358 clones (~19%) were visible at this FX layer
+  and ALL 68 were redundant. The other ~290 FSDP-unpack clones live
+  inside HOPs/subgraphs the pass doesn't reach. Consistent small
+  improvement across 3 runs suggests the gain is real but partially
+  masked by auto-bucketing already overlapping these clones with
+  compute. Memory unchanged (49.06 GiB).
+- **Lessons**: Stride-aware clone elimination is a small but safe win.
+  Bigger gains likely require reaching INTO the FSDP HOPs/subgraphs or
+  rewriting the unpack path to avoid issuing clones in the first place.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -498,3 +498,37 @@ learn from past experiments and avoid repeating failed approaches.
   fusion isn't always a win — measure first.
 
 ---
+
+## fuse_mm_reduce_scatter shape fix + residual-add Inductor — keep (PENDING)
+
+- **Idea**: (1) Fix the shape-meta bug in `fuse_mm_reduce_scatter_pass`
+  (was stamping 3D wait_tensor shape on a 2D runtime output, OK for
+  non-Inductor downstream but crashes any Inductor scoop with
+  `assert_size_stride`). (2) With the fix in place, tag bf16 residual
+  `aten.add.Tensor` nodes for `regional_inductor_pass` so the 224
+  residual adds (~14ms / 2.5% of step) get Inductor-compiled.
+- **Changes**: (1) After inserting `symm_mem.fused_matmul_reduce_scatter`,
+  stamp the actual 2D fake on the fused-op `meta["val"]` and insert an
+  `aten.reshape.default` back to original 3D shape with correct meta.
+  Route wait users to the reshape. (2) New
+  `annotate_residual_add_for_regional_inductor_pass` (similar template
+  to SwiGLU annotation), registered after the FlexAttention annotation.
+- **Result**: 224 bf16 adds tagged; 65 mm->RS pairs still fused. Bitwise
+  numerics PASS. 3-run tps **7,429 / 7,422 / 7,423** → avg **7,424
+  (+0.26% over 7,405, +3.66% over Run 3 production baseline)**, mfu
+  43.48% avg, memory unchanged (49.10 GiB), wall ~143 s.
+- **Analysis**: Two effects combine: the shape fix is perf-neutral (just
+  correctness) but UNBLOCKS Inductor scoops downstream of fused mm-RS;
+  residual-add Inductor compilation collapses 224 small add kernels but
+  most are already overlapped by `auto_overlap_bucketing_pass`, so the
+  gain is modest. All 3 confirmation runs above baseline → small but
+  consistent improvement. The shape fix is essential infra for any
+  future Inductor scoop work.
+- **Lessons**: (1) `fuse_mm_reduce_scatter_pass` shape meta needed
+  fixing — the bug was latent until residual-add tagging exposed it.
+  (2) Residual-add Inductor fusion: bitwise-safe but small payoff
+  at this scale. (3) The pointwise-fusion-Inductor direction is hitting
+  diminishing returns — most pointwise time is already hidden by comm
+  overlap.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -189,3 +189,31 @@ learn from past experiments and avoid repeating failed approaches.
   collective-chunk math).
 
 ---
+
+## 2-layer FSDP bucket plan — keep (PENDING)
+
+- **Idea**: Profiling showed FSDP AllGather only 28% overlapped, 61.6 ms
+  (5.8% of step) exposed. Default `get_default_transformer_block_buckets`
+  emits 32 single-layer buckets → only 1 layer of compute behind each AG.
+  Override `module_bucket_plans` with **2-layer buckets** (16 layer
+  buckets + tok_embeddings + [norm, lm_head] = 18 total) so each AG
+  covers 2 layers' params and can prefetch deeper.
+- **Changes**: Construct `two_layer_bucket_plan` locally in
+  `compile_time_passes` and pass it as `module_bucket_plans` to
+  `joint_transformer_block_bucketing_reordering_pass`. Drop unused
+  `get_default_transformer_block_buckets` import.
+- **Result**: 3 runs at tps 7,239 / 7,214 / 7,236 (avg **7,229,
+  +0.94%**), mfu 42.34% avg, memory 47.71 GiB (+0.19 GiB), wall_time
+  79–82 s. Bitwise numerics PASS.
+- **Analysis**: Small but consistent win — halves AG launch count
+  (34→18) and gives 2 layers of compute behind each prefetched AG.
+  Memory cost is tiny (2 layers of params live, not 1). The 0.94%
+  recovers ~1/6 of the exposed AG; deeper buckets (4-layer, 8-layer)
+  may keep paying with diminishing returns, traded against the
+  monotonic memory cost.
+- **Lessons**: (a) Bucket plan IS a tunable lever for FSDP comm overlap,
+  not fixed at default. (b) Profile-driven targeting (find the biggest
+  exposed comm bucket, scope an attack at it) works. (c) Worth sweeping
+  bucket size — try 4-layer next.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -268,3 +268,38 @@ learn from past experiments and avoid repeating failed approaches.
   may still help. Compile time grew 79→112 s, so be mindful.
 
 ---
+
+## Broad pointwise regional Inductor — discard (xxxxxxx)
+
+- **Idea**: Building on SwiGLU bitwise-safety result, tag a broader
+  set of pointwise targets (silu, mul, add, sub, neg, _to_copy,
+  view_as_complex/real) for regional Inductor — primarily to fuse the
+  RoPE chain `_to_copy→reshape→view_as_complex→mul→view_as_real→
+  reshape→_to_copy` (6 kernels per layer per Q/K, ~128 sites) into
+  one Triton kernel.
+- **Changes**: Added `annotate_pointwise_chains_for_regional_inductor_pass`
+  that tags all of {silu, silu_backward, mul.Tensor, mul.Scalar,
+  add.Tensor, add.Scalar, sub.Tensor, neg, _to_copy, view_as_complex,
+  view_as_real}. Inserted between flex-attention annotation and
+  `regional_inductor_pass`.
+- **Result**: 1328 pointwise nodes tagged (~10× SwiGLU's 128). tps
+  **7,192 (-0.51%)** vs 2-layer keep, mfu 42.11%, memory 47.71 GiB,
+  wall **246 s** (vs 79 s baseline — graph passes alone took 172 s).
+  Bitwise numerics PASS.
+- **Analysis**: The fusion target — RoPE complex multiplication —
+  triggers Inductor's `"does not support code generation for complex
+  operators"` warning. `view_as_complex` / complex `mul.Tensor` /
+  `view_as_real` fall back to non-fused codegen, so the intended
+  6-kernels-to-1 RoPE win never materializes. Meanwhile the rest of
+  the broad tagging fragments regions across half the graph, growing
+  compile time hugely with no steady-state benefit.
+- **Lessons**: **Inductor cannot codegen complex ops.** To fuse RoPE
+  we'd need a graph rewrite that converts
+  `view_as_complex→mul(complex)→view_as_real` into the equivalent
+  4-mul-2-add real-valued form **before** tagging. Risk: FMA promotion
+  may break bitwise (Inductor may emit `fma(a,c,-b*d)` whereas eager
+  complex_mul does separate mul/sub). Also: broad pointwise tagging
+  is high compile-time cost / low steady-state payoff because most
+  pointwise time sits next to matmul/comm that dominates anyway.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -433,3 +433,41 @@ learn from past experiments and avoid repeating failed approaches.
   subgraph hidden ops. 68 root-level clones is the actual ceiling here.
 
 ---
+
+## Custom mm→reduce_scatter fusion — keep (PENDING)
+
+- **Idea**: Upstream `micro_pipeline_tp_pass` cannot find mm→RS adjacency
+  in our graph (3 positional attempts all gave 0 fusions, 421 skips).
+  Write a *custom* fusion pass with a looser matcher that walks back from
+  each `_c10d_functional.reduce_scatter_tensor` through
+  `view/reshape/_to_copy/permute/transpose/t/_unsafe_view` AND through
+  `cat(split(input, dim=k))` (scatter_dim>0 pattern) to find a producer
+  `aten.mm.default`, then replace the chain with
+  `torch.ops.symm_mem.fused_matmul_reduce_scatter`.
+- **Changes**: New `fuse_mm_reduce_scatter_pass` (+ supporting helpers)
+  registered between `remove_redundant_contiguous_clone_pass` and
+  `auto_overlap_bucketing_pass`. Includes a dtype filter that skips
+  chains where downstream dtype != mm A dtype (i.e. backward weight-grad
+  RS with fp32 upcast — fusing would crash with bf16 vs fp32 grad mismatch).
+  Inferred scatter_dim by comparing mm output shape to RS input shape.
+- **Result**: **65 forward TP mm→RS fusions** per step (32 attn output +
+  32 mlp w2 + 1 extra). 290 candidates found, 225 correctly skipped on
+  dtype filter. Numerics PASS (bitwise) — chunked matmul + chunked RS
+  produces same bf16 result as unchunked because per-position rank-axis
+  reduction order is unchanged. **4-run tps: 7,408 / 7,396 / 7,406 /
+  7,408 → avg 7,405 (+1.17% over 7,319, +3.39% over Run 3 production
+  baseline 7,162)**. mfu 43.36% avg, memory 49.10 GiB (essentially
+  unchanged), wall 129 s.
+- **Analysis**: Targets the 61.5 ms exposed TP RS (the biggest remaining
+  bottleneck). NVLink symm_mem chunked-matmul-RS recovers a meaningful
+  fraction. The 225 backward weight-grad RS sites (fp32) remain
+  unattacked because `fused_matmul_reduce_scatter` only reduces in
+  `A.dtype` (bf16); fusing them would change reduction precision.
+- **Lessons**: (1) Upstream `micro_pipeline_tp_pass`'s matcher is too
+  strict for our DTensor lowering — a looser custom matcher unlocks
+  the win. (2) Bitwise identity holds when (a) the chunked op's
+  reduction order matches the unchunked, AND (b) the dtype filter
+  keeps fp32 grad reductions out. (3) This is the largest single
+  experiment win in Run 3 so far.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -217,3 +217,54 @@ learn from past experiments and avoid repeating failed approaches.
   bucket size — try 4-layer next.
 
 ---
+
+## 4-layer FSDP bucket plan — discard (xxxxxxx)
+
+- **Idea**: Continue the bucket-size sweep. Profiling at 2-layer left
+  ~50 ms of AG still exposed; 4-layer should hide more.
+- **Changes**: Replace 2-layer bucket plan with 4-layer (8 layer
+  buckets + tok_embeddings + [norm, lm_head] = 10 total buckets).
+- **Result**: 3-run avg tps **7,253** (+0.33% vs 2-layer), mfu 42.47%,
+  memory 47.62 GiB, wall ~80 s. Numerics PASS.
+- **Analysis**: Diminishing returns: 1→2 layer = +0.94%, 2→4 layer
+  = +0.33% (within noise). Likely hit a saturation: either the
+  remaining exposed AG is already mostly hidden by 2-layer prefetch,
+  or the bottleneck has shifted (TP RS bf16 dominates exposed comm
+  next). Memory cost was actually negligible (47.62 vs 47.71 GiB).
+- **Lessons**: Don't waste more experiments on bigger bucket sizes —
+  the curve is flat past 2-layer. Pivot to TP RS or compute-side.
+
+---
+
+## SwiGLU regional Inductor — discard (xxxxxxx)
+
+- **Idea**: 32× forward `silu→mul` and 32× backward `silu_backward→mul`
+  are unfused pointwise pairs (~40 ms / 14.8% of kernel time goes to
+  small elementwise kernels). Tag both with `compile_with_inductor`
+  so `regional_inductor_pass` produces a single fused Triton kernel
+  per site. Pure pointwise math with no add-after-mul → no FMA
+  promotion → should be bitwise-safe.
+- **Changes**: Added `annotate_swiglu_for_regional_inductor_pass`
+  in `passes.py` (mirrors `annotate_rmsnorm_for_regional_inductor_pass`
+  template). Tags `aten.silu.default` / `aten.silu_backward.default`
+  and their immediate `aten.mul.Tensor` consumers. Registered after
+  `annotate_flex_attention_for_regional_inductor_pass` and before
+  `regional_inductor_pass`.
+- **Result**: 128 SwiGLU nodes tagged across 32 layers; Inductor
+  compiled them. tps **7,239** (+0.14% vs 2-layer keep, noise).
+  Memory 47.71 GiB, wall 112 s (compile overhead). Bitwise numerics
+  PASS — confirms pure pointwise Inductor fusion preserves bitwise
+  identity.
+- **Analysis**: Fusion engaged but didn't move the needle. The
+  silu+mul pair output is consumed by the `w2` matmul whose memory
+  traffic dominates the savings from collapsing two pointwise
+  kernels into one. Alternatively the bf16 silu+mul eager kernels
+  are already well-coalesced, so kernel-launch savings are small.
+- **Lessons**: **Important meta-finding — pointwise Inductor fusion
+  IS bitwise-safe in this Run-3 setup.** That removes a barrier to
+  more aggressive pointwise-tagging experiments (RoPE complex mul,
+  residual chain, _to_copy chains). Where SwiGLU didn't pay, broader
+  tagging of the 818-count `direct_copy` and 423-count residual `add`
+  may still help. Compile time grew 79→112 s, so be mindful.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -565,3 +565,27 @@ learn from past experiments and avoid repeating failed approaches.
   while keeping the fusion broad.
 
 ---
+
+## RoPE complex→real rewrite — crash (xxxxxxx)
+
+- **Idea**: Inductor can't codegen complex ops, so RoPE chain (9 ms / 128
+  sites) stays unfused. Rewrite `view_as_real(mul.Tensor(view_as_complex(x),
+  freqs))` to explicit real-valued math `(ac-bd, ad+bc)` then tag for
+  regional Inductor.
+- **Changes**: Discovery showed 128 uniform sites (64 fwd + 64 bwd, same
+  complex64 buffer). Wrote a rewrite pass that splits into real/imag,
+  computes real-valued mul/sub/add, restacks. Handled backward's `_conj`
+  via `aten.conj_physical`.
+- **Result**: Bitwise numerics FAILED (loss diff ~5e-7, grad hash
+  mismatch). Reverted.
+- **Analysis**: Aten complex `mul.Tensor` uses a single hardware-FMA
+  per output component (`fma(a, c, -b*d)`) — one rounding. Our
+  4-mul-1-sub-1-add real decomposition does two roundings → different
+  last bit in bf16. There's no clean way to force aten to skip FMA, or
+  make our rewrite emit identical FMA, without a custom CUDA kernel.
+- **Lessons**: RoPE complex multiplication is a **hard floor** under
+  strict bitwise constraints (~9 ms / step). The rewrite WOULD work as
+  a `numerics_changing_optim` (loss-curve verified instead of bitwise);
+  not in scope for Run 3's bitwise-mandatory regime. Park.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -471,3 +471,30 @@ learn from past experiments and avoid repeating failed approaches.
   experiment win in Run 3 so far.
 
 ---
+
+## Custom AG→mm fusion — discard (xxxxxxx)
+
+- **Idea**: Mirror the successful `fuse_mm_reduce_scatter_pass` for the
+  forward column-parallel TP `all_gather → mm` chain. Use
+  `symm_mem.fused_all_gather_matmul` (signature
+  `(A_shard, [B_i], gather_dim, group_name) -> Tensors`).
+- **Changes**: New `fuse_all_gather_mm_pass` with multi-B fusion (so 1
+  AG feeding multiple mm consumers like Q/K/V is one fused op). Handles
+  the `t(gathered)` backward-path reuse via `return_A=True`.
+- **Result**: 65 AG→mm fusions (32 QKV+32 W1/W3+1 extra). Bitwise PASS.
+  6-run tps avg **7,395** (-0.13% vs 7,405 baseline). Memory **+3.87
+  GiB** (49.10 → 52.97) due to `return_A=True` keeping gathered
+  activations live for backward weight-grad mm.
+- **Analysis**: Auto-bucketer already overlaps standalone AGs well, the
+  AG shard size is small, and `fused_all_gather_matmul`'s chunked-AG
+  kernel adds enough sync overhead to offset the overlap win. The
+  +3.87 GiB memory cost is paid because every forward AG's gathered
+  output is reused by the backward grad-weight mm (via `t(gathered)`).
+- **Lessons**: AG→mm fusion is **bitwise-safe but net negative** at
+  this scale — opposite outcome from mm→RS fusion. The mm→RS win came
+  because TP RS was poorly overlapped (2.6%) and the fused chunked RS
+  hides better; AG was already 30.9% overlapped and the fused-op
+  overhead + memory cost exceeds the benefit. Lesson: aggressive
+  fusion isn't always a win — measure first.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -589,3 +589,30 @@ learn from past experiments and avoid repeating failed approaches.
   not in scope for Run 3's bitwise-mandatory regime. Park.
 
 ---
+
+## Custom topology-aware AR coalescer — discard (xxxxxxx)
+
+- **Idea**: Upstream `bucket_all_reduce` had topology bug. Write a custom
+  pass that chunks 67 TP weight-grad ARs into 8 groups, picks insertion
+  point between latest-input and earliest-consumer, relocates consumer
+  chains as needed to maintain topology.
+- **Changes**: New `coalesce_tp_all_reduce_pass`. Required physically
+  relocating the post-AR `_to_copy → reduce_scatter → wait → output`
+  chain (which terminates at the graph output) so consumers don't see
+  unwait outputs. Bitwise-safe by construction.
+- **Result**: 64/68 ARs absorbed into 8 chunks (chunk_size=8) or 1
+  chunk (chunk_size=64). Numerics PASS in all cases. tps **7,516**
+  (-0.12% noise). Same in chunk_size variants (8/16/64) all within
+  ±0.3%.
+- **Analysis**: Topology-aware coalescing WORKED — 8 chunks merged
+  bitwise-safely. But the 5 ms of total AR launch overhead is apparently
+  ALREADY overlapped by surrounding backward compute, so reducing the
+  collective count doesn't free critical-path time. Confirms the AR
+  bottleneck was theoretical, not measurable on this scale.
+- **Lessons**: (1) Topology-aware coalescing IS possible with explicit
+  consumer-chain relocation. (2) For tiny (8 KB) collectives whose total
+  is <1% of step, NCCL launch overhead is invisible behind compute —
+  coalescing yields ~0%. (3) Upstream `bucket_all_reduce`'s topology
+  bug isn't worth fixing in this codebase for these AR sizes.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -17,3 +17,31 @@ learn from past experiments and avoid repeating failed approaches.
 ```
 
 ---
+
+## Baseline — Run 3 production starting graph (2ffbabc5)
+
+- **Idea**: Establish the Run-3 baseline. `passes.py` runs the production
+  pass set: `remove_detach_pass`, `remove_identity_view/slice_pass`,
+  `normalize_view_ops_as_reshape`, `joint_transformer_block_bucketing_reordering_pass`
+  (with FSDP AG/RS overlap), `annotate_flex_attention_for_regional_inductor_pass`,
+  `regional_inductor_pass`, `insert_kernel_annotations_pass`,
+  `custom_codegen_pass`, then `cudagraph_pass`.
+- **Changes**: None (measure on `2ffbabc5` HEAD).
+- **Result**: tps = 7,162, mfu = 41.94%, memory = 47.52 GiB, wall_time = 84 s.
+  Bitwise numerics test (`aot_fx_trace_vs_eager`) passes.
+- **Analysis**: Within 6 tps of the documented production baseline (7,156).
+  Run 2 best on the unoptimized starting graph reached 6,048 tps after 23 iters;
+  this Run-3 starting point is already +18.4% above that. Run 2 saturated
+  at ~6,040 tps because it couldn't access reference implementations of
+  FSDP bucketing, AG/RS overlap, regional Inductor, kernel annotation, or
+  custom codegen — all of which are now baked in.
+- **Lessons**: Production graph is the new floor. Search must target wins
+  on top of regional Inductor + FSDP overlap + CUDA graphs. The Run 2
+  "easy wins" (detach removal, joint_graph_passes, schedule_overlap_bucketing,
+  cudagraph wrapping) are all already present. Look for: (1) optimizer/loss
+  folding into the captured graph (Run 2 noted 2.4% / 40 ms left outside);
+  (2) bitwise-safe Inductor flag flips that the production stack hasn't
+  set; (3) hot kernels under the regional-Inductor regions still missed;
+  (4) idle GPU gaps post-AG/RS-overlap.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -1,0 +1,19 @@
+# Autoresearch Experiment Log
+
+Cumulative log of every experiment in this run. Append-only — never
+overwrite previous entries. Re-read at the start of each loop iteration to
+learn from past experiments and avoid repeating failed approaches.
+
+## Format
+
+```markdown
+## <short title> — <status> (<commit hash>)
+
+- **Idea**: What optimization was attempted and why it was expected to help.
+- **Changes**: What was actually modified (brief summary, not a full diff).
+- **Result**: Perf numbers (tps, MFU, memory_gib, wall_time_s) or crash/error description.
+- **Analysis**: Why it worked, why it didn't help, or why it broke.
+- **Lessons**: Key takeaways — what to build on, what to avoid, what to try.
+```
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -155,3 +155,37 @@ learn from past experiments and avoid repeating failed approaches.
   earliest moved consumer. Try (a) next — it's a one-line reorder.
 
 ---
+
+## bucket_all_reduce before FSDP bucketing — crash (xxxxxxx)
+
+- **Idea**: Move `bucket_tp_all_reduce_pass` to run BEFORE
+  `joint_transformer_block_bucketing_reordering_pass` so the FSDP pass
+  sees one merged AR instead of 67 (avoiding the consumer-reorder
+  conflict that crashed the previous attempt).
+- **Changes**: Added `bucket_tp_all_reduce_pass` between
+  `normalize_view_ops_as_reshape` and the FSDP bucketing partial.
+- **Result**: Numerics PASS. Benchmark CRASHED with the same
+  `RuntimeError: Argument 'view_X' of Node '_to_copy_Y' was used before
+  it has been defined!` from `gm.graph.lint()` inside our pass.
+- **Analysis**: This rules out FSDP-overlap as the cause. The upstream
+  `merge_all_reduce_bucket` always inserts the merged collective at
+  `bucket_nodes[-1].next` (after the last bucketed AR). The split
+  outputs are created at that position. But many consumers of the
+  ORIGINAL waits live BETWEEN bucket_nodes[0] and bucket_nodes[-1].next,
+  so after redirection they reference split outputs that are defined
+  later → topologically invalid. This is a fundamental issue with
+  `merge_all_reduce_bucket` when bucketed ARs are spread out across the
+  graph: there's no single insertion point where (a) all inputs are
+  defined and (b) the position precedes every consumer.
+- **Lessons**: Upstream `bucket_all_reduce` is unusable as-is for
+  scattered ARs. Fixing it requires either: (i) hoisting all bucket
+  inputs to a single earliest position (expensive — disturbs FSDP grad
+  accumulation chain), or (ii) moving every consumer of every bucket
+  wait to a single latest position (also expensive). Both are
+  reimplementations of the upstream pass. Park this direction. The 67×
+  TP-AR launch overhead remains an open opportunity but needs a custom
+  bucketer that respects topology — or a completely different approach
+  (e.g. fold the AR into the downstream `reduce_scatter`'s
+  collective-chunk math).
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -532,3 +532,36 @@ learn from past experiments and avoid repeating failed approaches.
   overlap.
 
 ---
+
+## Extended SwiGLU chain regional Inductor — keep (PENDING)
+
+- **Idea**: The original `annotate_swiglu_for_regional_inductor_pass`
+  tagged only silu + immediate-mul user (128 nodes, +0.14% noise). But
+  the backward SwiGLU is `silu_backward → mul → mul → ...` (3+ ops).
+  Iterate from silu/silu_backward seeds, expanding to adjacent bf16
+  `mul.Tensor` neighbors until fixed point. This grows each Inductor
+  region to include the full forward AND backward SwiGLU computation,
+  yielding bigger fused Triton kernels.
+- **Changes**: New `annotate_swiglu_chains_for_regional_inductor_pass`
+  with seed+expand algorithm. Seeds: silu/silu_backward (bf16). Expand:
+  bf16 mul.Tensor whose all-Tensor inputs are bf16 AND which is adjacent
+  to a tagged node. Registered between FlexAttention annotation and
+  residual-add annotation.
+- **Result**: **160 nodes tagged (5 per layer × 32 = 32×(silu+mul) +
+  32×(silu_backward+mul+mul))**. Bitwise numerics PASS. 3-run tps
+  **7,524 / 7,529 / 7,523** → avg **7,525 (+1.36% over 7,424,
+  +5.07% over Run 3 production baseline 7,162)**, mfu 44.07% avg,
+  memory unchanged 49.10 GiB, wall ~166 s.
+- **Analysis**: The expanded fusion captures the FULL 5-op SwiGLU
+  forward+backward computation per layer in one Inductor kernel.
+  Eliminates 5 HBM round-trips per SwiGLU site vs the previous
+  2-op-only SwiGLU experiment. The +1.36% gain finally crosses the
+  noise threshold convincingly — three runs all above 7,498.
+- **Lessons**: (1) Connected-component pointwise tagging (vs op-by-op
+  tagging) is the right granularity for Inductor fusion — bigger
+  regions amortize per-region overhead better. (2) Backward SwiGLU
+  has a 3-op chain (silu_backward + 2 muls) that the original SwiGLU
+  pass missed. (3) Bf16-only filter on inputs ensures bitwise safety
+  while keeping the fusion broad.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -45,3 +45,29 @@ learn from past experiments and avoid repeating failed approaches.
   (4) idle GPU gaps post-AG/RS-overlap.
 
 ---
+
+## joint_graph_passes after no-op cleanup — discard (xxxxxxx)
+
+- **Idea**: Run upstream Inductor `joint_graph_passes` (CSE, noop removal,
+  fold_concat_then_split, constant folding of uniform values, etc.) on the
+  joint forward+backward graph right after `normalize_view_ops_as_reshape`
+  and before `joint_transformer_block_bucketing_reordering_pass`. Hope was
+  that a leaner graph would help bucketing/Inductor downstream.
+- **Changes**: Added `apply_joint_graph_passes` wrapping
+  `torch._inductor.fx_passes.joint_graph.joint_graph_passes`, registered
+  in `compile_time_passes`.
+- **Result**: tps = 7,170, mfu = 41.98%, memory = 47.52 GiB, wall_time = 81 s.
+  Bitwise numerics PASS. Delta +0.11% — well within ±1% noise.
+- **Analysis**: After `make_fx` tracing + existing no-op cleanup the joint
+  graph already has little algebraic redundancy. Llama3 8B is dominated
+  by large matmul/RMSNorm/SDPA/collective kernels; small op-count
+  reductions don't move steady-state. The wall_time drop is plausibly
+  startup variation.
+- **Lessons**: Upstream Inductor's joint_graph_passes is bitwise-safe on
+  this graph but a no-op for steady-state perf. Future cleanup wins
+  probably need to target the *post-bucketing* / *post-regional-Inductor*
+  graph (where new patterns appear) or fuse kernels that Inductor never
+  touches (RMSNorm, residual add, embedding+norm). Don't retry generic
+  pattern cleanup at the joint-graph stage.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -71,3 +71,31 @@ learn from past experiments and avoid repeating failed approaches.
   pattern cleanup at the joint-graph stage.
 
 ---
+
+## async_tensor_parallel_pass after bucketing — discard (xxxxxxx)
+
+- **Idea**: 130 unbucketed TP all_gathers + 130 reduce_scatters on group `'22'`
+  are launched separately every step. `async_tensor_parallel_pass` (already
+  in `passes.py`, gated by config) calls upstream
+  `micro_pipeline_tp_pass` to fuse `all_gather+mm → fused_all_gather_matmul`
+  and `mm+reduce_scatter → fused_matmul_reduce_scatter` via NVLink symm_mem.
+  Hard-enable it.
+- **Changes**: Removed the `if config.parallelism.enable_async_tensor_parallel:`
+  guard so `async_tensor_parallel_pass` always appends.
+- **Result**: tps = 7,023 (-1.9%), mfu = 41.13%, memory = 47.56 GiB, wall_time = 80 s.
+  Bitwise numerics PASS. Net regression.
+- **Analysis**: The pass emitted **99 "no producer matmul found for reduce
+  scatter, skipping fuse_matmul_reduce_scatter fusion"** warnings and **zero
+  fusions** of either `fused_all_gather_matmul` or
+  `fused_matmul_reduce_scatter`. By position #6 (after
+  `normalize_view_ops_as_reshape` and
+  `joint_transformer_block_bucketing_reordering_pass`) there are
+  reshape/view ops between `mm` and the adjacent collective that break the
+  upstream matcher's expected adjacency. The pass still walked the graph
+  and registered symm_mem groups, adding overhead with no benefit.
+- **Lessons**: Pass *position* is critical — `async_tensor_parallel_pass`
+  must run **BEFORE** view normalization and bucketing reorder for the
+  upstream matcher to find `mm→RS` / `AG→mm` adjacency. Next: move it to
+  the very start of `compile_time_passes` (or just after `remove_detach_pass`).
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -361,3 +361,32 @@ learn from past experiments and avoid repeating failed approaches.
   upstream topology bug.
 
 ---
+
+## async TP between normalize+bucket — discard (xxxxxxx)
+
+- **Idea**: Final untried position for `async_tensor_parallel_pass` —
+  between `normalize_view_ops_as_reshape` and `auto_overlap_bucketing_pass`.
+  After view normalization the matcher should see `aten.reshape.default`
+  instead of `view`/`_unsafe_view`, and before bucketing the mm→RS
+  adjacency should be intact.
+- **Changes**: Insert async_tensor_parallel_pass at position #5 (between
+  view normalization and bucketing), dropping the original conditional.
+- **Result**: tps **7,141 (-2.1%)**, numerics PASS, but **356 "no
+  producer matmul found" skips and 0 fusions**. AG-side also produced
+  zero fusions silently.
+- **Analysis**: Position is not the issue. The upstream
+  `_find_producer_matmul` whitelist (`reshape`, `_to_copy`, outer
+  `view`) doesn't match what sits between mm and RS in our graph —
+  presumably a `permute`/`transpose`/DTensor metadata op or a
+  non-whitelisted `_to_copy` variant. Without an explicit dump-and-rewrite
+  to fold those into the matched chain, async TP cannot engage on this
+  configuration from `passes.py` alone.
+- **Lessons**: Async TP is **fully blocked** at the upstream-matcher
+  level on Llama3 8B FSDP=4×TP=2 with DTensor lowering. Three pass
+  positions tried (start, middle, end) — all yield 0 fusions. Park
+  this direction until either (a) upstream loosens the matcher whitelist
+  or (b) we write a custom mm→RS fusion replacement that handles the
+  actual op pattern. TP RS (61.5 ms exposed, 5.9% of step) remains the
+  largest unattacked bottleneck.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -99,3 +99,59 @@ learn from past experiments and avoid repeating failed approaches.
   the very start of `compile_time_passes` (or just after `remove_detach_pass`).
 
 ---
+
+## async_TP first in compile_time_passes — discard (xxxxxxx)
+
+- **Idea**: Move `async_tensor_parallel_pass` to position #1 so upstream
+  `micro_pipeline_tp_pass` matcher sees `mm→RS` / `AG→mm` adjacency in
+  the joint graph before view normalization / FSDP bucketing perturb it.
+- **Changes**: Made `async_tensor_parallel_pass` the first appended pass,
+  unconditionally (dropped the config gate).
+- **Result**: tps = 7,164, mfu = 41.95%, memory = 47.52 GiB, wall_time = 79 s.
+  Bitwise numerics PASS. 0 fusions: 421 "no producer matmul found for
+  reduce scatter" skips. tps in ±1% of baseline.
+- **Analysis**: Position didn't help. `DTensor.redistribute` (which
+  produces the TP collectives during `make_fx`) decomposes via aten
+  `view`/`_unsafe_view`/`reshape`/`_to_copy`/`permute` between `mm` and
+  the collective. Upstream `find_producer_matmul` only traverses through
+  a narrow whitelist (`aten.reshape.default`, `aten._to_copy`,
+  `aten.view.default`); `_unsafe_view` and `permute` (which sit in the
+  Q/K/V reshape path and row-parallel output path) break the chain.
+- **Lessons**: `async_tensor_parallel_pass` at the joint-graph stage is
+  not engageable from `passes.py` alone — the breakers are intrinsic to
+  DTensor lowering, not artifacts of subsequent passes. Either upstream
+  needs a looser matcher, or we'd need to rewrite `mm→{view|reshape|
+  permute|_to_copy}*→RS` chains into direct adjacency ourselves
+  (reimplementing a chunk of `micro_pipeline_tp_pass`). Out of scope.
+
+---
+
+## bucket_all_reduce after FSDP bucketing — crash (xxxxxxx)
+
+- **Idea**: Coalesce 67 small TP `all_reduce` calls (RMSNorm weight grads,
+  8 KB bf16 each on TP-2 group) into one merged bucket via upstream
+  `torch._inductor.fx_passes.bucketing.bucket_all_reduce`. Bitwise-safe
+  in bf16 because per-position rank-axis reduction is unchanged.
+- **Changes**: Added `bucket_tp_all_reduce_pass` wrapping
+  `bucket_all_reduce(gm)`, registered after
+  `joint_transformer_block_bucketing_reordering_pass`.
+- **Result**: Bitwise numerics test PASSED. Benchmark CRASHED with
+  `RuntimeError: Argument 'view_4062' of Node '_to_copy_432' was used
+  before it has been defined!` from `gm.graph.lint()`.
+- **Analysis**: Bucketing logically engaged — the post-merge graph has
+  one big `all_reduce(cat([67 grads]))` instead of 67 separate AR calls,
+  bitwise correct. But the upstream FSDP `enable_fsdp_ag_rs_overlap=True`
+  reorder had already moved consumers of those AR-wait outputs EARLIER
+  in the graph (so the FSDP RS overlap can start sooner). After AR
+  bucketing inserts the merged collective at `bucket_nodes[-1].next`,
+  those moved-earlier consumers now reference an output defined LATER.
+  Topologically invalid. Numerics test happens to pass because that test
+  uses `enable_fsdp_ag_rs_overlap=False`, where the consumer reorder
+  doesn't happen.
+- **Lessons**: AR bucketing IS bitwise-safe (test passes). The crash is
+  pure graph-topology, fixable by either (a) running AR bucketing BEFORE
+  FSDP bucketing/overlap so FSDP sees 1 merged AR not 67, or
+  (b) inserting the merged AR at an `insertion_point` that precedes the
+  earliest moved consumer. Try (a) next — it's a one-line reorder.
+
+---

--- a/autoresearch/EXPERIMENT_LOG.md
+++ b/autoresearch/EXPERIMENT_LOG.md
@@ -335,3 +335,29 @@ learn from past experiments and avoid repeating failed approaches.
   experiments should layer on top of this rather than swap it out.
 
 ---
+
+## Re-profile post auto_overlap_bucketing — discovery (no commit)
+
+- **Idea**: Profile current keep state (auto_overlap_bucketing) to find
+  the new dominant bottleneck.
+- **Result**: GPU 98.2% busy, total comm 325 ms / step (63% overlapped).
+  Exposed comm: 119 ms (11.5% of 1037 ms step).
+  - TP RS bf16: **61.5 ms exposed (2.6% overlap)** — biggest remaining
+    target, untouched by auto-bucketing (which only processes FSDP
+    group '41', not TP group '22').
+  - FSDP AG: 53.8 ms (30.9% overlap, improved from 28% in baseline)
+  - FSDP RS f32: 34.7 ms (83% overlap, +5 ms worse than baseline)
+  - TP AR bf16: 2.6 ms exposed (RMSNorm wg)
+- **Analysis**: The +1.84% from auto_overlap_bucketing came mostly from
+  hiding the ~177 ms of copy/cat overhead behind compute (now <5 ms
+  exposed) — total comm exposed actually grew slightly (146 → 153 ms).
+  Auto-bucketer optimizes FSDP only; TP collectives remain scattered and
+  unbucketed. TP RS (61.5 ms exposed, 130 calls) is the single largest
+  remaining target.
+- **Lessons**: To make further progress: (a) **TP-side bucketing /
+  async TP** is the highest-impact direction; (b) async TP matcher
+  has been failing due to op adjacency — needs custom fusion or
+  graph rewrite; (c) the 67 TP AR coalescing is also stalled by
+  upstream topology bug.
+
+---

--- a/autoresearch/EXPERIMENT_PLAN.md
+++ b/autoresearch/EXPERIMENT_PLAN.md
@@ -1,0 +1,121 @@
+# Autoresearch Experiment Plan
+
+A comparative study of LLM-driven autonomous kernel fusion under different
+scaffolding conditions. Each run is a long-running autoresearch loop on a
+separate branch; the differences across runs answer specific questions about
+what the agent needs to be effective.
+
+## Goal
+
+Showcase what an LLM agent can autonomously discover when given the
+custom graph passes (added to `construct_default_graph_passes` and `compile_time_passes` in `passes.py`)
+on a Llama3 8B training graph, and quantify how much human scaffolding
+(curated ideas, reference implementations, starting-graph optimizations)
+changes the outcome.
+
+## Study design: 3-run progressive layering
+
+Each subsequent run adds capability over the previous one.
+Consecutive pairs form clean single-axis A/Bs; the cumulative shape across
+all 3 runs tells the headline story.
+
+| # | IDEAS | References | Graph passes | Added vs prior | Tests question |
+|---|---|---|---|---|---|
+| 1 | empty | only FX graph + `autoresearch.md` in-scope files | none | (baseline) | Can the LLM find useful fusions purely from graph inspection? |
+| 2 | curated | only FX graph + `autoresearch.md` in-scope files | none | + curated IDEAS | Do human-curated ideas (without reference implementations) help the agent find better fusions? |
+| 3 | curated | + in-repo reference implementations | production set | + curated IDEAS + reference access + production starting graph | Can autoresearch still add value on top of the already-optimized production graph? |
+
+"No graph passes" means `construct_default_graph_passes` returns the empty
+list and the agent's custom passes are the only ones running. "Production
+set" means the full set of in-repo numerics-preserving passes runs first
+and the agent layers on top.
+
+## Branches
+
+Run 1 lives on `ar_base`. Runs 2–3 each fork from `main` so they inherit
+the shared scaffolding but iterate independently. Each has its own
+`autoresearch.md` customized with the run-specific constraints.
+
+| # | Branch |
+|---|---|
+| 1 | `ar_base` |
+| 2 | `ar_ideas` |
+| 3 | `ar_hand_opt` |
+
+## Per-run constraints
+
+Each branch's `autoresearch.md` is the authoritative description of that
+run's constraints; this section gives a high-level summary only.
+
+### Run 1 — Pure Autonomy Baseline (Floor)
+
+- **IDEAS.md**: empty. Agent generates ideas from FX graph inspection alone.
+- **References**: the agent may read only the files explicitly enumerated
+  in `autoresearch.md`. External sources (upstream PyTorch source, torchao,
+  external kernel libraries, web content, papers, blog posts) are
+  forbidden, as are in-repo reference implementations of prior
+  optimization work.
+- **Numerics guardrail**: bitwise vs eager via
+  `test_bitwise_deterministic.py::TestLlama3*` cases (see `autoresearch.md`).
+- **Result**: 47 experiments, 5 keeps + 1 config change. TPS 4,481 → 6,492
+  (+44.9%) under non-deterministic measurement.
+
+### Run 2 — + Curated IDEAS
+
+- **IDEAS.md**: curated by the experimenter. Ideas provide optimization
+  directions but no implementation details.
+- **References**: same as Run 1 (only FX graph + `autoresearch.md`
+  in-scope files). In-repo reference implementations remain forbidden.
+- **Numerics guardrail**: same as Run 1.
+- **Result**: 42 experiments, 6 keeps. TPS 4,482 → 7,378 (+64.7%) under
+  non-deterministic measurement. Key lever: CUDA graphs (+30.5% single step).
+
+### Run 3 — + Production Starting Graph + Reference Access (Ceiling)
+
+- **IDEAS.md**: curated, same as Run 2.
+- **References**: in-repo reference implementations are now **allowed**
+  as design inspiration. The agent may read all files in
+  `torchtitan/experiments/graph_trainer/` including the production passes.
+- **Graph passes**: production pass set runs before the agent's passes.
+  The agent sees an already-optimized graph and must find further wins on
+  top.
+- **Numerics guardrail**: bitwise vs eager.
+- **Production baseline**: 7,156 tps (no SAC, non-deterministic).
+
+## Execution
+
+Sequential on a single 8×H100 node. Each run:
+
+1. Initial setup (branch + scaffolding) — minutes.
+2. Baseline benchmark + bitwise reproducibility check — ~20 min.
+3. Autoresearch loop — runs indefinitely until manually stopped
+   (`autoresearch.md` says NEVER STOP). Expect ~10–15 min per experiment.
+   Target ~24h+ per run for a robust signal.
+
+## Showcase artifact
+
+`autoresearch/scripts/plot_comparison.py` produces
+`autoresearch/comparison.png` — an overlay chart of incremental TPS by
+keep experiment for all runs + a production reference line.
+
+`autoresearch/scripts/benchmark_all_keeps.sh` re-measures every keep
+commit from all branches under uniform conditions (no `--debug.deterministic`,
+no SAC) for apples-to-apples comparison.
+
+## Results summary (non-deterministic, no SAC)
+
+| Run | Branch | Best TPS | Best MFU | # keep | # experiments |
+|---|---|---|---|---|---|
+| 1 | `ar_base` | 6,492 | 38.0% | 5 (+1 config) | 47 |
+| 2 | `ar_ideas` | 7,378 | 43.2% | 6 | 42 |
+| — | Production | 7,156 | 41.9% | — | — |
+| 3 | `ar_hand_opt` | TBD | TBD | TBD | TBD |
+
+## Status
+
+- [x] Run 1 complete — branch `ar_base`, 47 experiments, best 6,492 tps.
+- [x] Run 2 complete — branch `ar_ideas`, 42 experiments, best 7,378 tps.
+- [x] Uniform re-measurement of all keeps (benchmark_all_keeps.tsv).
+- [x] Comparison chart (comparison.png).
+- [ ] Run 3 setup + loop — branch `ar_hand_opt`.
+- [ ] Final showcase synthesis.

--- a/autoresearch/IDEAS.md
+++ b/autoresearch/IDEAS.md
@@ -20,14 +20,61 @@ the beginning:
 
 ## Ideas
 
-- [~] **Graph cleanup**: Remove no-ops from the graph to make it cleaner and easier for future optimizations.
-  - 2026-05-28 00:15 — Upstream `joint_graph_passes` (CSE, noop removal, constant folding) inserted after `normalize_view_ops_as_reshape` was bitwise-safe but +0.11% (noise). Production no-op cleanup is already adequate at the joint-graph stage. Any future cleanup wins likely live in the *post-bucketing* / *post-regional-Inductor* graph (new patterns appear there) or in fusing kernels Inductor never touches (RMSNorm, residual+norm, embedding+norm).
+- [x] **Graph cleanup**: Remove no-ops from the graph to make it cleaner and easier for future optimizations.
+  - 2026-05-28 00:15 — Upstream `joint_graph_passes` after no-op cleanup: bitwise-safe but +0.11% noise (graph already clean).
+  - 2026-05-28 04:15 — `remove_redundant_contiguous_clone_pass` removes 68 stride-already-contiguous `aten.clone(memory_format=contiguous_format)` calls per step (+0.34%, KEEP). Subgraph descent (Exp 22) and post-bucketing rerun (Exp 23) find 0 more. The other ~290 FSDP-weight-unpack clones from initial profile get consumed by auto-bucketing.
+  - 2026-05-28 08:00 — `remove_noop_to_copy_pass` finds 0 matches; no `aten._to_copy.default` in the graph is a kwargs-only no-op.
+
 - [x] **CUDA graphs**: If the model is CPU-bound, CUDA graphs remove CPU overhead.
-  - 2026-05-28 00:07 — Already in the production starting graph (`cudagraph_pass`). Nothing further to do at this layer.
-- [ ] **Computation/communication overlap**: If there are exposed communications, see if they can be overlapped with computations.
-- [ ] **Kernel fusions**: Find regions worth fusing and generate fused kernels. torch.compile, Triton kernels, or custom kernels could all help.
-- [ ] **Collective coalescing**: Bucket many small NCCL launches into fewer large ones to reduce launch overhead.
-- [ ] **Profile-driven optimization**: Profile the model, analyze the trace, and look for opportunities to optimize.
-- [ ] **Graph inspection**: Dump and study the FX graph to find optimization opportunities not covered by the ideas above.
-- [ ] **Study other frameworks**: Look at other pretraining frameworks (e.g. https://github.com/apple/axlearn, https://github.com/openxla/xla, Megatron-LM, DeepSpeed, etc.) for optimization ideas.
-- [ ] **Literature research**: When the above ideas are exhausted, search online for recent papers and blog posts on LLM training optimization to find new directions.
+  - 2026-05-28 00:07 — Already in production starting graph (`cudagraph_pass`).
+
+- [x] **Computation/communication overlap**: If there are exposed communications, see if they can be overlapped with computations.
+  - 2026-05-28 02:15 — `auto_overlap_bucketing_pass` (upstream `schedule_overlap_bucketing(collective_bucketing=True, max_memory_increase_gb=2.0, ratio=0.05)`) replaces manual N-layer plan (+0.90%, KEEP). 131 AG / 163 RS buckets.
+  - 2026-05-28 02:25 — `overlap_fsdp_ag_rs_pass` adds 0% (auto-bucketer already overlaps enough).
+  - 2026-05-28 02:35-11:30 — Parameter tuning (`compute_overlap_multipler`, `max_memory_increase_gb=16`, `max_in_flight_gb=32`, `max_compute_pre_fetch=20`, `pre_bucketing_fsdp_collectives_bucket_cap_mb=8/128`, `bucket_mode="custom_ops"/"coalesced"`, second post-Inductor call) — all noise or worse. Bucketer is at a local optimum; further wins blocked by the roofline cost model not seeing Triton-compiled compute times.
+
+- [x] **Kernel fusions**: Find regions worth fusing and generate fused kernels.
+  - 2026-05-28 01:30 — Initial SwiGLU annotation (silu + immediate-mul user, 128 nodes): +0.14% noise. Established bitwise-safety of pointwise Inductor fusion.
+  - 2026-05-28 01:50 — Broad pointwise tagging (1328 nodes incl. complex ops): -0.51% — Inductor can't codegen complex ops, fragments graph.
+  - 2026-05-28 05:00 — Custom `mm → reshape → reduce_scatter` fusion via `symm_mem.fused_matmul_reduce_scatter` (looser matcher than upstream's `micro_pipeline_tp_pass`): 65 fwd TP fusions, +1.17% (KEEP). 225 bwd weight-grad RS skipped on dtype filter (fp32 upcast).
+  - 2026-05-28 05:50 — Extended mm-RS to bwd dx-RS add-tree chains: -0.74% (linearity rewrite fragments into smaller RS ops).
+  - 2026-05-28 06:30 — Shape-fix in fuse_mm_reduce_scatter + residual-add Inductor (224 nodes): +0.26% (KEEP).
+  - 2026-05-28 06:50 — Extended SwiGLU chain (silu/silu_backward seeds, iterative expand to bf16 mul neighbors): 160 nodes, +1.36% (KEEP). Big win — connected-component tagging > op-by-op.
+  - 2026-05-28 07:10/09:20 — Unified pointwise pass (no improvement over disjoint SwiGLU+residual): noise.
+  - 2026-05-28 08:20 — Extend SwiGLU chain to absorb `_to_copy`: 0 new nodes (no adjacent `_to_copy` to chains).
+  - 2026-05-28 08:50 — RoPE complex→real-valued rewrite: CRASH on bitwise (FMA rounding differs). Hard floor under strict bitwise (~9 ms).
+
+- [x] **Collective coalescing**: Bucket many small NCCL launches into fewer large ones.
+  - 2026-05-28 00:40/00:50 — Upstream `bucket_all_reduce` for 67 TP weight-grad ARs: bitwise-safe but topology CRASH (`merge_all_reduce_bucket` inserts merged collective at `bucket_nodes[-1].next`, but consumers of earlier-bucketed ARs were before that → graph.lint() fail). Position-independent upstream bug. Fixing requires custom AR coalescer with topology awareness — out of scope.
+  - FSDP collectives ARE bucketed (via auto-bucketing keep).
+  - TP RS collectives ARE collapsed via custom mm-RS fusion keep.
+
+- [x] **Profile-driven optimization**: Profile the model, analyze the trace, and look for opportunities to optimize.
+  - 2026-05-28 00:55, 02:50, 06:30+ — Multiple profile rounds drove the experiments. Key findings logged in LEARNINGS.md.
+  - Profile-after-keep showed bucketer overlap regression post-Inductor (94%→11% AG overlap), drove the bucketer reordering / parameter experiments.
+
+- [x] **Graph inspection**: Dump and study the FX graph to find optimization opportunities.
+  - 2026-05-28 00:20 — Discovery experiment dumped post-production graph, identified key structural facts: regional Inductor was dormant, TP collectives unbucketed, FSDP collectives healthy, 358 clones with ~290 from FSDP unpack, hot RoPE/SwiGLU/residual unfused patterns.
+
+- [~] **Study other frameworks**: Look at other pretraining frameworks for optimization ideas.
+  - Not directly studied this run. Async-TP (micro_pipeline_tp) from upstream PyTorch was the most relevant comparable — blocked by matcher; we wrote our own.
+
+- [~] **Literature research**: Search online for recent papers and blog posts.
+  - Considered: gradient compression (numerics-changing), sequence parallelism (model change), CPU optimizer offload (latency cost), FP8 matmul (numerics-changing). None applicable under strict bitwise constraint with `passes.py`-only scope.
+
+## Final keep stack (cumulative +5.07% over Run 3 production 7,162 → 7,525 tps)
+
+1. `remove_redundant_contiguous_clone_pass` (68 clones/step)
+2. `fuse_mm_reduce_scatter_pass` w/ shape-fix reshape (65 fwd TP mm→RS fusions)
+3. `auto_overlap_bucketing_pass` (auto-bucketing, replaces manual bucket plan)
+4. `annotate_swiglu_chains_for_regional_inductor_pass` (160 nodes; iterative seed+expand from silu/silu_backward to bf16 mul neighbors)
+5. `annotate_residual_add_for_regional_inductor_pass` (224 bf16 adds)
+6. `regional_inductor_pass` (compiles all tagged regions)
+
+## Remaining hard limits (probably unreachable from `passes.py` alone)
+
+- ~9 ms RoPE complex multiplication — bitwise blocked by aten FMA usage
+- ~13-18 ms FSDP RS f32 exposure — auto-bucketer at local optimum
+- ~17 ms FSDP AG exposure (regressed post-Inductor) — roofline doesn't see Triton kernel times
+- ~17 ms bwd TP RS bf16 (add-tree pattern) — linearity rewrite hurts
+- 67 TP weight-grad AR coalescing — upstream `bucket_all_reduce` topology bug

--- a/autoresearch/IDEAS.md
+++ b/autoresearch/IDEAS.md
@@ -20,8 +20,10 @@ the beginning:
 
 ## Ideas
 
-- [ ] **Graph cleanup**: Remove no-ops from the graph to make it cleaner and easier for future optimizations.
-- [ ] **CUDA graphs**: If the model is CPU-bound, CUDA graphs remove CPU overhead.
+- [~] **Graph cleanup**: Remove no-ops from the graph to make it cleaner and easier for future optimizations.
+  - 2026-05-28 00:15 — Upstream `joint_graph_passes` (CSE, noop removal, constant folding) inserted after `normalize_view_ops_as_reshape` was bitwise-safe but +0.11% (noise). Production no-op cleanup is already adequate at the joint-graph stage. Any future cleanup wins likely live in the *post-bucketing* / *post-regional-Inductor* graph (new patterns appear there) or in fusing kernels Inductor never touches (RMSNorm, residual+norm, embedding+norm).
+- [x] **CUDA graphs**: If the model is CPU-bound, CUDA graphs remove CPU overhead.
+  - 2026-05-28 00:07 — Already in the production starting graph (`cudagraph_pass`). Nothing further to do at this layer.
 - [ ] **Computation/communication overlap**: If there are exposed communications, see if they can be overlapped with computations.
 - [ ] **Kernel fusions**: Find regions worth fusing and generate fused kernels. torch.compile, Triton kernels, or custom kernels could all help.
 - [ ] **Collective coalescing**: Bucket many small NCCL launches into fewer large ones to reduce launch overhead.

--- a/autoresearch/IDEAS.md
+++ b/autoresearch/IDEAS.md
@@ -1,0 +1,31 @@
+# Autoresearch Ideas
+
+Curated seed ideas for Run 3. Directional only — investigate the graph
+to figure out what's actually there and how to exploit it.
+
+## Format
+
+Each idea is a top-level bullet with a status checkbox:
+- `[ ]` — open, not yet explored
+- `[~]` — partially explored, more work possible
+- `[x]` — fully explored or no further opportunity
+
+Comments and findings go as **indented sub-bullets** with a timestamp at
+the beginning:
+
+```
+- [ ] **Idea name**: Description.
+  - YYYY-MM-DD HH:MM — Finding or comment.
+```
+
+## Ideas
+
+- [ ] **Graph cleanup**: Remove no-ops from the graph to make it cleaner and easier for future optimizations.
+- [ ] **CUDA graphs**: If the model is CPU-bound, CUDA graphs remove CPU overhead.
+- [ ] **Computation/communication overlap**: If there are exposed communications, see if they can be overlapped with computations.
+- [ ] **Kernel fusions**: Find regions worth fusing and generate fused kernels. torch.compile, Triton kernels, or custom kernels could all help.
+- [ ] **Collective coalescing**: Bucket many small NCCL launches into fewer large ones to reduce launch overhead.
+- [ ] **Profile-driven optimization**: Profile the model, analyze the trace, and look for opportunities to optimize.
+- [ ] **Graph inspection**: Dump and study the FX graph to find optimization opportunities not covered by the ideas above.
+- [ ] **Study other frameworks**: Look at other pretraining frameworks (e.g. https://github.com/apple/axlearn, https://github.com/openxla/xla, Megatron-LM, DeepSpeed, etc.) for optimization ideas.
+- [ ] **Literature research**: When the above ideas are exhausted, search online for recent papers and blog posts on LLM training optimization to find new directions.

--- a/autoresearch/LEARNINGS.md
+++ b/autoresearch/LEARNINGS.md
@@ -19,6 +19,28 @@ actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
 - Numerics gate FIRST, perf SECOND: a perf win that fails
   `aot_fx_trace_vs_eager` is `crash`, not `keep`.
 
+## Key structural findings (graph after production passes)
+
+- **Regional Inductor compiles nothing in this config.** Llama3 uses
+  `_scaled_dot_product_cudnn_attention` (cuDNN SDPA), not FlexAttention
+  HOPs, so `annotate_flex_attention_for_regional_inductor_pass` finds no
+  HOPs to tag and `regional_inductor_pass` is a no-op. The whole
+  regional-Inductor chain is dormant — `compile_with_inductor`
+  annotations are absent in the dumped graph.
+- **TP collectives are unbucketed**: 130 `all_gather_into_tensor` + 130
+  `reduce_scatter_tensor` on group `'22'` (TP-2). Each is a separate
+  small NCCL launch.
+- **TP weight-grad all_reduces are unbucketed**: 67 small `all_reduce('sum')`
+  on group `'22'` for RMSNorm-weight gradients (8 KB bf16 each), launched
+  serially in backward.
+- **FSDP collectives ARE bucketed**: 34 bucketed AGs (forward) + 34
+  bucketed RSs (backward) via `bucketing._pre_bucket_*` wrappers. Healthy.
+- **Hot unfused pointwise patterns** outside any Inductor region: 32×
+  RoPE blocks (mul/view_as_complex/view_as_real), 32× SwiGLU
+  (`silu→mul`), 32× residual `add` immediately preceding RMSNorm.
+- **290 FSDP weight `clone(contiguous_format)` calls** — one per param,
+  caused by bf16 bucket-buffer slice being non-contiguous. Large memcpy.
+
 ## Patterns that worked
 
 (none yet)
@@ -27,11 +49,14 @@ actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
 
 - Adding upstream Inductor `joint_graph_passes` at the joint-graph stage
   (after `normalize_view_ops_as_reshape`, before bucketing): bitwise-safe
-  but no perf win on this graph. The cleanup it performs (CSE, noop
-  removal, constant folding) finds nothing material because existing
-  no-op passes have already cleaned the graph and Llama3 8B compute is
-  dominated by large matmul/RMSNorm/SDPA/collective kernels with little
-  algebraic redundancy.
+  but +0.11% (noise). Llama3 8B has little algebraic redundancy at this
+  stage; existing no-op cleanup already covers what it would remove.
+- Hard-enabling `async_tensor_parallel_pass` **after** bucketing/view
+  normalization: 0 fusions engaged because reshape/view ops between
+  `mm` and the adjacent collective break upstream `micro_pipeline_tp_pass`'s
+  adjacency matcher. Net -1.9% from pass overhead alone. The pass MUST
+  run before view normalization and bucketing for the matcher to find
+  `mm→RS` / `AG→mm` adjacency.
 
 ## Tooling tips
 

--- a/autoresearch/LEARNINGS.md
+++ b/autoresearch/LEARNINGS.md
@@ -1,0 +1,25 @@
+# Autoresearch Learnings
+
+Living document of what works, what doesn't, and how to approach kernel
+fusion optimization effectively. The agent owns this file.
+
+Re-read at the start of each loop iteration alongside `IDEAS.md` and
+`EXPERIMENT_LOG.md`. Update after meaningful experiments (especially
+surprising results, both positive and negative). Keep concise and
+actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
+
+## Methodology
+
+(empty — agent populates)
+
+## Patterns that worked
+
+(empty — agent populates)
+
+## Patterns that didn't work
+
+(empty — agent populates)
+
+## Tooling tips
+
+(empty — agent populates)

--- a/autoresearch/LEARNINGS.md
+++ b/autoresearch/LEARNINGS.md
@@ -12,7 +12,8 @@ actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
 
 - Production starting graph baseline = 7,162 tps. Treat ±1% (≈±70 tps) as
   noise. A single benchmark within ±1% should be re-run before keeping or
-  discarding if the change is otherwise promising.
+  discarding if the change is otherwise promising. For wins above the
+  threshold, run 3× to confirm consistency.
 - Each experiment edits only `passes.py`. Revert with
   `git checkout -- torchtitan/experiments/graph_trainer/passes.py` before
   starting a new experiment so the baseline graph is consistent.
@@ -21,49 +22,142 @@ actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
 
 ## Key structural findings (graph after production passes)
 
-- **Regional Inductor compiles nothing in this config.** Llama3 uses
+- **Regional Inductor compiles nothing in the default config.** Llama3 uses
   `_scaled_dot_product_cudnn_attention` (cuDNN SDPA), not FlexAttention
   HOPs, so `annotate_flex_attention_for_regional_inductor_pass` finds no
-  HOPs to tag and `regional_inductor_pass` is a no-op. The whole
-  regional-Inductor chain is dormant — `compile_with_inductor`
-  annotations are absent in the dumped graph.
+  HOPs to tag and `regional_inductor_pass` is a no-op until WE tag patterns.
 - **TP collectives are unbucketed**: 130 `all_gather_into_tensor` + 130
-  `reduce_scatter_tensor` on group `'22'` (TP-2). Each is a separate
-  small NCCL launch.
+  `reduce_scatter_tensor` on group `'22'` (TP-2). Each is a separate small
+  NCCL launch.
 - **TP weight-grad all_reduces are unbucketed**: 67 small `all_reduce('sum')`
   on group `'22'` for RMSNorm-weight gradients (8 KB bf16 each), launched
   serially in backward.
-- **FSDP collectives ARE bucketed**: 34 bucketed AGs (forward) + 34
-  bucketed RSs (backward) via `bucketing._pre_bucket_*` wrappers. Healthy.
-- **Hot unfused pointwise patterns** outside any Inductor region: 32×
-  RoPE blocks (mul/view_as_complex/view_as_real), 32× SwiGLU
-  (`silu→mul`), 32× residual `add` immediately preceding RMSNorm.
-- **290 FSDP weight `clone(contiguous_format)` calls** — one per param,
-  caused by bf16 bucket-buffer slice being non-contiguous. Large memcpy.
+- **FSDP collectives ARE bucketed by default**: 34 bucketed AGs (fwd) + 34
+  bucketed RSs (bwd) via `bucketing._pre_bucket_*` wrappers.
+- **Hot unfused pointwise patterns**: 32× RoPE blocks (complex mul, ~9 ms),
+  32× SwiGLU (silu→mul), 32× residual `add` before RMSNorm.
 
-## Patterns that worked
+## Patterns that worked (cumulative +5.07% over Run 3 production)
 
-(none yet)
+1. **Auto-bucketing replaces manual N-layer FSDP plans (+0.90%)**. Upstream
+   `schedule_overlap_bucketing(collective_bucketing=True,
+   max_memory_increase_gb=2.0, max_memory_increase_ratio=0.05)` produces
+   a tighter, bandwidth-saturating schedule (131 AG / 163 RS buckets vs
+   the 18 from a 2-layer manual plan). Compile time +49 s.
+
+2. **Remove redundant `clone(contiguous_format)` (+0.34%)**. Walk the FX
+   graph for `aten.clone.default` whose input is already contiguous per
+   FakeTensor stride; replace uses with input. 68 redundant clones per step.
+   `gm.named_children()` descent and post-bucketing rerun add 0 more.
+
+3. **Custom `mm → reshape → reduce_scatter` fusion (+1.17%)**. Upstream
+   `micro_pipeline_tp_pass`'s matcher is too strict (`reshape→mm→reshape`
+   only); write a looser custom matcher that walks back through
+   view/reshape/_to_copy/permute/transpose/t/_unsafe_view + cat(split())
+   to find producer mm, then replace with `symm_mem.fused_matmul_reduce_scatter`.
+   65 forward TP fusions; dtype-filter skips the 225 backward weight-grad RS
+   that upcast to fp32 (`fused_matmul_reduce_scatter` reduces in mm.A dtype).
+   **Bitwise-safe** because chunked matmul + chunked RS doesn't reorder per-position
+   rank-axis reduction.
+
+4. **Shape-fix in `fuse_mm_reduce_scatter_pass` (perf-neutral; enables future work)**.
+   The fused op output is 2D `[M/G, N]` at runtime but original `wait_tensor`
+   meta was 3D `[1, S, D]`. Stamp the correct 2D fake on the fused-op node,
+   then insert an `aten.reshape.default` back to 3D so downstream consumers
+   see consistent shape. Required for any downstream Inductor scoop touching
+   fused-mm-RS outputs.
+
+5. **Residual-add Inductor compilation (+0.26%)**. Tag every bf16
+   `aten.add.Tensor` with `compile_with_inductor={}`. Inductor produces a
+   `triton_poi_fused_add_0` kernel per region. Bitwise-safe (pure pointwise).
+   224 nodes tagged.
+
+6. **Extended SwiGLU chain Inductor compilation (+1.36%)**. Seed with
+   bf16 silu/silu_backward, then iteratively expand to adjacent bf16
+   `mul.Tensor` whose all-Tensor inputs are bf16. Captures 5-op
+   forward+backward SwiGLU chain (vs original 2-op-only). 160 nodes tagged
+   yielding 64 fused regions (32 fwd + 32 bwd). Bitwise-safe because pure
+   bf16 pointwise.
 
 ## Patterns that didn't work
 
-- Adding upstream Inductor `joint_graph_passes` at the joint-graph stage
-  (after `normalize_view_ops_as_reshape`, before bucketing): bitwise-safe
-  but +0.11% (noise). Llama3 8B has little algebraic redundancy at this
-  stage; existing no-op cleanup already covers what it would remove.
-- Hard-enabling `async_tensor_parallel_pass` **after** bucketing/view
-  normalization: 0 fusions engaged because reshape/view ops between
-  `mm` and the adjacent collective break upstream `micro_pipeline_tp_pass`'s
-  adjacency matcher. Net -1.9% from pass overhead alone. The pass MUST
-  run before view normalization and bucketing for the matcher to find
-  `mm→RS` / `AG→mm` adjacency.
+- **Upstream `joint_graph_passes` / `post_grad_passes`** at any position
+  (+0.11% / +0.23% — noise). Graph is already too clean for upstream
+  pattern matchers; main wins come from MORE Inductor fusion of UNHANDLED
+  patterns (silu, add), not from re-CSE/folding.
+- **Async TP (`async_tensor_parallel_pass`)** at 3 different pass
+  positions — 0 fusions every time. Upstream `_find_producer_matmul`
+  whitelist (`reshape`, `_to_copy`, outer `view` only) doesn't match the
+  DTensor-lowered `mm → {view|permute|transpose|...}* → RS` chains in our
+  graph. Position doesn't matter; the matcher itself is the limit. Our
+  custom `fuse_mm_reduce_scatter_pass` is the fix.
+- **Upstream `bucket_all_reduce`** for the 67 TP weight-grad ARs:
+  topology bug. The merged collective is inserted at `bucket_nodes[-1].next`,
+  but consumers of earlier-bucketed ARs were *before* that position →
+  graph.lint() fails with "used before defined". Fixing requires custom
+  AR coalescer that respects topology (out of scope).
+- **Larger / smaller FSDP bucket cap** (8, 64, 128 MB): default 40.2 MB is
+  near-optimal at this scale. Smaller doesn't help (singletons), larger
+  doesn't help either (bandwidth already saturated).
+- **Bucketer param tuning** (`compute_overlap_multipler`,
+  `max_memory_increase_gb=8/16`, `max_in_flight_gb=32`, `bucket_mode="custom_ops"`,
+  `pre_bucketing_fsdp_collectives=False`): all in noise. The bucketer is
+  at a local optimum for this configuration; the binding constraint is the
+  roofline cost model (which doesn't see Triton/Inductor compute times)
+  not the memory or mode parameters.
+- **Re-running `auto_overlap_bucketing_pass` after `regional_inductor_pass`**:
+  -2.5%. The bucketer treats `invoke_subgraph` as opaque, so post-Inductor
+  rescheduling doesn't help — it just re-shuffles in ways that disrupt
+  the original schedule.
+- **`overlap_fsdp_ag_rs_pass` (separate stream for AG vs RS)**: 0% perf
+  change. Auto-bucketing already overlaps enough.
+- **Custom `AG → mm` fusion (mirror of mm-RS)**: bitwise-safe but -0.13%
+  with +3.87 GiB memory cost. Forward AG's gathered tensor is reused by
+  backward weight-grad mm via `t(gathered)`, forcing `return_A=True`
+  which holds the activation live for backward. Auto-bucketing already
+  overlapped most forward AG.
+- **Extending `fuse_mm_reduce_scatter_pass` to backward dx-RS add-tree
+  chains**: -0.74%. The backward `add_tree(RS([...]))` pattern with our
+  push-RS-through-leaves rewrite produces 2-3x smaller RS ops, exceeding
+  the auto-bucketer's overhead. The original add-tree pattern is more
+  efficient as a single large RS.
+- **RoPE complex → real-valued rewrite**: numerics CRASH. Aten complex mul
+  uses single-FMA (`fma(a,c,-b*d)`) per output component; our 4-mul-2-add
+  real decomposition does two roundings → different last bit in bf16.
+  Hard floor (~9 ms) under strict bitwise.
+- **Broad pointwise Inductor tagging including `view_as_complex/real`**:
+  Inductor can't codegen complex ops, fragments graph into many tiny
+  regions, -0.51% net.
+- **Disabling `custom_codegen_pass`**: 0% — cudagraph replay bypasses
+  FX forward at steady state.
+- **`remove_noop_to_copy_pass`**: 0 matches — no `_to_copy.default` in the
+  graph is a kwargs-only no-op (all are genuine dtype/layout casts).
+
+## Key insights
+
+- **Cumulative wins build from many small + 2-3 large fusion wins.**
+  The biggest single experiment was custom mm-RS fusion (+1.17%);
+  combined with auto-bucketing (+0.90%) and SwiGLU chains (+1.36%),
+  these three account for >70% of the total +5.07%.
+- **Inductor regional compilation IS bitwise-safe for pure bf16
+  pointwise ops** (proven by silu+mul, then add.Tensor, then
+  silu_backward chains). Bitwise breaks when ops involve reductions
+  (RMSNorm), complex math (RoPE), or cross-dtype casts where reduction
+  order matters (fp32 grad upcasts).
+- **Connected-component (seed+expand) tagging > op-by-op tagging**:
+  bigger Inductor regions amortize per-region overhead better. SwiGLU
+  with iterative expand (160 nodes, +1.36%) >> original SwiGLU pair
+  tagging (128 nodes, +0.14%).
+- **Bucketer roofline cost model has limits**: post-Inductor compute
+  is shorter than roofline thinks, so pre-Inductor bucketing
+  over-prefetches AG. Re-bucketing after Inductor doesn't fix this
+  because `invoke_subgraph` is treated as opaque.
 
 ## Tooling tips
 
-- `bash autoresearch/scripts/run_benchmark.sh` produces `run.log`.
+- `bash autoresearch/scripts/run_benchmark.sh` → `run.log`.
 - `grep "step:" run.log | tail -1` → steady-state tps/mfu/memory line.
 - `grep "benchmark_wall_time_s" run.log` → total wall time.
-- Numerics check (must pass): `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1`.
-  Failure → `crash` regardless of perf.
-- Inspect graph: add a one-line `gm.print_readable(...)` inside a temp pass,
-  run once, then remove before benchmarking.
+- Numerics: `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1`. Failure → `crash` regardless of perf.
+- Inspect graph: add a one-line `gm.print_readable(...)` in a temp pass, run 1-2 steps, remove before benchmarking.
+- Profile: add `--profiler.enable_profiling --profiler.profile_freq 15` and `--training.steps 25` to the benchmark cmd; trace lands in `outputs/profile_traces/iteration_15/rank0_trace.json`. Parse with Python (top kernels, exposed comm per collective).

--- a/autoresearch/LEARNINGS.md
+++ b/autoresearch/LEARNINGS.md
@@ -10,16 +10,35 @@ actionable — per-experiment details belong in `EXPERIMENT_LOG.md`.
 
 ## Methodology
 
-(empty — agent populates)
+- Production starting graph baseline = 7,162 tps. Treat ±1% (≈±70 tps) as
+  noise. A single benchmark within ±1% should be re-run before keeping or
+  discarding if the change is otherwise promising.
+- Each experiment edits only `passes.py`. Revert with
+  `git checkout -- torchtitan/experiments/graph_trainer/passes.py` before
+  starting a new experiment so the baseline graph is consistent.
+- Numerics gate FIRST, perf SECOND: a perf win that fails
+  `aot_fx_trace_vs_eager` is `crash`, not `keep`.
 
 ## Patterns that worked
 
-(empty — agent populates)
+(none yet)
 
 ## Patterns that didn't work
 
-(empty — agent populates)
+- Adding upstream Inductor `joint_graph_passes` at the joint-graph stage
+  (after `normalize_view_ops_as_reshape`, before bucketing): bitwise-safe
+  but no perf win on this graph. The cleanup it performs (CSE, noop
+  removal, constant folding) finds nothing material because existing
+  no-op passes have already cleaned the graph and Llama3 8B compute is
+  dominated by large matmul/RMSNorm/SDPA/collective kernels with little
+  algebraic redundancy.
 
 ## Tooling tips
 
-(empty — agent populates)
+- `bash autoresearch/scripts/run_benchmark.sh` produces `run.log`.
+- `grep "step:" run.log | tail -1` → steady-state tps/mfu/memory line.
+- `grep "benchmark_wall_time_s" run.log` → total wall time.
+- Numerics check (must pass): `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1`.
+  Failure → `crash` regardless of perf.
+- Inspect graph: add a one-line `gm.print_readable(...)` inside a temp pass,
+  run once, then remove before benchmarking.

--- a/autoresearch/autoresearch.md
+++ b/autoresearch/autoresearch.md
@@ -1,0 +1,126 @@
+# Autoresearch
+
+## This branch: Run 3 — Production Starting Graph + Curated IDEAS + References
+
+The goal is to see what an LLM agent can discover about optimizing a
+Llama3 8B training graph **on top of the already-optimized production
+pass set**, with full access to curated ideas, in-repo reference
+implementations, and online research. The agent starts from the
+production graph (which already has cleanup, bucketing, regional
+Inductor, and CUDA graphs) and must find further wins.
+
+## Reading scope (very important)
+
+### You MAY read
+
+- `torchtitan/experiments/graph_trainer/passes.py` — **the only file you modify**. Add custom pass functions and register them in `construct_default_graph_passes` or `compile_time_passes`.
+- `torchtitan/experiments/graph_trainer/trainer.py` — GraphTrainer (read-only).
+- `torchtitan/experiments/graph_trainer/make_fx_tracer.py` — make_fx tracing (read-only).
+- `torchtitan/experiments/graph_trainer/compile.py` — compile entry point (read-only).
+- `torchtitan/experiments/graph_trainer/graph_utils.py` — generic FX utilities (read-only).
+- `torchtitan/experiments/graph_trainer/llama3/` — the Llama3 graph_trainer
+  glue (read-only).
+- `torchtitan/models/llama3/`, `torchtitan/models/common/` — model
+  architecture (RMSNorm, Attention, RoPE, FF, Decoder) — read-only.
+- `autoresearch/IDEAS.md`, `autoresearch/LEARNINGS.md`,
+  `autoresearch/EXPERIMENT_LOG.md` — your living docs.
+- `autoresearch/scripts/` — reusable tools you own; create/modify as needed.
+- FX graph dumps you produce yourself (e.g. via a temporary `gm.print_readable()` pass).
+
+### You MUST NOT inspect git history
+
+- Do NOT run `git log`, `git log -p`, `git show <commit>`, `git diff <commit>`,
+  or `git blame`. Both the diffstats and the subject lines of prior commits
+  reference optimization techniques we want you to autonomously rediscover.
+- `git status` and `git diff` / `git diff --staged` (no commit refs, working
+  tree only) are fine.
+- To find commits *you* made during this run, look at
+  `autoresearch/results.tsv` — the second column records the commit hash of
+  each `keep` experiment.
+
+When unsure whether a source qualifies, err on the side of NOT reading it.
+
+## Constraints
+
+**Modify only** `torchtitan/experiments/graph_trainer/passes.py`.
+
+**Do NOT** modify `trainer.py`, `make_fx_tracer.py`, `graph_utils.py`, model code, or add dependencies.
+
+**Goal: minimize training step time while preserving bitwise-identical numerics.**
+
+**Memory** is a soft constraint — some increase is acceptable for meaningful speed gains.
+
+**Simplicity**: all else equal, simpler is better.
+
+## Benchmark
+
+```bash
+bash autoresearch/scripts/run_benchmark.sh
+```
+
+Extract steady-state metrics from the last step:
+
+```bash
+grep "step:" run.log | tail -1
+```
+
+Output format:
+```
+step: 20  loss: 8.12345  grad_norm: 1.2345  memory: 12.34GiB(25.00%)  tps: 12,345  tflops: 123.45  mfu: 12.34%
+```
+
+Profiling traces: add `--profiling.enable_profiling` to the run command.
+
+**Graph inspection**: Add a temporary `gm.print_readable()` call in your pass, run 1-2 steps, inspect output. Remove debug prints before benchmarking.
+
+## Verifying numerics
+
+```bash
+pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1
+```
+
+Any failure counts as `crash` regardless of perf improvement.
+
+**Do not read this test file's source** — it imports symbols whose names
+leak prior optimization techniques. Run it, inspect numerics.log on
+failure for the assertion message, and that's it.
+
+## Logging results
+
+Append to `autoresearch/results.tsv` (tab-separated). 8 columns:
+
+```
+timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
+```
+
+1. ISO 8601 timestamp
+2. Git commit hash (7 chars). `xxxxxxx` for `discard`/`crash`.
+3. Tokens per second. 0 for crashes.
+4. Peak memory GiB (.1f). 0.0 for crashes.
+5. Status: `keep`, `discard`, or `crash`
+6. MFU percent. 0.0 for crashes.
+7. Wall time in seconds. 0 for crashes.
+8. Short description.
+
+## The experiment loop
+
+LOOP FOREVER:
+
+1. Re-read `IDEAS.md`, `LEARNINGS.md`, and `EXPERIMENT_LOG.md`. Pick the next idea.
+2. **Delegate implementation to a subagent.** Spawn a subagent with a clear prompt describing what to implement in `passes.py`. The subagent does all the code changes, runs the benchmark, and verifies numerics. This keeps the main loop context clean. The subagent prompt should include:
+   - What optimization to attempt and why.
+   - The reading-scope restrictions above. Pass them through verbatim — the subagent must follow the same rules.
+   - The benchmark command: `bash autoresearch/scripts/run_benchmark.sh`
+   - How to extract results: `grep "step:" run.log | tail -1`
+   - The numerics check: `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1`
+   - That empty grep or numerics failure = `crash`.
+3. Read the subagent's result. Determine status: `keep` if tps improved + numerics pass; `discard` if no improvement; `crash` if crashed or numerics failed. Record in TSV.
+4. Append entry to `EXPERIMENT_LOG.md`.
+5. If `keep`: commit `passes.py`, `results.tsv`, `EXPERIMENT_LOG.md`, `IDEAS.md`, `LEARNINGS.md`. Message: `[autoresearch] <short description>`.
+6. If `discard` or `crash`: revert only `passes.py` (`git checkout -- torchtitan/experiments/graph_trainer/passes.py`), then commit the updated tracking files (`results.tsv`, `EXPERIMENT_LOG.md`, `IDEAS.md`, `LEARNINGS.md`) so future iterations remember what didn't work. Message: `[autoresearch] <short description> (<status>)`.
+
+**Benchmark variance**: TPS fluctuates ~1-3%. If delta is within noise, re-run to confirm.
+
+**Crashes**: Fix easy bugs and re-run. If fundamentally broken, skip and move on.
+
+**NEVER STOP**: Work indefinitely until manually interrupted. If out of ideas, profile, study the graph, try different approaches.

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -1,0 +1,1 @@
+timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -44,3 +44,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T13:20:00	xxxxxxx	7544	49.1	discard	44.18	150	tag_bridging_layout_ops: 0 hits (tagged regions are pointwise-connected, no layout ops between)
 2026-05-28T13:35:00	xxxxxxx	7542	49.1	discard	44.16	150	tag_extra_pointwise (mul.Scalar/where/clamp_min): 0 hits
 2026-05-28T13:50:00	xxxxxxx	0	0.0	crash	0.0	0	RMSNorm Inductor w/ strict-bitwise flags (emulate_precision_casts/disable_ftz/use_pytorch_libdevice): numerics CRASH (model_hash mismatch). RMSNorm bitwise truly unfeasible.
+2026-05-28T14:05:00	xxxxxxx	7547	49.1	discard	44.20	150	Inductor strict-bitwise flags on keeps: +0.29% noise (no codegen improvement, no bitwise issue to mitigate)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -30,3 +30,7 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T08:20:00	xxxxxxx	7526	49.1	discard	44.07	163	Extend SwiGLU chain to absorb _to_copy: 0 new nodes (no adjacent _to_copy to chain)
 2026-05-28T08:50:00	xxxxxxx	0	0.0	crash	0.0	0	RoPE complex->real rewrite: 128 sites uniform, bitwise FAIL (FMA promotion changes last bit) - hard floor under strict bitwise
 2026-05-28T09:20:00	xxxxxxx	7540	49.1	discard	44.15	151	Unified pointwise chain v2 (replace SwiGLU+residual): 384 nodes (same as disjoint), +0.20% noise
+2026-05-28T09:40:00	xxxxxxx	7541	49.1	discard	44.16	157	compute_overlap_multipler=0.7: +0.21% noise, no schedule shift
+2026-05-28T10:00:00	xxxxxxx	7557	49.1	discard	44.27	153	bucket_mode=custom_ops: +0.43% noise
+2026-05-28T10:20:00	xxxxxxx	7541	49.1	discard	44.16	149	compute_mul=0.7 + custom_ops bucket_mode combo: +0.21% noise (same scheduler decision)
+2026-05-28T10:40:00	xxxxxxx	7500	49.0	discard	44.00	152	max_memory_increase_gb=16, max_in_flight_gb=32: -0.33% (bucketer not memory-limited, cost model mismatch is the limit)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -16,4 +16,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T03:10:00	xxxxxxx	7141	49.1	discard	41.81	125	async TP between normalize+bucket: 356 'no producer matmul' skips, 0 fusions, -2.1%
 2026-05-28T03:25:00	xxxxxxx	7290	49.1	discard	42.69	136	remove custom_codegen_pass: 0 perf change (cudagraph bypasses FX forward at steady state)
 2026-05-28T03:45:00	xxxxxxx	7311	49.1	discard	42.81	129	apply_post_grad_passes after auto bucketing: +0.23% in noise, graph already clean
-2026-05-28T04:15:00	PENDING	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)
+2026-05-28T04:15:00	a9932dbc	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -40,3 +40,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T11:45:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_mode=coalesced: upstream AssertionError in OverlapScheduler._handle_wait
 2026-05-28T12:30:00	xxxxxxx	7516	49.1	discard	44.00	150	Custom topology-aware AR coalescer: 64/68 ARs into 8 chunks bitwise-safe, 0% perf (ARs already overlapped or off critical path)
 2026-05-28T12:45:00	xxxxxxx	7522	49.1	discard	44.02	150	enable_fusion_regions=True alone: 0% noise
+2026-05-28T13:00:00	xxxxxxx	7510	49.1	discard	43.98	150	prioritize_bucketing_during_scheduling=False: -0.2% noise

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -9,3 +9,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T01:10:00	xxxxxxx	7253	47.6	discard	42.47	80	4-layer FSDP bucket plan: +0.33% vs 2-layer (in noise)
 2026-05-28T01:30:00	xxxxxxx	7239	47.7	discard	42.39	112	SwiGLU regional Inductor (128 nodes tagged): +0.14% in noise, bitwise PASS - confirms pointwise fusion is bitwise-safe
 2026-05-28T01:50:00	xxxxxxx	7192	47.7	discard	42.11	246	Broad pointwise tag (1328 nodes, silu/mul/add/sub/_to_copy/view_as_complex): -0.51%, Inductor can't codegen complex ops
+2026-05-28T02:15:00	PENDING	7294	49.1	keep	42.72	128	auto_overlap_bucketing (schedule_overlap_bucketing): +0.90% over 2-layer manual (7291/7305/7287), +1.84% over Run3 baseline

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -18,4 +18,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T03:45:00	xxxxxxx	7311	49.1	discard	42.81	129	apply_post_grad_passes after auto bucketing: +0.23% in noise, graph already clean
 2026-05-28T04:15:00	a9932dbc	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)
 2026-05-28T04:30:00	xxxxxxx	7330	49.1	discard	42.92	127	clone removal with subgraph descent: 0 additional clones found at this pass position
-2026-05-28T05:00:00	PENDING	7405	49.1	keep	43.36	129	fuse_mm_reduce_scatter_pass: 65 TP fwd mm->RS fused via symm_mem, +1.15% (7408/7396/7406/7408)
+2026-05-28T05:00:00	a95df627	7405	49.1	keep	43.36	129	fuse_mm_reduce_scatter_pass: 65 TP fwd mm->RS fused via symm_mem, +1.15% (7408/7396/7406/7408)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -43,3 +43,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T13:00:00	xxxxxxx	7510	49.1	discard	43.98	150	prioritize_bucketing_during_scheduling=False: -0.2% noise
 2026-05-28T13:20:00	xxxxxxx	7544	49.1	discard	44.18	150	tag_bridging_layout_ops: 0 hits (tagged regions are pointwise-connected, no layout ops between)
 2026-05-28T13:35:00	xxxxxxx	7542	49.1	discard	44.16	150	tag_extra_pointwise (mul.Scalar/where/clamp_min): 0 hits
+2026-05-28T13:50:00	xxxxxxx	0	0.0	crash	0.0	0	RMSNorm Inductor w/ strict-bitwise flags (emulate_precision_casts/disable_ftz/use_pytorch_libdevice): numerics CRASH (model_hash mismatch). RMSNorm bitwise truly unfeasible.

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -22,4 +22,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T05:30:00	xxxxxxx	7395	53.0	discard	43.32	131	fuse_all_gather_mm_pass (65 AG->mm fusions): bitwise-safe but -0.13% perf, +3.87 GiB memory (forced return_A=True)
 2026-05-28T05:50:00	xxxxxxx	7350	49.1	discard	43.05	130	Extended mm-RS to bwd add-tree chains: 64 RS->160 smaller fused ops, -0.74% (auto-bucketer was already optimal)
 2026-05-28T06:15:00	xxxxxxx	0	0.0	crash	0.0	0	annotate_residual_add for Inductor: 224 adds tagged, runtime shape mismatch in fused mm-RS output (3D meta vs 2D runtime)
-2026-05-28T06:30:00	PENDING	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)
+2026-05-28T06:30:00	805058b5	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -36,3 +36,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T10:40:00	xxxxxxx	7500	49.0	discard	44.00	152	max_memory_increase_gb=16, max_in_flight_gb=32: -0.33% (bucketer not memory-limited, cost model mismatch is the limit)
 2026-05-28T10:55:00	xxxxxxx	7510	49.1	discard	44.06	141	8 MB pre-bucket cap: too small, 32/291 AG fused, -0.20% noise
 2026-05-28T11:15:00	xxxxxxx	7525	49.1	discard	44.07	149	Reorder: auto_overlap_bucketing after regional_inductor: identical (bucketer treats invoke_subgraph as opaque)
+2026-05-28T11:30:00	xxxxxxx	7530	49.3	discard	44.10	150	max_compute_pre_fetch=20: +0.07% noise (prefetch distance not the limit)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -42,3 +42,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T12:45:00	xxxxxxx	7522	49.1	discard	44.02	150	enable_fusion_regions=True alone: 0% noise
 2026-05-28T13:00:00	xxxxxxx	7510	49.1	discard	43.98	150	prioritize_bucketing_during_scheduling=False: -0.2% noise
 2026-05-28T13:20:00	xxxxxxx	7544	49.1	discard	44.18	150	tag_bridging_layout_ops: 0 hits (tagged regions are pointwise-connected, no layout ops between)
+2026-05-28T13:35:00	xxxxxxx	7542	49.1	discard	44.16	150	tag_extra_pointwise (mul.Scalar/where/clamp_min): 0 hits

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -45,3 +45,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T13:35:00	xxxxxxx	7542	49.1	discard	44.16	150	tag_extra_pointwise (mul.Scalar/where/clamp_min): 0 hits
 2026-05-28T13:50:00	xxxxxxx	0	0.0	crash	0.0	0	RMSNorm Inductor w/ strict-bitwise flags (emulate_precision_casts/disable_ftz/use_pytorch_libdevice): numerics CRASH (model_hash mismatch). RMSNorm bitwise truly unfeasible.
 2026-05-28T14:05:00	xxxxxxx	7547	49.1	discard	44.20	150	Inductor strict-bitwise flags on keeps: +0.29% noise (no codegen improvement, no bitwise issue to mitigate)
+2026-05-28T14:25:00	xxxxxxx	7538	49.1	discard	44.15	150	AR coalescer + tighter bucket combo: 0 ARs to coalesce (mm-RS fusion already absorbed them)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -47,3 +47,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T14:05:00	xxxxxxx	7547	49.1	discard	44.20	150	Inductor strict-bitwise flags on keeps: +0.29% noise (no codegen improvement, no bitwise issue to mitigate)
 2026-05-28T14:25:00	xxxxxxx	7538	49.1	discard	44.15	150	AR coalescer + tighter bucket combo: 0 ARs to coalesce (mm-RS fusion already absorbed them)
 2026-05-28T14:35:00	b41863ab	7535	49.1	verify	44.12	151	Final 3-run verification of keep state: 7534/7530/7541 = +5.21% over Run 3 baseline
+2026-05-28T14:50:00	xxxxxxx	7544	49.1	discard	44.18	150	max_compute_pre_fetch=400/800: noise (prefetch horizon non-binding at 200)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -24,3 +24,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T06:15:00	xxxxxxx	0	0.0	crash	0.0	0	annotate_residual_add for Inductor: 224 adds tagged, runtime shape mismatch in fused mm-RS output (3D meta vs 2D runtime)
 2026-05-28T06:30:00	805058b5	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)
 2026-05-28T06:50:00	6734e2e0	7525	49.1	keep	44.07	166	Extended SwiGLU chain (silu+silu_backward+adjacent bf16 muls iteratively): 160 nodes tagged for regional Inductor, +1.36% (7524/7529/7523)
+2026-05-28T07:10:00	xxxxxxx	7530	49.1	discard	44.10	145	Unified bf16 pointwise chain pass (replacing SwiGLU+residual): 352 nodes (-32), +0.07% noise

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -37,3 +37,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T10:55:00	xxxxxxx	7510	49.1	discard	44.06	141	8 MB pre-bucket cap: too small, 32/291 AG fused, -0.20% noise
 2026-05-28T11:15:00	xxxxxxx	7525	49.1	discard	44.07	149	Reorder: auto_overlap_bucketing after regional_inductor: identical (bucketer treats invoke_subgraph as opaque)
 2026-05-28T11:30:00	xxxxxxx	7530	49.3	discard	44.10	150	max_compute_pre_fetch=20: +0.07% noise (prefetch distance not the limit)
+2026-05-28T11:45:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_mode=coalesced: upstream AssertionError in OverlapScheduler._handle_wait

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -1,2 +1,3 @@
 timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-27T15:50:43	2ffbabc5	7162	47.5	baseline	41.94	84	Run 3 baseline: production passes (cleanup + FSDP bucketing/reorder + regional Inductor + cudagraph), no SAC, no extra custom passes
+2026-05-28T00:15:00	xxxxxxx	7170	47.5	discard	41.98	81	joint_graph_passes after normalize_view_ops_as_reshape: +0.11% in noise

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -2,3 +2,5 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-27T15:50:43	2ffbabc5	7162	47.5	baseline	41.94	84	Run 3 baseline: production passes (cleanup + FSDP bucketing/reorder + regional Inductor + cudagraph), no SAC, no extra custom passes
 2026-05-28T00:15:00	xxxxxxx	7170	47.5	discard	41.98	81	joint_graph_passes after normalize_view_ops_as_reshape: +0.11% in noise
 2026-05-28T00:23:00	xxxxxxx	7023	47.6	discard	41.13	80	async_tensor_parallel_pass after bucketing: 99 'no producer matmul' skips, -1.9% throughput
+2026-05-28T00:30:00	xxxxxxx	7164	47.5	discard	41.95	79	async_TP first in compile_time_passes: 0 fusions (DTensor redistribute inserts view/permute breaking matcher)
+2026-05-28T00:40:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce after FSDP bucketing: lint fail (FSDP overlap moves AR-wait consumers earlier, breaking topology)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -41,3 +41,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T12:30:00	xxxxxxx	7516	49.1	discard	44.00	150	Custom topology-aware AR coalescer: 64/68 ARs into 8 chunks bitwise-safe, 0% perf (ARs already overlapped or off critical path)
 2026-05-28T12:45:00	xxxxxxx	7522	49.1	discard	44.02	150	enable_fusion_regions=True alone: 0% noise
 2026-05-28T13:00:00	xxxxxxx	7510	49.1	discard	43.98	150	prioritize_bucketing_during_scheduling=False: -0.2% noise
+2026-05-28T13:20:00	xxxxxxx	7544	49.1	discard	44.18	150	tag_bridging_layout_ops: 0 hits (tagged regions are pointwise-connected, no layout ops between)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -9,4 +9,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T01:10:00	xxxxxxx	7253	47.6	discard	42.47	80	4-layer FSDP bucket plan: +0.33% vs 2-layer (in noise)
 2026-05-28T01:30:00	xxxxxxx	7239	47.7	discard	42.39	112	SwiGLU regional Inductor (128 nodes tagged): +0.14% in noise, bitwise PASS - confirms pointwise fusion is bitwise-safe
 2026-05-28T01:50:00	xxxxxxx	7192	47.7	discard	42.11	246	Broad pointwise tag (1328 nodes, silu/mul/add/sub/_to_copy/view_as_complex): -0.51%, Inductor can't codegen complex ops
-2026-05-28T02:15:00	PENDING	7294	49.1	keep	42.72	128	auto_overlap_bucketing (schedule_overlap_bucketing): +0.90% over 2-layer manual (7291/7305/7287), +1.84% over Run3 baseline
+2026-05-28T02:15:00	ab9a521f	7294	49.1	keep	42.72	128	auto_overlap_bucketing (schedule_overlap_bucketing): +0.90% over 2-layer manual (7291/7305/7287), +1.84% over Run3 baseline

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -34,3 +34,5 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T10:00:00	xxxxxxx	7557	49.1	discard	44.27	153	bucket_mode=custom_ops: +0.43% noise
 2026-05-28T10:20:00	xxxxxxx	7541	49.1	discard	44.16	149	compute_mul=0.7 + custom_ops bucket_mode combo: +0.21% noise (same scheduler decision)
 2026-05-28T10:40:00	xxxxxxx	7500	49.0	discard	44.00	152	max_memory_increase_gb=16, max_in_flight_gb=32: -0.33% (bucketer not memory-limited, cost model mismatch is the limit)
+2026-05-28T10:55:00	xxxxxxx	7510	49.1	discard	44.06	141	8 MB pre-bucket cap: too small, 32/291 AG fused, -0.20% noise
+2026-05-28T11:15:00	xxxxxxx	7525	49.1	discard	44.07	149	Reorder: auto_overlap_bucketing after regional_inductor: identical (bucketer treats invoke_subgraph as opaque)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -1,1 +1,2 @@
 timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
+2026-05-27T15:50:43	2ffbabc5	7162	47.5	baseline	41.94	84	Run 3 baseline: production passes (cleanup + FSDP bucketing/reorder + regional Inductor + cudagraph), no SAC, no extra custom passes

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -5,4 +5,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T00:30:00	xxxxxxx	7164	47.5	discard	41.95	79	async_TP first in compile_time_passes: 0 fusions (DTensor redistribute inserts view/permute breaking matcher)
 2026-05-28T00:40:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce after FSDP bucketing: lint fail (FSDP overlap moves AR-wait consumers earlier, breaking topology)
 2026-05-28T00:50:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce before FSDP bucketing: same lint fail, upstream topology bug not position-dependent
-2026-05-28T00:55:00	PENDING	7229	47.7	keep	42.34	79	2-layer FSDP bucket plan: +0.94% avg over 3 runs (7239/7214/7236), bitwise PASS
+2026-05-28T00:55:00	08d24de9	7229	47.7	keep	42.34	79	2-layer FSDP bucket plan: +0.94% avg over 3 runs (7239/7214/7236), bitwise PASS

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -38,3 +38,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T11:15:00	xxxxxxx	7525	49.1	discard	44.07	149	Reorder: auto_overlap_bucketing after regional_inductor: identical (bucketer treats invoke_subgraph as opaque)
 2026-05-28T11:30:00	xxxxxxx	7530	49.3	discard	44.10	150	max_compute_pre_fetch=20: +0.07% noise (prefetch distance not the limit)
 2026-05-28T11:45:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_mode=coalesced: upstream AssertionError in OverlapScheduler._handle_wait
+2026-05-28T12:30:00	xxxxxxx	7516	49.1	discard	44.00	150	Custom topology-aware AR coalescer: 64/68 ARs into 8 chunks bitwise-safe, 0% perf (ARs already overlapped or off critical path)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -10,3 +10,6 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T01:30:00	xxxxxxx	7239	47.7	discard	42.39	112	SwiGLU regional Inductor (128 nodes tagged): +0.14% in noise, bitwise PASS - confirms pointwise fusion is bitwise-safe
 2026-05-28T01:50:00	xxxxxxx	7192	47.7	discard	42.11	246	Broad pointwise tag (1328 nodes, silu/mul/add/sub/_to_copy/view_as_complex): -0.51%, Inductor can't codegen complex ops
 2026-05-28T02:15:00	ab9a521f	7294	49.1	keep	42.72	128	auto_overlap_bucketing (schedule_overlap_bucketing): +0.90% over 2-layer manual (7291/7305/7287), +1.84% over Run3 baseline
+2026-05-28T02:25:00	xxxxxxx	7274	49.1	discard	42.60	130	overlap_fsdp_ag_rs_pass unconditional: -0.27% (auto-bucketer already hides most AG)
+2026-05-28T02:35:00	xxxxxxx	7240	49.4	discard	42.40	129	schedule_overlap_bucketing tuned (memory 8GB, in_flight 16GB, compute_mul 1.5, fusion_regions): -0.74%, bucket count capped by pre-bucket FSDP
+2026-05-28T02:50:00	xxxxxxx	7287	49.1	discard	42.66	117	schedule_overlap_bucketing pre_bucketing=False: -0.10%, no schedule change

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -27,3 +27,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T07:10:00	xxxxxxx	7530	49.1	discard	44.10	145	Unified bf16 pointwise chain pass (replacing SwiGLU+residual): 352 nodes (-32), +0.07% noise
 2026-05-28T07:40:00	xxxxxxx	7339	49.1	discard	42.97	201	Second auto_overlap_bucketing after regional_inductor: -2.5% (re-shuffle disrupted schedule)
 2026-05-28T08:00:00	xxxxxxx	7525	49.1	discard	44.07	151	remove_noop_to_copy_pass: 0 matches (no _to_copy is a kwargs-no-op in this graph)
+2026-05-28T08:20:00	xxxxxxx	7526	49.1	discard	44.07	163	Extend SwiGLU chain to absorb _to_copy: 0 new nodes (no adjacent _to_copy to chain)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -29,3 +29,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T08:00:00	xxxxxxx	7525	49.1	discard	44.07	151	remove_noop_to_copy_pass: 0 matches (no _to_copy is a kwargs-no-op in this graph)
 2026-05-28T08:20:00	xxxxxxx	7526	49.1	discard	44.07	163	Extend SwiGLU chain to absorb _to_copy: 0 new nodes (no adjacent _to_copy to chain)
 2026-05-28T08:50:00	xxxxxxx	0	0.0	crash	0.0	0	RoPE complex->real rewrite: 128 sites uniform, bitwise FAIL (FMA promotion changes last bit) - hard floor under strict bitwise
+2026-05-28T09:20:00	xxxxxxx	7540	49.1	discard	44.15	151	Unified pointwise chain v2 (replace SwiGLU+residual): 384 nodes (same as disjoint), +0.20% noise

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -23,4 +23,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T05:50:00	xxxxxxx	7350	49.1	discard	43.05	130	Extended mm-RS to bwd add-tree chains: 64 RS->160 smaller fused ops, -0.74% (auto-bucketer was already optimal)
 2026-05-28T06:15:00	xxxxxxx	0	0.0	crash	0.0	0	annotate_residual_add for Inductor: 224 adds tagged, runtime shape mismatch in fused mm-RS output (3D meta vs 2D runtime)
 2026-05-28T06:30:00	805058b5	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)
-2026-05-28T06:50:00	PENDING	7525	49.1	keep	44.07	166	Extended SwiGLU chain (silu+silu_backward+adjacent bf16 muls iteratively): 160 nodes tagged for regional Inductor, +1.36% (7524/7529/7523)
+2026-05-28T06:50:00	6734e2e0	7525	49.1	keep	44.07	166	Extended SwiGLU chain (silu+silu_backward+adjacent bf16 muls iteratively): 160 nodes tagged for regional Inductor, +1.36% (7524/7529/7523)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -23,3 +23,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T05:50:00	xxxxxxx	7350	49.1	discard	43.05	130	Extended mm-RS to bwd add-tree chains: 64 RS->160 smaller fused ops, -0.74% (auto-bucketer was already optimal)
 2026-05-28T06:15:00	xxxxxxx	0	0.0	crash	0.0	0	annotate_residual_add for Inductor: 224 adds tagged, runtime shape mismatch in fused mm-RS output (3D meta vs 2D runtime)
 2026-05-28T06:30:00	805058b5	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)
+2026-05-28T06:50:00	PENDING	7525	49.1	keep	44.07	166	Extended SwiGLU chain (silu+silu_backward+adjacent bf16 muls iteratively): 160 nodes tagged for regional Inductor, +1.36% (7524/7529/7523)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -4,3 +4,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T00:23:00	xxxxxxx	7023	47.6	discard	41.13	80	async_tensor_parallel_pass after bucketing: 99 'no producer matmul' skips, -1.9% throughput
 2026-05-28T00:30:00	xxxxxxx	7164	47.5	discard	41.95	79	async_TP first in compile_time_passes: 0 fusions (DTensor redistribute inserts view/permute breaking matcher)
 2026-05-28T00:40:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce after FSDP bucketing: lint fail (FSDP overlap moves AR-wait consumers earlier, breaking topology)
+2026-05-28T00:50:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce before FSDP bucketing: same lint fail, upstream topology bug not position-dependent

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -20,3 +20,6 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T04:30:00	xxxxxxx	7330	49.1	discard	42.92	127	clone removal with subgraph descent: 0 additional clones found at this pass position
 2026-05-28T05:00:00	a95df627	7405	49.1	keep	43.36	129	fuse_mm_reduce_scatter_pass: 65 TP fwd mm->RS fused via symm_mem, +1.15% (7408/7396/7406/7408)
 2026-05-28T05:30:00	xxxxxxx	7395	53.0	discard	43.32	131	fuse_all_gather_mm_pass (65 AG->mm fusions): bitwise-safe but -0.13% perf, +3.87 GiB memory (forced return_A=True)
+2026-05-28T05:50:00	xxxxxxx	7350	49.1	discard	43.05	130	Extended mm-RS to bwd add-tree chains: 64 RS->160 smaller fused ops, -0.74% (auto-bucketer was already optimal)
+2026-05-28T06:15:00	xxxxxxx	0	0.0	crash	0.0	0	annotate_residual_add for Inductor: 224 adds tagged, runtime shape mismatch in fused mm-RS output (3D meta vs 2D runtime)
+2026-05-28T06:30:00	PENDING	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -1,3 +1,4 @@
 timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-27T15:50:43	2ffbabc5	7162	47.5	baseline	41.94	84	Run 3 baseline: production passes (cleanup + FSDP bucketing/reorder + regional Inductor + cudagraph), no SAC, no extra custom passes
 2026-05-28T00:15:00	xxxxxxx	7170	47.5	discard	41.98	81	joint_graph_passes after normalize_view_ops_as_reshape: +0.11% in noise
+2026-05-28T00:23:00	xxxxxxx	7023	47.6	discard	41.13	80	async_tensor_parallel_pass after bucketing: 99 'no producer matmul' skips, -1.9% throughput

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -13,3 +13,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T02:25:00	xxxxxxx	7274	49.1	discard	42.60	130	overlap_fsdp_ag_rs_pass unconditional: -0.27% (auto-bucketer already hides most AG)
 2026-05-28T02:35:00	xxxxxxx	7240	49.4	discard	42.40	129	schedule_overlap_bucketing tuned (memory 8GB, in_flight 16GB, compute_mul 1.5, fusion_regions): -0.74%, bucket count capped by pre-bucket FSDP
 2026-05-28T02:50:00	xxxxxxx	7287	49.1	discard	42.66	117	schedule_overlap_bucketing pre_bucketing=False: -0.10%, no schedule change
+2026-05-28T03:10:00	xxxxxxx	7141	49.1	discard	41.81	125	async TP between normalize+bucket: 356 'no producer matmul' skips, 0 fusions, -2.1%

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -18,3 +18,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T03:45:00	xxxxxxx	7311	49.1	discard	42.81	129	apply_post_grad_passes after auto bucketing: +0.23% in noise, graph already clean
 2026-05-28T04:15:00	a9932dbc	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)
 2026-05-28T04:30:00	xxxxxxx	7330	49.1	discard	42.92	127	clone removal with subgraph descent: 0 additional clones found at this pass position
+2026-05-28T05:00:00	PENDING	7405	49.1	keep	43.36	129	fuse_mm_reduce_scatter_pass: 65 TP fwd mm->RS fused via symm_mem, +1.15% (7408/7396/7406/7408)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -19,3 +19,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T04:15:00	a9932dbc	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)
 2026-05-28T04:30:00	xxxxxxx	7330	49.1	discard	42.92	127	clone removal with subgraph descent: 0 additional clones found at this pass position
 2026-05-28T05:00:00	a95df627	7405	49.1	keep	43.36	129	fuse_mm_reduce_scatter_pass: 65 TP fwd mm->RS fused via symm_mem, +1.15% (7408/7396/7406/7408)
+2026-05-28T05:30:00	xxxxxxx	7395	53.0	discard	43.32	131	fuse_all_gather_mm_pass (65 AG->mm fusions): bitwise-safe but -0.13% perf, +3.87 GiB memory (forced return_A=True)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -46,3 +46,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T13:50:00	xxxxxxx	0	0.0	crash	0.0	0	RMSNorm Inductor w/ strict-bitwise flags (emulate_precision_casts/disable_ftz/use_pytorch_libdevice): numerics CRASH (model_hash mismatch). RMSNorm bitwise truly unfeasible.
 2026-05-28T14:05:00	xxxxxxx	7547	49.1	discard	44.20	150	Inductor strict-bitwise flags on keeps: +0.29% noise (no codegen improvement, no bitwise issue to mitigate)
 2026-05-28T14:25:00	xxxxxxx	7538	49.1	discard	44.15	150	AR coalescer + tighter bucket combo: 0 ARs to coalesce (mm-RS fusion already absorbed them)
+2026-05-28T14:35:00	b41863ab	7535	49.1	verify	44.12	151	Final 3-run verification of keep state: 7534/7530/7541 = +5.21% over Run 3 baseline

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -8,3 +8,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T00:55:00	08d24de9	7229	47.7	keep	42.34	79	2-layer FSDP bucket plan: +0.94% avg over 3 runs (7239/7214/7236), bitwise PASS
 2026-05-28T01:10:00	xxxxxxx	7253	47.6	discard	42.47	80	4-layer FSDP bucket plan: +0.33% vs 2-layer (in noise)
 2026-05-28T01:30:00	xxxxxxx	7239	47.7	discard	42.39	112	SwiGLU regional Inductor (128 nodes tagged): +0.14% in noise, bitwise PASS - confirms pointwise fusion is bitwise-safe
+2026-05-28T01:50:00	xxxxxxx	7192	47.7	discard	42.11	246	Broad pointwise tag (1328 nodes, silu/mul/add/sub/_to_copy/view_as_complex): -0.51%, Inductor can't codegen complex ops

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -5,3 +5,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T00:30:00	xxxxxxx	7164	47.5	discard	41.95	79	async_TP first in compile_time_passes: 0 fusions (DTensor redistribute inserts view/permute breaking matcher)
 2026-05-28T00:40:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce after FSDP bucketing: lint fail (FSDP overlap moves AR-wait consumers earlier, breaking topology)
 2026-05-28T00:50:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce before FSDP bucketing: same lint fail, upstream topology bug not position-dependent
+2026-05-28T00:55:00	PENDING	7229	47.7	keep	42.34	79	2-layer FSDP bucket plan: +0.94% avg over 3 runs (7239/7214/7236), bitwise PASS

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -39,3 +39,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T11:30:00	xxxxxxx	7530	49.3	discard	44.10	150	max_compute_pre_fetch=20: +0.07% noise (prefetch distance not the limit)
 2026-05-28T11:45:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_mode=coalesced: upstream AssertionError in OverlapScheduler._handle_wait
 2026-05-28T12:30:00	xxxxxxx	7516	49.1	discard	44.00	150	Custom topology-aware AR coalescer: 64/68 ARs into 8 chunks bitwise-safe, 0% perf (ARs already overlapped or off critical path)
+2026-05-28T12:45:00	xxxxxxx	7522	49.1	discard	44.02	150	enable_fusion_regions=True alone: 0% noise

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -14,3 +14,6 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T02:35:00	xxxxxxx	7240	49.4	discard	42.40	129	schedule_overlap_bucketing tuned (memory 8GB, in_flight 16GB, compute_mul 1.5, fusion_regions): -0.74%, bucket count capped by pre-bucket FSDP
 2026-05-28T02:50:00	xxxxxxx	7287	49.1	discard	42.66	117	schedule_overlap_bucketing pre_bucketing=False: -0.10%, no schedule change
 2026-05-28T03:10:00	xxxxxxx	7141	49.1	discard	41.81	125	async TP between normalize+bucket: 356 'no producer matmul' skips, 0 fusions, -2.1%
+2026-05-28T03:25:00	xxxxxxx	7290	49.1	discard	42.69	136	remove custom_codegen_pass: 0 perf change (cudagraph bypasses FX forward at steady state)
+2026-05-28T03:45:00	xxxxxxx	7311	49.1	discard	42.81	129	apply_post_grad_passes after auto bucketing: +0.23% in noise, graph already clean
+2026-05-28T04:15:00	PENDING	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -25,3 +25,5 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T06:30:00	805058b5	7424	49.1	keep	43.48	143	Shape fix in fuse_mm_reduce_scatter_pass + annotate_residual_add for Inductor: 224 adds tagged, +0.26% (7429/7422/7423)
 2026-05-28T06:50:00	6734e2e0	7525	49.1	keep	44.07	166	Extended SwiGLU chain (silu+silu_backward+adjacent bf16 muls iteratively): 160 nodes tagged for regional Inductor, +1.36% (7524/7529/7523)
 2026-05-28T07:10:00	xxxxxxx	7530	49.1	discard	44.10	145	Unified bf16 pointwise chain pass (replacing SwiGLU+residual): 352 nodes (-32), +0.07% noise
+2026-05-28T07:40:00	xxxxxxx	7339	49.1	discard	42.97	201	Second auto_overlap_bucketing after regional_inductor: -2.5% (re-shuffle disrupted schedule)
+2026-05-28T08:00:00	xxxxxxx	7525	49.1	discard	44.07	151	remove_noop_to_copy_pass: 0 matches (no _to_copy is a kwargs-no-op in this graph)

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -17,3 +17,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T03:25:00	xxxxxxx	7290	49.1	discard	42.69	136	remove custom_codegen_pass: 0 perf change (cudagraph bypasses FX forward at steady state)
 2026-05-28T03:45:00	xxxxxxx	7311	49.1	discard	42.81	129	apply_post_grad_passes after auto bucketing: +0.23% in noise, graph already clean
 2026-05-28T04:15:00	a9932dbc	7319	49.1	keep	42.81	129	remove_redundant_contiguous_clone_pass: 68 redundant clones removed/step, +0.34% (7321/7323/7312)
+2026-05-28T04:30:00	xxxxxxx	7330	49.1	discard	42.92	127	clone removal with subgraph descent: 0 additional clones found at this pass position

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -6,3 +6,5 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T00:40:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce after FSDP bucketing: lint fail (FSDP overlap moves AR-wait consumers earlier, breaking topology)
 2026-05-28T00:50:00	xxxxxxx	0	0.0	crash	0.0	0	bucket_all_reduce before FSDP bucketing: same lint fail, upstream topology bug not position-dependent
 2026-05-28T00:55:00	08d24de9	7229	47.7	keep	42.34	79	2-layer FSDP bucket plan: +0.94% avg over 3 runs (7239/7214/7236), bitwise PASS
+2026-05-28T01:10:00	xxxxxxx	7253	47.6	discard	42.47	80	4-layer FSDP bucket plan: +0.33% vs 2-layer (in noise)
+2026-05-28T01:30:00	xxxxxxx	7239	47.7	discard	42.39	112	SwiGLU regional Inductor (128 nodes tagged): +0.14% in noise, bitwise PASS - confirms pointwise fusion is bitwise-safe

--- a/autoresearch/results.tsv
+++ b/autoresearch/results.tsv
@@ -28,3 +28,4 @@ timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
 2026-05-28T07:40:00	xxxxxxx	7339	49.1	discard	42.97	201	Second auto_overlap_bucketing after regional_inductor: -2.5% (re-shuffle disrupted schedule)
 2026-05-28T08:00:00	xxxxxxx	7525	49.1	discard	44.07	151	remove_noop_to_copy_pass: 0 matches (no _to_copy is a kwargs-no-op in this graph)
 2026-05-28T08:20:00	xxxxxxx	7526	49.1	discard	44.07	163	Extend SwiGLU chain to absorb _to_copy: 0 new nodes (no adjacent _to_copy to chain)
+2026-05-28T08:50:00	xxxxxxx	0	0.0	crash	0.0	0	RoPE complex->real rewrite: 128 sites uniform, bitwise FAIL (FMA promotion changes last bit) - hard floor under strict bitwise

--- a/autoresearch/scripts/run_benchmark.sh
+++ b/autoresearch/scripts/run_benchmark.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Autoresearch benchmark: Llama3 8B FSDP=4 TP=2 bs=1 on 8xH100.
+# Output goes to ./run.log with wall time appended.
+# Extra arguments are forwarded to run_train.sh.
+
+set -e
+
+start_time=$(date +%s)
+
+NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh \
+    --compile.mode aot_fx_trace \
+    --parallelism.data_parallel_shard_degree=4 \
+    --parallelism.tensor_parallel_degree=2 \
+    --dataloader.dataset c4_test \
+    --training.local_batch_size 1 \
+    --metrics.no-enable_tensorboard \
+    --profiler.no-enable_profiling \
+    --comm.trace_buf_size=0 \
+    --debug.seed 42 \
+    --training.steps 20 \
+    "$@" \
+    > run.log 2>&1
+
+elapsed=$(($(date +%s) - start_time))
+echo "benchmark_wall_time_s=${elapsed}" | tee -a run.log

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -84,6 +84,61 @@ def normalize_view_ops_as_reshape(
     return gm
 
 
+def remove_redundant_contiguous_clone_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+) -> torch.fx.GraphModule:
+    """Remove aten.clone(..., memory_format=contiguous_format) calls whose
+    input is already contiguous (per FakeTensor stride metadata).
+
+    FSDP weight-unpack patterns (split_with_sizes -> view.dtype -> clone) often
+    produce a clone whose input already has contiguous strides into the bucket
+    buffer; the clone(contiguous_format) is then a redundant memcpy. Running
+    this before ``auto_overlap_bucketing_pass`` lets the bucketer see fewer ops.
+    """
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    def _is_contig(t: FakeTensor) -> bool:
+        shape = list(t.size())
+        strides = list(t.stride())
+        expected: list = []
+        s = 1
+        for d in reversed(shape):
+            expected.append(s)
+            s *= d
+        return strides == list(reversed(expected))
+
+    removed = 0
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function":
+            continue
+        if node.target is not aten.clone.default:
+            continue
+        # Default ``memory_format`` for ``aten.clone`` is contiguous_format;
+        # treat both the explicit and the implicit case as redundant when the
+        # input already has contiguous strides.
+        mem_fmt = node.kwargs.get("memory_format", torch.contiguous_format)
+        if mem_fmt is not torch.contiguous_format:
+            continue
+        if not node.args or not isinstance(node.args[0], torch.fx.Node):
+            continue
+        in_node = node.args[0]
+        in_val = in_node.meta.get("val")
+        if not isinstance(in_val, FakeTensor):
+            continue
+        if not _is_contig(in_val):
+            continue
+        # Clone is redundant; route users to the input directly.
+        node.replace_all_uses_with(in_node)
+        gm.graph.erase_node(node)
+        removed += 1
+    if removed > 0:
+        logger.info(f"Removed {removed} redundant clone(contiguous_format) calls")
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
 def auto_overlap_bucketing_pass(
     gm: torch.fx.GraphModule,
     example_inputs=None,
@@ -175,6 +230,7 @@ def compile_time_passes(
         remove_identity_view_pass,
         remove_identity_slice_pass,
         normalize_view_ops_as_reshape,
+        remove_redundant_contiguous_clone_pass,
     ]
     # Preserve AG/RS overlap (separate streams for AG vs RS) before auto-bucketing.
     if config.compile.enable_fsdp_ag_rs_overlap:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -42,7 +42,7 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     snapshot_graph,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
-    joint_transformer_block_bucketing_reordering_pass,
+    overlap_fsdp_ag_rs_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
@@ -80,6 +80,31 @@ def normalize_view_ops_as_reshape(
         if node.op == "call_function" and node.target in view_targets:
             node.target = aten.reshape.default
     gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def auto_overlap_bucketing_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+) -> torch.fx.GraphModule:
+    """Auto-schedule FSDP collectives for overlap (replaces manual bucketing).
+
+    Uses upstream ``schedule_overlap_bucketing`` which estimates collective
+    and compute runtimes from a roofline model and picks bucket sizes
+    that saturate NCCL bandwidth, then reorders to maximize overlap.
+    Respects a memory budget so peak memory doesn't blow up.
+    """
+    from torch._inductor.fx_passes.overlap_scheduling import (
+        schedule_overlap_bucketing,
+    )
+
+    schedule_overlap_bucketing(
+        gm,
+        collective_bucketing=True,
+        max_memory_increase_gb=2.0,
+        max_memory_increase_ratio=0.05,
+    )
     gm.recompile()
     return gm
 
@@ -137,40 +162,24 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime.
 
-    ``joint_transformer_block_bucketing_reordering_pass`` optionally runs
-    ``overlap_fsdp_ag_rs_pass`` first (gated by
-    ``compile.enable_fsdp_ag_rs_overlap``) so that forward+backward
+    ``auto_overlap_bucketing_pass`` is preceded by ``overlap_fsdp_ag_rs_pass``
+    (gated by ``compile.enable_fsdp_ag_rs_overlap``) so that forward+backward
     all-gathers end up on a separate CUDA stream from reduce-scatters
-    (enabling AG/RS overlap in backward).
+    (enabling AG/RS overlap in backward) before the auto-bucketer reorders
+    the schedule.
     """
     from torchtitan.models.common.attention import FlexAttention
 
-    n_layers = len(config.model_spec.model.layers)
-    # Group transformer layers into 2-layer buckets to deepen FSDP AG prefetch.
-    # Default is one layer per bucket (34 buckets). With 2-layer buckets we get
-    # 16 layer-buckets + tok_embeddings + [norm, lm_head] = 18 buckets.
-    layer_buckets_2 = [
-        [f"layers.{i}", f"layers.{i+1}"]
-        for i in range(0, n_layers - (n_layers % 2), 2)
-    ]
-    if n_layers % 2:
-        layer_buckets_2.append([f"layers.{n_layers - 1}"])
-    two_layer_bucket_plan = [
-        "tok_embeddings",
-        *layer_buckets_2,
-        ["norm", "lm_head"],
-    ]
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
         remove_identity_slice_pass,
         normalize_view_ops_as_reshape,
-        functools.partial(
-            joint_transformer_block_bucketing_reordering_pass,
-            module_bucket_plans=two_layer_bucket_plan,
-            enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
-        ),
     ]
+    # Preserve AG/RS overlap (separate streams for AG vs RS) before auto-bucketing.
+    if config.compile.enable_fsdp_ag_rs_overlap:
+        passes.append(overlap_fsdp_ag_rs_pass)
+    passes.append(auto_overlap_bucketing_pass)
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -164,6 +164,303 @@ def auto_overlap_bucketing_pass(
     return gm
 
 
+def fuse_mm_reduce_scatter_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+) -> torch.fx.GraphModule:
+    """Custom matcher for mm -> {view|reshape|_to_copy|permute|transpose|_unsafe_view}* -> RS.
+
+    Replaces the chain with ``symm_mem.fused_matmul_reduce_scatter`` so the
+    matmul can be chunked and pipelined with the reduce-scatter over NVLink
+    symmetric memory. Looser than upstream ``micro_pipeline_tp_pass``'s
+    ``_find_producer_matmul`` which only whitelists ``reshape -> mm -> reshape``
+    (both sides) plus a bare ``mm``. Our graph has additional
+    ``_to_copy``/``permute``/``transpose`` ops between mm and the collective
+    on this Llama3 8B FSDP=4 x TP=2 configuration.
+    """
+    from torch._inductor.fx_passes.overlap_scheduling import get_group_name
+    from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+
+    # Force registration of the fused_matmul_reduce_scatter op (and friends).
+    # Importing the symmetric_memory module registers the ops with the
+    # ``symm_mem`` namespace; otherwise ``torch.ops.symm_mem.fused_matmul_reduce_scatter``
+    # raises AttributeError.
+    import torch.distributed._symmetric_memory  # noqa: F401
+
+    symm_mem = torch.ops.symm_mem
+
+    traversable_targets = {
+        aten.view.default,
+        aten.reshape.default,
+        aten._to_copy.default,
+        aten.permute.default,
+        aten.transpose.int,
+        aten.t.default,
+        aten._unsafe_view.default,
+    }
+
+    def _trace_back_to_mm(node: torch.fx.Node) -> torch.fx.Node | None:
+        """Walk single-input ops backwards until we hit an mm, or fail."""
+        cur: torch.fx.Node | None = node
+        while cur is not None and cur.target in traversable_targets:
+            if not cur.args or not isinstance(cur.args[0], torch.fx.Node):
+                return None
+            cur = cur.args[0]
+        if cur is not None and cur.target is aten.mm.default:
+            return cur
+        return None
+
+    def _decode_split_cat(
+        cat_node: torch.fx.Node,
+    ) -> tuple[torch.fx.Node, int] | None:
+        """If ``cat_node`` is the result of cat(split(input, ..., dim=k)), return
+        (input, k). Otherwise return None.
+        """
+        if cat_node.target is not aten.cat.default:
+            return None
+        if not cat_node.args:
+            return None
+        cat_inputs = cat_node.args[0]
+        if not isinstance(cat_inputs, (list, tuple)) or not cat_inputs:
+            return None
+        # All items should be getitem(split_node, idx).
+        split_node = None
+        seen_indices: set[int] = set()
+        for item in cat_inputs:
+            if not isinstance(item, torch.fx.Node):
+                return None
+            if item.target is not __import__("operator").getitem:
+                return None
+            if not item.args or not isinstance(item.args[0], torch.fx.Node):
+                return None
+            sn = item.args[0]
+            if split_node is None:
+                split_node = sn
+            elif sn is not split_node:
+                return None
+            seen_indices.add(int(item.args[1]))
+        if split_node is None:
+            return None
+        if split_node.target not in (
+            aten.split.Tensor,
+            aten.split_with_sizes.default,
+        ):
+            return None
+        # Decode scatter_dim — for split.Tensor: args = (input, size, dim?).
+        # For split_with_sizes: args = (input, sizes, dim?).
+        if not split_node.args or not isinstance(split_node.args[0], torch.fx.Node):
+            return None
+        split_input = split_node.args[0]
+        if len(split_node.args) >= 3:
+            scatter_dim = int(split_node.args[2])
+        else:
+            scatter_dim = int(split_node.kwargs.get("dim", 0))
+        return split_input, scatter_dim
+
+    rs_target = c10d.reduce_scatter_tensor.default
+    # Each candidate: (rs_node, walkback_start, producer_mm, scatter_dim_in_mm_output).
+    candidates: list[tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node, int]] = []
+    total_rs = 0
+    for node in gm.graph.nodes:
+        if node.target is not rs_target:
+            continue
+        total_rs += 1
+        rs_input = node.args[0]
+        if not isinstance(rs_input, torch.fx.Node):
+            continue
+        # If the RS input is a cat that comes from a split (scatter_dim>0
+        # decomposition), peel the split->cat off and continue walking
+        # back from the split's input. Record the scatter_dim implied
+        # by the split.
+        walk_start: torch.fx.Node = rs_input
+        forced_scatter_dim: int | None = None
+        decoded = _decode_split_cat(rs_input)
+        if decoded is not None:
+            walk_start, forced_scatter_dim = decoded
+        producer_mm = _trace_back_to_mm(walk_start)
+        if producer_mm is None:
+            continue
+        # Conservative: only fuse if mm has a single user along this chain,
+        # since the fused op doesn't return the mm result.
+        if len(producer_mm.users) != 1:
+            continue
+        candidates.append(
+            (node, walk_start, producer_mm, forced_scatter_dim or 0)
+        )
+
+    if not candidates:
+        return gm
+
+    # Register symmetric memory for any group we are about to fuse on.
+    groups: set[str] = set()
+    for rs_node, _, _, _ in candidates:
+        groups.add(get_group_name(rs_node))
+    for pg in groups:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            enable_symm_mem_for_group(pg)
+
+    def _prod(xs) -> int:
+        out = 1
+        for x in xs:
+            out *= int(x)
+        return out
+
+    fused = 0
+    skipped_no_wait = 0
+    skipped_shape = 0
+    for rs_node, rs_input, producer_mm, forced_scatter_dim in candidates:
+        # rs_node signature: reduce_scatter_tensor(input, reduce_op, group_size, group_name)
+        if len(rs_node.args) < 4:
+            continue
+        _, reduce_op, _, group_name = rs_node.args[:4]
+        # Find the wait_tensor user of the RS.
+        wait_user = None
+        for user in rs_node.users:
+            if user.target is c10d.wait_tensor.default:
+                wait_user = user
+                break
+        if wait_user is None:
+            skipped_no_wait += 1
+            continue
+
+        # Infer scatter_dim in the mm-output space. The fused op operates
+        # on the mm output (2D: M x N). If the chain transposes the mm
+        # output, scatter_dim in mm-output space is flipped.
+        mm_val = producer_mm.meta.get("val")
+        rs_input_val = rs_input.meta.get("val")
+        if mm_val is None or rs_input_val is None:
+            skipped_shape += 1
+            continue
+        mm_shape = tuple(mm_val.shape)
+        rs_in_shape = tuple(rs_input_val.shape)
+        # We expect mm_shape to be 2D (M, N).
+        if len(mm_shape) != 2:
+            skipped_shape += 1
+            continue
+        # rs_input (the split-input or pre-RS tensor) may be reshaped or
+        # transposed from mm output. Determine scatter_dim in mm-output
+        # space.
+        if forced_scatter_dim:
+            # The RS used a split->cat decomposition along a specific dim
+            # in rs_input space. Map that dim back to mm-output space via
+            # shape comparison (only handle trivial reshape that preserves
+            # the scattered dim's identity).
+            if (
+                len(rs_in_shape) >= 1
+                and rs_in_shape[-1] == mm_shape[1]
+                and _prod(rs_in_shape[:-1]) == mm_shape[0]
+            ):
+                # Reshape leading dims -> M; last dim is N.
+                scatter_dim = (
+                    1 if forced_scatter_dim == len(rs_in_shape) - 1 else 0
+                )
+            elif rs_in_shape == mm_shape:
+                scatter_dim = forced_scatter_dim
+            else:
+                skipped_shape += 1
+                continue
+        else:
+            # No split->cat decomposition: rs_input either matches mm or
+            # is a pure reshape/transpose of it.
+            if rs_in_shape == mm_shape:
+                scatter_dim = 0
+            elif rs_in_shape == (mm_shape[1], mm_shape[0]):
+                scatter_dim = 1
+            elif (
+                len(rs_in_shape) >= 1
+                and rs_in_shape[-1] == mm_shape[1]
+                and _prod(rs_in_shape[:-1]) == mm_shape[0]
+            ):
+                # Reshape that preserves N on last dim, collapses leading to M.
+                scatter_dim = 0
+            else:
+                skipped_shape += 1
+                continue
+
+        # The fused op outputs in mm's A dtype and performs the reduce
+        # in that dtype. If the original chain upcast (e.g. bf16 -> fp32
+        # via _to_copy) before RS, the original RS reduced in the
+        # upcast dtype for numerical stability (this is the TP
+        # weight-grad pattern). Fusing would change the reduction
+        # precision, so we skip those chains.
+        mm_a_dtype = mm_val.dtype
+        wait_val = wait_user.meta.get("val")
+        downstream_dtype = wait_val.dtype if wait_val is not None else mm_a_dtype
+        if downstream_dtype != mm_a_dtype:
+            skipped_shape += 1
+            continue
+
+        with gm.graph.inserting_before(rs_node):
+            fused_out = gm.graph.call_function(
+                symm_mem.fused_matmul_reduce_scatter.default,
+                args=(
+                    producer_mm.args[0],
+                    producer_mm.args[1],
+                    reduce_op,
+                    scatter_dim,
+                    group_name,
+                ),
+            )
+            # Copy fake-tensor metadata from the wait so downstream
+            # passes/lint see the correct output shape on the new node.
+            fused_out.meta["val"] = wait_val
+
+        # Redirect users of the wait to the fused op output. The fused
+        # op already returns the reduce-scattered result (waits internally).
+        wait_user.replace_all_uses_with(fused_out)
+        gm.graph.erase_node(wait_user)
+
+        # If this was a split->cat path, erase the cat + getitems + split
+        # nodes between the original rs_input and the walk_start (split's
+        # input). After this block, the original RS input's args[0] is no
+        # longer reachable through this RS.
+        original_rs_input = rs_node.args[0]
+        gm.graph.erase_node(rs_node)
+        if forced_scatter_dim and original_rs_input is not rs_input:
+            # original_rs_input is the cat node; its args[0] is list of getitems;
+            # each getitem points at the split node; split node points at rs_input.
+            cat_node = original_rs_input
+            if isinstance(cat_node, torch.fx.Node) and len(cat_node.users) == 0:
+                getitem_list = cat_node.args[0] if cat_node.args else []
+                gm.graph.erase_node(cat_node)
+                # Find the split node from any getitem.
+                split_node = None
+                if isinstance(getitem_list, (list, tuple)) and getitem_list:
+                    first = getitem_list[0]
+                    if isinstance(first, torch.fx.Node) and first.args:
+                        candidate = first.args[0]
+                        if isinstance(candidate, torch.fx.Node):
+                            split_node = candidate
+                for gi in getitem_list:
+                    if isinstance(gi, torch.fx.Node) and len(gi.users) == 0:
+                        gm.graph.erase_node(gi)
+                if split_node is not None and len(split_node.users) == 0:
+                    gm.graph.erase_node(split_node)
+
+        # Walk back through the rs_input chain and erase nodes that no
+        # longer have users. Stop at the mm.
+        cur: torch.fx.Node | None = rs_input
+        while isinstance(cur, torch.fx.Node) and cur is not producer_mm:
+            nxt = cur.args[0] if cur.args else None
+            if len(cur.users) == 0:
+                gm.graph.erase_node(cur)
+            cur = nxt if isinstance(nxt, torch.fx.Node) else None
+        if len(producer_mm.users) == 0:
+            gm.graph.erase_node(producer_mm)
+        fused += 1
+
+    if fused > 0 or skipped_shape > 0 or skipped_no_wait > 0:
+        logger.info(
+            f"Custom-fused {fused} mm->RS pairs into fused_matmul_reduce_scatter "
+            f"(scanned={total_rs}, candidates={len(candidates)}, "
+            f"skipped: no_wait={skipped_no_wait}, shape_or_dtype={skipped_shape})"
+        )
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
 def async_tensor_parallel_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
@@ -231,11 +528,19 @@ def compile_time_passes(
         remove_identity_slice_pass,
         normalize_view_ops_as_reshape,
         remove_redundant_contiguous_clone_pass,
+        # Custom mm->RS fusion BEFORE bucketing so the matcher sees the
+        # original mm->{reshape|_to_copy|...}->RS chains intact.
+        fuse_mm_reduce_scatter_pass,
     ]
     # Preserve AG/RS overlap (separate streams for AG vs RS) before auto-bucketing.
     if config.compile.enable_fsdp_ag_rs_overlap:
         passes.append(overlap_fsdp_ag_rs_pass)
     passes.append(auto_overlap_bucketing_pass)
+    # Auto-bucketing's pre-bucketing rewrite may introduce new redundant
+    # clone(contiguous_format) calls along the unpack chain
+    # (_pre_bucket_all_gather -> wait_tensor -> ... -> unpack -> mm).
+    # Run cleanup a second time to catch any that appear post-bucketing.
+    passes.append(remove_redundant_contiguous_clone_pass)
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -490,6 +490,77 @@ def fuse_mm_reduce_scatter_pass(
     return gm
 
 
+def annotate_swiglu_chains_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+) -> torch.fx.GraphModule:
+    """Tag bf16 pointwise chains around silu/silu_backward for Inductor fusion.
+
+    Seed with ``aten.silu``/``aten.silu_backward``, then iteratively expand to
+    adjacent ``aten.mul.Tensor`` neighbors whose tensor inputs are all bf16.
+    The connected component becomes a single Inductor region. Bitwise-safe
+    because pure bf16 pointwise mul is elementwise — same FP order as the
+    separate eager kernels.
+
+    The backward SwiGLU template is a chain ``silu_backward -> mul -> mul``
+    (and analogous forward ``silu -> mul``); 32 Llama3 layers gives ~3-4 ops
+    per layer that benefit from a single fused Triton kernel.
+    """
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    seed_targets = {aten.silu.default, aten.silu_backward.default}
+    expand_targets = {aten.mul.Tensor}
+
+    def _is_bf16_node(n: torch.fx.Node) -> bool:
+        v = n.meta.get("val")
+        if not isinstance(v, FakeTensor):
+            return False
+        return v.dtype == torch.bfloat16
+
+    def _all_bf16_inputs(n: torch.fx.Node) -> bool:
+        for a in n.args:
+            if isinstance(a, torch.fx.Node):
+                v = a.meta.get("val")
+                if isinstance(v, FakeTensor) and v.dtype != torch.bfloat16:
+                    return False
+        return True
+
+    tagged: set[torch.fx.Node] = set()
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if node.target in seed_targets and _is_bf16_node(node):
+            tagged.add(node)
+
+    # Iteratively expand to bf16 muls adjacent to tagged ops until fixed point.
+    changed = True
+    while changed:
+        changed = False
+        for node in gm.graph.nodes:
+            if node in tagged:
+                continue
+            if node.op != "call_function":
+                continue
+            if node.target not in expand_targets:
+                continue
+            if not _is_bf16_node(node) or not _all_bf16_inputs(node):
+                continue
+            neighbors_tagged = any(
+                isinstance(a, torch.fx.Node) and a in tagged for a in node.args
+            ) or any(u in tagged for u in node.users)
+            if neighbors_tagged:
+                tagged.add(node)
+                changed = True
+
+    for node in tagged:
+        node.meta.setdefault("custom", {})["compile_with_inductor"] = {}
+    if tagged:
+        logger.info(
+            f"Tagged {len(tagged)} SwiGLU-chain pointwise nodes for regional Inductor compilation"
+        )
+    return gm
+
+
 def annotate_residual_add_for_regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs=None,
@@ -635,6 +706,10 @@ def compile_time_passes(
                 flex_compile_config=FlexAttention.inductor_configs,
             )
         )
+        # Tag bf16 SwiGLU chains (silu/silu_backward + adjacent bf16 muls)
+        # before residual-add tagging so adds that are NOT part of the
+        # SwiGLU chain still get picked up by the residual-add pass.
+        passes.append(annotate_swiglu_chains_for_regional_inductor_pass)
         # Tag bf16 residual adds for regional Inductor (numerics-preserving:
         # pure pointwise bf16 fusion). Must run after the flex annotation
         # pass and before ``regional_inductor_pass`` so the tagger sees

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -143,12 +143,23 @@ def compile_time_passes(
     all-gathers end up on a separate CUDA stream from reduce-scatters
     (enabling AG/RS overlap in backward).
     """
-    from torchtitan.experiments.graph_trainer.common_utils import (
-        get_default_transformer_block_buckets,
-    )
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
+    # Group transformer layers into 2-layer buckets to deepen FSDP AG prefetch.
+    # Default is one layer per bucket (34 buckets). With 2-layer buckets we get
+    # 16 layer-buckets + tok_embeddings + [norm, lm_head] = 18 buckets.
+    layer_buckets_2 = [
+        [f"layers.{i}", f"layers.{i+1}"]
+        for i in range(0, n_layers - (n_layers % 2), 2)
+    ]
+    if n_layers % 2:
+        layer_buckets_2.append([f"layers.{n_layers - 1}"])
+    two_layer_bucket_plan = [
+        "tok_embeddings",
+        *layer_buckets_2,
+        ["norm", "lm_head"],
+    ]
     passes: list[Callable] = [
         remove_detach_pass,
         remove_identity_view_pass,
@@ -156,7 +167,7 @@ def compile_time_passes(
         normalize_view_ops_as_reshape,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
-            module_bucket_plans=get_default_transformer_block_buckets(n_layers),
+            module_bucket_plans=two_layer_bucket_plan,
             enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
         ),
     ]

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -155,16 +155,6 @@ def compile_time_passes(
         remove_identity_slice_pass,
         normalize_view_ops_as_reshape,
         functools.partial(
-            tag_with_memory_policy_pass,
-            config=config,
-        ),
-        functools.partial(
-            apply_cpu_offload_pass,
-            prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
-            defer_n_layers=config.compile.cpu_offload_defer_n_layers,
-        ),
-        selective_activation_remat_pass,
-        functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
             enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -391,6 +391,25 @@ def fuse_mm_reduce_scatter_pass(
             skipped_shape += 1
             continue
 
+        # Compute the actual 2D shape of the fused op's runtime output.
+        # The op returns ``A @ B`` reduce-scattered along ``scatter_dim``
+        # in the (2D) mm-output space; runtime shape is
+        # ``out_shape = [*A.shape[:-1], B.shape[1]]`` with
+        # ``out_shape[scatter_dim] //= group.size()`` (see
+        # ``_fused_matmul_reduce_scatter_impl`` in torch.distributed._symmetric_memory).
+        # We stamp this 2D shape on the fused-op node and insert an
+        # explicit reshape back to the original (3D) wait_tensor shape
+        # so downstream consumers (and any regional-Inductor scoop) see
+        # the correct shape on every node.
+        group_size = int(rs_node.args[2])
+        if scatter_dim == 0:
+            fused_2d_shape = (mm_shape[0] // group_size, mm_shape[1])
+        else:
+            fused_2d_shape = (mm_shape[0], mm_shape[1] // group_size)
+        # Create a FakeTensor for the fused op output by viewing wait_val
+        # (same element count and dtype/device) into the actual 2D shape.
+        fused_val = wait_val.view(*fused_2d_shape)
+
         with gm.graph.inserting_before(rs_node):
             fused_out = gm.graph.call_function(
                 symm_mem.fused_matmul_reduce_scatter.default,
@@ -402,13 +421,23 @@ def fuse_mm_reduce_scatter_pass(
                     group_name,
                 ),
             )
-            # Copy fake-tensor metadata from the wait so downstream
-            # passes/lint see the correct output shape on the new node.
-            fused_out.meta["val"] = wait_val
+            # Fused-op node sees the *actual* 2D runtime shape.
+            fused_out.meta["val"] = fused_val
+            # Reshape back to the original (possibly 3D) wait_tensor
+            # shape so downstream users see the same shape as before
+            # fusion. Without this, downstream regional-Inductor scoops
+            # that codegen ``assert_size_stride`` from meta crash with
+            # a shape mismatch (e.g. ``wrong number of dimensions``).
+            reshape_out = gm.graph.call_function(
+                aten.reshape.default,
+                args=(fused_out, list(wait_val.shape)),
+            )
+            reshape_out.meta["val"] = wait_val
 
-        # Redirect users of the wait to the fused op output. The fused
-        # op already returns the reduce-scattered result (waits internally).
-        wait_user.replace_all_uses_with(fused_out)
+        # Redirect users of the wait to the reshape (3D) view. The
+        # fused op already returns the reduce-scattered result (waits
+        # internally); the reshape just restores the original rank.
+        wait_user.replace_all_uses_with(reshape_out)
         gm.graph.erase_node(wait_user)
 
         # If this was a split->cat path, erase the cat + getitems + split
@@ -458,6 +487,50 @@ def fuse_mm_reduce_scatter_pass(
         )
     gm.graph.lint()
     gm.recompile()
+    return gm
+
+
+def annotate_residual_add_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+) -> torch.fx.GraphModule:
+    """Tag bf16 ``aten.add.Tensor`` (residual adds) for regional_inductor.
+
+    The Llama3 graph has many residual-add ops (post-attention and post-MLP)
+    on bf16 activations.  These are pure pointwise bf16 kernels; tagging them
+    for regional Inductor compilation lets Inductor fuse them into adjacent
+    elementwise ops, recovering a few ms of kernel time at no numerical cost
+    (bf16 add is commutative and associative-equivalent for the small chains
+    that result).
+
+    Only tags ``aten.add.Tensor`` nodes where both inputs are bf16 FakeTensors
+    so we never touch fp32 master-grad accumulation or scalar adds.
+    """
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    num_tagged = 0
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if node.target is not aten.add.Tensor:
+            continue
+        if len(node.args) < 2:
+            continue
+        a, b = node.args[0], node.args[1]
+        if not (isinstance(a, torch.fx.Node) and isinstance(b, torch.fx.Node)):
+            continue
+        a_val = a.meta.get("val")
+        b_val = b.meta.get("val")
+        if not (isinstance(a_val, FakeTensor) and isinstance(b_val, FakeTensor)):
+            continue
+        if a_val.dtype != torch.bfloat16 or b_val.dtype != torch.bfloat16:
+            continue
+        node.meta.setdefault("custom", {})["compile_with_inductor"] = {}
+        num_tagged += 1
+    if num_tagged > 0:
+        logger.info(
+            f"Tagged {num_tagged} bf16 add.Tensor nodes for regional Inductor compilation"
+        )
     return gm
 
 
@@ -562,6 +635,11 @@ def compile_time_passes(
                 flex_compile_config=FlexAttention.inductor_configs,
             )
         )
+        # Tag bf16 residual adds for regional Inductor (numerics-preserving:
+        # pure pointwise bf16 fusion). Must run after the flex annotation
+        # pass and before ``regional_inductor_pass`` so the tagger sees
+        # the final graph but the compiler picks up the new tags.
+        passes.append(annotate_residual_add_for_regional_inductor_pass)
         # Performance passes that may change numerics.
         if config.compile.numerics_changing_optim:
             from torchtitan.experiments.graph_trainer.performance_passes import (


### PR DESCRIPTION
## Summary

**Run 3 of 3** in the autoresearch comparative study: LLM-driven autonomous kernel fusion on Llama3 8B training graph.

- **Condition**: Curated IDEAS + reference implementations allowed + production pass set as starting graph (7,162 tps baseline).
- **Result**: 7,535 tps avg (**+5.21% over production baseline**), 6 keeps across ~20 experiments. mfu 44.07%.
- **Key keeps**:
  - 2-layer FSDP bucket plan (+0.94%)
  - Auto overlap bucketing via `schedule_overlap_bucketing` (+0.90%)
  - Remove redundant contiguous clones (+0.34%)
  - Custom mm→reduce_scatter fusion via `symm_mem` (+1.17%) — largest single win
  - Shape fix + residual-add Inductor (+0.26%)
  - Extended SwiGLU chain regional Inductor (+1.36%)
- **Numerics**: All kept passes are bitwise-safe vs eager.
- **Hard floors identified**: RoPE complex→real rewrite (FMA rounding), RMSNorm Inductor (reduction mismatch) — both require relaxing bitwise constraint.

See `autoresearch/EXPERIMENT_PLAN.md` for the full 3-run study design.

## Context

This is part of a 3-run progressive-layering study:
| Run | Branch | Condition | Best TPS |
|-----|--------|-----------|----------|
| 1 | `ar_base` | No ideas, no refs, no prod passes | 6,492 |
| 2 | `ar_ideas` | + curated IDEAS | 7,378 |
| 3 | `ar_hand_opt` | + refs + production starting graph | 7,535 |

Run 3 demonstrates that autoresearch can still find meaningful wins (+5.21%) on top of an already-optimized production graph, including a custom mm→RS fusion that upstream's matcher couldn't handle.

## Test plan
- [x] Bitwise numerics verified for all kept passes
- [x] 3-run final verification: 7,524 / 7,529 / 7,523 tps (avg 7,525 at SwiGLU keep), then 7,535 avg at final state
- [x] Full experiment log in EXPERIMENT_LOG.md