### PR TITLE
[ate_bench] ATE-Bench reproduction for TorchTitan (agent-task efficiency)

### DIFF
--- a/agent_tooling/ate_bench/.gitignore
+++ b/agent_tooling/ate_bench/.gitignore
@@ -1,0 +1,2 @@
+# ATE-Bench run outputs (transcripts, metrics, summaries) are generated artifacts.
+results/

--- a/agent_tooling/ate_bench/.gitignore
+++ b/agent_tooling/ate_bench/.gitignore
@@ -1,2 +1,6 @@
 # ATE-Bench run outputs (transcripts, metrics, summaries) are generated artifacts.
 results/
+# Task artifacts produced by the agent (routing traces, profiles, logs).
+workspace/
+# Transient per-attempt git worktrees (new-feature runner).
+worktrees/

--- a/agent_tooling/ate_bench/README.md
+++ b/agent_tooling/ate_bench/README.md
@@ -29,36 +29,56 @@ Five metrics, reported independently (no single scalar):
 | Per-turn context | mean of `input + cache_read + cache_creation` per assistant turn | ✅ (Table 5) |
 | Output tokens | sum of assistant `output_tokens` | ✅ (Table 5) |
 | Session duration | `result.duration_ms` | extra |
-| Active GPU time | training-run GPU time | ❌ N/A for Q&A (no training) |
+| Active GPU time | sampled via `gpu_monitor.py` (nvidia-smi) | ❌ N/A for Q&A; ✅ for operate/feature |
 
 ## Task suite (20 tasks, paper §4 / Appendix B)
 | Category | Count | Status here |
 |---|---|---|
-| **Q&A** — answer a code-property question, read-only, cite `file:line` | 12 | ✅ runnable (`tasks/qa/`) |
-| **Operate & Profile** — run / train+eval / routing trace / Nsight | 4 | 📋 specified, deferred (`tasks/operate_profile/`) |
-| **New Feature** — port Diff-attn / DynMoE / MoBA / MoE++ end-to-end | 4 | 📋 specified, deferred (`tasks/new_feature/`) |
+| **Q&A** — answer a code-property question, read-only, cite `file:line` | 12 | ✅ runnable (`run_qa.py`) |
+| **Operate & Profile** — run / train+eval / routing trace / Nsight | 4 | ✅ harness ready, GPU-gated (`run_operate.py`) |
+| **New Feature** — port Diff-attn / DynMoE / MoBA / MoE++ end-to-end | 4 | ✅ harness ready, GPU-gated (`run_feature.py`) |
 
-Q&A is CPU-only and needs no checkpoints/data, so it's the first runnable slice.
-The GPU categories need 8 GPUs, an MoE checkpoint, DCLM data, vLLM +
-lm-evaluation-harness, and Nsight Systems — their full specs and correctness
-checks are captured in the two category READMEs, ready to wire up later.
+Q&A is CPU-only (no checkpoints/data) and runs today. The operate/feature harness
+is complete — prompts, runners, programmatic checks, GPU-time monitor, and the
+LLM judge — but actually *passing* the tasks needs the GPU substrate (see
+**Prerequisites** below). Without it the agent still runs and effort metrics are
+logged; the artifact/loss checks just won't pass.
+
+### TorchTitan mapping (fixed config, paper Appendix B)
+`PP=4, EP=2, DP=1`, seq_len 2048, global batch 1024, BF16, 8 GPUs → TorchTitan's
+`run_train.sh` with `--parallelism.{pipeline,expert}_parallel_degree` etc. Model:
+an MoE model (`deepseek_v3` default; also `qwen3` `debugmodel_moe`, `llama4`,
+`gpt_oss`). Dataset: **C4** (TorchTitan native; the paper used DCLM). Checkpoint
+export/import: `scripts/checkpoint_conversion/convert_{to,from}_hf.py`. All encoded
+in `runner/repro_config.py` + `setup/train.sh`.
 
 ## Layout
 ```
 agent_tooling/ate_bench/
-  README.md                     <- this file
+  README.md
   tasks/
-    qa/
-      universal_instruction.txt <- prepended verbatim to every Q&A query
-      q01_process_groups.md ... q12_checkpoint_serialization.md
-    operate_profile/README.md   <- 4 tasks specified (deferred)
-    new_feature/README.md       <- 4 tasks specified (deferred)
+    qa/            universal_instruction.txt + q01..q12          (read-only Q&A)
+    operate_profile/  preamble.md + op1..op4 + README            (run/instrument/profile)
+    new_feature/      preamble.md + nf1..nf4 + references.md + rules/  (integrate arch)
+  setup/
+    train.sh       fixed-config TorchTitan launcher (the "provided training script")
+    evaluate.sh    OP2 export-to-HF + lm-eval HellaSwag via vLLM
   runner/
-    run_qa.py                   <- drives the fixed agent per task, N runs
-    metrics.py                  <- stream-json transcript -> 5 metrics
-    aggregate.py                <- medians -> Table-5-style report
-    grade_qa.md                 <- human citation-grading protocol
-  results/<label>/              <- transcripts + metrics (created on run)
+    run_qa.py        read-only Q&A runner
+    run_operate.py   operate/profile runner (full tools, GPU-time, artifact checks)
+    run_feature.py   new-feature runner (worktree per attempt, loss check + judge)
+    metrics.py       stream-json transcript -> effort metrics
+    aggregate.py     medians -> Table-style report (+ GPU time, correctness)
+    repro_config.py  fixed config + prompt placeholder rendering
+    agent_session.py shared headless-agent runner + GPU monitor
+    gpu_monitor.py   active GPU time via nvidia-smi sampling
+    judge.py         independent LLM judge for new-feature rules
+    worktrees.py     git worktree isolation for feature attempts
+    grade_qa.md      human citation-grading protocol (Q&A)
+    checks/          op1..op4 + nf_loss_curve programmatic checks
+  workspace/<label>/  task artifacts (routing-traces/, heavy-kernels/, ...)  [gitignored]
+  results/<label>/    transcripts + metrics                                   [gitignored]
+  worktrees/          transient per-attempt worktrees                         [gitignored]
 ```
 
 ## Run the Q&A suite
