### PR TITLE
Add shape suffix annotations to attention module

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,6 +93,17 @@ this for the comments and docstrings you are adding or rewriting.
   ``DataParallelMeshDims``, etc.): match the upstream spelling at the call
   site, then assign into a locally named ``mesh_axis_names`` if the value
   flows through our code.
+- **Shape-suffix tensor names.** In model code, name tensors with shape
+  suffixes (Noam Shazeer convention:
+  https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd),
+  e.g. `x_BLD`, `q_BLNH`, `out_TNH`. Capital-letter suffixes denote *logical*
+  tensor dimensions, not a physical sharding layout -- a name like
+  `routed_input_RD` keeps the same suffix whether or not `R` is a local shard
+  under EP/SP. Letters are scoped per module, not global: give each module that
+  uses them a legend in a top-of-file comment, and don't assume a letter means
+  the same thing across files (e.g. `N` is num heads in `attention.py` but
+  routed tokens in `moe.py`). Apply this to newly written or rewritten model
+  tensor code; don't churn unrelated code just to add suffixes.
 
 ### Code Placement
 - Put code in the **most general applicable location**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ When appropriate, one should consider
   - To add a unit test, put it in the [tests](tests/) folder and follow the existing test files.
   - To add a GPU integration test, create a new `OverrideDefinitions` in [integration_tests](tests/integration_tests/). It will override the default config to run on the Llama 3 debug model (see [config_registry.py](torchtitan/models/llama3/config_registry.py)).
 - Updating [README](README.md) and writing a new note in the [docs](docs/) folder on installation and usage, similar to [float8.md](torchtitan/components/quantization/float8.md).
