### PR TITLE
[graph_trainer] AC remat: give recompute dups independent custom meta

### DIFF
--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -24,6 +24,19 @@ from torchtitan.experiments.graph_trainer.common_utils import _is_backward_node
 log = logging.getLogger(__name__)
 
 
+def _privatize_custom_meta(node: fx.Node) -> None:
+    """Give ``node`` its own ``meta["custom"]`` dict.
+
+    ``fx.Graph.node_copy`` / ``dict.update`` shallow-copy ``meta``, so a copied node
+    ends up sharing its source's nested ``custom`` dict; annotating one would then
+    silently mutate the other. A shallow copy suffices -- callers only add or
+    replace keys, they don't mutate the values in place.
+    """
+    custom = node.meta.get("custom")
+    if custom is not None:
+        node.meta["custom"] = dict(custom)
+
+
 def _collect_backward_regions(
     gm: fx.GraphModule,
 ) -> list[tuple[int, int, bool]]:
@@ -295,7 +308,8 @@ def selective_activation_remat_pass(
                 continue
             with gm.graph.inserting_before(bwd_target):
                 dup_attr = gm.graph.get_attr(arg.target)
-            dup_attr.meta.update(arg.meta)
+                dup_attr.meta.update(arg.meta)  # shares arg's nested custom dict
+                _privatize_custom_meta(dup_attr)
             dups[arg] = dup_attr
         return dups
 
@@ -322,6 +336,7 @@ def selective_activation_remat_pass(
 
         with gm.graph.inserting_before(bwd_target):
             dup = gm.graph.node_copy(fwd_node, remat_and_dup_get_attr)
+            _privatize_custom_meta(dup)  # node_copy shares fwd_node's custom dict
         dup.name = fwd_node.name + "_recomputed"
         dup.meta["autograd_backward"] = True
         recomputed_nodes[fwd_node] = dup

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -571,6 +571,36 @@ class TestApplySACPass(TestCase):
         self.assertEqual(len(recomputed_nodes), 1)
         self.assertTrue(recomputed_nodes[0].meta["autograd_backward"])
 
+    def test_remat_dup_gets_independent_custom_meta(self):
+        # fx.Graph.node_copy shallow-copies node.meta, so without intervention a
+        # recompute dup shares the SAME nested meta["custom"] dict as its forward
+        # original -- annotating one would silently mutate the other. The pass must
+        # give the dup its own copy (preserving the values).
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        fwd = graph.call_function(torch.ops.aten.add.Tensor, args=(x, x))
+        # A forward consumer keeps the original alive (remat erases originals whose
+        # consumers are all backward) so we can compare it against the dup.
+        fwd_use = graph.call_function(torch.ops.aten.relu.default, args=(fwd,))
+        bwd = graph.call_function(torch.ops.aten.mul.Tensor, args=(fwd, 2))
+        graph.output((fwd_use, bwd))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fwd.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+        fwd.meta["custom"] = {_MODULE_FQN: "layers.0.attention_norm"}
+        bwd.meta["autograd_backward"] = True
+
+        gm = selective_activation_remat_pass(gm)
+
+        fwd_node = next(n for n in gm.graph.nodes if n.name == "add_tensor")
+        dup = next(n for n in gm.graph.nodes if n.name == "add_tensor_recomputed")
+        # Independent dict object, same values preserved.
+        self.assertIsNot(dup.meta["custom"], fwd_node.meta["custom"])
+        self.assertEqual(dup.meta["custom"][_MODULE_FQN], "layers.0.attention_norm")
+        # Mutating the dup's annotation must not leak into the original.
+        dup.meta["custom"]["cudagraph_partition"] = "cudagraph_9"
+        self.assertNotIn("cudagraph_partition", fwd_node.meta["custom"])
+
 
 class TestFullMemoryPolicy(TestCase):
     """Unit tests for the full recompute memory policy."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3536
* #3535
* #3534
* #3533
* __->__ #3530
* #3529

fx.Graph.node_copy (and the get_attr meta.update) shallow-copy node.meta, so a
recompute duplicate ends up sharing the SAME nested meta["custom"] dict object
as its forward original. custom holds per-node annotations (module_fqn, EP role,
tags written by later passes); while the dict is shared, annotating one node
silently mutates the other, so a forward node and its backward recompute twin
can no longer be told apart by their annotations.

Fix: a small _privatize_custom_meta helper shallow-copies meta["custom"], called
at each duplication site right where the share is introduced -- after node_copy
and after the get_attr meta.update. Shallow copy suffices (only the dict is
written to; its values are immutable). Numerically neutral -- only changes
meta-dict identity.

Test: test_remat_dup_gets_independent_custom_meta asserts the dup gets a distinct
custom dict, preserves the values, and that mutating it doesn't leak to the
original.