@@ -93,6 +113,42 @@ claude -p --output-format stream-json --verbose \
 ```
 with the target `--repo` as the working directory.
 
+## Run the Operate & Profile suite (GPU)
+```bash
+python agent_tooling/ate_bench/runner/run_operate.py \
+    --tasks all --runs 3 --label titan \
+    --module deepseek_v3 --config deepseek_v3_debugmodel \
+    --out agent_tooling/ate_bench/results/operate_titan
+python agent_tooling/ate_bench/runner/aggregate.py agent_tooling/ate_bench/results/operate_titan
+```
+Full toolset (edits auto-accepted), runs in the main checkout, GPU time measured,
+and after each attempt the task's programmatic artifact check runs (OP1 finite
+loss at step 5, OP2 finite HellaSwag, OP3 routing-trace npz validation, OP4
+top-kernels CSV schema). OP3 instruments code in the working tree — `git checkout`
+afterward to reset.
+
+## Run the New-Feature suite (GPU)
+```bash
+python agent_tooling/ate_bench/runner/run_feature.py \
+    --tasks all --runs 3 --label titan \
+    --judge-model claude-opus-4-7 \
+    --out agent_tooling/ate_bench/results/feature_titan
+python agent_tooling/ate_bench/runner/aggregate.py agent_tooling/ate_bench/results/feature_titan
+```
+Each attempt runs in an isolated git **worktree** off `main`. Correctness has two
+axes (paper B.3): the 64-step CE loss must decrease + stay finite
+(`checks/nf_loss_curve.py`), **and** an independent LLM **judge** must PASS the diff
+against the 3 fixed per-feature rules (`runner/judge.py`, `tasks/new_feature/rules/`).
+Both must hold.
+
+## Prerequisites for the GPU tasks
+- **8 GPUs** for the fixed mesh (PP=4 × EP=2). The `*_debugmodel` configs are tiny
+  (harness validation); paper-scale numbers need a full MoE config + checkpoint.
+- A **released MoE checkpoint** (OP3/OP4 resume from it; download via
+  `scripts/checkpoint_conversion/` + `scripts/download_hf_assets.py`).
+- **vLLM + lm-evaluation-harness** for OP2; **Nsight Systems** (`nsys`) for OP4.
+- **C4** dataset access for training (TorchTitan's default loader).
+
 ## Reproducing the paper's comparison
 To compare TorchTitan vs PithTrain (or Megatron-LM) fairly, run the **same**
 `run_qa.py` with `--repo` pointed at each framework's checkout (each on the commit
@@ -104,9 +160,15 @@ you want), then `aggregate.py dir1 dir2`. Correctness is graded per
   `--model` to pin a model; there is no verified CLI flag for reasoning effort, so
   absolute numbers will not match the paper. Keep the agent **identical across
   frameworks** in any one comparison — that's what makes the comparison valid.
-- **`Bash` is pre-approved.** Faithful to the paper (the agent gets Read/Grep/Glob/
-  Bash), but it means the headless agent can run arbitrary read-only shell
-  commands without prompting. `Edit`/`Write`/`NotebookEdit` are disabled, so it
-  cannot modify the working tree — but run only against repos you trust.
+- **Tool access differs by category.** Q&A is read-only (`Edit`/`Write`/
+  `NotebookEdit` disabled). Operate and new-feature get the **full toolset with
+  edits auto-accepted** (`--permission-mode acceptEdits`) since they must run and
+  modify the framework — so the headless agent runs arbitrary shell/edits without
+  prompting. New-feature attempts are isolated in throwaway git worktrees;
+  operate runs in the main checkout (OP3 leaves instrumentation edits — reset with
+  `git checkout`). Run only against repos you trust.
 - **Correctness gates the metrics.** Effort numbers are only meaningful for
-  *correct* attempts. Grade Q&A answers (`runner/grade_qa.md`) before reporting.
+  *correct* attempts. Q&A is human-graded (`runner/grade_qa.md`); operate/feature
+  correctness is computed automatically (artifact checks; loss curve + LLM judge).
+- **`active_gpu_time_s` needs nvidia-smi.** Without a GPU it reports `null`
+  (Q&A always does, by design).

--- a/agent_tooling/ate_bench/README.md
+++ b/agent_tooling/ate_bench/README.md
@@ -1,0 +1,112 @@
+# ATE-Bench (reproduction for TorchTitan)
+
+A local reproduction of **ATE-Bench**, the *Agent-Task Efficiency* benchmark from
+**PithTrain: A Compact and Agent-Native MoE Training System**
+([arXiv:2605.31463](https://arxiv.org/abs/2605.31463),
+[github.com/mlc-ai/pith-train](https://github.com/mlc-ai/pith-train)).
+
+ATE-Bench is **not released as runnable code** by the authors — it is specified in
+the paper (Appendix B: task descriptions + correctness checks; Appendix C:
+per-attempt values). This folder reconstructs it so we can run it against
+TorchTitan.
+
+## The idea (paper §4)
+Standard coding benchmarks (SWE-bench, MLE-bench, ...) **hold the codebase fixed
+and vary the agent** to score agent capability. ATE-Bench **inverts this**: it
+holds the *agent* fixed and varies the *framework*, so differences in agent cost
+isolate **framework design**. Lower agent cost on the same tasks = a more
+agent-friendly framework.
+
+The paper's fixed agent was **Claude Code (Opus 4.7, `xhigh` effort)**; each task
+was run **3 times** and **medians** reported across **PithTrain, Megatron-LM, and
+TorchTitan** (TorchTitan at commit `d84e83d`).
+
+## Effort metrics (lower is better)
+Five metrics, reported independently (no single scalar):
+| Metric | Source | Q&A? |
+|---|---|---|
+| Agent turns | `result.num_turns` | ✅ (Table 5) |
+| Per-turn context | mean of `input + cache_read + cache_creation` per assistant turn | ✅ (Table 5) |
+| Output tokens | sum of assistant `output_tokens` | ✅ (Table 5) |
+| Session duration | `result.duration_ms` | extra |
+| Active GPU time | training-run GPU time | ❌ N/A for Q&A (no training) |
+
+## Task suite (20 tasks, paper §4 / Appendix B)
+| Category | Count | Status here |
+|---|---|---|
+| **Q&A** — answer a code-property question, read-only, cite `file:line` | 12 | ✅ runnable (`tasks/qa/`) |
+| **Operate & Profile** — run / train+eval / routing trace / Nsight | 4 | 📋 specified, deferred (`tasks/operate_profile/`) |
+| **New Feature** — port Diff-attn / DynMoE / MoBA / MoE++ end-to-end | 4 | 📋 specified, deferred (`tasks/new_feature/`) |
+
+Q&A is CPU-only and needs no checkpoints/data, so it's the first runnable slice.
+The GPU categories need 8 GPUs, an MoE checkpoint, DCLM data, vLLM +
+lm-evaluation-harness, and Nsight Systems — their full specs and correctness
+checks are captured in the two category READMEs, ready to wire up later.
+
+## Layout
+```
+agent_tooling/ate_bench/
+  README.md                     <- this file
+  tasks/
+    qa/
+      universal_instruction.txt <- prepended verbatim to every Q&A query
+      q01_process_groups.md ... q12_checkpoint_serialization.md
+    operate_profile/README.md   <- 4 tasks specified (deferred)
+    new_feature/README.md       <- 4 tasks specified (deferred)
+  runner/
+    run_qa.py                   <- drives the fixed agent per task, N runs
+    metrics.py                  <- stream-json transcript -> 5 metrics
+    aggregate.py                <- medians -> Table-5-style report
+    grade_qa.md                 <- human citation-grading protocol
+  results/<label>/              <- transcripts + metrics (created on run)
+```
+
+## Run the Q&A suite
+```bash
+# one task, one run (smoke test)
+python agent_tooling/ate_bench/runner/run_qa.py \
+    --repo /home/bahuang/local/torchtitan_autodev \
+    --tasks q01 --runs 1 \
+    --out agent_tooling/ate_bench/results/titan
+
+# full suite, 3 runs (paper protocol)
+python agent_tooling/ate_bench/runner/run_qa.py \
+    --repo /home/bahuang/local/torchtitan_autodev \
+    --tasks all --runs 3 \
+    --out agent_tooling/ate_bench/results/titan
+
+# summarize (medians, Table-5 style)
+python agent_tooling/ate_bench/runner/aggregate.py \
+    agent_tooling/ate_bench/results/titan
+
+# cross-framework comparison (two+ results dirs side by side)
+python agent_tooling/ate_bench/runner/aggregate.py \
+    agent_tooling/ate_bench/results/titan \
+    agent_tooling/ate_bench/results/pithtrain
+```
+
+The agent is invoked headless and read-only:
+```
+claude -p --output-format stream-json --verbose \
+  --allowedTools Read Grep Glob Bash \
+  --disallowedTools Edit Write NotebookEdit
+```
+with the target `--repo` as the working directory.
+
+## Reproducing the paper's comparison
+To compare TorchTitan vs PithTrain (or Megatron-LM) fairly, run the **same**
+`run_qa.py` with `--repo` pointed at each framework's checkout (each on the commit
+you want), then `aggregate.py dir1 dir2`. Correctness is graded per
+`runner/grade_qa.md` before comparing effort.
+
+## Important caveats
+- **Agent ≠ paper's.** The paper used **Opus 4.7 at `xhigh` effort**. Pass
+  `--model` to pin a model; there is no verified CLI flag for reasoning effort, so
+  absolute numbers will not match the paper. Keep the agent **identical across
+  frameworks** in any one comparison — that's what makes the comparison valid.
+- **`Bash` is pre-approved.** Faithful to the paper (the agent gets Read/Grep/Glob/
+  Bash), but it means the headless agent can run arbitrary read-only shell
+  commands without prompting. `Edit`/`Write`/`NotebookEdit` are disabled, so it
+  cannot modify the working tree — but run only against repos you trust.
+- **Correctness gates the metrics.** Effort numbers are only meaningful for
+  *correct* attempts. Grade Q&A answers (`runner/grade_qa.md`) before reporting.

--- a/agent_tooling/ate_bench/README.md
+++ b/agent_tooling/ate_bench/README.md
@@ -46,7 +46,16 @@ logged; the artifact/loss checks just won't pass.
 
 ### TorchTitan mapping (fixed config, paper Appendix B)
 `PP=4, EP=2, DP=1`, seq_len 2048, global batch 1024, BF16, 8 GPUs → TorchTitan's
-`run_train.sh` with `--parallelism.{pipeline,expert}_parallel_degree` etc. Model:
+`run_train.sh` with `--parallelism.{pipeline,expert}_parallel_degree` etc.
+
+> **Mesh-notation gotcha (a framework-design difference ATE-Bench is about).** The
+> paper's mesh is multiplicative (`PP*EP*DP = 8`). TorchTitan's mesh requires
+> `dp_replicate*dp_shard*cp*tp*pp == world_size` with **EP carved from the data
+> axis**, not multiplied on top. So we set `pp=4`, `dp_shard=-1` (auto → 2 on 8
+> GPUs), `ep=2` (experts sharded across that data axis of 2). Setting `dp_shard=1`
+> fails validation (`1*1*1*1*4 != 8`).
+
+Model:
 an MoE model (`deepseek_v3` default; also `qwen3` `debugmodel_moe`, `llama4`,
 `gpt_oss`). Dataset: **C4** (TorchTitan native; the paper used DCLM). Checkpoint
 export/import: `scripts/checkpoint_conversion/convert_{to,from}_hf.py`. All encoded

--- a/agent_tooling/ate_bench/RESULTS_feature_titan.md
+++ b/agent_tooling/ate_bench/RESULTS_feature_titan.md
@@ -1,0 +1,54 @@
+# ATE-Bench New-Feature results — TorchTitan
+
+> **Status: all 4 architectures reproduced end-to-end (1 run each).** Each was
+> integrated into `deepseek_v3` by a fixed headless agent, trained 64 steps on real
+> C4, and judged on its 3 architectural rules. **All 4 CORRECT** (loss decreases +
+> judge PASS on all rules).
+
+## Setup
+- **Framework:** TorchTitan @ branch tip (per-attempt git worktree off the tip).
+- **Base model:** `deepseek_v3_debugmodel` (6 layers, 8 experts), mesh `pp=4, ep=2,
+  dp_shard=auto`, seq 2048, **global batch 64**, real `allenai/c4`, BF16, 8×H100.
+  (gbs=64 not the paper's 1024: 1024 is for 30B models; on the debug model it gives
+  grad-accum 64 + a degenerate loss. gbs=64 learns cleanly — see RESULTS_gpu_titan.)
+- **Implementing agent:** headless Claude Code (`opus-4-6` default), full tools.
+- **Correctness (paper B.3):** (1) 64-step CE loss decreases + finite; (2) an
+  independent LLM judge (`judge.py`) PASSes the `git diff` vs base against 3 fixed
+  per-feature rules. Both must hold.
+
+## Results
+
+| Task | Architecture | Loss (median first-8 → last-8) | Judge rules | Diff | Verdict |
+|---|---|---|---|---|---|
+| NF1 | Differential Attention | 4.29 → 2.77 | 3/3 PASS | 157 ln | ✅ CORRECT |
+| NF2 | DynMoE | 4.42 → 2.86 | 3/3 PASS | 329 ln | ✅ CORRECT |
+| NF3 | MoBA | 4.56 → 2.81 | 3/3 PASS | 151 ln | ✅ CORRECT |
+| NF4 | MoE++ | 4.53 → 2.87 | 3/3 PASS | 337 ln | ✅ CORRECT |
+
+**4/4 architectures integrated, trained, and verified.** What the judge confirmed:
+- **NF1 Diff:** `q.chunk(2)`/`k.chunk(2)`; learned per-head `lambda_{q1,k1,q2,k2}`
+  params; output `softmax(Q1K1^T)V − lambda·softmax(Q2K2^T)V`.
+- **NF2 DynMoE:** per-expert sigmoid gate (cosine sim), learned `threshold_E`
+  `nn.Parameter` → variable-k via hard mask; fixed-k aux loss disabled.
+- **NF3 MoBA:** configurable `block_size` (128); mean-pooled block-key gate
+  (`matmul(q, k_mean)`); causal masking (future blocks excluded, current handled).
+- **NF4 MoE++:** zero/copy/constant zero-computation experts; router widened
+  (`num_experts + num_zc`); heterogeneous load-balance loss for the zero experts.
+
+## Effort (single run; TorchTitan column only)
+| Task | Agent turns | Active GPU-time (GPU-s, 8 GPUs) |
+|---|---|---|
+| NF2 | 55 | 3320 (~7 min wall) |
+| NF3 | 33 | 3163 |
+| NF4 | 46 | 3499 |
+(NF1's turn/GPU counts were lost when its first attempt over-ran the timeout; its
+verdict was salvaged from the worktree + log.)
+
+## Caveats
+- **1 run, not 3.** The paper medians over 3 attempts. All 4 already PASS at 1 run,
+  so the pass/fail signal is solid; 3-run medians would only tighten the *effort*
+  numbers (and those are TorchTitan-only — the cross-framework 62%/64% headline
+  needs PithTrain/Megatron, absent here).
+- **Debug-scale base + gbs=64**, not paper-scale. This validates that each
+  architecture integrates and trains; it is not a paper-fidelity numeric match.
+- **Judge = `opus-4-6` default**, not the paper's `opus-4-7 @ xhigh`.

--- a/agent_tooling/ate_bench/RESULTS_gpu_titan.md
+++ b/agent_tooling/ate_bench/RESULTS_gpu_titan.md
@@ -1,0 +1,53 @@
+# ATE-Bench GPU tasks — validation status (TorchTitan)
+
+This records what was validated end-to-end for the **Operate & Profile** and
+**New-Feature** categories on 8×H100, and what blocks a paper-fidelity run.
+
+## ✅ Validated: the fixed mesh trains on 8×H100
+`setup/train.sh` with the corrected mapping (`pp=4, dp_shard=-1 (auto→2), ep=2`)
+launches and trains the `deepseek_v3_debugmodel` (6 layers, 8 experts):
+
+```
+Model deepseek_v3 debugmodel size: 33,014,016 total parameters
+PP rank 0 building stage_idx 0 ...   # 4 pipeline stages, 1F1B, 8 microbatches
+Applied fully_shard to the model
+Trainer initialized: local batch 8, global batch 1024, grad-accum 64, seq 2048
+Training starts at step 1
+step: 1  loss: ...  grad_norm: 3.43  tps: 2,219  mfu: 0.12%
+step: 2  loss: ...  grad_norm: 4.31
+```
+So the operate/feature harness *can* drive real distributed MoE training — the
+mesh-notation fix (EP carved from the data axis, not multiplicative) is confirmed
+on hardware.
+
+## ⚠️ The debug model is not a meaningful numeric reproduction
+- **Degenerate loss.** Step loss prints as a constant `-128.0` (a valid CE loss
+  for a fresh model is ~ln(vocab) ≈ 10). The `33M` debug model on the tiny bundled
+  `c4_test` set (which re-loops *within* a single step) does not learn — so the
+  new-feature **loss-decreases** check cannot pass on it regardless of the agent's
+  change.
+- **Slow at the paper config.** `global_batch_size=1024` → grad-accum 64 →
+  ~107 s/step on the debug model. The paper's `gbs=1024` targets 30B-class models
+  on DCLM, not a debug model.
+
+**Conclusion:** the debug model is good for *plumbing* validation (the mesh, the
+launcher, log parsing, GPU-time monitoring) but not for reproducing the paper's
+GPU numbers.
+
+## ❌ What a paper-fidelity GPU run needs (not available here)
+- A **real MoE model + released checkpoint** (paper: Qwen3-30B-A3B / DeepSeek-V2-
+  Lite / GPT-OSS-20B). OP3/OP4 explicitly "resume from the released HF checkpoint";
+  NF needs a model that actually learns in 64 steps.
+- **vLLM + lm-evaluation-harness** for OP2 (not installed in this env).
+- **DCLM/C4 at scale** (only the tiny `c4_test` is bundled).
+- Multi-hour compute per task × 3 runs × (operate+feature) × the 3 frameworks the
+  paper compares — and PithTrain/Megatron-LM checkouts aren't present, so the
+  cross-framework headline (62%/64%) is out of scope here regardless.
+
+## Net
+- **Mesh + launcher: validated on 8×H100.** ✅
+- **Operate/feature numeric reproduction: blocked** on real model/checkpoint/deps,
+  not on the harness. The harness, checks, GPU monitor, and judge are in place and
+  unit-tested; point them at a real MoE config + checkpoint to produce real numbers.
+- The **Q&A column is the reproducible slice in this environment** (see
+  `RESULTS_qa_titan.md`).

--- a/agent_tooling/ate_bench/RESULTS_qa_titan.md
+++ b/agent_tooling/ate_bench/RESULTS_qa_titan.md
@@ -1,60 +1,63 @@
 # ATE-Bench Q&A results — TorchTitan
 
-> **Status: IN PROGRESS.** A background 12×3 sweep is running; **1/36 runs**
-> complete as of this commit. This file will be regenerated with the full medians
-> (and `aggregate.py` output) once the sweep finishes.
+> **Status: COMPLETE.** 12 tasks × 3 runs = **36/36 runs, 0 errors.** Medians below.
 
 ## Setup
 - **Framework under test:** TorchTitan @ `f854797fc` (this branch).
-- **Fixed agent:** Claude Code headless, model `claude-opus-4-6` (the env default).
-  The paper used **Opus 4.7 @ `xhigh` effort** — so absolute numbers will differ;
-  trends/ratios are the comparable part. Keep the agent identical across frameworks
-  for any real comparison.
+- **Fixed agent:** Claude Code headless, model `claude-opus-4-6` (env default), 1M
+  context window. The paper used **Opus 4.7 @ `xhigh` effort** — so absolute
+  numbers differ; treat trends/ratios as the comparable part.
 - **Tools:** read-only `Read/Grep/Glob/Bash` (`Edit/Write/NotebookEdit` disabled),
   matching the paper's Q&A setup.
-- **Protocol:** 12 Q&A tasks × 3 runs, **median** reported (lower = more efficient).
-  Effort metrics taken from `result.modelUsage` (the authoritative billed usage).
+- **Protocol:** median of 3 attempts (lower = more efficient). Effort metrics from
+  `result.modelUsage` (authoritative billed usage).
+- **Reproduce:** `run_qa.py --repo $(pwd) --tasks all --runs 3 --out <dir>` then
+  `aggregate.py <dir>`.
 
 ## Ours vs. paper (paper Table 5, TorchTitan column)
 
-| Task | Turns (paper) | Turns (ours) | Per-Turn Ctx (paper) | Per-Turn Ctx (ours) | Output Tok (paper) | Output Tok (ours) |
+| Task | Turns ours | Turns paper | Per-Turn Ctx ours | Per-Turn Ctx paper | Output ours | Output paper |
 |---|---|---|---|---|---|---|
-| Q1  | 18 | 16\* | 44.3K | 62.9K\* | 7.1K | 9.7K\* |
-| Q2  | 28 | _running_ | 43.5K | _running_ | 7.8K | _running_ |
-| Q3  | 14 | _running_ | 36.1K | _running_ | 3.5K | _running_ |
-| Q4  | 26 | _running_ | 39.7K | _running_ | 6.9K | _running_ |
-| Q5  | 19 | _running_ | 41.7K | _running_ | 4.8K | _running_ |
-| Q6  | 4  | _running_ | 29.9K | _running_ | 2.3K | _running_ |
-| Q7  | 12 | _running_ | 30.0K | _running_ | 3.4K | _running_ |
-| Q8  | 11 | _running_ | 32.7K | _running_ | 3.5K | _running_ |
-| Q9  | 16 | _running_ | 38.6K | _running_ | 6.0K | _running_ |
-| Q10 | 17 | _running_ | 38.8K | _running_ | 5.1K | _running_ |
-| Q11 | 8  | _running_ | 30.1K | _running_ | 2.5K | _running_ |
-| Q12 | 5  | _running_ | 33.9K | _running_ | 2.2K | _running_ |
+| Q1  | 11 | 18 | 73.1K  | 44.3K | 9.7K  | 7.1K |
+| Q2  | 32 | 28 | 33.7K  | 43.5K | 7.2K  | 7.8K |
+| Q3  | 9  | 14 | 73.2K  | 36.1K | 7.0K  | 3.5K |
+| Q4  | 18 | 26 | 186.4K | 39.7K | 12.3K | 6.9K |
+| Q5  | 7  | 19 | 90.8K  | 41.7K | 7.4K  | 4.8K |
+| Q6  | 5  | 4  | 28.9K  | 29.9K | 1.7K  | 2.3K |
+| Q7  | 10 | 12 | 27.5K  | 30.0K | 2.5K  | 3.4K |
+| Q8  | 15 | 11 | 33.7K  | 32.7K | 3.1K  | 3.5K |
+| Q9  | 9  | 16 | 294.8K | 38.6K | 14.1K | 6.0K |
+| Q10 | 20 | 17 | 37.1K  | 38.8K | 4.8K  | 5.1K |
+| Q11 | 9  | 8  | 24.9K  | 30.1K | 2.7K  | 2.5K |
+| Q12 | 8  | 5  | 30.9K  | 33.9K | 2.0K  | 2.2K |
+| **Σ/median** | **153 total** | **178 total** | median 35.4K | median 37.5K | **70.5K total** | **55.1K total** |
 
-\* 1 of 3 runs so far (not yet a median). An earlier single smoke run of Q1 gave
-19 turns / 39.5K / 8.9K — note the run-to-run spread (16–19 turns, 39.5–62.9K
-context), which is exactly why the paper medians over 3 attempts.
+## What the numbers say
+- **Agent turns track the paper well** — total 153 vs 178 (our agent is ~14% leaner
+  on turns), per-task within a handful on most questions. The TorchTitan codebase
+  imposes a similar number of agent steps on both agents.
+- **Output tokens are comparable** (within ~1.3×), slightly higher for us.
+- **Per-turn context is the big divergence**, driven by the *agent*, not the
+  framework: on exploration-heavy questions our medians blow up — **Q9 (CP) 294.8K
+  vs 38.6K, Q4 (seeds) 186.4K vs 39.7K, Q5 (attention) 90.8K vs 41.7K**. The env's
+  `opus-4-6` with a 1M window reads broadly and keeps a large working context;
+  `opus-4-7 @ xhigh` in the paper ran much tighter. On cheap, localized questions
+  (Q6 RoPE, Q7 SwiGLU, Q11/Q12) the two agents match closely.
+- **Takeaway:** the *turn-count* signal (how many agent steps the framework demands)
+  reproduces the paper's TorchTitan column; the *context* metric is dominated by the
+  agent model difference and isn't comparable across agents — exactly why ATE-Bench
+  insists on holding the agent fixed across frameworks.
 
-**Early read:** our Q1 lands in the paper's TorchTitan ballpark on turns
-(16 vs 18) and output tokens (9.7K vs 7.1K); per-turn context runs higher
-(`opus-4-6` here vs `opus-4-7 xhigh` in the paper, different context budgeting).
+## Caveats
+- **Correctness not yet graded.** Effort numbers only count for *correct* attempts
+  (paper had all 108 Q&A attempts satisfied). Grade per `runner/grade_qa.md` (or an
+  LLM-judge pass) before drawing firm conclusions; the `correct` column in
+  `aggregate.py` is `-` until graded.
+- **Agent ≠ paper's** (`opus-4-6` vs `opus-4-7 @ xhigh`) → absolute numbers differ.
 
-## What this does and does not reproduce
-- ✅ **TorchTitan Q&A column** (this file) — the CPU-only, fully runnable slice.
-- ❌ **PithTrain / Megatron-LM columns** — not reproducible here (no checkouts), so
-  the paper's *relative* headline (62% fewer turns / 64% less GPU time) cannot be
-  reproduced — those are cross-framework deltas.
-- ⏳ **Operate & Profile / New-Feature** — GPU-gated (8×H100 are available, but they
-  need a real MoE checkpoint, vLLM+lm-eval, Nsight, and C4); harness is ready.
-
-## Reproduce
-```bash
-python agent_tooling/ate_bench/runner/run_qa.py \
-    --repo $(pwd) --tasks all --runs 3 \
-    --out agent_tooling/ate_bench/results/titan_full
-python agent_tooling/ate_bench/runner/aggregate.py \
-    agent_tooling/ate_bench/results/titan_full
-```
-Correctness must be human-graded (`runner/grade_qa.md`) before drawing conclusions
-— effort numbers only count for *correct* attempts.
+## Scope (unchanged)
+- ✅ **TorchTitan Q&A column** — this file (reproduced).
+- ❌ **PithTrain / Megatron-LM columns** — no checkouts → the cross-framework
+  headline (62% fewer turns / 64% less GPU time) is out of scope here.
+- ⏳ **Operate & Profile / New-Feature** — mesh validated on 8×H100
+  (`RESULTS_gpu_titan.md`); numeric repro blocked on a real MoE checkpoint + deps.

--- a/agent_tooling/ate_bench/RESULTS_qa_titan.md
+++ b/agent_tooling/ate_bench/RESULTS_qa_titan.md
@@ -1,0 +1,60 @@
+# ATE-Bench Q&A results — TorchTitan
+
+> **Status: IN PROGRESS.** A background 12×3 sweep is running; **1/36 runs**
+> complete as of this commit. This file will be regenerated with the full medians
+> (and `aggregate.py` output) once the sweep finishes.
+
+## Setup
+- **Framework under test:** TorchTitan @ `f854797fc` (this branch).
+- **Fixed agent:** Claude Code headless, model `claude-opus-4-6` (the env default).
+  The paper used **Opus 4.7 @ `xhigh` effort** — so absolute numbers will differ;
+  trends/ratios are the comparable part. Keep the agent identical across frameworks
+  for any real comparison.
+- **Tools:** read-only `Read/Grep/Glob/Bash` (`Edit/Write/NotebookEdit` disabled),
+  matching the paper's Q&A setup.
+- **Protocol:** 12 Q&A tasks × 3 runs, **median** reported (lower = more efficient).
+  Effort metrics taken from `result.modelUsage` (the authoritative billed usage).
+
+## Ours vs. paper (paper Table 5, TorchTitan column)
+
+| Task | Turns (paper) | Turns (ours) | Per-Turn Ctx (paper) | Per-Turn Ctx (ours) | Output Tok (paper) | Output Tok (ours) |
+|---|---|---|---|---|---|---|
+| Q1  | 18 | 16\* | 44.3K | 62.9K\* | 7.1K | 9.7K\* |
+| Q2  | 28 | _running_ | 43.5K | _running_ | 7.8K | _running_ |
+| Q3  | 14 | _running_ | 36.1K | _running_ | 3.5K | _running_ |
+| Q4  | 26 | _running_ | 39.7K | _running_ | 6.9K | _running_ |
+| Q5  | 19 | _running_ | 41.7K | _running_ | 4.8K | _running_ |
+| Q6  | 4  | _running_ | 29.9K | _running_ | 2.3K | _running_ |
+| Q7  | 12 | _running_ | 30.0K | _running_ | 3.4K | _running_ |
+| Q8  | 11 | _running_ | 32.7K | _running_ | 3.5K | _running_ |
+| Q9  | 16 | _running_ | 38.6K | _running_ | 6.0K | _running_ |
+| Q10 | 17 | _running_ | 38.8K | _running_ | 5.1K | _running_ |
+| Q11 | 8  | _running_ | 30.1K | _running_ | 2.5K | _running_ |
+| Q12 | 5  | _running_ | 33.9K | _running_ | 2.2K | _running_ |
+
+\* 1 of 3 runs so far (not yet a median). An earlier single smoke run of Q1 gave
+19 turns / 39.5K / 8.9K — note the run-to-run spread (16–19 turns, 39.5–62.9K
+context), which is exactly why the paper medians over 3 attempts.
+
+**Early read:** our Q1 lands in the paper's TorchTitan ballpark on turns
+(16 vs 18) and output tokens (9.7K vs 7.1K); per-turn context runs higher
+(`opus-4-6` here vs `opus-4-7 xhigh` in the paper, different context budgeting).
+
+## What this does and does not reproduce
+- ✅ **TorchTitan Q&A column** (this file) — the CPU-only, fully runnable slice.
+- ❌ **PithTrain / Megatron-LM columns** — not reproducible here (no checkouts), so
+  the paper's *relative* headline (62% fewer turns / 64% less GPU time) cannot be
+  reproduced — those are cross-framework deltas.
+- ⏳ **Operate & Profile / New-Feature** — GPU-gated (8×H100 are available, but they
+  need a real MoE checkpoint, vLLM+lm-eval, Nsight, and C4); harness is ready.
+
+## Reproduce
+```bash
+python agent_tooling/ate_bench/runner/run_qa.py \
+    --repo $(pwd) --tasks all --runs 3 \
+    --out agent_tooling/ate_bench/results/titan_full
+python agent_tooling/ate_bench/runner/aggregate.py \
+    agent_tooling/ate_bench/results/titan_full
+```
+Correctness must be human-graded (`runner/grade_qa.md`) before drawing conclusions
+— effort numbers only count for *correct* attempts.

--- a/agent_tooling/ate_bench/runner/agent_session.py
+++ b/agent_tooling/ate_bench/runner/agent_session.py
@@ -46,7 +46,11 @@ def run_session(
         )
         rc, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
     except subprocess.TimeoutExpired as exc:
-        rc, stdout, stderr = 124, (exc.stdout or ""), (exc.stderr or "") + "\n[timeout]"
+        def _s(x):
+            if x is None:
+                return ""
+            return x.decode("utf-8", "replace") if isinstance(x, (bytes, bytearray)) else x
+        rc, stdout, stderr = 124, _s(exc.stdout), _s(exc.stderr) + "\n[timeout]"
     gpu = mon.stop() if mon else {}
 
     tp = Path(transcript_path)

--- a/agent_tooling/ate_bench/runner/agent_session.py
+++ b/agent_tooling/ate_bench/runner/agent_session.py
@@ -1,0 +1,67 @@
+"""Shared headless-agent session runner with GPU-time monitoring.
+
+Used by run_operate.py and run_feature.py. Invokes the fixed agent headless,
+captures the stream-json transcript, parses ATE effort metrics, and measures
+active GPU time across the session.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import metrics as metrics_mod  # noqa: E402
+from gpu_monitor import GpuMonitor  # noqa: E402
+
+
+def run_session(
+    prompt: str,
+    cwd: str | Path,
+    transcript_path: str | Path,
+    *,
+    allowed_tools: list[str],
+    disallowed_tools: tuple[str, ...] | list[str] = (),
+    permission_mode: str | None = None,
+    model: str | None = None,
+    timeout: int = 3600,
+    monitor_gpu: bool = True,
+):
+    """Run one agent session. Returns (TaskMetrics|None, returncode, stderr, gpu_stats)."""
+    cmd = ["claude", "-p", "--output-format", "stream-json", "--verbose"]
+    if allowed_tools:
+        cmd += ["--allowedTools", *allowed_tools]
+    if disallowed_tools:
+        cmd += ["--disallowedTools", *list(disallowed_tools)]
+    if permission_mode:
+        cmd += ["--permission-mode", permission_mode]
+    if model:
+        cmd += ["--model", model]
+
+    mon = GpuMonitor().start() if monitor_gpu else None
+    try:
+        proc = subprocess.run(
+            cmd, input=prompt, capture_output=True, text=True, cwd=str(cwd), timeout=timeout
+        )
+        rc, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        rc, stdout, stderr = 124, (exc.stdout or ""), (exc.stderr or "") + "\n[timeout]"
+    gpu = mon.stop() if mon else {}
+
+    tp = Path(transcript_path)
+    tp.parent.mkdir(parents=True, exist_ok=True)
+    tp.write_text(stdout or "", encoding="utf-8")
+    if stderr:
+        tp.with_suffix(".stderr.log").write_text(stderr, encoding="utf-8")
+
+    m = None
+    if (stdout or "").strip():
+        try:
+            m = metrics_mod.parse_transcript(tp)
+        except Exception as exc:  # noqa: BLE001
+            print(f"    ! failed to parse transcript: {exc}", file=sys.stderr)
+    # Fold active GPU time into the metrics object.
+    if m is not None and gpu:
+        m.active_gpu_time_s = gpu.get("active_gpu_time_s")
+    return m, rc, stderr, gpu

--- a/agent_tooling/ate_bench/runner/aggregate.py
+++ b/agent_tooling/ate_bench/runner/aggregate.py
@@ -26,11 +26,24 @@ METRIC_KEYS = [
     ("per_turn_context", "Per-Turn Ctx"),
     ("output_tokens", "Output Tok"),
     ("session_duration_s", "Duration(s)"),
+    ("active_gpu_time_s", "GPU Time(s)"),
 ]
 
 
+def _is_correct(row: dict) -> bool | None:
+    """Pull a correctness verdict from operate (passed) or feature (correct) rows."""
+    c = row.get("correctness")
+    if not isinstance(c, dict):
+        return None
+    if "correct" in c:
+        return bool(c["correct"])
+    if "passed" in c:
+        return bool(c["passed"])
+    return None
+
+
 def load_task_medians(results_dir: Path) -> dict[str, dict]:
-    """Return {task_id: {metric: median_value, 'n': n_ok, 'n_err': n_err}}."""
+    """Return {task_id: {metric: median_value, 'n', 'n_err', 'n_correct'}}."""
     out: dict[str, dict] = {}
     for task_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):
         metric_files = sorted(task_dir.glob("run*.metrics.json"))
@@ -39,7 +52,14 @@ def load_task_medians(results_dir: Path) -> dict[str, dict]:
         rows = [json.loads(f.read_text()) for f in metric_files]
         ok = [r for r in rows if not r.get("is_error") and not r.get("error")]
         n_err = len(rows) - len(ok)
-        agg: dict = {"n": len(ok), "n_err": n_err}
+        verdicts = [_is_correct(r) for r in rows]
+        graded = [v for v in verdicts if v is not None]
+        agg: dict = {
+            "n": len(ok),
+            "n_err": n_err,
+            "n_correct": sum(1 for v in graded if v),
+            "n_graded": len(graded),
+        }
         for key, _ in METRIC_KEYS:
             vals = [r[key] for r in ok if r.get(key) is not None]
             agg[key] = median(vals) if vals else None
@@ -52,19 +72,20 @@ def _fmt(key: str, val) -> str:
         return "-"
     if key in ("per_turn_context", "output_tokens"):
         return f"{val / 1000:.1f}K"
-    if key == "session_duration_s":
+    if key in ("session_duration_s", "active_gpu_time_s"):
         return f"{val:.0f}"
     return f"{val:.0f}"
 
 
 def print_single(label: str, medians: dict[str, dict]) -> None:
     print(f"\n# {label}  (median of attempts; lower is more efficient)\n")
-    header = ["Task", "n(ok/err)"] + [h for _, h in METRIC_KEYS]
-    widths = [max(len(header[0]), 6), 10] + [max(len(h), 12) for _, h in METRIC_KEYS]
+    header = ["Task", "n(ok/err)", "correct"] + [h for _, h in METRIC_KEYS]
+    widths = [max(len(header[0]), 6), 10, 8] + [max(len(h), 12) for _, h in METRIC_KEYS]
     print("  ".join(h.ljust(w) for h, w in zip(header, widths)))
     print("  ".join("-" * w for w in widths))
     for task_id, agg in medians.items():
-        row = [task_id, f"{agg['n']}/{agg['n_err']}"]
+        correct = f"{agg['n_correct']}/{agg['n_graded']}" if agg.get("n_graded") else "-"
+        row = [task_id, f"{agg['n']}/{agg['n_err']}", correct]
         row += [_fmt(k, agg.get(k)) for k, _ in METRIC_KEYS]
         print("  ".join(c.ljust(w) for c, w in zip(row, widths)))
 

--- a/agent_tooling/ate_bench/runner/aggregate.py
+++ b/agent_tooling/ate_bench/runner/aggregate.py
@@ -1,0 +1,119 @@
+"""Aggregate ATE-Bench Q&A run metrics into a Table-5-style report.
+
+Reads the output directory produced by run_qa.py (one subdir per task, each with
+``runN.metrics.json`` files) and reports the *median* across attempts per task,
+matching the paper's protocol (median of 3 independent attempts; lower is more
+efficient). Prints Agent Turns / Per-Turn Context / Output Tokens (the three Q&A
+metrics in paper Table 5) plus session duration, and writes summary.json.
+
+Usage:
+    python agent_tooling/ate_bench/runner/aggregate.py <results_dir> [<results_dir2> ...]
+
+Passing two or more results dirs (e.g. one per framework) prints them side by side
+so you can reproduce the cross-framework comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import median
+
+
+METRIC_KEYS = [
+    ("agent_turns", "Turns"),
+    ("per_turn_context", "Per-Turn Ctx"),
+    ("output_tokens", "Output Tok"),
+    ("session_duration_s", "Duration(s)"),
+]
+
+
+def load_task_medians(results_dir: Path) -> dict[str, dict]:
+    """Return {task_id: {metric: median_value, 'n': n_ok, 'n_err': n_err}}."""
+    out: dict[str, dict] = {}
+    for task_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):
+        metric_files = sorted(task_dir.glob("run*.metrics.json"))
+        if not metric_files:
+            continue
+        rows = [json.loads(f.read_text()) for f in metric_files]
+        ok = [r for r in rows if not r.get("is_error") and not r.get("error")]
+        n_err = len(rows) - len(ok)
+        agg: dict = {"n": len(ok), "n_err": n_err}
+        for key, _ in METRIC_KEYS:
+            vals = [r[key] for r in ok if r.get(key) is not None]
+            agg[key] = median(vals) if vals else None
+        out[task_dir.name] = agg
+    return out
+
+
+def _fmt(key: str, val) -> str:
+    if val is None:
+        return "-"
+    if key in ("per_turn_context", "output_tokens"):
+        return f"{val / 1000:.1f}K"
+    if key == "session_duration_s":
+        return f"{val:.0f}"
+    return f"{val:.0f}"
+
+
+def print_single(label: str, medians: dict[str, dict]) -> None:
+    print(f"\n# {label}  (median of attempts; lower is more efficient)\n")
+    header = ["Task", "n(ok/err)"] + [h for _, h in METRIC_KEYS]
+    widths = [max(len(header[0]), 6), 10] + [max(len(h), 12) for _, h in METRIC_KEYS]
+    print("  ".join(h.ljust(w) for h, w in zip(header, widths)))
+    print("  ".join("-" * w for w in widths))
+    for task_id, agg in medians.items():
+        row = [task_id, f"{agg['n']}/{agg['n_err']}"]
+        row += [_fmt(k, agg.get(k)) for k, _ in METRIC_KEYS]
+        print("  ".join(c.ljust(w) for c, w in zip(row, widths)))
+
+
+def print_compare(by_label: dict[str, dict[str, dict]]) -> None:
+    """Side-by-side per-metric comparison across frameworks/labels."""
+    labels = list(by_label)
+    all_tasks = sorted({t for m in by_label.values() for t in m})
+    for key, hname in METRIC_KEYS:
+        print(f"\n# {hname}  (median; lower is more efficient)\n")
+        header = ["Task"] + labels
+        widths = [6] + [max(len(lbl), 10) for lbl in labels]
+        print("  ".join(h.ljust(w) for h, w in zip(header, widths)))
+        print("  ".join("-" * w for w in widths))
+        for task_id in all_tasks:
+            row = [task_id]
+            for lbl in labels:
+                agg = by_label[lbl].get(task_id, {})
+                row.append(_fmt(key, agg.get(key)))
+            print("  ".join(c.ljust(w) for c, w in zip(row, widths)))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("results", nargs="+", type=Path, help="results dir(s) from run_qa.py")
+    args = ap.parse_args(argv)
+
+    by_label: dict[str, dict[str, dict]] = {}
+    for d in args.results:
+        d = d.expanduser().resolve()
+        if not d.is_dir():
+            ap.error(f"{d} is not a directory")
+        label = d.name
+        medians = load_task_medians(d)
+        by_label[label] = medians
+        summary_path = d / "summary.json"
+        summary_path.write_text(json.dumps(medians, indent=2), encoding="utf-8")
+
+    if len(by_label) == 1:
+        (label,) = by_label
+        print_single(label, by_label[label])
+    else:
+        print_compare(by_label)
+
+    print()
+    for d in args.results:
+        print(f"Wrote {d.expanduser().resolve() / 'summary.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/checks/__init__.py
+++ b/agent_tooling/ate_bench/runner/checks/__init__.py
@@ -1,0 +1,48 @@
+"""Programmatic correctness checks for ATE-Bench operate/profile + new-feature tasks.
+
+Each check exposes a ``check(...) -> CheckResult`` function and a small CLI. The
+checks verify the *artifact* the agent produced (or the training log), matching
+the paper's "verify the artifact, not the path taken" protocol (Appendix B.2.2,
+B.3.2).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# TorchTitan logs: "step: {N:2}  loss: {avg:8.5f} ...". (metrics.py:527-528)
+_STEP_LOSS = re.compile(
+    r"step:\s*(\d+).*?loss:\s*([0-9]*\.?[0-9]+(?:[eE][+-]?\d+)?)"
+)
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+def parse_loss_log(text: str) -> list[tuple[int, float]]:
+    """Extract [(step, loss), ...] from a TorchTitan training log.
+
+    Only training lines are returned ("validate step:" lines are skipped).
+    """
+    out: list[tuple[int, float]] = []
+    for line in strip_ansi(text).splitlines():
+        if "validate" in line.lower():
+            continue
+        m = _STEP_LOSS.search(line)
+        if m:
+            out.append((int(m.group(1)), float(m.group(2))))
+    return out
+
+
+@dataclass
+class CheckResult:
+    passed: bool
+    detail: str
+    extra: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {"passed": self.passed, "detail": self.detail, "extra": self.extra}

--- a/agent_tooling/ate_bench/runner/checks/nf_loss_curve.py
+++ b/agent_tooling/ate_bench/runner/checks/nf_loss_curve.py
@@ -1,0 +1,81 @@
+"""New-feature check (loss axis): CE loss decreases over the 64-step run and is finite.
+
+Paper (B.3): correctness has two axes; this is the first — the modified pipeline
+must produce a learnable model, i.e. cross-entropy loss decreases across the run
+and stays finite (no NaN, no explosion). The second axis (the three per-feature
+rules) is judged separately by judge.py.
+
+"Decreases" is checked robustly against noise: the median loss of the last window
+must be below the median of the first window, and every step's loss must be
+finite.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from checks import CheckResult, parse_loss_log
+else:
+    from . import CheckResult, parse_loss_log
+
+
+def check(
+    log_text: str,
+    min_steps: int = 64,
+    window: int = 8,
+) -> CheckResult:
+    pairs = parse_loss_log(log_text)
+    if not pairs:
+        return CheckResult(False, "no 'step: N  loss: ...' lines found in log")
+    pairs.sort(key=lambda p: p[0])
+    losses = [loss for _, loss in pairs]
+
+    non_finite = [s for s, loss in pairs if not math.isfinite(loss)]
+    if non_finite:
+        return CheckResult(
+            False,
+            f"loss not finite at steps {non_finite[:5]}",
+            {"n_non_finite": len(non_finite)},
+        )
+    if len(losses) < min_steps:
+        return CheckResult(
+            False,
+            f"only {len(losses)} steps logged, expected >= {min_steps}",
+            {"steps": len(losses)},
+        )
+    w = min(window, len(losses) // 2)
+    first = statistics.median(losses[:w])
+    last = statistics.median(losses[-w:])
+    if not (last < first):
+        return CheckResult(
+            False,
+            f"loss did not decrease: median first-{w}={first:.4f} -> last-{w}={last:.4f}",
+            {"first": first, "last": last},
+        )
+    return CheckResult(
+        True,
+        f"loss finite and decreasing: median first-{w}={first:.4f} -> last-{w}={last:.4f}",
+        {"first": first, "last": last, "steps": len(losses)},
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("log", type=Path, help="path to the 64-step training log")
+    ap.add_argument("--min-steps", type=int, default=64)
+    ap.add_argument("--window", type=int, default=8)
+    args = ap.parse_args(argv)
+    res = check(args.log.read_text(errors="ignore"), args.min_steps, args.window)
+    print(("PASS " if res.passed else "FAIL ") + res.detail)
+    return 0 if res.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/checks/op1_getting_started.py
+++ b/agent_tooling/ate_bench/runner/checks/op1_getting_started.py
@@ -1,0 +1,77 @@
+"""OP1 check: the smoke training script reaches step 5 with a finite loss.
+
+Paper (B.2.2): after the agent finishes installing deps, the harness re-runs the
+read-only training script and parses the log; accepted iff step 5 prints a finite
+loss value. Pass an existing log with --log, or --rerun to launch train.sh.
+"""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from checks import CheckResult, parse_loss_log
+else:
+    from . import CheckResult, parse_loss_log
+
+TRAIN_SH = Path(__file__).resolve().parents[2] / "setup" / "train.sh"
+
+
+def check(log_text: str, target_step: int = 5) -> CheckResult:
+    pairs = parse_loss_log(log_text)
+    if not pairs:
+        return CheckResult(False, "no 'step: N  loss: ...' lines found in log")
+    by_step = dict(pairs)
+    if target_step not in by_step:
+        return CheckResult(
+            False,
+            f"did not reach step {target_step} (max step seen: {max(by_step)})",
+            {"steps_seen": sorted(by_step)},
+        )
+    loss = by_step[target_step]
+    if not math.isfinite(loss):
+        return CheckResult(False, f"step {target_step} loss is not finite: {loss}")
+    return CheckResult(
+        True, f"reached step {target_step} with finite loss {loss}", {"loss": loss}
+    )
+
+
+def rerun(steps: int = 5, timeout: int = 1800) -> str:
+    proc = subprocess.run(
+        ["bash", str(TRAIN_SH)],
+        env={"STEPS": str(steps), **_env()},
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.stdout + "\n" + proc.stderr
+
+
+def _env() -> dict:
+    import os
+
+    return dict(os.environ)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--log", type=Path, help="path to an existing training log")
+    g.add_argument("--rerun", action="store_true", help="launch setup/train.sh (read-only)")
+    ap.add_argument("--step", type=int, default=5)
+    args = ap.parse_args(argv)
+
+    text = args.log.read_text(errors="ignore") if args.log else rerun(args.step)
+    res = check(text, args.step)
+    print(("PASS " if res.passed else "FAIL ") + res.detail)
+    return 0 if res.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/checks/op2_train_evaluate.py
+++ b/agent_tooling/ate_bench/runner/checks/op2_train_evaluate.py
@@ -1,0 +1,56 @@
+"""OP2 check: the eval pipeline produced a finite HellaSwag score.
+
+Paper (B.2.2): satisfied when evaluate.sh runs to completion and writes a finite
+HellaSwag score; the score is not required to clear any quality threshold (25
+steps from random init is expected near-random).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from checks import CheckResult
+else:
+    from . import CheckResult
+
+
+def check(hellaswag_json: str | Path) -> CheckResult:
+    p = Path(hellaswag_json)
+    if not p.exists():
+        return CheckResult(False, f"missing eval output: {p}")
+    try:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        return CheckResult(False, f"eval output is not valid JSON: {exc}")
+    score = data.get("hellaswag_acc")
+    if score is None:
+        return CheckResult(False, f"no 'hellaswag_acc' key in {p}", {"keys": list(data)})
+    try:
+        score = float(score)
+    except (TypeError, ValueError):
+        return CheckResult(False, f"hellaswag_acc is not a number: {score!r}")
+    if not math.isfinite(score):
+        return CheckResult(False, f"hellaswag_acc is not finite: {score}")
+    return CheckResult(
+        True, f"pipeline completed; finite HellaSwag acc={score:.4f}", {"acc": score}
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("hellaswag_json", help="path to evaluate.sh's hellaswag.json")
+    args = ap.parse_args(argv)
+    res = check(args.hellaswag_json)
+    print(("PASS " if res.passed else "FAIL ") + res.detail)
+    return 0 if res.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/checks/op3_routing_trace.py
+++ b/agent_tooling/ate_bench/runner/checks/op3_routing_trace.py
@@ -1,0 +1,126 @@
+"""OP3 check: per-token MoE routing trace npz files are valid.
+
+Paper (B.2.2): verify that the expected per-step ``step-<id:08d>.npz`` files are
+present and each carries expert-ID and gating-weight arrays of the correct shape
+for every MoE layer over every token in the global batch; expert-IDs within
+``[0, num_experts)``; gating weights non-negative and summing to 1 over the top-k
+selected experts for every token.
+
+Expected schema per .npz (see op3_collect_routing_trace.md):
+  layer{L:02d}_expert_ids      int   [num_tokens, top_k]
+  layer{L:02d}_gating_weights  float [num_tokens, top_k]
+  num_experts                  scalar
+
+Default expected step count is 4: 8M tokens / (global_batch 1024 * seq_len 2048)
+= 4 steps.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from checks import CheckResult
+else:
+    from . import CheckResult
+
+_LAYER_RE = re.compile(r"layer(\d+)_expert_ids")
+
+
+def _check_one_npz(path: Path, sum_tol: float) -> tuple[bool, str]:
+    try:
+        z = np.load(path)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"{path.name}: cannot load npz ({exc})"
+    keys = set(z.files)
+    if "num_experts" not in keys:
+        return False, f"{path.name}: missing 'num_experts' scalar"
+    num_experts = int(np.asarray(z["num_experts"]).reshape(-1)[0])
+    layers = sorted(int(m.group(1)) for k in keys if (m := _LAYER_RE.fullmatch(k)))
+    if not layers:
+        return False, f"{path.name}: no 'layer{{L:02d}}_expert_ids' arrays found"
+
+    n_tokens_ref = None
+    for layer in layers:
+        ids_key = f"layer{layer:02d}_expert_ids"
+        w_key = f"layer{layer:02d}_gating_weights"
+        if w_key not in keys:
+            return False, f"{path.name}: layer {layer} missing {w_key}"
+        ids = np.asarray(z[ids_key])
+        w = np.asarray(z[w_key])
+        if ids.ndim != 2 or w.ndim != 2:
+            return False, f"{path.name}: layer {layer} arrays must be 2D [tokens, top_k]"
+        if ids.shape != w.shape:
+            return False, f"{path.name}: layer {layer} id/weight shape mismatch {ids.shape} vs {w.shape}"
+        n_tokens, top_k = ids.shape
+        if n_tokens_ref is None:
+            n_tokens_ref = n_tokens
+        elif n_tokens != n_tokens_ref:
+            return False, f"{path.name}: layer {layer} token count {n_tokens} != {n_tokens_ref}"
+        if ids.min() < 0 or ids.max() >= num_experts:
+            return False, (
+                f"{path.name}: layer {layer} expert id out of range "
+                f"[0,{num_experts}): min={ids.min()} max={ids.max()}"
+            )
+        if w.min() < -sum_tol:
+            return False, f"{path.name}: layer {layer} has negative gating weight {w.min()}"
+        sums = w.astype(np.float64).sum(axis=1)
+        if not np.allclose(sums, 1.0, atol=sum_tol):
+            bad = int(np.count_nonzero(np.abs(sums - 1.0) > sum_tol))
+            return False, (
+                f"{path.name}: layer {layer} gating weights do not sum to 1 for "
+                f"{bad}/{n_tokens} tokens (e.g. {sums[np.argmax(np.abs(sums-1.0))]:.4f})"
+            )
+    return True, f"{path.name}: {len(layers)} layers, {n_tokens_ref} tokens OK"
+
+
+def check(
+    routing_traces_dir: str | Path,
+    expected_steps: int = 4,
+    sum_tol: float = 1e-3,
+) -> CheckResult:
+    d = Path(routing_traces_dir)
+    if not d.is_dir():
+        return CheckResult(False, f"routing-traces dir not found: {d}")
+    files = sorted(d.glob("step-*.npz"))
+    if len(files) < expected_steps:
+        return CheckResult(
+            False,
+            f"expected >= {expected_steps} step-*.npz files, found {len(files)}",
+            {"files": [f.name for f in files]},
+        )
+    details = []
+    for f in files:
+        ok, msg = _check_one_npz(f, sum_tol)
+        details.append(msg)
+        if not ok:
+            return CheckResult(False, msg, {"per_file": details})
+    return CheckResult(
+        True,
+        f"{len(files)} routing-trace files valid",
+        {"per_file": details},
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("routing_traces_dir", help="dir containing step-*.npz")
+    ap.add_argument("--expected-steps", type=int, default=4)
+    ap.add_argument("--sum-tol", type=float, default=1e-3)
+    args = ap.parse_args(argv)
+    res = check(args.routing_traces_dir, args.expected_steps, args.sum_tol)
+    print(("PASS " if res.passed else "FAIL ") + res.detail)
+    for line in res.extra.get("per_file", []):
+        print("  ", line)
+    return 0 if res.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/checks/op4_heavy_kernels.py
+++ b/agent_tooling/ate_bench/runner/checks/op4_heavy_kernels.py
@@ -1,0 +1,88 @@
+"""OP4 check: top-kernels.csv matches the prescribed schema.
+
+Paper (B.2.2): the CSV is checked programmatically against the schema (header,
+exactly three rows sorted by total time descending); kernel *names* are validated
+by a human against the Nsight GUI. We also confirm the raw profile.nsys-rep is
+present so the result is reproducible.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from checks import CheckResult
+else:
+    from . import CheckResult
+
+EXPECTED_HEADER = ["kernel_name", "total_time_ms", "instances", "mean_time_ms"]
+
+
+def check(heavy_kernels_dir: str | Path, require_nsys_rep: bool = True) -> CheckResult:
+    d = Path(heavy_kernels_dir)
+    csv_path = d / "top-kernels.csv"
+    if not csv_path.exists():
+        return CheckResult(False, f"missing {csv_path}")
+    with open(csv_path, newline="") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        return CheckResult(False, "top-kernels.csv is empty")
+    header, *data = rows
+    header = [h.strip() for h in header]
+    if header != EXPECTED_HEADER:
+        return CheckResult(False, f"header {header} != {EXPECTED_HEADER}")
+    if len(data) != 3:
+        return CheckResult(False, f"expected exactly 3 data rows, got {len(data)}")
+
+    totals = []
+    for i, row in enumerate(data, 1):
+        if len(row) != 4:
+            return CheckResult(False, f"row {i} has {len(row)} columns, expected 4")
+        name, total, inst, mean = row
+        if not name.strip():
+            return CheckResult(False, f"row {i} has empty kernel_name")
+        try:
+            total_f = float(total)
+            inst_i = int(float(inst))
+            mean_f = float(mean)
+        except ValueError as exc:
+            return CheckResult(False, f"row {i} non-numeric value: {exc}")
+        totals.append(total_f)
+        # sanity: mean ~= total / instances (loose; allow rounding)
+        if inst_i > 0 and total_f > 0:
+            expected_mean = total_f / inst_i
+            if abs(expected_mean - mean_f) > max(0.05 * expected_mean, 1e-3):
+                return CheckResult(
+                    False,
+                    f"row {i}: mean_time_ms {mean_f} != total/instances {expected_mean:.4f}",
+                )
+    if totals != sorted(totals, reverse=True):
+        return CheckResult(False, f"rows not sorted by total_time_ms descending: {totals}")
+
+    if require_nsys_rep:
+        reps = list(d.glob("*.nsys-rep"))
+        if not reps:
+            return CheckResult(False, f"no raw *.nsys-rep profile in {d}")
+
+    return CheckResult(
+        True, "top-kernels.csv schema + ordering valid; profile present", {"totals": totals}
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("heavy_kernels_dir", help="dir with top-kernels.csv + *.nsys-rep")
+    ap.add_argument("--no-nsys-rep", action="store_true", help="skip the .nsys-rep presence check")
+    args = ap.parse_args(argv)
+    res = check(args.heavy_kernels_dir, require_nsys_rep=not args.no_nsys_rep)
+    print(("PASS " if res.passed else "FAIL ") + res.detail)
+    return 0 if res.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/gpu_monitor.py
+++ b/agent_tooling/ate_bench/runner/gpu_monitor.py
@@ -1,0 +1,118 @@
+"""Measure 'active GPU time' during an agent session by sampling nvidia-smi.
+
+ATE-Bench reports *active GPU time* for the operate/profile and new-feature tasks
+(the GPU busy time the agent's training runs consume). We approximate it by
+polling per-GPU utilization at a fixed interval and integrating the busy time:
+
+    active_gpu_time_s = sum over GPUs of (interval * count of samples where
+                                          utilization > busy_threshold_pct)
+
+i.e. GPU-seconds of busy time, summed across all visible GPUs. This counts a GPU
+as "active" while it is doing work, which is the quantity that differs between
+frameworks for the same task. If nvidia-smi is unavailable (no GPU), the monitor
+degrades gracefully and reports ``active_gpu_time_s = None``.
+
+Usage (around the agent subprocess):
+
+    mon = GpuMonitor().start()
+    ... run the agent ...
+    stats = mon.stop()   # {'active_gpu_time_s': float|None, 'wall_s': float, ...}
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+
+
+def _sample_utilization() -> list[int] | None:
+    """Return per-GPU utilization percentages, or None if nvidia-smi is unavailable."""
+    if shutil.which("nvidia-smi") is None:
+        return None
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    vals = []
+    for line in out.stdout.strip().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                vals.append(int(float(line)))
+            except ValueError:
+                pass
+    return vals or None
+
+
+@dataclass
+class GpuMonitor:
+    interval_s: float = 1.0
+    busy_threshold_pct: int = 5
+    _busy_gpu_seconds: float = 0.0
+    _samples: int = 0
+    _available: bool = False
+    _t0: float = 0.0
+    _stop: threading.Event = field(default_factory=threading.Event)
+    _thread: threading.Thread | None = None
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            util = _sample_utilization()
+            if util is not None:
+                self._available = True
+                busy = sum(1 for u in util if u > self.busy_threshold_pct)
+                self._busy_gpu_seconds += busy * self.interval_s
+                self._samples += 1
+            self._stop.wait(self.interval_s)
+
+    def start(self) -> "GpuMonitor":
+        self._t0 = time.time()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> dict:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval_s * 3)
+        wall = time.time() - self._t0
+        return {
+            "active_gpu_time_s": (self._busy_gpu_seconds if self._available else None),
+            "wall_s": wall,
+            "samples": self._samples,
+            "interval_s": self.interval_s,
+            "busy_threshold_pct": self.busy_threshold_pct,
+            "gpu_monitor_available": self._available,
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone: monitor a wrapped command, print active GPU time."""
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--interval", type=float, default=1.0)
+    ap.add_argument("cmd", nargs=argparse.REMAINDER, help="-- command to run and monitor")
+    args = ap.parse_args(argv)
+    cmd = args.cmd[1:] if args.cmd and args.cmd[0] == "--" else args.cmd
+    if not cmd:
+        ap.error("provide a command after --")
+    mon = GpuMonitor(interval_s=args.interval).start()
+    rc = subprocess.run(cmd).returncode
+    print(json.dumps(mon.stop(), indent=2))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/grade_qa.md
+++ b/agent_tooling/ate_bench/runner/grade_qa.md
@@ -1,0 +1,48 @@
+# Q&A Correctness Grading Protocol (ATE-Bench, Appendix B.1.2)
+
+The effort metrics (turns, per-turn context, output tokens) only count if the
+attempt is **correct**. Q&A correctness is graded by humans, not programmatically,
+because the answer is a set of code citations whose truth must be checked against
+the code on disk.
+
+## What the agent returns
+Each Q&A answer is wrapped in `<final_answer>...</final_answer>` and cites file
+paths, function names, and line numbers in the framework codebase that implement
+the behavior the question asks about, with **one citation per claim** and a
+step-by-step trace of the execution path.
+
+## Grading procedure (from the paper)
+1. **Two independent graders.** Each grader opens every cited code location and
+   verifies that the code there actually does what the agent claims in the answer.
+2. **Satisfied** = both graders confirm **every** citation against the code on
+   disk. A single wrong/uncheckable citation fails the attempt.
+3. **Disagreements** are resolved by a third reader who looks **only** at the
+   cited evidence (not the agent's prose).
+4. **Negative answers count.** If a feature is genuinely absent, a correct
+   "absent, verified" answer (citing the grep/pattern that returned zero matches,
+   or the file inspected that lacks it) is accepted and preferred over a
+   fabricated one.
+
+In the paper, all 108 Q&A attempts (12 questions x 3 frameworks x 3 attempts) were
+judged satisfied by both graders — i.e. the comparison is purely about *effort*,
+since correctness saturates.
+
+## Recording results
+For each `run<N>.jsonl` transcript, record a verdict in
+`results/<label>/<task_id>/run<N>.grade.json`:
+
+```json
+{ "satisfied": true, "grader_notes": "all 3 citations verified", "graders": ["A", "B"] }
+```
+
+Only attempts with `"satisfied": true` should be included when comparing effort
+across frameworks. `aggregate.py` currently medians over runs that the agent
+itself did not error on; once grades exist, filter to satisfied attempts before
+reporting (an optional `--grades` mode can be added).
+
+## Tip: bootstrap grading with an LLM judge
+The paper grades Q&A by hand but judges the *new-feature* tasks with an
+independent `claude-opus-4-7` session at xhigh effort against fixed rules. You can
+mirror that for a first pass on Q&A — have a fresh agent re-open each cited
+`file.py:LINE` and confirm it supports the claim — then spot-check by hand. Keep
+the judge independent from the agent that produced the answer.

--- a/agent_tooling/ate_bench/runner/judge.py
+++ b/agent_tooling/ate_bench/runner/judge.py
@@ -1,0 +1,119 @@
+"""Independent LLM judge for new-feature rule-based correctness (paper B.3.2).
+
+Each new-feature attempt is judged by an *independent* agent session given the
+three fixed rules and the agent's ``git diff`` against ``main``; the judge returns
+PASS/FAIL per rule (overall PASS iff all three pass). The paper used a
+``claude-opus-4-7`` session at xhigh effort. The judge sees only the rules and the
+diff — not the repo, and not the implementing agent's reasoning.
+
+Returns: {"overall": "PASS"|"FAIL", "rules": [{"id","verdict","reason"}, ...], ...}
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Keep the diff within the judge's context; note truncation if it exceeds this.
+MAX_DIFF_CHARS = 200_000
+
+_PROMPT = """\
+You are an independent, skeptical code reviewer. You are given THREE required \
+rules that a code change must satisfy, and a git diff. Decide PASS or FAIL for \
+each rule STRICTLY from the diff: mark PASS only if the diff clearly implements \
+the rule; if the evidence is absent or you are uncertain, mark FAIL.
+
+Respond with ONLY a JSON object (no prose, no code fence) of exactly this shape:
+{{"rules":[{{"id":1,"verdict":"PASS","reason":"..."}},{{"id":2,"verdict":"FAIL","reason":"..."}},{{"id":3,"verdict":"PASS","reason":"..."}}],"overall":"FAIL"}}
+"overall" is "PASS" iff all three rules are "PASS".
+
+=== RULES ===
+{rules}
+
+=== GIT DIFF ===
+{diff}
+"""
+
+
+def _extract_json(text: str) -> dict | None:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        return json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        # Try to salvage the largest valid {...} via a non-greedy scan.
+        for m in re.finditer(r"\{.*\}", text[start : end + 1], re.DOTALL):
+            try:
+                return json.loads(m.group(0))
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+def judge_feature(
+    rules_text: str,
+    diff_text: str,
+    model: str | None = None,
+    timeout: int = 600,
+) -> dict:
+    truncated = False
+    if len(diff_text) > MAX_DIFF_CHARS:
+        diff_text = diff_text[:MAX_DIFF_CHARS] + "\n... [diff truncated] ...\n"
+        truncated = True
+
+    prompt = _PROMPT.format(rules=rules_text.strip(), diff=diff_text.strip())
+    cmd = ["claude", "-p", "--output-format", "json"]
+    if model:
+        cmd += ["--model", model]
+    proc = subprocess.run(
+        cmd, input=prompt, capture_output=True, text=True, timeout=timeout
+    )
+    raw_text = ""
+    if proc.stdout.strip():
+        try:
+            raw_text = json.loads(proc.stdout).get("result", "")
+        except json.JSONDecodeError:
+            raw_text = proc.stdout
+    verdict = _extract_json(raw_text)
+    if verdict is None:
+        return {
+            "overall": "ERROR",
+            "rules": [],
+            "error": "could not parse judge JSON",
+            "raw": raw_text[:2000],
+            "diff_truncated": truncated,
+        }
+    # Normalize / enforce overall = all PASS.
+    rules = verdict.get("rules", [])
+    all_pass = bool(rules) and all(
+        str(r.get("verdict", "")).upper() == "PASS" for r in rules
+    )
+    verdict["overall"] = "PASS" if all_pass else "FAIL"
+    verdict["diff_truncated"] = truncated
+    return verdict
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rules", required=True, type=Path, help="rules markdown file")
+    ap.add_argument("--diff", required=True, type=Path, help="git diff file (or '-' for stdin)")
+    ap.add_argument("--model", default=None, help="judge model (paper: claude-opus-4-7 @ xhigh)")
+    ap.add_argument("--timeout", type=int, default=600)
+    args = ap.parse_args(argv)
+
+    rules_text = args.rules.read_text(encoding="utf-8")
+    diff_text = sys.stdin.read() if str(args.diff) == "-" else args.diff.read_text(errors="ignore")
+    verdict = judge_feature(rules_text, diff_text, args.model, args.timeout)
+    print(json.dumps(verdict, indent=2))
+    return 0 if verdict.get("overall") == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/metrics.py
+++ b/agent_tooling/ate_bench/runner/metrics.py
@@ -1,0 +1,160 @@
+"""Parse Claude Code stream-json transcripts into ATE-Bench effort metrics.
+
+ATE-Bench (PithTrain, arXiv:2605.31463) reports five *effort* metrics per task:
+session duration, active GPU time, agent turns, per-turn context, and output
+tokens. For the Q&A category only agent turns / per-turn context / output tokens
+are reported (paper Table 5); active GPU time is N/A because Q&A does not run
+training.
+
+Computed from the JSONL emitted by:
+    claude -p --output-format stream-json --verbose
+
+IMPORTANT — where the numbers come from. The streamed per-message ``usage`` blocks
+are *partial snapshots*: one assistant turn shows up as several ``assistant``
+events sharing a ``message.id``, and their ``output_tokens`` are tiny incremental
+values that do NOT sum to the real total. The authoritative, billed usage is the
+final ``result`` event's ``modelUsage`` (this is what cost is computed from). So:
+
+    agent_turns      = result.num_turns
+    output_tokens    = sum(modelUsage[*].outputTokens)
+    per_turn_context = (sum of input-side tokens across all turns) / num_turns
+                       where input-side = inputTokens + cacheReadInputTokens
+                                          + cacheCreationInputTokens
+    session_duration = result.duration_ms / 1000
+
+We cross-check agent_turns against the count of unique assistant ``message.id``s.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_FINAL_RE = re.compile(r"<final_answer>(.*?)</final_answer>", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_final_answer(text: str | None) -> str | None:
+    if not text:
+        return None
+    m = _FINAL_RE.search(text)
+    return m.group(1).strip() if m else None
+
+
+def _model_usage_totals(model_usage: dict) -> tuple[int, int]:
+    """Return (total_output_tokens, total_input_side_tokens) from modelUsage."""
+    out = 0
+    inp = 0
+    for v in (model_usage or {}).values():
+        out += int(v.get("outputTokens", 0) or 0)
+        inp += (
+            int(v.get("inputTokens", 0) or 0)
+            + int(v.get("cacheReadInputTokens", 0) or 0)
+            + int(v.get("cacheCreationInputTokens", 0) or 0)
+        )
+    return out, inp
+
+
+@dataclass
+class TaskMetrics:
+    # The three Q&A metrics (paper Table 5):
+    agent_turns: int | None
+    per_turn_context: float | None  # mean input-side context per turn
+    output_tokens: int  # total billed output tokens
+    # The other two ATE metrics (reported for non-Q&A categories):
+    session_duration_s: float | None
+    active_gpu_time_s: float | None  # None for Q&A (no training run)
+    # Provenance / cross-checks (not paper metrics):
+    unique_assistant_messages: int = 0
+    total_cost_usd: float | None = None
+    model: str | None = None
+    is_error: bool | None = None
+    final_answer: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def parse_transcript(path: str | Path) -> TaskMetrics:
+    """Parse one stream-json transcript file into a :class:`TaskMetrics`."""
+    message_ids: set[str] = set()
+    result: dict | None = None
+
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            etype = ev.get("type")
+            if etype == "assistant":
+                mid = (ev.get("message") or {}).get("id")
+                if mid:
+                    message_ids.add(mid)
+            elif etype == "result":
+                result = ev
+
+    n_unique = len(message_ids)
+    if result is None:
+        # No final result event (timeout/crash mid-stream). Fall back to what we
+        # can: turn count from unique messages; totals unknown.
+        return TaskMetrics(
+            agent_turns=n_unique or None,
+            per_turn_context=None,
+            output_tokens=0,
+            session_duration_s=None,
+            active_gpu_time_s=None,
+            unique_assistant_messages=n_unique,
+            is_error=True,
+        )
+
+    num_turns = result.get("num_turns") or n_unique or None
+    duration_ms = result.get("duration_ms")
+    duration_s = (duration_ms / 1000.0) if duration_ms else None
+    model_usage = result.get("modelUsage") or {}
+    out_tokens, in_side = _model_usage_totals(model_usage)
+    per_turn_context = (in_side / num_turns) if (in_side and num_turns) else None
+    model = next(iter(model_usage.keys()), None)
+
+    return TaskMetrics(
+        agent_turns=num_turns,
+        per_turn_context=per_turn_context,
+        output_tokens=out_tokens,
+        session_duration_s=duration_s,
+        active_gpu_time_s=None,
+        unique_assistant_messages=n_unique,
+        total_cost_usd=result.get("total_cost_usd"),
+        model=model,
+        is_error=result.get("is_error"),
+        final_answer=_extract_final_answer(result.get("result")),
+    )
+
+
+def _k(x: float | None) -> str:
+    return "-" if x is None else f"{x / 1000:.1f}K"
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Parse a Claude stream-json transcript")
+    ap.add_argument("transcript", help="path to a *.jsonl stream-json transcript")
+    args = ap.parse_args(argv)
+
+    m = parse_transcript(args.transcript)
+    print(json.dumps(m.to_dict(), indent=2))
+    dur = f"{m.session_duration_s:.0f}s" if m.session_duration_s else "-"
+    print(
+        f"\nAgent Turns: {m.agent_turns}  |  Per-Turn Context: "
+        f"{_k(m.per_turn_context)}  |  Output Tokens: {_k(m.output_tokens)}  |  "
+        f"Duration: {dur}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/repro_config.py
+++ b/agent_tooling/ate_bench/runner/repro_config.py
@@ -1,0 +1,110 @@
+"""TorchTitan-specific settings for the ATE-Bench reproduction.
+
+Encodes the paper's fixed evaluation config (Appendix B): ``PP=4, EP=2, DP=1``,
+seq_len 2048, global batch 1024, BF16, 8 GPUs — mapped onto TorchTitan's real
+infrastructure:
+
+- launcher: ``run_train.sh`` (``MODULE``/``CONFIG`` env + CLI overrides)
+- parallelism flags: ``--parallelism.{pipeline,expert}_parallel_degree`` etc.
+- model: an MoE model (paper used Qwen3-30B-A3B / DeepSeek-V2-Lite / GPT-OSS-20B;
+  TorchTitan analogs: ``deepseek_v3``, ``qwen3`` (``debugmodel_moe``), ``llama4``,
+  ``gpt_oss``)
+- dataset: C4 (TorchTitan native; the paper used DCLM)
+- checkpoints: ``scripts/checkpoint_conversion/convert_{to,from}_hf.py``
+
+The ``*_debugmodel`` configs are tiny and meant for harness validation / smoke
+runs; reproducing paper-scale numbers needs a full MoE config and a real
+checkpoint on 8 GPUs. Mesh degrees are overridable (env in setup/train.sh, or
+fields here) so the harness can run a 1-GPU smoke before the full 8-GPU config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# .../agent_tooling/ate_bench/runner/repro_config.py
+RUNNER_DIR = Path(__file__).resolve().parent
+ATE_ROOT = RUNNER_DIR.parent
+REPO_ROOT = ATE_ROOT.parents[1]  # agent_tooling/.. -> repo root
+SETUP_DIR = ATE_ROOT / "setup"
+
+
+@dataclass
+class ReproConfig:
+    # Which framework/model is under test.
+    module: str = "deepseek_v3"
+    config: str = "deepseek_v3_debugmodel"
+    label: str = "titan"  # used for workspace/<label>/... and results/<label>/
+
+    # Fixed mesh (paper Appendix B).
+    ngpu: int = 8
+    pipeline_parallel_degree: int = 4
+    expert_parallel_degree: int = 2
+    data_parallel_shard_degree: int = 1
+
+    # Fixed training shape.
+    seq_len: int = 2048
+    global_batch_size: int = 1024
+    dataset: str = "c4"  # paper used DCLM; TorchTitan native is C4
+
+    workspace: Path = field(default_factory=lambda: ATE_ROOT / "workspace")
+
+    def parallelism_flags(self) -> list[str]:
+        return [
+            f"--parallelism.pipeline_parallel_degree={self.pipeline_parallel_degree}",
+            f"--parallelism.expert_parallel_degree={self.expert_parallel_degree}",
+            f"--parallelism.data_parallel_shard_degree={self.data_parallel_shard_degree}",
+        ]
+
+    def workspace_dir(self) -> Path:
+        return self.workspace / self.label
+
+    def routing_traces_dir(self) -> Path:
+        return self.workspace_dir() / "routing-traces"
+
+    def heavy_kernels_dir(self) -> Path:
+        return self.workspace_dir() / "heavy-kernels"
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["workspace"] = str(self.workspace)
+        return d
+
+
+    def render(self, text: str, task_id: str = "", workspace_root: Path | None = None) -> str:
+        """Substitute {{PLACEHOLDER}} tokens in a task prompt with config values.
+
+        Script paths are repo-root-relative so they resolve whether the agent runs
+        in the main checkout (operate tasks) or a worktree (new-feature). Pass an
+        absolute ``workspace_root`` (the main checkout's workspace) so worktree
+        runs still write artifacts where the checks read them.
+        """
+        train_sh = "agent_tooling/ate_bench/setup/train.sh"
+        evaluate_sh = "agent_tooling/ate_bench/setup/evaluate.sh"
+        ws = str(workspace_root) if workspace_root else "agent_tooling/ate_bench/workspace"
+        repl = {
+            "{{NGPU}}": str(self.ngpu),
+            "{{MODULE}}": self.module,
+            "{{CONFIG}}": self.config,
+            "{{LABEL}}": self.label,
+            "{{SEQ_LEN}}": str(self.seq_len),
+            "{{GLOBAL_BATCH_SIZE}}": str(self.global_batch_size),
+            "{{MESH}}": (
+                f"PP={self.pipeline_parallel_degree}, EP={self.expert_parallel_degree}, "
+                f"DP={self.data_parallel_shard_degree}"
+            ),
+            "{{TRAIN_SH}}": train_sh,
+            "{{EVALUATE_SH}}": evaluate_sh,
+            "{{WORKSPACE}}": ws,
+            "{{ROUTING_TRACES_DIR}}": f"{ws}/{self.label}/routing-traces",
+            "{{HEAVY_KERNELS_DIR}}": f"{ws}/{self.label}/heavy-kernels",
+            "{{TASK_ID}}": task_id,
+        }
+        for k, v in repl.items():
+            text = text.replace(k, v)
+        return text
+
+
+# Singleton default; runners may build their own with overrides.
+DEFAULT = ReproConfig()

--- a/agent_tooling/ate_bench/runner/repro_config.py
+++ b/agent_tooling/ate_bench/runner/repro_config.py
@@ -37,11 +37,16 @@ class ReproConfig:
     config: str = "deepseek_v3_debugmodel"
     label: str = "titan"  # used for workspace/<label>/... and results/<label>/
 
-    # Fixed mesh (paper Appendix B).
+    # Fixed mesh (paper Appendix B): PP=4, EP=2, DP=1.
+    # NOTE: the paper's notation is multiplicative (PP*EP*DP = 8), but TorchTitan's
+    # mesh is dp_replicate*dp_shard*cp*tp*pp == world_size with EP *carved from* the
+    # data axis (not multiplied on top). So on 8 GPUs we set pp=4 and leave
+    # dp_shard=-1 (auto -> 8/(1*1*1*4)=2); EP=2 then shards experts across that data
+    # axis of 2. dp_shard=1 would fail validation (1*1*1*1*4 != 8).
     ngpu: int = 8
     pipeline_parallel_degree: int = 4
     expert_parallel_degree: int = 2
-    data_parallel_shard_degree: int = 1
+    data_parallel_shard_degree: int = -1  # auto-fill the mesh; EP overlaps this axis
 
     # Fixed training shape.
     seq_len: int = 2048

--- a/agent_tooling/ate_bench/runner/repro_config.py
+++ b/agent_tooling/ate_bench/runner/repro_config.py
@@ -99,6 +99,7 @@ class ReproConfig:
                 f"PP={self.pipeline_parallel_degree}, EP={self.expert_parallel_degree}, "
                 f"DP={self.data_parallel_shard_degree}"
             ),
+            "{{DATASET}}": self.dataset,
             "{{TRAIN_SH}}": train_sh,
             "{{EVALUATE_SH}}": evaluate_sh,
             "{{WORKSPACE}}": ws,

--- a/agent_tooling/ate_bench/runner/run_feature.py
+++ b/agent_tooling/ate_bench/runner/run_feature.py
@@ -63,6 +63,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--label", default="titan")
     ap.add_argument("--module", default=rc.DEFAULT.module)
     ap.add_argument("--config", default=rc.DEFAULT.config)
+    ap.add_argument("--dataset", default=rc.DEFAULT.dataset, help="training dataset (c4 / c4_test)")
+    ap.add_argument(
+        "--global-batch-size", type=int, default=rc.DEFAULT.global_batch_size,
+        help="paper uses 1024 (for 30B models); use ~64 for the debug model so 64 "
+        "steps show a decreasing loss without grad-accum blowup",
+    )
     ap.add_argument("--model", default=None, help="implementing agent model")
     ap.add_argument("--judge-model", default=None, help="judge model (paper: claude-opus-4-7 @ xhigh)")
     ap.add_argument("--out", type=Path, required=True)
@@ -71,7 +77,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--keep-worktrees", action="store_true", help="don't remove worktrees after")
     args = ap.parse_args(argv)
 
-    cfg = rc.ReproConfig(module=args.module, config=args.config, label=args.label)
+    cfg = rc.ReproConfig(
+        module=args.module, config=args.config, label=args.label,
+        dataset=args.dataset, global_batch_size=args.global_batch_size,
+    )
     all_tasks = discover_tasks()
     selected = list(all_tasks) if args.tasks == "all" else [t.strip() for t in args.tasks.split(",")]
     unknown = [t for t in selected if t not in all_tasks]
@@ -81,6 +90,15 @@ def main(argv: list[str] | None = None) -> int:
     out = args.out.expanduser().resolve()
     out.mkdir(parents=True, exist_ok=True)
     wt_root = rc.ATE_ROOT / "worktrees"
+
+    # Base worktrees on the CURRENT branch tip (it carries the ate_bench tooling,
+    # which is not on main), and diff the agent's changes against that same point so
+    # the judge sees only the agent's model-code edits, not the tooling.
+    import subprocess as _sp
+    base_ref = _sp.run(
+        ["git", "-C", str(rc.REPO_ROOT), "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip() or "HEAD"
 
     print(f"ATE-Bench New-Feature | module={cfg.module} config={cfg.config} "
           f"label={cfg.label} model={args.model or 'default'} judge={args.judge_model or 'default'}")
@@ -98,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
             wt = wt_root / f"{task_id}-run{run_idx}"
             row: dict = {"run": run_idx}
             try:
-                worktrees.create_worktree(rc.REPO_ROOT, wt, base="main")
+                worktrees.create_worktree(rc.REPO_ROOT, wt, base=base_ref)
             except Exception as exc:  # noqa: BLE001
                 print(f"  run {run_idx}: worktree create failed: {exc}")
                 row.update({"error": True, "detail": str(exc)})
@@ -112,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
                     model=args.model, timeout=args.timeout,
                     monitor_gpu=not args.no_gpu_monitor,
                 )
-                diff = worktrees.diff_vs_base(wt, "main")
+                diff = worktrees.diff_vs_base(wt, base_ref)
                 (tdir / f"run{run_idx}.diff").write_text(diff)
 
                 # Axis 1: loss curve (log saved by the agent under the shared workspace).

--- a/agent_tooling/ate_bench/runner/run_feature.py
+++ b/agent_tooling/ate_bench/runner/run_feature.py
@@ -1,0 +1,158 @@
+"""Run ATE-Bench New-Feature tasks (NF1-NF4) with the fixed agent.
+
+Each attempt integrates a published architecture (Diff attention / DynMoE / MoBA /
+MoE++) into the base MoE model end-to-end. To match the paper (B.3.2) each attempt
+runs in an isolated git worktree off ``main`` so the change can be diffed against
+``main`` and attempts don't collide. Correctness has two axes:
+
+  1. loss axis  — 64-step CE loss decreases and stays finite (checks/nf_loss_curve)
+  2. rule axis  — an independent LLM judge scores the diff against 3 fixed rules
+                  (runner/judge.py; paper used claude-opus-4-7 @ xhigh)
+
+An attempt is correct iff both axes pass. We also log active GPU time.
+
+GPU-gated: needs 8 GPUs + C4 data to actually train. Without it the agent still
+runs, the diff + judge still work, but the loss check will not pass.
+
+Example:
+    python agent_tooling/ate_bench/runner/run_feature.py \
+        --tasks nf1 --runs 1 --label titan \
+        --judge-model claude-opus-4-7 \
+        --out agent_tooling/ate_bench/results/feature_titan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import repro_config as rc  # noqa: E402
+import judge as judge_mod  # noqa: E402
+import worktrees  # noqa: E402
+from agent_session import run_session  # noqa: E402
+from checks import nf_loss_curve  # noqa: E402
+
+TASKS_DIR = Path(__file__).resolve().parent.parent / "tasks" / "new_feature"
+PREAMBLE = TASKS_DIR / "preamble.md"
+REFERENCES = TASKS_DIR / "references.md"
+RULES_DIR = TASKS_DIR / "rules"
+
+ALLOWED_TOOLS = ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+
+
+def discover_tasks() -> dict[str, Path]:
+    return {p.name.split("_", 1)[0]: p for p in sorted(TASKS_DIR.glob("nf[0-9]_*.md"))}
+
+
+def build_prompt(task_path: Path, cfg: rc.ReproConfig) -> str:
+    task_id = task_path.name.split("_", 1)[0]
+    ws_root = cfg.workspace.resolve()
+    preamble = cfg.render(PREAMBLE.read_text(), task_id, workspace_root=ws_root).strip()
+    body = task_path.read_text().strip()
+    refs = REFERENCES.read_text().strip()
+    return f"{preamble}\n\n{body}\n\n---\n## Reference materials\n{refs}\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tasks", default="all", help="comma list (nf1,nf3) or 'all'")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--label", default="titan")
+    ap.add_argument("--module", default=rc.DEFAULT.module)
+    ap.add_argument("--config", default=rc.DEFAULT.config)
+    ap.add_argument("--model", default=None, help="implementing agent model")
+    ap.add_argument("--judge-model", default=None, help="judge model (paper: claude-opus-4-7 @ xhigh)")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--timeout", type=int, default=10800)
+    ap.add_argument("--no-gpu-monitor", action="store_true")
+    ap.add_argument("--keep-worktrees", action="store_true", help="don't remove worktrees after")
+    args = ap.parse_args(argv)
+
+    cfg = rc.ReproConfig(module=args.module, config=args.config, label=args.label)
+    all_tasks = discover_tasks()
+    selected = list(all_tasks) if args.tasks == "all" else [t.strip() for t in args.tasks.split(",")]
+    unknown = [t for t in selected if t not in all_tasks]
+    if unknown:
+        ap.error(f"unknown tasks {unknown}; available {list(all_tasks)}")
+
+    out = args.out.expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    wt_root = rc.ATE_ROOT / "worktrees"
+
+    print(f"ATE-Bench New-Feature | module={cfg.module} config={cfg.config} "
+          f"label={cfg.label} model={args.model or 'default'} judge={args.judge_model or 'default'}")
+    print(f"tasks={selected} runs={args.runs} out={out}\n")
+
+    manifest = {"config": cfg.to_dict(), "model": args.model, "judge_model": args.judge_model, "results": {}}
+    for task_id in selected:
+        prompt = build_prompt(all_tasks[task_id], cfg)
+        rules_text = (RULES_DIR / f"{task_id}.rules.md").read_text()
+        print(f"=== {task_id} ===")
+        per_run = []
+        for run_idx in range(1, args.runs + 1):
+            tdir = out / task_id
+            tdir.mkdir(parents=True, exist_ok=True)
+            wt = wt_root / f"{task_id}-run{run_idx}"
+            row: dict = {"run": run_idx}
+            try:
+                worktrees.create_worktree(rc.REPO_ROOT, wt, base="main")
+            except Exception as exc:  # noqa: BLE001
+                print(f"  run {run_idx}: worktree create failed: {exc}")
+                row.update({"error": True, "detail": str(exc)})
+                per_run.append(row)
+                continue
+            try:
+                transcript = tdir / f"run{run_idx}.jsonl"
+                m, code, _stderr, gpu = run_session(
+                    prompt, wt, transcript,
+                    allowed_tools=ALLOWED_TOOLS, permission_mode="acceptEdits",
+                    model=args.model, timeout=args.timeout,
+                    monitor_gpu=not args.no_gpu_monitor,
+                )
+                diff = worktrees.diff_vs_base(wt, "main")
+                (tdir / f"run{run_idx}.diff").write_text(diff)
+
+                # Axis 1: loss curve (log saved by the agent under the shared workspace).
+                log_path = cfg.workspace_dir() / task_id / "train.log"
+                if log_path.exists():
+                    loss_res = nf_loss_curve.check(log_path.read_text(errors="ignore")).to_dict()
+                else:
+                    loss_res = {"passed": False, "detail": f"no train.log at {log_path}"}
+
+                # Axis 2: independent rule judge over the diff.
+                verdict = judge_mod.judge_feature(rules_text, diff, model=args.judge_model)
+
+                correct = bool(loss_res.get("passed")) and verdict.get("overall") == "PASS"
+                row.update({
+                    **(m.to_dict() if m else {"error": True, "returncode": code}),
+                    "gpu": gpu,
+                    "correctness": {
+                        "correct": correct,
+                        "loss_axis": loss_res,
+                        "rule_axis": verdict,
+                    },
+                })
+                (tdir / f"run{run_idx}.metrics.json").write_text(json.dumps(row, indent=2))
+                turns = (m.agent_turns if m else None)
+                agt = gpu.get("active_gpu_time_s")
+                print(f"  run {run_idx}: turns={turns} "
+                      f"gpu_time={'%.0fs' % agt if agt is not None else 'n/a'} "
+                      f"loss={loss_res.get('passed')} judge={verdict.get('overall')} "
+                      f"correct={correct}")
+            finally:
+                if not args.keep_worktrees:
+                    worktrees.remove_worktree(rc.REPO_ROOT, wt)
+            per_run.append(row)
+        manifest["results"][task_id] = per_run
+        print()
+
+    (out / "run_manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"Wrote {out / 'run_manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/run_operate.py
+++ b/agent_tooling/ate_bench/runner/run_operate.py
@@ -1,0 +1,137 @@
+"""Run ATE-Bench Operate-and-Profile tasks (OP1-OP4) with the fixed agent.
+
+Unlike Q&A, these tasks run/instrument/profile the framework, so the agent gets
+the full toolset (edits auto-accepted) and we measure *active GPU time* alongside
+the effort metrics. After each attempt the task's programmatic artifact check runs
+(paper B.2.2: verify the artifact, not the path taken).
+
+These tasks are GPU-gated: they need 8 GPUs, an MoE checkpoint, vLLM +
+lm-eval-harness (OP2), and Nsight Systems (OP4). Without that substrate the agent
+still runs and metrics are logged, but the artifact checks will fail/skip.
+
+Example:
+    python agent_tooling/ate_bench/runner/run_operate.py \
+        --tasks op3 --runs 1 --label titan \
+        --out agent_tooling/ate_bench/results/operate_titan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import repro_config as rc  # noqa: E402
+from agent_session import run_session  # noqa: E402
+from checks import op1_getting_started, op2_train_evaluate  # noqa: E402
+from checks import op3_routing_trace, op4_heavy_kernels  # noqa: E402
+
+TASKS_DIR = Path(__file__).resolve().parent.parent / "tasks" / "operate_profile"
+PREAMBLE = TASKS_DIR / "preamble.md"
+
+# Operate tasks edit/run the framework: full toolset, edits auto-accepted.
+ALLOWED_TOOLS = ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+
+
+def run_check(task_id: str, cfg: rc.ReproConfig) -> dict:
+    """Run the task's programmatic artifact check; never raises."""
+    try:
+        if task_id == "op1":
+            log = op1_getting_started.rerun(steps=5)
+            return op1_getting_started.check(log, target_step=5).to_dict()
+        if task_id == "op2":
+            hs = cfg.workspace_dir() / "eval" / "hellaswag.json"
+            return op2_train_evaluate.check(hs).to_dict()
+        if task_id == "op3":
+            return op3_routing_trace.check(cfg.routing_traces_dir()).to_dict()
+        if task_id == "op4":
+            return op4_heavy_kernels.check(cfg.heavy_kernels_dir()).to_dict()
+    except Exception as exc:  # noqa: BLE001
+        return {"passed": False, "detail": f"check errored: {exc}", "extra": {}}
+    return {"passed": False, "detail": "no check for task", "extra": {}}
+
+
+def discover_tasks() -> dict[str, Path]:
+    return {
+        p.name.split("_", 1)[0]: p
+        for p in sorted(TASKS_DIR.glob("op[0-9]_*.md"))
+    }
+
+
+def build_prompt(task_path: Path, cfg: rc.ReproConfig) -> str:
+    task_id = task_path.name.split("_", 1)[0]
+    preamble = cfg.render(PREAMBLE.read_text(encoding="utf-8"), task_id).strip()
+    body = task_path.read_text(encoding="utf-8").strip()
+    lines = body.splitlines()
+    if lines and lines[0].startswith("#"):
+        body = "\n".join(lines[1:]).strip()
+    body = cfg.render(body, task_id)
+    return f"{preamble}\n\n{body}\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tasks", default="all", help="comma list (op1,op3) or 'all'")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--label", default="titan", help="framework label (workspace/<label>/...)")
+    ap.add_argument("--module", default=rc.DEFAULT.module)
+    ap.add_argument("--config", default=rc.DEFAULT.config)
+    ap.add_argument("--model", default=None, help="agent model (paper: Opus 4.7 @ xhigh)")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--timeout", type=int, default=5400)
+    ap.add_argument("--no-gpu-monitor", action="store_true")
+    args = ap.parse_args(argv)
+
+    cfg = rc.ReproConfig(module=args.module, config=args.config, label=args.label)
+    all_tasks = discover_tasks()
+    selected = list(all_tasks) if args.tasks == "all" else [t.strip() for t in args.tasks.split(",")]
+    unknown = [t for t in selected if t not in all_tasks]
+    if unknown:
+        ap.error(f"unknown tasks {unknown}; available {list(all_tasks)}")
+
+    out = args.out.expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    cfg.workspace_dir().mkdir(parents=True, exist_ok=True)
+
+    print(f"ATE-Bench Operate&Profile | module={cfg.module} config={cfg.config} "
+          f"label={cfg.label} model={args.model or 'default'}")
+    print(f"tasks={selected} runs={args.runs} out={out}\n")
+
+    manifest = {"config": cfg.to_dict(), "model": args.model, "results": {}}
+    for task_id in selected:
+        prompt = build_prompt(all_tasks[task_id], cfg)
+        print(f"=== {task_id} ===")
+        per_run = []
+        for run_idx in range(1, args.runs + 1):
+            tdir = out / task_id
+            transcript = tdir / f"run{run_idx}.jsonl"
+            m, code, _stderr, gpu = run_session(
+                prompt, rc.REPO_ROOT, transcript,
+                allowed_tools=ALLOWED_TOOLS,
+                permission_mode="acceptEdits",
+                model=args.model, timeout=args.timeout,
+                monitor_gpu=not args.no_gpu_monitor,
+            )
+            check_res = run_check(task_id, cfg)
+            row = (m.to_dict() if m else {"error": True, "returncode": code})
+            row.update({"run": run_idx, "gpu": gpu, "correctness": check_res})
+            tdir.mkdir(parents=True, exist_ok=True)
+            (tdir / f"run{run_idx}.metrics.json").write_text(json.dumps(row, indent=2))
+            per_run.append(row)
+            turns = (m.agent_turns if m else None)
+            agt = gpu.get("active_gpu_time_s")
+            print(f"  run {run_idx}: turns={turns} "
+                  f"gpu_time={'%.0fs' % agt if agt is not None else 'n/a'} "
+                  f"correct={check_res.get('passed')} ({check_res.get('detail')})")
+        manifest["results"][task_id] = per_run
+        print()
+
+    (out / "run_manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"Wrote {out / 'run_manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/run_qa.py
+++ b/agent_tooling/ate_bench/runner/run_qa.py
@@ -1,0 +1,239 @@
+"""Run ATE-Bench Q&A tasks against a target framework with a fixed agent.
+
+Reproduces the Q&A category of ATE-Bench (PithTrain, arXiv:2605.31463): a *fixed*
+coding agent is pointed at a framework codebase and asked code-property questions
+with read-only tools; we log the effort metrics. The paper's fixed agent was
+Claude Code (Opus 4.7, xhigh effort), each task run 3 times with medians reported.
+
+The agent is invoked headless:
+    claude -p --output-format stream-json --verbose
+      --allowedTools Read Grep Glob Bash
+      --disallowedTools Edit Write NotebookEdit
+run with the target repo as the working directory so the agent explores *that*
+codebase. The universal instruction (tasks/qa/universal_instruction.txt) is
+prepended verbatim to each question.
+
+Example:
+    python agent_tooling/ate_bench/runner/run_qa.py \
+        --repo /home/bahuang/local/torchtitan_autodev \
+        --tasks all --runs 3 --out agent_tooling/ate_bench/results/titan
+
+Then summarize with:
+    python agent_tooling/ate_bench/runner/aggregate.py agent_tooling/ate_bench/results/titan
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Allow running as a plain script (python .../run_qa.py) by importing the sibling.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import metrics as metrics_mod  # noqa: E402
+
+QA_DIR = Path(__file__).resolve().parent.parent / "tasks" / "qa"
+UNIVERSAL = QA_DIR / "universal_instruction.txt"
+
+# Faithful to the paper: read-only exploration tools, mutating tools disabled.
+ALLOWED_TOOLS = ["Read", "Grep", "Glob", "Bash"]
+DISALLOWED_TOOLS = ["Edit", "Write", "NotebookEdit"]
+
+
+def discover_tasks() -> dict[str, Path]:
+    """Return {task_id: prompt_path} for q01..q12, sorted by id."""
+    tasks: dict[str, Path] = {}
+    for p in sorted(QA_DIR.glob("q[0-9][0-9]_*.md")):
+        task_id = p.name.split("_", 1)[0]  # e.g. "q01"
+        tasks[task_id] = p
+    return tasks
+
+
+def build_prompt(task_path: Path) -> str:
+    universal = UNIVERSAL.read_text(encoding="utf-8").strip()
+    body = task_path.read_text(encoding="utf-8").strip()
+    # Drop the leading "# Qn: Title" heading; keep the question text only, as the
+    # paper prepends the universal instruction followed by the query text.
+    lines = body.splitlines()
+    if lines and lines[0].startswith("#"):
+        body = "\n".join(lines[1:]).strip()
+    return f"{universal}\n\n{body}\n"
+
+
+def git_commit(repo: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def run_once(
+    prompt: str,
+    repo: Path,
+    transcript_path: Path,
+    model: str | None,
+    timeout: int,
+) -> tuple[metrics_mod.TaskMetrics | None, int, str]:
+    """Run the fixed agent once; write transcript; return (metrics, returncode, stderr)."""
+    cmd = [
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--allowedTools",
+        *ALLOWED_TOOLS,
+        "--disallowedTools",
+        *DISALLOWED_TOOLS,
+    ]
+    if model:
+        cmd += ["--model", model]
+
+    proc = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        cwd=str(repo),
+        timeout=timeout,
+    )
+    transcript_path.write_text(proc.stdout, encoding="utf-8")
+    if proc.stderr:
+        transcript_path.with_suffix(".stderr.log").write_text(
+            proc.stderr, encoding="utf-8"
+        )
+    m = None
+    if proc.stdout.strip():
+        try:
+            m = metrics_mod.parse_transcript(transcript_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"    ! failed to parse transcript: {exc}", file=sys.stderr)
+    return m, proc.returncode, proc.stderr
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--repo",
+        required=True,
+        type=Path,
+        help="path to the framework checkout the agent should explore",
+    )
+    ap.add_argument(
+        "--tasks",
+        default="all",
+        help="comma-separated task ids (e.g. q01,q05) or 'all'",
+    )
+    ap.add_argument("--runs", type=int, default=3, help="attempts per task (paper: 3)")
+    ap.add_argument(
+        "--model",
+        default=None,
+        help="agent model override (default: CLI default). Paper used Opus 4.7 "
+        "at xhigh effort; set this to match the comparison you want.",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="output directory for transcripts + metrics",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=1800,
+        help="per-attempt timeout in seconds (default 1800)",
+    )
+    args = ap.parse_args(argv)
+
+    repo = args.repo.expanduser().resolve()
+    if not repo.is_dir():
+        ap.error(f"--repo {repo} is not a directory")
+    if not UNIVERSAL.exists():
+        ap.error(f"missing universal instruction: {UNIVERSAL}")
+
+    all_tasks = discover_tasks()
+    if args.tasks.strip().lower() == "all":
+        selected = list(all_tasks)
+    else:
+        selected = [t.strip() for t in args.tasks.split(",") if t.strip()]
+        unknown = [t for t in selected if t not in all_tasks]
+        if unknown:
+            ap.error(f"unknown task ids {unknown}; available: {list(all_tasks)}")
+
+    out = args.out.expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    commit = git_commit(repo)
+
+    run_manifest = {
+        "repo": str(repo),
+        "repo_commit": commit,
+        "model": args.model,
+        "runs_per_task": args.runs,
+        "tasks": selected,
+        "allowed_tools": ALLOWED_TOOLS,
+        "disallowed_tools": DISALLOWED_TOOLS,
+        "results": {},
+    }
+
+    print(f"ATE-Bench Q&A  |  repo={repo}  commit={commit}  model={args.model or 'default'}")
+    print(f"tasks={selected}  runs={args.runs}  out={out}\n")
+
+    for task_id in selected:
+        task_path = all_tasks[task_id]
+        prompt = build_prompt(task_path)
+        title = task_path.read_text(encoding="utf-8").splitlines()[0].lstrip("# ").strip()
+        print(f"=== {task_id}: {title} ===")
+        per_run = []
+        for run_idx in range(1, args.runs + 1):
+            tdir = out / task_id
+            tdir.mkdir(parents=True, exist_ok=True)
+            transcript_path = tdir / f"run{run_idx}.jsonl"
+            t0 = time.time()
+            m, rc, stderr = run_once(
+                prompt, repo, transcript_path, args.model, args.timeout
+            )
+            wall = time.time() - t0
+            if m is None:
+                tail = (stderr or "").strip().splitlines()[-1:] or ["(no output)"]
+                print(f"  run {run_idx}: FAILED rc={rc} wall={wall:.0f}s  {tail[0]}")
+                per_run.append({"run": run_idx, "error": True, "returncode": rc})
+                continue
+            md = m.to_dict()
+            md["run"] = run_idx
+            md["wall_time_s"] = wall
+            (tdir / f"run{run_idx}.metrics.json").write_text(
+                json.dumps(md, indent=2), encoding="utf-8"
+            )
+            per_run.append(md)
+            print(
+                f"  run {run_idx}: turns={m.agent_turns}  "
+                f"ctx={_k(m.per_turn_context)}  out={_k(m.output_tokens)}  "
+                f"dur={m.session_duration_s:.0f}s  err={m.is_error}"
+            )
+        run_manifest["results"][task_id] = per_run
+        print()
+
+    (out / "run_manifest.json").write_text(
+        json.dumps(run_manifest, indent=2), encoding="utf-8"
+    )
+    print(f"Wrote run manifest -> {out / 'run_manifest.json'}")
+    print(f"Summarize with: python {Path(__file__).with_name('aggregate.py')} {out}")
+    return 0
+
+
+def _k(x: float | None) -> str:
+    return "-" if x is None else f"{x / 1000:.1f}K"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_tooling/ate_bench/runner/worktrees.py
+++ b/agent_tooling/ate_bench/runner/worktrees.py
@@ -1,0 +1,36 @@
+"""Git worktree helpers for isolating new-feature attempts.
+
+Each new-feature attempt runs in its own detached worktree off ``main`` so that
+attempts don't collide and the agent's full change can be diffed against ``main``
+(paper B.3.2 judges the ``git diff`` against main).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(repo: Path, *args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, timeout=timeout
+    )
+
+
+def create_worktree(repo: Path, path: Path, base: str = "main") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    res = _git(repo, "worktree", "add", "--detach", str(path), base)
+    if res.returncode != 0:
+        raise RuntimeError(f"git worktree add failed: {res.stderr.strip()}")
+    return path
+
+
+def diff_vs_base(worktree: Path, base: str = "main") -> str:
+    """Full diff of the agent's changes vs base, including new (untracked) files."""
+    _git(worktree, "add", "-A")
+    res = _git(worktree, "diff", "--cached", base)
+    return res.stdout
+
+
+def remove_worktree(repo: Path, path: Path) -> None:
+    _git(repo, "worktree", "remove", "--force", str(path))

--- a/agent_tooling/ate_bench/runner/worktrees.py
+++ b/agent_tooling/ate_bench/runner/worktrees.py
@@ -33,4 +33,11 @@ def diff_vs_base(worktree: Path, base: str = "main") -> str:
 
 
 def remove_worktree(repo: Path, path: Path) -> None:
-    _git(repo, "worktree", "remove", "--force", str(path))
+    # Worktrees can end up "locked" (esp. on network mounts); a single --force won't
+    # remove a locked worktree. Unlock, double-force, then fall back to rm + prune.
+    _git(repo, "worktree", "unlock", str(path))
+    res = _git(repo, "worktree", "remove", "--force", "--force", str(path))
+    if res.returncode != 0:
+        import shutil
+        shutil.rmtree(path, ignore_errors=True)
+        _git(repo, "worktree", "prune")

--- a/agent_tooling/ate_bench/setup/evaluate.sh
+++ b/agent_tooling/ate_bench/setup/evaluate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/bash
+# ATE-Bench OP2 (Train and Evaluate) — read-only evaluation script.
+#
+# Consumes the pipeline output the agent produced (a TorchTitan checkpoint), and:
+#   1. exports it to HuggingFace format via TorchTitan's converter
+#   2. runs lm-evaluation-harness HellaSwag (zero-shot) on it via vLLM
+#   3. writes a finite score to $OUT/hellaswag.json
+#
+# The task tests PIPELINE correctness, not model quality: 25 steps from random
+# init is expected to be near-random on HellaSwag. The harness accepts the
+# attempt iff this script completes and writes a finite score.
+#
+# Prereqs (OP2 is GPU-gated): vllm + lm-eval installed, a GPU visible.
+#
+# Usage:
+#   CKPT_DIR=<torchtitan checkpoint dir> STEP=25 \
+#   HF_OUT=<dir> OUT=<dir> bash agent_tooling/ate_bench/setup/evaluate.sh
+set -euo pipefail
+
+: "${CKPT_DIR:?set CKPT_DIR to the TorchTitan checkpoint directory}"
+STEP="${STEP:-25}"
+HF_OUT="${HF_OUT:-$CKPT_DIR/hf_export}"
+OUT="${OUT:-$(dirname "$CKPT_DIR")/eval}"
+TOKENIZER="${TOKENIZER:-./tests/assets/tokenizer}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+mkdir -p "$HF_OUT" "$OUT"
+
+echo "[ate_bench] exporting TorchTitan checkpoint (step $STEP) -> HF format at $HF_OUT"
+python scripts/checkpoint_conversion/convert_to_hf.py \
+    "$CKPT_DIR" "$HF_OUT" --step "$STEP" || {
+  echo "convert_to_hf.py failed; check its --help for the exact arg signature" >&2
+  exit 2
+}
+# TorchTitan exports weights only; copy a tokenizer so vLLM can load the model.
+cp -n "$TOKENIZER"/* "$HF_OUT"/ 2>/dev/null || true
+
+echo "[ate_bench] running lm-eval HellaSwag (zero-shot) via vLLM"
+lm_eval --model vllm \
+    --model_args "pretrained=$HF_OUT,dtype=bfloat16,gpu_memory_utilization=0.8" \
+    --tasks hellaswag --num_fewshot 0 \
+    --output_path "$OUT" \
+    --log_samples || {
+  echo "lm_eval failed; ensure vllm + lm-eval-harness are installed" >&2
+  exit 3
+}
+
+# Surface a single finite score for the harness check.
+python - "$OUT" <<'PY'
+import json, sys, glob, os
+out = sys.argv[1]
+files = sorted(glob.glob(os.path.join(out, "**", "results*.json"), recursive=True))
+if not files:
+    print("no lm-eval results json found", file=sys.stderr); sys.exit(4)
+res = json.load(open(files[-1]))
+acc = res.get("results", {}).get("hellaswag", {})
+score = acc.get("acc,none", acc.get("acc"))
+json.dump({"hellaswag_acc": score}, open(os.path.join(out, "hellaswag.json"), "w"), indent=2)
+print("hellaswag_acc =", score)
+PY

--- a/agent_tooling/ate_bench/setup/train.sh
+++ b/agent_tooling/ate_bench/setup/train.sh
@@ -22,7 +22,9 @@ CONFIG="${CONFIG:-deepseek_v3_debugmodel}"
 NGPU="${NGPU:-8}"
 PP="${PP:-4}"
 EP="${EP:-2}"
-DP="${DP:-1}"
+# dp_shard: -1 = auto-fill the mesh (world_size/(dp_replicate*cp*tp*pp)). EP is
+# carved from this data axis, not multiplied on top, so PP=4 on 8 GPUs -> dp_shard=2.
+DP="${DP:--1}"
 SEQ_LEN="${SEQ_LEN:-2048}"
 GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-1024}"
 
@@ -32,8 +34,11 @@ cd "$REPO_ROOT"
 
 echo "[ate_bench] module=$MODULE config=$CONFIG ngpu=$NGPU mesh(PP=$PP,EP=$EP,DP=$DP) steps=$STEPS"
 
-MODULE="$MODULE" CONFIG="$CONFIG" NGPU="$NGPU" ${COMM_MODE:+COMM_MODE=$COMM_MODE} \
-  ./run_train.sh \
+# run_train.sh reads these from the environment.
+export MODULE CONFIG NGPU
+[ -n "${COMM_MODE:-}" ] && export COMM_MODE
+
+./run_train.sh \
     --parallelism.pipeline_parallel_degree="$PP" \
     --parallelism.expert_parallel_degree="$EP" \
     --parallelism.data_parallel_shard_degree="$DP" \

--- a/agent_tooling/ate_bench/setup/train.sh
+++ b/agent_tooling/ate_bench/setup/train.sh
@@ -38,6 +38,13 @@ echo "[ate_bench] module=$MODULE config=$CONFIG ngpu=$NGPU mesh(PP=$PP,EP=$EP,DP
 export MODULE CONFIG NGPU
 [ -n "${COMM_MODE:-}" ] && export COMM_MODE
 
+# With pipeline parallelism the loss is computed on the LAST pipeline stage; rank 0
+# (first stage) only prints a sentinel value. Log the last stage's rank so the
+# captured loss is the real one (and the loss-curve check sees a true curve).
+if [ "${PP}" -gt 1 ] && [ -z "${LOG_RANK:-}" ]; then
+  export LOG_RANK="$(( NGPU - NGPU / PP ))"
+fi
+
 ./run_train.sh \
     --parallelism.pipeline_parallel_degree="$PP" \
     --parallelism.expert_parallel_degree="$EP" \

--- a/agent_tooling/ate_bench/setup/train.sh
+++ b/agent_tooling/ate_bench/setup/train.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+# ATE-Bench fixed-config training launcher for TorchTitan.
+#
+# This is the "provided training script" the operate-and-profile tasks refer to
+# (paper Appendix B.2). It encodes the paper's fixed evaluation config:
+#   PP=4, EP=2, DP=1, seq_len 2048, global batch 1024, BF16, 8 GPUs
+# mapped onto TorchTitan's run_train.sh. Treat it as READ-ONLY documentation of
+# best practice — the agent's job (OP1) is to make the *environment* able to run
+# it, not to edit it.
+#
+# Overridable via env for smoke runs (e.g. a 1-GPU dry run):
+#   STEPS=5 NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel \
+#   PP=4 EP=2 DP=1 bash agent_tooling/ate_bench/setup/train.sh
+#
+#   # single-GPU config-validation (no NCCL, no real GPUs):
+#   COMM_MODE=fake_backend PP=1 EP=1 DP=1 NGPU=8 bash .../setup/train.sh
+set -euo pipefail
+
+STEPS="${STEPS:-5}"
+MODULE="${MODULE:-deepseek_v3}"
+CONFIG="${CONFIG:-deepseek_v3_debugmodel}"
+NGPU="${NGPU:-8}"
+PP="${PP:-4}"
+EP="${EP:-2}"
+DP="${DP:-1}"
+SEQ_LEN="${SEQ_LEN:-2048}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-1024}"
+
+# repo root = three levels up from setup/ (agent_tooling/ate_bench/setup)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[ate_bench] module=$MODULE config=$CONFIG ngpu=$NGPU mesh(PP=$PP,EP=$EP,DP=$DP) steps=$STEPS"
+
+MODULE="$MODULE" CONFIG="$CONFIG" NGPU="$NGPU" ${COMM_MODE:+COMM_MODE=$COMM_MODE} \
+  ./run_train.sh \
+    --parallelism.pipeline_parallel_degree="$PP" \
+    --parallelism.expert_parallel_degree="$EP" \
+    --parallelism.data_parallel_shard_degree="$DP" \
+    --training.seq_len="$SEQ_LEN" \
+    --training.global_batch_size="$GLOBAL_BATCH_SIZE" \
+    --training.steps="$STEPS" \
+    "$@"

--- a/agent_tooling/ate_bench/tasks/new_feature/README.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/README.md
@@ -1,0 +1,64 @@
+# ATE-Bench — New-Feature tasks (4 tasks) — DEFERRED
+
+Each task mimics integrating a recently published modeling architecture into a
+training framework. The agent is given the same materials an engineer would
+consult: the arXiv paper and the reference implementation. From these, the agent
+must produce a training script that integrates the new feature into the base model
+and runs on DCLM under the fixed config below. **Specified here but not yet wired
+into the runner** (requires GPUs + DCLM data).
+
+Fixed evaluation config (shared with operate-and-profile tasks): parallelism mesh
+`PP=4, EP=2, DP=1`, sequence length `2048`, global batch size `1024`, precision
+`BF16`, on 8 GPUs.
+
+Coverage rationale: two tasks revise the attention mechanism and two require
+changes at the FFN (MoE) layer, so the suite spans the architectural subsystems a
+training framework must accommodate. None of the four architectures had been
+integrated into any of the three compared frameworks at the time of the study, so
+all frameworks start from the same point.
+
+## Tasks (Appendix B.3.1)
+
+### NF1 — Diff (Differential Attention) [Ye et al.]
+Differential attention replaces a single softmax-attention map with the difference
+of two parallel softmax maps,
+`Attn(Q,K,V) = (softmax(Q1 K1^T) - lambda * softmax(Q2 K2^T)) V`, where `lambda`
+is a learned per-head scalar. Integrating it involves splitting the per-head Q/K
+projections in half and introducing `lambda` as a trainable parameter with the
+published initialisation schedule.
+
+### NF2 — DynMoE
+Standard MoE fixes the number of activated experts `k` per token. DynMoE replaces
+top-k selection with a per-expert sigmoid gate and a learned threshold, so the
+count of active experts varies per token. Integrating it involves replacing the
+top-k routing kernel of the framework and reformulating the load-balancing
+auxiliary loss for a variable-k regime.
+
+### NF3 — MoBA (Mixture of Block Attention)
+MoBA partitions the key/value sequence into fixed-size blocks and routes each
+query to the top-k blocks selected by a learned gate, yielding sub-quadratic
+attention cost in the sequence length. Integrating it involves inserting
+block-level routing between the Q/K projection and the attention computation,
+composing with the existing attention backend, and preserving causal masking
+inside each selected block.
+
+### NF4 — MoE++
+MoE++ augments a standard MoE expert pool with three zero-computation expert types
+(`zero`, `copy`, and `constant`), allowing easy tokens to be routed past the
+feed-forward layer entirely. Integrating it involves extending the expert pool
+definition with the zero-computation variants, widening the router output to cover
+them, and adjusting the load-balancing loss to prevent the zero experts from
+absorbing all easy tokens.
+
+## Correctness (Appendix B.3.2)
+Two axes, both must hold:
+1. **Loss axis:** cross-entropy loss must decrease across the 64-step run and
+   remain finite (no explosion, no NaN) — evidence the modified pipeline produces
+   a learnable model.
+2. **Rule axis:** each task decomposes into three required components (the
+   architectural elements that distinguish the new feature from the baseline).
+   The rules are fixed before inspecting any attempt. Each attempt is judged by an
+   independent `claude-opus-4-7` session at xhigh effort, given the three rules
+   and the git diff produced by the agent against `main`; the judge returns
+   PASS/FAIL per rule. This guards against a passing-loss reading from an
+   unchanged model.

--- a/agent_tooling/ate_bench/tasks/new_feature/README.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/README.md
@@ -1,11 +1,14 @@
-# ATE-Bench — New-Feature tasks (4 tasks) — DEFERRED
+# ATE-Bench — New-Feature tasks (4 tasks)
 
 Each task mimics integrating a recently published modeling architecture into a
 training framework. The agent is given the same materials an engineer would
-consult: the arXiv paper and the reference implementation. From these, the agent
-must produce a training script that integrates the new feature into the base model
-and runs on DCLM under the fixed config below. **Specified here but not yet wired
-into the runner** (requires GPUs + DCLM data).
+consult: the arXiv paper and the reference implementation (`references.md`). From
+these, the agent must produce a training script that integrates the new feature
+into the base model and runs on C4 (TorchTitan native; paper used DCLM) under the
+fixed config below. The harness is **wired up**: prompts (`nf1..nf4`), per-feature
+judge rules (`rules/`), runner (`runner/run_feature.py`, worktree-isolated), loss
+check (`runner/checks/nf_loss_curve.py`), and LLM judge (`runner/judge.py`).
+Running it requires GPUs + C4 data.
 
 Fixed evaluation config (shared with operate-and-profile tasks): parallelism mesh
 `PP=4, EP=2, DP=1`, sequence length `2048`, global batch size `1024`, precision

--- a/agent_tooling/ate_bench/tasks/new_feature/nf1_diff_attention.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/nf1_diff_attention.md
@@ -1,0 +1,17 @@
+# NF1: Differential Attention (Diff Transformer)
+
+Integrate **differential attention** into the base model. Differential attention
+replaces a single softmax-attention map with the **difference of two parallel
+softmax maps**:
+
+```
+Attn(Q, K, V) = ( softmax(Q1 K1^T) - lambda * softmax(Q2 K2^T) ) V
+```
+
+where `lambda` is a **learned per-head scalar**. The construction cancels
+common-mode attention noise, sharpening which tokens receive mass.
+
+Integrating it involves splitting the per-head Q/K projections in half (into
+`Q1,Q2` and `K1,K2`) and introducing `lambda` as a trainable parameter with the
+**published initialisation/reparameterisation schedule** (see the reference
+implementation in `references.md`).

--- a/agent_tooling/ate_bench/tasks/new_feature/nf2_dynmoe.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/nf2_dynmoe.md
@@ -1,0 +1,11 @@
+# NF2: DynMoE
+
+Integrate **DynMoE** into the base MoE model. Standard MoE fixes the number of
+activated experts `k` per token. DynMoE replaces top-`k` selection with a
+**per-expert sigmoid gate and a learned threshold**, so the count of active
+experts **varies per token**.
+
+Integrating it involves replacing the framework's top-`k` routing
+(`torchtitan/models/common/moe.py`, `TokenChoiceTopKRouter`) with the
+gate-and-threshold mechanism, and **reformulating the load-balancing auxiliary
+loss for a variable-`k` regime** (see `references.md`).

--- a/agent_tooling/ate_bench/tasks/new_feature/nf3_moba.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/nf3_moba.md
@@ -1,0 +1,10 @@
+# NF3: MoBA (Mixture of Block Attention)
+
+Integrate **MoBA** into the base model. MoBA partitions the key/value sequence
+into **fixed-size blocks** and routes each query to the **top-`k` blocks** selected
+by a learned gate, yielding sub-quadratic attention cost in the sequence length.
+
+Integrating it involves inserting **block-level routing** between the Q/K
+projection and the attention computation (`torchtitan/models/common/attention.py`),
+composing with the existing attention backend, and **preserving causal masking
+inside each selected block** (see `references.md`).

--- a/agent_tooling/ate_bench/tasks/new_feature/nf4_moeplusplus.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/nf4_moeplusplus.md
@@ -1,0 +1,11 @@
+# NF4: MoE++
+
+Integrate **MoE++** into the base MoE model. MoE++ augments a standard MoE expert
+pool with **three zero-computation expert types** (`zero`, `copy`, and
+`constant`), allowing easy tokens to be routed past the feed-forward layer
+entirely.
+
+Integrating it involves **extending the expert pool definition** with the
+zero-computation variants, **widening the router output** to cover them
+(`torchtitan/models/common/moe.py`), and **adjusting the load-balancing loss** to
+prevent the zero experts from absorbing all easy tokens (see `references.md`).

--- a/agent_tooling/ate_bench/tasks/new_feature/preamble.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/preamble.md
@@ -5,8 +5,9 @@ You are given the same materials an engineer would consult: the architecture's
 arXiv paper and its reference implementation (see `references.md`). Produce a
 **training script that integrates the new feature into the base MoE model** and
 runs on the C4 dataset under the fixed config: pipeline parallel = 4, expert
-parallel = 2, data-parallel shard = 1, sequence length 2048, global batch 1024,
-BF16, on {{NGPU}} GPUs, with `MODULE={{MODULE}}`, `CONFIG={{CONFIG}}`.
+parallel = 2, data-parallel shard = auto (`-1`; EP is carved from the data axis,
+so on {{NGPU}} GPUs the data axis is 2 and EP=2 shards experts across it), sequence
+length 2048, global batch 1024, BF16, with `MODULE={{MODULE}}`, `CONFIG={{CONFIG}}`.
 
 Run training for **64 steps**. Your change is correct only if **both** hold:
 1. cross-entropy loss **decreases** across the 64-step run and stays **finite**

--- a/agent_tooling/ate_bench/tasks/new_feature/preamble.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/preamble.md
@@ -31,3 +31,9 @@ Where the relevant code lives in TorchTitan:
 
 Save the 64-step training log to `{{WORKSPACE}}/{{LABEL}}/{{TASK_ID}}/train.log`
 so the loss-curve check can read it.
+
+**Stop condition (important).** The complete deliverable is: your code edits + ONE
+successful 64-step training run whose loss decreases and stays finite. As soon as
+that single run succeeds, you are DONE — stop and report. Do NOT run repeated
+trainings, hyperparameter sweeps, ablations, baseline comparisons, or extended
+verification. If the first run fails, fix and retry, but keep iterations minimal.

--- a/agent_tooling/ate_bench/tasks/new_feature/preamble.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/preamble.md
@@ -1,0 +1,26 @@
+You are integrating a newly published model architecture into the **TorchTitan**
+training framework. Use your full toolset (Read, Grep, Glob, Bash, Edit, Write).
+
+You are given the same materials an engineer would consult: the architecture's
+arXiv paper and its reference implementation (see `references.md`). Produce a
+**training script that integrates the new feature into the base MoE model** and
+runs on the C4 dataset under the fixed config: pipeline parallel = 4, expert
+parallel = 2, data-parallel shard = 1, sequence length 2048, global batch 1024,
+BF16, on {{NGPU}} GPUs, with `MODULE={{MODULE}}`, `CONFIG={{CONFIG}}`.
+
+Run training for **64 steps**. Your change is correct only if **both** hold:
+1. cross-entropy loss **decreases** across the 64-step run and stays **finite**
+   (no NaN, no explosion);
+2. your implementation clearly exhibits the architecture's **three distinguishing
+   components** (from the paper) in your `git diff` against `main` — these are
+   judged independently, so make the intended mechanism evident in the diff (a
+   passing loss from an unchanged model does not count).
+
+Where the relevant code lives in TorchTitan:
+- attention: `torchtitan/models/common/attention.py`, `.../common/decoder.py`
+- MoE routing + experts: `torchtitan/models/common/moe.py`
+  (`TokenChoiceTopKRouter`), `.../common/token_dispatcher.py`
+- per-model layer assembly: `torchtitan/models/{{MODULE}}/model.py`
+
+Save the 64-step training log to `{{WORKSPACE}}/{{LABEL}}/{{TASK_ID}}/train.log`
+so the loss-curve check can read it.

--- a/agent_tooling/ate_bench/tasks/new_feature/preamble.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/preamble.md
@@ -4,10 +4,16 @@ training framework. Use your full toolset (Read, Grep, Glob, Bash, Edit, Write).
 You are given the same materials an engineer would consult: the architecture's
 arXiv paper and its reference implementation (see `references.md`). Produce a
 **training script that integrates the new feature into the base MoE model** and
-runs on the C4 dataset under the fixed config: pipeline parallel = 4, expert
+runs on the `{{DATASET}}` dataset under the config: pipeline parallel = 4, expert
 parallel = 2, data-parallel shard = auto (`-1`; EP is carved from the data axis,
 so on {{NGPU}} GPUs the data axis is 2 and EP=2 shards experts across it), sequence
-length 2048, global batch 1024, BF16, with `MODULE={{MODULE}}`, `CONFIG={{CONFIG}}`.
+length 2048, global batch {{GLOBAL_BATCH_SIZE}}, BF16, with `MODULE={{MODULE}}`,
+`CONFIG={{CONFIG}}`.
+
+Launch training with the provided script, e.g.:
+```
+STEPS=64 GLOBAL_BATCH_SIZE={{GLOBAL_BATCH_SIZE}} bash {{TRAIN_SH}} --dataloader.dataset={{DATASET}} 2>&1 | tee {{WORKSPACE}}/{{LABEL}}/{{TASK_ID}}/train.log
+```
 
 Run training for **64 steps**. Your change is correct only if **both** hold:
 1. cross-entropy loss **decreases** across the 64-step run and stays **finite**

--- a/agent_tooling/ate_bench/tasks/new_feature/references.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/references.md
@@ -1,0 +1,18 @@
+# New-Feature references
+
+The agent is given, for each task, the architecture's **arXiv paper** and its
+**reference implementation** — the same materials an engineer would consult. The
+run_feature runner passes the links below into the prompt; for an offline/airgapped
+run, clone the repos and download the PDFs first and point the agent at local
+paths instead.
+
+> Note: arXiv IDs / repos below are the best-known sources for each architecture
+> (the PithTrain paper cites these by number, not URL). Verify against the paper's
+> bibliography if exact-match matters.
+
+| Task | Architecture | arXiv | Reference implementation |
+|---|---|---|---|
+| NF1 | Differential Transformer (Diff attention) | 2410.05258 | github.com/microsoft/unilm (Diff-Transformer) |
+| NF2 | DynMoE | 2405.14297 | github.com/LINs-lab/DynMoE |
+| NF3 | MoBA (Mixture of Block Attention) | 2502.13189 | github.com/MoonshotAI/MoBA |
+| NF4 | MoE++ | 2410.07348 | github.com/SkyworkAI/MoE-plus-plus |

--- a/agent_tooling/ate_bench/tasks/new_feature/rules/nf1.rules.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/rules/nf1.rules.md
@@ -1,0 +1,16 @@
+# NF1 (Differential Attention) — correctness rules
+
+Three required components. Each is PASS only if the agent's `git diff` against
+`main` clearly implements it; otherwise FAIL.
+
+1. **Split Q/K into two halves.** The per-head query and key projections are split
+   into two groups (`Q1,Q2` and `K1,K2`), producing two separate attention score
+   maps `softmax(Q1 K1^T)` and `softmax(Q2 K2^T)` over the same value tensor.
+2. **Learned per-head lambda.** A trainable per-head scalar `lambda` is introduced
+   (e.g. via the reparameterisation `lambda = exp(l_q1·l_k1) - exp(l_q2·l_k2) +
+   lambda_init`) and initialised on the published schedule (depth-dependent
+   `lambda_init`). It must be a registered learnable parameter, not a constant.
+3. **Difference of the two maps.** The attention output uses the *difference*
+   `softmax(Q1 K1^T) - lambda * softmax(Q2 K2^T)` applied to `V` (with the
+   published sublayer/group norm and `(1 - lambda_init)` output scaling), not a
+   single softmax map.

--- a/agent_tooling/ate_bench/tasks/new_feature/rules/nf2.rules.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/rules/nf2.rules.md
@@ -1,0 +1,15 @@
+# NF2 (DynMoE) — correctness rules
+
+Three required components. Each is PASS only if the agent's `git diff` against
+`main` clearly implements it; otherwise FAIL.
+
+1. **Per-expert sigmoid gate.** Routing uses an independent sigmoid gate per
+   expert (each expert gated on its own), replacing the softmax-over-experts
+   top-`k` selection in `TokenChoiceTopKRouter`.
+2. **Learned threshold → variable-k.** A learned threshold decides which experts
+   are active per token, so the number of activated experts varies per token
+   (not a fixed `top_k`). The dispatch path must handle a variable number of
+   selected experts per token.
+3. **Variable-k load-balancing loss.** The auxiliary load-balancing loss is
+   reformulated for the variable-`k` regime (it must not assume a constant `k`
+   per token, e.g. the fixed-`k` switch/aux loss).

--- a/agent_tooling/ate_bench/tasks/new_feature/rules/nf3.rules.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/rules/nf3.rules.md
@@ -1,0 +1,15 @@
+# NF3 (MoBA) — correctness rules
+
+Three required components. Each is PASS only if the agent's `git diff` against
+`main` clearly implements it; otherwise FAIL.
+
+1. **Block partitioning.** The key/value sequence is partitioned into fixed-size
+   blocks of a configurable block size.
+2. **Top-k block routing by a learned gate.** Each query is routed to the top-`k`
+   blocks selected by a learned gate (e.g. query · mean-pooled-block-key scores),
+   inserted between the Q/K projection and the attention computation. Attention is
+   computed only over the selected blocks (sub-quadratic), not all keys.
+3. **Causal masking preserved per block.** Causal correctness is preserved: a
+   query never attends to future tokens, the current block is handled causally
+   (always selected / partially masked), and past-block selection respects the
+   causal order.

--- a/agent_tooling/ate_bench/tasks/new_feature/rules/nf4.rules.md
+++ b/agent_tooling/ate_bench/tasks/new_feature/rules/nf4.rules.md
@@ -1,0 +1,14 @@
+# NF4 (MoE++) — correctness rules
+
+Three required components. Each is PASS only if the agent's `git diff` against
+`main` clearly implements it; otherwise FAIL.
+
+1. **Zero-computation experts added.** The expert pool is extended with the three
+   zero-computation expert types — `zero` (outputs zero), `copy` (identity), and
+   `constant` (a learned constant vector) — alongside the existing FFN experts.
+2. **Router widened to cover them.** The router output dimension is widened so the
+   gate can select the zero-computation experts for a token (they participate in
+   routing, not bypassed).
+3. **Load-balancing loss adjusted.** The load-balancing loss is adjusted to
+   prevent the zero-computation experts from absorbing all easy tokens (e.g. a
+   gating-residual / capped-share term), not the unmodified baseline aux loss.

--- a/agent_tooling/ate_bench/tasks/operate_profile/README.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/README.md
@@ -1,11 +1,12 @@
-# ATE-Bench — Operate-and-Profile tasks (4 tasks) — DEFERRED
+# ATE-Bench — Operate-and-Profile tasks (4 tasks)
 
 These tasks drive a real training workflow end-to-end. They require GPUs, a
-pre-staged MoE checkpoint, pre-tokenized data (DCLM/DCLM-derived), vLLM +
-lm-evaluation-harness, and Nsight Systems. They are **specified here but not yet
-wired into the runner** (Q&A is the first runnable slice). Correctness is checked
-on the *artifact the agent produces*, not the path taken — a mix of programmatic
-checks and human inspection.
+pre-staged MoE checkpoint, pre-tokenized data (TorchTitan uses C4; paper used
+DCLM), vLLM + lm-evaluation-harness, and Nsight Systems. The harness is **wired
+up**: prompts (`op1..op4`), runner (`runner/run_operate.py`), and programmatic
+checks (`runner/checks/op*.py`) — but passing them needs the GPU substrate above.
+Correctness is checked on the *artifact the agent produces*, not the path taken —
+a mix of programmatic checks and human inspection.
 
 Fixed evaluation config (shared with new-feature tasks): parallelism mesh
 `PP=4, EP=2, DP=1`, sequence length `2048`, global batch size `1024`, precision

--- a/agent_tooling/ate_bench/tasks/operate_profile/README.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/README.md
@@ -1,0 +1,64 @@
+# ATE-Bench — Operate-and-Profile tasks (4 tasks) — DEFERRED
+
+These tasks drive a real training workflow end-to-end. They require GPUs, a
+pre-staged MoE checkpoint, pre-tokenized data (DCLM/DCLM-derived), vLLM +
+lm-evaluation-harness, and Nsight Systems. They are **specified here but not yet
+wired into the runner** (Q&A is the first runnable slice). Correctness is checked
+on the *artifact the agent produces*, not the path taken — a mix of programmatic
+checks and human inspection.
+
+Fixed evaluation config (shared with new-feature tasks): parallelism mesh
+`PP=4, EP=2, DP=1`, sequence length `2048`, global batch size `1024`, precision
+`BF16`, on 8 GPUs.
+
+## Tasks (Appendix B.2.1)
+
+### OP1 — Getting Started
+Set up the Python environment for the framework and run the provided 5-step smoke
+training script. Success means the script reaches step 5 with a finite loss. The
+agent must install all dependencies the script needs so that running `bash
+train.sh` as-is succeeds; `train.sh` itself documents best practices for training
+MoE models and is read-only. Pre-tokenized DCLM and the converted base-model
+checkpoint are pre-staged.
+- **Check:** after the agent finishes installing deps, the harness re-runs the
+  (read-only) training script and parses the log; accepted only if step 5 prints
+  a finite loss value.
+
+### OP2 — Train and Evaluate
+Drive the full setup → train → export → evaluate pipeline for the base model. The
+agent trains from random initialization for 25 steps, exports the resulting
+checkpoint to HuggingFace format, and runs lm-evaluation-harness HellaSwag
+(zero-shot) on it via vLLM. Tests pipeline correctness, not model quality:
+HellaSwag is expected to be near-random after 25 steps from random init.
+Initialization must be random; everything outside the fixed mesh and step count
+(LR, optimizer, scheduler, data preprocessing) is left to the agent.
+- **Check:** a read-only `evaluate.sh` consumes the agent's pipeline output, loads
+  the export into vLLM, runs HellaSwag (zero-shot). Satisfied when `evaluate.sh`
+  completes and writes a finite score (no quality threshold).
+
+### OP3 — Collect Routing Trace
+Instrument training to dump the per-token MoE routing trace for the first 8M
+training tokens. For each MoE layer, the top-k expert IDs and their gating weights
+must be captured for every token in the global batch. Training resumes from the
+released HuggingFace checkpoint (router is in its trained, load-balanced regime;
+no warmup required). Output schema: one `step-<step_id:08d>.npz` file per step
+under `workspace/<framework>/routing-traces/`, each containing the expert-ID and
+gating-weight arrays.
+- **Check (programmatic):** four `step-<step_id:08d>.npz` files present; each
+  carries expert-ID and gating-weight arrays of the correct shape for every MoE
+  layer over every token in the global batch; expert-ID values within
+  `[0, num_experts)`; gating weights non-negative and sum to 1 over the top-k
+  selected experts for every token.
+
+### OP4 — Report Heavy Kernels
+Profile a 7-step training run with Nsight Systems and identify the top 3 most
+expensive CUDA kernels by total GPU time, aggregated across all 8 ranks. Training
+resumes from the released HuggingFace checkpoint; profile only step 7 (steps 1–6
+are warmup for cudagraph capture, NCCL handshake, and allocator priming). Output:
+a single CSV at `workspace/<framework>/heavy-kernels/top-kernels.csv` with header
+`kernel_name,total_time_ms,instances,mean_time_ms` and exactly three rows sorted
+by `total_time_ms` descending, plus the raw `profile.nsys-rep`.
+- **Check:** CSV validated programmatically against the schema (header, exactly
+  three rows sorted by total time descending). Kernel names validated by a human
+  reader who opens `profile.nsys-rep` in the Nsight Systems GUI (CUDA GPU Kernel
+  Summary, Stats System view) and confirms the top three match.

--- a/agent_tooling/ate_bench/tasks/operate_profile/op1_getting_started.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/op1_getting_started.md
@@ -1,0 +1,14 @@
+# OP1: Getting Started
+
+Set up the Python environment for this training framework and run the provided
+smoke training script for 5 steps. **Success means the script reaches step 5 with
+a finite loss.**
+
+Install all dependencies the script needs so that running
+```
+STEPS=5 bash {{TRAIN_SH}}
+```
+succeeds as-is. The script is read-only and documents best practices for training
+MoE models under the fixed config. The tokenizer and a debug dataset are already
+pre-staged in the repo. Do not modify the training script or the mesh — your job
+is to make the environment able to run it.

--- a/agent_tooling/ate_bench/tasks/operate_profile/op2_train_and_evaluate.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/op2_train_and_evaluate.md
@@ -1,0 +1,22 @@
+# OP2: Train and Evaluate
+
+Drive the full **setup → train → export → evaluate** pipeline for the base MoE
+model under the fixed config.
+
+1. Train from **random initialization** for **25 steps** using the provided
+   launcher.
+2. Export the resulting checkpoint to **HuggingFace format** (see
+   `scripts/checkpoint_conversion/convert_to_hf.py`).
+3. The read-only `{{EVALUATE_SH}}` will load your export into **vLLM** and run
+   **lm-evaluation-harness HellaSwag (zero-shot)**.
+
+This tests **pipeline correctness, not model quality**: the HellaSwag score is
+expected to be near-random because 25 steps from random init barely trains the
+model. Initialization **must** be random; everything outside the fixed mesh and
+step count (LR, optimizer, scheduler, data preprocessing) is up to you.
+
+Produce the checkpoint such that the grader can run:
+```
+CKPT_DIR=<your checkpoint dir> STEP=25 bash {{EVALUATE_SH}}
+```
+and have it complete and write a finite HellaSwag score.

--- a/agent_tooling/ate_bench/tasks/operate_profile/op3_collect_routing_trace.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/op3_collect_routing_trace.md
@@ -1,0 +1,27 @@
+# OP3: Collect Routing Trace
+
+Instrument training to dump the **per-token MoE routing trace** for the first
+**8M training tokens**. For **each MoE layer**, capture the **top-k expert IDs**
+and their **gating weights** for **every token in the global batch**.
+
+Resume training from the released HuggingFace checkpoint so the router is in its
+trained, load-balanced regime — routing decisions are model-intrinsic and valid
+from step 1, so no warmup is required. (The MoE routing lives in
+`torchtitan/models/common/moe.py`.)
+
+**Output schema:** one `step-<step_id:08d>.npz` file per step under
+```
+{{ROUTING_TRACES_DIR}}/
+```
+Each `.npz` must contain, for each MoE layer index `L` (0-based), two arrays of
+shape `[num_tokens, top_k]` covering every token in the global batch
+(`num_tokens = global_batch_size * seq_len`):
+- `layer{L:02d}_expert_ids`  — int array of selected expert IDs
+- `layer{L:02d}_gating_weights` — float array of the corresponding gating weights
+
+plus a scalar array `num_experts` (the MoE expert count). The grader checks that:
+- the expected number of per-step files are present,
+- arrays have the correct shape for every MoE layer over every token,
+- expert-ID values are within `[0, num_experts)`,
+- gating weights are non-negative and sum to 1 over the top-k selected experts for
+  every token.

--- a/agent_tooling/ate_bench/tasks/operate_profile/op4_report_heavy_kernels.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/op4_report_heavy_kernels.md
@@ -1,0 +1,21 @@
+# OP4: Report Heavy Kernels
+
+Profile a **7-step** training run with **Nsight Systems** and identify the **top 3
+most expensive CUDA kernels by total GPU time, aggregated across all 8 ranks**.
+
+Resume training from the released HuggingFace checkpoint. Profile **only step 7**
+— steps 1–6 are warmup for cudagraph capture, NCCL handshake, and allocator
+priming, so they are not representative.
+
+**Output:** a single CSV at
+```
+{{HEAVY_KERNELS_DIR}}/top-kernels.csv
+```
+with header exactly:
+```
+kernel_name,total_time_ms,instances,mean_time_ms
+```
+and **exactly three rows**, sorted by `total_time_ms` **descending**. Also save
+the raw `profile.nsys-rep` in the same directory so the result is reproducible
+(the kernel names are validated by a human against the Nsight GUI's CUDA GPU
+Kernel Summary).

--- a/agent_tooling/ate_bench/tasks/operate_profile/preamble.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/preamble.md
@@ -3,9 +3,10 @@ Use your full toolset (Read, Grep, Glob, Bash, Edit, Write) as needed to complet
 the task end-to-end.
 
 **Fixed evaluation config (do not change the mesh).** Pipeline parallel = 4,
-expert parallel = 2, data-parallel shard = 1; sequence length 2048; global batch
-size 1024; BF16 precision; on {{NGPU}} GPUs. Model under test: `MODULE={{MODULE}}`,
-`CONFIG={{CONFIG}}` (an MoE model).
+expert parallel = 2, data-parallel shard = auto (`-1`, fills the mesh; EP is carved
+from the data axis, so on {{NGPU}} GPUs the data axis is 2 and EP=2 shards experts
+across it); sequence length 2048; global batch size 1024; BF16 precision. Model
+under test: `MODULE={{MODULE}}`, `CONFIG={{CONFIG}}` (an MoE model).
 
 **Launch training with the provided script (treat it as read-only):**
 ```

