### PR TITLE
[Module][Qwen3-VL] Module-build conversion for vision encoder

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_vl.py
@@ -92,8 +92,8 @@ def build_inputs(hf_model_path, model_flavor, num_samples, image_size=224):
 
     model_config = model_registry(model_flavor).model
     encoder_config = model_config.vision_encoder  # pyrefly: ignore[missing-attribute]
-    patch_size = encoder_config.patch_size
-    temporal_patch_size = encoder_config.temporal_patch_size
+    patch_size = encoder_config.patch_embed.patch_size
+    temporal_patch_size = encoder_config.patch_embed.temporal_patch_size
     merge_size = encoder_config.spatial_merge_size
 
     hf_inputs, tt_inputs, pixel_comparisons = [], [], []

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -16,7 +16,7 @@ from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader
-from .model.autoencoder import AutoEncoderParams
+from .model.autoencoder import AutoEncoder
 from .model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -247,7 +247,7 @@ def _flux_dev() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,
@@ -359,7 +359,7 @@ def _flux_schnell() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,
@@ -471,7 +471,7 @@ def _flux_debug() -> FluxModel.Config:
             bias=True,
             param_init=_XAVIER_LINEAR,
         ),
-        autoencoder_params=AutoEncoderParams(
+        autoencoder=AutoEncoder.Config(
             resolution=256,
             in_channels=3,
             ch=128,

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -17,6 +17,7 @@ from torchtitan.protocols.model_spec import ModelSpec
 
 from .flux_datasets import FluxDataLoader
 from .model.autoencoder import AutoEncoder
+from .model.hf_embedder import FluxEmbedder
 from .model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -42,6 +43,9 @@ _ZERO_LINEAR = {"weight": nn.init.zeros_, "bias": nn.init.zeros_}
 _XAVIER_LINEAR = {"weight": nn.init.xavier_uniform_, "bias": nn.init.zeros_}
 _NORMAL_02 = {"weight": partial(nn.init.normal_, std=0.02), "bias": nn.init.zeros_}
 _NORM_INIT = {"weight": nn.init.ones_}
+
+_T5_ENCODER_VERSION = "google/t5-v1_1-xxl"
+_CLIP_ENCODER_VERSION = "openai/clip-vit-large-patch14"
 
 
 def _make_double_block_config(
@@ -258,6 +262,8 @@ def _flux_dev() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,
@@ -370,6 +376,8 @@ def _flux_schnell() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,
@@ -482,6 +490,8 @@ def _flux_debug() -> FluxModel.Config:
             scale_factor=0.3611,
             shift_factor=0.1159,
         ),
+        clip_encoder=FluxEmbedder.Config(version=_CLIP_ENCODER_VERSION),
+        t5_encoder=FluxEmbedder.Config(version=_T5_ENCODER_VERSION),
         pe_config=EmbedND.Config(dim=128, theta=10_000, axes_dim=(16, 56, 56)),
         time_in_config=MLPEmbedder.Config(
             in_dim=256,

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -36,8 +36,6 @@ def flux_debugmodel() -> FluxTrainer.Config:
             max_t5_encoding_len=256,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=1),
@@ -97,8 +95,6 @@ def flux_dev() -> FluxTrainer.Config:
             max_t5_encoding_len=512,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=100),
@@ -149,8 +145,6 @@ def flux_schnell() -> FluxTrainer.Config:
             max_t5_encoding_len=256,
         ),
         encoder=FluxEncoderConfig(
-            t5_encoder="google/t5-v1_1-xxl",
-            clip_encoder="openai/clip-vit-large-patch14",
             autoencoder_path="assets/hf/FLUX.1-dev/ae.safetensors",
         ),
         metrics=MetricsProcessor.Config(log_freq=100),

--- a/torchtitan/models/flux/configs.py
+++ b/torchtitan/models/flux/configs.py
@@ -11,10 +11,10 @@ from dataclasses import dataclass, field
 class FluxEncoderConfig:
     """Configuration for Flux encoders (T5 text encoder, CLIP text encoder, and autoencoder)."""
 
-    t5_encoder: str = "google/t5-v1_1-small"
-    """HuggingFace model name or local path for the T5 text encoder."""
-    clip_encoder: str = "openai/clip-vit-large-patch14"
-    """HuggingFace model name or local path for the CLIP text encoder."""
+    t5_encoder: str = ""
+    """Override for the T5 text encoder version/path. Empty uses the model registry default."""
+    clip_encoder: str = ""
+    """Override for the CLIP text encoder version/path. Empty uses the model registry default."""
     autoencoder_path: str = (
         "torchtitan/experiments/flux/assets/autoencoder/ae.safetensors"
     )

--- a/torchtitan/models/flux/model/autoencoder.py
+++ b/torchtitan/models/flux/model/autoencoder.py
@@ -16,37 +16,28 @@ from torchtitan.models.common.nn_modules import Conv2d, GroupNorm
 from torchtitan.protocols.module import Module, ModuleList
 
 
-@dataclass
-class AutoEncoderParams:
-    resolution: int = 256
-    in_channels: int = 3
-    ch: int = 128
-    out_ch: int = 3
-    ch_mult: tuple[int, ...] = (1, 2, 4, 4)
-    num_res_blocks: int = 2
-    z_channels: int = 16
-    scale_factor: float = 0.3611
-    shift_factor: float = 0.1159
-
-
 def swish(x: Tensor) -> Tensor:
     return x * torch.sigmoid(x)
 
 
-class AttnBlock(Module):
-    def __init__(self, in_channels: int):
-        super().__init__()
-        self.in_channels = in_channels
+def _norm(num_channels: int) -> GroupNorm.Config:
+    return GroupNorm.Config(num_groups=32, num_channels=num_channels, eps=1e-6)
 
