### PR TITLE
[graph_trainer] Add remove_b2b_transpose_pass; bundle graph cleanup into canonicalize_graph_pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -14,7 +14,8 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 - ``inductor_passes.py`` — regional and full Inductor compilation
 - ``cudagraph.py`` — cudagraph wrapping and kernel annotations
 - ``fsdp_passes.py`` — FSDP bucketing and resharding
-- ``remove_noop_passes.py`` — no-op removal (detach, identity view/slice)
+- ``remove_noop_passes.py`` — graph cleanup bundled as ``canonicalize_graph_pass``
+  (detach, identity view/slice, back-to-back transpose, view→reshape normalization)
 - ``performance_passes.py`` — opt-in numerics-changing optimizations
 - ``selective_activation_remat.py`` — activation rematerialization
 - ``cpu_offload.py`` — CPU offload insertion
@@ -54,34 +55,14 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
     tag_with_memory_policy_pass,
 )
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
-    remove_detach_pass,
-    remove_identity_slice_pass,
-    remove_identity_view_pass,
+    canonicalize_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.selective_activation_remat import (
     selective_activation_remat_pass,
 )
 from torchtitan.tools.logging import logger
 
-aten = torch.ops.aten
 c10d = torch.ops._c10d_functional
-
-
-def normalize_view_ops_as_reshape(
-    gm: torch.fx.GraphModule,
-    example_inputs=None,
-) -> torch.fx.GraphModule:
-    """Replace aten.view and aten._unsafe_view with aten.reshape.
-
-    Downstream passes expect aten.reshape.default for pattern matching.
-    """
-    view_targets = {aten.view.default, aten._unsafe_view.default}
-    for node in gm.graph.nodes:
-        if node.op == "call_function" and node.target in view_targets:
-            node.target = aten.reshape.default
-    gm.graph.lint()
-    gm.recompile()
-    return gm
 
 
 def async_tensor_parallel_pass(
@@ -150,10 +131,7 @@ def compile_time_passes(
 
     n_layers = len(config.model_spec.model.layers)
     passes: list[Callable] = [
-        remove_detach_pass,
-        remove_identity_view_pass,
-        remove_identity_slice_pass,
-        normalize_view_ops_as_reshape,
+        canonicalize_graph_pass,
         functools.partial(
             tag_with_memory_policy_pass,
             config=config,

--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -4,13 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Graph passes that remove semantically no-op nodes.
+"""Graph cleanup passes for traced forward-backward graphs.
 
-These passes simplify traced forward-backward graphs by eliminating nodes
-that are identity operations in the context of a fully traced graph (no
-autograd, no symbolic shape changes).  Removing them reduces graph noise
-and improves downstream pass effectiveness (bucketing, scheduling,
-cudagraph compatibility).
+These passes simplify traced graphs by eliminating nodes that are identity
+operations in the context of a fully traced graph (no autograd, no symbolic
+shape changes) and by canonicalizing equivalent view ops to a single target.
+Removing/normalizing them reduces graph noise and improves downstream pass
+effectiveness (bucketing, scheduling, cudagraph compatibility).
+
+``canonicalize_graph_pass`` bundles every individual sub-pass here into a
+single pass-list entry; the sub-passes remain public so they can be tested
+(and reasoned about) in isolation.
 """
 
 import sys
@@ -103,6 +107,49 @@ def remove_identity_view_pass(
     return gm
 
 
+def remove_b2b_transpose_pass(
+    gm: torch.fx.GraphModule, example_inputs=None
+) -> torch.fx.GraphModule:
+    """Remove back-to-back ``t(t(x))`` transposes that cancel out.
+
+    ``aten.t`` on a (<=2-D) tensor swaps the two dimensions.  Applying it
+    twice yields the original tensor (identical shape and strides), so the
+    back-to-back pair is a no-op regardless of shape.  These pairs appear in
+    traced graphs from ``F.linear`` when FSDP redistributes weight tensors.
+
+    Args:
+        gm: The traced graph module.
+        example_inputs: Unused, accepted for pass interface compatibility.
+
+    Returns:
+        The graph module with back-to-back transpose pairs collapsed.
+    """
+    count = 0
+    for node in list(gm.graph.nodes):
+        # A node whose target is the ``aten.t.default`` OpOverload is always a
+        # call_function node, so no explicit node.op check is needed.
+        if node.target is not torch.ops.aten.t.default:
+            continue
+        inp = node.args[0]
+        if isinstance(inp, torch.fx.Node) and inp.target is torch.ops.aten.t.default:
+            original = inp.args[0]
+            node.replace_all_uses_with(original)
+            gm.graph.erase_node(node)
+            count += 1
+            # The inner transpose may still feed other consumers; only erase
+            # it once it has no remaining users.
+            if not inp.users:
+                gm.graph.erase_node(inp)
+                count += 1
+
+    if count > 0:
+        gm.graph.lint()
+        gm.recompile()
+        logger.info(f"Removed {count} back-to-back transpose node(s) from the graph")
+
+    return gm
+
+
 def remove_identity_slice_pass(
     gm: torch.fx.GraphModule, example_inputs=None
 ) -> torch.fx.GraphModule:
@@ -164,4 +211,67 @@ def remove_identity_slice_pass(
 
     gm.graph.lint()
     gm.recompile()
+    return gm
+
+
+def normalize_view_ops_as_reshape(
+    gm: torch.fx.GraphModule, example_inputs=None
+) -> torch.fx.GraphModule:
+    """Retarget ``aten.view`` and ``aten._unsafe_view`` to ``aten.reshape``.
+
+    These three ops are equivalent on contiguous tensors; downstream passes
+    pattern-match on ``aten.reshape.default``, so this canonicalizes the
+    others to that single target.
+
+    Args:
+        gm: The traced graph module.
+        example_inputs: Unused, accepted for pass interface compatibility.
+
+    Returns:
+        The graph module with view ops normalized to reshape.
+    """
+    view_targets = {
+        torch.ops.aten.view.default,
+        torch.ops.aten._unsafe_view.default,
+    }
+    count = 0
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target in view_targets:
+            node.target = torch.ops.aten.reshape.default
+            count += 1
+
+    if count > 0:
+        gm.graph.lint()
+        gm.recompile()
+        logger.info(f"Normalized {count} view op(s) to reshape")
+
+    return gm
+
+
+def canonicalize_graph_pass(
+    gm: torch.fx.GraphModule, example_inputs=None
+) -> torch.fx.GraphModule:
+    """Canonicalize and simplify the graph as a single pass-list entry.
+
+    Bundles the numerics-preserving simplification passes so the pass list
+    in ``compile_time_passes`` has one entry instead of several:
+
+    1. ``remove_detach_pass`` — drop autograd-only ``detach`` nodes.
+    2. ``remove_identity_view_pass`` — drop ``view``/``reshape``/
+       ``_unsafe_view`` nodes whose output shape equals their input.
+    3. ``remove_b2b_transpose_pass`` — collapse back-to-back ``t(t(x))`` pairs.
+    4. ``remove_identity_slice_pass`` — drop full-dimension slices.
+    5. ``normalize_view_ops_as_reshape`` — canonicalize remaining
+       ``view``/``_unsafe_view`` nodes to ``reshape``.
+
+    Each sub-pass lints and recompiles internally, so no extra work is
+    needed here. The ordering is irrelevant for correctness (the sub-passes
+    act on disjoint op sets, and identity-view removal also handles
+    ``reshape``), but is kept stable for readable tlparse diffs.
+    """
+    gm = remove_detach_pass(gm, example_inputs)
+    gm = remove_identity_view_pass(gm, example_inputs)
+    gm = remove_b2b_transpose_pass(gm, example_inputs)
+    gm = remove_identity_slice_pass(gm, example_inputs)
+    gm = normalize_view_ops_as_reshape(gm, example_inputs)
     return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -40,11 +40,14 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_full_memory_policy,
     tag_sac_policy,
 )
-from torchtitan.experiments.graph_trainer.passes import (
+from torchtitan.experiments.graph_trainer.passes import selective_activation_remat_pass
+from torchtitan.experiments.graph_trainer.remove_noop_passes import (
+    canonicalize_graph_pass,
+    normalize_view_ops_as_reshape,
+    remove_b2b_transpose_pass,
     remove_detach_pass,
     remove_identity_slice_pass,
     remove_identity_view_pass,
-    selective_activation_remat_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
 from torchtitan.experiments.graph_trainer.tests.test_cpu_offload import (  # noqa: F401
@@ -1209,6 +1212,112 @@ class TestRemoveIdentityViewPass(TestCase):
         self.assertEqual(len(list(result.graph.nodes)), num_nodes_before)
 
 
+class TestRemoveB2BTransposePass(TestCase):
+    """Unit tests for the remove_b2b_transpose_pass graph pass."""
+
+    def _count_t_nodes(self, gm):
+        """Count aten.t.default call_function nodes."""
+        return sum(
+            1
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.aten.t.default
+        )
+
+    def test_b2b_transpose_pair_removed(self):
+        """``t(t(x))`` collapses: both transpose nodes are removed and the
+        consumer reads the original tensor directly."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(t2,))
+        graph.output(relu)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(self._count_t_nodes(gm), 2)
+
+        remove_b2b_transpose_pass(gm)
+
+        self.assertEqual(self._count_t_nodes(gm), 0)
+        # relu now consumes the placeholder directly.
+        relu_node = next(
+            n for n in gm.graph.nodes if n.target is torch.ops.aten.relu.default
+        )
+        self.assertEqual(relu_node.args[0].op, "placeholder")
+
+        # Numerics preserved: relu(t(t(x))) == relu(x).
+        x = torch.randn(3, 4)
+        self.assertEqual(gm(x), torch.relu(x))
+
+    def test_single_transpose_preserved(self):
+        """A lone transpose is not a back-to-back pair and must be kept."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        graph.output(t)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        remove_b2b_transpose_pass(gm)
+
+        self.assertEqual(self._count_t_nodes(gm), 1)
+        x = torch.randn(3, 4)
+        self.assertEqual(gm(x), x.t())
+
+    def test_inner_transpose_with_other_user_kept(self):
+        """When the inner transpose feeds another consumer, only the outer
+        transpose is removed; the inner one stays for its other user."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        # t1 also feeds a relu, so it cannot be erased.
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(t1,))
+        graph.output((t2, relu))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(self._count_t_nodes(gm), 2)
+
+        remove_b2b_transpose_pass(gm)
+
+        # Outer transpose removed, inner one kept (still used by relu).
+        self.assertEqual(self._count_t_nodes(gm), 1)
+
+        x = torch.randn(3, 4)
+        out_t2, out_relu = gm(x)
+        self.assertEqual(out_t2, x)  # t(t(x)) == x
+        self.assertEqual(out_relu, torch.relu(x.t()))
+
+    def test_chain_of_transposes(self):
+        """An odd-length chain ``t(t(t(x)))`` collapses to a single ``t(x)``."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        t1 = graph.call_function(torch.ops.aten.t.default, args=(x,))
+        t2 = graph.call_function(torch.ops.aten.t.default, args=(t1,))
+        t3 = graph.call_function(torch.ops.aten.t.default, args=(t2,))
+        graph.output(t3)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.assertEqual(self._count_t_nodes(gm), 3)
+
+        remove_b2b_transpose_pass(gm)
+
+        self.assertEqual(self._count_t_nodes(gm), 1)
+        x = torch.randn(3, 4)
+        self.assertEqual(gm(x), x.t())
+
+    def test_graph_without_transpose_unchanged(self):
+        """Graphs without transpose nodes are returned unchanged."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        neg = graph.call_function(torch.ops.aten.neg.default, args=(relu,))
+        graph.output(neg)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        num_nodes_before = len(list(gm.graph.nodes))
+
+        result = remove_b2b_transpose_pass(gm)
+
+        self.assertIs(result, gm)
+        self.assertEqual(len(list(result.graph.nodes)), num_nodes_before)
+
+
 class TestRemoveIdentitySlicePass(TestCase):
     """Unit tests for the remove_identity_slice_pass graph pass."""
 
@@ -1629,10 +1738,6 @@ class TestAnnotateModuleFqns(TestCase):
 
 class TestNormalizeViewOpsAsReshape(TestCase):
     def test_replaces_view_and_unsafe_view(self):
-        from torchtitan.experiments.graph_trainer.passes import (
-            normalize_view_ops_as_reshape,
-        )
-
         aten = torch.ops.aten
         g = torch.fx.Graph()
         x = g.placeholder("x")
@@ -1649,6 +1754,37 @@ class TestNormalizeViewOpsAsReshape(TestCase):
         normalize_view_ops_as_reshape(gm)
         for n in gm.graph.nodes:
             self.assertNotIn(n.target, {aten.view.default, aten._unsafe_view.default})
+
+
+class TestCanonicalizeGraphPass(TestCase):
+    """Unit tests for the combined canonicalize_graph_pass entry."""
+
+    def test_runs_all_subpasses(self):
+        """A single call drops detach + back-to-back transpose nodes and
+        normalizes the surviving view op to reshape."""
+        aten = torch.ops.aten
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        d = graph.call_function(aten.detach.default, args=(x,))
+        t1 = graph.call_function(aten.t.default, args=(d,))
+        t2 = graph.call_function(aten.t.default, args=(t1,))
+        # Non-identity view (shape changes), left without fake meta so the
+        # identity-view removal skips it and only normalization applies.
+        v = graph.call_function(aten.view.default, args=(t2, [2, 8]))
+        graph.output(v)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        canonicalize_graph_pass(gm)
+
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(aten.detach.default, targets)
+        self.assertNotIn(aten.t.default, targets)
+        self.assertNotIn(aten.view.default, targets)
+        self.assertIn(aten.reshape.default, targets)
+
+        # Numerics preserved: reshape(t(t(detach(x))), [2, 8]) == x.reshape(2, 8).
+        x = torch.randn(4, 4)
+        self.assertEqual(gm(x), x.reshape(2, 8))
 
 
 class TestAsyncTensorParallelPass(FSDPTest):


### PR DESCRIPTION
## Summary

Two related graph-pass changes in `graph_trainer`:

1. **Add `remove_b2b_transpose_pass`** — collapses back-to-back `aten.t(aten.t(x))` transpose pairs. These appear in traced fwd+bwd graphs from `F.linear` when `simple_fsdp` redistributes weight tensors. Two consecutive `aten.t` form an involution (identical shape *and* strides), so removing them is **bitwise numerics-preserving**. The pass also handles chains (`t(t(t(x))) -> t(x)`) and keeps the inner transpose when it still feeds other consumers.

2. **Bundle the no-op cleanup passes into a single `canonicalize_graph_pass` entry** in `compile_time_passes`:
   - `remove_detach_pass`
   - `remove_identity_view_pass`
   - `remove_b2b_transpose_pass`
   - `remove_identity_slice_pass`
   - `normalize_view_ops_as_reshape`

   `normalize_view_ops_as_reshape` moves from `passes.py` into `remove_noop_passes.py` alongside the other graph-cleanup passes. The sub-passes stay public so each is unit-tested in isolation.

## Why

The cleanup passes are all numerics-preserving local rewrites that ran as four separate pass-list entries. Folding them into one `canonicalize_graph_pass` keeps `compile_time_passes` readable and groups them as one logical step, while the new b2b-transpose rewrite removes redundant transpose pairs that `F.linear` + FSDP introduce.

## Behavior note

`--compile.disable_passes` now toggles `canonicalize_graph_pass` as a whole rather than the individual sub-passes. No callsite (configs/scripts/README) disabled them individually, so nothing breaks.

## Verification

Ran the llama3 debug model (FSDP=4, TP=2, `aot_fx_trace`, `--compile.debug_graph_passes`). `remove_b2b_transpose_pass` logs its removal count directly:

```
[rank0]:[titan] - root - INFO - Removed 129 back-to-back transpose node(s) from the graph
```

`canonicalize_graph_pass` is pass #1; its op-count diff confirms the same 129 nodes (`t.default: 215 -> 86`):

```
nodes: 2460 -> 1851 (-609)
  t.default:        215 -> 86  (-129)   <- remove_b2b_transpose_pass
  detach.default:    40 -> 0   (-40)
  view.default:     634 -> 0   (-634)
  _unsafe_view:      43 -> 0   (-43)
  slice.Tensor:      40 -> 0   (-40)
  reshape.default:    0 -> 277 (+277)
```

3 training steps, loss `8.11353 -> 7.80330 -> 7.09355`.

## Test plan

```bash
pytest torchtitan/experiments/graph_trainer/tests/test_passes.py \
  -k "TestRemoveB2BTransposePass or TestCanonicalizeGraphPass or \
      TestNormalizeViewOpsAsReshape or TestRemoveDetachPass or \
      TestRemoveIdentityViewPass or TestRemoveIdentitySlicePass"
```

Added `TestRemoveB2BTransposePass` (pair removal + numerics, lone transpose kept, inner transpose with another user kept, chain collapse, no-op on transpose-free graphs) and `TestCanonicalizeGraphPass` (end-to-end bundle). All pass; `pre-commit run --all-files` clean.