--- a/agent_tooling/ate_bench/tasks/operate_profile/preamble.md
+++ b/agent_tooling/ate_bench/tasks/operate_profile/preamble.md
@@ -1,0 +1,18 @@
+You are working on the **TorchTitan** training framework at the repository root.
+Use your full toolset (Read, Grep, Glob, Bash, Edit, Write) as needed to complete
+the task end-to-end.
+
+**Fixed evaluation config (do not change the mesh).** Pipeline parallel = 4,
+expert parallel = 2, data-parallel shard = 1; sequence length 2048; global batch
+size 1024; BF16 precision; on {{NGPU}} GPUs. Model under test: `MODULE={{MODULE}}`,
+`CONFIG={{CONFIG}}` (an MoE model).
+
+**Launch training with the provided script (treat it as read-only):**
+```
+bash {{TRAIN_SH}}      # env knobs: STEPS, MODULE, CONFIG, NGPU, PP, EP, DP
+```
+It wraps TorchTitan's `./run_train.sh` with the fixed config above. For a no-GPU
+config check you may use `COMM_MODE=fake_backend PP=1 EP=1 DP=1`.
+
+**Write every task artifact under `{{WORKSPACE}}/{{LABEL}}/`** exactly as the task
+specifies — the grader checks the artifact, not the path you took to produce it.

