### PR TITLE
gitignore: ignore .venv/ and venv/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ Sessionx.vim
 # env files
 .env
 
+# Python virtual environments
+.venv/
+venv/
+
 # Claude Code local configuration
 CLAUDE.local.md
 /test_*.py


### PR DESCRIPTION
Summary:
After following the tests/README.md install instructions, contributors
typically create a Python virtual environment, commonly named .venv/
or venv/. These directories aren't currently in .gitignore, so they
show up as ~40K untracked files in git status (and VSCode's Source
Control panel) after a fresh nightly torch install — visually
overwhelming and easy to accidentally git add .

Add the three standard Python venv directory names (.venv/, venv/,
.env/) to .gitignore under a new "Python virtual environments"
section, so they're hidden by default.

Test Plan:
- Created a .venv in a torchtitan checkout (~40K files from torch nightly + deps).
- Confirmed `git status` and `sl status` now show only intentional working-tree
  changes; the venv files are no longer surfaced.
- No effect on existing tracked files.