### PR TITLE
[graph_trainer] Preserve DTensor shape in SimpleFSDP rewrap

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
+from torch._prims_common import make_contiguous_strides_for
 
 from torch.distributed._tensor import (
     distribute_tensor,
@@ -22,6 +23,7 @@ from torch.distributed._tensor import (
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
+from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
 
 from torchtitan.protocols.module import Module
@@ -201,8 +203,18 @@ class ReplicateComputation(Module):
             dp_mesh = self.device_mesh
             # re-wrap 2D DTensor to 1D DTensor on dp_mesh for efficient FSDP all-gather
             sharded_local_tensor = x.to_local()
+            non_dp_placements = tuple(x._spec.placements[-non_dp_mesh_dims:])
+            dp_global_shape, _ = compute_local_shape_and_global_offset(
+                x._spec.tensor_meta.shape,
+                x._spec.mesh,
+                [Replicate()] * dp_mesh.ndim + list(non_dp_placements),
+            )
             sharded_dtensor = DTensor.from_local(
-                sharded_local_tensor, dp_mesh, self.param_sharding
+                sharded_local_tensor,
+                dp_mesh,
+                self.param_sharding,
+                shape=torch.Size(dp_global_shape),
+                stride=make_contiguous_strides_for(dp_global_shape),
             )
 
             # the actual FSDP's fwd all-gather & bwd reduce-scatter
@@ -219,7 +231,6 @@ class ReplicateComputation(Module):
                 grad_placements=self.grad_placements
             )
 
-            non_dp_placements = tuple(x._spec.placements[-non_dp_mesh_dims:])
             non_dp_mesh_dim_names = tuple(
                 x._spec.mesh.mesh_dim_names[-non_dp_mesh_dims:]
             )

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -10,10 +10,17 @@ from unittest.mock import patch
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from torch.distributed._tensor import DTensor, Replicate, Shard, distribute_tensor
+from torch.distributed.device_mesh import init_device_mesh
 
 from torchtitan.config.configs import TrainingConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+from torchtitan.experiments.graph_trainer.simple_fsdp import (
+    _distribute_dtensor,
+    MixedPrecisionPolicy,
+    ReplicateComputation,
+)
 
 
 class TestApplySimpleFSDPSingleRank(unittest.TestCase):
@@ -73,6 +80,56 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         x = torch.randn(2, 8, dtype=torch.bfloat16)
         y = model(x)
         self.assertEqual(y.dtype, torch.bfloat16)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestReplicateComputationUnevenShard(unittest.TestCase):
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _run_rms_norm_weight_replicate_compute(self, *, dp: int, tp: int) -> None:
+        dim = 256
+        dist.init_process_group("fake", rank=0, world_size=dp * tp)
+        mesh = init_device_mesh(
+            "cuda",
+            (dp, tp),
+            mesh_dim_names=("dp_shard", "tp"),
+        )
+        tp_mesh = mesh["tp"]
+        dp_mesh = mesh["dp_shard"]
+
+        param = _distribute_dtensor(
+            distribute_tensor(
+                torch.randn(dim, device="cuda"),
+                tp_mesh,
+                [Replicate()],
+            ),
+            dp_mesh,
+            [Shard(0)],
+        )
+        rc = ReplicateComputation(
+            dp_mesh,
+            (Shard(0),),
+            "fully_shard",
+            MixedPrecisionPolicy(),
+        )
+
+        weight = rc.replicate_compute(param)
+        weight_local = weight.to_local() if isinstance(weight, DTensor) else weight
+        self.assertEqual(weight_local.shape, (dim,))
+
+        input = torch.randn(4, dim, device="cuda")
+        torch.rms_norm(input, (dim,), weight_local, 1e-5)
+
+    def test_rms_norm_weight_unpads_uneven_dp_tp_shard(self):
+        for dp, tp in ((3, 2), (9, 8)):
+            with self.subTest(dp=dp, tp=tp):
+                try:
+                    self._run_rms_norm_weight_replicate_compute(dp=dp, tp=tp)
+                finally:
+                    if dist.is_initialized():
+                        dist.destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SimpleFSDP's multi-dimensional mesh path rewraps the local shard on the DP mesh before running the FSDP all-gather. When the DP shard is uneven, that local shard is padded for uniform collectives. Calling DTensor.from_local without explicit metadata makes DTensor infer the logical global shape from the padded local size, so a llama debug RMSNorm weight of 256 becomes 258 for dp=3,tp=2 and 261 for dp=9,tp=8.

Preserve the original DTensor shape metadata across this rewrap by computing the logical DP-global shape after accounting for the non-DP mesh placements, then passing that shape and a contiguous stride to DTensor.from_local. This keeps the all-gather in DTensor's normal redistribute path while preventing padded collective rows from becoming part of the logical parameter shape. The EP case computes the DP-global/non-DP-local shape, for example 256 experts with EP=8 becomes 32 experts on the collapsed DP mesh.

Test Plan:

```bash
python -m unittest torchtitan.experiments.graph_trainer.tests.test_simple_fsdp.TestReplicateComputationUnevenShard.test_rms_norm_weight_unpads_uneven_dp_tp_shard -v
# Verified before the fix: fails with torch.Size([258]) for dp=3,tp=2 and torch.Size([261]) for dp=9,tp=8.
```

```bash
python -m unittest torchtitan.experiments.graph_trainer.tests.test_simple_fsdp -v
```

```bash
python - <<'PY'
import torch
import torch.distributed as dist
from torch.distributed._tensor import DTensor, Shard, distribute_tensor
from torch.distributed.device_mesh import init_device_mesh
from torchtitan.experiments.graph_trainer.simple_fsdp import _distribute_dtensor, MixedPrecisionPolicy, ReplicateComputation

EP, DP, E_TOTAL, F, D = 8, 9, 256, 4, 4
dist.init_process_group('fake', rank=0, world_size=EP * DP)
mesh = init_device_mesh('cuda', (DP, EP), mesh_dim_names=('dp_shard', 'ep'))
param = _distribute_dtensor(
    distribute_tensor(torch.randn(E_TOTAL, F, D, device='cuda'), mesh['ep'], [Shard(0)]),
    mesh['dp_shard'],
    [Shard(0)],
)
out = ReplicateComputation(mesh['dp_shard'], (Shard(0),), 'fully_shard', MixedPrecisionPolicy()).replicate_compute(param)
local = out.to_local() if isinstance(out, DTensor) else out
print('out global', tuple(out.shape) if isinstance(out, DTensor) else tuple(out.shape))
print('local', tuple(local.shape))
dist.destroy_process_group()
PY
# out global (256, 4, 4)
# local (32, 4, 4)
```

```bash
black --check torchtitan/experiments/graph_trainer/simple_fsdp.py torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
```

`lintrunner -a` was attempted but this checkout has no `.lintrunner.toml`, so it cannot run here. `pre-commit` is not installed in the active environment and no nearby `.venv` exists.

Authored with assistance from an AI assistant.