### PR TITLE
[tests] Add HF checkpoint round-trip test + per-model adapter fixes

### DIFF
--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -68,6 +68,10 @@ _MODEL_FLAVORS = [
     # Different shape-suffix naming (mlp1_*_EGD/EG, mlp2_*_EDF/ED) but same
     # expert_bias_E semantics as llama4.
     ("gpt_oss", "debugmodel"),
+    # deepseek_v3: MLA attention + MoE with per-expert HF keys. Unique among
+    # MoE models here: HF DeepSeek has e_score_correction_bias as a real
+    # buffer, so expert_bias_E genuinely round-trips (no exclusion needed).
+    ("deepseek_v3", "debugmodel"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -72,6 +72,11 @@ _MODEL_FLAVORS = [
     # MoE models here: HF DeepSeek has e_score_correction_bias as a real
     # buffer, so expert_bias_E genuinely round-trips (no exclusion needed).
     ("deepseek_v3", "debugmodel"),
+    # qwen3: weight-tied lm_head + GQA. Exercises the from_hf input-copy
+    # contract and the tying-restore path.
+    ("qwen3", "debugmodel"),
+    # qwen3: fused-QKV variant of the above.
+    ("qwen3", "debugmodel_fused_qkv"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -64,6 +64,10 @@ _MODEL_FLAVORS = [
     # (w1_EFD / w2_EDF / w3_EFD), dense FF mappings on non-MoE layers, and
     # expert_bias_E reinit (see _NATIVE_EXCLUSIONS).
     ("llama4", "debugmodel"),
+    # gpt_oss: gated MoE with gate_up_proj fused into a single mlp1 weight.
+    # Different shape-suffix naming (mlp1_*_EGD/EG, mlp2_*_EDF/ED) but same
+    # expert_bias_E semantics as llama4.
+    ("gpt_oss", "debugmodel"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,
@@ -81,6 +85,10 @@ _NATIVE_EXCLUSIONS: dict[tuple[str, str], list[str]] = {
     # round-trip by design; the optimizer pre-hook recomputes it during
     # training. Resuming from an HF checkpoint loses any accumulated bias.
     ("llama4", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
+    # gpt_oss: same expert_bias_E story as llama4 — HF transformers' gpt_oss
+    # router has no equivalent buffer, so the round-trip resets the bias to
+    # zeros by design.
+    ("gpt_oss", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
 }
 
 

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -41,6 +41,7 @@ Then two assertions:
 import filecmp
 import importlib
 import os
+import re
 import tempfile
 import unittest
 
@@ -59,7 +60,28 @@ _MODEL_FLAVORS = [
     # llama3: fused-QKV path, exercises fused_to_separate_qkv /
     # separate_to_fused_qkv.
     ("llama3", "debugmodel_fused_qkv"),
+    # llama4: interleaved dense + MoE decoder. Exercises shape-suffix MoE keys
+    # (w1_EFD / w2_EDF / w3_EFD), dense FF mappings on non-MoE layers, and
+    # expert_bias_E reinit (see _NATIVE_EXCLUSIONS).
+    ("llama4", "debugmodel"),
 ]
+
+# Native-side keys (or regex patterns) excluded from the bitwise comparison,
+# keyed by (model_name, flavor). Every exclusion MUST have a comment that
+# explains why the key cannot round-trip exactly through HF format — these
+# are intentional design carve-outs, not unexplained skips.
+_NATIVE_EXCLUSIONS: dict[tuple[str, str], list[str]] = {
+    # llama4: `moe.expert_bias_E` is auxiliary-loss-free load-balancing bias
+    # (DeepSeek paper, adapted for Qwen/Mixtral-style routers including
+    # llama4). HF transformers' Llama4 router has no equivalent buffer
+    # (Llama4Router is plain nn.Linear with bias=False), so there is no
+    # HF key to map to. The adapter intentionally drops it on to_hf
+    # (matches HF format) and reinitializes it to zeros on from_hf
+    # (preserves the key set). The bias therefore does not survive an HF
+    # round-trip by design; the optimizer pre-hook recomputes it during
+    # training. Resuming from an HF checkpoint loses any accumulated bias.
+    ("llama4", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
+}
 
 
 def _build_model_and_adapter(model_name: str, flavor: str):
@@ -89,6 +111,17 @@ class TestHFCheckpointRoundtrip(unittest.TestCase):
         # native → HF (second pass)
         hf_second = adapter.to_hf(tt_back)
 
+        # Native keys that are intentionally excluded from the bitwise tensor
+        # comparison (e.g. buffers that have no HF equivalent and get
+        # reinitialized to zeros on from_hf). The key set itself is still
+        # required to match — exclusions only apply to tensor-value comparison.
+        exclusion_patterns = [
+            re.compile(p) for p in _NATIVE_EXCLUSIONS.get((model_name, flavor), [])
+        ]
+
+        def _is_excluded(fqn: str) -> bool:
+            return any(p.search(fqn) for p in exclusion_patterns)
+
         # ---- Native-side: tt_back must equal tt_orig key-for-key, bit-for-bit.
         missing = tt_orig.keys() - tt_back.keys()
         extra = tt_back.keys() - tt_orig.keys()
@@ -111,6 +144,8 @@ class TestHFCheckpointRoundtrip(unittest.TestCase):
                 f"{model_name}/{flavor}: native dtype diverged for {fqn}: "
                 f"{orig_tensor.dtype} vs {back_tensor.dtype}",
             )
+            if _is_excluded(fqn):
+                continue
             if not torch.equal(orig_tensor, back_tensor):
                 max_abs_diff = (
                     (orig_tensor.to(torch.float64) - back_tensor.to(torch.float64))

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Bit-exact HuggingFace checkpoint round-trip tests.
+
+torchtitan ships per-model ``StateDictAdapter`` implementations that map
+between its native state dict layout and the HuggingFace safetensors
+layout. Every transformation those adapters perform — key rename, RoPE
+permutation, fused-vs-separate QKV repack, weight tying — is by design a
+pure tensor reshuffle (no arithmetic, no dtype change). The end-to-end
+checkpoint round-trip (native ↔ HF, then ↔ native again) must therefore
+be invertible **bit-for-bit**, both as in-memory dicts and as
+serialized safetensors files on disk.
+
+This test catches conversion bugs that forward-pass numerical tests miss
+when the bug is self-consistent — e.g., a swapped axis in ``_permute``
+that makes the adapter agree with itself but disagree with HuggingFace's
+own conversion script, or a key-rename typo that silently drops weights
+on one direction of the conversion.
+
+Per model+flavor under test:
+
+1. Build the model on CPU with random init; capture native state dict.
+2. ``to_hf`` it once → ``hf_first``.
+3. Round-trip ``from_hf(hf_first)`` → ``tt_back``.
+4. ``to_hf(tt_back)`` again → ``hf_second``.
+
+Then two assertions:
+
+* **Native-side bit equality**: ``torch.equal(orig, tt_back)`` for every
+  key. Catches loss across ``to_hf ∘ from_hf``.
+* **HF-side file byte equality**: serialize ``hf_first`` and
+  ``hf_second`` to safetensors and compare the resulting files
+  byte-for-byte. Catches loss across ``from_hf ∘ to_hf`` *and* any
+  non-determinism the safetensors layer introduces.
+"""
+
+import filecmp
+import importlib
+import os
+import tempfile
+import unittest
+
+import safetensors.torch
+import torch
+
+
+# (model_name, flavor) pairs that exercise distinct adapter code paths.
+# Every registered decoder-family adapter has a "debugmodel" flavor that
+# constructs a tiny config suitable for CPU unit tests. New models are
+# added here as their adapters are audited and any round-trip bugs they
+# expose are fixed in their own diffs.
+_MODEL_FLAVORS = [
+    # llama3: vanilla GQA, separate QKV. Baseline correct adapter.
+    ("llama3", "debugmodel"),
+    # llama3: fused-QKV path, exercises fused_to_separate_qkv /
+    # separate_to_fused_qkv.
+    ("llama3", "debugmodel_fused_qkv"),
+]
+
+
+def _build_model_and_adapter(model_name: str, flavor: str):
+    """Construct a CPU-initialized model and its state_dict adapter."""
+    model_module = importlib.import_module(f"torchtitan.models.{model_name}")
+    spec = model_module.model_registry(flavor)
+    model_config = spec.model
+    with torch.device("cpu"):
+        model = model_config.build()
+    model.to_empty(device="cpu")
+    model.init_weights(buffer_device=torch.device("cpu"))
+    adapter = spec.state_dict_adapter(model_config, hf_assets_path=None)
+    return model, adapter
+
+
+class TestHFCheckpointRoundtrip(unittest.TestCase):
+    """End-to-end HF checkpoint round-trip is bit-exact in both formats."""
+
+    def _assert_roundtrip(self, model_name: str, flavor: str) -> None:
+        model, adapter = _build_model_and_adapter(model_name, flavor)
+        tt_orig = model.state_dict()
+
+        # native → HF (first pass)
+        hf_first = adapter.to_hf(tt_orig)
+        # HF → native
+        tt_back = adapter.from_hf(hf_first)
+        # native → HF (second pass)
+        hf_second = adapter.to_hf(tt_back)
+
+        # ---- Native-side: tt_back must equal tt_orig key-for-key, bit-for-bit.
+        missing = tt_orig.keys() - tt_back.keys()
+        extra = tt_back.keys() - tt_orig.keys()
+        self.assertFalse(
+            missing or extra,
+            f"{model_name}/{flavor}: native key set diverged "
+            f"missing={sorted(missing)} extra={sorted(extra)}",
+        )
+        for fqn, orig_tensor in tt_orig.items():
+            back_tensor = tt_back[fqn]
+            self.assertEqual(
+                orig_tensor.shape,
+                back_tensor.shape,
+                f"{model_name}/{flavor}: native shape diverged for {fqn}: "
+                f"{tuple(orig_tensor.shape)} vs {tuple(back_tensor.shape)}",
+            )
+            self.assertEqual(
+                orig_tensor.dtype,
+                back_tensor.dtype,
+                f"{model_name}/{flavor}: native dtype diverged for {fqn}: "
+                f"{orig_tensor.dtype} vs {back_tensor.dtype}",
+            )
+            if not torch.equal(orig_tensor, back_tensor):
+                max_abs_diff = (
+                    (orig_tensor.to(torch.float64) - back_tensor.to(torch.float64))
+                    .abs()
+                    .max()
+                    .item()
+                )
+                self.fail(
+                    f"{model_name}/{flavor}: native bitwise mismatch at "
+                    f"{fqn} (max|Δ|={max_abs_diff:.3e}, "
+                    f"shape={tuple(orig_tensor.shape)})"
+                )
+
+        # ---- HF-side: serialize both passes, compare safetensors bytes.
+        with tempfile.TemporaryDirectory() as td:
+            path_a = os.path.join(td, "first.safetensors")
+            path_b = os.path.join(td, "second.safetensors")
+            safetensors.torch.save_file(hf_first, path_a)
+            safetensors.torch.save_file(hf_second, path_b)
+            if not filecmp.cmp(path_a, path_b, shallow=False):
+                size_a = os.path.getsize(path_a)
+                size_b = os.path.getsize(path_b)
+                self.fail(
+                    f"{model_name}/{flavor}: safetensors files diverged "
+                    f"(first={size_a}B, second={size_b}B). The "
+                    f"to_hf ∘ from_hf composition is not the identity on "
+                    f"the HF side."
+                )
+
+    def test_roundtrip_is_bit_exact(self) -> None:
+        for model_name, flavor in _MODEL_FLAVORS:
+            with self.subTest(model_name=model_name, flavor=flavor):
+                self._assert_roundtrip(model_name, flavor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/deepseek_v3/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/state_dict_adapter.py
@@ -43,10 +43,11 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
             # Transformer Layer
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE Module
-            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1",
-            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3",
-            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2",
+            # MoE Module. The _EFD / _EDF suffixes are torchtitan's shape-suffix
+            # convention (E=experts, F=ffn, D=hidden) added in PR #3425.
+            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1_EFD",
+            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3_EFD",
+            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2_EDF",
             "model.layers.{}.mlp.gate.weight": "layers.{}.moe.router.gate.weight",
             "model.layers.{}.mlp.shared_experts.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "model.layers.{}.mlp.shared_experts.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",

--- a/torchtitan/models/gpt_oss/state_dict_adapter.py
+++ b/torchtitan/models/gpt_oss/state_dict_adapter.py
@@ -52,13 +52,22 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
             # Transformer layer
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE
-            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.experts.mlp1_weight",
-            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.experts.mlp1_bias",
-            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.experts.mlp2_weight",
-            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.experts.mlp2_bias",
+            # MoE. The _EGD / _EG / _EDF / _ED suffixes are torchtitan's
+            # shape-suffix convention (E=experts, G=gate, F=ffn, D=hidden)
+            # added in PR #3425.
+            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.experts.mlp1_weight_EGD",
+            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.experts.mlp1_bias_EG",
+            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.experts.mlp2_weight_EDF",
+            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.experts.mlp2_bias_ED",
             "model.layers.{}.mlp.router.weight": "layers.{}.moe.router.gate.weight",
             "model.layers.{}.mlp.router.bias": "layers.{}.moe.router.gate.bias",
+            # expert_bias_E is auxiliary-loss-free load-balancing state (DeepSeek
+            # paper, adapted for Qwen/Mixtral-style routers including gpt_oss).
+            # HF transformers' gpt_oss router has no equivalent buffer, so to_hf
+            # drops this key and from_hf reinitializes it to zeros. See
+            # test_hf_checkpoint_roundtrip exclusion for the matching test
+            # contract.
+            None: "layers.{}.moe.expert_bias_E",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "lm_head.weight",
         }
@@ -188,12 +197,17 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 if abstract_key not in to_hf_map:
                     continue
                 hf_key = to_hf_map[abstract_key]
+                if hf_key is None:
+                    # Intentionally dropped (e.g. expert_bias_E — see from_hf_map comment).
+                    continue
                 hf_key = hf_key.format(layer_num)
                 hf_state_dict[hf_key] = value
             else:
                 if key not in to_hf_map:
                     continue
                 hf_key = to_hf_map[key]
+                if hf_key is None:
+                    continue
                 hf_state_dict[hf_key] = value
 
         return hf_state_dict
@@ -277,5 +291,17 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
             raise ValueError(
                 f"Incomplete Q/K/V bias projections for layers: {list(pending_qkv_bias.keys())}"
             )
+
+        # Restore expert_bias_E (zeros) for every MoE layer. The HF format
+        # doesn't have a key for this auxiliary-loss-free load-balancing bias,
+        # so to_hf drops it; we reinitialize it to zeros so the native key set
+        # stays complete. The bias gets recomputed by the optimizer pre-hook
+        # during training; resuming from an HF checkpoint loses any
+        # accumulated bias state.
+        for layer_idx, layer_cfg in enumerate(self.model_config.layers):
+            if getattr(layer_cfg, "moe", None) is not None:
+                state_dict[f"layers.{layer_idx}.moe.expert_bias_E"] = torch.zeros(
+                    layer_cfg.moe.num_experts
+                )
 
         return state_dict

--- a/torchtitan/models/llama4/state_dict_adapter.py
+++ b/torchtitan/models/llama4/state_dict_adapter.py
@@ -49,8 +49,19 @@ class Llama4StateDictAdapter(StateDictAdapter):
             **qkv_map,
             "language_model.model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
             "language_model.model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
+            # Dense FF layers (non-MoE layers in llama4's interleaved MoE pattern).
+            "language_model.model.layers.{}.feed_forward.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
+            "language_model.model.layers.{}.feed_forward.up_proj.weight": "layers.{}.feed_forward.w3.weight",
+            "language_model.model.layers.{}.feed_forward.down_proj.weight": "layers.{}.feed_forward.w2.weight",
+            # MoE layers. The _EFD / _EDF suffixes are torchtitan's shape-suffix
+            # convention (E=experts, F=ffn, D=hidden) added in PR #3425.
             "language_model.model.layers.{}.feed_forward.router.weight": "layers.{}.moe.router.gate.weight",
-            "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2",
+            "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2_EDF",
+            # expert_bias_E is auxiliary-loss-free load-balancing state (DeepSeek
+            # paper, adapted for Qwen/Mixtral-style routers). HF transformers'
+            # Llama4 router has no equivalent buffer (plain nn.Linear, bias=False),
+            # so to_hf drops this key and from_hf reinitializes it to zeros.
+            # See state_dict_adapter test exclusion for the matching test contract.
             None: "layers.{}.moe.expert_bias_E",
             "language_model.model.layers.{}.feed_forward.shared_expert.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "language_model.model.layers.{}.feed_forward.shared_expert.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
@@ -108,27 +119,26 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 ] = wv
             elif key in to_hf_map:
                 # do direct mapping
-                if key in "layers.{}.moe.experts.w2":
-                    # we transpose the expert weights for torchtitan optimization purpose
-                    value = value.transpose(-1, -2)
+                if key == "layers.{}.moe.experts.w2_EDF":
+                    # we transpose the expert weights for torchtitan optimization purpose;
+                    # .contiguous() so safetensors can serialize the view.
+                    value = value.transpose(-1, -2).contiguous()
 
                 new_key = to_hf_map[key]
                 if new_key is None:
+                    # Intentionally dropped (e.g. expert_bias_E — see from_hf_map comment).
                     continue
                 if layer_num:
                     new_key = new_key.format(layer_num)
                 hf_state_dict[new_key] = value
             elif key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
+                "layers.{}.moe.experts.w1_EFD",
+                "layers.{}.moe.experts.w3_EFD",
             ]:
                 # handle collecting values to combine
                 hf_abstract_key = (
                     "language_model.model.layers.{}.feed_forward.experts.gate_up_proj"
                 )
-                # pyrefly: ignore [unnecessary-comparison]
-                if hf_abstract_key is None:
-                    continue
                 to_combine[hf_abstract_key.format(layer_num)][
                     key.format(layer_num)
                 ] = value
@@ -140,13 +150,15 @@ class Llama4StateDictAdapter(StateDictAdapter):
             combine_values = []
             # put into correct order to combine
             for tt_abstract_key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
+                "layers.{}.moe.experts.w1_EFD",
+                "layers.{}.moe.experts.w3_EFD",
             ]:
                 tt_key = tt_abstract_key.format(layer_num)
                 # we transpose the expert weights for torchtitan optimization purpose
                 combine_values.append(tt_fqn_map[tt_key].transpose(-1, -2))
 
+            # torch.cat produces a fresh contiguous tensor, so no extra
+            # .contiguous() needed here.
             value = torch.cat(combine_values, dim=-1)
             hf_state_dict[hf_fqn] = value
 
@@ -217,12 +229,24 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 w1, w3 = value.chunk(2, dim=-1)
                 # we transpose the expert weights for torchtitan optimization purpose
                 w1, w3 = w1.transpose(-1, -2), w3.transpose(-1, -2)
-                state_dict["layers.{}.moe.experts.w1".format(layer_num)] = w1
-                state_dict["layers.{}.moe.experts.w3".format(layer_num)] = w3
+                state_dict["layers.{}.moe.experts.w1_EFD".format(layer_num)] = w1
+                state_dict["layers.{}.moe.experts.w3_EFD".format(layer_num)] = w3
 
         if self.fuse_qkv and pending_qkv:
             raise ValueError(
                 f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
             )
+
+        # Restore expert_bias_E (zeros) for every MoE layer. The HF format
+        # doesn't have a key for this auxiliary-loss-free load-balancing bias,
+        # so to_hf drops it; we reinitialize it to zeros so the native key set
+        # stays complete. The bias gets recomputed by the optimizer pre-hook
+        # during training, but resuming from an HF checkpoint loses any
+        # accumulated bias state.
+        for layer_idx, layer_cfg in enumerate(self.model_config.layers):
+            if getattr(layer_cfg, "moe", None) is not None:
+                state_dict[f"layers.{layer_idx}.moe.expert_bias_E"] = torch.zeros(
+                    layer_cfg.moe.num_experts
+                )
 
         return state_dict

--- a/torchtitan/models/qwen3/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/state_dict_adapter.py
@@ -181,6 +181,14 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
         2. Concate separate expert's wegiht into GroupedExperts' weight.
         """
 
+        # Shallow-copy the input so we never mutate the caller's dict. The
+        # weight-tying restore below adds `lm_head.weight` to whichever dict
+        # we iterate; without this copy it leaks back into the caller and
+        # corrupts any later use of the HF dict (notably, makes the dict
+        # unserializable via safetensors because `lm_head.weight` and
+        # `model.embed_tokens.weight` would share storage).
+        hf_state_dict = dict(hf_state_dict)
+
         state_dict = {}
         expert_weights_by_layer = {}  # {layer: {abstract_key: {expert_id: tensor}}}
         # Collect Q/K/V per layer for fusing (only used when fuse_qkv=True)


### PR DESCRIPTION
## Summary

Adds a CPU-only unit test that exercises every per-model `StateDictAdapter` end-to-end through the HuggingFace checkpoint round-trip (`native → HF → native → HF`), asserting both native-side bitwise equality and HF-side byte-equality of the serialized safetensors files. Fixes the round-trip bugs the test exposes in `llama4`, `gpt_oss`, `deepseek_v3`, and `qwen3`.

The conversion adapters perform pure tensor reshuffles (key rename, RoPE permutation, fused-vs-separate QKV repack, weight tying handling), with no arithmetic and no dtype changes. The round-trip must therefore be invertible bit-for-bit. The new test catches conversion bugs that forward-pass numerical tests would miss when the bug is self-consistent — e.g., a swapped axis in `_permute` that makes the adapter agree with itself but disagree with HuggingFace's own conversion script, or a key-rename typo that silently drops weights on one direction.

### Stack overview

1. `[tests] Add parameterized HuggingFace checkpoint round-trip test` — new `tests/unit_tests/test_hf_checkpoint_roundtrip.py` with a parameterized framework over `(model_name, flavor)` pairs, llama3 cases only. Establishes the test infrastructure (model build, adapter call, native + file-level assertions, `_NATIVE_EXCLUSIONS` for keys that intentionally cannot round-trip bit-exactly).

2. `[llama4] Round-trip MoE expert weights through HF adapter` — fixes three bugs the test exposes: MoE expert weight shape-suffix mismatch (`w1`/`w2`/`w3` → `w1_EFD`/`w2_EDF`/`w3_EFD`, from PR #3425), missing dense FF layer mappings (llama4's interleaved-MoE pattern means non-MoE layers had nowhere to map), and `expert_bias_E` reset semantics (HF transformers' Llama4 router has no equivalent buffer, so the bias is dropped on `to_hf` and reinitialized to zeros on `from_hf` — documented as a `_NATIVE_EXCLUSIONS` entry). Also adds `.contiguous()` after the `w2` transpose so safetensors can serialize the view.

3. `[gpt_oss] Round-trip MoE expert weights through HF adapter` — same class of fix as llama4: MoE shape-suffix rename (`mlp1_weight`/`mlp2_weight` → `mlp1_weight_EGD`/`mlp2_weight_EDF`/etc.), missing `expert_bias_E` mapping (HF gpt_oss has no equivalent — same reset-to-zeros design as llama4), and a `None`-key guard in `to_hf` for the new dropped entry.

4. `[deepseek_v3] Complete MoE to_hf_map for shape-suffix expert weights` — fixes the `KeyError: 'layers.{}.moe.experts.w1_EFD'` by renaming the three MoE expert entries in `from_hf_map`. deepseek_v3 is the only MoE model here where `expert_bias_E` actually round-trips: HF DeepSeek has `e_score_correction_bias` as a real buffer (originally introduced by the DeepSeek paper as part of the model definition), and the adapter already maps to it. No `_NATIVE_EXCLUSIONS` entry needed.

5. `[qwen3] Stop mutating from_hf input dict (weight-tying restore)` — `from_hf` was silently mutating its caller's dict to restore the tied `lm_head.weight` alias for weight-tied models. The alias created shared storage between two keys in the input dict, which safetensors refuses to serialize. Fix: shallow-copy the input dict at the top of `from_hf` so the tying restore only happens on the local copy. Native semantics unchanged (still produces a state dict with both keys sharing storage, matching `model.state_dict()` for a tied model).

### Adapter audit notes

Each per-model diff includes an audit for the `from_hf` input-mutation antipattern. Only qwen3 has it. Across the four MoE adapters, the shape-suffix rename was the most pervasive issue (a fallout of PR #3425's `_EFD`/`_EDF` rename touching `common/moe.py` but not the adapters).

Known follow-ups not in this stack:

- qwen3's MoE adapter ALSO has the `w1`/`w2`/`w3` → `w1_EFD`/`w2_EDF`/`w3_EFD` mismatch. The non-MoE `debugmodel` and `debugmodel_fused_qkv` flavors don't exercise it, so the current test doesn't catch it. Adding `debugmodel_moe` to `_MODEL_FLAVORS` will need that adapter fix too.
- deepseek_v3's `to_hf` doesn't guard against `None` values from inverted `to_hf_map`. Today it has no `None` entries; if one is added later, the same `if hf_key is None: continue` guard from llama4 / gpt_oss will be needed.
- The test is self-consistent (verifies the adapter is its own inverse) but doesn't verify against a real HF checkpoint on disk. A second test that loads a fixture HF safetensors file and checks `from_hf` produces equivalent native state would catch a different class of bug (adapter agrees with itself but disagrees with HF). Out of scope for this PR.

## Test Plan

- `python -m unittest tests.unit_tests.test_hf_checkpoint_roundtrip -v` — passes for all 7 subtests:
  - `llama3/debugmodel`
  - `llama3/debugmodel_fused_qkv`
  - `llama4/debugmodel`
  - `gpt_oss/debugmodel`
  - `deepseek_v3/debugmodel`
  - `qwen3/debugmodel`
  - `qwen3/debugmodel_fused_qkv`
- Test runtime: ~7 seconds total (CPU-only).
- No GPU integration tests added; no changes to training code, only state-dict conversion adapters and a new unit test.
