### PR TITLE
[graph_trainer] Skip MoE tests due to upstream PyTorch regressions

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -303,6 +303,11 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
         # === aot_fx_trace mode tests ===
         # Note: cudagraph is auto-skipped for DSv3 because MoE load-balancing
         # introduces CUDA→CPU transfers incompatible with CUDA graph capture.
+        #
+        # TODO: aot_fx_trace MoE tests are disabled due to an upstream PyTorch
+        # regression: histc's meta kernel doesn't support int64 inputs,
+        # breaking tracing for all MoE models. Re-enable once the histc
+        # meta kernel is fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -318,6 +323,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+CP+EP",
             "aot_fx_trace_deepseek_v3_fsdp_tp_cp_ep",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -333,6 +339,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -349,6 +356,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+full_inductor",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_full_inductor",
             ngpu=8,
+            disabled=True,
         ),
         OverrideDefinitions(
             [
@@ -364,7 +372,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+HybridEP",
             "aot_fx_trace_deepseek_v3_hybridep",
             ngpu=4,
-            disabled=not _DEEPEP_AVAILABLE,
+            disabled=True,
         ),
     ]
 
@@ -387,6 +395,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_qwen3_fsdp_tp_cp",
             ngpu=8,
         ),
+        # TODO: disabled due to upstream histc int64 regression (see DSv3 comment)
         OverrideDefinitions(
             [
                 [
@@ -401,6 +410,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace qwen3 MoE FSDP+TP+EP",
             "aot_fx_trace_qwen3_moe_fsdp_tp_ep",
             ngpu=8,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -69,6 +69,8 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_name="aot_fx_trace_llama3_precompile_fsdp_tp",
             ngpu=8,
         ),
+        # TODO: disabled due to upstream histc int64 regression breaking
+        # MoE model tracing. Re-enable once fixed upstream.
         PrecompileTestDefinition(
             precompile_command=(
                 "python -m torchtitan.experiments.graph_trainer.precompile_main"
@@ -92,6 +94,7 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_descr="aot_fx_trace deepseek_v3 precompile FSDP+TP+EP",
             test_name="aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep",
             ngpu=8,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -381,9 +381,9 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
-    )
+    # TODO: expected hashes are stale due to upstream PyTorch nightly changes.
+    # Run `EXPECTTEST_ACCEPT=1 pytest <this_file>` on H100 to update.
+    @unittest.skip("DSv3 expected hashes stale after upstream PyTorch changes")
     def test_eager_self_deterministic(self):
         """Eager mode: results match hardcoded expected values.
 
@@ -507,9 +507,9 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skipUnless(
-        has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
-    )
+    # TODO: expected hashes are stale due to upstream PyTorch nightly changes.
+    # Run `EXPECTTEST_ACCEPT=1 pytest <this_file>` on H100 to update.
+    @unittest.skip("DSv3 FlexAttn expected hashes stale after upstream PyTorch changes")
     def test_eager_self_deterministic(self):
         """Eager results match hardcoded expected values.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* #3510
* #3509
* #3508
* #3507
* #3506
* #3505
* __->__ #3504

Disable graph_trainer MoE tests broken by upstream PyTorch nightly:

1. histc meta kernel doesn't support int64 — breaks all aot_fx_trace
   MoE integration tests and precompile tests.
2. DSv3 bitwise deterministic expected hashes are stale after upstream
   numerics changes.

Affected tests:
- aot_fx_trace_deepseek_v3_{fsdp_tp_cp_ep,fsdp_tp_ep_flexattn,
  fsdp_tp_ep_full_inductor,hybridep}
- aot_fx_trace_qwen3_moe_fsdp_tp_ep
- aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
- TestDSv3BitwiseDeterministic::test_eager_self_deterministic
- TestDSv3FlexAttnBitwiseDeterministic::test_eager_self_deterministic

Re-enable once fixed upstream.