+- Following the tensor shape-suffix naming convention for new model code (e.g. `x_BLD`, `q_BLNH`, `out_TNH`), with a per-module legend comment as in [attention.py](torchtitan/models/common/attention.py). Capital suffixes name logical tensor dimensions (not sharding layout) and are scoped per file.
 - Adding a new file with benchmark results in [benchmarks](benchmarks) folder.
 - Creating GitHub issues for things that cannot be addressed at the moment.
 - Writing a post on [PyTorch Forums](https://discuss.pytorch.org/c/distributed/torchtitan/44) and linking to it.

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -4,6 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Shape suffix legend
+# (https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd):
+#   B = batch, L = sequence length, D = model dimension,
+#   N = num heads (N is used for both query and kv heads in GQA;
+#       the variable name xq/xk/xv disambiguates),
+#   H = head dimension (per-head dim),
+#   T = packed tokens (B*L, used by VarlenAttention)
+
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import ClassVar, NamedTuple
@@ -98,9 +106,9 @@ class VarlenAttention(Module):
 
     def forward(
         self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        q_BLNH: torch.Tensor,
+        k_BLNH: torch.Tensor,
+        v_BLNH: torch.Tensor,
         *,
         attention_masks: VarlenMetadata,
         scale: float | None = None,
@@ -115,19 +123,20 @@ class VarlenAttention(Module):
         max_q = attention_masks.max_q
         max_k = attention_masks.max_k
 
-        batch_size, seq_len, _, head_dim = q.shape
+        B, L, _, H = q_BLNH.shape
+        T = B * L
 
-        # varlen attention expects (bs*seqlen, n_heads, head_dim)
-        xq_packed = q.reshape(batch_size * seq_len, -1, head_dim)
-        xk_packed = k.reshape(batch_size * seq_len, -1, head_dim)
-        xv_packed = v.reshape(batch_size * seq_len, -1, head_dim)
+        # varlen attention expects (T, N, H)
+        q_TNH = q_BLNH.reshape(T, -1, H)
+        k_TNH = k_BLNH.reshape(T, -1, H)
+        v_TNH = v_BLNH.reshape(T, -1, H)
 
         # Some operators can upcast under AMP, but varlen attention currently only
         # supports bf16/fp16 inputs. If this changes, or fp16 training support
         # is added, this may need to be revisited.
-        xq_packed = xq_packed.to(torch.bfloat16)
-        xk_packed = xk_packed.to(torch.bfloat16)
-        xv_packed = xv_packed.to(torch.bfloat16)
+        q_TNH = q_TNH.to(torch.bfloat16)
+        k_TNH = k_TNH.to(torch.bfloat16)
+        v_TNH = v_TNH.to(torch.bfloat16)
 
         varlen_kwargs = dict()
 
@@ -145,10 +154,10 @@ class VarlenAttention(Module):
         if kwargs.get("enable_gqa", False):
             varlen_kwargs["enable_gqa"] = True
 
-        out_packed = varlen_attn(
-            xq_packed,
-            xk_packed,
-            xv_packed,
+        out_TNH = varlen_attn(
+            q_TNH,
+            k_TNH,
+            v_TNH,
             cu_seq_q,
             cu_seq_k,
             max_q,
@@ -157,18 +166,18 @@ class VarlenAttention(Module):
             window_size=self.window_size,
             **varlen_kwargs,  # pyrefly: ignore [bad-argument-type]
         )
-        assert isinstance(out_packed, torch.Tensor)
+        assert isinstance(out_TNH, torch.Tensor)
         # Reshape back to the format expected by GQAttention.forward()
-        out = out_packed.view(batch_size, seq_len, -1, head_dim)
+        out_BLNH = out_TNH.view(B, L, -1, H)
 
-        return out.to(q.dtype)
+        return out_BLNH.to(q_BLNH.dtype)
 
 
 class FlexAttention(Module):
     """Inner attention using ``flex_attention`` with torch.compile and CP support.
 
     Each backend handles its own layout transpose: ``forward()`` transposes from
-    ``(bs, seq, heads, dim)`` to ``(bs, heads, seq, dim)`` before calling
+    ``(B, L, N, H)`` to ``(B, N, L, H)`` before calling
     ``flex_attention``, and transposes back before returning.
 
     Note:
@@ -209,9 +218,9 @@ class FlexAttention(Module):
 
     def forward(
         self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        q_BLNH: torch.Tensor,
+        k_BLNH: torch.Tensor,
+        v_BLNH: torch.Tensor,
         *,
         attention_masks: BlockMask,
         score_mod: _score_mod_signature | None = None,
@@ -224,8 +233,10 @@ class FlexAttention(Module):
             attention_masks, BlockMask
         ), f"attention_masks must be instance of BlockMask, got {type(attention_masks)}"
 
-        # Transpose to (bs, heads, seq, dim) for flex_attention
-        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+        # Transpose to (B, N, L, H) for flex_attention
+        q_BNLH = q_BLNH.transpose(1, 2)
+        k_BNLH = k_BLNH.transpose(1, 2)
+        v_BNLH = v_BLNH.transpose(1, 2)
 
         # 1. _compiled_flex_attn has to be a class variable, otherwise there will
         #    be multiple compiled flex_attention instances, which can be slow.
@@ -237,27 +248,27 @@ class FlexAttention(Module):
         # an inductor sub-compile (see distributed/compile.py). A null context on
         # the default inductor / eager paths, so no dead metadata is emitted.
         with maybe_regional_inductor(FlexAttention.inductor_configs):
-            out, aux = FlexAttention._compiled_flex_attn(
-                q,
-                k,
-                v,
+            out_BNLH, aux = FlexAttention._compiled_flex_attn(
+                q_BNLH,
+                k_BNLH,
+                v_BNLH,
                 block_mask=attention_masks,
                 scale=scale,
                 enable_gqa=enable_gqa,
                 return_aux=AuxRequest(lse=return_lse),
                 kernel_options=self.kernel_options,
             )
-        # Transpose back to (bs, seq, heads, dim)
+        # Transpose back to (B, L, N, H)
         if return_lse:
-            return out.transpose(1, 2), aux.lse.transpose(1, 2)
-        return out.transpose(1, 2)
+            return out_BNLH.transpose(1, 2), aux.lse.transpose(1, 2)
+        return out_BNLH.transpose(1, 2)
 
 
 class ScaledDotProductAttention(Module):
     """Inner attention using ``F.scaled_dot_product_attention`` with CP support.
 
     Each backend handles its own layout transpose: ``forward()`` transposes from
-    ``(bs, seq, heads, dim)`` to ``(bs, heads, seq, dim)`` before calling
+    ``(B, L, N, H)`` to ``(B, N, L, H)`` before calling
     ``scaled_dot_product_attention``, and transposes back before returning.
 
     Note:
@@ -284,9 +295,9 @@ class ScaledDotProductAttention(Module):
 
     def forward(
         self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        q_BLNH: torch.Tensor,
+        k_BLNH: torch.Tensor,
+        v_BLNH: torch.Tensor,
         *,
         attention_masks: AttentionMasksType | None = None,
         scale: float | None = None,
@@ -299,14 +310,23 @@ class ScaledDotProductAttention(Module):
                 "ScaledDotProductAttention does not support attention_masks; it "
                 "only supports causal/non-causal attention via is_causal."
             )
-        # Transpose to (bs, heads, seq, dim) for SDPA
-        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+        # Transpose to (B, N, L, H) for SDPA
+        q_BNLH, k_BNLH, v_BNLH = (
+            q_BLNH.transpose(1, 2),
+            k_BLNH.transpose(1, 2),
+            v_BLNH.transpose(1, 2),
+        )
         with sdpa_kernel(self.sdpa_backends, set_priority=True):
-            out = F.scaled_dot_product_attention(
-                q, k, v, scale=scale, is_causal=is_causal, enable_gqa=enable_gqa
+            out_BNLH = F.scaled_dot_product_attention(
+                q_BNLH,
+                k_BNLH,
+                v_BNLH,
+                scale=scale,
+                is_causal=is_causal,
+                enable_gqa=enable_gqa,
             )
-        # Transpose back to (bs, seq, heads, dim)
-        return out.transpose(1, 2)
+        # Transpose back to (B, L, N, H)
+        return out_BNLH.transpose(1, 2)
 
 
 def get_causal_mask_mod() -> _mask_mod_signature:
@@ -701,29 +721,30 @@ class GQAttention(BaseAttention):
 
     def forward(
         self,
-        x: torch.Tensor,
+        x_BLD: torch.Tensor,
         attention_masks: AttentionMasksType | None,
         positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        bs, seqlen, _ = x.shape
-        xq, xk, xv = self.qkv_linear(x)
+        B, L, _ = x_BLD.shape
+        xq_BLNH, xk_BLNH, xv_BLNH = self.qkv_linear(x_BLD)
 
         # Optional QK normalization (before RoPE, per Qwen3)
         if self.q_norm is not None or self.k_norm is not None:
             assert self.q_norm is not None and self.k_norm is not None
-            xq = self.q_norm(xq)
-            xk = self.k_norm(xk)
+            xq_BLNH = self.q_norm(xq_BLNH)
+            xk_BLNH = self.k_norm(xk_BLNH)
 
         # Apply rotary embeddings
-        xq, xk = self.rope(xq, xk, positions)
+        xq_BLNH, xk_BLNH = self.rope(xq_BLNH, xk_BLNH, positions)
 
-        output = self.inner_attention(
-            xq,
-            xk,
-            xv,
+        # inner_attention returns (B, L, N, H)
+        out_BLNH = self.inner_attention(
+            xq_BLNH,
+            xk_BLNH,
+            xv_BLNH,
             attention_masks=attention_masks,
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
         ).contiguous()
-        output = output.view(bs, seqlen, -1)
-        return self.wo(output)
+        out_BLD = out_BLNH.view(B, L, -1)
+        return self.wo(out_BLD)

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -198,14 +198,14 @@ def set_gqa_inner_attention_local_map(
     )
     inner_attention_cfg.sharding_config = ShardingConfig(
         in_src_shardings={
-            "q": q_placements,
-            "k": kv_src_placements,
-            "v": kv_src_placements,
+            "q_BLNH": q_placements,
+            "k_BLNH": kv_src_placements,
+            "v_BLNH": kv_src_placements,
         },
         in_dst_shardings={
-            "q": q_placements,
-            "k": kv_dst_placements,
-            "v": kv_dst_placements,
+            "q_BLNH": q_placements,
+            "k_BLNH": kv_dst_placements,
+            "v_BLNH": kv_dst_placements,
         },
         out_src_shardings=out_src,
         local_map=LocalMapConfig(


### PR DESCRIPTION
## Summary
Add shape suffix annotations to `attention.py` following the [Noam Shazeer shape suffix convention](https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd), matching the style introduced for MoE in #3425.

Each attention backend's layout transformation is now explicit in variable names:
- `_BLNH`: shared input/output layout (batch, seq, heads, head_dim)
- `_TNH`: VarlenAttention packed layout (T = B*L)
- `_BNLH`: FlexAttention / SDPA heads-first layout

No functional changes — rename only.

## Test plan
- `pre-commit run --all-files`
- Existing attention unit and integration tests (no behavioral change)
```
NCCL_NVLS_ENABLE=0 python scripts/loss_compare.py . main --baseline-module='llama3' 
--baseline-config='llama3_debugmodel' --baseline-options="
--parallelism.data_parallel_shard_degree 2 --parallelism.t
ensor_parallel_degree 2" --baseline-ngpus=4 --test-module=
'llama3' --test-config='llama3_debugmodel' --test-options=
"--parallelism.data_parallel_shard_degree 2 --parallelism.
tensor_parallel_degree 2" --test-ngpus=4 --assert-equal --
no-seed-checkpoint
```