--- a/agent_tooling/ate_bench/tasks/qa/q01_process_groups.md
+++ b/agent_tooling/ate_bench/tasks/qa/q01_process_groups.md
@@ -1,0 +1,7 @@
+# Q1: Process Groups / Device Mesh
+
+Trace the sequence of function calls from the main training entry script down to
+the initialization of the PyTorch distributed process groups or DeviceMesh.
+Detail the exact file paths, function names, and line numbers where the world
+size and ranks for the parallel groups present in this codebase (any of DP, TP,
+PP, EP, CP that this repo actually supports) are assigned.

--- a/agent_tooling/ate_bench/tasks/qa/q02_config_propagation.md
+++ b/agent_tooling/ate_bench/tasks/qa/q02_config_propagation.md
@@ -1,0 +1,5 @@
+# Q2: Configuration Propagation
+
+Locate the exact file and line numbers where the user-provided configuration for
+hidden_size or dim is parsed. Trace how this specific variable propagates down to
+the instantiation of the first Transformer block.

--- a/agent_tooling/ate_bench/tasks/qa/q03_data_loading_sharding.md
+++ b/agent_tooling/ate_bench/tasks/qa/q03_data_loading_sharding.md
@@ -1,0 +1,6 @@
+# Q3: Data Loading & Sharding
+
+Trace the initialization of the dataset and dataloader. Identify the file, class,
+and line number where the global dataset is sliced or partitioned among the Data
+Parallel ranks to ensure each rank receives a unique, non-overlapping subset of
+data.

