### PR TITLE
Refactor gypo.py into trainer.py and train.py

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -81,7 +81,7 @@ jobs:
           --index-strategy unsafe-best-match
 
         # 4. Install torchtitan in editable mode because integration test spawns
-        # python grpo.py as a subprocess
+        # python train.py as a subprocess
         uv pip install -e .
 
         # 5. Download HF model checkpoint for tests

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -88,7 +88,7 @@ jobs:
           --index-strategy unsafe-best-match
 
         # 5. Install torchtitan in editable mode because integration test spawns
-        # python grpo.py as a subprocess
+        # python train.py as a subprocess
         uv pip install -e .
 
         # 6. Download HF model checkpoint for tests

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -8,7 +8,7 @@ This directory contains code for RL training using TorchTitan model definitions 
 The integration consists of the following components:
 
 1. **vLLM Model Wrapper** (`models/vllm_wrapper.py`): Adapts TorchTitan models for vLLM's inference engine
-2. **RL Training Loop** (`grpo.py`): GRPO-based RL training with Monarch actors (single-turn only for now)
+2. **RL Training Loop** (`train.py`): GRPO-based RL training with Monarch actors (single-turn only for now)
 
 
 ## Key features available
@@ -73,7 +73,7 @@ python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-1.7B --local_dir torch
 
 7. Run simple GRPO RL loop to learn sum digits task. This also serves as an end-to-end smoke test that your environment is set up correctly.
 ```bash
-python torchtitan/experiments/rl/grpo.py --module rl --config rl_grpo_qwen3_0_6b
+python torchtitan/experiments/rl/train.py --module rl --config rl_grpo_qwen3_0_6b
 ```
 
 **NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
