### PR TITLE
[graph_trainer] Re-baseline eager bitwise hashes (Llama3Flex, Qwen3 MoE)

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -458,11 +458,11 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757183074951""")
         assert_expected_inline(
             model_hash,
-            """bc9fbc09b6f14f4cb1e1f75a691da0a4be5905cb0e02f9c29512c268dc43ff81""",
+            """2cc38288f1641b058a56a1930af77dcb33c91fb12176cfdb59f436c9a2b3addd""",
         )
         assert_expected_inline(
             grad_hash,
-            """66b847a7f479b464c883e1cce759d4b38d7a78f3c319463b8402710b69ac4530""",
+            """9163c0f93a0a8dbf02208dae3ee0b427a97e3dd39e83b84847d2ed4b4e2bc495""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -590,11 +590,11 @@ class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.297995567321777""")
         assert_expected_inline(
             model_hash,
-            """81697f98f47d153b64d35719b42f7d2de6d1e7436a1c1c3cf79415aef3b8e2de""",
+            """c4f3d5d6a4dacffc82a0845ef620dcbdb053d9785ce64b8dd5b5e181f4fe2d1b""",
         )
         assert_expected_inline(
             grad_hash,
-            """bb6d6fb73d9796843ce78d40966ed78a1479fbc8e26dc824e4e1dd77b7cbfaa5""",
+            """b24c4d0201f11a825bbf49269592968ffd53d5b52bc0486bcacafae91e90eee3""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -653,11 +653,11 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.297987461090088""")
         assert_expected_inline(
             model_hash,
-            """4d79b03cf9eaee53df27befad54d3db9177f2127a658e0c8140a02565926ea50""",
+            """85240276507f93d2dbc8b09d5dad5f86623bcd49423abe64fba787b74d7f6d81""",
         )
         assert_expected_inline(
             grad_hash,
-            """cf4a8c8a0f1ce6ae836fc6a01f608e4d21821abf1f7e4804ec7da3c6f803d1af""",
+            """74877b0fa386c66c3154e0371adb86c9255527f0d48fb623feb7ee70ee79d409""",
         )
 
     def test_aot_fx_trace_vs_eager(self):


### PR DESCRIPTION
## Summary

`test_eager_self_deterministic` baselines for **Llama3 FlexAttention**, **Qwen3 MoE**, and **Qwen3 MoE FlexAttention** drifted after upstream PyTorch nightly numerics changes — the same class of drift #3432/#3482 already handled for DSv3. The H100.8 CI was red on these three.

This is the **pure-eager path** (base `Trainer`, no compile/trace):
- Loss strings are **unchanged** → low-order numeric drift, not a real break.
- `test_aot_fx_trace_vs_eager` still passes → the trace path stays bitwise-identical to eager; only the absolute `model_hash`/`grad_hash` baselines were stale.

## How the new hashes were obtained
- **Qwen3 MoE** / **Qwen3 MoE FlexAttn**: regenerated on a local H100 and verified **bitwise-equal to the CI nightly (cu130)** `model_hash`, so their `grad_hash` is authoritative.
- **Llama3 FlexAttn**: local (CUDA 12.8) diverges from CI (cu130) for this flex path, so both hashes were taken from the CI run.

## Validation
GraphTrainer 8-GPU H100 CI green on this branch: bitwise suite **21 passed, 3 skipped** (the 3 skips are the pre-existing FlexAttn-precompile tests). Loss strings untouched.

> Note (separate issue): one earlier run on this branch hit a **flaky** `qwen3_moe` FSDP+TP+EP all-to-all crash (`RuntimeError: Split sizes doesn't match total dim 0 size`) — intermittent, unrelated to this test-only change (the prior main run on #3429 passed that flavor and failed only on these same stale hashes). Worth a separate look.