--- a/agent_tooling/ate_bench/tasks/qa/q04_seed_management.md
+++ b/agent_tooling/ate_bench/tasks/qa/q04_seed_management.md
@@ -1,0 +1,6 @@
+# Q4: Distributed Seed Management
+
+Find where the random seeds are set for data loading versus model initialization.
+Provide the exact file paths and line numbers, and trace how seeds are
+differentiated across different parallel groups (or, if they are deliberately
+shared, where and why).

--- a/agent_tooling/ate_bench/tasks/qa/q05_attention_kernel_dispatch.md
+++ b/agent_tooling/ate_bench/tasks/qa/q05_attention_kernel_dispatch.md
@@ -1,0 +1,8 @@
+# Q5: Attention Kernel Dispatch
+
+Locate the core attention module. Trace the logic that selects between an
+optimised kernel (FlashAttention, PyTorch SDPA flash backend, ring attention,
+etc.) and any fallback math implementation. Identify the exact file, class, line
+number, and configuration flag/condition controlling this dispatch. If the
+dispatch is delegated to the PyTorch scaled_dot_product_attention, say so and
+cite the call site.

--- a/agent_tooling/ate_bench/tasks/qa/q06_rope.md
+++ b/agent_tooling/ate_bench/tasks/qa/q06_rope.md
@@ -1,0 +1,6 @@
+# Q6: RoPE Implementation
+
+Find where the Rotary Positional Embedding (RoPE) is implemented. Locate the
+function that precomputes the frequency tensor (sine/cosine cache). Provide the
+file path, class/function name, and exact line numbers of the tensor operations
+where the rotary transform is applied to the Query and Key tensors.

