### PR TITLE
[graph_trainer] Skip Llama3 precompile test due to upstream CUDA graph regression

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -68,6 +68,9 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             test_descr="aot_fx_trace llama3 precompile FSDP+TP",
             test_name="aot_fx_trace_llama3_precompile_fsdp_tp",
             ngpu=8,
+            # TODO: disabled due to upstream CUDA graph device-side assert
+            # regression in PyTorch nightly. Re-enable once fixed.
+            disabled=True,
         ),
         # TODO: disabled due to upstream histc int64 regression breaking
         # MoE model tracing. Re-enable once fixed upstream.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* #3510
* __->__ #3509
* #3508
* #3507
* #3506
* #3505
* #3504

The aot_fx_trace_llama3_precompile_fsdp_tp test hits device-side assert
during CUDA graph replay, same upstream regression as the other
cuDNN/CUDA graph failures.