### PR TITLE
[core] Apply NUMA binding on CUDA hardware for local memory bandwidth

### DIFF
--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -73,6 +73,13 @@ The `--compile.memory_policy` config selects the tagging strategy.
 New policies (e.g. budget-aware mixed SAC + offload) should be added
 as new branches in `tag_with_memory_policy_pass`.
 
+**NUMA binding for CPU offload:** On multi-NUMA machines (e.g. GB200
+NVLink-C2C), D2H/H2D bandwidth is ~350 GB/s NUMA-local vs ~120 GB/s
+cross-NUMA. `Trainer` automatically applies NUMA binding
+(`AffinityMode.NODE`) on CUDA hardware at init, pinning each worker
+to the NUMA node of its GPU. Falls back gracefully on non-CUDA
+hardware or when `numactl` is unavailable.
+
 **Inspecting tags:** `log_activation_memory_policy` (`log_activation_memory_policy.py`)
 prints all forward nodes consumed by backward, grouped by layer with
 identical patterns consolidated. Shows memory, dtype, policy

--- a/torchtitan/experiments/graph_trainer/cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/cpu_offload.py
@@ -25,6 +25,12 @@ Reload pattern (backward):
 This module works with the make_fx traced joint fwd+bwd graph, using
 ``meta["custom"]["module_fqn"]`` for layer boundaries and
 ``meta["autograd_backward"]`` to distinguish forward from backward nodes.
+
+NUMA note: On multi-NUMA machines (e.g. GB200 NVLink-C2C), CPU offload
+bandwidth depends on pinned memory landing on the NUMA node local to the
+GPU (~350 GB/s local vs ~120 GB/s cross-NUMA). Trainer automatically
+applies NUMA binding (``AffinityMode.NODE``) on CUDA hardware at init
+(see ``_maybe_apply_numa_binding`` in torchtitan/trainer.py).
 """
 
 import operator

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -53,6 +53,31 @@ from torchtitan.tools.logging import logger
 from torchtitan.tools.profiler import Profiler
 
 
+def _maybe_apply_numa_binding(gpu_index: int, device_type: str) -> None:
+    """Pin this process to the NUMA node of its GPU for local memory bandwidth.
+
+    On multi-NUMA machines (e.g. GB200 NVLink-C2C), pinned-memory allocations
+    that land on the GPU's local NUMA node get ~350 GB/s D2H bandwidth vs
+    ~120 GB/s cross-NUMA. Must run before any pinned memory is allocated.
+    """
+    if device_type != "cuda":
+        return
+    from torch.numa.binding import (
+        AffinityMode,
+        NumaOptions,
+        _maybe_apply_numa_binding_to_current_process,
+    )
+
+    _maybe_apply_numa_binding_to_current_process(
+        gpu_index=gpu_index,
+        numa_options=NumaOptions(
+            affinity_mode=AffinityMode.NODE,
+            should_fall_back_if_binding_fails=True,
+        ),
+    )
+    logger.info("NUMA binding applied for GPU %d", gpu_index)
+
+
 class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
@@ -194,9 +219,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         torch._C._log_api_usage_once("torchtitan.train")
 
         self.config = config
-        assert (
-            config.model_spec is not None
-        ), "model_spec must be set before creating Trainer"
+        assert config.model_spec is not None, (
+            "model_spec must be set before creating Trainer"
+        )
         model_spec = config.model_spec
 
         device_module, device_type = utils.device_module, utils.device_type
@@ -204,6 +229,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
+
+        _maybe_apply_numa_binding(self.device.index, device_type)
 
         # init distributed and build meshes
         self.parallel_dims = parallel_dims = self.init_distributed()
@@ -389,23 +416,19 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if parallel_dims.pp_enabled:
                 if self.pp_has_last_stage:
                     lm_head = self.model_parts[-1].lm_head
-                    assert (
-                        lm_head is not None
-                    ), "Last PP stage must have lm_head for ChunkedCELoss"
+                    assert lm_head is not None, (
+                        "Last PP stage must have lm_head for ChunkedCELoss"
+                    )
                     self.loss_fn.set_lm_head(
                         lm_head  # pyrefly: ignore[bad-argument-type]
                     )
-                    self.model_parts[
-                        -1
-                    ]._skip_lm_head = True  # pyrefly: ignore[bad-argument-type]
+                    self.model_parts[-1]._skip_lm_head = True  # pyrefly: ignore[bad-argument-type]
             else:
                 assert len(self.model_parts) == 1
                 lm_head = self.model_parts[0].lm_head
                 assert lm_head is not None, "Model must have lm_head for ChunkedCELoss"
                 self.loss_fn.set_lm_head(lm_head)  # pyrefly: ignore[bad-argument-type]
-                self.model_parts[
-                    0
-                ]._skip_lm_head = True  # pyrefly: ignore[bad-argument-type]
+                self.model_parts[0]._skip_lm_head = True  # pyrefly: ignore[bad-argument-type]
 
         # initialize device memory monitor and get peak flops for MFU calculation
         device_memory_monitor = self.metrics_processor.device_memory_monitor
@@ -604,9 +627,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             inner_attention = attn_config.inner_attention
 
             if attn_config.mask_type == "block_causal":
-                assert (
-                    positions is not None
-                ), "block_causal mask requires per-document positions from the dataloader"
+                assert positions is not None, (
+                    "block_causal mask requires per-document positions from the dataloader"
+                )
             else:
                 positions = torch.arange(
                     inputs.shape[1], dtype=torch.int32, device=inputs.device
@@ -780,7 +803,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             return
 
         with sl.log_trace_span("collect_dist_metrics"):
-
             sl.log_trace_scalar({"global_valid_tokens": int(global_valid_tokens)})
 
             if parallel_dims.dp_cp_enabled:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3520
* __->__ #3519

Pin each worker to the NUMA node of its GPU at Trainer init via
torch.numa.binding. On multi-NUMA machines (e.g. GB200 NVLink-C2C)
this ensures pinned-memory allocations land locally, yielding ~330 GB/s
D2H bandwidth vs ~115 GB/s cross-NUMA (~3x improvement).

Falls back gracefully on non-CUDA hardware or when numactl is unavailable.