### PR TITLE
For Monarch Future, use `await fut` instead of `fut.get()` when applicable

### DIFF
--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -534,12 +534,12 @@ class RLTrainer(Configurable):
 
         # Initial weight sync from trainer to generator
         with sl.log_trace_span("trainer_push_model_state_dict"):
-            self.trainer.push_model_state_dict.call().get()
+            await self.trainer.push_model_state_dict.call()
         with sl.log_trace_span("generator_pull_model_state_dict"):
-            self.generator.pull_model_state_dict.call(0).get()
+            await self.generator.pull_model_state_dict.call(0)
 
     @sl.log_trace_span("_collect_rollouts")
-    def _collect_rollouts(
+    async def _collect_rollouts(
         self,
         num_groups: int,
         step: int,
@@ -565,7 +565,7 @@ class RLTrainer(Configurable):
             for env in envs
         ]
         completions, generation_metrics = self._get_rank_0_value(
-            self.generator.generate.call(tokenized_prompts).get()
+            await self.generator.generate.call(tokenized_prompts)
         )
 
         trajectories: list[Trajectory] = []
@@ -690,11 +690,11 @@ class RLTrainer(Configurable):
             for env in envs
         ]
         completions, generation_metrics = self._get_rank_0_value(
-            self.generator.generate.call(
+            await self.generator.generate.call(
                 tokenized_prompts,
                 sampling_config=greedy,
                 metrics_prefix="validation_generator",
-            ).get()
+            )
         )
 
         trajectories = [
@@ -753,11 +753,6 @@ class RLTrainer(Configurable):
             # Propagate the step counter to actors for structured logging.
             self.trainer.sync_log_step.call(step)
             self.generator.sync_log_step.call(step)
-            # Cancellation point for Ctrl-C (KeyboardInterrupt) handling.
-            # This yields to the event loop to check for cancellation, which
-            # doesn't happen with `.get` calls.
-            # TODO: investigate replacing `.get()` with `await
-            await asyncio.sleep(0)
 
             t_step_start = time.perf_counter()
 
@@ -776,7 +771,7 @@ class RLTrainer(Configurable):
             # rows, so actual token consumption may exceed collected_tokens.
             num_tokens_target = self.batcher.num_tokens_target(self.trainer_dp_degree)
             while collected_tokens < num_tokens_target:
-                new_trajectories, new_metrics = self._collect_rollouts(
+                new_trajectories, new_metrics = await self._collect_rollouts(
                     num_groups, step=step, group_offset=group_offset
                 )
                 trajectories.extend(new_trajectories)
@@ -812,9 +807,9 @@ class RLTrainer(Configurable):
             for microbatch in microbatches:
                 with sl.log_trace_span("trainer_forward_backward_call"):
                     mb_metrics = self._get_rank_0_value(
-                        self.trainer.forward_backward.call(
+                        await self.trainer.forward_backward.call(
                             microbatch, num_global_valid_tokens
-                        ).get()
+                        )
                     )
                     for k, v in mb_metrics.items():
                         if k not in fwd_bwd_metrics:
@@ -825,7 +820,7 @@ class RLTrainer(Configurable):
                             fwd_bwd_metrics[k] += v
             with sl.log_trace_span("trainer_optim_step_call"):
                 optim_output = self._get_rank_0_value(
-                    self.trainer.optim_step.call().get()
+                    await self.trainer.optim_step.call()
                 )
             trainer_policy_version = optim_output.policy_version
             optimizer_metrics = optim_output.metrics
@@ -836,10 +831,10 @@ class RLTrainer(Configurable):
             # instead of having `trainer.optim_step` return it
             t_push_start = time.perf_counter()
             with sl.log_trace_span("trainer_push_model_state_dict"):
-                self.trainer.push_model_state_dict.call().get()
+                await self.trainer.push_model_state_dict.call()
             t_weight_sync_push_s = time.perf_counter() - t_push_start
             with sl.log_trace_span("generator_pull_model_state_dict"):
-                self.generator.pull_model_state_dict.call(trainer_policy_version).get()
+                await self.generator.pull_model_state_dict.call(trainer_policy_version)
             t_weight_sync_total_s = time.perf_counter() - t_push_start
             t_step_s = time.perf_counter() - t_step_start
             # --- divergence check before any logging ---


### PR DESCRIPTION
when Monarch's `Future.get()` is called from within an active event loop, it blocks synchronously and does not yield control. As a result, it may degrade performance by preventing other tasks from running, and can potentially cause deadlocks if this future depends on them. [Monarch encourages](https://github.com/meta-pytorch/monarch/blob/017244c8a608f8ccf22f94c2f542cee00f1fecc4/python/monarch/_src/actor/future.py#L114-L115) its users to use 'await' instead in this situation.

This PR updates `grpo.py` to be consistent with this recommendation.

## Test Plan

I run the smoke test from the README to make sure the smoke test still works with both `torchmonarch==0.4.1` and `--pre monarch`. I also verified I could cancel the test in the middle of training by `ctrl+c`.