### PR TITLE
[Quantization] Consolidate MXFP8 Linear and GroupedExperts converters

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -11,66 +11,64 @@ from typing import Literal
 from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.common.nn_modules import Linear
+from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
 
 from .utils import swap_token_dispatcher
 
+try:
+    from torchao.prototype.moe_training.mxfp8_linear import (
+        MXFP8Linear as TorchAOMXFP8Linear,
+    )
 
-class MXFP8Linear(Linear):
-    """Linear that applies MXFP8 quantization in its constructor."""
+    class MXFP8Linear(TorchAOMXFP8Linear, Module):
+        """Inherits from Module (not Linear) to satisfy the Module protocol
+        (init_states, _param_init) while avoiding MRO conflicts with
+        Linear.__init__. Config still inherits from Linear.Config for
+        field compatibility.
+        """
 
-    @dataclass(kw_only=True, slots=True)
-    class Config(Linear.Config):
-        """Drop-in replacement for Linear.Config that builds MXFP8Linear."""
+        @dataclass(kw_only=True, slots=True)
+        class Config(Linear.Config):
+            """Drop-in replacement for Linear.Config that builds MXFP8Linear."""
 
-        _recipe_name: str = "mxfp8_rceil"
+            pass
 
-    def __init__(self, config: Config):
-        super().__init__(config)
-        from torchao.prototype.moe_training.config import (
-            MXFP8TrainingOpConfig,
-            MXFP8TrainingRecipe,
-        )
-        from torchao.quantization.quant_api import quantize_
+        def __init__(self, config: Config):
+            TorchAOMXFP8Linear.__init__(
+                self,
+                config.in_features,
+                config.out_features,
+                bias=config.bias,
+            )
 
-        recipe = MXFP8TrainingRecipe(config._recipe_name)
-        mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-        quantize_(self, config=mxfp8_op_config)
+except ImportError:
+    MXFP8Linear = None
 
 
 class MXFP8LinearConverter(QuantizationConverter):
-    """Apply MXFP8 quantization to modules matching FQNs (e.g. Flux blocks)."""
+    """Replace matching Linear.Config with MXFP8Linear.Config."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
-        recipe_name: Literal["mxfp8_rceil"] = "mxfp8_rceil"
-        """
-        Quantization recipe name for grouped GEMMs. Options: ["mxfp8_rceil"]
-
-        - mxfp8_rceil: MXFP8 dynamic quantization with RCEIL rounding mode when computing the e8m0 scale factors.
-        """
-
         fqns: list[str] = field(default_factory=list)
         """
-        *Prototype feature, performance optimization still in progress*
-        Comma-separated list of fully qualified names of MoE modules to apply MXFP8 dynamic quantization
-        on grouped GEMM operations.
-        This is a prototype feature that requires the torchao nightly build.
+        List of fully qualified names of modules to apply MXFP8 quantization to.
+        Only Linear.Config entries whose FQN contains a match are converted.
+        If empty, all Linear modules are converted.
         """
 
     def __init__(self, config: Config):
         self.config = config
 
-        if find_spec("torchao") is None:
+        if MXFP8Linear is None:
             raise ImportError(
                 "torchao is not installed. Please install it to use MXFP8 linear layers."
             )
 
-        # Can be removed if we enable the emulated versions
-        assert has_cuda_capability(
-            10, 0
-        ), "MXFP8 is only supported on SM100 or later architectures"
+        if not has_cuda_capability(10, 0):
+            raise ValueError("MXFP8 is only supported on SM100 or later architectures")
 
         if not self.config.model_compile_enabled:
             logger.warning(
@@ -79,6 +77,7 @@ class MXFP8LinearConverter(QuantizationConverter):
             )
 
     def convert(self, model_config) -> None:
+        assert MXFP8Linear is not None
         fqns = self.config.fqns
         for fqn, config, parent, attr in model_config.traverse(Linear.Config):
             if not fqns or any(target_fqn in fqn for target_fqn in fqns):
@@ -87,17 +86,13 @@ class MXFP8LinearConverter(QuantizationConverter):
                     out_features=config.out_features,
                     bias=config.bias,
                     param_init=config.param_init,
-                    _recipe_name=self.config.recipe_name,
                 )
                 if isinstance(parent, list):
                     parent[attr] = new_config
                 else:
                     setattr(parent, attr, new_config)
 
-        logger.info(
-            f"Converted modules to use dynamic {self.config.recipe_name} "
-            "quantization for grouped_mm and linear ops"
-        )
+        logger.info("Converted Linear layers to MXFP8Linear")
 
 
 _mxfp8_experts_cache: dict[type, type] = {}
@@ -153,7 +148,8 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
         """
         Quantization recipe name for grouped GEMMs. Options: ["mxfp8_rceil"]
 
-        - mxfp8_rceil: MXFP8 dynamic quantization with RCEIL rounding mode when computing the e8m0 scale factors.
+        - mxfp8_rceil: MXFP8 dynamic quantization with RCEIL rounding mode
+          when computing the e8m0 scale factors.
         """
 
     def __init__(self, config: Config):
@@ -164,9 +160,8 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                 "torchao is not installed. Please install it to use MXFP8 MoE training."
             )
 
-        assert has_cuda_capability(
-            10, 0
-        ), "MXFP8 is only supported on SM100 or later architectures"
+        if not has_cuda_capability(10, 0):
+            raise ValueError("MXFP8 is only supported on SM100 or later architectures")
 
         if not self.config.model_compile_enabled:
             logger.warning(
@@ -191,5 +186,5 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
 
         logger.info(
             f"Converted GroupedExperts to use dynamic {self.config.recipe_name} "
-            "quantization for grouped_mm and linear ops"
+            "quantization for grouped_mm ops"
         )

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -69,16 +69,15 @@ def has_quantization(model_config) -> bool:
     )
     from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
 
-    has_quant_linear = (
-        any(
-            isinstance(config, (Float8Linear.Config, MXFP8Linear.Config))
-            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
-        )
-        if Float8Linear is not None
-        else any(
-            isinstance(config, MXFP8Linear.Config)
-            for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
-        )
+    quant_linear_types: list[type] = []
+    if Float8Linear is not None:
+        quant_linear_types.append(Float8Linear.Config)
+    if MXFP8Linear is not None:
+        quant_linear_types.append(MXFP8Linear.Config)
+
+    has_quant_linear = bool(quant_linear_types) and any(
+        isinstance(config, tuple(quant_linear_types))
+        for _fqn, config, _parent, _attr in model_config.traverse(Linear.Config)
     )
     quant_experts_types = tuple(
         cls.Config  # type: ignore[attr-defined]


### PR DESCRIPTION
Migrate MXFP8Linear to use torchao's native MXFP8Linear (pytorch/ao#4374) instead of Linear + quantize_(), following the same pattern as Float8Linear.

Merge MXFP8LinearConverter and MXFP8GroupedExpertsConverter into a single MXFP8Converter that handles both Linear and GroupedExperts in one pass. For dense models (no GroupedExperts), the MoE traversal is a no-op.

Fixes pytorch/torchtitan#3219