-        self.norm = GroupNorm.Config(
-            num_groups=32,
-            num_channels=in_channels,
-            eps=1e-6,
-        ).build()
+
+class AttnBlock(Module):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.in_channels = config.in_channels
+
+        self.norm = _norm(config.in_channels).build()
 
         conv1x1 = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=1,
         )
         self.q = conv1x1.build()
@@ -73,38 +64,34 @@ class AttnBlock(Module):
 
 
 class ResnetBlock(Module):
-    def __init__(self, in_channels: int, out_channels: int):
-        super().__init__()
-        self.in_channels = in_channels
-        out_channels = in_channels if out_channels is None else out_channels
-        self.out_channels = out_channels
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+        out_channels: int
 
-        self.norm1 = GroupNorm.Config(
-            num_groups=32,
-            num_channels=in_channels,
-            eps=1e-6,
-        ).build()
+    def __init__(self, config: Config):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.out_channels = config.out_channels
+
+        self.norm1 = _norm(config.in_channels).build()
         self.conv1 = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=out_channels,
+            in_channels=config.in_channels,
+            out_channels=config.out_channels,
             kernel_size=3,
             padding=1,
         ).build()
-        self.norm2 = GroupNorm.Config(
-            num_groups=32,
-            num_channels=out_channels,
-            eps=1e-6,
-        ).build()
+        self.norm2 = _norm(config.out_channels).build()
         self.conv2 = Conv2d.Config(
-            in_channels=out_channels,
-            out_channels=out_channels,
+            in_channels=config.out_channels,
+            out_channels=config.out_channels,
             kernel_size=3,
             padding=1,
         ).build()
         if self.in_channels != self.out_channels:
             self.nin_shortcut = Conv2d.Config(
-                in_channels=in_channels,
-                out_channels=out_channels,
+                in_channels=config.in_channels,
+                out_channels=config.out_channels,
                 kernel_size=1,
             ).build()
 
@@ -125,12 +112,16 @@ class ResnetBlock(Module):
 
 
 class Downsample(Module):
-    def __init__(self, in_channels: int):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
         # no asymmetric padding in torch conv, must do it ourselves
         self.conv = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=3,
             stride=2,
         ).build()
@@ -143,11 +134,15 @@ class Downsample(Module):
 
 
 class Upsample(Module):
-    def __init__(self, in_channels: int):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
         self.conv = Conv2d.Config(
-            in_channels=in_channels,
-            out_channels=in_channels,
+            in_channels=config.in_channels,
+            out_channels=config.in_channels,
             kernel_size=3,
             padding=1,
         ).build()
@@ -159,65 +154,69 @@ class Upsample(Module):
 
 
 class Encoder(Module):
