### PR TITLE
[RL] Fix vLLM 1.0 KV-cache layout

### DIFF
--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -97,7 +97,7 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
             kv_cache: shape =
-                [2, num_blocks, block_size, num_kv_heads, head_size]
+                [num_blocks, 2, block_size, num_kv_heads, head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -135,7 +135,7 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
         ), "Encoder-only attention not supported yet."
 
         # For decoder and cross-attention, use KV cache as before
-        key_cache, value_cache = kv_cache.unbind(0)
+        key_cache, value_cache = kv_cache.unbind(1)
 
         assert not self.kv_cache_dtype.startswith(
             "fp8"


### PR DESCRIPTION
vLLM changed the paged KV-cache layout from `[2, num_blocks, ...]` to `[num_blocks, 2, ...]` (the key/value split moved from dim 0 to dim 1).

Our custom `PyTorchVarlenAttentionImpl` still unpacked it with `kv_cache.unbind(0)`, so the RL integration tests failed with:

```
ValueError: too many values to unpack (expected 2)
```

Fix: `kv_cache.unbind(0)` → `kv_cache.unbind(1)`, matching vLLM 1.0's `FlashAttentionImpl.forward()`.

https://github.com/vllm-project/vllm/blob/ca17b6b17/vllm/v1/attention/backends/flash_attn.py#L734
