### PR TITLE
[graph_trainer] Re-apply custom_codegen_pass for precompile artifacts…

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -238,6 +238,12 @@ def construct_default_graph_passes(
         passes.extend(
             compile_time_passes(traced_result, config, use_cudagraph=want_cudagraph)
         )
+    else:
+        # GraphModule.__reduce__ strips _CodegenGraphModule's fast dispatch
+        # during pickling, falling back to slow FX graph interpretation.
+        # Re-apply custom_codegen_pass to regenerate the monolithic Python
+        # forward from the graph IR which survives the pickle round-trip.
+        passes.append(custom_codegen_pass)
 
     if want_cudagraph:
         static_input_indices = list(range(traced_result.num_static_inputs))


### PR DESCRIPTION
… at training time

When a precompile artifact is saved, `GraphModule.__reduce__` (in PyTorch) reconstructs the module via `reduce_graph_module`, which always creates a base `GraphModule` -- discarding `_CodegenGraphModule`'s optimized forward that dispatches through a single monolithic Python function. The deserialized artifact falls back to the default FX `GraphModule.forward()`, which interprets ~4000+ graph nodes one-by-one through Python dict lookups and function calls.

This costs ~230 ms per training step (~2.5% overhead) on Llama3 8B at 8xH100, showing up as a ~1pp MFU gap between precompile and JIT paths.

The fix adds `custom_codegen_pass` to the runtime pass list when a precompile artifact is loaded. This pass regenerates the fast monolithic Python forward from the graph IR (which survives the pickle round-trip intact). It does not duplicate any graph transformation -- it is purely a dispatch optimization.

Measured on Llama3 8B, flex_attention, sac_and_offload, TP=1 FSDP=8, 8xH100 (steps 7-20 steady-state avg MFU):

| Config                      | Before | After  |
|-----------------------------|--------|--------|
| JIT (no VLR, upper bound)   | 42.75% | 42.75% |
| Precompile + VLR            | 41.69% | 42.20% |

The remaining ~0.55pp gap vs JIT is the intrinsic `--virtual-local-rank` overhead (CUDA device mapping indirection), confirmed by running JIT with VLR under warm inductor cache (42.84%).

Authored by Claude.

Test Plan:
```
cd torchtitan

# 1. Build precompile artifact (single GPU)
python -m torchtitan.experiments.graph_trainer.precompile_main \
  --module graph_trainer.llama3 \
  --config graph_trainer_llama3_8b_flex_attn \
  --parallelism.tensor-parallel-degree 1 \
  --parallelism.data-parallel-shard-degree 8 \
  --compile.memory-policy sac_and_offload \
  --compile.enable --compile.mode aot_fx_trace \
  --compile.inductor-compilation regional \
  --compile.precompile-artifact-dir /tmp/precompile_test

# 2. Train with artifact -- verify custom_codegen_pass appears in log
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False \
NCCL_GRAPH_REGISTER=0 \
torchrun --nproc_per_node=8 --virtual-local-rank \
  --local-ranks-filter 0 --role rank --tee 3 \
  -m torchtitan.train \
  --module graph_trainer.llama3 \
  --config graph_trainer_llama3_8b_flex_attn \
  --parallelism.tensor-parallel-degree 1 \
  --compile.memory-policy sac_and_offload \
  --compile.enable --compile.mode aot_fx_trace \
  --compile.inductor-compilation regional \
  --compile.disable-passes cudagraph_pass \
  --compile.precompile-artifact-dir /tmp/precompile_test \
  --training.steps 10

# Expected: log shows "Applying 1 graph passes: custom_codegen_pass"
# and "[CUSTOM_CODEGEN] Loaded module from ..."
# Numerics: bitwise identical to JIT path (verified 20 steps)
```