### PR TITLE
[graph_trainer] dce: drop dead _assert_async runtime asserts

### DIFF
--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -23,6 +23,28 @@ import torch
 
 from torchtitan.tools.logging import logger
 
+# Op overloads that are registered side-effectful but that we want DCE to treat
+# as pure (so unused instances, and their now-orphaned input chains, are dropped).
+# Currently just the ``aten._assert_async`` runtime asserts; add other removable
+# side-effect ops here as they come up.
+_FORCE_PURE_TARGETS = (
+    torch.ops.aten._assert_async.msg,
+    torch.ops.aten._assert_async.default,
+)
+
+
+def _is_impure_for_dce(node: torch.fx.Node) -> bool:
+    """``is_impure_node`` for DCE that forces :data:`_FORCE_PURE_TARGETS` pure.
+
+    Mirrors the default ``node.is_impure()`` for every node except the targets in
+    :data:`_FORCE_PURE_TARGETS`, which we report as pure so dead-code elimination
+    can drop them (and their now-orphaned input chains). See
+    ``eliminate_dead_code_pass``.
+    """
+    if node.op == "call_function" and node.target in _FORCE_PURE_TARGETS:
+        return False
+    return node.is_impure()
+
 
 def eliminate_dead_code_pass(
     gm: torch.fx.GraphModule, example_inputs=None
@@ -35,6 +57,10 @@ def eliminate_dead_code_pass(
     dropped. Running it first shrinks the graph for every downstream pass (memory
     policy, bucketing, cudagraph partitioning), and removes orphaned subtrees left
     by tracing so they don't get scheduled or counted.
+
+    Dead ``aten._assert_async`` runtime asserts are dropped too, via the custom
+    :func:`_is_impure_for_dce` (default DCE keeps them, and their condition chain,
+    as side-effectful). They are pure runtime guards with no bearing on numerics.
 
     Keeping a side-effecting custom op alive: a custom op with a real side effect
     but no users (e.g. a debug/log op, a barrier, an in-place buffer write) is
@@ -67,7 +93,7 @@ def eliminate_dead_code_pass(
     Returns:
         The graph module with dead code removed.
     """
-    if gm.graph.eliminate_dead_code():
+    if gm.graph.eliminate_dead_code(is_impure_node=_is_impure_for_dce):
         gm.graph.lint()
         gm.recompile()
         logger.info("Eliminated dead code from the graph")

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -895,6 +895,27 @@ class TestBucketingPrefetchOrder(FSDPTest):
                 f"(full order: {layer_ids})",
             )
 
+    def test_drops_assert_async_and_dead_chain(self):
+        # _assert_async is side-effectful, so plain DCE keeps it (and its whole
+        # le/all condition chain). The pass erases the assert, then DCE reaps the
+        # now-orphaned chain; unrelated live nodes are untouched.
+        aten = torch.ops.aten
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        le = g.call_function(aten.le.Scalar, (x, 5))
+        reduced = g.call_function(aten.all.default, (le,))
+        g.call_function(aten._assert_async.msg, (reduced, "cond"))  # side-effect
+        out = g.call_function(aten.relu.default, (x,))
+        g.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+        eliminate_dead_code_pass(gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(aten._assert_async.msg, targets)
+        self.assertNotIn(aten.le.Scalar, targets)
+        self.assertNotIn(aten.all.default, targets)
+        self.assertIn(aten.relu.default, targets)
+
 
 class TestRemoveDetachPass(TestCase):
     """Unit tests for the remove_detach_pass graph pass."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3548
* #3547
* #3546
* __->__ #3545
* #3544
* #3536
* #3535
* #3533

_assert_async is registered side-effectful, so eliminate_dead_code keeps it (and
its whole condition chain, e.g. le/all) even when the assert's result is unused.
These are pure runtime guards with no bearing on numerics (and the device->host
check is awkward for cudagraph capture), so erase them first, then DCE reaps the
orphaned chain.