### PR TITLE
[Module][Flux] Convert Flux modules to fully config-based

### DIFF
--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -16,7 +16,7 @@ from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader
-from .model.autoencoder import AutoEncoderParams
+from .model.autoencoder import AutoEncoder
 from .model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -247,7 +247,7 @@ def _flux_dev() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,
@@ -359,7 +359,7 @@ def _flux_schnell() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,
@@ -471,7 +471,7 @@ def _flux_debug() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -17,6 +17,7 @@ from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader
 from .model.autoencoder import AutoEncoder
+from .model.hf_embedder import FluxEmbedder
 from .model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -42,6 +43,9 @@ _ZERO_LINEAR = {"weight": nn.init.zeros_, "bias": nn.init.zeros_}
 _XAVIER_LINEAR = {"weight": nn.init.xavier_uniform_, "bias": nn.init.zeros_}
 _NORMAL_02 = {"weight": partial(nn.init.normal_, std=0.02), "bias": nn.init.zeros_}
 _NORM_INIT = {"weight": nn.init.ones_}
+
+_T5_ENCODER_VERSION = "google/t5-v1_1-xxl"
+_CLIP_ENCODER_VERSION = "openai/clip-vit-large-patch14"
 
 
 def _make_double_block_config(
@@ -258,6 +262,8 @@ def _flux_dev() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,
@@ -370,6 +376,8 @@ def _flux_schnell() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,
@@ -482,6 +490,8 @@ def _flux_debug() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -36,8 +36,6 @@ def flux_debugmodel() -> FluxTrainer.Config:
             max_t5_encoding_len=256,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
@@ -97,8 +95,6 @@ def flux_dev() -> FluxTrainer.Config:
             max_t5_encoding_len=512,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
@@ -149,8 +145,6 @@ def flux_schnell() -> FluxTrainer.Config:
             max_t5_encoding_len=256,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=100),

--- a/torchtitan/models/flux/configs.py
+++ b/torchtitan/models/flux/configs.py
@@ -11,10 +11,10 @@ from dataclasses import dataclass, field
 class FluxEncoderConfig:
     """Configuration for Flux encoders (T5 text encoder, CLIP text encoder, and autoencoder)."""
 
-    t5_encoder: str = "google/t5-v1_1-small"
-    """HuggingFace model name or local path for the T5 text encoder."""
-    clip_encoder: str = "openai/clip-vit-large-patch14"
-    """HuggingFace model name or local path for the CLIP text encoder."""
+    t5_encoder: str = ""
+    """Override for the T5 text encoder version/path. Empty uses the model registry default."""
+    clip_encoder: str = ""
+    """Override for the CLIP text encoder version/path. Empty uses the model registry default."""
     autoencoder_path: str = (
         "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"
     )

--- a/torchtitan/models/flux/model/autoencoder.py
+++ b/torchtitan/models/flux/model/autoencoder.py
@@ -16,37 +16,28 @@ from torchtitan.models.common.nn_modules import Conv2d, GroupNorm
 from torchtitan.protocols.module import Module, ModuleList
 
 
-@dataclass
-class AutoEncoderParams:
-    resolution: int = 256
-    in_channels: int = 3
-    ch: int = 128
-    out_ch: int = 3
-    ch_mult: tuple[int, ...] = (1, 2, 4, 4)
-    num_res_blocks: int = 2
-    z_channels: int = 16
-    scale_factor: float = 0.3611
-    shift_factor: float = 0.1159
-
-
 def swish(x: Tensor) -> Tensor:
     return x * torch.sigmoid(x)
 
 
-class AttnBlock(Module):
-    def __init__(self, in_channels: int):
-        super().__init__()
-        self.in_channels = in_channels
+def _norm(num_channels: int) -> GroupNorm.Config:
+    return GroupNorm.Config(num_groups=32, num_channels=num_channels, eps=1e-6)
 
