### PR TITLE
[Do NOT review] use vllm's triton kernel to calculate logprobs

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -82,6 +82,8 @@ jobs:
 
         # 4. Install torchtitan in editable mode because integration test spawns
         # python grpo.py as a subprocess
+        # The checkout is mounted from the host and may not be writable by ci-user.
+        sudo chown $(id -u):$(id -g) "$PWD"
         uv pip install -e .
 
         # 5. Download HF model checkpoint for tests

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -89,6 +89,8 @@ jobs:
 
         # 5. Install torchtitan in editable mode because integration test spawns
         # python grpo.py as a subprocess
+        # The checkout is mounted from the host and may not be writable by ci-user.
+        sudo chown $(id -u):$(id -g) "$PWD"
         uv pip install -e .
 
         # 6. Download HF model checkpoint for tests

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -65,6 +65,38 @@ def compute_logprobs(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
     ).reshape(B, S)
 
 
+@torch.no_grad()
+@sl.log_trace_span("compute_vllm_compatible_logprobs")
+def compute_vllm_compatible_logprobs(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    *,
+    loss_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute selected-token logprobs with vLLM's Triton kernel.
+
+    This helper is for generator-vs-trainer identity diagnostics only. The
+    differentiable training loss uses ``compute_logprobs`` above.
+    """
+    from torch.distributed.tensor import DTensor
+    from vllm.v1.worker.gpu.sample.logprob import compute_token_logprobs
+
+    if isinstance(logits, DTensor):
+        logits = logits.to_local()
+
+    if logits.device.type != "cuda":
+        raise RuntimeError("vLLM-compatible logprob verification requires CUDA.")
+
+    B, S, V = logits.shape
+    token_ids = labels.reshape(B * S, 1).to(torch.int64)
+    if loss_mask is not None:
+        token_ids = token_ids.masked_fill(~loss_mask.reshape(B * S, 1), 0)
+    else:
+        token_ids = token_ids.masked_fill(token_ids == IGNORE_INDEX, 0)
+
+    return compute_token_logprobs(logits.reshape(B * S, V), token_ids).reshape(B, S)
+
+
 @dataclass(frozen=True, slots=True)
 class PartialLogprobDrift:
     """Per-rank generator-vs-trainer logprob drift awaiting reduction across the loss-mesh."""
@@ -413,6 +445,11 @@ class PolicyTrainer(Actor, Configurable):
                 token_ids, attention_masks=attention_masks, positions=positions
             )
         policy_logprobs = compute_logprobs(logits, labels)
+        identity_logprobs = compute_vllm_compatible_logprobs(
+            logits.detach(),
+            labels,
+            loss_mask=loss_mask,
+        )
 
         with sl.log_trace_span("loss_fn"):
             loss, loss_metrics = self.loss_fn(
@@ -430,7 +467,7 @@ class PolicyTrainer(Actor, Configurable):
         # Metrics for bitwise verification of policy logprobs.
         verification: PartialLogprobDrift = verify_logprob_identity(
             generator_logprobs=generator_logprobs,
-            policy_logprobs=policy_logprobs,
+            policy_logprobs=identity_logprobs,
             loss_mask=loss_mask,
             num_global_valid_tokens=num_global_valid_tokens,
         )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -464,7 +464,9 @@ class PolicyTrainer(Actor, Configurable):
         with sl.log_trace_span("model_backward"):
             loss.backward()
 
-        # Metrics for bitwise verification of policy logprobs.
+        # Metrics for bitwise verification of policy logprobs. This compares
+        # trainer logits post-processed by vLLM's selected-token logprob kernel
+        # against the generator logprobs produced by vLLM.
         verification: PartialLogprobDrift = verify_logprob_identity(
             generator_logprobs=generator_logprobs,
             policy_logprobs=identity_logprobs,

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -134,16 +134,19 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
             AttentionType.ENCODER,
         ), "Encoder-only attention not supported yet."
 
-        # For decoder and cross-attention, use KV cache as before
-        # This backend inherits vLLM's FlashAttention cache contract, so K/V
-        # must be the leading dimension. Keep this explicit until we know which
-        # vLLM allocation path produced the CI-only layout mismatch.
-        if kv_cache.shape[0] != 2:
+        # vLLM may hand CUSTOM backends either FlashAttention's historical
+        # [2, num_blocks, block_size, num_kv_heads, head_size] layout or the
+        # generic NHD [num_blocks, 2, block_size, num_kv_heads, head_size]
+        # layout used by its cache allocator.
+        if kv_cache.shape[0] == 2:
+            key_cache, value_cache = kv_cache.unbind(0)
+        elif kv_cache.ndim == 5 and kv_cache.shape[1] == 2:
+            key_cache, value_cache = kv_cache.unbind(1)
+        else:
             raise ValueError(
                 "Unexpected KV cache layout for PyTorchVarlenAttentionImpl: "
                 f"shape={tuple(kv_cache.shape)}, stride={tuple(kv_cache.stride())}"
             )
-        key_cache, value_cache = kv_cache.unbind(0)
 
         assert not self.kv_cache_dtype.startswith(
             "fp8"

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -135,6 +135,14 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
         ), "Encoder-only attention not supported yet."
 
         # For decoder and cross-attention, use KV cache as before
+        # This backend inherits vLLM's FlashAttention cache contract, so K/V
+        # must be the leading dimension. Keep this explicit until we know which
+        # vLLM allocation path produced the CI-only layout mismatch.
+        if kv_cache.shape[0] != 2:
+            raise ValueError(
+                "Unexpected KV cache layout for PyTorchVarlenAttentionImpl: "
+                f"shape={tuple(kv_cache.shape)}, stride={tuple(kv_cache.stride())}"
+            )
         key_cache, value_cache = kv_cache.unbind(0)
 
         assert not self.kv_cache_dtype.startswith(

--- a/torchtitan/experiments/rl/observability/metrics/processor.py
+++ b/torchtitan/experiments/rl/observability/metrics/processor.py
@@ -61,6 +61,7 @@ class MetricsProcessor(Configurable):
                 "rollout/response_length/max",
                 "train/grad_norm/mean",
                 "train/lr",
+                "bit_wise/logprob_diff/max",
                 "perf/tokens_per_second",
                 "timing/step",
             ]


### PR DESCRIPTION
Testing why logprobs under batch invariant mode shows slightly differences