### PR TITLE
[graph_trainer] Drop custom_codegen_pass from the default pass list

### DIFF
--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -37,7 +37,6 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
     cudagraph_pass,
     insert_kernel_annotations_pass,
 )
-from torchtitan.experiments.graph_trainer.custom_codegen import custom_codegen_pass
 from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
     snapshot_graph,
@@ -157,8 +156,7 @@ def compile_time_passes(
     if inductor_compilation == "full":
         # Compile the entire graph into optimized Triton kernels. Must
         # be terminal — the FX graph is no longer authoritative after
-        # this pass, so custom_codegen_pass and
-        # insert_kernel_annotations_pass cannot follow.
+        # this pass, so insert_kernel_annotations_pass cannot follow.
         passes.append(full_inductor_compilation_pass)
     if inductor_compilation == "regional":
         # FlexAttention HOPs must be compiled (via regional_inductor) to
@@ -180,20 +178,8 @@ def compile_time_passes(
             passes.append(annotate_rmsnorm_for_regional_inductor_pass)
         passes.append(regional_inductor_pass)
         if use_cudagraph:
-            # Must run before custom_codegen_pass (last in pre_passes)
-            # which replaces the GraphModule's forward().
-            # Also must run before cudagraph_pass.
+            # Must run before cudagraph_pass (which replaces forward()).
             passes.append(insert_kernel_annotations_pass)
-        # TODO: Switch to upstream PyTorch implementation when
-        # https://github.com/pytorch/pytorch/pull/178246 lands.
-        # custom_codegen_pass saves the FX graph to disk for:
-        # 1. Debugging: inspect the generated graph code directly
-        # 2. Profiling provenance: dual-path codegen with _RecordFunctionFast
-        #    gives fine-grained operator-level attribution in profiler traces
-        # 3. User-editable codegen: users can directly modify the generated
-        #    program on disk for fine-grain scheduling optimizations, with
-        #    hot-reload picking up changes at runtime
-        passes.append(custom_codegen_pass)
     return passes
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3548
* #3547
* #3546
* #3545
* #3544
* #3536
* __->__ #3535
* #3533

custom_codegen_pass (dumps the FX graph to disk for debugging / profiling
provenance / user-editable codegen) isn't pulling its weight right now, and it
complicates the cudagraph pipeline -- it rebinds each submodule's forward(),
which conflicts with piecewise cudagraph wrapping. Drop it from
compile_time_passes. The pass function itself stays in custom_codegen.py (still
unit-tested by TestCustomCodegenPass); only its use in the default pipeline is
removed.
