### PR TITLE
[graph_trainer] memory_policy: always save sym_size/shape ops

### DIFF
--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -180,6 +180,15 @@ def tag_sac_policy(
                 node.meta["recompute"] = parent.meta["recompute"]
             continue
 
+        # Always save sym-int nodes (shape reads like sym_size/sym_stride, and
+        # tensor->int scalar conversions) rather than recompute them: recomputing
+        # a shape read pins the parent tensor alive in backward just to reread its
+        # size. We key off meta["val"] being a SymInt -- mirroring AOT Autograd's
+        # partitioner, which saves SymInts (cheap scalars) but never SymFloats.
+        if "val" in node.meta and isinstance(node.meta["val"], torch.SymInt):
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+            continue
+
         # NOTE: The eager SAC policy (activation_checkpoint.py) alternates
         # mm ops between MUST_SAVE and PREFER_RECOMPUTE. We omit that here
         # because the alternating heuristic is arbitrary.

--- a/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_cpu_offload.py
@@ -111,6 +111,64 @@ class TestCpuOffloadPass(TestCase):
                 "layers.2", fqn, "Last layer nodes should not be tagged for offload"
             )
 
+    def test_must_save_sym_int_not_offloaded(self):
+        """A MUST_SAVE sym-int node must survive tag_all_offloadable_activations.
+
+        tag_sac_policy force-saves sym-int shape reads (sym_size etc.). The
+        offload pass only considers nodes whose meta["val"] is a real tensor, so
+        a sym-int (whose val is a SymInt) must be left untouched -- otherwise its
+        MUST_SAVE tag would be flipped to MUST_CPU_OFFLOAD.
+        """
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        from torchtitan.experiments.graph_trainer.cpu_offload import (
+            tag_all_offloadable_activations,
+        )
+
+        shape_env = ShapeEnv()
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = self._make_fake_val()
+
+        # Forward tensor in a non-last layer: a genuine offload candidate.
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+        mm.meta["autograd_backward"] = False
+        mm.meta["custom"] = {"module_fqn": "layers.0.block"}
+        mm.meta["val"] = self._make_fake_val()
+
+        # Sym-int shape read of mm in the same non-last layer, force-saved as
+        # tag_sac_policy would. Its val is a SymInt, not a tensor.
+        sym = graph.call_function(torch.ops.aten.sym_size.int, args=(mm, 0))
+        sym.meta["autograd_backward"] = False
+        sym.meta["custom"] = {"module_fqn": "layers.0.block"}
+        sym.meta["val"] = shape_env.create_unbacked_symint()
+        sym.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+        # Backward consumers (last layer): mm feeds a bwd matmul; sym feeds a
+        # bwd view's size arg -- both forward values are live into backward.
+        bwd_mm = graph.call_function(torch.ops.aten.mm.default, args=(mm, mm))
+        bwd_mm.meta["autograd_backward"] = True
+        bwd_mm.meta["custom"] = {"module_fqn": "layers.1.block"}
+        bwd_mm.meta["val"] = self._make_fake_val()
+
+        bwd_view = graph.call_function(
+            torch.ops.aten.view.default, args=(bwd_mm, [sym, sym])
+        )
+        bwd_view.meta["autograd_backward"] = True
+        bwd_view.meta["custom"] = {"module_fqn": "layers.1.block"}
+        bwd_view.meta["val"] = self._make_fake_val()
+
+        graph.output(bwd_view)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_all_offloadable_activations(gm)
+
+        # The sym-int keeps its MUST_SAVE tag (never flipped to CPU offload)...
+        self.assertIs(sym.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        # ...while the real tensor in the same non-last layer WAS offloaded,
+        # proving the pass ran and would have touched the sym node if eligible.
+        self.assertIs(mm.meta["recompute"], CheckpointPolicy.MUST_CPU_OFFLOAD)
+
     def test_tag_no_backward_consumers(self):
         """Forward nodes without backward consumers should NOT be tagged."""
         from torchtitan.experiments.graph_trainer.cpu_offload import (

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -16,6 +16,7 @@ from torch._inductor.fx_passes.bucketing import (
 )
 from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.traceback import preserve_node_meta
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import TestCase
@@ -449,6 +450,33 @@ class TestApplySACPass(TestCase):
         nodes = self._get_call_function_nodes(gm)
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+    def test_sym_size_ops_always_saved(self):
+        """Sym-int nodes are forced MUST_SAVE regardless of policy: recomputing a
+        shape read would pin the parent tensor alive just to reread its size."""
+        # sym_size produces a SymInt only for symbolic dims, so tag the node's
+        # meta["val"] with a real SymInt — that is what is_sym_node keys off.
+        shape_env = ShapeEnv()
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        sym = graph.call_function(torch.ops.aten.sym_size.int, args=(relu, 0))
+        sym.meta["val"] = shape_env.create_unbacked_symint()
+        graph.output(relu)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        # Even a recompute-everything policy must save sym_size.
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+
+        tags = {
+            n.target: n.meta["recompute"]
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+        }
+        self.assertEqual(tags[torch.ops.aten.sym_size.int], CheckpointPolicy.MUST_SAVE)
+        self.assertEqual(
+            tags[torch.ops.aten.relu.default], CheckpointPolicy.MUST_RECOMPUTE
+        )
 
     def test_getitem_propagates_parent_tags(self):
         """operator.getitem nodes should inherit the parent's recompute tag."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3548
* #3547
* __->__ #3546
* #3545
* #3544
* #3536
* #3535
* #3533

Symbolic size/shape-extraction ops (sym_size, sym_numel, sym_stride,
sym_storage_offset) are forced to MUST_SAVE in tag_sac_policy. Each returns a
SymInt (free to keep), while recomputing it would pin the parent tensor alive in
backward just to read its size -- e.g. recomputing sym_size.int(all_to_all_single,
0) keeps the whole all-to-all output. Applies to every memory policy (shared
tagging); numerics-preserving (save vs recompute is the same value).