### PR TITLE
[ROCm] Remove check for hip support for symmetric memory.

### DIFF
--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -221,12 +221,11 @@ class ParallelismConfig:
             )
         if self.enable_fsdp_symm_mem and (
             not torch.cuda.is_available()
-            or torch.version.hip is not None
             or torch.cuda.get_device_capability() < (9, 0)
         ):
             raise ValueError(
-                "parallelism.enable_fsdp_symm_mem is only supported on NVIDIA "
-                "GPUs with compute capability 9.0 or newer."
+                "For NVIDIA GPUs, parallelism.enable_fsdp_symm_mem is only supported "
+                "for compute capability 9.0 or newer."
             )
 
     context_parallel_rotate_method: Literal["allgather", "alltoall"] = "allgather"

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -221,7 +221,10 @@ class ParallelismConfig:
             )
         if self.enable_fsdp_symm_mem and (
             not torch.cuda.is_available()
-            or torch.cuda.get_device_capability() < (9, 0)
+            or (
+                torch.version.hip is None
+                and torch.cuda.get_device_capability() < (9, 0)
+            )
         ):
             raise ValueError(
                 "For NVIDIA GPUs, parallelism.enable_fsdp_symm_mem is only supported "


### PR DESCRIPTION
This PR removed check for hip support for symmetric memory because symmetric memory is now supported on ROCm.