### PR TITLE
[graph_trainer] Re-enable llama3 AutoParallel numerics test (was empty_strided shadow-node bug)

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -454,9 +454,6 @@ def _build_async_tp_tests() -> list[OverrideDefinitions]:
 def _build_autoparallel_tests() -> list[OverrideDefinitions]:
     """AutoParallel integration tests for default runners."""
     return [
-        # TODO: disabled due to upstream AutoParallel regression in nightly:
-        # nll_loss assertion failure (t >= 0 && t < n_classes) from incorrect
-        # loss partitioning. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -471,7 +468,6 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
             "autoparallel llama3 FSDP+TP",
             "autoparallel_llama3_fsdp_tp",
             ngpu=4,
-            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -366,7 +366,6 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 class TestGraphTrainerAutoParallelNumerics(unittest.TestCase):
     """Test graph_trainer AutoParallel numerics equivalence against eager."""
 
-    @unittest.skip("upstream AutoParallel nll_loss assertion regression")
     def test_llama3_aot_fx_trace_autoparallel_vs_eager(self):
         self.assertTrue(_run_autoparallel_llama3_loss_compare())
 


### PR DESCRIPTION
## Summary

The skip on `test_llama3_aot_fx_trace_autoparallel_vs_eager` and the integration test `autoparallel_llama3_fsdp_tp` blamed an *"upstream AutoParallel nll_loss assertion regression"* / *"incorrect loss partitioning"*. That was a **misattribution** — it is the same `empty_strided` dead-shadow-node bug that #3480 root-caused and fixed with `_remove_dead_empty_strided_chains`.

## Root cause

AutoParallel produces a **model-only** graph (vocab-sharded DTensor logits); the loss op is applied afterwards inside graph_trainer's `make_fwd_bwd_step`, which is traced by `minimal_fx_tracer` — **exactly the graph the DCE cleans**. Under the unfixed nightly, DTensor shard propagation leaves a dead `nll_loss` shadow node reading an uninitialized `empty_strided` target, which trips the bounds check `t >= 0 && t < n_classes` at runtime — the same failure class as the embedding OOB in #3480. `_remove_dead_empty_strided_chains` strips that dead chain. The upstream fix is pytorch/pytorch #185865.

Minimal isolation (simulating the unfixed nightly by restoring the pre-fix `_propagate_tensor_meta_non_cached`) confirms the DCE removes the dead bounds-checked shadow op:
```
before: empty_strided=2, embedding=2   # dead aten.embedding(empty_strided_w, empty_strided_idx) [num_users=0]
after _remove_dead_empty_strided_chains: empty_strided=0, embedding=1
```

## Verification

Ran on 8×H100 with `autoparallel` installed — loss matches eager:
```
Max loss difference: step=11 baseline=3.6115226 test=3.6113948 diff=0.000128
1 passed in 226.67s
```

CI runs this unit test on the **unfixed** nightly (`integration_test_8gpu_graph_trainer.yaml`), so it exercises the DCE path directly. Keep `_remove_dead_empty_strided_chains` until #185865 lands.

## Left disabled (verified separate, still-open bugs)

- **DSv3 AutoParallel** — different failure, not the shadow-node bug.
- **JIT (#2149)** — confirmed still reproduces `AssertionError: Node tangents_2 was invalid, but is output` in `torch/_functorch/partitioners.py`.

## Test plan

```bash
pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerAutoParallelNumerics::test_llama3_aot_fx_trace_autoparallel_vs_eager
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)