### PR TITLE
[graph_trainer] cudagraph: piecewise partition engine for DSv3 MoE on H100

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -62,13 +62,51 @@ class GraphTrainerCompileConfig(CompileConfig):
 
     inductor_compilation: Literal["regional", "full"] = "regional"
     """
-    Inductor compilation strategy. Mutually exclusive options:
+    Inductor compilation strategy — how ops are *code-generated* (orthogonal to
+    ``cudagraph_mode``, which controls how the result is *captured* for replay):
         regional: compile tagged regions (e.g. FlexAttention HOPs) with
-            regional_inductor while leaving the rest interpreted.
-        full: compile the entire graph with inductor into optimized
-            Triton kernels. Provides better performance but may change
-            bitwise numerics compared to regional/interpreted execution.
+            regional_inductor while leaving the rest interpreted. The FX graph
+            stays partitionable, so all ``cudagraph_mode`` options apply.
+        full: compile the entire graph with inductor into optimized Triton
+            kernels (one opaque program). Better performance but may change
+            bitwise numerics. CUDA graphs for this path are handled by **Inductor
+            internally** (it has its own cudagraph support), so ``cudagraph_mode``
+            is ignored here — there is no FX graph left for us to wrap or
+            partition.
     """
+
+    cudagraph_mode: Literal["off", "auto", "full"] = "auto"
+    """
+    CUDA graph capture strategy for the ``inductor_compilation=regional`` path
+    (ignored when ``inductor_compilation=full``, which uses Inductor's own
+    cudagraphs):
+        off: no CUDA graph.
+        auto (default): best-effort. Capture the whole joint graph as one CUDA
+            graph if it is cudagraph-compatible; otherwise partition it and capture
+            the compatible regions (running incompatible regions such as the MoE
+            block eagerly between replays); if nothing is capturable, run without
+            CUDA graph. This is what enables CUDA graph for DeepSeek-V3 on H100
+            (the MoE block is captured piecewise). Note: ``auto`` does not silently
+            fall back to eager if a region deemed capturable nonetheless fails to
+            capture at runtime (a gap in the compatibility checks) — that surfaces
+            as an error; fix the check or use ``off``.
+        full: capture the entire joint fwd+bwd graph as one CUDA graph. **Raises**
+            if the graph is not fully cudagraph-compatible (e.g. MoE _grouped_mm on
+            sm_90 / H100, EP token-routing splits, unpinned CPU<->CUDA copies,
+            data-dependent shapes). Use this to assert/require a single full
+            capture.
+
+    Mental model: a full CUDA graph is just the special case where the whole graph
+    is one capturable piece; ``auto`` produces that when possible and otherwise
+    falls back to capturing the safe pieces.
+    """
+
+    cudagraph_min_capture_size: int = 8
+    """Piecewise cudagraph only: a capturable region with fewer than this many ops
+    runs eager instead of being captured. A standalone CUDA graph (private memory
+    pool + per-step input copy-in) is not worth it for a handful of ops -- e.g. a
+    lone op stranded between two eager MoE blocks. Raising it captures fewer, larger
+    regions (less per-segment overhead/memory); 1 captures every safe region."""
 
     numerics_changing_optim: bool = False
     """Enable passes that improve performance but may change numerics

--- a/torchtitan/experiments/graph_trainer/cudagraph.py
+++ b/torchtitan/experiments/graph_trainer/cudagraph.py
@@ -13,6 +13,7 @@ during compilation.
 
 import gzip
 import json
+import operator
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -20,10 +21,12 @@ from typing import Any
 import torch
 from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
 from torch._library.opaque_object import is_opaque_value
+from torch.fx.passes.split_module import split_module
 from torch.utils._ordered_set import OrderedSet
 
 from torchtitan.config.function import Function
 from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
+from torchtitan.experiments.graph_trainer.debug_utils import tlparse_log_graph_pass
 from torchtitan.tools.logging import logger
 
 
@@ -45,12 +48,11 @@ class _CUDAGraphManager:
 
         self._initialized = True
 
-        # create a global cudagraph memory pool to allow memory reuse across cudagraphs.
+        # shared pool so cudagraphs can reuse memory across captures.
         self.graph_pool = torch.cuda.graph_pool_handle()
 
-        # create a global cuda stream for graph capture. we need to use a single stream
-        # for all allocations to the memory pool, otherwise the allocations to separate
-        # streams will not be used.
+        # single capture stream for the pool: allocations on other streams won't
+        # reuse it.
         self.stream = torch.cuda.Stream()
 
         # use a dummy graph to keep the global graph pool alive
@@ -324,15 +326,11 @@ def _iter_tensors(val: Any) -> list[torch.Tensor]:
     return []
 
 
-def is_cudagraphable(
-    node: torch.fx.Node, dyn_map: dict[torch.fx.Node, bool] | None = None
-) -> bool:
+def is_cudagraphable(node: torch.fx.Node) -> bool:
     """Whether ``node`` can be captured by a CUDA graph.
 
     Per-node predicate for the partitioner (:func:`cudagraph_pass`) and the
-    build-time gate (:func:`is_full_cudagraphable`). ``dyn_map``, when given, is a
-    precomputed ``{node: has_dynamic_shape(out)}`` map so the shape check is an
-    O(1) lookup instead of recomputing per consumer.
+    build-time gate (:func:`is_full_cudagraphable`).
 
     flex_attention HOPs count as cudagraphable: regional_inductor compiles them to
     Triton kernels before cudagraph, so this never sees a flex HOP at capture time.
