### PR TITLE
Compress exported Kineto profiler traces as .json.gz

### DIFF
--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -24,7 +24,7 @@ from torchtitan.tools.utils import device_module
 # Paths expects by meta internal tooling
 PROFILE_DIR = "profiling/traces"  # Profiler.Config.save_traces_folder default
 PROFILE_ITER_DIR = "iteration_{step}"  # PROFILE_DIR/{PROFILE_ITER_DIR}
-PROFILE_FILE = "rank{rank}_trace.json"  # PROFILE_DIR/PROFILE_ITER_DIR/{PROFILE_FILE}
+PROFILE_FILE = "rank{rank}_trace.json.gz"  # PROFILE_DIR/PROFILE_ITER_DIR/{PROFILE_FILE}
 
 MEMORY_DIR = (
     "profiling/memory_snapshot"  # Profiler.Config.save_memory_snapshot_folder default


### PR DESCRIPTION
## Summary

- Export profiler traces as `.json.gz` instead of `.json`.
- PyTorch `export_chrome_trace()` handles gzip natively; Perfetto loads them correctly.
- On llama3_debugmodel_ce_loss (8 GPUs): ~5 MB → ~302 KB per trace (>16×).

## Test plan

- [x] Manual run on 8 GPUs:
  ```bash
  torchrun --nproc_per_node=8 \
    -m torchtitan.train \
    --module llama3 \
    --config llama3_debugmodel_ce_loss \
    --profiler.enable_profiling \
    --profiler.profile_freq 5 \
    --profiler.profiler_warmup 2 \
    --profiler.profiler_active 1
  ```
- [x] Verify output at `outputs/profiling/traces/iteration_*/rank*_trace.json.gz`
- [x] Single trace size: `~5 MB → ~302 KB` (`>16×` compression)
- [x] Open `rank0_trace.json.gz` in https://ui.perfetto.dev/ — loads and parses correctly