-        self.norm = GroupNorm.Config(
-            num_groups=32,
-            num_channels=in_channels,
-            eps=1e-6,
-        ).build()
+
+class AttnBlock(Module):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.in_channels = config.in_channels
+
+        self.norm = _norm(config.in_channels).build()
 
         conv1x1 = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=1,
         )
         self.q = conv1x1.build()
@@ -73,38 +64,34 @@ class AttnBlock(Module):
 
 
 class ResnetBlock(Module):
-    def __init__(self, in_channels: int, out_channels: int):
-        super().__init__()
-        self.in_channels = in_channels
-        out_channels = in_channels if out_channels is None else out_channels
-        self.out_channels = out_channels
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+        out_channels: int
 
-        self.norm1 = GroupNorm.Config(
-            num_groups=32,
-            num_channels=in_channels,
-            eps=1e-6,
-        ).build()
+    def __init__(self, config: Config):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.out_channels = config.out_channels
+
+        self.norm1 = _norm(config.in_channels).build()
         self.conv1 = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=out_channels,
+            in_channels=config.in_channels,
+            out_channels=config.out_channels,
             kernel_size=3,
             padding=1,
         ).build()
-        self.norm2 = GroupNorm.Config(
-            num_groups=32,
-            num_channels=out_channels,
-            eps=1e-6,
-        ).build()
+        self.norm2 = _norm(config.out_channels).build()
         self.conv2 = Conv2d.Config(
-            in_channels=out_channels,
-            out_channels=out_channels,
+            in_channels=config.out_channels,
+            out_channels=config.out_channels,
             kernel_size=3,
             padding=1,
         ).build()
         if self.in_channels != self.out_channels:
             self.nin_shortcut = Conv2d.Config(
-                in_channels=in_channels,
-                out_channels=out_channels,
+                in_channels=config.in_channels,
+                out_channels=config.out_channels,
                 kernel_size=1,
             ).build()
 
@@ -125,12 +112,16 @@ class ResnetBlock(Module):
 
 
 class Downsample(Module):
-    def __init__(self, in_channels: int):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
         # no asymmetric padding in torch conv, must do it ourselves
         self.conv = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=3,
             stride=2,
         ).build()
@@ -143,11 +134,15 @@ class Downsample(Module):
 
 
 class Upsample(Module):
-    def __init__(self, in_channels: int):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
         self.conv = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=3,
             padding=1,
         ).build()
@@ -159,65 +154,69 @@ class Upsample(Module):
 
 
 class Encoder(Module):