@@ -376,12 +374,9 @@ def is_cudagraphable(
         return False
 
     # Op with a dynamic (data-dependent / unbacked-SymInt) input or output shape.
-    def _dyn(n: torch.fx.Node) -> bool:
-        if dyn_map is not None:
-            return dyn_map.get(n, False)
-        return _has_dynamic_shape(n.meta.get("val"))
-
-    if _dyn(node) or any(_dyn(inp) for inp in node.all_input_nodes):
+    if _has_dynamic_shape(node.meta.get("val")) or any(
+        _has_dynamic_shape(inp.meta.get("val")) for inp in node.all_input_nodes
+    ):
         return False
 
     # Pure-CPU op: every tensor in its inputs and output lives on CPU. A CUDA graph
@@ -400,36 +395,8 @@ def is_cudagraphable(
 def is_full_cudagraphable(gm: torch.fx.GraphModule) -> bool:
     """True if every node is cudagraphable (:func:`is_cudagraphable`), i.e. the
     graph can be captured as one full CUDA graph. Used to resolve
-    ``cudagraph_mode='auto'`` to full vs piecewise at pipeline-build time. Run on
-    the pre-inductor graph; flex counts as cudagraphable (compiled before capture),
-    matching the post-inductor reality."""
+    ``cudagraph_mode='auto'`` at pipeline-build time."""
     return all(is_cudagraphable(node) for node in gm.graph.nodes)
-
-
-def is_cudagraph_compatible(
-    gm: torch.fx.GraphModule,
-    *,
-    skip_flex_attention_check: bool = False,
-) -> bool:
-    """Whole-graph cudagraph gate: True iff the graph has no cudagraph-unsafe op.
-
-    Used by the all-or-nothing :func:`cudagraph_pass` and by
-    ``full_inductor_compilation_pass`` (which stashes its pre-collapse verdict in
-    ``gm.meta`` -- the collapse hides ops from the scan). Delegates to the per-node
-    predicate via :func:`is_full_cudagraphable`.
-
-    TODO: ``skip_flex_attention_check`` is now a no-op (flex_attention HOPs are no
-    longer flagged -- regional_inductor compiles them before cudagraph). Remove the
-    arg (and, once the all-or-nothing path is gone, this whole function) in a later
-    PR.
-    """
-    if gm.meta.get("cudagraph_compatible") is False:
-        logger.warning(
-            "Skipping cudagraph: gm.meta['cudagraph_compatible'] is False "
-            "(set by full_inductor_compilation_pass before the collapse)."
-        )
-        return False
-    return is_full_cudagraphable(gm)
 
 
 def get_static_input_indices(gm: torch.fx.GraphModule, is_forward: bool) -> list[int]:
@@ -547,7 +514,7 @@ def insert_kernel_annotations_pass(
     return gm
 
 
-def cudagraph_pass(
+def full_cudagraph_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
     *,
@@ -555,44 +522,23 @@ def cudagraph_pass(
     static_input_indices: list[int] | None = None,
     tensor_input_indices: list[int] | None = None,
 ) -> torch.fx.GraphModule:
-    """
-    Apply cudagraph.
+    """Capture the entire joint graph as one CUDA graph — the single-subgraph case
+    of :func:`cudagraph_pass`.
 
-    This pass wraps the forward function with cudagraph during compilation and does
-    not record cudagraph until runtime.
-    - For the first run, it will warm up operators such as nccl.
-    - For the second run, it will record cudagraph and replay cudagraph.
-    - For the following runs, it will replay cudagraph.
+    Wraps ``gm.forward`` with a :class:`CUDAGraphWrapper`; capture happens lazily
+    at runtime (warm up on call 1, record on call 2, replay after).
 
     Args:
         gm: The graph module to wrap.
         example_inputs: Example inputs for warmup/recording.
-        is_forward: Whether this is a forward graph (True) or backward graph
-            (False). Used to infer which inputs have stable tensor addresses
-            when ``static_input_indices`` is not provided. Defaults to True --
-            graph_trainer traces a single fwd+loss+bwd graph and always wraps it
-            as the forward.
+        is_forward: Whether to infer static-input indices as for a forward graph
+            (used only when ``static_input_indices`` is not provided).
         static_input_indices: Explicit list of input indices with stable tensor
-            addresses. When provided, ``is_forward`` is not used for inference.
-        tensor_input_indices: Indices of graph inputs that are tensors (as
-            opposed to opaque values like DeviceMesh). Used to compute which
-            inputs need copying for cudagraph replay. When not provided, this
-            is inferred from ``example_inputs``.
+            addresses (params/buffers).
+        tensor_input_indices: Indices of graph inputs that are tensors (vs opaque
+            values like DeviceMesh). When not provided, inferred from
+            ``example_inputs``.
     """
-    if not isinstance(gm, torch.fx.GraphModule):
-        raise TypeError(
-            f"cudagraph_pass requires a GraphModule but got {type(gm).__name__}. "
-            f"Ensure cudagraph is not combined with passes that replace the "
-            f"GraphModule (e.g. full_inductor_compilation)."
-        )
-
-    if not is_cudagraph_compatible(gm):
-        logger.warning(
-            "Skipping cudagraph: graph is not compatible after all preceding "
-            "passes. Use --compile.disable_passes cudagraph_pass to silence."
-        )
-        return gm
-
     if static_input_indices is None:
         static_input_indices = get_static_input_indices(gm, is_forward)
     gm.forward = CUDAGraphWrapper(
@@ -601,5 +547,292 @@ def cudagraph_pass(
         static_input_indices,
         tensor_input_indices=tensor_input_indices,
     )
-    logger.info("Applied cudagraph pass.")
+    logger.info("Applied full cudagraph pass (single capturable subgraph).")
     return gm
+
+
+def _node_module_fqn(node: torch.fx.Node) -> str | None:
+    """The ``module_fqn`` annotation on ``node`` (set by ``annotate_module_fqns``),
+    or None if unannotated."""
+    return (node.meta.get("custom") or {}).get(_MODULE_FQN)
+
+
+def _fqn_in_tainted_subtree(fqn: str | None, tainted: set[str]) -> bool:
+    """Return True if ``fqn`` names a tainted module or a descendant of one.
+
+    Membership is by dotted-prefix: a node in ``a.b.experts.w1`` is in the subtree
+    of a tainted ``a.b.experts``."""
+    if not fqn or not tainted:
+        return False
+    while fqn:
+        if fqn in tainted:
+            return True
+        fqn = fqn.rpartition(".")[0]
+    return False
+
+
+def _producer_call_node(arg: Any) -> torch.fx.Node | None:
+    """Return the ``call_module`` node that produced ``arg`` in the top-level
+    split graph, or None. Handles both single-output submodules (the arg is the
+    call node directly) and multi-output submodules (the arg is a ``getitem`` of
+    the call node)."""
+    if not isinstance(arg, torch.fx.Node):
+        return None
+    if arg.op == "call_module":
+        return arg
+    if arg.op == "call_function" and arg.target is operator.getitem:
+        parent = arg.args[0]
+        if isinstance(parent, torch.fx.Node) and parent.op == "call_module":
+            return parent
+    return None
+
+
+def _compute_partition(
+    gm: torch.fx.GraphModule, min_capture_size: int = 1
+) -> tuple[dict[torch.fx.Node, int], dict[int, bool]]:
+    """Partition the graph into contiguous eager/capturable runs in one pass.
+
+    Calls :func:`is_cudagraphable` once per node, then taints any module that
+    directly owns an unsafe op so its whole subtree runs eager (see
+    :func:`_fqn_in_tainted_subtree`) -- keeping each data-dependent module (e.g. MoE
+    routed experts + token routing) eager as one region while leaving sibling dense
+    modules capturable. Contiguous same-kind runs share one monotonic subgraph id
+    (split_module's grad/autocast requirement).
+
+    A capturable run shorter than ``min_capture_size`` is demoted to eager (a private
+    pool + per-step copy-in isn't worth a handful of ops); since such runs are always
+    flanked by eager runs, this just coalesces them (numerically neutral).
+
+    Returns ``(node_to_subgraph_id, subgraph_is_eager)``, the latter mapping each
+    subgraph id to whether it runs eager. Also stamps observability tags
+    ``node.meta["custom"]["cudagraphable"]`` and ``["cudagraph_id"]`` on each node.
+    """
+    # Per-node predicate, computed once (the hot path on large graphs).
+    unsafe_nodes: set[torch.fx.Node] = {
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function" and not is_cudagraphable(node)
+    }
+
+    # Taint the module that directly owns each unsafe op; its whole subtree runs
+    # eager. The carve granularity is exactly the unsafe node's own module_fqn --
+    # no hardcoded names, no fixed-depth truncation.
+    eager_fqns: set[str] = set()
+    for node in unsafe_nodes:
+        fqn = _node_module_fqn(node)
+        if fqn:
+            eager_fqns.add(fqn)
+
+    # A call_function node is eager if it is itself unsafe or lives in a tainted
+    # subtree; get_attr/etc. are neutral and ride whichever run they fall in.
+    real_nodes = [n for n in gm.graph.nodes if n.op not in ("placeholder", "output")]
+    node_is_eager: dict[torch.fx.Node, bool] = {}
+    for node in real_nodes:
+        if node.op == "call_function":
+            eager = node in unsafe_nodes or _fqn_in_tainted_subtree(
+                _node_module_fqn(node), eager_fqns
+            )
+        else:
+            eager = False
+        node_is_eager[node] = eager
+
+    # Demote too-small capturable runs to eager (not worth a separate CUDA graph +
+    # copy-in). Skip when there are no unsafe nodes: the whole graph is one capturable
+    # run for a full capture, and demoting it would wrongly force it eager (failing
+    # require_full).
+    if min_capture_size > 1 and unsafe_nodes:
+        i = 0
+        n = len(real_nodes)
+        while i < n:
+            j = i
+            while (
+                j < n and node_is_eager[real_nodes[j]] == node_is_eager[real_nodes[i]]
+            ):
+                j += 1
+            if not node_is_eager[real_nodes[i]] and (j - i) < min_capture_size:
+                for k in range(i, j):
+                    node_is_eager[real_nodes[k]] = True
+            i = j
+
+    # Assign contiguous-run subgraph ids from the (possibly demoted) eager status,
+    # recording each subgraph's eager/capturable kind as we go.
+    node_to_subgraph_id: dict[torch.fx.Node, int] = {}
+    subgraph_is_eager: dict[int, bool] = {}
+    subgraph_id = 0
+    prev_eager: bool | None = None
+    for node in gm.graph.nodes:
+        if node.op in ("placeholder", "output"):
+            node_to_subgraph_id[node] = subgraph_id
+            continue
+        eager = node_is_eager[node]
+        if prev_eager is None or eager != prev_eager:
+            subgraph_id += 1
+            prev_eager = eager
+        node_to_subgraph_id[node] = subgraph_id
+        subgraph_is_eager[subgraph_id] = eager
+        # Observability tags (carried onto submodule nodes by split_module):
+        # whether the op itself is cudagraph-safe, and the subgraph it lands in
+        # ("eager" for an eager region, else the captured subgraph id).
+        custom = node.meta.setdefault("custom", {})
+        custom["cudagraphable"] = node not in unsafe_nodes
+        custom["cudagraph_id"] = "eager" if eager else subgraph_id
+    return node_to_subgraph_id, subgraph_is_eager
+
+
+def cudagraph_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+    *,
+    require_full: bool = False,
+    static_input_indices: list[int] | None = None,
+    tensor_input_indices: list[int] | None = None,
+    min_capture_size: int = 1,
+) -> torch.fx.GraphModule:
+    """Capture the joint graph with CUDA graphs by partitioning it into
+    capture-safe subgraphs.
+
+    The single CUDA graph engine; a full CUDA graph is the special case where the
+    whole graph is one subgraph. It carves out eager regions (cudagraph-incompatible
+    ops -- MoE ``_grouped_mm`` on sm_90, EP token-routing, unpinned CPU<->CUDA
+    copies) from capture-safe regions, then:
+
+    - **0 eager regions** -> capture the whole graph (:func:`full_cudagraph_pass`).
+    - **>=1 eager region**: if ``require_full`` (``cudagraph_mode='full'``),
+      **raise**. Otherwise capture each safe subgraph in its own CUDA graph and run
+      the eager regions between replays (enables CUDA graph for DeepSeek-V3 on H100).
+
+    If nothing is capturable, the graph is returned un-wrapped (valid no-op). Capture
+    errors at runtime are not swallowed: they usually mean a gap in the unsafe-op
+    predicate -- fix it (or use ``cudagraph_mode='off'``) rather than run eager.
+
+    Args:
+        gm: The traced forward+backward graph module.
+        example_inputs: Example inputs (used by the single-subgraph full capture).
+        require_full: When True (explicit ``cudagraph_mode='full'``), raise if the
+            graph is not one capturable subgraph instead of partitioning.
+        static_input_indices: Top-level input indices with stable addresses
+            (params/buffers -- the leading ``num_static_inputs`` flat inputs).
+        tensor_input_indices: Top-level tensor input indices (single-subgraph full
+            capture only; per-subgraph indices are derived from node metadata).
+        min_capture_size: Capturable subgraphs with fewer than this many nodes run
+            eager instead (not worth a separate CUDA graph + per-step copy-in).
+            Default 1 captures everything.
+    """
+    # Carve out the tainted module subtrees and assign contiguous-run subgraph ids
+    # in a single pass (the predicate is the hot path, so it runs once per node).
+    node_to_subgraph_id, subgraph_is_eager = _compute_partition(
+        gm, min_capture_size=min_capture_size
+    )
+    tlparse_log_graph_pass(
+        gm,
+        graph_name="cudagraph_partition",
+        extra_meta=["cudagraphable", "cudagraph_id"],
+    )
+
+    if not any(subgraph_is_eager.values()):
+        # The whole graph is one capturable subgraph -> full CUDA graph.
+        logger.info("cudagraph: whole graph is one subgraph; applying full cudagraph.")
+        return full_cudagraph_pass(
+            gm,
+            example_inputs,
+            is_forward=True,
+            static_input_indices=static_input_indices,
+            tensor_input_indices=tensor_input_indices,
+        )
+
+    if require_full:
+        # Fail loudly rather than partition: the 'full' pipeline kept passes
+        # (bucketing, custom_codegen) that assume a single capture.
+        raise ValueError(
+            "compile.cudagraph_mode='full' but the graph is not one capturable "
+            "subgraph: it contains cudagraph-incompatible ops/blocks (e.g. MoE "
+            "_grouped_mm on sm_90, EP token-routing splits, data-dependent shapes; "
+            "see the warnings above). Use cudagraph_mode='auto' (best-effort: captures "
+            "the safe regions and runs the rest eagerly)."
+        )
+
+    if all(subgraph_is_eager.values()):
+        # Every subgraph is eager: skip the split and return the original graph
+        # (auto -> no cudagraph fallback).
+        logger.info("cudagraph: nothing capturable; running without cudagraph.")
+        return gm
+
+    # Split into per-id submodules, preserving original node order so in-place
+    # mutations (e.g. MoE counter copy_) and collectives keep their relative
+    # ordering across the eager/cudagraph boundary.
+    split_gm = split_module(
+        gm,
+        gm,
+        lambda n: node_to_subgraph_id[n],
+        keep_original_order=True,
+    )
+
+    # Classify submodules; wrap each capture-safe one in its own cudagraph.
+    placeholder_index = {
+        n: i
+        for i, n in enumerate(n for n in split_gm.graph.nodes if n.op == "placeholder")
+    }
+    # _arg_is_static relies on split_module preserving top-level input order/count
+    # (placeholder position i == original input i); assert it rather than silently
+    # misclassify static vs copy-in inputs.
+    num_orig_placeholders = sum(1 for n in gm.graph.nodes if n.op == "placeholder")
+    assert len(placeholder_index) == num_orig_placeholders, (
+        f"split_module changed the top-level input count "
+        f"({len(placeholder_index)} != {num_orig_placeholders}); "
+        f"static-input classification would be unreliable."
+    )
+
+    # split_module names each submodule "submod_<id>" with the subgraph id we
+    # returned, so we recover its kind by parsing the name (assumes no
+    # partition_affix, which we don't pass).
+    def _submod_is_cudagraphable(call_node: torch.fx.Node) -> bool:
+        subgraph_id = int(call_node.target.removeprefix("submod_"))
+        return not subgraph_is_eager[subgraph_id]
+
+    call_module_nodes = [n for n in split_gm.graph.nodes if n.op == "call_module"]
+    call_cudagraph_module_nodes = [
+        n for n in call_module_nodes if _submod_is_cudagraphable(n)
+    ]
+
+    static_set = set(static_input_indices or [])
+
+    def _arg_is_static(arg: Any) -> bool:
+        """A subgraph input is static (stable address, no copy-in) if it is a
+        param/buffer placeholder or the output of another cudagraph subgraph."""
+        if not isinstance(arg, torch.fx.Node):
+            return False
+        if arg.op == "placeholder":
+            return placeholder_index.get(arg, -1) in static_set
+        producer = _producer_call_node(arg)
+        return producer is not None and producer in call_cudagraph_module_nodes
+
+    for call_node in call_cudagraph_module_nodes:
+        submod = getattr(split_gm, call_node.target)
+        submod_placeholders = [n for n in submod.graph.nodes if n.op == "placeholder"]
+        call_args = call_node.args
+
+        seg_static_indices: list[int] = []
+        seg_tensor_indices: list[int] = []
+        for j, (arg, ph) in enumerate(zip(call_args, submod_placeholders)):
+            val = ph.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                seg_tensor_indices.append(j)
+                if _arg_is_static(arg):
+                    seg_static_indices.append(j)
+
+        # example_inputs is unused here (the wrapper only consults it when
+        # tensor_input_indices is None, which we always provide), so pass ().
+        submod.forward = CUDAGraphWrapper(
+            submod.forward,
+            (),
+            tuple(seg_static_indices),
+            tensor_input_indices=seg_tensor_indices,
+        )
+
+    num_cudagraph_subgraphs = len(call_cudagraph_module_nodes)
+    num_eager_subgraphs = len(call_module_nodes) - num_cudagraph_subgraphs
+    logger.info(
+        f"Applied piecewise cudagraph: {num_cudagraph_subgraphs} cudagraph subgraph(s), "
+        f"{num_eager_subgraphs} eager subgraph(s)."
+    )
+    return split_gm

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -225,23 +225,11 @@ def full_inductor_compilation_pass(
     decompositions, and caching for free) instead of duplicating that prep
     around a direct ``compile_fx_inner`` call.
 
-    The collapse hides cudagraph-incompatible ops (unpinned D2H copies,
-    sm<10 ``_grouped_mm``) inside the opaque ``standalone_compile_inner``
-    node, so the later :func:`is_cudagraph_compatible` scan can't see
-    them. Snapshot the verdict on the pre-collapse gm and stash it on
-    the result so the downstream scan can honor it.
-
     Must be the **terminal** pass — no FX-graph-level passes (e.g.
     ``custom_codegen_pass``, ``insert_kernel_annotations_pass``) can
     run after this because the FX graph is no longer authoritative.
     """
     import torch._inductor.config as ic
-
-    from torchtitan.experiments.graph_trainer.cudagraph import is_cudagraph_compatible
-
-    pre_collapse_cudagraph_compatible = is_cudagraph_compatible(
-        gm, skip_flex_attention_check=True
-    )
 
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():
@@ -258,9 +246,4 @@ def full_inductor_compilation_pass(
     # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.
     with ic.patch(reorder_for_peak_memory=True):
         result = regional_inductor_pass(gm, example_inputs)
-
-    # Carry the pre-collapse cudagraph verdict forward via gm.meta. The
-    # collapse is information-destroying; this is how downstream passes
-    # know whether the artifact contains hidden cudagraph-incompatible ops.
-    result.meta["cudagraph_compatible"] = pre_collapse_cudagraph_compatible
     return result

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -35,6 +35,7 @@ from torchtitan.experiments.graph_trainer.cpu_offload import apply_cpu_offload_p
 from torchtitan.experiments.graph_trainer.cudagraph import (
     cudagraph_pass,
     insert_kernel_annotations_pass,
+    is_full_cudagraphable,
 )
 from torchtitan.experiments.graph_trainer.debug_utils import (
     log_graph_diff,
@@ -103,11 +104,42 @@ def async_tensor_parallel_pass(
     return gm
 
 
+def _resolve_cudagraph_kind(
+    traced_result: "TracedResult", config: "GraphTrainer.Config"
+) -> str:
+    """Resolve the CUDA graph kind from config + the traced graph.
+
+    Returns the internal kind ``"off"``, ``"full"``, or ``"piecewise"``. (The
+    user-facing ``cudagraph_mode`` is ``off``/``auto``/``full``; ``piecewise`` is
+    only reached internally, as the fallback ``auto`` chooses.) It is the same
+    single engine either way (full == the one-piece special case of piecewise);
+    the kind only selects how the *pipeline* prepares the graph: ``piecewise``
+    skips bucketing/kernel-annotations (they conflict with
+    submodule splitting), while ``full`` keeps them. ``cudagraph_mode='auto'`` is
+    resolved to full vs piecewise via :func:`is_full_cudagraphable`.
+
+    Returns ``"off"`` when cudagraph is disabled, or when
+    ``inductor_compilation='full'`` — that path delegates CUDA graphs to Inductor
+    (there is no FX graph left for us to wrap/partition), so ``cudagraph_mode``
+    does not apply.
+    """
+    cc = config.compile
+    if cc.inductor_compilation == "full":
+        return "off"
+    if cc.cudagraph_mode == "off" or "cudagraph_pass" in cc.disable_passes:
+        return "off"
+    if cc.cudagraph_mode == "full":
+        return "full"
+    # auto: best-effort. full (one piece) if the graph has no cudagraph-unsafe op,
+    # else piecewise. (flex is excluded -- regional_inductor compiles it first.)
+    if is_full_cudagraphable(traced_result.gm):
+        return "full"
+    return "piecewise"
+
+
 def compile_time_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
-    *,
-    use_cudagraph: bool = False,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -115,8 +147,10 @@ def compile_time_passes(
     that compiled Triton kernels are baked into the artifact. Otherwise
     they run at trace time via ``construct_default_graph_passes``.
 
-    cudagraph is excluded because it needs to re-capture the graph into
-    an in-memory CUDA graph at runtime.
+    The cudagraph wrapping itself is excluded (it must re-capture at runtime), but
+    cudagraph mode does affect this list: ``piecewise`` skips bucketing and
+    kernel-annotations (they conflict with submodule splitting), while ``full``
+    keeps bucketing and adds kernel-annotations.
 
     ``joint_transformer_block_bucketing_reordering_pass`` optionally runs
     ``overlap_fsdp_ag_rs_pass`` first (gated by
@@ -130,6 +164,8 @@ def compile_time_passes(
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
+    cudagraph_kind = _resolve_cudagraph_kind(traced_result, config)
+    piecewise = cudagraph_kind == "piecewise"
     passes: list[Callable] = [
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
@@ -143,20 +179,36 @@ def compile_time_passes(
             defer_n_layers=config.compile.cpu_offload_defer_n_layers,
         ),
         selective_activation_remat_pass,
-        functools.partial(
-            joint_transformer_block_bucketing_reordering_pass,
-            module_bucket_plans=get_default_transformer_block_buckets(n_layers),
-            enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
-        ),
     ]
+    if not piecewise:
+        # Bucketing fuses FSDP collectives into ``bucketing._pre_bucket_*`` custom
+        # ops and reorders AG/RS prefetch *across* transformer blocks. It does not
+        # compose with piecewise cudagraph (verified on DSv3 FSDP+TP+EP):
+        #   1. A bucketing custom op lands in a captured segment and fails capture
+        #      with ``CUDA error: invalid argument``.
+        #   2. The cross-block prefetch reordering shatters the partition (64 vs 31
+        #      captured segments; eager op count explodes) because hoisted
+        #      collectives no longer line up with the per-block carve-out.
+        # Skip it in piecewise so captured segments contain only plain functional
+        # collectives (all_gather/reduce_scatter/all_reduce + wait), which capture
+        # fine. Trade-off: no collective bucketing/overlap in piecewise. TODO: a
+        # carve-out-aware bucketing that prefetches within (not across) captured
+        # regions and emits capture-safe ops.
+        passes.append(
+            functools.partial(
+                joint_transformer_block_bucketing_reordering_pass,
+                module_bucket_plans=get_default_transformer_block_buckets(n_layers),
+                enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
+            )
+        )
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
     inductor_compilation = config.compile.inductor_compilation
     if inductor_compilation == "full":
-        # Compile the entire graph into optimized Triton kernels. Must
-        # be terminal — the FX graph is no longer authoritative after
-        # this pass, so insert_kernel_annotations_pass cannot follow.
+        # Compile the entire graph into optimized Triton kernels. Must be
+        # terminal — the FX graph is no longer authoritative after this pass, so
+        # insert_kernel_annotations_pass cannot follow.
         passes.append(full_inductor_compilation_pass)
     if inductor_compilation == "regional":
         # FlexAttention HOPs must be compiled (via regional_inductor) to
@@ -177,7 +229,11 @@ def compile_time_passes(
 
             passes.append(annotate_rmsnorm_for_regional_inductor_pass)
         passes.append(regional_inductor_pass)
-        if use_cudagraph:
+        # Piecewise cudagraph splits the graph into submodules and wraps each
+        # capture-safe submodule's forward(); insert_kernel_annotations_pass also
+        # rebinds forward, which would clobber the cudagraph wrappers, so skip it in
+        # piecewise mode. Per-submodule annotation is a follow-up.
+        if cudagraph_kind == "full":
             # Must run before cudagraph_pass (which replaces forward()).
             passes.append(insert_kernel_annotations_pass)
     return passes
@@ -194,24 +250,37 @@ def construct_default_graph_passes(
 
     When ``precompile_artifact_dir`` is set, the artifact has graph
     transformed during precompile phase, so only cudagraph is returned.
-    """
-    want_cudagraph = "cudagraph_pass" not in config.compile.disable_passes
 
+    CUDA graph capture is controlled by ``compile.cudagraph_mode``
+    (off/auto/full/piecewise) and is delegated to Inductor when
+    ``inductor_compilation='full'``; see :func:`_resolve_cudagraph_kind`.
+    """
     has_precompile_artifact = bool(config.compile.precompile_artifact_dir)
 
     passes: list[Callable] = []
     if not has_precompile_artifact:
-        passes.extend(
-            compile_time_passes(traced_result, config, use_cudagraph=want_cudagraph)
-        )
+        passes.extend(compile_time_passes(traced_result, config))
 
-    if want_cudagraph:
+    cudagraph_kind = _resolve_cudagraph_kind(traced_result, config)
+    if cudagraph_kind != "off":
         static_input_indices = list(range(traced_result.num_static_inputs))
         passes.append(
             functools.partial(
                 cudagraph_pass,
+                # 'full' (explicit or auto-resolved) is strict: the engine must
+                # capture one piece, else raise. The kind was resolved from the
+                # PRE-inductor graph (is_full_cudagraphable); requiring full here
+                # makes the engine re-check the POST-inductor graph and fail loudly
+                # if they disagree, instead of silently splitting a graph the
+                # pipeline already prepared for a single capture (bucketing kept).
+                # In normal operation the predictor is exact, so this never fires
+                # for auto. 'piecewise' is not strict.
+                require_full=(cudagraph_kind == "full"),
                 static_input_indices=static_input_indices,
                 tensor_input_indices=traced_result.tensor_input_indices,
+                # Demote tiny capturable regions (e.g. a lone op between eager MoE
+                # blocks) to eager -- not worth a private pool + copy-in.
+                min_capture_size=config.compile.cudagraph_min_capture_size,
             )
         )
     return passes

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -25,6 +25,7 @@ def build_minimal_trainer(
     compile_enable_passes: bool = True,
     compile_passes: list[str] | None = None,
     compile_numerics_changing_optim: bool = False,
+    compile_cudagraph_mode: str = "auto",
     tokenizer=None,
     fsdp_reshard_after_forward: str = "default",
 ) -> Trainer:
@@ -49,6 +50,8 @@ def build_minimal_trainer(
                 memory_policy="default",
                 pass_pipeline="default",
                 inductor_compilation="regional",
+                cudagraph_mode=compile_cudagraph_mode,
+                cudagraph_min_capture_size=1,
                 numerics_changing_optim=compile_numerics_changing_optim,
                 disable_passes=[],
                 enable_fsdp_ag_rs_overlap=False,

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -299,8 +299,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ngpu=8,
         ),
         # === aot_fx_trace mode tests ===
-        # Note: cudagraph is auto-skipped for DSv3 because MoE load-balancing
-        # introduces CUDA→CPU transfers incompatible with CUDA graph capture.
+        # Note: cudagraph_mode defaults to 'auto', which for DSv3 resolves to
+        # *piecewise* — the MoE block (grouped_mm / EP all-to-all / data-dependent
+        # shapes) runs eager while the dense/attention regions are captured.
         #
         # TODO: FSDP+TP+CP+EP is disabled: tracing fails with "aten.add.Tensor
         # got mixed torch.Tensor and DTensor" — a separate CP+EP issue,
@@ -335,6 +336,24 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+FlexAttn",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_flexattn",
+            ngpu=8,
+        ),
+        # Piecewise CUDA graph (cudagraph_mode=auto -> piecewise): the MoE block
+        # runs eager, the dense/attention regions are captured. Guards the
+        # distributed piecewise capture path for DSv3 + EP.
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel_ep",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 4",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 FSDP+TP+EP (piecewise cudagraph)",
+            "aot_fx_trace_deepseek_v3_fsdp_tp_ep_piecewise",
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -81,6 +81,8 @@ class BitwiseDeterministicBase(unittest.TestCase):
     annotate_model: Callable
     model_flavor: str
     attn_backend: str = "sdpa"
+    # cudagraph mode for the traced runs; subclasses override (Llama3 -> "full").
+    cudagraph_mode: str = "auto"
 
     def setUp(self):
         # Disable max_autotune for FlexAttention to ensure bitwise-identical
@@ -144,8 +146,11 @@ class BitwiseDeterministicBase(unittest.TestCase):
         *,
         enable_passes: bool = True,
         numerics_changing_optim: bool = False,
+        cudagraph_mode: str | None = None,
     ) -> tuple[torch.Tensor, str, str]:
         """Run forward-backward-optimizer steps using the given trainer class."""
+        if cudagraph_mode is None:
+            cudagraph_mode = self.cudagraph_mode
         # Annotate after deepcopy: annotate_fn wrappers capture bound methods
         # that don't rebind correctly through copy.deepcopy.
         self.annotate_model(model)
@@ -155,6 +160,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
             trainer_cls,
             compile_enable_passes=enable_passes,
             compile_numerics_changing_optim=numerics_changing_optim,
+            compile_cudagraph_mode=cudagraph_mode,
             tokenizer=HuggingFaceTokenizer(tokenizer_path=_TOKENIZER_PATH),
         )
         global_valid_tokens = torch.tensor(
@@ -174,7 +180,11 @@ class BitwiseDeterministicBase(unittest.TestCase):
         return loss.detach().clone(), hash_model(model), hash_gradient(model)
 
     def _run_steps_with_precompile(
-        self, model: nn.Module, *, enable_passes: bool = True
+        self,
+        model: nn.Module,
+        *,
+        enable_passes: bool = True,
+        cudagraph_mode: str | None = None,
     ) -> tuple[torch.Tensor, str, str]:
         """Run steps using the precompile save/load path.
 
@@ -183,6 +193,8 @@ class BitwiseDeterministicBase(unittest.TestCase):
         the loaded artifact — identical to what happens during
         torchrun training with --compile.precompile_artifact_dir.
         """
+        if cudagraph_mode is None:
+            cudagraph_mode = self.cudagraph_mode
         from torchtitan.experiments.graph_trainer.make_fx_tracer import (
             minimal_fx_tracer,
             run_traced,
@@ -230,6 +242,8 @@ class BitwiseDeterministicBase(unittest.TestCase):
                 compile=SimpleNamespace(
                     memory_policy="default",
                     inductor_compilation="regional",
+                    cudagraph_mode=cudagraph_mode,
+                    disable_passes=[],
                     numerics_changing_optim=False,
                     cpu_offload_prefetch_n_layers=1,
                     cpu_offload_defer_n_layers=1,
@@ -263,7 +277,10 @@ class BitwiseDeterministicBase(unittest.TestCase):
                 compile=SimpleNamespace(
                     precompile_artifact_dir="precompiled",
                     inductor_compilation="regional",
+                    cudagraph_mode=cudagraph_mode,
+                    cudagraph_min_capture_size=1,
                     disable_passes=[],
+                    debug_graph_passes=False,
                 ),
             )
             passes = construct_default_graph_passes(loaded_result, load_config)
@@ -322,6 +339,8 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
     model_registry = staticmethod(llama3_model_registry)
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_llama)
+    # Llama3 is dense/fully cudagraph-capturable: exercise the full-capture path.
+    cudagraph_mode = "full"
 
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
@@ -443,6 +462,8 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_llama)
+    # Llama3 is dense/fully cudagraph-capturable: exercise the full-capture path.
+    cudagraph_mode = "full"
 
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -6,6 +6,7 @@
 
 import operator
 import sys
+import unittest
 from unittest.mock import patch
 
 import torch
@@ -27,6 +28,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     annotate_module_fqns,
 )
 from torchtitan.experiments.graph_trainer.cudagraph import (
+    _fqn_in_tainted_subtree,
+    cudagraph_pass,
+    CUDAGraphWrapper,
     insert_kernel_annotations_pass,
     is_cudagraphable,
     is_full_cudagraphable,
@@ -896,6 +900,38 @@ class TestBucketingPrefetchOrder(FSDPTest):
                 f"layer {backward_ids[i]} after layer {backward_ids[i - 1]} "
                 f"(full order: {layer_ids})",
             )
+
+
+class TestEliminateDeadCodePass(TestCase):
+    """Unit tests for eliminate_dead_code_pass."""
+
+    def test_removes_dead_pure_node_keeps_live(self):
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        live = g.call_function(torch.ops.aten.relu.default, (x,))
+        g.call_function(torch.ops.aten.add.Tensor, (x, x))  # dead: no users
+        g.output(live)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+        eliminate_dead_code_pass(gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertIn(torch.ops.aten.relu.default, targets)
+        self.assertNotIn(torch.ops.aten.add.Tensor, targets)
+
+    def test_keeps_impure_node_with_no_users(self):
+        # copy_ mutates its first arg (impure); DCE must keep it even though its
+        # own result is unused.
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        y = g.placeholder("y")
+        g.call_function(torch.ops.aten.copy_.default, (x, y))  # impure, unused result
+        out = g.call_function(torch.ops.aten.relu.default, (x,))
+        g.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+        eliminate_dead_code_pass(gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertIn(torch.ops.aten.copy_.default, targets)
 
 
 class TestRemoveDetachPass(TestCase):
@@ -2256,36 +2292,247 @@ class TestSelectiveActivationRematPass(TestCase):
             self.assertIs(inp, bwd_wait)
 
 
-class TestEliminateDeadCodePass(TestCase):
-    """Unit tests for eliminate_dead_code_pass."""
+@unittest.skipUnless(torch.cuda.is_available(), "piecewise cudagraph requires CUDA")
+class TestPiecewiseCudagraphPass(TestCase):
+    """cudagraph_pass must split a graph at cudagraph-unsafe ops (here CPU<->CUDA
+    copies, which are unsafe on any device), wrap each capture-safe region in its
+    own CUDA graph, leave the unsafe ops eager, and replay bitwise-identically to
+    eager across capture and several steps. ``require_full`` (cudagraph_mode=full)
+    must instead raise when the graph is not one capturable subgraph."""
 
-    def test_removes_dead_pure_node_keeps_live(self):
-        g = torch.fx.Graph()
-        x = g.placeholder("x")
-        live = g.call_function(torch.ops.aten.relu.default, (x,))
-        g.call_function(torch.ops.aten.add.Tensor, (x, x))  # dead: no users
-        g.output(live)
-        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    def tearDown(self):
+        # Free captured graphs/private pools and reset the global manager so
+        # other tests can still register cudagraph wrappers in this process.
+        from torchtitan.experiments.graph_trainer import cudagraph as cg
 
-        eliminate_dead_code_pass(gm)
-        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
-        self.assertIn(torch.ops.aten.relu.default, targets)
-        self.assertNotIn(torch.ops.aten.add.Tensor, targets)
+        cg.cudagraph_teardown()
+        cg._cg_manager = cg._CUDAGraphManager()
+        super().tearDown()
 
-    def test_keeps_impure_node_with_no_users(self):
-        # copy_ mutates its first arg (impure); DCE must keep it even though its
-        # own result is unused.
-        g = torch.fx.Graph()
-        x = g.placeholder("x")
-        y = g.placeholder("y")
-        g.call_function(torch.ops.aten.copy_.default, (x, y))  # impure, unused result
-        out = g.call_function(torch.ops.aten.relu.default, (x,))
-        g.output(out)
-        gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    @staticmethod
+    def _wrapped_submodules(split_gm):
+        return [
+            m
+            for _, m in split_gm.named_children()
+            if isinstance(m, torch.fx.GraphModule)
+            and isinstance(getattr(m, "forward", None), CUDAGraphWrapper)
+        ]
 
-        eliminate_dead_code_pass(gm)
-        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
-        self.assertIn(torch.ops.aten.copy_.default, targets)
+    def test_split_and_replay_matches_eager(self):
+        device = "cuda"
+        dim, batch = 8, 4
+
+        def fn(w1, w2, x):
+            h = torch.relu(x @ w1)  # safe subgraph (CUDA only)
+            # Unsafe: cuda->cpu then cpu->cuda round trip (two _to_copy ops).
+            s = h.sum().to("cpu").to(device)
+            return torch.relu((h + s) @ w2)  # safe subgraph (CUDA only)
+
+        w1 = torch.randn(dim, dim, device=device)
+        w2 = torch.randn(dim, dim, device=device)
+        x = torch.randn(batch, dim, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(w1, w2, x)
+
+        # Indices 0,1 (w1,w2) are params (stable addresses); index 2 (x) is a
+        # user input that must be copied in each step.
+        split_gm = cudagraph_pass(
+            gm, (), static_input_indices=[0, 1], tensor_input_indices=[0, 1, 2]
+        )
+
+        # require_full=True on this (incompatible) graph must raise — full is the
+        # one-subgraph special case and this graph is not one subgraph.
+        gm_full = make_fx(fn, tracing_mode="fake")(w1, w2, x)
+        with self.assertRaises(ValueError):
+            cudagraph_pass(
+                gm_full,
+                (),
+                require_full=True,
+                static_input_indices=[0, 1],
+                tensor_input_indices=[0, 1, 2],
+            )
+
+        # Two CUDA-only safe regions captured; the unsafe ops stay eager.
+        self.assertEqual(len(self._wrapped_submodules(split_gm)), 2)
+
+        # Capture + replay must match eager over several steps with a fresh x
+        # each step (exercises copy-in for the user input and the eager-produced
+        # scalar, and cross-subgraph static reuse of the first region's output).
+        for _ in range(4):
+            x = torch.randn(batch, dim, device=device)
+            torch.testing.assert_close(split_gm(w1, w2, x), fn(w1, w2, x))
+
+    def test_min_capture_size_demotes_small_subgraphs(self):
+        # Same graph as above: two ~3-op capturable regions around an eager copy.
+        device = "cuda"
+        dim, batch = 8, 4
+
+        def fn(w1, w2, x):
+            h = torch.relu(x @ w1)
+            s = h.sum().to("cpu").to(device)
+            return torch.relu((h + s) @ w2)
+
+        w1 = torch.randn(dim, dim, device=device)
+        w2 = torch.randn(dim, dim, device=device)
+        x = torch.randn(batch, dim, device=device)
+
+        # min_capture_size larger than every capturable region -> all demoted to
+        # eager -> nothing captured, original graph returned un-wrapped.
+        gm = make_fx(fn, tracing_mode="fake")(w1, w2, x)
+        out = cudagraph_pass(
+            gm,
+            (),
+            static_input_indices=[0, 1],
+            tensor_input_indices=[0, 1, 2],
+            min_capture_size=1000,
+        )
+        self.assertEqual(len(self._wrapped_submodules(out)), 0)
+        for _ in range(3):
+            x = torch.randn(batch, dim, device=device)
+            torch.testing.assert_close(out(w1, w2, x), fn(w1, w2, x))
+
+    def test_min_capture_size_partial_demotion(self):
+        # A large capturable region, then an eager CPU<->CUDA copy, then a tiny
+        # (1-op) capturable region. With a threshold between the two, only the small
+        # trailing region is demoted: the big one stays captured. Exercises the
+        # demotion interacting with contiguity/subgraph-id reassignment (not the
+        # all-or-nothing extremes the other tests cover), plus replay correctness.
+        device = "cuda"
+        dim, batch = 8, 4
+
+        def fn(w1, x):
+            h = x @ w1
+            for _ in range(8):
+                h = torch.relu(h)  # big capturable region (mm + 8 relu + sum)
+            s = h.sum().to("cpu").to(device)  # eager: CPU<->CUDA round trip
+            return h + s  # tiny trailing capturable region (1 op) -> demoted
+
+        w1 = torch.randn(dim, dim, device=device)
+        x = torch.randn(batch, dim, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(w1, x)
+
+        split_gm = cudagraph_pass(
+            gm,
+            (),
+            static_input_indices=[0],
+            tensor_input_indices=[0, 1],
+            min_capture_size=4,
+        )
+        # Exactly the big region is captured; the 1-op trailing region runs eager.
+        self.assertEqual(len(self._wrapped_submodules(split_gm)), 1)
+        for _ in range(4):
+            x = torch.randn(batch, dim, device=device)
+            torch.testing.assert_close(split_gm(w1, x), fn(w1, x))
+
+    def test_no_unsafe_ops_falls_back_to_whole_graph(self):
+        device = "cuda"
+        dim, batch = 8, 4
+
+        def fn(w1, x):
+            return torch.relu(x @ w1)
+
+        w1 = torch.randn(dim, dim, device=device)
+        x = torch.randn(batch, dim, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(w1, x)
+
+        out_gm = cudagraph_pass(
+            gm, (), static_input_indices=[0], tensor_input_indices=[0, 1]
+        )
+
+        # No unsafe ops -> full (single-subgraph) cudagraph: the top-level forward is
+        # wrapped and no child submodules are created.
+        self.assertIsInstance(out_gm.forward, CUDAGraphWrapper)
+        self.assertEqual(len(self._wrapped_submodules(out_gm)), 0)
+        for _ in range(4):
+            x = torch.randn(batch, dim, device=device)
+            torch.testing.assert_close(out_gm(w1, x), fn(w1, x))
+
+    @staticmethod
+    def _clean_gm():
+        return make_fx(lambda w, x: torch.relu(x @ w), tracing_mode="fake")(
+            torch.randn(8, 8, device="cuda"), torch.randn(4, 8, device="cuda")
+        )
+
+    @staticmethod
+    def _unsafe_gm():
+        def fn(w, x):  # CPU<->CUDA copy makes it not one subgraph
+            h = torch.relu(x @ w)
+            return h + h.sum().to("cpu").to("cuda")
+
+        return make_fx(fn, tracing_mode="fake")(
+            torch.randn(8, 8, device="cuda"), torch.randn(4, 8, device="cuda")
+        )
+
+    def test_is_full_cudagraphable(self):
+        self.assertTrue(is_full_cudagraphable(self._clean_gm()))
+        self.assertFalse(is_full_cudagraphable(self._unsafe_gm()))
+
+    def test_resolve_cudagraph_kind(self):
+        from types import SimpleNamespace
+
+        from torchtitan.experiments.graph_trainer.passes import _resolve_cudagraph_kind
+
+        def cfg(mode, inductor="regional", disable=()):
+            return SimpleNamespace(
+                compile=SimpleNamespace(
+                    cudagraph_mode=mode,
+                    inductor_compilation=inductor,
+                    disable_passes=list(disable),
+                )
+            )
+
+        clean = SimpleNamespace(gm=self._clean_gm())
+        unsafe = SimpleNamespace(gm=self._unsafe_gm())
+        self.assertEqual(_resolve_cudagraph_kind(clean, cfg("off")), "off")
+        self.assertEqual(_resolve_cudagraph_kind(clean, cfg("full")), "full")
+        # auto: one subgraph -> full; not one subgraph -> piecewise.
+        self.assertEqual(_resolve_cudagraph_kind(clean, cfg("auto")), "full")
+        self.assertEqual(_resolve_cudagraph_kind(unsafe, cfg("auto")), "piecewise")
+        # inductor_compilation=full delegates to Inductor -> our kind is off.
+        self.assertEqual(
+            _resolve_cudagraph_kind(clean, cfg("auto", inductor="full")), "off"
+        )
+        # disable_passes is an escape hatch.
+        self.assertEqual(
+            _resolve_cudagraph_kind(clean, cfg("auto", disable=["cudagraph_pass"])),
+            "off",
+        )
+
+    def test_nothing_capturable_returns_unwrapped(self):
+        # Only a CPU<->CUDA copy, no capturable CUDA compute -> 0 captured ->
+        # the original graph is returned un-wrapped (no cudagraph).
+        gm = make_fx(lambda x: x.to("cpu"), tracing_mode="fake")(
+            torch.randn(4, device="cuda")
+        )
+        out = cudagraph_pass(gm, (), static_input_indices=[], tensor_input_indices=[0])
+        self.assertIs(out, gm)
+        self.assertNotIsInstance(out.forward, CUDAGraphWrapper)
+        self.assertEqual(len(self._wrapped_submodules(out)), 0)
+
+
+class TestFqnInTaintedSubtree(TestCase):
+    """Pure-logic tests for the module-subtree carve-out membership: a node is
+    eager if its FQN is a tainted module or a descendant of one. The granularity
+    is whatever the unsafe nodes' own ``module_fqn`` annotations give -- no
+    hardcoded names, no fixed FQN-depth truncation."""
+
+    def test_subtree_membership(self):
+        tainted = {"layers.1.moe.experts", "layers.3.moe.experts"}
+        # The tainted module itself, and any descendant, are in the subtree.
+        self.assertTrue(_fqn_in_tainted_subtree("layers.1.moe.experts", tainted))
+        self.assertTrue(_fqn_in_tainted_subtree("layers.1.moe.experts.w1", tainted))
+        # Sibling dense modules are NOT carved out (the whole point of the refinement).
+        self.assertFalse(
+            _fqn_in_tainted_subtree("layers.1.moe.shared_experts", tainted)
+        )
+        self.assertFalse(_fqn_in_tainted_subtree("layers.1.moe.router.gate", tainted))
+        self.assertFalse(_fqn_in_tainted_subtree("layers.1.moe", tainted))
+        self.assertFalse(_fqn_in_tainted_subtree("layers.1.attention.wq", tainted))
+        # A prefix that only shares a string fragment (not a dotted ancestor) is out.
+        self.assertFalse(_fqn_in_tainted_subtree("layers.1.moe.experts_extra", tainted))
+        # Unannotated / empty FQN and empty taint set are never in a subtree.
+        self.assertFalse(_fqn_in_tainted_subtree(None, tainted))
+        self.assertFalse(_fqn_in_tainted_subtree("", tainted))
+        self.assertFalse(_fqn_in_tainted_subtree("layers.1.moe.experts", set()))
 
 
 class TestIsFullCudagraphable(TestCase):
@@ -2303,7 +2550,7 @@ class TestIsFullCudagraphable(TestCase):
 
     def test_local_scalar_dense_is_unsafe(self):
         # _local_scalar_dense (.item()/.tolist()) extracts a host scalar a CUDA
-        # graph replay can't reproduce -> unsafe, so the graph is not one piece.
+        # graph replay can't reproduce -> unsafe, so the graph is not one subgraph.
         g = torch.fx.Graph()
         x = g.placeholder("x")
         s = g.call_function(torch.ops.aten._local_scalar_dense.default, (x,))

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -253,17 +253,6 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
 class TestCudagraphPass(unittest.TestCase):
     """Test cudagraph_pass behavior."""
 
-    def test_non_graphmodule_raises(self):
-        """cudagraph_pass rejects non-GraphModule callables (e.g.
-        OutputCode from full_inductor_compilation)."""
-        from torchtitan.experiments.graph_trainer.passes import cudagraph_pass
-
-        def plain_fn(*args):
-            return args
-
-        with self.assertRaisesRegex(TypeError, "requires a GraphModule"):
-            cudagraph_pass(plain_fn, (torch.zeros(4),), static_input_indices=[0])
-
     def test_graphmodule_wraps_forward(self):
         """cudagraph_pass wraps gm.forward with CUDAGraphWrapper."""
         from torchtitan.experiments.graph_trainer.passes import cudagraph_pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3548
* #3547
* #3546
* #3545
* #3544
* #3536
* #3535
* #3533

Make cudagraph_pass a single partitioning engine: split the joint fwd+loss+bwd
graph into eager regions (modules owning a cudagraph-unsafe op) and capture-safe
regions, capture each safe region in its own CUDA graph, and run the eager
regions between replays. A full CUDA graph is the special case of one subgraph.
Enables CUDA graphs for DeepSeek-V3 on H100, where MoE _grouped_mm / EP
token-routing / data-dependent shapes block a whole-graph capture.

- _compute_partition: taints the module subtree owning each unsafe op
  (_fqn_in_tainted_subtree; granularity from the unsafe node's own module_fqn --
  no hardcoded names), demotes capturable runs below min_capture_size to eager,
  and assigns contiguous-run subgraph ids.
- cudagraph_pass: 0 eager regions -> one full capture (full_cudagraph_pass);
  >=1 -> split_module + wrap each capture-safe submodule. Cross-subgraph
  cudagraph->cudagraph edges are static (no copy-in); user/eager-produced inputs
  are copied in. require_full raises for cudagraph_mode='full'. Submodules are
  classified by split_module's "submod_<id>" name (the subgraph id), not metadata.
- config cudagraph_mode (off/auto/full) + cudagraph_min_capture_size; passes
  _resolve_cudagraph_kind wires it (piecewise skips bucketing/custom_codegen/
  kernel-annotations). Removes is_cudagraph_compatible + the full_inductor stash
  (resolve returns 'off' for inductor_compilation='full', delegating to Inductor).

Perf (DSv3 16B, 8xH100, FSDP dp=4/tp=2/ep=2, aot_fx_trace, 20 steps, steady
state): piecewise cudagraph 109.94 TFLOPS / 6,072 tps / 11.12% MFU / 60.5 GiB
vs no cudagraph 76.97 TFLOPS / 4,251 tps / 7.78% MFU / 51.8 GiB -- ~1.43x
throughput for +8.7 GiB (53 cudagraph + 52 eager subgraphs).

Tests: TestPiecewiseCudagraphPass (split/capture/replay, require_full raise,
min_capture_size demotion), TestFqnInTaintedSubtree; integration entry for DSv3
FSDP+TP+EP; bitwise determinism for the piecewise (DSv3/Qwen3) and full (Llama3)
paths.