### PR TITLE
[GraphTrainer][autoresearch] Add autoresearch harness

### DIFF
--- a/torchtitan/experiments/graph_trainer/autoresearch/README.md
+++ b/torchtitan/experiments/graph_trainer/autoresearch/README.md
@@ -1,0 +1,45 @@
+# Autoresearch Harness
+
+An autonomous experiment loop for graph-pass / kernel optimization in
+TorchTitan's `graph_trainer`. An LLM agent iteratively edits a single
+file (`torchtitan/experiments/graph_trainer/passes.py`), benchmarks each
+change, and keeps it only if training-step time improves **and** numerics
+stay bitwise-identical to the eager reference. It runs indefinitely until
+manually stopped.
+
+The harness lives at `torchtitan/experiments/graph_trainer/autoresearch/`.
+File paths in this README are relative to that directory; commands are run
+from the repo root.
+
+## Files
+
+| File | Owner | Purpose |
+|---|---|---|
+| `autoresearch.md` | experimenter + agent | The agent's operating manual. Fill in the `[SETUP]` sections before starting a run. |
+| `ideas.md` | experimenter + agent | Optimization ideas. Seed with curated directions, or leave empty for pure-autonomy. |
+| `experiment_log.md` | agent | Append-only journal: idea / changes / result / analysis / lessons per experiment. |
+| `learnings.md` | agent | Distilled, cross-experiment learnings. |
+| `results.tsv` | agent | Machine-readable performance tracking (one row per experiment). |
+| `scripts/run_benchmark.sh` | experimenter | Benchmark command — edit the model/config/parallelism for your run. |
+
+## Starting a run
+
+1. Edit `scripts/run_benchmark.sh` for your model, config, and
+   parallelism.
+2. Fill in the `[SETUP]` sections of `autoresearch.md`: the target,
+   starting graph, scaffolding level (curated ideas / reference access /
+   web), the reading-scope restrictions, and the numerics-check command.
+3. Optionally seed `ideas.md` with curated optimization directions.
+4. Record the baseline as the first row of `results.tsv` and the first
+   entry of `experiment_log.md`.
+5. Point the agent at `autoresearch.md` and let the loop run.
+
+## Design properties
+
+- **Asynchronous**: the shared files are the only communication channel
+  between human and agent; neither needs to be online at the same time.
+- **Auditable**: every experiment is logged with full context, and the
+  commit tree preserves all code states including failures.
+- **Safe**: numerics correctness is a hard gate. Failed experiments
+  revert `passes.py` only; the best-so-far state always remains HEAD.
+- **Compounding**: each `keep` builds on all previous keeps.

