### PR TITLE
[graph_trainer] Add IvanKobzarev as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 
 /torchtitan/experiments/forge/ @joecummings @felipemello1 @daniellepintz @tianyu-l @wwwjn @fegin
 
-/torchtitan/experiments/graph_trainer/ @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare
+/torchtitan/experiments/graph_trainer/ @IvanKobzarev @yiming0416 @tianyu-l @SherlockNoMad @xmfan @aditvenk @sanketpurandare

--- a/torchtitan/experiments/graph_trainer/.claude/autodev.md
+++ b/torchtitan/experiments/graph_trainer/.claude/autodev.md
@@ -248,7 +248,7 @@ their input change the work.
 drop untrusted authors at the CLI level:
 
 ```bash
-TRUSTED='["yiming0416","tianyu-l","SherlockNoMad","xmfan","aditvenk"]'
+TRUSTED='["IvanKobzarev","yiming0416","tianyu-l","SherlockNoMad","xmfan","aditvenk","sanketpurandare"]'
 PR={PR_NUMBER}
 
 # Fetch all trusted comments (inline + top-level) in one shot


### PR DESCRIPTION
## What

`IvanKobzarev` is now working on it. This adds `@IvanKobzarev` as a graph_trainer owner:

- `.github/CODEOWNERS` — add `@IvanKobzarev` to the `graph_trainer/` entry.
- `torchtitan/experiments/graph_trainer/.claude/autodev.md` — add `IvanKobzarev` to the autodev `TRUSTED` reviewer allowlist, and also add `sanketpurandare` so the list matches CODEOWNERS.

## Why

Reflect the current team composition so PR reviews route to the right owners and the autodev agent acts on the correct set of trusted reviewers.

## Notes

- `IvanKobzarev` is the confirmed GitHub handle (matches git history `IvanKobzarev <ivan.kobzarev@gmail.com>` and the existing `TODO(ivankobzarev)` in `fsdp_passes.py`).
- The `experiments/README.md` owners table is intentionally left unchanged for now.
- Docs/config only — no code or behavior change.