### PR TITLE
[graph_trainer] Skip AutoParallel numerics test due to upstream regression

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -371,6 +371,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 class TestGraphTrainerAutoParallelNumerics(unittest.TestCase):
     """Test graph_trainer AutoParallel numerics equivalence against eager."""
 
+    @unittest.skip("upstream AutoParallel nll_loss assertion regression")
     def test_llama3_aot_fx_trace_autoparallel_vs_eager(self):
         self.assertTrue(_run_autoparallel_llama3_loss_compare())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* #3510
* #3509
* #3508
* __->__ #3507
* #3506
* #3505
* #3504

Also skip test_llama3_aot_fx_trace_autoparallel_vs_eager in the
numerics tests — same upstream AutoParallel nll_loss assertion failure.