--- a/agent_tooling/ate_bench/tasks/qa/q07_swiglu_mlp.md
+++ b/agent_tooling/ate_bench/tasks/qa/q07_swiglu_mlp.md
@@ -1,0 +1,6 @@
+# Q7: SwiGLU / MLP Block
+
+Locate the Feed-Forward Network (FFN) implementation. Identify the file and line
+number where the SwiGLU activation (or equivalent gated linear unit) is
+mathematically applied. Trace how the up-projection tensor is chunked or split
+before the activation function.

--- a/agent_tooling/ate_bench/tasks/qa/q08_norm_placement.md
+++ b/agent_tooling/ate_bench/tasks/qa/q08_norm_placement.md
@@ -1,0 +1,6 @@
+# Q8: Normalization Placement
+
+Find the implementation of the main Transformer layer. Provide the file and exact
+line numbers where the normalization (RMSNorm or LayerNorm) is applied before the
+attention module. Detail where the epsilon (eps) term is added for numerical
+stability.

--- a/agent_tooling/ate_bench/tasks/qa/q09_context_sequence_parallel.md
+++ b/agent_tooling/ate_bench/tasks/qa/q09_context_sequence_parallel.md
@@ -1,0 +1,7 @@
+# Q9: Context / Sequence Parallelism
+
+Find where sequence parallelism (or context parallelism) is handled. Identify the
+exact file and line numbers where the sequence dimension of the input tensor is
+sharded, gathered, or scattered across ranks during the forward and backward
+passes. If the codebase does not support CP/SP, say so and cite the negative
+evidence.

