### PR TITLE
[cpu-offload] Fix wait_tensor dep edge for non-Tensor consumers

### DIFF
--- a/torchtitan/experiments/graph_trainer/cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/cpu_offload.py
@@ -55,6 +55,26 @@ aten = torch.ops.aten
 
 
 # ============================================================
+# Helpers
+# ============================================================
+
+
+def _find_tensor_child(node: Node) -> Node | None:
+    """Find a Tensor-producing child of a non-Tensor node (e.g. getitem after sort).
+
+    Used to create a data-dependency edge through wait_tensor's
+    last_use_of_storage arg when the actual last consumer produces
+    a non-Tensor value. Returns None if no Tensor child exists.
+    """
+    for user in node.users:
+        if user.op == "call_function" and isinstance(
+            user.meta.get("val"), torch.Tensor
+        ):
+            return user
+    return None
+
+
+# ============================================================
 # Node eligibility
 # ============================================================
 
@@ -399,9 +419,9 @@ def apply_cpu_offload_pass(
 
     for node, bwd_users in offloadable:
         val = node.meta.get("val")
-        assert (
-            val is not None
-        ), f"Node {node.name} tagged for offload has no 'val' metadata"
+        assert val is not None, (
+            f"Node {node.name} tagged for offload has no 'val' metadata"
+        )
 
         device = val.device
         # Propagate source node metadata to offload chain nodes so
@@ -418,7 +438,7 @@ def apply_cpu_offload_pass(
             offload_node.meta["val"] = val.to(torch.device("cpu"))
 
         # Find the last forward consumer of this node's storage (including
-        # through views) so the wait_tensor encodes the dependency directly.
+        # through views) so the defer pass knows the earliest safe point.
         chain_nodes, _ = _get_storage_chain(node)
         last_consumer = node
         last_consumer_pos = node_to_index[node]
@@ -430,10 +450,19 @@ def apply_cpu_offload_pass(
                 last_consumer = c
                 last_consumer_pos = c_pos
 
+        # ao::wait_tensor's last_use_of_storage arg enforces a topo edge
+        # so GPU storage stays alive until the last consumer finishes.
+        # The schema requires Optional[Tensor], so if the last consumer
+        # produces a non-Tensor (e.g. sort returns a tuple), find a
+        # Tensor-producing child (e.g. getitem) to preserve the edge.
+        last_use_arg = last_consumer
+        if not isinstance(last_consumer.meta.get("val"), torch.Tensor):
+            last_use_arg = _find_tensor_child(last_consumer)
+
         with gm.graph.inserting_after(offload_node):
             wait_offload_node = gm.graph.call_function(
                 torch.ops.ao.wait_tensor.default,
-                args=(offload_node, node, last_consumer),
+                args=(offload_node, node, last_use_arg),
             )
             wait_offload_node.meta.update(src_meta)
             wait_offload_node.meta["val"] = offload_node.meta["val"]

--- a/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
@@ -647,6 +647,82 @@ class TestCpuOffloadPass(TestCase):
             "dep should follow view chain to the last consumer of the storage",
         )
 
+    def test_wait_dep_non_tensor_consumer(self):
+        """When the last consumer produces a non-Tensor (e.g. sort -> tuple),
+        dep should use a Tensor-producing child (getitem) to preserve the
+        topo edge in wait_tensor."""
+        import operator
+
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        # Layer 0: mm (tagged for offload)
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = self._make_fake_val()
+        mm.meta["recompute"] = CheckpointPolicy.MUST_CPU_OFFLOAD
+
+        # Layer 1: sort consumes mm's output, returns tuple (non-Tensor val)
+        sort = graph.call_function(torch.ops.aten.sort.default, args=(mm,))
+        sort.meta["autograd_backward"] = False
+        sort.meta["custom"] = {"module_fqn": "layers.1.block"}
+        sort.meta["val"] = (self._make_fake_val(), self._make_fake_val())
+
+        # getitem extracts a Tensor from sort's tuple output
+        getitem = graph.call_function(operator.getitem, args=(sort, 0))
+        getitem.meta["autograd_backward"] = False
+        getitem.meta["custom"] = {"module_fqn": "layers.1.block"}
+        getitem.meta["val"] = self._make_fake_val()
+
+        # Layer 2
+        mm2 = graph.call_function(torch.ops.aten.mm.default, args=(getitem, getitem))
+        mm2.meta["autograd_backward"] = False
+        mm2.meta["custom"] = {"module_fqn": "layers.2.block"}
+        mm2.meta["val"] = self._make_fake_val()
+
+        # Backward: uses mm directly
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(mm2, mm))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
+        bwd.meta["val"] = self._make_fake_val()
+
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        apply_cpu_offload_pass(gm, defer_n_layers=1, prefetch_lookahead=0)
+
+        # Find the forward wait for mm's offload
+        fwd_waits = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target is torch.ops.ao.wait_tensor.default
+            and not n.meta.get("autograd_backward")
+        ]
+        self.assertEqual(len(fwd_waits), 1)
+        wait = fwd_waits[0]
+
+        # dep (args[2]) should be the getitem (Tensor child of sort),
+        # not None, preserving the topo edge through sort.
+        dep = wait.args[2]
+        self.assertIsNotNone(dep, "dep should not be None for non-Tensor consumer")
+        self.assertIs(
+            dep.target,
+            operator.getitem,
+            "dep should be getitem (Tensor child of the non-Tensor sort node)",
+        )
+        self.assertIsInstance(
+            dep.meta.get("val"),
+            torch.Tensor,
+            "dep must produce a Tensor to satisfy wait_tensor schema",
+        )
+
     def test_single_layer_tagged(self):
         """With only one layer, nodes are still tagged (last-layer skip only applies with multiple layers)."""
         from torchtitan.experiments.graph_trainer.cpu_offload import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3520
* #3519

When the last forward consumer of an offloaded tensor's storage
produces a non-Tensor value (e.g. aten.sort returns a tuple), the
wait_tensor's last_use_of_storage arg cannot reference it directly
(schema requires Optional[Tensor]).

Previously this passed the node directly, causing a schema checker
error at runtime. Fix: find a Tensor-producing child of the
non-Tensor consumer (e.g. getitem after sort) and use that as the
dep arg. This preserves the data dependency chain
(tensor -> sort -> getitem -> wait_tensor) so the wait is always
ordered after the real last consumer.