### PR TITLE
[graph_trainer] Add view replay and tuning for CPU activation offloading

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -86,6 +86,12 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Maximum CPU memory budget (in GB per rank) for offloaded activations.
     Tensors are selected largest-first until the budget is exhausted."""
 
+    cpu_offload_view_replay: bool = False
+    """When True, offload tensors whose backward consumers reach them through
+    view chains (transpose, reshape, etc.) by replaying the view ops after
+    reload. Without this, only tensors with direct backward consumers are
+    offloaded."""
+
     enable_fsdp_ag_rs_overlap: bool = False
     """When True, run ``overlap_fsdp_ag_rs_pass``. The pass moves backward
     FSDP all-gathers onto a separate CUDA stream from reduce-scatters so the

--- a/torchtitan/experiments/graph_trainer/cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/cpu_offload.py
@@ -200,6 +200,42 @@ def _has_recompute_consumer(node: Node) -> bool:
     return False
 
 
+def _collect_view_replay_info(
+    node: Node,
+) -> tuple[list[Node], list[tuple[Node, Node]]]:
+    """Collect view chain nodes and backward consumers reachable through views.
+
+    Starting from node, walks through view op users recursively. For each
+    view node encountered, records backward consumers that need redirection
+    after the view chain is replayed in backward.
+
+    Does not include direct backward users of node itself (those are handled
+    separately by the caller).
+
+    Returns:
+        replay_views: view nodes to replay in backward (graph order)
+        view_bwd_redirects: (consumed_view_node, bwd_user) pairs to redirect
+    """
+    replay_views: list[Node] = []
+    view_bwd_redirects: list[tuple[Node, Node]] = []
+    visited_views: set[Node] = set()
+
+    def _walk(n: Node, in_chain: bool) -> None:
+        for user in n.users:
+            if user.op != "call_function":
+                continue
+            if _is_backward_node(user):
+                if in_chain:
+                    view_bwd_redirects.append((n, user))
+            elif _is_view(user) and user not in visited_views:
+                visited_views.add(user)
+                replay_views.append(user)
+                _walk(user, True)
+
+    _walk(node, False)
+    return replay_views, view_bwd_redirects
+
+
 # ============================================================
 # Forward/backward node classification for make_fx traced graphs
 # ============================================================
@@ -342,6 +378,7 @@ def apply_cpu_offload_pass(
     *,
     prefetch_lookahead: int = 1,
     defer_n_layers: int = 1,
+    enable_view_replay: bool = False,
 ) -> torch.fx.GraphModule:
     """Insert ao offload/reload/wait_tensor ops for nodes tagged ``MUST_CPU_OFFLOAD``.
 
@@ -371,15 +408,20 @@ def apply_cpu_offload_pass(
     Returns:
         The transformed GraphModule with offload/reload ops inserted.
     """
-    # 1. Collect nodes tagged for offload with their backward consumers.
-    offloadable: list[tuple[Node, list[Node]]] = []
+    # 1. Collect nodes tagged for offload with backward consumers (direct + through views).
+    offloadable: list[tuple[Node, list[Node], list[Node], list[tuple[Node, Node]]]] = []
     for node in gm.graph.nodes:
         if node.meta.get("recompute") is not CheckpointPolicy.MUST_CPU_OFFLOAD:
             continue
-        bwd_users = [u for u in node.users if _is_backward_node(u)]
-        if not bwd_users:
+        direct_bwd_users = [u for u in node.users if _is_backward_node(u)]
+        if enable_view_replay:
+            replay_views, view_bwd_redirects = _collect_view_replay_info(node)
+        else:
+            replay_views, view_bwd_redirects = [], []
+        all_bwd_users = direct_bwd_users + [u for _, u in view_bwd_redirects]
+        if not all_bwd_users:
             continue
-        offloadable.append((node, bwd_users))
+        offloadable.append((node, direct_bwd_users, replay_views, view_bwd_redirects))
 
     if not offloadable:
         return gm