--- a/agent_tooling/ate_bench/tasks/qa/q10_fsdp_ddp_wrapping.md
+++ b/agent_tooling/ate_bench/tasks/qa/q10_fsdp_ddp_wrapping.md
@@ -1,0 +1,5 @@
+# Q10: FSDP / DDP Wrapping
+
+Locate the exact file and line numbers where the core model is wrapped with Fully
+Sharded Data Parallel (FSDP1 or FSDP2) or Distributed Data Parallel (DDP)
+wrappers, and identify the device-mesh axes used for sharding/replication.

--- a/agent_tooling/ate_bench/tasks/qa/q11_grad_clipping.md
+++ b/agent_tooling/ate_bench/tasks/qa/q11_grad_clipping.md
@@ -1,0 +1,5 @@
+# Q11: Global Gradient Clipping
+
+Trace the logic for global gradient norm clipping. Find the file, function, and
+exact line number where the global norm of the gradients is computed (including
+any reduction across distributed ranks) before the optimizer step.

--- a/agent_tooling/ate_bench/tasks/qa/q12_checkpoint_serialization.md
+++ b/agent_tooling/ate_bench/tasks/qa/q12_checkpoint_serialization.md
@@ -1,0 +1,5 @@
+# Q12: Distributed Checkpoint Serialization
+
+Locate the model checkpoint saving logic. Detail whether the system uses a rank-0
+gather approach or distributed sharded saving (e.g., PyTorch DCP). Provide the
+exact file path and line numbers where the disk serialization occurs.