-    def __init__(
-        self,
-        resolution: int,
-        in_channels: int,
-        ch: int,
-        ch_mult: list[int],
-        num_res_blocks: int,
-        z_channels: int,
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        resolution: int
+        in_channels: int
+        ch: int
+        ch_mult: tuple[int, ...]
+        num_res_blocks: int
+        z_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.ch = ch
-        self.num_resolutions = len(ch_mult)
-        self.num_res_blocks = num_res_blocks
-        self.resolution = resolution
-        self.in_channels = in_channels
+        self.ch = config.ch
+        self.num_resolutions = len(config.ch_mult)
+        self.num_res_blocks = config.num_res_blocks
+        self.resolution = config.resolution
+        self.in_channels = config.in_channels
         # downsampling
         self.conv_in = Conv2d.Config(
-            in_channels=in_channels,
+            in_channels=config.in_channels,
             out_channels=self.ch,
             kernel_size=3,
             padding=1,
         ).build()
 
-        curr_res = resolution
-        in_ch_mult = (1,) + tuple(ch_mult)
-        self.in_ch_mult = in_ch_mult
+        curr_res = config.resolution
+        in_ch_mult = (1,) + tuple(config.ch_mult)
         self.down = ModuleList()
         block_in = self.ch
         for i_level in range(self.num_resolutions):
             block = ModuleList()
             attn = ModuleList()
-            block_in = ch * in_ch_mult[i_level]
-            block_out = ch * ch_mult[i_level]
+            block_in = config.ch * in_ch_mult[i_level]
+            block_out = config.ch * config.ch_mult[i_level]
             for _ in range(self.num_res_blocks):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block.append(
+                    ResnetBlock.Config(
+                        in_channels=block_in, out_channels=block_out
+                    ).build()
+                )
                 block_in = block_out
             down = Module()
             down.block = block
             down.attn = attn
             if i_level != self.num_resolutions - 1:
-                down.downsample = Downsample(block_in)
+                down.downsample = Downsample.Config(in_channels=block_in).build()
                 curr_res = curr_res // 2
             self.down.append(down)
 
         # middle
         self.mid = Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
-        self.mid.attn_1 = AttnBlock(block_in)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.block_1 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
+        self.mid.attn_1 = AttnBlock.Config(in_channels=block_in).build()
+        self.mid.block_2 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
 
         # end
-        self.norm_out = GroupNorm.Config(
-            num_groups=32,
-            num_channels=block_in,
-            eps=1e-6,
-        ).build()
+        self.norm_out = _norm(block_in).build()
         self.conv_out = Conv2d.Config(
             in_channels=block_in,
-            out_channels=2 * z_channels,
+            out_channels=2 * config.z_channels,
             kernel_size=3,
             padding=1,
         ).build()
@@ -254,32 +253,33 @@ class Encoder(Module):
 
 
 class Decoder(Module):
-    def __init__(
-        self,
-        ch: int,
-        out_ch: int,
-        ch_mult: list[int],
-        num_res_blocks: int,
-        in_channels: int,
-        resolution: int,
-        z_channels: int,
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        ch: int
+        out_ch: int
+        ch_mult: tuple[int, ...]
+        num_res_blocks: int
+        in_channels: int
+        resolution: int
+        z_channels: int
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.ch = ch
-        self.num_resolutions = len(ch_mult)
-        self.num_res_blocks = num_res_blocks
-        self.resolution = resolution
-        self.in_channels = in_channels
+        self.ch = config.ch
+        self.num_resolutions = len(config.ch_mult)
+        self.num_res_blocks = config.num_res_blocks
+        self.resolution = config.resolution
+        self.in_channels = config.in_channels
         self.ffactor = 2 ** (self.num_resolutions - 1)
 
         # compute in_ch_mult, block_in and curr_res at lowest res
-        block_in = ch * ch_mult[self.num_resolutions - 1]
-        curr_res = resolution // 2 ** (self.num_resolutions - 1)
-        self.z_shape = (1, z_channels, curr_res, curr_res)
+        block_in = config.ch * config.ch_mult[self.num_resolutions - 1]
+        curr_res = config.resolution // 2 ** (self.num_resolutions - 1)
+        self.z_shape = (1, config.z_channels, curr_res, curr_res)
 
         # z to block_in
         self.conv_in = Conv2d.Config(
-            in_channels=z_channels,
+            in_channels=config.z_channels,
             out_channels=block_in,
             kernel_size=3,
             padding=1,
@@ -287,36 +287,40 @@ class Decoder(Module):
 
         # middle
         self.mid = Module()
-        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
-        self.mid.attn_1 = AttnBlock(block_in)
-        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.block_1 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
+        self.mid.attn_1 = AttnBlock.Config(in_channels=block_in).build()
+        self.mid.block_2 = ResnetBlock.Config(
+            in_channels=block_in, out_channels=block_in
+        ).build()
 
         # upsampling
         self.up = ModuleList()
         for i_level in reversed(range(self.num_resolutions)):
             block = ModuleList()
             attn = ModuleList()
-            block_out = ch * ch_mult[i_level]
+            block_out = config.ch * config.ch_mult[i_level]
             for _ in range(self.num_res_blocks + 1):
-                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block.append(
+                    ResnetBlock.Config(
+                        in_channels=block_in, out_channels=block_out
+                    ).build()
+                )
                 block_in = block_out
             up = Module()
             up.block = block
             up.attn = attn
             if i_level != 0:
-                up.upsample = Upsample(block_in)
+                up.upsample = Upsample.Config(in_channels=block_in).build()
                 curr_res = curr_res * 2
             self.up.insert(0, up)  # prepend to get consistent order
 
         # end
-        self.norm_out = GroupNorm.Config(
-            num_groups=32,
-            num_channels=block_in,
-            eps=1e-6,
-        ).build()
+        self.norm_out = _norm(block_in).build()
         self.conv_out = Conv2d.Config(
             in_channels=block_in,
-            out_channels=out_ch,
+            out_channels=config.out_ch,
             kernel_size=3,
             padding=1,
         ).build()
@@ -359,10 +363,15 @@ class Decoder(Module):
 
 
 class DiagonalGaussian(Module):
-    def __init__(self, sample: bool = True, chunk_dim: int = 1):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        sample: bool = True
+        chunk_dim: int = 1
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.sample = sample
-        self.chunk_dim = chunk_dim
+        self.sample = config.sample
+        self.chunk_dim = config.chunk_dim
 
     def forward(self, z: Tensor) -> Tensor:
         mean, logvar = torch.chunk(z, 2, dim=self.chunk_dim)
@@ -374,32 +383,41 @@ class DiagonalGaussian(Module):
 
 
 class AutoEncoder(Module):
-    def __init__(self, params: AutoEncoderParams):
-        super().__init__()
-        self.params = params
-        self.encoder = Encoder(
-            resolution=params.resolution,
-            in_channels=params.in_channels,
-            ch=params.ch,
-            # pyrefly: ignore [bad-argument-type]
-            ch_mult=params.ch_mult,
-            num_res_blocks=params.num_res_blocks,
-            z_channels=params.z_channels,
-        )
-        self.decoder = Decoder(
-            resolution=params.resolution,
-            in_channels=params.in_channels,
-            ch=params.ch,
-            out_ch=params.out_ch,
-            # pyrefly: ignore [bad-argument-type]
-            ch_mult=params.ch_mult,
-            num_res_blocks=params.num_res_blocks,
-            z_channels=params.z_channels,
-        )
-        self.reg = DiagonalGaussian()
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        resolution: int = 256
+        in_channels: int = 3
+        ch: int = 128
+        out_ch: int = 3
+        ch_mult: tuple[int, ...] = (1, 2, 4, 4)
+        num_res_blocks: int = 2
+        z_channels: int = 16
+        scale_factor: float = 0.3611
+        shift_factor: float = 0.1159
 
-        self.scale_factor = params.scale_factor
-        self.shift_factor = params.shift_factor
+    def __init__(self, config: Config):
+        super().__init__()
+        self.encoder = Encoder.Config(
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            ch=config.ch,
+            ch_mult=config.ch_mult,
+            num_res_blocks=config.num_res_blocks,
+            z_channels=config.z_channels,
+        ).build()
+        self.decoder = Decoder.Config(
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            ch=config.ch,
+            out_ch=config.out_ch,
+            ch_mult=config.ch_mult,
+            num_res_blocks=config.num_res_blocks,
+            z_channels=config.z_channels,
+        ).build()
+        self.reg = DiagonalGaussian.Config().build()
+
+        self.scale_factor = config.scale_factor
+        self.shift_factor = config.shift_factor
 
     def encode(self, x: Tensor) -> Tensor:
         z = self.reg(self.encoder(x))
@@ -416,22 +434,22 @@ class AutoEncoder(Module):
 
 def load_ae(
     ckpt_path: str,
-    autoencoder_params: AutoEncoderParams,
+    autoencoder_config: AutoEncoder.Config,
     device: str | torch.device = "cuda",
     dtype=torch.bfloat16,
     random_init=False,
 ) -> AutoEncoder:
-    """
-    Load the autoencoder from the given model name.
+    """Build the autoencoder from a Config and optionally load weights.
+
     Args:
-        name (str): The name of the autoencoder.
-        device (str or torch.device): The device to load the autoencoder to.
-    Returns:
-        AutoEncoder: The loaded autoencoder.
+        ckpt_path: Path to the autoencoder checkpoint.
+        autoencoder_config: AutoEncoder.Config to instantiate.
+        device: Device to load the autoencoder to.
+        dtype: Target dtype after loading.
+        random_init: If True, skip checkpoint loading.
     """
-    # Loading the autoencoder
     with torch.device(device):
-        ae = AutoEncoder(autoencoder_params)
+        ae = autoencoder_config.build()
 
     if random_init:
         return ae.to(dtype=dtype)

--- a/torchtitan/models/flux/model/hf_embedder.py
+++ b/torchtitan/models/flux/model/hf_embedder.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from dataclasses import dataclass, field
+from typing import Any
 
 from torch import Tensor
 
@@ -13,35 +15,41 @@ from transformers import CLIPTextModel, T5EncoderModel
 
 
 class FluxEmbedder(Module):
-    def __init__(self, version: str, random_init=False, **hf_kwargs):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        version: str
+        random_init: bool = False
+        hf_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.is_clip = "clip" in version.lower()
+        self.is_clip = "clip" in config.version.lower()
         self.output_key = "pooler_output" if self.is_clip else "last_hidden_state"
         if self.is_clip:
-            if random_init:
+            if config.random_init:
                 # Initialize CLIP model with random weights for test purpose only
                 self.hf_module = CLIPTextModel._from_config(
                     # pyrefly: ignore [missing-attribute]
                     CLIPTextModel.config_class.from_pretrained(
-                        os.path.join(version, "config.json"), **hf_kwargs
+                        os.path.join(config.version, "config.json"), **config.hf_kwargs
                     )
                 )
             else:
                 self.hf_module: CLIPTextModel = CLIPTextModel.from_pretrained(
-                    version, **hf_kwargs
+                    config.version, **config.hf_kwargs
                 )
         else:
-            if random_init:
+            if config.random_init:
                 # Initialize T5 model with random weights for test purpose only
                 self.hf_module = T5EncoderModel._from_config(
                     # pyrefly: ignore [missing-attribute]
                     T5EncoderModel.config_class.from_pretrained(
-                        os.path.join(version, "config.json"), **hf_kwargs
+                        os.path.join(config.version, "config.json"), **config.hf_kwargs
                     )
                 )
             else:
                 self.hf_module: T5EncoderModel = T5EncoderModel.from_pretrained(
-                    version, **hf_kwargs
+                    config.version, **config.hf_kwargs
                 )
 
         self.hf_module = self.hf_module.eval().requires_grad_(False)

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn, Tensor
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.flux.model.autoencoder import AutoEncoder
+from torchtitan.models.flux.model.hf_embedder import FluxEmbedder
 from torchtitan.models.flux.model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -44,6 +45,11 @@ class FluxModel(BaseModel):
         theta: int = 10_000
         qkv_bias: bool = True
         autoencoder: AutoEncoder.Config = field(default_factory=AutoEncoder.Config)
+
+        # Text encoder configs, set by the model registry. The trainer can
+        # override version and random_init when it builds the encoders.
+        clip_encoder: FluxEmbedder.Config
+        t5_encoder: FluxEmbedder.Config
 
         # Sub-component configs (all required — set by the model registry)
         pe_config: EmbedND.Config

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import torch
 from torch import nn, Tensor
 from torchtitan.models.common.nn_modules import Linear
-from torchtitan.models.flux.model.autoencoder import AutoEncoderParams
+from torchtitan.models.flux.model.autoencoder import AutoEncoder
 from torchtitan.models.flux.model.layers import (
     DoubleStreamBlock,
     EmbedND,
@@ -43,7 +43,7 @@ class FluxModel(BaseModel):
         axes_dim: tuple = (16, 56, 56)
         theta: int = 10_000
         qkv_bias: bool = True
-        autoencoder_params: AutoEncoderParams = field(default_factory=AutoEncoderParams)
+        autoencoder: AutoEncoder.Config = field(default_factory=AutoEncoder.Config)
 
         # Sub-component configs (all required — set by the model registry)
         pe_config: EmbedND.Config
@@ -110,8 +110,6 @@ class FluxModel(BaseModel):
 
     def __init__(self, config: Config):
         super().__init__()
-
-        self.config = config
 
         self.in_channels = config.in_channels
         self.out_channels = config.out_channels

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -6,7 +6,7 @@
 
 import time
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import torch
 
@@ -15,7 +15,7 @@ from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.models.flux.configs import FluxEncoderConfig, Inference
 from torchtitan.models.flux.model.autoencoder import load_ae
-from torchtitan.models.flux.model.hf_embedder import FluxEmbedder
+from torchtitan.models.flux.model.model import FluxModel
 from torchtitan.models.flux.parallelize import parallelize_encoders
 from torchtitan.models.flux.tokenizer import FluxTokenizerContainer
 from torchtitan.models.flux.utils import (
@@ -78,27 +78,33 @@ class FluxTrainer(Trainer):
         # load components
         assert config.model_spec is not None
         model_args = config.model_spec.model
+        assert isinstance(model_args, FluxModel.Config)
 
         self.autoencoder = load_ae(
             config.encoder.autoencoder_path,
-            # pyrefly: ignore [missing-attribute]
             model_args.autoencoder,
             device=self.device,
             dtype=self._dtype,
             random_init=config.encoder.random_init,
         )
 
+        # Use the encoder configs from the model registry, overriding version
+        # and random_init from the trainer encoder config if set.
+        clip_encoder_config = model_args.clip_encoder
+        t5_encoder_config = model_args.t5_encoder
         self.clip_encoder = (
-            FluxEmbedder.Config(
-                version=config.encoder.clip_encoder,
+            replace(
+                clip_encoder_config,
+                version=config.encoder.clip_encoder or clip_encoder_config.version,
                 random_init=config.encoder.random_init,
             )
             .build()
             .to(device=self.device, dtype=self._dtype)
         )
         self.t5_encoder = (
-            FluxEmbedder.Config(
-                version=config.encoder.t5_encoder,
+            replace(
+                t5_encoder_config,
+                version=config.encoder.t5_encoder or t5_encoder_config.version,
                 random_init=config.encoder.random_init,
             )
             .build()

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -82,23 +82,30 @@ class FluxTrainer(Trainer):
         self.autoencoder = load_ae(
             config.encoder.autoencoder_path,
             # pyrefly: ignore [missing-attribute]
-            model_args.autoencoder_params,
+            model_args.autoencoder,
             device=self.device,
             dtype=self._dtype,
             random_init=config.encoder.random_init,
         )
 
-        self.clip_encoder = FluxEmbedder(
-            version=config.encoder.clip_encoder,
-            random_init=config.encoder.random_init,
-        ).to(device=self.device, dtype=self._dtype)
-        self.t5_encoder = FluxEmbedder(
-            version=config.encoder.t5_encoder,
-            random_init=config.encoder.random_init,
-        ).to(device=self.device, dtype=self._dtype)
+        self.clip_encoder = (
+            FluxEmbedder.Config(
+                version=config.encoder.clip_encoder,
+                random_init=config.encoder.random_init,
+            )
+            .build()
+            .to(device=self.device, dtype=self._dtype)
+        )
+        self.t5_encoder = (
+            FluxEmbedder.Config(
+                version=config.encoder.t5_encoder,
+                random_init=config.encoder.random_init,
+            )
+            .build()
+            .to(device=self.device, dtype=self._dtype)
+        )
 
         # Apply FSDP to the T5 model / CLIP model
-        # pyrefly: ignore [bad-assignment]
         self.t5_encoder, self.clip_encoder = parallelize_encoders(
             t5_model=self.t5_encoder,
             clip_model=self.clip_encoder,

--- a/torchtitan/models/qwen3_vl/__init__.py
+++ b/torchtitan/models/qwen3_vl/__init__.py
@@ -18,7 +18,7 @@ from torchtitan.models.common.config_utils import (
     make_moe_config,
     make_router_config,
 )
-from torchtitan.models.common.nn_modules import RMSNorm
+from torchtitan.models.common.nn_modules import LayerNorm, RMSNorm
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.qwen3.model import Qwen3TransformerBlock
 from torchtitan.models.utils import validate_converter_order
@@ -29,7 +29,15 @@ from torchtitan.protocols.model_spec import ModelSpec
 from .model import Qwen3VLModel
 from .parallelize import parallelize_qwen3_vl
 from .state_dict_adapter import Qwen3VLStateDictAdapter
-from .vision_encoder import Qwen3VLVisionEncoder
+from .vision_encoder import (
+    PatchEmbed,
+    PatchMerger,
+    Qwen3VLVisionEncoder,
+    VisionAttention,
+    VisionMLP,
+    VisionRotaryEmbedding,
+    VisionTransformerBlock,
+)
 
 __all__ = [
     "parallelize_qwen3_vl",
@@ -95,8 +103,46 @@ def _qwen3_vl_norm(dim: int) -> RMSNorm.Config:
     return RMSNorm.Config(normalized_shape=dim, eps=_EPS, param_init=_NORM_INIT)
 
 
-def _qwen3_vl_q_norm(dim: int) -> RMSNorm.Config:
-    return RMSNorm.Config(normalized_shape=dim, eps=_EPS, param_init=_NORM_INIT)
+def _vl_layer_norm(normalized_shape: int) -> LayerNorm.Config:
+    return LayerNorm.Config(normalized_shape=normalized_shape, eps=_EPS)
+
+
+def _build_qwen3_vl_vision_block(
+    *, dim: int, ffn_dim: int, n_heads: int
+) -> VisionTransformerBlock.Config:
+    return VisionTransformerBlock.Config(
+        attn=VisionAttention.Config(
+            dim=dim,
+            n_heads=n_heads,
+            qkv=_vl_linear(dim, dim * 3),
+            proj=_vl_linear(dim, dim),
+        ),
+        mlp=VisionMLP.Config(
+            fc1=_vl_linear(dim, ffn_dim),
+            fc2=_vl_linear(ffn_dim, dim),
+        ),
+        norm1=_vl_layer_norm(dim),
+        norm2=_vl_layer_norm(dim),
+    )
+
+
+def _build_qwen3_vl_merger(
+    *,
+    dim: int,
+    out_hidden_size: int,
+    spatial_merge_size: int,
+    use_postshuffle_norm: bool,
+) -> PatchMerger.Config:
+    merged_hidden_size = dim * (spatial_merge_size**2)
+    norm_dim = merged_hidden_size if use_postshuffle_norm else dim
+    return PatchMerger.Config(
+        hidden_size=dim,
+        spatial_merge_size=spatial_merge_size,
+        fc1=_vl_linear(merged_hidden_size, merged_hidden_size),
+        fc2=_vl_linear(merged_hidden_size, out_hidden_size),
+        norm=_vl_layer_norm(norm_dim),
+        use_postshuffle_norm=use_postshuffle_norm,
+    )
 
 
 def _vl_vision_encoder_config(
@@ -115,25 +161,39 @@ def _vl_vision_encoder_config(
 ) -> Qwen3VLVisionEncoder.Config:
     """Build a fully-specified Qwen3VLVisionEncoder.Config."""
     patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
-    merged_hidden_size = dim * (spatial_merge_size**2)
+    head_dim = dim // n_heads
     return Qwen3VLVisionEncoder.Config(
         dim=dim,
-        ffn_dim=ffn_dim,
-        n_layers=n_layers,
         n_heads=n_heads,
-        patch_size=patch_size,
-        temporal_patch_size=temporal_patch_size,
         spatial_merge_size=spatial_merge_size,
-        out_hidden_size=out_hidden_size,
         num_position_embeddings=num_position_embeddings,
         deepstack_visual_indices=deepstack_visual_indices,
-        patch_embed_proj=_vl_linear(patch_dim, dim),
-        attn_qkv=_vl_linear(dim, dim * 3),
-        attn_proj=_vl_linear(dim, dim),
-        mlp_fc1=_vl_linear(dim, ffn_dim),
-        mlp_fc2=_vl_linear(ffn_dim, dim),
-        merger_fc1=_vl_linear(merged_hidden_size, merged_hidden_size),
-        merger_fc2=_vl_linear(merged_hidden_size, out_hidden_size),
+        patch_embed=PatchEmbed.Config(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            proj=_vl_linear(patch_dim, dim),
+        ),
+        rotary_pos_emb=VisionRotaryEmbedding.Config(dim=head_dim // 2),
+        layers=[
+            _build_qwen3_vl_vision_block(dim=dim, ffn_dim=ffn_dim, n_heads=n_heads)
+            for _ in range(n_layers)
+        ],
+        merger=_build_qwen3_vl_merger(
+            dim=dim,
+            out_hidden_size=out_hidden_size,
+            spatial_merge_size=spatial_merge_size,
+            use_postshuffle_norm=False,
+        ),
+        deepstack_mergers=[
+            _build_qwen3_vl_merger(
+                dim=dim,
+                out_hidden_size=out_hidden_size,
+                spatial_merge_size=spatial_merge_size,
+                use_postshuffle_norm=True,
+            )
+            for _ in range(len(deepstack_visual_indices))
+        ],
         param_init=_POS_EMBED_INIT,
     )
 
@@ -166,7 +226,7 @@ def _build_qwen3_vl_layers(
                     inner_attention=inner_attention,
                     mask_type=mask_type,
                     rope_backend="cos_sin",
-                    qk_norm=_qwen3_vl_q_norm(head_dim),
+                    qk_norm=_qwen3_vl_norm(head_dim),
                 ),
                 feed_forward=make_ffn_config(
                     dim=dim,
@@ -211,7 +271,7 @@ def _build_qwen3_vl_moe_layers(
                     inner_attention=inner_attention,
                     mask_type=mask_type,
                     rope_backend="cos_sin",
-                    qk_norm=_qwen3_vl_q_norm(head_dim),
+                    qk_norm=_qwen3_vl_norm(head_dim),
                 ),
                 moe=make_moe_config(
                     num_experts=num_experts,

--- a/torchtitan/models/qwen3_vl/state_dict_adapter.py
+++ b/torchtitan/models/qwen3_vl/state_dict_adapter.py
@@ -206,13 +206,13 @@ class Qwen3VLStateDictAdapter(StateDictAdapter):
                 # Linear weight (out, C*T*H*W) -> Conv3d weight (out, C, T, H, W)
                 # Plain reshape since both use channel-first (c pt ph pw) layout.
                 if tt_key == "vision_encoder.patch_embed.proj.weight":
-                    encoder = self.model_config.vision_encoder
+                    patch_embed = self.model_config.vision_encoder.patch_embed
                     hf_value = value.reshape(
                         value.shape[0],
-                        encoder.in_channels,
-                        encoder.temporal_patch_size,
-                        encoder.patch_size,
-                        encoder.patch_size,
+                        patch_embed.in_channels,
+                        patch_embed.temporal_patch_size,
+                        patch_embed.patch_size,
+                        patch_embed.patch_size,
                     )
                 hf_state_dict[hf_key] = hf_value
 

--- a/torchtitan/models/qwen3_vl/vision_encoder.py
+++ b/torchtitan/models/qwen3_vl/vision_encoder.py
@@ -488,7 +488,6 @@ class Qwen3VLVisionEncoder(Module):
         # DeepStack: layer indices for extracting intermediate visual features
         deepstack_visual_indices: list[int] = field(default_factory=lambda: [7, 15, 23])
 
-        # Sub-module configs (built in the registry).
         patch_embed: PatchEmbed.Config
         rotary_pos_emb: VisionRotaryEmbedding.Config
         layers: list[VisionTransformerBlock.Config]

--- a/torchtitan/models/qwen3_vl/vision_encoder.py
+++ b/torchtitan/models/qwen3_vl/vision_encoder.py
@@ -227,24 +227,22 @@ class PatchEmbed(Module):
     Same weighted sum, but Linear uses efficient batched matrix multiplication.
     """
 
-    def __init__(
-        self,
-        patch_size: int,
-        temporal_patch_size: int,
-        in_channels: int,
-        embed_dim: int,
-        *,
-        proj: Linear.Config,
-    ):
-        super().__init__()
-        self.patch_size = patch_size
-        self.temporal_patch_size = temporal_patch_size
-        self.in_channels = in_channels
-        self.embed_dim = embed_dim
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        patch_size: int
+        temporal_patch_size: int
+        in_channels: int
+        proj: Linear.Config
 
-        # patch_dim matches the flattened patch from collator: (pt * ph * pw * c)
-        self.patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
-        self.proj = proj.build()
+    def __init__(self, config: Config):
+        super().__init__()
+        # Kept on the Module so the state-dict adapter can reshape
+        # Linear weights into 5D Conv3d weights.
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+
+        self.proj = config.proj.build()
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Project patches to embeddings.
@@ -261,11 +259,19 @@ class PatchEmbed(Module):
 class VisionRotaryEmbedding(Module):
     """2D Rotary Position Embedding for Vision Transformer."""
 
-    def __init__(self, dim: int, theta: float = 10000.0):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        dim: int
+        theta: float = 10000.0
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.dim = dim
-        self.theta = theta
-        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.dim = config.dim
+        self.theta = config.theta
+        inv_freq = 1.0 / (
+            config.theta
+            ** (torch.arange(0, config.dim, 2, dtype=torch.float) / config.dim)
+        )
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def _init_self_buffers(self, *, buffer_device: torch.device | None = None) -> None:
@@ -291,39 +297,35 @@ class VisionRotaryEmbedding(Module):
 class PatchMerger(Module):
     """Merge spatial patches to reduce sequence length.
 
-    Args:
-        hidden_size: Hidden dimension of input features
-        out_hidden_size: Output hidden dimension after merging
-        spatial_merge_size: Number of patches to merge per spatial dimension
-        use_postshuffle_norm: If True, apply LayerNorm after spatial reshape
-            (norm dim = hidden_size * spatial_merge_size^2). If False, apply
-            before reshape (norm dim = hidden_size). DeepStack mergers use
-            postshuffle norm; the main merger uses pre-shuffle norm
+    ``use_postshuffle_norm``: If True, apply LayerNorm after spatial reshape
+    (norm dim = hidden_size * spatial_merge_size^2). If False, apply
+    before reshape (norm dim = hidden_size). DeepStack mergers use
+    postshuffle norm; the main merger uses pre-shuffle norm. The caller
+    must set ``norm.normalized_shape`` to match the chosen mode.
     """
 
-    def __init__(
-        self,
-        hidden_size: int,
-        out_hidden_size: int,
-        spatial_merge_size: int,
-        *,
-        fc1: Linear.Config,
-        fc2: Linear.Config,
-        use_postshuffle_norm: bool = False,
-    ):
-        super().__init__()
-        self.spatial_merge_size = spatial_merge_size
-        self.merged_hidden_size = hidden_size * (spatial_merge_size**2)
-        self.use_postshuffle_norm = use_postshuffle_norm
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        hidden_size: int
+        spatial_merge_size: int
+        fc1: Linear.Config
+        fc2: Linear.Config
+        norm: LayerNorm.Config
+        act_fn: GELU.Config = field(
+            default_factory=lambda: GELU.Config(approximate="tanh")
+        )
+        use_postshuffle_norm: bool = False
 
-        norm_dim = self.merged_hidden_size if use_postshuffle_norm else hidden_size
-        self.norm = LayerNorm.Config(
-            normalized_shape=norm_dim,
-            eps=1e-6,
-        ).build()
-        self.linear_fc1 = fc1.build()
-        self.act_fn = GELU.Config(approximate="tanh").build()
-        self.linear_fc2 = fc2.build()
+    def __init__(self, config: Config):
+        super().__init__()
+        self.spatial_merge_size = config.spatial_merge_size
+        self.merged_hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = config.use_postshuffle_norm
+
+        self.norm = config.norm.build()
+        self.linear_fc1 = config.fc1.build()
+        self.act_fn = config.act_fn.build()
+        self.linear_fc2 = config.fc2.build()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Merge spatial patches and project to output dimension.
@@ -356,17 +358,25 @@ class PatchMerger(Module):
 class VisionAttention(Module):
     """Multi-head attention with FlexAttention for efficient batched processing."""
 
-    def __init__(
-        self, dim: int, n_heads: int, *, qkv: Linear.Config, proj: Linear.Config
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        dim: int
+        n_heads: int
+        qkv: Linear.Config
+        proj: Linear.Config
+        flex_attention: FlexAttention.Config = field(
+            default_factory=lambda: FlexAttention.Config()
+        )
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.dim = dim
-        self.num_heads = n_heads
+        self.dim = config.dim
+        self.num_heads = config.n_heads
         self.head_dim = self.dim // self.num_heads
 
-        self.qkv = qkv.build()
-        self.proj = proj.build()
-        self.flex_attention = FlexAttention.Config().build()
+        self.qkv = config.qkv.build()
+        self.proj = config.proj.build()
+        self.flex_attention = config.flex_attention.build()
 
     def forward(
         self,
@@ -390,12 +400,9 @@ class VisionAttention(Module):
         qkv = self.qkv(hidden_states).reshape(
             num_vision, max_num_patch, 3, -1, self.head_dim
         )
-        q, k, v = qkv.permute(2, 0, 1, 3, 4).unbind(
-            0
-        )  # Each: (num_vision, max_num_patch, heads, head_dim)
-
+        # Each: (num_vision, max_num_patch, n_heads, head_dim)
+        q, k, v = qkv.permute(2, 0, 1, 3, 4).unbind(0)
         q, k = apply_rotary_emb_cos_sin(q, k, rope_cache)
-
         attn_output = self.flex_attention(q, k, v, attention_masks=attention_mask)
         attn_output = attn_output.reshape(num_vision, max_num_patch, -1)
         return self.proj(attn_output)
@@ -404,11 +411,19 @@ class VisionAttention(Module):
 class VisionMLP(Module):
     """Feed-forward network with GELU activation."""
 
-    def __init__(self, *, fc1: Linear.Config, fc2: Linear.Config):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        fc1: Linear.Config
+        fc2: Linear.Config
+        act_fn: GELU.Config = field(
+            default_factory=lambda: GELU.Config(approximate="tanh")
+        )
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.linear_fc1 = fc1.build()
-        self.linear_fc2 = fc2.build()
-        self.act_fn = GELU.Config(approximate="tanh").build()
+        self.linear_fc1 = config.fc1.build()
+        self.linear_fc2 = config.fc2.build()
+        self.act_fn = config.act_fn.build()
 
     def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
         return self.linear_fc2(self.act_fn(self.linear_fc1(hidden_state)))
@@ -417,28 +432,19 @@ class VisionMLP(Module):
 class VisionTransformerBlock(Module):
     """Single transformer block for vision encoder."""
 
-    def __init__(
-        self,
-        dim: int,
-        n_heads: int,
-        layer_norm_eps: float,
-        *,
-        attn_qkv: Linear.Config,
-        attn_proj: Linear.Config,
-        mlp_fc1: Linear.Config,
-        mlp_fc2: Linear.Config,
-    ):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        attn: VisionAttention.Config
+        mlp: VisionMLP.Config
+        norm1: LayerNorm.Config
+        norm2: LayerNorm.Config
+
+    def __init__(self, config: Config):
         super().__init__()
-        self.norm1 = LayerNorm.Config(
-            normalized_shape=dim,
-            eps=layer_norm_eps,
-        ).build()
-        self.norm2 = LayerNorm.Config(
-            normalized_shape=dim,
-            eps=layer_norm_eps,
-        ).build()
-        self.attn = VisionAttention(dim, n_heads, qkv=attn_qkv, proj=attn_proj)
-        self.mlp = VisionMLP(fc1=mlp_fc1, fc2=mlp_fc2)
+        self.norm1 = config.norm1.build()
+        self.norm2 = config.norm2.build()
+        self.attn = config.attn.build()
+        self.mlp = config.mlp.build()
 
     def forward(
         self,
@@ -464,49 +470,38 @@ class Qwen3VLVisionEncoder(Module):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
-        """Configuration for Qwen3-VL Vision Encoder (ViT)."""
+        """Configuration for Qwen3-VL Vision Encoder (ViT).
 
-        dim: int = 1280
-        ffn_dim: int = 5120
-        n_layers: int = 32
-        n_heads: int = 16
+        ``num_position_embeddings`` and ``dim`` stay on this Config because
+        ``pos_embed`` is an ``nn.Parameter`` owned directly by the encoder
+        (not factored into a sub-Module). ``n_heads`` is kept to derive
+        ``head_dim`` inside ``compute_position_embeddings``.
+        ``spatial_merge_size`` and ``deepstack_visual_indices`` are read by
+        ``Qwen3VLModel``.
+        """
 
-        patch_size: int = 16
-        temporal_patch_size: int = 2
-        in_channels: int = 3
+        dim: int
+        n_heads: int
         spatial_merge_size: int = 2
-
-        out_hidden_size: int = 3584  # maps to LLM hidden size
         num_position_embeddings: int = 4096
-        layer_norm_eps: float = 1e-6
-        rope_theta: float = 10000.0
 
         # DeepStack: layer indices for extracting intermediate visual features
         deepstack_visual_indices: list[int] = field(default_factory=lambda: [7, 15, 23])
 
-        # Per-layer Linear configs for vision encoder sub-modules
-        patch_embed_proj: Linear.Config
-        attn_qkv: Linear.Config
-        attn_proj: Linear.Config
-        mlp_fc1: Linear.Config
-        mlp_fc2: Linear.Config
-        merger_fc1: Linear.Config
-        merger_fc2: Linear.Config
+        # Sub-module configs (built in the registry).
+        patch_embed: PatchEmbed.Config
+        rotary_pos_emb: VisionRotaryEmbedding.Config
+        layers: list[VisionTransformerBlock.Config]
+        merger: PatchMerger.Config
+        deepstack_mergers: list[PatchMerger.Config]
 
     def __init__(self, config: Config):
         super().__init__()
         self.config = config
         self.spatial_merge_size = config.spatial_merge_size
-        self.patch_size = config.patch_size
         self.spatial_merge_unit = config.spatial_merge_size**2
 
-        self.patch_embed = PatchEmbed(
-            patch_size=config.patch_size,
-            temporal_patch_size=config.temporal_patch_size,
-            in_channels=config.in_channels,
-            embed_dim=config.dim,
-            proj=config.patch_embed_proj,
-        )
+        self.patch_embed = config.patch_embed.build()
 
         # nn.Parameter (not nn.Embedding) because we interpolate the weight directly
         self.num_position_embeddings = config.num_position_embeddings
@@ -515,51 +510,20 @@ class Qwen3VLVisionEncoder(Module):
         )
         self.num_grid_per_side = int(config.num_position_embeddings**0.5)
 
-        head_dim = config.dim // config.n_heads
-        self.rotary_pos_emb = VisionRotaryEmbedding(
-            head_dim // 2, theta=config.rope_theta
-        )
+        self.rotary_pos_emb = config.rotary_pos_emb.build()
         # Cached RoPE freq table — recomputed only when max_hw grows
         self._cached_freq_table: torch.Tensor | None = None
 
         self.layers = ModuleDict(
-            {
-                str(idx): VisionTransformerBlock(
-                    config.dim,
-                    config.n_heads,
-                    config.layer_norm_eps,
-                    attn_qkv=config.attn_qkv,
-                    attn_proj=config.attn_proj,
-                    mlp_fc1=config.mlp_fc1,
-                    mlp_fc2=config.mlp_fc2,
-                )
-                for idx in range(config.n_layers)
-            }
+            {str(idx): layer.build() for idx, layer in enumerate(config.layers)}
         )
 
-        self.merger = PatchMerger(
-            hidden_size=config.dim,
-            out_hidden_size=config.out_hidden_size,
-            spatial_merge_size=config.spatial_merge_size,
-            fc1=config.merger_fc1,
-            fc2=config.merger_fc2,
-        )
+        self.merger = config.merger.build()
 
         # DeepStack mergers for intermediate layers
-        # DeepStack mergers use postshuffle norm (norm after spatial reshape)
         self.deepstack_visual_indices = config.deepstack_visual_indices
         self.deepstack_merger_list = ModuleList(
-            [
-                PatchMerger(
-                    hidden_size=config.dim,
-                    out_hidden_size=config.out_hidden_size,
-                    spatial_merge_size=config.spatial_merge_size,
-                    fc1=config.merger_fc1,
-                    fc2=config.merger_fc2,
-                    use_postshuffle_norm=True,
-                )
-                for _ in range(len(config.deepstack_visual_indices))
-            ]
+            [cfg.build() for cfg in config.deepstack_mergers]
         )
 
     def compute_position_embeddings(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3447
* __->__ #3446
* #3445

Change all module classes to be config-based and are set during __init__.py. This unblocks us to do parallelize() for qwen3-vl (not in this PR).

Verified the loss bit-wise parity with 100 steps.