### PR TITLE
[graph_trainer] Fix cudagraph silently skipped with full inductor compilation

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -305,7 +305,11 @@ _FLEX_ATTENTION_OPS = {
 }
 
 
-def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
+def is_cudagraph_compatible(
+    gm: torch.fx.GraphModule,
+    *,
+    skip_flex_attention_check: bool = False,
+) -> bool:
     """Check whether the graph can be safely captured by CUDA graph.
 
     Returns False (with a warning) when the graph contains patterns
@@ -325,6 +329,12 @@ def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
       Math implementation that is incompatible with CUDA graph capture.
       The expected workflow is to apply regional_inductor first to compile
       flex_attention regions, then apply cudagraph.
+
+    Args:
+        gm: The graph module to check.
+        skip_flex_attention_check: When True, skip the flex_attention HOP
+            check. Used by ``full_inductor_compilation_pass`` which always
+            compiles flex_attention HOPs away during the collapse.
     """
     # ``full_inductor_compilation_pass`` collapses the FX graph into one
     # opaque ``standalone_compile_inner`` node, hiding ops the per-node
@@ -378,14 +388,15 @@ def is_cudagraph_compatible(gm: torch.fx.GraphModule) -> bool:
                 )
                 return False
 
-    for node in gm.graph.nodes:
-        if node.op == "call_function" and node.target in _FLEX_ATTENTION_OPS:
-            logger.warning(
-                "Skipping cudagraph: graph contains flex_attention higher-order "
-                "ops that require regional_inductor to compile before cudagraph "
-                "can capture"
-            )
-            return False
+    if not skip_flex_attention_check:
+        for node in gm.graph.nodes:
+            if node.op == "call_function" and node.target in _FLEX_ATTENTION_OPS:
+                logger.warning(
+                    "Skipping cudagraph: graph contains flex_attention higher-order "
+                    "ops that require regional_inductor to compile before cudagraph "
+                    "can capture"
+                )
+                return False
 
     return True
 

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -239,7 +239,9 @@ def full_inductor_compilation_pass(
 
     from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
 
-    pre_collapse_cudagraph_compatible = is_cudagraph_compatible(gm)
+    pre_collapse_cudagraph_compatible = is_cudagraph_compatible(
+        gm, skip_flex_attention_check=True
+    )
 
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():


### PR DESCRIPTION


`full_inductor_compilation_pass` checks `is_cudagraph_compatible()` before collapsing the FX graph into an opaque inductor-compiled node. At that point, flex_attention higher-order ops (HOPs) are still present in the graph and are flagged as cudagraph-incompatible. The verdict `cudagraph_compatible=False` is stashed in `gm.meta` and carried forward.

After the collapse, the flex_attention HOPs are compiled into Triton kernels inside `standalone_compile_inner`, and the resulting graph is actually cudagraph-compatible. But the stashed verdict blocks `cudagraph_pass` from applying.

The fix adds a `skip_flex_attention_check` parameter to `is_cudagraph_compatible()`. `full_inductor_compilation_pass` uses it because it always compiles flex_attention HOPs away during the collapse. Other callers (regional inductor path, direct cudagraph_pass) retain the default behavior.

Verified on llama3 8B, 8x H100:
- GT+FullInd+CG now correctly captures CUDA graph on all GPUs
- FSDP=8: 43.35% MFU (unchanged, GPU-compute-bound)
- TP=8: 22.93% MFU (was 22.74% before fix)
- Precompile+CG also works (requires artifact rebuild with this fix)

Test Plan:
```
# Verify cudagraph is applied (should print "Applied cudagraph pass"):
NCCL_GRAPH_REGISTER=0 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False \
torchrun --nproc_per_node=8 --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
  -m torchtitan.train \
  --module graph_trainer.llama3 \
  --config graph_trainer_llama3_debugmodel_flex_attn \
  --compile.inductor_compilation full \
  --training.steps 3 --profiler.no-enable_profiling --metrics.log_freq 1 \
  2>&1 | grep -i cudagraph
```

Authored with Claude Code.