### PR TITLE
[graph_trainer] Drop dead nodes from the make_fx trace

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -155,59 +155,27 @@ def _wrap_subclasses(
     return wrapped
 
 
-def _remove_cpu_shadow_chains(gm: torch.fx.GraphModule) -> None:
-    """Remove dead CPU tensor chains left by DTensor's shadow-op bookkeeping.
+def _eliminate_dead_code(gm: torch.fx.GraphModule) -> None:
+    """Erase dead nodes from the make_fx trace (mostly DTensor shadow ops).
 
-    DTensor keeps CPU "shadow" copies of tensor metadata (size, stride) as
-    regular aten ops.  After make_fx tracing these ops end up in the graph but
-    never feed a real GPU computation, so they are pure overhead.  This pass
-    finds every chain rooted at a CPU ``empty_strided`` whose outputs never
-    reach a GPU node with downstream users, and erases the whole chain.
+    DTensor sharding propagation and metadata bookkeeping leave the make_fx graph
+    dominated by dead nodes (~97% on the debug MoE models) that never feed a real
+    output. One such chain is an expand+gather twin of the real RoPE path, rooted
+    at an uninitialized ``empty_strided`` whose result is discarded. This used to
+    be harmless overhead, but the upstream vectorized gather kernel now
+    bounds-checks indices and asserts on the garbage index, crashing at runtime.
 
-    TODO: figure out a way to avoid tracing them into graph in the first place.
+    ``eliminate_dead_code`` removes only userless nodes that its ``is_impure``
+    predicate considers pure. That predicate keeps mutating-schema ops (the
+    make_fx graph is non-functional: ``index_put_``, ``scatter_``, ``add_`` ...),
+    random/effectful ops, placeholders, and the output node — so it is safe here
+    while dropping the dead shadow chains (verified bitwise-identical to eager via
+    test_bitwise_deterministic).
+
+    TODO: figure out a way to avoid tracing the shadow ops into the graph in the
+    first place; the bulk source is not yet pinned down.
     """
-    to_remove: set[torch.fx.Node] = set()
-
-    for node in gm.graph.nodes:
-        if node in to_remove:
-            continue
-
-        if not (
-            node.op == "call_function"
-            and node.target == torch.ops.aten.empty_strided.default
-        ):
-            continue
-        device = node.kwargs.get("device")
-        if device is None or device.type != "cpu":
-            continue
-
-        chain: set[torch.fx.Node] = set()
-        queue = [node]
-        feeds_gpu = False
-
-        while queue and not feeds_gpu:
-            current = queue.pop()
-            if current in chain:
-                continue
-            chain.add(current)
-            for user in current.users:
-                val = user.meta.get("val")
-                if isinstance(val, torch.Tensor) and val.device.type != "cpu":
-                    if user.users:
-                        feeds_gpu = True
-                        break
-                    chain.add(user)
-                    continue
-                queue.append(user)
-
-        if not feeds_gpu:
-            to_remove |= chain
-
-    for node in reversed(list(gm.graph.nodes)):
-        if node in to_remove:
-            gm.graph.erase_node(node)
-
-    gm.graph.lint()
+    gm.graph.eliminate_dead_code()
     gm.recompile()
 
 
@@ -564,7 +532,7 @@ def minimal_fx_tracer(
         # Must run before DCE so that forward nodes used for matching aren't removed.
         _copy_fwd_metadata_to_bw_nodes(traced)
 
-        _remove_cpu_shadow_chains(traced)
+        _eliminate_dead_code(traced)
         if _insert_runtime_asserts:
             _insert_runtime_asserts_pass(traced, fake_mode)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3512
* __->__ #3511
* #3510
* #3509
* #3508
* #3507
* #3506
* #3505
* #3504

The upstream histc int64 meta-kernel fix unblocked MoE tracing, after which the
aot_fx_trace MoE runs crashed at runtime with 'vectorized_gather_kernel index
out of bounds' (IndexKernelUtils.cu).

Root cause: make_fx keeps the full trace, and DTensor sharding propagation plus
metadata bookkeeping leave it ~97% dead (164307 of 169526 nodes on qwen3 MoE
debug). One such dead chain is an expand+gather twin of the real RoPE path,
rooted at an uninitialized empty_strided index buffer whose result is discarded;
the upstream vectorized gather kernel now bounds-checks indices and asserts on
the garbage index.

Run torch.fx eliminate_dead_code after tracing. Its is_impure predicate keeps
mutating-schema ops (the graph is non-functional: index_put_/scatter_/add_ all
report is_mutable=True), random/effectful ops, placeholders, and the output
node, so it is safe here while dropping the dead shadow chains. This also
subsumes the old CPU shadow-chain removal.

Results (qwen3 MoE, 8xH100): generated graph 519,976 -> 26,978 lines (~19x
smaller through every downstream pass and codegen); test_bitwise_deterministic
aot_fx_trace + precompile pass (numerics bitwise-identical to eager).

TODO: avoid tracing the shadow ops in the first place; the bulk source is not
the sharding-prop tensor-meta path and is not yet pinned down.