### PR TITLE
Fix model test failure in #3395: rope refactor

### DIFF
--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -109,8 +109,9 @@ class Decoder(BaseModel):
 
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
-                n_heads = self.layers[0].attention.n_heads
-                n_kv_heads = self.layers[0].attention.n_kv_heads or n_heads
+                attention = self.layers[0].attention
+                n_heads = attention.n_heads
+                n_kv_heads = getattr(attention, "n_kv_heads", None) or n_heads
                 if n_heads % tp != 0:
                     raise ValueError(
                         f"tensor_parallel_degree ({tp}) must divide "

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -408,6 +408,9 @@ def apply_rotary_emb_cos_sin(
     positions = _maybe_wrap_positions(positions, xq)
     head_dim = xq.shape[-1]
     if rope_cache.ndim != 4:
+        # Qwen3-VL MRoPE passes a pre-broadcast 4D RoPE cache where shape[0]
+        # is batch size, not max sequence length, so only validate positions
+        # for non-4D indexed caches.
         if positions is not None:
             _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
         rope_cache = _reshape_for_broadcast_cos_sin(rope_cache, xq, positions)

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -408,9 +408,8 @@ def apply_rotary_emb_cos_sin(
     positions = _maybe_wrap_positions(positions, xq)
     head_dim = xq.shape[-1]
     if rope_cache.ndim != 4:
-        # Qwen3-VL MRoPE passes a pre-broadcast 4D RoPE cache where shape[0]
-        # is batch size, not max sequence length, so only validate positions
-        # for non-4D indexed caches.
+        # Qwen3-VL MRoPE validates position IDs before building its 4D cache.
+        # Here shape[0] is max sequence length only for non-4D indexed caches.
         if positions is not None:
             _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
         rope_cache = _reshape_for_broadcast_cos_sin(rope_cache, xq, positions)

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -406,10 +406,10 @@ def apply_rotary_emb_cos_sin(
         positions: optional position indices
     """
     positions = _maybe_wrap_positions(positions, xq)
-    if positions is not None:
-        _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
     head_dim = xq.shape[-1]
     if rope_cache.ndim != 4:
+        if positions is not None:
+            _maybe_check_max_pos(positions, max_valid_pos=rope_cache.shape[0] - 1)
         rope_cache = _reshape_for_broadcast_cos_sin(rope_cache, xq, positions)
     cos = rope_cache[..., :head_dim].to(device=xq.device)
     sin = rope_cache[..., head_dim:].to(device=xq.device)

--- a/torchtitan/models/qwen3_vl/model.py
+++ b/torchtitan/models/qwen3_vl/model.py
@@ -13,6 +13,7 @@ from torch.distributed.tensor import DTensor
 
 from torchtitan.models.common.attention import AttentionMasksType, GQAttention
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.rope import _maybe_check_max_pos
 from torchtitan.models.qwen3.model import Qwen3Model
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 
@@ -289,6 +290,7 @@ class Qwen3VLModel(Qwen3Model):
         freqs_cis = self.freqs_cis
         if isinstance(freqs_cis, DTensor):
             freqs_cis = freqs_cis.to_local()
+        _maybe_check_max_pos(position_ids, max_valid_pos=freqs_cis.shape[0] - 1)
         head_dim = freqs_cis.shape[-1] // 2
         cos_cache = freqs_cis[:, :head_dim]
         sin_cache = freqs_cis[:, head_dim:]


### PR DESCRIPTION
Fixs needed in #3395.

This is by running model test on a 8GPU devmachine, as our main branch CI keeps failing.
- decoder.py: shared TP validation assumed every attention config has n_kv_heads, but DeepSeek V3 MLA only has n_heads, so we fall back to n_heads when KV heads are not separate.
 
- rope.py: Qwen3-VL MRoPE passes a pre-broadcast 4D RoPE cache where shape[0] is batch size, not max sequence length, so the position bounds check must only run for non-4D indexed caches. cc @shuhuayu 