-    def __init__(
-        self,
-        resolution: int,
-        in_channels: int,
-        ch: int,
-        ch_mult: list[int],
-        num_res_blocks: int,
-        z_channels: int,
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        resolution: int
+        in_channels: int
+        ch: int
+        ch_mult: tuple[int, ...]
+        num_res_blocks: int
+        z_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.ch = ch
-        self.num_resolutions = len(ch_mult)
-        self.num_res_blocks = num_res_blocks
-        self.resolution = resolution
-        self.in_channels = in_channels
+        self.ch = config.ch
+        self.num_resolutions = len(config.ch_mult)
+        self.num_res_blocks = config.num_res_blocks
+        self.resolution = config.resolution
+        self.in_channels = config.in_channels
         # downsampling
         self.conv_in = Conv2d.Config(
-            in_channels=in_channels,
+            in_channels=config.in_channels,
             out_channels=self.ch,
             kernel_size=3,
             padding=1,
         ).build()
 
-        curr_res = resolution
-        in_ch_mult = (1,) + tuple(ch_mult)
-        self.in_ch_mult = in_ch_mult
+        curr_res = config.resolution
+        in_ch_mult = (1,) + tuple(config.ch_mult)
         self.down = ModuleList()
         block_in = self.ch
         for i_level in range(self.num_resolutions):
             block = ModuleList()
             attn = ModuleList()
-            block_in = ch * in_ch_mult[i_level]
-            block_out = ch * ch_mult[i_level]
+            block_in = config.ch * in_ch_mult[i_level]
+            block_out = config.ch * config.ch_mult[i_level]
             for _ in range(self.num_res_blocks):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block.append(
+                    ResnetBlock.Config(
+                        in_channels=block_in, out_channels=block_out
+                    ).build()
+                )
                 block_in = block_out
             down = Module()
             down.block = block
             down.attn = attn
             if i_level != self.num_resolutions - 1:
-                down.downsample = Downsample(block_in)
+                down.downsample = Downsample.Config(in_channels=block_in).build()
                 curr_res = curr_res // 2
             self.down.append(down)
 
         # middle
         self.mid = Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
-        self.mid.attn_1 = AttnBlock(block_in)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.block_1 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
+        self.mid.attn_1 = AttnBlock.Config(in_channels=block_in).build()
+        self.mid.block_2 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
 
         # end
-        self.norm_out = GroupNorm.Config(
-            num_groups=32,
-            num_channels=block_in,
-            eps=1e-6,
-        ).build()
+        self.norm_out = _norm(block_in).build()
         self.conv_out = Conv2d.Config(
             in_channels=block_in,
-            out_channels=2 * z_channels,
+            out_channels=2 * config.z_channels,
             kernel_size=3,
             padding=1,
         ).build()
@@ -254,32 +253,33 @@ class Encoder(Module):
 
 
 class Decoder(Module):
-    def __init__(
-        self,
-        ch: int,
-        out_ch: int,
-        ch_mult: list[int],
-        num_res_blocks: int,
-        in_channels: int,
-        resolution: int,
-        z_channels: int,
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        ch: int
+        out_ch: int
+        ch_mult: tuple[int, ...]
+        num_res_blocks: int
+        in_channels: int
+        resolution: int
+        z_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.ch = ch
-        self.num_resolutions = len(ch_mult)
-        self.num_res_blocks = num_res_blocks
-        self.resolution = resolution
-        self.in_channels = in_channels
+        self.ch = config.ch
+        self.num_resolutions = len(config.ch_mult)
+        self.num_res_blocks = config.num_res_blocks
+        self.resolution = config.resolution
+        self.in_channels = config.in_channels
         self.ffactor = 2 ** (self.num_resolutions - 1)
 
         # compute in_ch_mult, block_in and curr_res at lowest res
-        block_in = ch * ch_mult[self.num_resolutions - 1]
-        curr_res = resolution // 2 ** (self.num_resolutions - 1)
-        self.z_shape = (1, z_channels, curr_res, curr_res)
+        block_in = config.ch * config.ch_mult[self.num_resolutions - 1]
+        curr_res = config.resolution // 2 ** (self.num_resolutions - 1)
+        self.z_shape = (1, config.z_channels, curr_res, curr_res)
 
         # z to block_in
         self.conv_in = Conv2d.Config(
-            in_channels=z_channels,
+            in_channels=config.z_channels,
             out_channels=block_in,
             kernel_size=3,
             padding=1,
@@ -287,36 +287,40 @@ class Decoder(Module):
 
         # middle
         self.mid = Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
-        self.mid.attn_1 = AttnBlock(block_in)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.block_1 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
+        self.mid.attn_1 = AttnBlock.Config(in_channels=block_in).build()
+        self.mid.block_2 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
 
         # upsampling
         self.up = ModuleList()
         for i_level in reversed(range(self.num_resolutions)):
             block = ModuleList()
             attn = ModuleList()
-            block_out = ch * ch_mult[i_level]
+            block_out = config.ch * config.ch_mult[i_level]
             for _ in range(self.num_res_blocks + 1):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block.append(
+                    ResnetBlock.Config(
+                        in_channels=block_in, out_channels=block_out
+                    ).build()
+                )
                 block_in = block_out
             up = Module()
             up.block = block
             up.attn = attn
             if i_level != 0:
-                up.upsample = Upsample(block_in)
+                up.upsample = Upsample.Config(in_channels=block_in).build()
                 curr_res = curr_res * 2
             self.up.insert(0, up)  # prepend to get consistent order
 
         # end
-        self.norm_out = GroupNorm.Config(
-            num_groups=32,
-            num_channels=block_in,
-            eps=1e-6,
-        ).build()
+        self.norm_out = _norm(block_in).build()
         self.conv_out = Conv2d.Config(
             in_channels=block_in,
-            out_channels=out_ch,
+            out_channels=config.out_ch,
             kernel_size=3,
             padding=1,
         ).build()
@@ -359,10 +363,15 @@ class Decoder(Module):
 
 
 class DiagonalGaussian(Module):
-    def __init__(self, sample: bool = True, chunk_dim: int = 1):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        sample: bool = True
+        chunk_dim: int = 1
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.sample = sample
-        self.chunk_dim = chunk_dim
+        self.sample = config.sample
+        self.chunk_dim = config.chunk_dim
 
     def forward(self, z: Tensor) -> Tensor:
         mean, logvar = torch.chunk(z, 2, dim=self.chunk_dim)
@@ -374,32 +383,41 @@ class DiagonalGaussian(Module):
 
 
 class AutoEncoder(Module):
-    def __init__(self, params: AutoEncoderParams):
-        super().__init__()
-        self.params = params
-        self.encoder = Encoder(
-            resolution=params.resolution,
-            in_channels=params.in_channels,
-            ch=params.ch,
-            # pyrefly: ignore [bad-argument-type]
-            ch_mult=params.ch_mult,
-            num_res_blocks=params.num_res_blocks,
-            z_channels=params.z_channels,
-        )
-        self.decoder = Decoder(
-            resolution=params.resolution,
-            in_channels=params.in_channels,
-            ch=params.ch,
-            out_ch=params.out_ch,
-            # pyrefly: ignore [bad-argument-type]
-            ch_mult=params.ch_mult,
-            num_res_blocks=params.num_res_blocks,
-            z_channels=params.z_channels,
-        )
-        self.reg = DiagonalGaussian()
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        resolution: int = 256
+        in_channels: int = 3
+        ch: int = 128
+        out_ch: int = 3
+        ch_mult: tuple[int, ...] = (1, 2, 4, 4)
+        num_res_blocks: int = 2
+        z_channels: int = 16
+        scale_factor: float = 0.3611
+        shift_factor: float = 0.1159
 
-        self.scale_factor = params.scale_factor
-        self.shift_factor = params.shift_factor
+    def __init__(self, config: Config):
+        super().__init__()
+        self.encoder = Encoder.Config(
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            ch=config.ch,
+            ch_mult=config.ch_mult,
+            num_res_blocks=config.num_res_blocks,
+            z_channels=config.z_channels,
+        ).build()
+        self.decoder = Decoder.Config(
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            ch=config.ch,
+            out_ch=config.out_ch,
+            ch_mult=config.ch_mult,
+            num_res_blocks=config.num_res_blocks,
+            z_channels=config.z_channels,
+        ).build()
+        self.reg = DiagonalGaussian.Config().build()
+
+        self.scale_factor = config.scale_factor
+        self.shift_factor = config.shift_factor
 
     def encode(self, x: Tensor) -> Tensor:
         z = self.reg(self.encoder(x))
@@ -416,22 +434,22 @@ class AutoEncoder(Module):
 
 def load_ae(
     ckpt_path: str,
-    autoencoder_params: AutoEncoderParams,
+    autoencoder_config: AutoEncoder.Config,
     device: str | torch.device = "cuda",
     dtype=torch.bfloat16,
     random_init=False,
 ) -> AutoEncoder:
-    """
-    Load the autoencoder from the given model name.
+    """Build the autoencoder from a Config and optionally load weights.
+
     Args:
-        name (str): The name of the autoencoder.
-        device (str or torch.device): The device to load the autoencoder to.
-    Returns:
-        AutoEncoder: The loaded autoencoder.
+        ckpt_path: Path to the autoencoder checkpoint.
+        autoencoder_config: AutoEncoder.Config to instantiate.
+        device: Device to load the autoencoder to.
+        dtype: Target dtype after loading.
+        random_init: If True, skip checkpoint loading.
     """
-    # Loading the autoencoder
     with torch.device(device):
-        ae = AutoEncoder(autoencoder_params)
+        ae = autoencoder_config.build()
 
     if random_init:
         return ae.to(dtype=dtype)

--- a/torchtitan/models/flux/model/hf_embedder.py
+++ b/torchtitan/models/flux/model/hf_embedder.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from dataclasses import dataclass, field
+from typing import Any
 
 from torch import Tensor
 
@@ -13,35 +15,41 @@ from transformers import CLIPTextModel, T5EncoderModel
 
 
 class FluxEmbedder(Module):
-    def __init__(self, version: str, random_init=False, **hf_kwargs):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        version: str
+        random_init: bool = False
+        hf_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.is_clip = "clip" in version.lower()
+        self.is_clip = "clip" in config.version.lower()
         self.output_key = "pooler_output" if self.is_clip else "last_hidden_state"
         if self.is_clip:
-            if random_init:
+            if config.random_init:
                 # Initialize CLIP model with random weights for test purpose only
                 self.hf_module = CLIPTextModel._from_config(
                     # pyrefly: ignore [missing-attribute]
                     CLIPTextModel.config_class.from_pretrained(
-                        os.path.join(version, "config.json"), **hf_kwargs
+                        os.path.join(config.version, "config.json"), **config.hf_kwargs
                     )
                 )
             else:
                 self.hf_module: CLIPTextModel = CLIPTextModel.from_pretrained(
-                    version, **hf_kwargs
+                    config.version, **config.hf_kwargs
                 )
         else:
-            if random_init:
+            if config.random_init:
                 # Initialize T5 model with random weights for test purpose only
                 self.hf_module = T5EncoderModel._from_config(
                     # pyrefly: ignore [missing-attribute]
                     T5EncoderModel.config_class.from_pretrained(
-                        os.path.join(version, "config.json"), **hf_kwargs
+                        os.path.join(config.version, "config.json"), **config.hf_kwargs
                     )
                 )
             else:
                 self.hf_module: T5EncoderModel = T5EncoderModel.from_pretrained(
-                    version, **hf_kwargs
+                    config.version, **config.hf_kwargs
                 )
 
         self.hf_module = self.hf_module.eval().requires_grad_(False)

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn, Tensor
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.flux.model.autoencoder import AutoEncoder
+from torchtitan.models.flux.model.hf_embedder import FluxEmbedder
 from torchtitan.models.flux.model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -44,6 +45,11 @@ class FluxModel(BaseModel):
         theta: int = 10_000
         qkv_bias: bool = True
         autoencoder: AutoEncoder.Config = field(default_factory=AutoEncoder.Config)
+
+        # Text encoder configs, set by the model registry. The trainer can
+        # override version and random_init when it builds the encoders.
+        clip_encoder: FluxEmbedder.Config
+        t5_encoder: FluxEmbedder.Config
 
         # Sub-component configs (all required — set by the model registry)
         pe_config: EmbedND.Config

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import torch
 from torch import nn, Tensor
 from torchtitan.models.common.nn_modules import Linear
-from torchtitan.models.flux.model.autoencoder import AutoEncoderParams
+from torchtitan.models.flux.model.autoencoder import AutoEncoder
 from torchtitan.models.flux.model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -43,7 +43,7 @@ class FluxModel(BaseModel):
         axes_dim: tuple = (16, 56, 56)
         theta: int = 10_000
         qkv_bias: bool = True
-        autoencoder_params: AutoEncoderParams = field(default_factory=AutoEncoderParams)
+        autoencoder: AutoEncoder.Config = field(default_factory=AutoEncoder.Config)
 
         # Sub-component configs (all required — set by the model registry)
         pe_config: EmbedND.Config
@@ -110,8 +110,6 @@ class FluxModel(BaseModel):
 
     def __init__(self, config: Config):
         super().__init__()
-
-        self.config = config
 
         self.in_channels = config.in_channels
         self.out_channels = config.out_channels

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -6,7 +6,7 @@
 
 import time
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import torch
 
@@ -15,7 +15,7 @@ from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.models.flux.configs import FluxEncoderConfig, Inference
 from torchtitan.models.flux.model.autoencoder import load_ae
-from torchtitan.models.flux.model.hf_embedder import FluxEmbedder
+from torchtitan.models.flux.model.model import FluxModel
 from torchtitan.models.flux.parallelize import parallelize_encoders
 from torchtitan.models.flux.tokenizer import FluxTokenizerContainer
 from torchtitan.models.flux.utils import (
@@ -78,27 +78,33 @@ class FluxTrainer(Trainer):
         # load components
         assert config.model_spec is not None
         model_args = config.model_spec.model
+        assert isinstance(model_args, FluxModel.Config)
 
         self.autoencoder = load_ae(
             config.encoder.autoencoder_path,
-            # pyrefly: ignore [missing-attribute]
             model_args.autoencoder,
             device=self.device,
             dtype=self._dtype,
             random_init=config.encoder.random_init,
         )
 
+        # Use the encoder configs from the model registry, overriding version
+        # and random_init from the trainer encoder config if set.
+        clip_encoder_config = model_args.clip_encoder
+        t5_encoder_config = model_args.t5_encoder
         self.clip_encoder = (
-            FluxEmbedder.Config(
-                version=config.encoder.clip_encoder,
+            replace(
+                clip_encoder_config,
+                version=config.encoder.clip_encoder or clip_encoder_config.version,
                 random_init=config.encoder.random_init,
             )
             .build()
             .to(device=self.device, dtype=self._dtype)
         )
         self.t5_encoder = (
-            FluxEmbedder.Config(
-                version=config.encoder.t5_encoder,
+            replace(
+                t5_encoder_config,
+                version=config.encoder.t5_encoder or t5_encoder_config.version,
                 random_init=config.encoder.random_init,
             )
             .build()

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -82,23 +82,30 @@ class FluxTrainer(Trainer):
         self.autoencoder = load_ae(
             config.encoder.autoencoder_path,
             # pyrefly: ignore [missing-attribute]
-            model_args.autoencoder_params,
+            model_args.autoencoder,
             device=self.device,
             dtype=self._dtype,
             random_init=config.encoder.random_init,
         )
 
-        self.clip_encoder = FluxEmbedder(
-            version=config.encoder.clip_encoder,
-            random_init=config.encoder.random_init,
-        ).to(device=self.device, dtype=self._dtype)
-        self.t5_encoder = FluxEmbedder(
-            version=config.encoder.t5_encoder,
-            random_init=config.encoder.random_init,
-        ).to(device=self.device, dtype=self._dtype)
+        self.clip_encoder = (
+            FluxEmbedder.Config(
+                version=config.encoder.clip_encoder,
+                random_init=config.encoder.random_init,
+            )
+            .build()
+            .to(device=self.device, dtype=self._dtype)
+        )
+        self.t5_encoder = (
+            FluxEmbedder.Config(
+                version=config.encoder.t5_encoder,
+                random_init=config.encoder.random_init,
+            )
+            .build()
+            .to(device=self.device, dtype=self._dtype)
+        )
 
         # Apply FSDP to the T5 model / CLIP model
-        # pyrefly: ignore [bad-assignment]
         self.t5_encoder, self.clip_encoder = parallelize_encoders(
             t5_model=self.t5_encoder,
             clip_model=self.clip_encoder,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3447
* #3446
* __->__ #3445

**Summary**
As title, no logic change, just convert all the module classes to be config-based.

Verified the loss bit-wise parity with 100 steps.