### PR TITLE
[graph_trainer] canonicalize: drop no-op lift_fresh_copy of tensor constants

### DIFF
--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -324,6 +324,61 @@ def normalize_view_ops_as_reshape(
     return gm
 
 
+def _is_mutated(node: torch.fx.Node) -> bool:
+    """True if any user mutates ``node`` in place (a write-aliased arg position)."""
+    for user in node.users:
+        schema = getattr(user.target, "_schema", None)
+        if schema is None:
+            continue
+        for i, arg in enumerate(user.args):
+            if arg is node and i < len(schema.arguments):
+                alias = schema.arguments[i].alias_info
+                if alias is not None and alias.is_write:
+                    return True
+    return False
+
+
+def remove_lift_fresh_copy_pass(
+    gm: torch.fx.GraphModule, example_inputs=None
+) -> torch.fx.GraphModule:
+    """Drop ``aten.lift_fresh_copy`` clones of a baked tensor constant.
+
+    ``lift_fresh_copy`` clones a freshly-lifted constant so a downstream in-place op
+    can mutate the copy without touching the constant. When the input is a baked
+    tensor constant (a ``get_attr``) and the copy is never mutated -- e.g. it is only
+    read as the value of an ``index_put_`` (a masked ``tensor[mask] = const``) -- the
+    clone does nothing, so consumers can read the constant directly. The
+    ``_is_mutated`` guard keeps this numerics-preserving (removing a mutated copy
+    would clobber the shared constant).
+
+    Args:
+        gm: The traced graph module.
+        example_inputs: Unused, accepted for pass interface compatibility.
+
+    Returns:
+        The graph module with redundant lift_fresh_copy nodes removed.
+    """
+    count = 0
+    for node in list(gm.graph.nodes):
+        if node.target is not torch.ops.aten.lift_fresh_copy.default:
+            continue
+        inp = node.args[0]
+        if not (isinstance(inp, torch.fx.Node) and inp.op == "get_attr"):
+            continue
+        if _is_mutated(node):
+            continue
+        node.replace_all_uses_with(inp)
+        gm.graph.erase_node(node)
+        count += 1
+
+    if count > 0:
+        gm.graph.lint()
+        gm.recompile()
+        logger.info(f"Removed {count} lift_fresh_copy node(s) on tensor constants")
+
+    return gm
+
+
 def canonicalize_graph_pass(
     gm: torch.fx.GraphModule, example_inputs=None
 ) -> torch.fx.GraphModule:
@@ -337,7 +392,9 @@ def canonicalize_graph_pass(
        ``_unsafe_view`` nodes whose output shape equals their input.
     3. ``remove_b2b_transpose_pass`` — collapse back-to-back ``t(t(x))`` pairs.
     4. ``remove_identity_slice_pass`` — drop full-dimension slices.
-    5. ``normalize_view_ops_as_reshape`` — canonicalize remaining
+    5. ``remove_lift_fresh_copy_pass`` — drop ``lift_fresh_copy`` clones of an
+       unmutated tensor constant.
+    6. ``normalize_view_ops_as_reshape`` — canonicalize remaining
        ``view``/``_unsafe_view`` nodes to ``reshape``.
 
     Each sub-pass lints and recompiles internally, so no extra work is
@@ -349,5 +406,6 @@ def canonicalize_graph_pass(
     gm = remove_identity_view_pass(gm, example_inputs)
     gm = remove_b2b_transpose_pass(gm, example_inputs)
     gm = remove_identity_slice_pass(gm, example_inputs)
+    gm = remove_lift_fresh_copy_pass(gm, example_inputs)
     gm = normalize_view_ops_as_reshape(gm, example_inputs)
     return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -1868,6 +1868,46 @@ class TestCanonicalizeGraphPass(TestCase):
         x = torch.randn(4, 4)
         self.assertEqual(gm(x), x.reshape(2, 8))
 
+    def test_removes_lift_fresh_copy_of_unmutated_constant(self):
+        """lift_fresh_copy of a tensor constant is dropped when the copy is only
+        read (here as the value added to x), so consumers read the constant."""
+        aten = torch.ops.aten
+        m = torch.nn.Module()
+        m._const = torch.tensor(5)
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        const = graph.get_attr("_const")
+        lf = graph.call_function(aten.lift_fresh_copy.default, args=(const,))
+        graph.output(graph.call_function(aten.add.Tensor, args=(x, lf)))
+        gm = torch.fx.GraphModule(m, graph)
+
+        canonicalize_graph_pass(gm)
+
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(aten.lift_fresh_copy.default, targets)
+        # Numerics preserved: x + lift_fresh_copy(5) == x + 5.
+        x = torch.randn(4)
+        self.assertEqual(gm(x), x + 5)
+
+    def test_keeps_mutated_lift_fresh_copy(self):
+        """A lift_fresh_copy whose copy is mutated in place is kept -- removing it
+        would clobber the shared constant."""
+        aten = torch.ops.aten
+        m = torch.nn.Module()
+        m._const = torch.tensor([1.0, 2.0])
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        const = graph.get_attr("_const")
+        lf = graph.call_function(aten.lift_fresh_copy.default, args=(const,))
+        graph.call_function(aten.add_.Tensor, args=(lf, x))  # mutates the copy
+        graph.output(lf)
+        gm = torch.fx.GraphModule(m, graph)
+
+        canonicalize_graph_pass(gm)
+
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertIn(aten.lift_fresh_copy.default, targets)
+
 
 class TestAsyncTensorParallelPass(FSDPTest):
     """Verify async_tensor_parallel_pass produces fused ops."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3548
* #3547
* #3546
* #3545
* __->__ #3544
* #3536
* #3535
* #3533

aten.lift_fresh_copy clones a baked tensor constant so a downstream in-place op
can mutate the copy. When the input is a get_attr constant and the copy is never
mutated (e.g. the value of an index_put_ masked fill), the clone is a no-op --
consumers can read the constant directly. Guarded by a write-alias check so it
stays numerics-preserving. Added to canonicalize_graph_pass.