### PR TITLE
[CI] Migrate H100 8-GPU integration test to OSDC (ARC)

### DIFF
--- a/.ci/docker/common/install_user.sh
+++ b/.ci/docker/common/install_user.sh
@@ -7,9 +7,9 @@
 
 set -ex
 
-# Same as ec2-user
-echo "ci-user:x:1000:1000::/var/lib/ci-user:" >> /etc/passwd
-echo "ci-user:x:1000:" >> /etc/group
+# 1001 matches the OSDC/ARC runner uid so it can clean up $GITHUB_WORKSPACE
+echo "ci-user:x:1001:1001::/var/lib/ci-user:" >> /etc/passwd
+echo "ci-user:x:1001:" >> /etc/group
 # Needed on Focal or newer
 echo "ci-user:*:19110:0:99999:7:::" >> /etc/shadow
 

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -27,15 +27,17 @@ permissions:
   contents: read
 
 jobs:
+  # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-cuda: mt-l-bx86iamx-176-1800-h100-8
 
+  # Step 2: Use the dynamic matrix in the build-test job
   build-test:
     needs: set-matrix
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@huydo/linux-job-v3-shell-bash
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -37,7 +37,7 @@ jobs:
   # Step 2: Use the dynamic matrix in the build-test job
   build-test:
     needs: set-matrix
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@huydo/linux-job-v3-shell-bash
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -23,21 +23,19 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 
 jobs:
-  # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
     uses: ./.github/workflows/set-matrix.yaml
     with:
-      runner-cuda: linux.aws.h100.8
+      runner-cuda: mt-l-bx86iamx-176-1800-h100-8
 
-  # Step 2: Use the dynamic matrix in the build-test job
   build-test:
     needs: set-matrix
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
@@ -45,7 +43,8 @@ jobs:
       runner: ${{ matrix.runner }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      docker-image: ${{ matrix.docker-image }}
+      # Private-ECR image, tagged with the .ci/docker hash from set-matrix.yaml.
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45
@@ -66,19 +65,21 @@ jobs:
         if [ -n "${{ matrix.torch-version }}" ]; then
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
-        python -m pip install --force-reinstall --pre \
-          "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+
+        # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+        python -m pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy
+        # Clear PIP_EXTRA_INDEX_URL so the default cpu index can't supply a +cpu torch.
+        PIP_EXTRA_INDEX_URL= python -m pip install --force-reinstall --pre "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
 
         if [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
           export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
           echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
         fi
 
-        USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
+        USE_CPP=0 PIP_EXTRA_INDEX_URL= python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
-        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
-        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
+        mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
 
         # Enable CPP stacktraces for debugging symmetric memory initialization errors.
         # Disable Nvlink Sharp. The CI machine seems to be unstable state to support

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -20,6 +20,9 @@ on:
       matrix:
         description: dynamically set matrix
         value: ${{ jobs.set.outputs.matrix }}
+      docker-hash:
+        description: Git tree hash of .ci/docker, used to build the OSDC image tag
+        value: ${{ jobs.set.outputs.docker-hash }}
 
 jobs:
   set:
@@ -27,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
+      docker-hash: ${{ steps.set.outputs.docker-hash }}
     env:
       # Event flags evaluated by github actions before the step runs:
       IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -43,9 +47,15 @@ jobs:
       CUDA_RUNNER_INPUT: ${{ inputs.runner-cuda }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - id: set
         run: |
           set -euo pipefail
+
+          # .ci/docker tree hash, used to build the OSDC image tag.
+          DOCKER_HASH=$(git rev-parse HEAD:.ci/docker)
+          echo "docker-hash=${DOCKER_HASH}" >> "$GITHUB_OUTPUT"
 
           # Select runner if provided, else use default value
           ROCM_RUNNER="${ROCM_RUNNER_INPUT:-$DEFAULT_ROCM_RUNNER}"

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -36,8 +36,7 @@ jobs:
         USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
-        # Write coverage data/report under RUNNER_TEMP: the mounted workspace isn't
-        # writable by the container user (ci-user) when its uid differs from the host's.
-        mkdir -p "${RUNNER_TEMP}"
-        export COVERAGE_FILE="${RUNNER_TEMP}/.coverage"
-        pytest tests/unit_tests --cov=. --cov-report=xml:"${RUNNER_TEMP}/coverage.xml" --durations=20 -vv
+        # Write coverage data/report to /tmp (world-writable): the mounted workspace and
+        # RUNNER_TEMP are owned by the host uid, which the container user (ci-user) can't write.
+        export COVERAGE_FILE=/tmp/.coverage
+        pytest tests/unit_tests --cov=. --cov-report=xml:/tmp/coverage.xml --durations=20 -vv

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -36,4 +36,8 @@ jobs:
         USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
-        pytest tests/unit_tests --cov=. --cov-report=xml --durations=20 -vv
+        # Write coverage data/report under RUNNER_TEMP: the mounted workspace isn't
+        # writable by the container user (ci-user) when its uid differs from the host's.
+        mkdir -p "${RUNNER_TEMP}"
+        export COVERAGE_FILE="${RUNNER_TEMP}/.coverage"
+        pytest tests/unit_tests --cov=. --cov-report=xml:"${RUNNER_TEMP}/coverage.xml" --durations=20 -vv


### PR DESCRIPTION
Migrate the H100 8-GPU integration test to OSDC (ARC) runners now that capacity is available.

- `build-test` runs on `linux_job_v3` (`mt-l-bx86iamx-176-1800-h100-8`), inside the torchtitan CI image from ECR, tagged with the `.ci/docker` hash that `set-matrix.yaml` now returns.
- ROCm is included on v3 as well to see if it passes.