### PR TITLE
ci: skip torchcomms TP+PP+compile flavor until PG registration is fixed

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -676,6 +676,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "torchcomms_3d_dp+tp+pp+compile",
             ngpu=8,
             skip_rocm_test=True,
+            disabled=True,  # torchcomms-managed TP PG not registered in c10d; resolve fails under compile
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
Skips the failing `FSDP+TP+PP+compile with torchcomms` CI flavor.

## Problem
Functional collectives (`torch.ops._c10d_functional.all_reduce_`) resolve
process groups by name from the c10d registry. When `--comm.mode torchcomms`
is used, torchcomms manages the TP process group outside that registry, so
resolution fails at runtime under `torch.compile`:

RuntimeError: Could not resolve the process group registered under the name 20

## Fix
Marks the flavor `disabled=True` to unblock CI. Same pattern as the
existing disabled `2D async TP compile` flavor.

The real fix belongs in torchcomms — it needs to register its managed PGs
with c10d so functional collectives can resolve them by name.

## Test
No new tests needed — this disables a broken flavor until upstream is fixed.

Ref: pytorch/pytorch#186031