--- a/torchtitan/experiments/graph_trainer/autoresearch/autoresearch.md
+++ b/torchtitan/experiments/graph_trainer/autoresearch/autoresearch.md
@@ -1,0 +1,148 @@
+# Autoresearch
+
+Autoresearch is an autonomous experiment loop: an LLM agent iterates on
+GPU-kernel / graph-pass optimizations for a training graph, making it
+faster while preserving bitwise-identical numerics to the eager
+reference. It runs indefinitely until manually stopped.
+
+This file is the agent's operating manual. Sections marked **[SETUP]**
+are filled in per run before the loop starts; everything else is the
+generic harness contract.
+
+## [SETUP] This run
+
+Describe the run before starting the loop:
+
+- **Target model / config**: e.g. `Llama3 8B FSDP=4 TP=2 bs=1 on 8×H100`.
+- **Starting graph**: e.g. empty `construct_default_graph_passes` (raw
+  aten graph) vs. the production pass set (cleanup + bucketing + regional
+  Inductor + CUDA graphs already applied).
+- **Scaffolding level**: which of {curated IDEAS, in-repo reference
+  implementations, online research} the agent may use. Tighten the
+  *Reading scope* below to match.
+- **Goal**: what is being measured (e.g. "find further wins on top of the
+  production graph").
+
+## Reading scope (very important)
+
+### You MAY read
+
+- `torchtitan/experiments/graph_trainer/passes.py` — **the only file you modify**. Add custom pass functions and register them in `construct_default_graph_passes` or `compile_time_passes`.
+- `torchtitan/experiments/graph_trainer/trainer.py` — GraphTrainer (read-only).
+- `torchtitan/experiments/graph_trainer/make_fx_tracer.py` — make_fx tracing (read-only).
+- `torchtitan/experiments/graph_trainer/compile.py` — compile entry point (read-only).
+- `torchtitan/experiments/graph_trainer/graph_utils.py` — generic FX utilities (read-only).
+- `torchtitan/experiments/graph_trainer/<model>/` — the model's graph_trainer
+  glue (read-only).
+- `torchtitan/models/<model>/`, `torchtitan/models/common/` — model
+  architecture (RMSNorm, Attention, RoPE, FF, Decoder) — read-only.
+- `torchtitan/experiments/graph_trainer/autoresearch/ideas.md`, `torchtitan/experiments/graph_trainer/autoresearch/learnings.md`,
+  `torchtitan/experiments/graph_trainer/autoresearch/experiment_log.md` — your living docs.
+- `torchtitan/experiments/graph_trainer/autoresearch/scripts/` — reusable tools you own; create/modify as needed.
+- FX graph dumps you produce yourself (e.g. via a temporary `gm.print_readable()` pass).
+
+### You MUST NOT read
+
+Do NOT read the numerics test source (see below).
+
+When unsure whether a source qualifies, err on the side of NOT reading it.
+
+### You MUST NOT inspect git history
+
+- Do NOT run `git log`, `git log -p`, `git show <commit>`, `git diff <commit>`,
+  or `git blame`. Both the diffstats and the subject lines of prior commits
+  reference optimization techniques we want you to autonomously rediscover.
+- `git status` and `git diff` / `git diff --staged` (no commit refs, working
+  tree only) are fine.
+- To find commits *you* made during this run, look at
+  `torchtitan/experiments/graph_trainer/autoresearch/results.tsv` — the second column records the commit hash of
+  each `keep` experiment.
+
+## Constraints
+
+**Modify only** `torchtitan/experiments/graph_trainer/passes.py`.
+
+**Do NOT** modify `trainer.py`, `make_fx_tracer.py`, `graph_utils.py`, model code, or add dependencies.
+
+**Goal: minimize training step time while preserving bitwise-identical numerics.**
+
+**Memory** is a soft constraint — some increase is acceptable for meaningful speed gains.
+
+**Simplicity**: all else equal, simpler is better.
+
+## Benchmark
+
+```bash
+bash torchtitan/experiments/graph_trainer/autoresearch/scripts/run_benchmark.sh
+```
+
+Extract steady-state metrics from the last step:
+
+```bash
+grep "step:" run.log | tail -1
+```
+
+Output format:
+```
+step: 20  loss: 8.12345  grad_norm: 1.2345  memory: 12.34GiB(25.00%)  tps: 12,345  tflops: 123.45  mfu: 12.34%
+```
+
+Profiling traces: add `--profiler.enable_profiling` to the run command.
+
+**Graph inspection**: Add a temporary `gm.print_readable()` call in your pass, run 1-2 steps, inspect output. Remove debug prints before benchmarking.
+
+## [SETUP] Verifying numerics
+
+The numerics gate compares the optimized graph against the eager
+reference via the bitwise-vs-eager test, e.g.:
+
+```bash
+pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -k "TestLlama3BitwiseDeterministic and aot_fx_trace_vs_eager" -x > numerics.log 2>&1
+```
+
+(Replace `TestLlama3...` with the model's test case.) Any failure counts
+as `crash` regardless of perf improvement.
+
+**Do not read the numerics test file's source** — it imports symbols
+whose names leak prior optimization techniques. Run it, inspect
+numerics.log on failure for the assertion message, and that's it.
+
+## Logging results
+
+Append to `torchtitan/experiments/graph_trainer/autoresearch/results.tsv` (tab-separated). 8 columns:
+
+```
+timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description
+```
+
+1. ISO 8601 timestamp
+2. Git commit hash (7 chars). `xxxxxxx` for `discard`/`crash`.
+3. Tokens per second. 0 for crashes.
+4. Peak memory GiB (.1f). 0.0 for crashes.
+5. Status: `keep`, `discard`, or `crash`
+6. MFU percent. 0.0 for crashes.
+7. Wall time in seconds. 0 for crashes.
+8. Short description.
+
+## The experiment loop
+
+LOOP FOREVER:
+
+1. Re-read `ideas.md`, `learnings.md`, and `experiment_log.md`. Pick the next idea.
+2. **Delegate implementation to a subagent.** Spawn a subagent with a clear prompt describing what to implement in `passes.py`. The subagent does all the code changes, runs the benchmark, and verifies numerics. This keeps the main loop context clean. The subagent prompt should include:
+   - What optimization to attempt and why.
+   - The reading-scope restrictions above. Pass them through verbatim — the subagent must follow the same rules.
+   - The benchmark command: `bash torchtitan/experiments/graph_trainer/autoresearch/scripts/run_benchmark.sh`
+   - How to extract results: `grep "step:" run.log | tail -1`
+   - The numerics check (the command from the *Verifying numerics* section).
+   - That empty grep or numerics failure = `crash`.
+3. Read the subagent's result. Determine status: `keep` if tps improved + numerics pass; `discard` if no improvement; `crash` if crashed or numerics failed. Record in TSV.
+4. Append entry to `experiment_log.md`.
+5. If `keep`: commit `passes.py`, `results.tsv`, `experiment_log.md`, `ideas.md`, `learnings.md`. Message: `[autoresearch] <short description>`.
+6. If `discard` or `crash`: revert only `passes.py` (`git checkout -- torchtitan/experiments/graph_trainer/passes.py`), then commit the updated tracking files (`results.tsv`, `experiment_log.md`, `ideas.md`, `learnings.md`) so future iterations remember what didn't work. Message: `[autoresearch] <short description> (<status>)`.
+
+**Benchmark variance**: TPS fluctuates ~1-3%. If delta is within noise, re-run to confirm.
+
+**Crashes**: Fix easy bugs and re-run. If fundamentally broken, skip and move on.
+
+**NEVER STOP**: Work indefinitely until manually interrupted. If out of ideas, profile, study the graph, try different approaches.

--- a/torchtitan/experiments/graph_trainer/autoresearch/experiment_log.md
+++ b/torchtitan/experiments/graph_trainer/autoresearch/experiment_log.md
@@ -1,0 +1,21 @@
+# Autoresearch Experiment Log
+
+Cumulative log of every experiment in this run. Append-only — never
+overwrite previous entries. Re-read at the start of each loop iteration to
+learn from past experiments and avoid repeating failed approaches.
+
+## Format
+
+```markdown
+## <short title> — <status> (<commit hash>)
+
+- **Idea**: What optimization was attempted and why it was expected to help.
+- **Changes**: What was actually modified (brief summary, not a full diff).
+- **Result**: Perf numbers (tps, MFU, memory_gib, wall_time_s) or crash/error description.
+- **Analysis**: Why it worked, why it didn't help, or why it broke.
+- **Lessons**: Key takeaways — what to build on, what to avoid, what to try.
+```
+
+---
+
+(empty — the agent appends one entry per experiment, starting with the baseline)

--- a/torchtitan/experiments/graph_trainer/autoresearch/ideas.md
+++ b/torchtitan/experiments/graph_trainer/autoresearch/ideas.md
@@ -1,0 +1,24 @@
+# Autoresearch Ideas
+
+Optimization ideas for this run. Seed with human-curated directions, or
+leave empty for a pure-autonomy run where the agent generates its own
+ideas from FX graph inspection.
+
+## Format
+
+Each idea is a top-level bullet with a status checkbox:
+- `[ ]` — open, not yet explored
+- `[~]` — partially explored, more work possible
+- `[x]` — fully explored or no further opportunity
+
+Comments and findings go as **indented sub-bullets** with a timestamp at
+the beginning:
+
+```
+- [ ] **Idea name**: Description.
+  - YYYY-MM-DD HH:MM — Finding or comment.
+```
+
+## Ideas
+
+(empty — populate with curated seeds, or let the agent generate from graph inspection)

--- a/torchtitan/experiments/graph_trainer/autoresearch/learnings.md
+++ b/torchtitan/experiments/graph_trainer/autoresearch/learnings.md
@@ -1,0 +1,25 @@
+# Autoresearch Learnings
+
+Living document of what works, what doesn't, and how to approach kernel
+fusion optimization effectively. The agent owns this file.
+
+Re-read at the start of each loop iteration alongside `ideas.md` and
+`experiment_log.md`. Update after meaningful experiments (especially
+surprising results, both positive and negative). Keep concise and
+actionable — per-experiment details belong in `experiment_log.md`.
+
+## Methodology
+
+(empty — agent populates)
+
+## Patterns that worked
+
+(empty — agent populates)
+
+## Patterns that didn't work
+
+(empty — agent populates)
+
+## Tooling tips
+
+(empty — agent populates)

--- a/torchtitan/experiments/graph_trainer/autoresearch/results.tsv
+++ b/torchtitan/experiments/graph_trainer/autoresearch/results.tsv
@@ -1,0 +1,1 @@
+timestamp	commit	tps	memory_gib	status	mfu_pct	wall_time_s	description

--- a/torchtitan/experiments/graph_trainer/autoresearch/scripts/run_benchmark.sh
+++ b/torchtitan/experiments/graph_trainer/autoresearch/scripts/run_benchmark.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Autoresearch benchmark: Llama3 8B FSDP=4 TP=2 bs=1 on 8xH100.
+# Output goes to ./run.log with wall time appended.
+# Extra arguments are forwarded to run_train.sh.
+
+set -e
+
+start_time=$(date +%s)
+
+NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh \
+    --compile.mode aot_fx_trace \
+    --parallelism.data_parallel_shard_degree=4 \
+    --parallelism.tensor_parallel_degree=2 \
+    --dataloader.dataset c4_test \
+    --training.local_batch_size 1 \
+    --metrics.no-enable_tensorboard \
+    --profiler.no-enable_profiling \
+    --comm.trace_buf_size=0 \
+    --debug.seed 42 \
+    --training.steps 20 \
+    "$@" \
+    > run.log 2>&1
+
+elapsed=$(($(date +%s) - start_time))
+echo "benchmark_wall_time_s=${elapsed}" | tee -a run.log


### PR DESCRIPTION
## Summary

Adds a reusable **autoresearch harness** — an autonomous LLM-agent experiment loop for graph-pass / kernel optimization in `graph_trainer`. The agent iteratively edits `passes.py`, benchmarks each change, and keeps it only if training-step time improves **and** numerics stay bitwise-identical to eager (via the bitwise-vs-eager test). It runs indefinitely until manually stopped.

The three runs produced by this harness are open as PRs:
- #3440 — Run 1 (`ar_base`): pure-autonomy baseline, +44.9% TPS.
- #3441 — Run 2 (`ar_ideas`): + curated ideas, +64.7% TPS.
- #3442 — Run 3 (`ar_hand_opt`): + references + production starting graph, +5.21% over production.

Lives at `torchtitan/experiments/graph_trainer/autoresearch/`:

| File | Owner | Purpose |
|---|---|---|
| `autoresearch.md` | experimenter + agent | Agent operating manual, with `[SETUP]` sections filled in per run (target, starting graph, scaffolding level, reading scope, numerics check). |
| `README.md` | experimenter | Quickstart + file roles. |
| `ideas.md` / `experiment_log.md` / `learnings.md` / `results.tsv` | agent | Empty tracking templates (format headers only). |
| `scripts/run_benchmark.sh` | experimenter | Benchmark harness (edit per model/config). |

## Why

This harness drove a 3-run study on Llama3 8B that autonomously discovered bitwise-safe graph-pass optimizations (FSDP collective bucketing, CUDA graphs, custom mm→reduce_scatter fusion, regional Inductor fusions, etc.). Extracting the scaffolding so it can be reused for future models/graphs.

## Scope

- Pure additive — only `torchtitan/experiments/graph_trainer/autoresearch/` is touched; no core or graph_trainer code changes.
- Ships **empty** templates; run-specific results from the 3 validation runs live on their own branches (`ar_base` → #3440, `ar_ideas` → #3441, `ar_hand_opt` → #3442), not here.

## Test plan

- Harness is docs + a benchmark shell script; no code paths affected.
- `pre-commit run --all-files` passes on the added files.
- Paths/commands cross-checked against graph_trainer's existing benchmark docs; the numerics gate is the existing `test_bitwise_deterministic.py` bitwise-vs-eager test.
- Validated end-to-end across 3 Llama3 8B autoresearch runs (#3440, #3441, #3442).