### PR TITLE
[DRAFT] Demo of DP=2 on 4 GPU mesh (Dense, MoE)

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -231,11 +231,10 @@ class VLLMGenerator(Actor, Configurable):
                     f"Generator does not support context parallelism, "
                     f"got cp={p.context_parallel_degree}"
                 )
-            if p.expert_parallel_degree > 1:
-                raise ValueError(
-                    f"Generator does not support expert parallelism, "
-                    f"got ep={p.expert_parallel_degree}"
-                )
+            # EXPERIMENT: allow expert parallelism (ep > 1). Core
+            # parallelize_qwen3 calls model.parallelize() when ep_enabled, which
+            # shards GroupedExperts on the ep mesh and wires the token
+            # dispatcher's all-to-all (handled entirely below the controller).
             if p.enable_sequence_parallel:
                 raise ValueError(
                     "Generator does not support sequence parallelism: "
@@ -312,10 +311,18 @@ class VLLMGenerator(Actor, Configurable):
             dtype=config.model_dtype,
             tensor_parallel_size=config.parallelism.tensor_parallel_degree,
             # With external_launcher, world_size = tp*pp*dp must match the number
-            # of ranks Monarch spawned. Passing data_parallel_size makes vLLM size
-            # its world correctly and auto-assign each rank's dp_rank from $RANK
-            # (PR #24899). Same value on every rank (SPMD).
-            data_parallel_size=config.parallelism.data_parallel_replicate_degree,
+            # of ranks Monarch spawned. vLLM's data-parallel degree is the number
+            # of independent-data groups = dp_replicate * dp_shard (the latter
+            # carries DP-attention for the MoE EP layout). vLLM auto-assigns each
+            # rank's dp_rank from $RANK (PR #24899). Same value on every rank (SPMD).
+            data_parallel_size=(
+                max(config.parallelism.data_parallel_replicate_degree, 1)
+                * max(config.parallelism.data_parallel_shard_degree, 1)
+            ),
+            # When EP is on, vLLM spreads experts across the dp*tp world and runs
+            # the cross-group all-to-all; the torchtitan MoE module issues it via
+            # its own ep mesh (model.parallelize), this flag aligns vLLM's groups.
+            enable_expert_parallel=config.parallelism.expert_parallel_degree > 1,
             # Monarch already spawned TP workers via proc mesh. "external_launcher"
             # tells vLLM to run one worker per process (no subprocess spawning)
             distributed_executor_backend="external_launcher",

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -215,11 +215,12 @@ class VLLMGenerator(Actor, Configurable):
             # VLLMGenerator only supports TP. vLLM handles its own parallelism;
             # we only apply TP via the core parallelize function.
             p = self.parallelism
-            if p.data_parallel_replicate_degree != 1:
-                raise ValueError(
-                    f"Generator does not support data parallel replication, "
-                    f"got dp_replicate={p.data_parallel_replicate_degree}"
-                )
+            # EXPERIMENT: allow data-parallel replication (dp_replicate > 1) so
+            # the generator runs as `dp_replicate` independent vLLM engines, each
+            # a `tensor_parallel_degree`-rank TP group. vLLM's external_launcher
+            # DP support (PR #24899) sizes world_size = tp*pp*dp and auto-derives
+            # each rank's dp_rank from $RANK. Prompt sharding across replicas is
+            # done by the controller (see RLTrainer._generate_sharded).
             if p.pipeline_parallel_degree > 1:
                 raise ValueError(
                     f"Generator does not support pipeline parallelism, "
@@ -310,6 +311,11 @@ class VLLMGenerator(Actor, Configurable):
             config_format=TORCHTITAN_CONFIG_FORMAT,
             dtype=config.model_dtype,
             tensor_parallel_size=config.parallelism.tensor_parallel_degree,
+            # With external_launcher, world_size = tp*pp*dp must match the number
+            # of ranks Monarch spawned. Passing data_parallel_size makes vLLM size
+            # its world correctly and auto-assign each rank's dp_rank from $RANK
+            # (PR #24899). Same value on every rank (SPMD).
+            data_parallel_size=config.parallelism.data_parallel_replicate_degree,
             # Monarch already spawned TP workers via proc mesh. "external_launcher"
             # tells vLLM to run one worker per process (no subprocess spawning)
             distributed_executor_backend="external_launcher",

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -212,15 +212,13 @@ class VLLMGenerator(Actor, Configurable):
         """Debug and determinism settings."""
 
         def __post_init__(self):
-            # VLLMGenerator only supports TP. vLLM handles its own parallelism;
-            # we only apply TP via the core parallelize function.
+            # Supported generator parallelism: tensor, data (replicate + shard),
+            # and expert. Pipeline/context/sequence parallelism are rejected
+            # below. The model's TP/EP sharding is applied by the core
+            # parallelize_fn; data parallelism is driven by vLLM (each DP group
+            # has its own KV cache), and the controller shards prompts across the
+            # DP groups (RLTrainer._generate_sharded).
             p = self.parallelism
-            # EXPERIMENT: allow data-parallel replication (dp_replicate > 1) so
-            # the generator runs as `dp_replicate` independent vLLM engines, each
-            # a `tensor_parallel_degree`-rank TP group. vLLM's external_launcher
-            # DP support (PR #24899) sizes world_size = tp*pp*dp and auto-derives
-            # each rank's dp_rank from $RANK. Prompt sharding across replicas is
-            # done by the controller (see RLTrainer._generate_sharded).
             if p.pipeline_parallel_degree > 1:
                 raise ValueError(
                     f"Generator does not support pipeline parallelism, "
@@ -231,10 +229,6 @@ class VLLMGenerator(Actor, Configurable):
                     f"Generator does not support context parallelism, "
                     f"got cp={p.context_parallel_degree}"
                 )
-            # EXPERIMENT: allow expert parallelism (ep > 1). Core
-            # parallelize_qwen3 calls model.parallelize() when ep_enabled, which
-            # shards GroupedExperts on the ep mesh and wires the token
-            # dispatcher's all-to-all (handled entirely below the controller).
             if p.enable_sequence_parallel:
                 raise ValueError(
                     "Generator does not support sequence parallelism: "
@@ -313,15 +307,15 @@ class VLLMGenerator(Actor, Configurable):
             # With external_launcher, world_size = tp*pp*dp must match the number
             # of ranks Monarch spawned. vLLM's data-parallel degree is the number
             # of independent-data groups = dp_replicate * dp_shard (the latter
-            # carries DP-attention for the MoE EP layout). vLLM auto-assigns each
-            # rank's dp_rank from $RANK (PR #24899). Same value on every rank (SPMD).
+            # carries DP-attention for the MoE EP layout). vLLM derives each
+            # rank's dp_rank from its global rank. Same value on every rank (SPMD).
             data_parallel_size=(
                 max(config.parallelism.data_parallel_replicate_degree, 1)
                 * max(config.parallelism.data_parallel_shard_degree, 1)
             ),
-            # When EP is on, vLLM spreads experts across the dp*tp world and runs
-            # the cross-group all-to-all; the torchtitan MoE module issues it via
-            # its own ep mesh (model.parallelize), this flag aligns vLLM's groups.
+            # Set when ep > 1. The expert all-to-all is performed by the torchtitan
+            # MoE module via its own ep mesh (applied by the core parallelize_fn's
+            # model.parallelize()), not by vLLM's native FusedMoE.
             enable_expert_parallel=config.parallelism.expert_parallel_degree > 1,
             # Monarch already spawned TP workers via proc mesh. "external_launcher"
             # tells vLLM to run one worker per process (no subprocess spawning)

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -472,6 +472,10 @@ class PolicyTrainer(Actor, Configurable):
                 self.config.training.max_norm,
                 foreach=True,
                 pp_mesh=self.parallel_dims.get_optional_mesh("pp"),
+                # With EP, expert params live on the ep mesh and dense params on
+                # the tp mesh; this routes to the multi-mesh-aware grad-norm path
+                # (else torch.stack fails across the two meshes).
+                ep_enabled=self.parallel_dims.ep_enabled,
             )
 
         with sl.log_trace_span("optim"):

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -11,6 +11,8 @@ Each function returns a complete ``RLTrainer.Config`` and is discoverable by
 ``ConfigManager`` via ``--module rl --config <function_name>``.
 """
 
+import dataclasses
+
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -20,13 +22,109 @@ from torchtitan.config import (
     ParallelismConfig,
     TrainingConfig,
 )
-from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
+from torchtitan.experiments.rl.actors.generator import (
+    SamplingConfig,
+    VLLMCudagraphConfig,
+    VLLMGenerator,
+)
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
 from torchtitan.experiments.rl.grpo import GRPOLoss, RLTrainer
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.sum_digits import SumDigitsEnv
 from torchtitan.models.qwen3 import model_registry
+
+
+def _qwen3_moe_fullvocab_spec(vocab_size: int = 151936):
+    """A tiny Qwen3-MoE (``debugmodel_moe``) patched to the Qwen3 tokenizer vocab.
+
+    ``debugmodel_moe`` ships with ``vocab_size=2048`` (for unit tests with a dummy
+    tokenizer), which is incompatible with the real Qwen3-0.6B tokenizer used by
+    the env (vocab 151936) — prompt token ids would index out of the embedding.
+    Patch the vocab on the embedding + lm_head so the model runs with the real
+    tokenizer (random-init weights; no HF checkpoint exists for this debug model).
+    """
+    spec = model_registry("debugmodel_moe", attn_backend="varlen")
+    model = dataclasses.replace(
+        spec.model,
+        vocab_size=vocab_size,
+        tok_embeddings=dataclasses.replace(
+            spec.model.tok_embeddings, num_embeddings=vocab_size
+        ),
+        lm_head=dataclasses.replace(spec.model.lm_head, out_features=vocab_size),
+    )
+    return dataclasses.replace(spec, model=model, flavor="debugmodel_moe_fullvocab")
+
+
+def rl_grpo_qwen3_moe_dp2_ep4() -> RLTrainer.Config:
+    """GRPO smoke test: tiny Qwen3-MoE generator with DP-attention + EP (6 GPUs).
+
+    Generator (4 GPUs): ``dp_shard=2 x tp=2``, ``ep=4`` — experts sharded across all
+    4 ranks (cross-group all-to-all), attention DP=2/TP=2; the controller shards
+    prompts across the 2 DP groups (``RLTrainer._generate_sharded``). Trainer
+    (2 GPUs): ``tp=2``, ``ep=2``. Random-init weights (no HF checkpoint exists for
+    the debug MoE), so this validates the EP plumbing — expert sharding, the
+    all-to-all, and weight-sync resharding (trainer ep2 -> generator ep4) — not
+    task learning (reward stays ~0). ``enforce_eager`` since MoE dynamic shapes
+    break full CUDA-graph capture.
+    """
+    group_size = 8
+    return RLTrainer.Config(
+        model_spec=_qwen3_moe_fullvocab_spec(),
+        hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
+        num_steps=3,
+        num_prompts_per_step=5,
+        num_validation_samples=20,
+        compile=CompileConfig(enable=False),
+        env=SumDigitsEnv.Config(seed=42, correctness_reward=1.0, format_reward=0.3),
+        validation_env=SumDigitsEnv.Config(
+            seed=99, correctness_reward=1.0, format_reward=0.3
+        ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
+        batcher=Batcher.Config(
+            batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
+        ),
+        trainer=PolicyTrainer.Config(
+            optimizer=OptimizersContainer.Config(lr=2e-6),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=2,
+                decay_type="linear",
+            ),
+            training=TrainingConfig(dtype="bfloat16"),
+            parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
+                tensor_parallel_degree=2,
+                expert_parallel_degree=2,
+                disable_loss_parallel=True,
+            ),
+            checkpoint=CheckpointManager.Config(
+                enable=True,
+                initial_load_in_hf=False,
+                interval=10,
+                last_save_model_only=False,
+            ),
+            loss=GRPOLoss.Config(),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            parallelism=ParallelismConfig(
+                data_parallel_replicate_degree=1,
+                data_parallel_shard_degree=2,
+                tensor_parallel_degree=2,
+                expert_parallel_degree=4,
+                enable_sequence_parallel=False,
+                disable_loss_parallel=True,
+            ),
+            checkpoint=CheckpointManager.Config(enable=False),
+            cudagraph=VLLMCudagraphConfig(enable=False),
+            sampling=SamplingConfig(
+                n=group_size,
+                temperature=0.8,
+                top_p=0.95,
+                max_tokens=100,
+            ),
+        ),
+    )
 
 
 def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -86,6 +86,68 @@ def rl_grpo_qwen3_0_6b() -> RLTrainer.Config:
     )
 
 
+def rl_grpo_qwen3_0_6b_gen_tp2dp2() -> RLTrainer.Config:
+    """GRPO config for Qwen3-0.6B with a tp2 x dp2 generator (6 GPUs: 4 gen + 2 train).
+
+    Same total generator GPUs as ``rl_grpo_qwen3_0_6b`` (4), but laid out as two
+    independent data-parallel vLLM engines (TP=2 each) instead of one TP=4 engine.
+    Exercises the controller's prompt-sharding path (RLTrainer._generate_sharded).
+    """
+    group_size = 8
+    return RLTrainer.Config(
+        model_spec=model_registry("0.6B", attn_backend="varlen"),
+        hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
+        num_steps=10,
+        num_prompts_per_step=5,
+        num_validation_samples=20,
+        compile=CompileConfig(enable=True, backend="aot_eager"),
+        env=SumDigitsEnv.Config(seed=42, correctness_reward=1.0, format_reward=0.3),
+        validation_env=SumDigitsEnv.Config(
+            seed=99, correctness_reward=1.0, format_reward=0.3
+        ),
+        metrics=MetricsProcessor.Config(enable_wandb=True),
+        batcher=Batcher.Config(
+            batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
+        ),
+        trainer=PolicyTrainer.Config(
+            optimizer=OptimizersContainer.Config(lr=2e-6),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=2,
+                decay_type="linear",
+            ),
+            training=TrainingConfig(),
+            parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
+                tensor_parallel_degree=2,
+                disable_loss_parallel=True,
+            ),
+            checkpoint=CheckpointManager.Config(
+                enable=True,
+                initial_load_in_hf=True,
+                interval=10,
+                last_save_model_only=False,
+            ),
+            loss=GRPOLoss.Config(),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            parallelism=ParallelismConfig(
+                tensor_parallel_degree=2,
+                data_parallel_replicate_degree=2,
+                enable_sequence_parallel=False,
+                disable_loss_parallel=True,
+            ),
+            checkpoint=CheckpointManager.Config(enable=False),
+            sampling=SamplingConfig(
+                n=group_size,
+                temperature=0.8,
+                top_p=0.95,
+                max_tokens=100,
+            ),
+        ),
+    )
+
+
 def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:
     """GRPO training config for Qwen3-1.7B (6 GPUs: 4 gen + 2 train)."""
     group_size = 8

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -358,6 +358,65 @@ class RLTrainer(Configurable):
             kwargs["gpus"] = 0
         return result.item(**kwargs)
 
+    async def _generate_sharded(
+        self,
+        tokenized_prompts: list[list[int]],
+        *,
+        sampling_config: SamplingConfig | None = None,
+        metrics_prefix: str = "generator",
+    ) -> tuple[list[Completion], list[m.Metric]]:
+        """Run generation across the generator's data-parallel replicas.
+
+        The generator mesh is laid out as ``dp_replicate`` independent vLLM
+        engines, each a ``tensor_parallel_degree``-rank TP group occupying a
+        contiguous block of ranks (replica ``r`` -> gpus ``[r*tp, (r+1)*tp)``),
+        matching vLLM's ``dp_rank = RANK // tp`` grouping. Prompts are sharded
+        across replicas (strided), broadcast to every TP rank within a replica
+        (TP requires identical input), and the completions gathered. At
+        ``dp_replicate == 1`` this is exactly the previous broadcast-and-take-
+        rank-0 behavior.
+
+        Replicas are dispatched concurrently: vLLM's external_launcher DP runs a
+        per-step coordination all-reduce across the dp group, so every replica
+        must be in its engine loop together -- sequential dispatch would deadlock.
+        """
+        p = self.config.generator.parallelism
+        dp = p.data_parallel_replicate_degree
+        tp = p.tensor_parallel_degree
+
+        # Strided assignment: replica r owns global indices r, r+dp, r+2dp, ...
+        replica_global_idx = [
+            list(range(r, len(tokenized_prompts), dp)) for r in range(dp)
+        ]
+
+        async def _run_replica(r: int):
+            idxs = replica_global_idx[r]
+            shard = [tokenized_prompts[i] for i in idxs]
+            logger.info(
+                "[dp-shard] replica %d (gpus %d:%d) <- %d prompts (global idx %s)",
+                r,
+                r * tp,
+                (r + 1) * tp,
+                len(shard),
+                idxs,
+            )
+            replica = self.generator.slice(gpus=slice(r * tp, (r + 1) * tp))
+            completions, metrics = self._get_rank_0_value(
+                await replica.generate.call(
+                    shard,
+                    sampling_config=sampling_config,
+                    metrics_prefix=metrics_prefix,
+                )
+            )
+            for c in completions:  # local shard index -> global prompt index
+                c.prompt_idx = idxs[c.prompt_idx]
+            return completions, metrics
+
+        per_replica = await asyncio.gather(*(_run_replica(r) for r in range(dp)))
+        completions = [c for comps, _ in per_replica for c in comps]
+        generation_metrics = [mm for _, mets in per_replica for mm in mets]
+        return completions, generation_metrics
+
     @staticmethod
     def _compute_world_size(p: ParallelismConfig) -> int:
         """Compute world size from all parallel dimensions."""
@@ -564,8 +623,8 @@ class RLTrainer(Configurable):
             self.tokenizer.encode(env.prompt, add_bos=True, add_eos=False)
             for env in envs
         ]
-        completions, generation_metrics = self._get_rank_0_value(
-            await self.generator.generate.call(tokenized_prompts)
+        completions, generation_metrics = await self._generate_sharded(
+            tokenized_prompts
         )
 
         trajectories: list[Trajectory] = []
@@ -689,12 +748,10 @@ class RLTrainer(Configurable):
             self.tokenizer.encode(env.prompt, add_bos=True, add_eos=False)
             for env in envs
         ]
-        completions, generation_metrics = self._get_rank_0_value(
-            await self.generator.generate.call(
-                tokenized_prompts,
-                sampling_config=greedy,
-                metrics_prefix="validation_generator",
-            )
+        completions, generation_metrics = await self._generate_sharded(
+            tokenized_prompts,
+            sampling_config=greedy,
+            metrics_prefix="validation_generator",
         )
 
         trajectories = [

--- a/torchtitan/experiments/rl/grpo.py
+++ b/torchtitan/experiments/rl/grpo.py
@@ -381,7 +381,12 @@ class RLTrainer(Configurable):
         must be in its engine loop together -- sequential dispatch would deadlock.
         """
         p = self.config.generator.parallelism
-        dp = p.data_parallel_replicate_degree
+        # Number of independent-data groups = dp_replicate * dp_shard. The MoE EP
+        # layout puts DP-attention on dp_shard (dp_replicate=1); the dense DP
+        # layout uses dp_replicate. Both must be sharded across here.
+        dp = max(p.data_parallel_replicate_degree, 1) * max(
+            p.data_parallel_shard_degree, 1
+        )
         tp = p.tensor_parallel_degree
 
         # Strided assignment: replica r owns global indices r, r+dp, r+2dp, ...

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -97,7 +97,7 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
             kv_cache: shape =
-                [2, num_blocks, block_size, num_kv_heads, head_size]
+                [num_blocks, 2, block_size, num_kv_heads, head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -134,8 +134,11 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
             AttentionType.ENCODER,
         ), "Encoder-only attention not supported yet."
 
-        # For decoder and cross-attention, use KV cache as before
-        key_cache, value_cache = kv_cache.unbind(0)
+        # For decoder and cross-attention, use KV cache as before.
+        # vLLM's FlashAttentionBackend.get_kv_cache_shape lays the cache out as
+        # (num_blocks, 2, block_size, num_kv_heads, head_size), so the K/V split
+        # is on dim 1, not dim 0.
+        key_cache, value_cache = kv_cache.unbind(1)
 
         assert not self.kv_cache_dtype.startswith(
             "fp8"

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -171,9 +171,14 @@ class VLLMModelWrapper(Module):
 
         # Build ParallelDims from the torchtitan ParallelismConfig (the
         # controller's source of truth) rather than vLLM's parallel_config.
+        # dp_shard carries DP-attention for the MoE EP layout (dp_replicate=1,
+        # dp_shard>1, ep=dp_shard*tp). With skip_dp=True (inference) no FSDP is
+        # applied, so dp_shard just provides the mesh axis: dense params stay
+        # TP-sharded + replicated across dp_shard groups, experts go on the ep
+        # mesh. Previously hardcoded to 1 (TP-only).
         self.parallel_dims = ParallelDims(
             dp_replicate=parallelism.data_parallel_replicate_degree,
-            dp_shard=1,
+            dp_shard=max(parallelism.data_parallel_shard_degree, 1),
             cp=1,
             tp=parallelism.tensor_parallel_degree,
             pp=1,

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -297,8 +297,16 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
             input_splits_list = input_splits.tolist()
             output_splits_list = output_splits.tolist()
 
-        # All-to-all dispatch tokens to EP ranks
-        routed_input_RD = all_to_all_single_autograd(
+        # All-to-all dispatch tokens to EP ranks. The autograd variant is needed
+        # for gradient flow during training, but it has no CUDA kernel under
+        # torch.inference_mode() (vLLM runs the generator there), so fall back to
+        # the plain collective when grad is disabled (inference).
+        _all_to_all = (
+            all_to_all_single_autograd
+            if torch.is_grad_enabled()
+            else all_to_all_single
+        )
+        routed_input_RD = _all_to_all(
             routed_input_ND,
             output_splits_list,
             input_splits_list,
@@ -426,7 +434,13 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
 
         # All-to-all combine: returns AsyncCollectiveTensor — the a2a runs
         # on the NCCL stream and won't block until the tensor is accessed.
-        routed_output_RD = all_to_all_single_autograd(
+        # See dispatch(): autograd a2a for training, plain a2a under inference.
+        _all_to_all = (
+            all_to_all_single_autograd
+            if torch.is_grad_enabled()
+            else all_to_all_single
+        )
+        routed_output_RD = _all_to_all(
             routed_output_RD,
             metadata.input_splits,
             metadata.output_splits,


### PR DESCRIPTION
## Summary
Enables the experiments/rl GRPO loop to run the vLLM generator with data parallelism and expert parallelism, illustrated by two configs:
  - `rl_grpo_qwen3_0_6b_gen_tp2dp2` — dense DP (`tp2 × dp_replicate2`): two independent TP-engine replicas, prompts sharded across them.
  - `rl_grpo_qwen3_moe_dp2_ep4` — MoE DP-attention + EP (`tp2 × dp_shard2 × ep4`): experts sharded across all 4 ranks with a cross-group all-to-all, attention data-parallel.

Both keep the unified trainer/generator model (so bitwise-parity is preserved) and reuse vLLM's external_launcher DP support — vLLM sizes `world_size = tp·pp·dp` and assigns each rank's `dp_rank` from its global rank; the controller (`_generate_sharded`) shards prompts across the DP groups.

## Changes
- **vLLM KV-cache fix** (`attention.py`): split the cache on dim 1 (`get_kv_cache_shape` is `(num_blocks, 2, …)`) — fixes a hang on current vLLM nightlies. *(standalone bug fix)*
- **Controller**: `_generate_sharded` dispatches per-DP-group shards (`dp = dp_replicate × dp_shard`), broadcasts within each TP group, gathers and remaps `prompt_idx`.
- **Generator**: relax DP/EP guards; pass `data_parallel_size` + `enable_expert_parallel`; thread `dp_shard` into `ParallelDims`.
- **MoE inference** (`token_dispatcher.py`, core): use the non-autograd `all_to_all_single` under `inference_mode()` (the autograd variant has no CUDA kernel there); autograd retained for training.
- **Trainer**: pass `ep_enabled` to `clip_grad_norm_` (multi-mesh grad-norm for ep-vs-tp params).

## Testing (6 GPUs: 4 gen + 2 train)
- Dense `tp2/dp2`: learns the sum-digits task — reward **0.47 → 0.92** over 10 steps, validation **0.385 → 0.70**; weight-sync replicates across the dp axis.
- MoE `dp2/ep4`: end-to-end **plumbing smoke test** with a random-init tiny MoE
  (no MoE checkpoint fits the tp2 trainer) — both DP groups get distinct shards, the ep4 all-to-all runs, weight-sync reshards trainer ep2 → generator ep4, optim_step's multi-mesh grad-norm passes; 3 steps + validation complete
  (reward ~0 = random weights, expected).

## Appendix

https://metamate.internalmeta.com/view/artifact/9558eb99-e5bf-4280-a778-bce7ce6acf4f/architecture-diagram

<img width="652" height="788" alt="image" src="https://github.com/user-attachments/assets/62435f4f-6c9a-4c37-b078-d7096fb4e3e3" />

<img width="654" height="589" alt="image" src="https://github.com/user-attachments/assets/019aa200-ba4d-4082-b842-80bb11f4da87" />

<img width="714" height="786" alt="image" src="https://github.com/user-attachments/assets/071b1331-12ce-49c0-9e57-b497936eec1e" />

