### PR TITLE
ci: skip fsdp_symm_mem on ROCm leg of 8 GPU H100 integration tests

### DIFF
--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -87,5 +87,5 @@ jobs:
         # Disable Nvlink Sharp. The CI machine seems to be unstable state to support
         # NLVS according to several CI runs.
         # DeepEP needs CUDA_HOME specified to JIT kernels.
-        CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --test_suite h100 $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
+        CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --gpu_arch_type ${{ matrix.gpu-arch-type }} --test_suite h100 $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -49,6 +49,9 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "FSDP symmetric memory",
             "fsdp_symm_mem",
             ngpu=2,
+            # NOTE: --parallelism.enable-fsdp-symm-mem hard-errors at config
+            # parse time on non-NVIDIA-Hopper GPUs, so skip on ROCm runners.
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
## Summary

The `fsdp_symm_mem` test added to `tests/integration_tests/h100.py` in #58b03444 fails on every commit to `main` on the ROCm `gfx950` leg of the `8 GPU Integration Test on H100` workflow. The underlying flag `--parallelism.enable-fsdp-symm-mem` hard-errors at config-parse time on non-NVIDIA-Hopper hardware:

```
Error parsing parallelism: parallelism.enable_fsdp_symm_mem is only
supported on NVIDIA GPUs with compute capability 9.0 or newer.
```

→ `torchtitan.train` exits nonzero → workflow fails. Persistent on `main` since `58b03444` (verified across 4 consecutive main runs).

Failing run for reference: https://github.com/pytorch/torchtitan/actions/runs/26560730775

## Fix

Uses the existing `skip_rocm_test` mechanism already in active use by `tests/integration_tests/features.py` (3 tests, e.g. `fsdp+varlen_attn+per_op_sac`). Two coordinated changes:

1. **`tests/integration_tests/h100.py`** — add `skip_rocm_test=True` to the `fsdp_symm_mem` `OverrideDefinitions` entry.
2. **`.github/workflows/integration_test_8gpu_h100.yaml`** — pass `--gpu_arch_type ${{ matrix.gpu-arch-type }}` to `run_tests.py` so the skip marker is honored on the ROCm leg.

Change 2 is required for change 1 to take effect: `run_tests.py` defaults `--gpu_arch_type` to `cuda` when unset, so without it the `skip_rocm_test` flag is silently ignored. This brings `h100.yaml` in line with `integration_test_8gpu_features.yaml:139` and `integration_test_8gpu_models.yaml:82`, which already pass the flag.

## Scope

- `float8` and `hsdp+cp+compile+float8` in `h100.py` continue to run unchanged on both CUDA and ROCm.
- CUDA H100 leg is completely unaffected — `fsdp_symm_mem` still runs there.
- Only the ROCm leg of `8 GPU Integration Test on H100` changes behavior: the broken test is skipped.

## Test plan

- Pre-commit clean (flake8, ufmt, codespell, pydoclint all pass; pyrefly not installed locally).
- Verify in CI that the ROCm leg of `8 GPU Integration Test on H100` now passes on this PR.
- Verify CUDA H100 leg still runs `fsdp_symm_mem`.