### PR TITLE
[graph_trainer] cudagraph_pass: default is_forward to True

### DIFF
--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -550,7 +550,7 @@ def cudagraph_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
     *,
-    is_forward: bool,
+    is_forward: bool = True,
     static_input_indices: list[int] | None = None,
     tensor_input_indices: list[int] | None = None,
 ) -> torch.fx.GraphModule:
@@ -568,7 +568,9 @@ def cudagraph_pass(
         example_inputs: Example inputs for warmup/recording.
         is_forward: Whether this is a forward graph (True) or backward graph
             (False). Used to infer which inputs have stable tensor addresses
-            when ``static_input_indices`` is not provided.
+            when ``static_input_indices`` is not provided. Defaults to True --
+            graph_trainer traces a single fwd+loss+bwd graph and always wraps it
+            as the forward.
         static_input_indices: Explicit list of input indices with stable tensor
             addresses. When provided, ``is_forward`` is not used for inference.
         tensor_input_indices: Indices of graph inputs that are tensors (as

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -210,7 +210,6 @@ def construct_default_graph_passes(
         passes.append(
             functools.partial(
                 cudagraph_pass,
-                is_forward=True,
                 static_input_indices=static_input_indices,
                 tensor_input_indices=traced_result.tensor_input_indices,
             )

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -262,9 +262,7 @@ class TestCudagraphPass(unittest.TestCase):
             return args
 
         with self.assertRaisesRegex(TypeError, "requires a GraphModule"):
-            cudagraph_pass(
-                plain_fn, (torch.zeros(4),), is_forward=True, static_input_indices=[0]
-            )
+            cudagraph_pass(plain_fn, (torch.zeros(4),), static_input_indices=[0])
 
     def test_graphmodule_wraps_forward(self):
         """cudagraph_pass wraps gm.forward with CUDAGraphWrapper."""
@@ -278,9 +276,7 @@ class TestCudagraphPass(unittest.TestCase):
         ) as MockWrapper:
             mock_instance = MagicMock()
             MockWrapper.return_value = mock_instance
-            result = cudagraph_pass(
-                gm, example_inputs, is_forward=True, static_input_indices=[0]
-            )
+            result = cudagraph_pass(gm, example_inputs, static_input_indices=[0])
             self.assertIs(result, gm)
             self.assertIs(gm.forward, mock_instance)
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -939,7 +939,7 @@ class TestTraceDTensor(unittest.TestCase):
                 f"{name} should have been migrated to CUDA",
             )
 
-        gm = cudagraph_pass(gm, traced.example_inputs, is_forward=True)
+        gm = cudagraph_pass(gm, traced.example_inputs)
         real_x = torch.zeros(4, dtype=torch.float32, device=self.DEVICE)
         expected = f({}, real_x.clone())
         for _ in range(3):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3536
* __->__ #3538
* #3535
* #3534
* #3533
* #3530
* #3529

graph_trainer traces a single fwd+loss+bwd graph and always wraps it as the
forward, so every callsite passes is_forward=True. Make True the default and drop
the explicit kwarg from the callsites (construct_default_graph_passes and the
precompile/trace tests). Behavior-preserving; isolates this cleanup from the
piecewise engine commit that follows.