### PR TITLE
[CI] Migrate GraphTrainer & RL H100 integration tests to OSDC (ARC)

### DIFF
--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -16,8 +16,8 @@ DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
 
 # Dependencies for DeepEP compilation (NVSHMEM needs libcudacxx, IB headers).
 sudo apt-get update -qq && sudo apt-get install -y -qq rdma-core libibverbs1 libmlx5-1 libibverbs-dev
-# sudo apt-get autoclean && sudo apt-get clean
-# sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # CCCL headers live under include/cccl/ in CUDA 13+ — symlink so
 # NVSHMEM's #include "cuda/std/tuple" resolves correctly.

--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -16,8 +16,8 @@ DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
 
 # Dependencies for DeepEP compilation (NVSHMEM needs libcudacxx, IB headers).
 sudo apt-get update -qq && sudo apt-get install -y -qq rdma-core libibverbs1 libmlx5-1 libibverbs-dev
-sudo apt-get clean
-sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+sudo apt-get autoclean && sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 # CCCL headers live under include/cccl/ in CUDA 13+ — symlink so
 # NVSHMEM's #include "cuda/std/tuple" resolves correctly.

--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -17,6 +17,7 @@ DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
 # Dependencies for DeepEP compilation (NVSHMEM needs libcudacxx, IB headers).
 sudo apt-get update -qq && sudo apt-get install -y -qq rdma-core libibverbs1 libmlx5-1 libibverbs-dev
 sudo apt-get autoclean && sudo apt-get clean
+echo "HERE I AM"
 sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # CCCL headers live under include/cccl/ in CUDA 13+ — symlink so

--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -10,7 +10,7 @@
 # breakage from upstream changes. Update the commit hash when
 # upgrading to a newer DeepEP version.
 
-set -ex
+set -eux
 
 DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
 

--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -16,9 +16,8 @@ DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
 
 # Dependencies for DeepEP compilation (NVSHMEM needs libcudacxx, IB headers).
 sudo apt-get update -qq && sudo apt-get install -y -qq rdma-core libibverbs1 libmlx5-1 libibverbs-dev
-sudo apt-get autoclean && sudo apt-get clean
-echo "HERE I AM"
-sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# sudo apt-get autoclean && sudo apt-get clean
+# sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # CCCL headers live under include/cccl/ in CUDA 13+ — symlink so
 # NVSHMEM's #include "cuda/std/tuple" resolves correctly.

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -24,18 +24,31 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 
 jobs:
-  build-test:
+  # Step 1: Dynamically compute the matrix based on conditions
+  set-matrix:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: ./.github/workflows/set-matrix.yaml
     with:
