### PR TITLE
Use torchmonarch stable

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -65,7 +65,7 @@ jobs:
         pip install uv
 
         # 1. Install Monarch and TorchStore
-        uv pip install torchmonarch==0.4.1
+        uv pip install torchmonarch
         uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
         uv pip install pygtrie portpicker
 

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -54,7 +54,7 @@ jobs:
         pip install uv
 
         # 1. Install Monarch and TorchStore
-        uv pip install torchmonarch==0.3.0
+        uv pip install torchmonarch
         uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
         uv pip install pygtrie portpicker
 

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -29,7 +29,7 @@ source titan-rl/bin/activate
 
 1. Install Monarch and TorchStore from main:
 ```bash
-uv pip install torchmonarch==0.4.1
+uv pip install torchmonarch
 uv pip install --no-deps "git+https://github.com/meta-pytorch/torchstore.git@main"
 uv pip install pygtrie portpicker
 ```


### PR DESCRIPTION
monarch's latest stable release is 0.5.0:
https://pypi.org/project/torchmonarch/0.5.0/

Instead of pinning a version, it is better to install the latest stable directly, so we do use a version that is too old.