### PR TITLE
[graph_trainer] Skip AutoParallel test due to upstream nll_loss regression

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -468,6 +468,9 @@ def _build_async_tp_tests() -> list[OverrideDefinitions]:
 def _build_autoparallel_tests() -> list[OverrideDefinitions]:
     """AutoParallel integration tests for default runners."""
     return [
+        # TODO: disabled due to upstream AutoParallel regression in nightly:
+        # nll_loss assertion failure (t >= 0 && t < n_classes) from incorrect
+        # loss partitioning. Re-enable once fixed upstream.
         OverrideDefinitions(
             [
                 [
@@ -482,6 +485,7 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
             "autoparallel llama3 FSDP+TP",
             "autoparallel_llama3_fsdp_tp",
             ngpu=4,
+            disabled=True,
         ),
     ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* #3510
* #3509
* #3508
* #3507
* __->__ #3506
* #3505
* #3504

Disable autoparallel_llama3_fsdp_tp: upstream AutoParallel regression
causes nll_loss assertion failure (t >= 0 && t < n_classes) from
incorrect loss partitioning with TP.