### PR TITLE
fix(gpt_oss): avoid swiglu intermediate allocation

### DIFF
--- a/tests/unit_tests/test_gpt_oss_moe.py
+++ b/tests/unit_tests/test_gpt_oss_moe.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from torchtitan.models.gpt_oss.moe import swiglu
+
+
+def _reference_swiglu(x, alpha: float = 1.702, limit: float = 7.0):
+    x_glu, x_linear = x[..., ::2], x[..., 1::2]
+    x_glu = x_glu.clamp(min=None, max=limit)
+    x_linear = x_linear.clamp(min=-limit, max=limit)
+    out_glu = x_glu * torch.sigmoid(alpha * x_glu)
+    return out_glu * (x_linear + 1)
+
+
+def test_swiglu_matches_reference_formula_and_gradients():
+    torch.manual_seed(0)
+    x = torch.randn(4, 8, dtype=torch.float64, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+
+    out = swiglu(x, alpha=1.5, limit=2.0)
+    out_ref = _reference_swiglu(x_ref, alpha=1.5, limit=2.0)
+
+    torch.testing.assert_close(out, out_ref)
+
+    grad = torch.randn_like(out)
+    out.backward(grad)
+    out_ref.backward(grad)
+
+    torch.testing.assert_close(x.grad, x_ref.grad)

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -47,7 +47,7 @@ def swiglu(x, alpha: float = 1.702, limit: float = 7.0):
     x_linear = x_linear.clamp(min=-limit, max=limit)
     out_glu = x_glu * torch.sigmoid(alpha * x_glu)
     # Note we add an extra bias of 1 to the linear layer
-    return out_glu * (x_linear + 1)
+    return torch.addcmul(out_glu, out_glu, x_linear)
 
 
 class GptOssGroupedExperts(Module):


### PR DESCRIPTION
## Summary
- Replace `out_glu * (x_linear + 1)` in gpt_oss `swiglu` with `torch.addcmul(out_glu, out_glu, x_linear)`.
- Avoid materializing the large `(x_linear + 1)` intermediate in eager mode while preserving the same computation.
- Add a unit test covering forward value and gradient equivalence against the original formula.

## Issues
- Fixes #3437