### PR TITLE
[graph_trainer] Skip cuDNN/FlexAttention tests due to upstream PyTorch regressions

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -180,6 +180,10 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
         ),
         # === aot_fx_trace mode tests ===
         # Note: aot_fx_trace applies cudagraph by default, so skip_rocm_test=True.
+        #
+        # TODO: disabled due to upstream PyTorch cuDNN regression in nightly:
+        # CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH with CUDA graphs + context
+        # parallelism. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -195,8 +199,12 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_cp",
             ngpu=8,
             skip_rocm_test=True,
+            disabled=True,
         ),
         # async_tp test lives in graph_trainer_h100 suite (needs NVLink).
+        # TODO: disabled due to upstream PyTorch FlexAttention regression in
+        # nightly: device-side assert triggered during CUDA graph replay.
+        # Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -210,6 +218,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace llama3 FSDP+TP+FlexAttn",
             "aot_fx_trace_llama3_fsdp_tp_flexattn",
             ngpu=8,
+            disabled=True,
         ),
         # TODO: Disabled due to upstream PyTorch cuDNN regression in nightly
         # dev20260506. _scaled_dot_product_cudnn_attention fails with
@@ -380,6 +389,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
 def _build_qwen3_tests() -> list[OverrideDefinitions]:
     """Qwen3-based integration tests (dense + MoE)."""
     return [
+        # TODO: disabled due to upstream PyTorch cuDNN regression in nightly:
+        # CUDA graphs + context parallelism triggers
+        # CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -394,6 +406,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace qwen3 FSDP+TP+CP",
             "aot_fx_trace_qwen3_fsdp_tp_cp",
             ngpu=8,
+            disabled=True,
         ),
         # TODO: disabled due to upstream histc int64 regression (see DSv3 comment)
         OverrideDefinitions(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* #3510
* #3509
* #3508
* #3507
* #3506
* __->__ #3505
* #3504

Disable three integration tests hitting upstream PyTorch nightly regressions:

- aot_fx_trace_llama3_fsdp_tp_cp: cuDNN CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH
  with CUDA graphs + context parallelism
- aot_fx_trace_llama3_fsdp_tp_flexattn: FlexAttention device-side assert
  triggered during CUDA graph replay
- aot_fx_trace_qwen3_fsdp_tp_cp: same cuDNN + CP issue as Llama3