--- a/agent_tooling/ate_bench/tasks/qa/universal_instruction.txt
+++ b/agent_tooling/ate_bench/tasks/qa/universal_instruction.txt
@@ -1,0 +1,9 @@
+Your task is to explore this training framework codebase and answer the question
+that follows. Every claim must be verified against the code on disk before you
+state it: use your CLI tools (Read, Grep, Glob, Bash) to locate the exact symbol,
+file, and line, then cite the path/to/file.py:LINE you actually read. Wrap your
+final response in <final_answer> tags, trace the execution path step by step, and
+give one citation per claim. If a feature is genuinely absent from this codebase,
+say so explicitly and cite negative evidence (the grep command and pattern that
+returned zero matches, or the file you inspected that does not contain it). A
+correct "absent, verified" answer is preferred over a fabricated one.


### PR DESCRIPTION
## Summary
Adds a reproduction of **ATE-Bench** — the *Agent-Task Efficiency* benchmark from
**PithTrain: A Compact and Agent-Native MoE Training System**
([arXiv:2605.31463](https://arxiv.org/abs/2605.31463)) — under
`agent_tooling/ate_bench/`, run against TorchTitan.

ATE-Bench inverts standard coding benchmarks: it holds the **agent fixed** and
varies the **framework**, so differences in agent cost isolate framework design.
The paper does not release the benchmark as code (it's specified in Appendix B/C);
this rebuilds it.

> ⚠️ **Draft / experimental.** This is agent tooling under `agent_tooling/`, not a
> core change. Opened as a draft for review. `pre-commit` not yet run.

## What's here
- **Q&A (12 tasks)** — read-only code-property questions, cite `file:line`.
  Runnable today (CPU). `runner/run_qa.py`.
- **Operate & Profile (4)** — getting-started / train+eval / routing-trace /
  heavy-kernels. Harness ready, GPU-gated. `runner/run_operate.py` + `checks/`.
- **New Feature (4)** — Diff attention / DynMoE / MoBA / MoE++. Worktree-isolated;
  correctness = 64-step loss curve **and** an independent LLM judge over the diff
  vs `main`. `runner/run_feature.py`, `runner/judge.py`.
- Shared: effort-metric parser (`metrics.py`, from `result.modelUsage`), GPU-time
  monitor, `aggregate.py` (Table-5-style medians), and the fixed-config TorchTitan
  launcher (`setup/train.sh`).

## Results so far
See **`agent_tooling/ate_bench/RESULTS_qa_titan.md`**. The 12×3 Q&A sweep is
running in the background (**1/36 complete** at PR time); Q1 lands in the paper's
TorchTitan ballpark (16 vs 18 turns; 9.7K vs 7.1K output tokens). I'll update the
results table with full medians once the sweep finishes.

## Honest scope (what this does NOT reproduce)
- **PithTrain / Megatron-LM columns** — no checkouts here, so the paper's *relative*
  headline (62% fewer turns / 64% less GPU time) can't be reproduced; those are
  cross-framework deltas.
- **Agent ≠ paper's** — env default is `opus-4-6`; the paper used Opus 4.7 @ `xhigh`.
  Absolute numbers differ; trends compare. Keep the agent identical across
  frameworks for any real comparison.
- **GPU tasks** need a real MoE checkpoint, vLLM+lm-eval, Nsight, and C4 data.

## Notable framework-design finding
The paper's mesh notation (`PP*EP*DP` multiplicative) doesn't map 1:1 to TorchTitan,
where `dp_replicate*dp_shard*cp*tp*pp == world_size` and **EP is carved from the
data axis**. So `PP=4, EP=2, DP=1` → `pp=4, dp_shard=-1 (auto→2), ep=2` on 8 GPUs.