@@ -391,7 +433,8 @@ def apply_cpu_offload_pass(
     total_bytes = 0
     wait_offload_map: dict[Node, Node] = {}
 
-    for node, bwd_users in offloadable:
+    replay_count = 0
+    for node, direct_bwd_users, replay_views, view_bwd_redirects in offloadable:
         val = node.meta.get("val")
         assert (
             val is not None
@@ -435,7 +478,8 @@ def apply_cpu_offload_pass(
         wait_offload_map[node] = wait_offload_node
 
         # --- Backward: async CPU->GPU reload before earliest consumer ---
-        first_consumer = min(bwd_users, key=lambda n: node_to_index[n])
+        all_bwd_users = direct_bwd_users + [u for _, u in view_bwd_redirects]
+        first_consumer = min(all_bwd_users, key=lambda n: node_to_index[n])
 
         with gm.graph.inserting_before(first_consumer):
             reload_node = gm.graph.call_function(
@@ -449,14 +493,45 @@ def apply_cpu_offload_pass(
         with gm.graph.inserting_before(first_consumer):
             wait_node = gm.graph.call_function(
                 torch.ops.ao.wait_tensor.default,
-                args=(reload_node,),
+                args=(reload_node, wait_offload_node),
             )
             wait_node.meta.update(src_meta)
             wait_node.meta["val"] = val
             wait_node.meta["autograd_backward"] = True
 
-        for user in bwd_users:
+        for user in direct_bwd_users:
             user.replace_input_with(node, wait_node)
+
+        # View replay: clone view ops in backward, redirect view-chain consumers
+        if replay_views:
+            replay_count += 1
+            replay_map: dict[Node, Node] = {node: wait_node}
+            sorted_views = sorted(replay_views, key=lambda n: node_to_index[n])
+            for view_node in sorted_views:
+                new_args = tuple(
+                    replay_map.get(a, a) if isinstance(a, Node) else a
+                    for a in view_node.args
+                )
+                new_kwargs = {
+                    k: replay_map.get(v, v) if isinstance(v, Node) else v
+                    for k, v in view_node.kwargs.items()
+                }
+                with gm.graph.inserting_before(first_consumer):
+                    replayed = gm.graph.call_function(
+                        view_node.target,
+                        args=new_args,
+                        kwargs=new_kwargs,
+                    )
+                    replayed.meta.update(
+                        {k: v for k, v in view_node.meta.items() if k != "recompute"}
+                    )
+                    replayed.meta["autograd_backward"] = True
+                replay_map[view_node] = replayed
+
+            for consumed_node, bwd_user in view_bwd_redirects:
+                replayed = replay_map.get(consumed_node)
+                if replayed is not None:
+                    bwd_user.replace_input_with(consumed_node, replayed)
 
         logger.debug(
             f"CPU offload: offloading {node.name} "
@@ -479,6 +554,7 @@ def apply_cpu_offload_pass(
     logger.info(
         f"CPU offload: offloaded {len(offloadable)} tensors "
         f"({total_bytes / 1024 / 1024:.2f} MB), "
+        f"{replay_count} with view replay, "
         f"deferred {deferred} forward waits"
     )
     return gm

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -294,7 +294,8 @@ def _sac_and_offload_memory_policy_pass(
     """SAC + CPU offload: apply default SAC, then offload within budget."""
     _default_memory_policy_pass(gm, config=config)
     tag_all_offloadable_activations(
-        gm, cpu_budget_gb=config.compile.cpu_offload_budget_gb
+        gm,
+        cpu_budget_gb=config.compile.cpu_offload_budget_gb,
     )
     return gm
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -140,6 +140,7 @@ def compile_time_passes(
             apply_cpu_offload_pass,
             prefetch_lookahead=config.compile.cpu_offload_prefetch_n_layers,
             defer_n_layers=config.compile.cpu_offload_defer_n_layers,
+            enable_view_replay=config.compile.cpu_offload_view_replay,
         ),
         selective_activation_remat_pass,
         functools.partial(

--- a/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
@@ -474,24 +474,16 @@ class TestCpuOffloadPass(TestCase):
                     f"should precede wait at pos {wait_pos}",
                 )
 
-    def test_view_chain_only_backward_users_not_offloaded(self):
-        """Nodes whose only backward users come through a view chain are not offloaded.
+    def _build_view_chain_graph(self):
+        """Build a graph where backward consumers reach the base through a view chain.
 
-        Views are excluded from offloading, and the base tensor (mm) has no
-        direct backward users — only indirect ones through the view. Since
-        apply_cpu_offload_pass only collects direct backward users, the base
-        tensor won't get offload ops inserted even if tagged.
+        Forward:  mm (layer 0) -> view (layer 0) -> relu (layer 0) -> mm2 (layer 1)
+        Backward: bwd_mm uses view output (NOT mm directly)
         """
-        from torchtitan.experiments.graph_trainer.cpu_offload import (
-            apply_cpu_offload_pass,
-            tag_all_offloadable_activations,
-        )
-
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         x.meta["val"] = self._make_fake_val()
 
-        # Forward layer 0: mm -> view -> relu
         mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
         mm.meta["autograd_backward"] = False
         mm.meta["custom"] = {"module_fqn": "layers.0.block"}
@@ -507,31 +499,90 @@ class TestCpuOffloadPass(TestCase):
         relu.meta["custom"] = {"module_fqn": "layers.0.block"}
         relu.meta["val"] = self._make_fake_val()
 
-        # Forward layer 1
         mm2 = graph.call_function(torch.ops.aten.mm.default, args=(relu, relu))
         mm2.meta["autograd_backward"] = False
         mm2.meta["custom"] = {"module_fqn": "layers.1.block"}
         mm2.meta["val"] = self._make_fake_val()
 
-        # Backward: uses view output (NOT mm directly)
         bwd = graph.call_function(torch.ops.aten.mm.default, args=(mm2, view))
         bwd.meta["autograd_backward"] = True
         bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
         bwd.meta["val"] = self._make_fake_val()
 
         graph.output(bwd)
-        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
 
+    def test_view_chain_not_offloaded_without_replay(self):
+        """Without view replay, nodes with only view-chain backward users are skipped."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        gm = self._build_view_chain_graph()
         tag_all_offloadable_activations(gm)
-        gm = apply_cpu_offload_pass(gm)
+        gm = apply_cpu_offload_pass(gm, enable_view_replay=False)
 
-        # No view replay — only one view op (the original forward one)
+        offload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.offload.default
+        ]
         view_ops = [
             n
             for n in gm.graph.nodes
             if n.op == "call_function" and n.target is torch.ops.aten.view.default
         ]
-        self.assertEqual(len(view_ops), 1, "Expected only the original view op")
+        self.assertEqual(len(offload_ops), 0, "No offloads without view replay")
+        self.assertEqual(len(view_ops), 1, "Only the original forward view")
+
+    def test_view_chain_offloaded_with_replay(self):
+        """With view replay, the base tensor is offloaded and views are replayed in backward."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        gm = self._build_view_chain_graph()
+        tag_all_offloadable_activations(gm)
+        gm = apply_cpu_offload_pass(gm, enable_view_replay=True)
+
+        offload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.offload.default
+        ]
+        reload_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.ao.reload.default
+        ]
+        view_ops = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is torch.ops.aten.view.default
+        ]
+
+        self.assertGreater(len(offload_ops), 0, "Base tensor should be offloaded")
+        self.assertGreater(len(reload_ops), 0, "Base tensor should be reloaded")
+        # 2 views: original forward + replayed backward
+        self.assertEqual(len(view_ops), 2, "View should be replayed in backward")
+
+        # The replayed view should be marked as backward
+        replayed_views = [v for v in view_ops if v.meta.get("autograd_backward")]
+        self.assertEqual(len(replayed_views), 1, "Replayed view should be backward")
+
+        # The backward consumer should use the replayed view, not the forward one
+        bwd_mm = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target is torch.ops.aten.mm.default
+            and n.meta.get("autograd_backward")
+        ]
+        self.assertEqual(len(bwd_mm), 1)
+        # bwd_mm should reference the replayed view (backward), not the original
+        self.assertIn(replayed_views[0], bwd_mm[0].args)
 
     def test_wait_dep_points_to_last_forward_consumer(self):
         """Forward wait_tensor dep arg should reference the last forward consumer."""
@@ -646,6 +697,83 @@ class TestCpuOffloadPass(TestCase):
             torch.ops.aten.relu.default,
             "dep should follow view chain to the last consumer of the storage",
         )
+
+    def test_view_replay_multi_view_same_consumer(self):
+        """A backward node consuming two different views of the same base must have both redirected."""
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            apply_cpu_offload_pass,
+            tag_all_offloadable_activations,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        # Layer 0: mm -> view, mm -> reshape (two views of same base)
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = self._make_fake_val()
+
+        view = graph.call_function(torch.ops.aten.view.default, args=(mm, [64, 64]))
+        view.meta["autograd_backward"] = False
+        view.meta["custom"] = {"module_fqn": "layers.0.block"}
+        view.meta["val"] = self._make_fake_val()
+
+        reshape = graph.call_function(
+            torch.ops.aten.reshape.default, args=(mm, [64, 64])
+        )
+        reshape.meta["autograd_backward"] = False
+        reshape.meta["custom"] = {"module_fqn": "layers.0.block"}
+        reshape.meta["val"] = self._make_fake_val()
+
+        # Layer 1
+        mm2 = graph.call_function(torch.ops.aten.mm.default, args=(view, reshape))
+        mm2.meta["autograd_backward"] = False
+        mm2.meta["custom"] = {"module_fqn": "layers.1.block"}
+        mm2.meta["val"] = self._make_fake_val()
+
+        # Backward: uses BOTH view and reshape
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(view, reshape))
+        bwd.meta["autograd_backward"] = True
+        bwd.meta["custom"] = {"module_fqn": "layers.0.block"}
+        bwd.meta["val"] = self._make_fake_val()
+
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+        gm = apply_cpu_offload_pass(gm, enable_view_replay=True)
+
+        # Both view and reshape should be replayed in backward
+        bwd_views = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target
+            in (torch.ops.aten.view.default, torch.ops.aten.reshape.default)
+            and n.meta.get("autograd_backward")
+        ]
+        self.assertEqual(len(bwd_views), 2, "Both view and reshape should be replayed")
+
+        # The backward mm should use BOTH replayed views, not the originals
+        bwd_mm = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target is torch.ops.aten.mm.default
+            and n.meta.get("autograd_backward")
+        ]
+        self.assertEqual(len(bwd_mm), 1)
+        for arg in bwd_mm[0].args:
+            if isinstance(arg, torch.fx.Node) and arg.target in (
+                torch.ops.aten.view.default,
+                torch.ops.aten.reshape.default,
+            ):
+                self.assertTrue(
+                    arg.meta.get("autograd_backward"),
+                    f"Backward mm should use replayed view, not original: {arg.name}",
+                )
 
     def test_single_layer_tagged(self):
         """With only one layer, nodes are still tagged (last-layer skip only applies with multiple layers)."""

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -207,6 +207,14 @@ class GraphTrainer(Trainer):
 
         return loss
 
+    def train(self):
+        from torch._functorch._activation_offloading.offload_ops import (
+            pinned_memory_pool,
+        )
+
+        with pinned_memory_pool():
+            super().train()
+
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3521

## Summary

  Activations whose backward consumers reach them through view chains (transpose,
  reshape, permute, etc.) could not previously be offloaded because the views
  share storage with the base tensor. This change replays the view ops after
  reload in backward, enabling offloading of these tensors.

  Also fixes backward keepalive: passes the CPU pinned tensor as `keepalive` to
  the backward `wait_tensor`, so pinned memory is freed after H2D completes (was a
  memory leak).

  New config field on `GraphTrainerCompileConfig`:
  - `cpu_offload_view_replay` (bool, default False): enables view replay.

  Wraps `GraphTrainer.train()` with `pinned_memory_pool()` context manager to
  enable pinned buffer reuse across training steps.

  ## Results (8xH100, with pinned memory pool)

  `budget` = `--compile.cpu_offload_budget_gb` (max CPU GB per rank)
  `defer`  = `--compile.cpu_offload_defer_n_layers` (overlap window)

  | Model    | Budget | Defer | Mem Saved | TPS Overhead |
  |----------|--------|-------|-----------|--------------|
  | Llama 8B |   5 GB |     8 |      9.9% |        <1%   |
  | Llama 8B |   8 GB |     8 |     16.6% |        <5%   |
  | Llama 8B |  10 GB |     8 |     20.4% |        <7%   |
  | Llama 8B | 100 GB |     1 |     33.4% |       <23%   |
  | Qwen 14B |   8 GB |     8 |     10.4% |      <0.5%   |
  | Qwen 14B |  10 GB |     8 |     13.0% |        <1%   |
  | Qwen 14B |  15 GB |     8 |     19.8% |        <2%   |
  | Qwen 14B |  20 GB |     3 |     25.2% |        <6%   |
  | Qwen 14B | 100 GB |     1 |     38.2% |       <19%   |

  Best efficiency: Qwen3 14B at budget=8GB defer=8 achieves 21.3x ratio (10.4%
  memory saved at 0.5% TPS cost). defer=8 is critical for dense models; MoE models
  (DSv3) must use defer=1.

  ## Test plan

  - [x] 17 unit tests pass (`test_cpu_offload.py`): view replay on/off, multi-view
  same consumer, existing offload/prefetch/defer tests
  - [x] Numerics verification: step 1 bitwise identical with seed=42; steps 2+
  divergence matches baseline-vs-baseline (NCCL non-determinism)
  - [x] Pre-commit lint passes
  - [x] Benchmarked on Llama3 8B and Qwen3 14B across budget × defer sweep (45+
  runs)
