### PR TITLE
[graph_trainer] Compatibility layer with --activation_checkpoint.mode trainer flag

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field, fields, replace
 from typing import Literal
 
 from torchtitan.components.loss import ChunkedCELoss, CrossEntropyLoss
-from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.config.configs import CompileConfig
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
@@ -144,12 +143,6 @@ def to_graph_trainer_config(
         model=graph_model,
     )
     d.pop("compile")
-
-    # graph_trainer uses graph-based SAC instead of eager AC. Override any
-    # non-"none" AC mode to "selective" so callers don't need per-config fixups.
-    ac = d.get("activation_checkpoint")
-    if ac is not None and ac.mode != "none":
-        d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
 
     # TODO: graph_trainer doesn't yet support ChunkedCELoss
     if isinstance(d.get("loss"), ChunkedCELoss.Config):

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -195,7 +195,7 @@ def tag_sac_policy(
                 break
 
     gm.recompile()
-    logger.info("Applied selective activation checkpointing (SAC) graph pass.")
+    logger.info("Applied activation checkpointing graph pass.")
     if boundary_saves:
         logger.info(f"  Forced {boundary_saves} nodes to MUST_SAVE at layer boundaries")
     for layer_id in sorted(layer_stats):
@@ -257,6 +257,7 @@ def tag_with_memory_policy_pass(
     example_inputs: tuple | None = None,
     *,
     config: "GraphTrainer.Config",
+    memory_policy: str | None = None,
 ) -> torch.fx.GraphModule:
     """Tag forward nodes with MUST_SAVE, PREFER_RECOMPUTE, or MUST_CPU_OFFLOAD.
 
@@ -268,7 +269,7 @@ def tag_with_memory_policy_pass(
     Other memory policies combining SAC and CPU offload can be added
     via ``register_memory_policy`` without modifying this function.
     """
-    memory_policy = config.compile.memory_policy
+    memory_policy = memory_policy or config.compile.memory_policy
     if memory_policy not in MEMORY_POLICY_REGISTRY:
         raise ValueError(
             f"Unknown memory_policy: {memory_policy!r}. "

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -154,22 +154,31 @@ def compile_time_passes(
         remove_identity_view_pass,
         remove_identity_slice_pass,
         normalize_view_ops_as_reshape,
-        functools.partial(
-            tag_with_memory_policy_pass,
-            config=config,
-        ),
-        functools.partial(
-            apply_cpu_offload_pass,
-            prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
-            defer_n_layers=config.compile.cpu_offload_defer_n_layers,
-        ),
-        selective_activation_remat_pass,
+    ]
+    memory_policy = _graph_activation_checkpointing_memory_policy(config)
+    if memory_policy is not None:
+        passes.extend(
+            [
+                functools.partial(
+                    tag_with_memory_policy_pass,
+                    config=config,
+                    memory_policy=memory_policy,
+                ),
+                functools.partial(
+                    apply_cpu_offload_pass,
+                    prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
+                    defer_n_layers=config.compile.cpu_offload_defer_n_layers,
+                ),
+                selective_activation_remat_pass,
+            ]
+        )
+    passes.append(
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
             enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
-        ),
-    ]
+        )
+    )
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
@@ -215,6 +224,45 @@ def compile_time_passes(
         #    hot-reload picking up changes at runtime
         passes.append(custom_codegen_pass)
     return passes
+
+
+def _graph_activation_checkpointing_memory_policy(
+    config: "GraphTrainer.Config",
+) -> str | None:
+    """Map activation_checkpoint.mode onto a graph-trainer memory policy."""
+    ac_config = getattr(config, "activation_checkpoint", None)
+    mode = getattr(ac_config, "mode", "selective")
+    memory_policy = config.compile.memory_policy
+    if mode == "none":
+        if memory_policy != "default":
+            warnings.warn(
+                "--activation_checkpoint.mode=none disables graph_trainer "
+                f"memory policy {memory_policy!r}.",
+                stacklevel=2,
+            )
+        logger.info(
+            "Skipping graph_trainer activation checkpointing because "
+            "activation_checkpoint.mode='none'."
+        )
+        return None
+    if mode == "selective":
+        return memory_policy
+    if mode == "full":
+        raise ValueError(
+            "GraphTrainer aot_fx_trace does not support "
+            "--activation_checkpoint.mode=full. Use "
+            "--activation_checkpoint.mode=selective or none."
+        )
+    if mode == "memory_budget":
+        raise ValueError(
+            "GraphTrainer aot_fx_trace does not support "
+            "--activation_checkpoint.mode=memory_budget. Use "
+            "--activation_checkpoint.mode=selective or none."
+        )
+    else:
+        raise ValueError(
+            f"Unknown activation_checkpoint.mode for GraphTrainer: {mode!r}."
+        )
 
 
 def construct_default_graph_passes(


### PR DESCRIPTION
[graph_trainer] Compatibility layer with --activation_checkpoint.mode trainer flag

Add a GraphTrainer compatibility layer for --activation_checkpoint.mode instead of rewriting all non-none modes to selective during config conversion. Idea is for comparison between eager trainer and graph trainer to be a single CONFIG swap.

Mapping for aot_fx_trace:
- none: skip graph memory-policy, CPU-offload, and selective-remat passes.
- selective: use the configured --compile.memory_policy path as before.
- full: error out explicitly because GraphTrainer has no full-remat equivalent.
- memory_budget: error out explicitly because GraphTrainer has no memory-budget partitioner equivalent.

Before:
```
> NCCL_DEBUG=WARN  NGPU=4 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b wp ./run_train.sh     --parallelism.data_parallel_shard_degree 4     --parallelism.expert_parallel_degree 4 --compile.inductor_compilation regional --activation_checkpoint.mode none

step: 10  loss: 11.18046  grad_norm:  2.4060  memory: 106.16GiB(38.38%)  tps: 12,197  tflops: 220.84  mfu: 8.83%
```

After:
```
> NCCL_DEBUG=WARN  NGPU=4 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b wp ./run_train.sh     --parallelism.data_parallel_shard_degree 4     --parallelism.expert_parallel_degree 4 --compile.inductor_compilation regional --activation_checkpoint.mode none

step: 10  loss: 11.19506  grad_norm:  2.5130  memory: 163.56GiB(59.13%)  tps: 14,996  tflops: 271.52  mfu: 10.86%
```