-      runner: linux.aws.h100.8
-      gpu-arch-type: cuda
-      gpu-arch-version: "13.0"
-      docker-image: torchtitan-ubuntu-22.04-clang12
+      runner-cuda: mt-l-bx86iamx-176-1800-h100-8
+      is-experimental: true
+
+  # Step 2: Use the dynamic matrix in the build-test job
+  build-test:
+    needs: set-matrix
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    with:
+      runner: ${{ matrix.runner }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      # Private-ECR image, tagged with the .ci/docker hash from set-matrix.yaml.
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45
@@ -52,13 +65,15 @@ jobs:
 
         pip config --user set global.progress_bar off
 
-        python -m pip install --force-reinstall --pre \
-          torch --index-url https://download.pytorch.org/whl/nightly/cu130
+        # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+        python -m pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy
+        # Clear PIP_EXTRA_INDEX_URL so the default cpu index can't supply a +cpu torch.
+        PIP_EXTRA_INDEX_URL= python -m pip install --force-reinstall --pre \
+          torch --index-url ${{ matrix.index-url }}
         python -m pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         python -m pip install git+https://github.com/meta-pytorch/autoparallel.git
 
-        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
-        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
+        mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
 
         # Install DeepEP for HybridEP integration test
         bash /install_deepep.sh

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -49,7 +49,7 @@ jobs:
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 360
+      timeout: 45
       script: |
         set -eux
 
@@ -85,7 +85,6 @@ jobs:
 
         # Install DeepEP for HybridEP integration test
         bash /install_deepep.sh
-        pip freeze
 
         # Enable CPP stacktraces for debugging symmetric memory initialization errors.
         # Disable Nvlink Sharp. The CI machine seems to be unstable state to support

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -85,8 +85,7 @@ jobs:
 
         # Install DeepEP for HybridEP integration test
         bash /install_deepep.sh
-
-        sleep 7200
+        pip freeze
 
         # Enable CPP stacktraces for debugging symmetric memory initialization errors.
         # Disable Nvlink Sharp. The CI machine seems to be unstable state to support

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -86,6 +86,8 @@ jobs:
         # Install DeepEP for HybridEP integration test
         bash /install_deepep.sh
 
+        sleep 7200
+
         # Enable CPP stacktraces for debugging symmetric memory initialization errors.
         # Disable Nvlink Sharp. The CI machine seems to be unstable state to support
         # NLVS according to several CI runs.

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -49,7 +49,7 @@ jobs:
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 45
+      timeout: 360
       script: |
         set -eux
 

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -22,18 +22,31 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 
 jobs:
-  build-test:
+  # Step 1: Dynamically compute the matrix based on conditions
+  set-matrix:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl')
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: ./.github/workflows/set-matrix.yaml
     with:
-      runner: linux.aws.h100.8
-      gpu-arch-type: cuda
-      gpu-arch-version: "13.0"
-      docker-image: torchtitan-ubuntu-22.04-clang12
+      runner-cuda: mt-l-bx86iamx-176-1800-h100-8
+      is-experimental: true
+
+  # Step 2: Use the dynamic matrix in the build-test job
+  build-test:
+    needs: set-matrix
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    with:
+      runner: ${{ matrix.runner }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      # Private-ECR image, tagged with the .ci/docker hash from set-matrix.yaml.
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
       timeout: 45
@@ -68,8 +81,9 @@ jobs:
 
         # torchvision must be installed from the nightly channel alongside torch
         # so its C++ extensions (e.g. torchvision::nms) match the torch ABI.
-        uv pip install torch torchvision vllm xformers --pre \
-          --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
+        # Clear PIP_EXTRA_INDEX_URL so the default cpu index can't supply a +cpu torch.
+        PIP_EXTRA_INDEX_URL= uv pip install torch torchvision vllm xformers --pre \
+          --extra-index-url ${{ matrix.index-url }} \
           --index-strategy unsafe-best-match
         uv pip install torchdata==0.12.0.dev20260327 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
@@ -80,8 +94,7 @@ jobs:
         # 6. Download HF model checkpoint for tests
         MODEL_PATH=$(python -c "from huggingface_hub import snapshot_download; print(snapshot_download('Qwen/Qwen3-0.6B'))")
 
-        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
-        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
+        mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
 
         # Install nvcc so FlashInfer can JIT compile its CUDA kernels.
         # vLLM uses FlashInfer sampler by default (vllm-project/vllm#40376)


### PR DESCRIPTION
Migrate the two remaining `linux.aws.h100.8` integration tests to the OSDC (ARC) H100 runners (`mt-l-bx86iamx-176-1800-h100-8`), following the same pattern as #3464, which migrated `integration_test_8gpu_h100.yaml`.

### Workflows migrated
- `.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml`
- `.github/workflows/integration_test_8gpu_rl_h100.yaml`

### Changes (both files)
- Route through `set-matrix.yaml` with `runner-cuda: mt-l-bx86iamx-176-1800-h100-8` and `is-experimental: true` (CUDA-only, no ROCm) — matching the other experiment workflows (`integration_test_4gpu_rl`, `8gpu_torchft`, `8gpu_transformers_modeling_backend`).
- `linux_job_v2.yml` → `linux_job_v3.yml`.
- Pull the private-ECR image tagged with the `.ci/docker` tree hash that `set-matrix.yaml` returns, instead of the bare public image name.
- Install torch from `${{ matrix.index-url }}` and clear `PIP_EXTRA_INDEX_URL` so the in-cluster cpu pypi-cache can't supply a `+cpu` torch build (FA3's `test/cu130` index in the RL workflow is preserved as-is).
- Drop `sudo mkdir/chown` for the artifacts dir (the v3 container user uid matches the OSDC runner); fix the `permissions:` block indentation.

### Behavior note
As with the sibling experiment workflows, the CUDA job runs on push to `main`, on the cron schedule, and on PR `synchronize` while the relevant ciflow label (`ciflow/h100.8` / `ciflow/rl`) is present. The bare `labeled` event itself produces an empty matrix (a property of the shared `set-matrix.yaml` + `is-experimental` path), so a subsequent push triggers the actual run.

### Motivation
`linux.aws.h100.8` capacity is being consolidated onto OSDC/ARC H100 runners; this finishes the migration started in #3464.