@@ -103,7 +103,7 @@ If you want to run true on-policy mode in TorchTitan RL and debug generator/trai
 Now we only support logprob bitwise parity when trainer and generator are under the same parallelism.
 Example:
 ```bash
-python torchtitan/experiments/rl/grpo.py --module rl --config  rl_grpo_qwen3_0_6b_batch_invariant
+python torchtitan/experiments/rl/train.py --module rl --config  rl_grpo_qwen3_0_6b_batch_invariant
 ```
 
 This config sets `DebugConfig(batch_invariant=True, deterministic=True)` and `training.dtype="bfloat16"` (required so the trainer computes in the same precision as the generator, as a limitation because TP only doesn't naturally support mixed precision training).

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -27,9 +27,9 @@ from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGener
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
 from torchtitan.experiments.rl.examples.sum_digits import SumDigitsRollouter
-from torchtitan.experiments.rl.grpo import GRPOLoss, RLTrainer
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
+from torchtitan.experiments.rl.trainer import GRPOLoss, RLTrainer
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.qwen3 import model_registry
 from torchtitan.protocols.model import ModelConfigConverter

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -7,9 +7,9 @@
 """
 Integration tests for the RL unified workstream.
 
-Runs the full GRPO training loop (simple_grpo.py) with different
+Runs the full GRPO training loop (train.py) with different
 parallelism configurations. Uses OverrideDefinitions from the shared
-test infrastructure but with a custom runner since simple_grpo.py is
+test infrastructure but with a custom runner since train.py is
 a Monarch script (run with ``python``, not ``torchrun``).
 
 Usage:
@@ -102,7 +102,7 @@ def run_single_test(
     """Run a single RL integration test.
 
     Unlike the standard run_tests which uses ``./run_train.sh`` (torchrun),
-    this runs ``python simple_grpo.py`` directly since the RL script manages
+    this runs ``python train.py`` directly since the RL script manages
     its own distributed setup via Monarch.
     """
     test_name = test_flavor.test_name
@@ -111,7 +111,7 @@ def run_single_test(
     for override_arg in test_flavor.override_args:
         cmd_parts = [
             "python",
-            "torchtitan/experiments/rl/grpo.py",
+            "torchtitan/experiments/rl/train.py",
             f"--dump_folder {dump_folder}",
         ]
         if hf_assets_path:

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -63,7 +63,7 @@ from torchtitan.experiments.rl.config_registry import (
     rl_grpo_qwen3_0_6b_batch_invariant,
     rl_grpo_qwen3_0_6b_flex_batch_invariant,
 )
-from torchtitan.experiments.rl.grpo import RLTrainer
+from torchtitan.experiments.rl.trainer import RLTrainer
 from torchtitan.experiments.rl.models.vllm_registry import (
     registry_to_vllm,
     VLLM_MODEL_NAME,

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -63,11 +63,11 @@ from torchtitan.experiments.rl.config_registry import (
     rl_grpo_qwen3_0_6b_batch_invariant,
     rl_grpo_qwen3_0_6b_flex_batch_invariant,
 )
-from torchtitan.experiments.rl.trainer import RLTrainer
 from torchtitan.experiments.rl.models.vllm_registry import (
     registry_to_vllm,
     VLLM_MODEL_NAME,
 )
+from torchtitan.experiments.rl.trainer import RLTrainer
 from torchtitan.models.common.attention import (
     create_attention_mask,
     FlexAttention,

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from torchtitan.experiments.rl import grpo
+from torchtitan.experiments.rl import train
 from torchtitan.experiments.rl.actors.generator import VLLMGenerator
 from torchtitan.experiments.rl.batcher import Batcher
 
@@ -22,7 +22,7 @@ class _FakeRLTrainer:
         self.events = []
         self.instances.append(self)
 
-    async def setup_async(self):
+    async def setup_async(self, *, trainer_mesh=None, generator_mesh=None):
         self.events.append("setup")
         if getattr(self.config, "fail_setup", False):
             raise RuntimeError("setup failed")
@@ -44,6 +44,10 @@ class _FakeDebug:
 
 class _FakeTrainerConfig:
     debug = _FakeDebug()
+    # main() reads config.trainer.parallelism to size the trainer mesh; the
+    # value is irrelevant here because stub_mesh_provisioning stubs
+    # _compute_world_size, so a placeholder is enough to resolve the access.
+    parallelism = None
 
 
 class _FakeConfig:
@@ -51,6 +55,15 @@ class _FakeConfig:
 
     dump_folder = "/tmp/test_rl"
     trainer = _FakeTrainerConfig()
+    # main() also reads config.generator.parallelism (same stubbing applies).
+    generator = SimpleNamespace(parallelism=None)
+
+    @property
+    def __class__(self):
+        # main() does `assert isinstance(config, RLTrainer.Config)`. Reporting
+        # that type lets this lightweight stand-in pass the check (the
+        # unittest.mock `spec` idiom) without constructing a real Config.
+        return train.RLTrainer.Config
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
@@ -89,37 +102,51 @@ def _make_stub_rl_trainer():
         def to_dict(self):
             return {}
 
-    return grpo.RLTrainer(_StubConfig())
+    return train.RLTrainer(_StubConfig())
 
 
-def test_main_shuts_down_after_success(monkeypatch):
+@pytest.fixture
+def stub_mesh_provisioning(monkeypatch):
+    """Stub the Monarch mesh provisioning ``main()`` runs before ``setup_async``.
+
+    ``spawn_proc_mesh`` spawns real GPU proc meshes and ``_compute_world_size``
+    reads parallelism degrees; neither matters to shutdown behavior, so stub
+    both and let the test intercept at the ``_FakeRLTrainer`` boundary.
+    """
+    monkeypatch.setattr(train, "_compute_world_size", lambda p: 1)
+    monkeypatch.setattr(
+        train, "spawn_proc_mesh", lambda *args, **kwargs: (object(), object())
+    )
+
+
+def test_main_shuts_down_after_success(monkeypatch, stub_mesh_provisioning):
     _FakeConfigManager.config = _FakeConfig()
     _FakeRLTrainer.instances = []
-    monkeypatch.setattr(grpo, "ConfigManager", _FakeConfigManager)
+    monkeypatch.setattr(train, "ConfigManager", _FakeConfigManager)
 
-    asyncio.run(grpo.main())
+    asyncio.run(train.main())
 
     assert _FakeRLTrainer.instances[0].events == ["setup", "train", "close"]
 
 
-def test_main_shuts_down_after_train_failure(monkeypatch):
+def test_main_shuts_down_after_train_failure(monkeypatch, stub_mesh_provisioning):
     _FakeConfigManager.config = _FakeConfig(fail_train=True)
     _FakeRLTrainer.instances = []
-    monkeypatch.setattr(grpo, "ConfigManager", _FakeConfigManager)
+    monkeypatch.setattr(train, "ConfigManager", _FakeConfigManager)
 
     with pytest.raises(RuntimeError, match="train failed"):
-        asyncio.run(grpo.main())
+        asyncio.run(train.main())
 
     assert _FakeRLTrainer.instances[0].events == ["setup", "train", "close"]
 
 
-def test_main_shuts_down_after_setup_failure(monkeypatch):
+def test_main_shuts_down_after_setup_failure(monkeypatch, stub_mesh_provisioning):
     _FakeConfigManager.config = _FakeConfig(fail_setup=True)
     _FakeRLTrainer.instances = []
-    monkeypatch.setattr(grpo, "ConfigManager", _FakeConfigManager)
+    monkeypatch.setattr(train, "ConfigManager", _FakeConfigManager)
 
     with pytest.raises(RuntimeError, match="setup failed"):
-        asyncio.run(grpo.main())
+        asyncio.run(train.main())
 
     assert _FakeRLTrainer.instances[0].events == ["setup", "close"]
 
@@ -134,17 +161,17 @@ def test_rl_trainer_shutdown_is_noop_before_meshes_spawn():
     assert trainer._proc_meshes == []
 
 
-def test_main_swallows_cancellation_after_shutdown(monkeypatch):
+def test_main_swallows_cancellation_after_shutdown(monkeypatch, stub_mesh_provisioning):
     """Signal-driven cancellation surfaces as ``CancelledError`` from the
     running task; ``main`` runs ``close`` in ``finally`` and the explicit
     ``except`` clause swallows the interrupt so the process exits 0
     without a traceback."""
     _FakeConfigManager.config = _FakeConfig(cancel_train=True)
     _FakeRLTrainer.instances = []
-    monkeypatch.setattr(grpo, "ConfigManager", _FakeConfigManager)
+    monkeypatch.setattr(train, "ConfigManager", _FakeConfigManager)
 
     # No exception escapes; close still ran.
-    asyncio.run(grpo.main())
+    asyncio.run(train.main())
 
     assert _FakeRLTrainer.instances[0].events == ["setup", "train", "close"]
 

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -1,0 +1,208 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+RL training loop using Monarch Actors.
+
+This demonstrates:
+1. Distributed actor architecture with VLLMGenerator (vLLM) and PolicyTrainer (TorchTitan)
+   running on separate GPU meshes
+2. Weight synchronization across meshes via TorchStore: the trainer publishes its
+   model state dict and the generator pulls it into its own parallelism layout,
+   with direct GPU-to-GPU RDMA transfer when available
+3. Envs driven rollouts; reward and advantage computation live inline
+   in the controller.
+
+Command to run:
+python3 torchtitan/experiments/rl/train.py \
+    --module rl --config rl_grpo_qwen3_0_6b \
+    --hf_assets_path=<path_to_model_checkpoint>
+"""
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# must run before torch import. Set it as early as possible to avoid other
+# imports transitively importing torch.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+from monarch.actor import HostMesh, ProcMesh, this_host
+
+from torchtitan.config import ConfigManager, ParallelismConfig
+from torchtitan.experiments.rl.trainer import RLTrainer
+from torchtitan.observability import structured_logger as sl
+
+
+logger = logging.getLogger(__name__)
+
+
+class PerHostProvisioner:
+    """Allocates non-overlapping GPU ranges within a single host.
+
+    On the same host, the trainer and generator run on separate GPU
+    meshes (e.g. GPUs 0-3 for training, GPUs 4-7 for generation). Each
+    call to `allocate(n)` reserves the next *n* GPUs and returns a
+    bootstrap callable that sets `CUDA_VISIBLE_DEVICES` before CUDA
+    initializes in the spawned process, ensuring each mesh only sees its
+    own devices.
+    """
+
+    def __init__(self, total_gpus: int = 8):
+        self.total_gpus = total_gpus
+        self.next_gpu = 0
+
+    @property
+    def available(self) -> int:
+        return self.total_gpus - self.next_gpu
+
+    def allocate(self, num_gpus: int) -> Callable[[], None]:
+        if num_gpus > self.available:
+            raise RuntimeError(
+                f"Requested {num_gpus} GPUs but only {self.available} "
+                f"available (total={self.total_gpus}, allocated={self.next_gpu})"
+            )
+        gpu_ids = list(range(self.next_gpu, self.next_gpu + num_gpus))
+        self.next_gpu += num_gpus
+
+        def _bootstrap():
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
+            # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
+            import torch  # noqa: F401
+
+        return _bootstrap
+
+
+@dataclass
+class HostMeshes:
+    trainer: HostMesh
+    generator: HostMesh
+    gpus_per_node: int
+
+
+def _compute_world_size(p: ParallelismConfig) -> int:
+    """Compute world size from all parallel dimensions."""
+    dp_shard = max(p.data_parallel_shard_degree, 1)
+    return (
+        p.data_parallel_replicate_degree
+        * dp_shard
+        * p.tensor_parallel_degree
+        * p.pipeline_parallel_degree
+        * p.context_parallel_degree
+    )
+
+
+def spawn_proc_mesh(
+    trainer_world_size: int,
+    generator_world_size: int,
+    host_meshes: HostMeshes | None = None,
+) -> tuple[ProcMesh, ProcMesh]:
+    """Spawn the trainer and generator proc meshes.
+
+    Args:
+        trainer_world_size: Number of GPU procs to spawn for the trainer.
+        generator_world_size: Number of GPU procs to spawn for the generator.
+        host_meshes: Caller-provided trainer/generator host meshes. When
+            provided, each role is spawned on its provided host mesh. None means
+            both roles are spawned on ``this_host()``by using non-overlapping
+            GPU ranges.
+
+    Returns:
+        The ``(trainer_mesh, generator_mesh)`` proc meshes.
+    """
+    total_gpus = trainer_world_size + generator_world_size
+    logger.info(
+        f"{generator_world_size} generator GPUs + "
+        f"{trainer_world_size} trainer GPUs = {total_gpus} total"
+    )
+
+    if host_meshes is not None:
+        trainer_host_mesh = host_meshes.trainer
+        generator_host_mesh = host_meshes.generator
+        gpus_per_node = host_meshes.gpus_per_node
+
+        trainer_nodes = trainer_host_mesh.sizes["hosts"]
+        generator_nodes = generator_host_mesh.sizes["hosts"]
+        # Validate that world sizes are evenly divisible by node counts
+        assert trainer_world_size % trainer_nodes == 0, (
+            f"trainer_world_size ({trainer_world_size}) must be "
+            f"evenly divisible by trainer_nodes ({trainer_nodes})"
+        )
+        assert generator_world_size % generator_nodes == 0, (
+            f"generator_world_size ({generator_world_size}) must be "
+            f"evenly divisible by generator_nodes ({generator_nodes})"
+        )
+
+        # Compute GPUs per node for each role based on the world size and
+        # number of nodes allocated to that role
+        trainer_gpus_per_node = trainer_world_size // trainer_nodes
+        generator_gpus_per_node = generator_world_size // generator_nodes
+
+        # Use PerHostProvisioner to set CUDA_VISIBLE_DEVICES so each role
+        # only sees its own GPUs and doesn't conflict with other
+        # processes on the node
+        trainer_provisioner = PerHostProvisioner(total_gpus=gpus_per_node)
+        generator_provisioner = PerHostProvisioner(total_gpus=gpus_per_node)
+
+        trainer_mesh = trainer_host_mesh.spawn_procs(
+            per_host={"gpus": trainer_gpus_per_node},
+            bootstrap=trainer_provisioner.allocate(trainer_gpus_per_node),
+        )
+        generator_mesh = generator_host_mesh.spawn_procs(
+            per_host={"gpus": generator_gpus_per_node},
+            bootstrap=generator_provisioner.allocate(generator_gpus_per_node),
+        )
+    else:
+        # Single-node mode: partition GPUs on this_host() via
+        # CUDA_VISIBLE_DEVICES
+        provisioner = PerHostProvisioner(total_gpus=total_gpus)
+        trainer_mesh = this_host().spawn_procs(
+            per_host={"gpus": trainer_world_size},
+            bootstrap=provisioner.allocate(trainer_world_size),
+        )
+        generator_mesh = this_host().spawn_procs(
+            per_host={"gpus": generator_world_size},
+            bootstrap=provisioner.allocate(generator_world_size),
+        )
+
+    return trainer_mesh, generator_mesh
+
+
+async def main():
+    config = ConfigManager().parse_args()
+    assert isinstance(config, RLTrainer.Config)
+    sl.init_structured_logger(
+        source="rl_controller",
+        output_dir=config.dump_folder,
+        rank=0,
+        enable=config.trainer.debug.enable_structured_logging,
+    )
+    sl.log_trace_instant("structured_logger_started")
+
+    rl_trainer: RLTrainer = config.build()
+    try:
+        trainer_world_size = _compute_world_size(config.trainer.parallelism)
+        generator_world_size = _compute_world_size(config.generator.parallelism)
+        trainer_mesh, generator_mesh = spawn_proc_mesh(
+            trainer_world_size,
+            generator_world_size,
+            host_meshes=None,
+        )
+        await rl_trainer.setup_async(
+            trainer_mesh=trainer_mesh,
+            generator_mesh=generator_mesh,
+        )
+        await rl_trainer.train()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logger.info("Interrupted; attempting graceful shutdown...")
+    finally:
+        await rl_trainer.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -5,20 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-RL training loop using Monarch Actors.
-
-This demonstrates:
-1. Distributed actor architecture with VLLMGenerator (vLLM) and PolicyTrainer (TorchTitan)
-   running on separate GPU meshes
-2. Weight synchronization across meshes: trainer gathers full (unsharded) weights,
-   generator reshards to match its own parallelism layout via distribute_tensor
-3. Envs driven rollouts; reward and advantage computation live inline
-   in the controller.
-
-Command to run:
-python3 torchtitan/experiments/rl/grpo.py \
-    --module rl --config rl_grpo_qwen3_0_6b \
-    --hf_assets_path=<path_to_model_checkpoint>
+RL trainer used for synchronous grpo training.
 """
 
 import asyncio
@@ -27,7 +14,6 @@ import math
 import os
 import statistics
 import time
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 
@@ -36,15 +22,9 @@ os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import torch
 import torchstore as ts
-from monarch.actor import this_host
+from monarch.actor import ProcMesh
 from monarch.spmd import setup_torch_elastic_env_async
-
-from torchtitan.config import (
-    CompileConfig,
-    ConfigManager,
-    Configurable,
-    ParallelismConfig,
-)
+from torchtitan.config import CompileConfig, Configurable
 from torchtitan.experiments.rl.actors.generator import (
     Completion,
     SamplingConfig,
@@ -144,42 +124,6 @@ class GRPOLoss(Configurable):
             }
 
         return loss, metrics
-
-
-class Provisioner:
-    """Allocates non-overlapping GPU ranges for Monarch proc meshes.
-
-    In non-colocated mode, the trainer and generator run on separate GPU
-    meshes (e.g. GPUs 0-3 for training, GPUs 4-7 for generation). Each
-    call to `allocate(n)` reserves the next *n* GPUs and returns a
-    bootstrap callable that sets `CUDA_VISIBLE_DEVICES` before CUDA
-    initializes in the spawned process, ensuring each mesh only sees its
-    own devices.
-    """
-
-    def __init__(self, total_gpus: int = 8):
-        self.total_gpus = total_gpus
-        self.next_gpu = 0
-
-    @property
-    def available(self) -> int:
-        return self.total_gpus - self.next_gpu
-
-    def allocate(self, num_gpus: int) -> Callable[[], None]:
-        if num_gpus > self.available:
-            raise RuntimeError(
-                f"Requested {num_gpus} GPUs but only {self.available} "
-                f"available (total={self.total_gpus}, allocated={self.next_gpu})"
-            )
-        gpu_ids = list(range(self.next_gpu, self.next_gpu + num_gpus))
-        self.next_gpu += num_gpus
-
-        def _bootstrap():
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
-            # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
-            import torch  # noqa: F401
-
-        return _bootstrap
 
 
 def _log_samples(rollout_groups: list[RolloutGroup]) -> None:
@@ -369,32 +313,14 @@ class RLTrainer(Configurable):
                 logger.exception("mesh.stop[%d] failed", i)
         self._proc_meshes = []
 
-    def _get_rank_0_value(self, result, has_gpus: bool = True):
-        """Extract rank 0 result, handling both single and multi-node meshes.
+    def _get_rank_0_value(self, result):
+        """Extract rank 0 result from a Monarch ValueMesh.
 
         Monarch actor endpoints return results from all ranks in the mesh.
-        This picks out rank 0's result by indexing into the host and GPU
-        dimensions as needed (multi-node meshes have an extra host dimension).
-        This should be used in cases where all ranks return the same result.
+        This method picks out rank 0's result. This should be used in cases
+        where all ranks return the same result.
         """
-        kwargs = {}
-        if self._multi_node:
-            kwargs["hosts"] = 0
-        if has_gpus:
-            kwargs["gpus"] = 0
-        return result.item(**kwargs)
-
-    @staticmethod
-    def _compute_world_size(p: ParallelismConfig) -> int:
-        """Compute world size from all parallel dimensions."""
-        dp_shard = max(p.data_parallel_shard_degree, 1)
-        return (
-            p.data_parallel_replicate_degree
-            * dp_shard
-            * p.tensor_parallel_degree
-            * p.pipeline_parallel_degree
-            * p.context_parallel_degree
-        )
+        return result.get(0)
 
     def _shard_episodes(self, episodes: list[Episode]) -> list[list[Episode]]:
         """Round-robin partition episodes across DP ranks."""
@@ -407,10 +333,8 @@ class RLTrainer(Configurable):
     async def setup_async(
         self,
         *,
-        host_mesh=None,
-        trainer_nodes: int | None = None,
-        generator_nodes: int | None = None,
-        gpus_per_node: int | None = None,
+        trainer_mesh: ProcMesh,
+        generator_mesh: ProcMesh,
     ):
         """Spawn Monarch actors on separate meshes and initialize weights.
 
@@ -419,21 +343,14 @@ class RLTrainer(Configurable):
         weight push/pull are all ``await``-based runtime side effects
         that cannot run in a synchronous constructor.
 
-        Creates separate GPU meshes for trainer and generator and
-        synchronizes initial weights from trainer to generator. Must be
-        called before :meth:`train`.
+        The trainer and generator meshes are provisioned by the caller
+        (see ``create_proc_mesh``) on disjoint GPUs; this method only
+        spawns the actors on them and synchronizes initial weights from
+        trainer to generator. Must be called before :meth:`train`.
 
         Args:
-            host_mesh: Optional multi-node HostMesh. When provided,
-                whole nodes are dedicated to trainer vs generator
-                roles instead of partitioning GPUs on a single host.
-            trainer_nodes: Number of nodes for the trainer (required when
-                host_mesh is provided).
-            generator_nodes: Number of nodes for the generator (required when
-                host_mesh is provided).
-            gpus_per_node: GPUs per node, assumed to be the same across all
-                nodes (no heterogeneous node configurations). Required when
-                host_mesh is provided.
+            trainer_mesh: ProcMesh the trainer actor is spawned on.
+            generator_mesh: ProcMesh the generator actor is spawned on.
         """
         # Thread pool for TokenEnv's asyncio.to_thread renderer calls — one worker per
         # concurrent rollout, capped by CPUs.
@@ -448,86 +365,16 @@ class RLTrainer(Configurable):
 
         config = self.config
 
-        self.trainer_world_size = self._compute_world_size(config.trainer.parallelism)
-        self.generator_world_size = self._compute_world_size(
-            config.generator.parallelism
-        )
         trainer_parallelism = config.trainer.parallelism
         dp_shard = max(trainer_parallelism.data_parallel_shard_degree, 1)
         self.trainer_dp_degree = (
             trainer_parallelism.data_parallel_replicate_degree * dp_shard
         )
 
-        total_gpus = self.trainer_world_size + self.generator_world_size
-        logger.info(
-            f"{self.generator_world_size} generator GPUs + "
-            f"{self.trainer_world_size} trainer GPUs = {total_gpus} total"
-        )
-
-        self._multi_node = host_mesh is not None
-
         # TODO(observability): the mesh_spawn span wraps ~80 LoC of branching
-        # provisioner logic. Pull a Provisioner.spawn_meshes(...) helper and
+        # provisioner logic. Pull a PerHostProvisioner.spawn_meshes(...) helper and
         # shrink this span to a single call.
         with sl.log_trace_span("mesh_spawn"):
-            if host_mesh is not None:
-                # Multi-node mode: dedicate whole nodes to trainer vs generator
-                if (
-                    trainer_nodes is None
-                    or generator_nodes is None
-                    or gpus_per_node is None
-                ):
-                    raise ValueError(
-                        "trainer_nodes, generator_nodes, and gpus_per_node are "
-                        "required when host_mesh is provided"
-                    )
-                # Validate that world sizes are evenly divisible by node counts
-                assert self.trainer_world_size % trainer_nodes == 0, (
-                    f"trainer_world_size ({self.trainer_world_size}) must be "
-                    f"evenly divisible by trainer_nodes ({trainer_nodes})"
-                )
-                assert self.generator_world_size % generator_nodes == 0, (
-                    f"generator_world_size ({self.generator_world_size}) must be "
-                    f"evenly divisible by generator_nodes ({generator_nodes})"
-                )
-
-                # Compute GPUs per node for each role based on the config's
-                # world size and number of nodes allocated to that role
-                trainer_gpus_per_node = self.trainer_world_size // trainer_nodes
-                generator_gpus_per_node = self.generator_world_size // generator_nodes
-
-                trainer_host_mesh = host_mesh.slice(hosts=slice(0, trainer_nodes))
-                generator_host_mesh = host_mesh.slice(
-                    hosts=slice(trainer_nodes, trainer_nodes + generator_nodes)
-                )
-
-                # Use Provisioner to set CUDA_VISIBLE_DEVICES so each role
-                # only sees its own GPUs and doesn't conflict with other
-                # processes on the node
-                trainer_provisioner = Provisioner(total_gpus=gpus_per_node)
-                generator_provisioner = Provisioner(total_gpus=gpus_per_node)
-
-                trainer_mesh = trainer_host_mesh.spawn_procs(
-                    per_host={"gpus": trainer_gpus_per_node},
-                    bootstrap=trainer_provisioner.allocate(trainer_gpus_per_node),
-                )
-                generator_mesh = generator_host_mesh.spawn_procs(
-                    per_host={"gpus": generator_gpus_per_node},
-                    bootstrap=generator_provisioner.allocate(generator_gpus_per_node),
-                )
-            else:
-                # Single-node mode: partition GPUs on this_host() via
-                # CUDA_VISIBLE_DEVICES
-                provisioner = Provisioner(total_gpus=total_gpus)
-                trainer_mesh = this_host().spawn_procs(
-                    per_host={"gpus": self.trainer_world_size},
-                    bootstrap=provisioner.allocate(self.trainer_world_size),
-                )
-                generator_mesh = this_host().spawn_procs(
-                    per_host={"gpus": self.generator_world_size},
-                    bootstrap=provisioner.allocate(self.generator_world_size),
-                )
-
             # Store proc meshes for cleanup
             self._proc_meshes = [trainer_mesh, generator_mesh]
 
@@ -1159,28 +1006,3 @@ class RLTrainer(Configurable):
             post = post_validation_agg.get(key, float("nan"))
             logger.info(f"  {key}:  {pre:+.3f}  /  {post:+.3f}")
         logger.info("=" * 60)
-
-
-async def main():
-    config = ConfigManager().parse_args()
-    sl.init_structured_logger(
-        source="rl_controller",
-        output_dir=config.dump_folder,
-        rank=0,
-        # pyrefly: ignore [missing-attribute]
-        enable=config.trainer.debug.enable_structured_logging,
-    )
-    sl.log_trace_instant("structured_logger_started")
-
-    rl_trainer = config.build()
-    try:
-        await rl_trainer.setup_async()
-        await rl_trainer.train()
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        logger.info("Interrupted; attempting graceful shutdown...")
-    finally:
-        await rl_trainer.close()
-
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -24,6 +24,7 @@ import torch
 import torchstore as ts
 from monarch.actor import ProcMesh
 from monarch.spmd import setup_torch_elastic_env_async
+
 from torchtitan.config import CompileConfig, Configurable
 from torchtitan.experiments.rl.actors.generator import (
     Completion,


### PR DESCRIPTION
`grpo.py` logically contains two parts:
* The runner part that parses the config, build Trainer, and kick off training
* The actual Trainer.

This is similar to how pretraining is set up, and provides a cleaner structure. This PR does the refactoring.
