### PR TITLE
docs: clarify nightly torch install in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -18,11 +18,65 @@ This directory contains tests for the torchtitan project, including unit tests a
 
 ### Prerequisites
 
-Ensure you have all development dependencies installed:
+For most users, install stable PyTorch and the rest of the dependencies
+from PyPI:
 
 ```bash
-pip install -r requirements-dev.txt
 pip install -r requirements.txt
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
+PyTorch comes in as a transitive dependency of `torchdata` (stable from
+PyPI). This is the fast path — it works for unit tests and most local
+development, but it pins you to whatever stable torch happens to be
+current, which may lag behind what CI tests against.
+
+#### Developer path: nightly torch matching CI
+
+To match the exact torch / torchao / torchdata / torchvision versions
+that CI runs against (and to pick up features only in nightlies), install
+them explicitly from the nightly index for your hardware **before**
+`pip install -e .`. PyTorch publishes one nightly index per hardware
+target:
+
+| Hardware | Index URL |
+|---|---|
+| CPU only | `https://download.pytorch.org/whl/nightly/cpu` |
+| CUDA 13.0 | `https://download.pytorch.org/whl/nightly/cu130` |
+| CUDA 12.8 | `https://download.pytorch.org/whl/nightly/cu128` |
+| ROCm 6.4 | `https://download.pytorch.org/whl/nightly/rocm6.4` |
+
+(See <https://pytorch.org/get-started/locally/> for the current list of
+channels.) The install pattern below mirrors what
+`.github/workflows/integration_test_8gpu_h100.yaml` runs in CI, with the
+index URL substituted for your hardware:
+
+```bash
+# Pick the URL for your hardware from the table above
+INDEX_URL=https://download.pytorch.org/whl/nightly/cu130
+
+# 1. Pre-install torch's pure-Python deps (faster than letting pip re-resolve).
+pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy
+
+# 2. torch + torchvision — clear PIP_EXTRA_INDEX_URL so a default extra
+#    index can't slip in a +cpu wheel when you wanted CUDA.
+PIP_EXTRA_INDEX_URL= pip install --force-reinstall --pre torch torchvision \
+  --index-url ${INDEX_URL}
+
+# 3. torchao — USE_CPP=0 matches CI: skips C++/CUDA kernels for a faster
+#    install. Drop it if you need the accelerated kernels.
+USE_CPP=0 PIP_EXTRA_INDEX_URL= pip install --pre torchao \
+  --index-url ${INDEX_URL}
+
+# 4. torchdata
+pip install --pre torchdata \
+  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+# 5. Finally install torchtitan + dev tooling. The earlier nightly installs
+#    satisfy torch/torchao/torchdata so the resolver won't replace them.
+pip install -e .
+pip install -r requirements-dev.txt
 ```
 
 ### Running Integration Tests


### PR DESCRIPTION
Summary:
The existing tests/README.md "Prerequisites" section presented a single install path that mixed stable PyPI dependencies with CI-matching nightly torch. Two problems: most users just want torchtitan running locally and don't care about CI parity (and the section made that look complicated), while developers who DO want CI parity were missing the actual install pattern (the existing one only matched the CPU unit-test workflow, not the GPU integration tests where most real development happens).

Split into two paths:

1. Fast path for most users: `pip install -r requirements.txt && pip install -r requirements-dev.txt && pip install -e .`. PyTorch comes in transitively from PyPI as a stable build. Works for unit tests and most local development.

2. Developer path for CI parity / nightly features: explicit nightly install before `pip install -e .`, parameterized by INDEX_URL. Mirrors what `.github/workflows/integration_test_8gpu_h100.yaml` runs in CI (its index URL is matrix-parameterized per hardware target). Lists the channels PyTorch publishes (CPU, CUDA 13.0/12.8, ROCm 6.4) and links to <https://pytorch.org/get-started/locally/> for the current set.

The developer-path sequence also surfaces three things that aren't obvious from a generic `pip install` command: pre-installing torch's pure-Python deps (`filelock typing-extensions setuptools sympy networkx jinja2 fsspec numpy`) to skip pip re-resolving them, clearing `PIP_EXTRA_INDEX_URL=` before the torch install so a default extra index can't sneak in a +cpu wheel when you asked for CUDA, and the note that torchdata always comes from the CPU nightly index regardless of hardware (it's pure Python).

Test Plan:
- Followed the fast-path instructions in a fresh venv on a Linux x86_64 devserver; `pytest tests/unit_tests/` runs to completion (the test_state_dict_adapter.py round-trip test passed) against stable torch from PyPI.
- Followed the developer-path instructions with INDEX_URL=https://download.pytorch.org/whl/nightly/cpu (no GPU on this host); same tests pass against nightly torch.
- Diff is documentation-only; no code changes.