### PR TITLE
[flux] Fix Pyrefly type error in denoise CFG path

### DIFF
--- a/torchtitan/models/flux/inference/sampling.py
+++ b/torchtitan/models/flux/inference/sampling.py
@@ -180,11 +180,10 @@ def denoise(
     timesteps = get_schedule(denoising_steps, latent_height * latent_width, shift=True)
 
     if enable_classifier_free_guidance:
+        assert empty_t5_encodings is not None and empty_clip_encodings is not None
         # Double batch size for CFG: [unconditional, conditional]
         latents = torch.cat([latents, latents], dim=0)
-        # pyrefly: ignore [no-matching-overload]
         t5_encodings = torch.cat([empty_t5_encodings, t5_encodings], dim=0)
-        # pyrefly: ignore [no-matching-overload]
         clip_encodings = torch.cat([empty_clip_encodings, clip_encodings], dim=0)
         bsz *= 2
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* #3511
* __->__ #3510
* #3509
* #3508
* #3507
* #3506
* #3505
* #3504

Add assertion that empty_t5_encodings and empty_clip_encodings are not
None before passing to torch.cat, narrowing the type from Tensor | None
to Tensor.