### PR TITLE
[qwen3] Round-trip dense and MoE HF adapters

### DIFF
--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Bit-exact HuggingFace checkpoint adapter tests.
+
+torchtitan ships per-model ``StateDictAdapter`` implementations that map
+between its native state dict layout and the HuggingFace safetensors
+layout. Every transformation those adapters perform — key rename, RoPE
+permutation, fused-vs-separate QKV repack, weight tying — is by design a
+pure tensor reshuffle (no arithmetic, no dtype change). The adapter-level
+checkpoint round-trip (native -> HF -> native) must therefore reconstruct
+the native state dict **bit-for-bit**.
+
+This test catches conversion bugs that drop keys, change tensor metadata,
+or lose values across the adapter boundary. It also writes the HF-format
+dict to safetensors after ``from_hf`` consumes it, catching unserializable
+adapter output and ``from_hf`` input mutations that leave the HF dict
+invalid for checkpointing.
+
+Per model+flavor under test:
+
+1. Build the model on CPU with random init; capture native state dict.
+2. ``to_hf`` it once → ``hf_first``.
+3. Round-trip ``from_hf(hf_first)`` → ``tt_back``.
+
+Then two assertions:
+
+* **Native-side bit equality**: ``torch.equal(orig, tt_back)`` for every
+  key. Catches loss across ``to_hf`` followed by ``from_hf``.
+* **HF-side serialization**: serialize ``hf_first`` to safetensors.
+  Catches adapter output that cannot be saved as an HF checkpoint.
+"""
+
+import importlib
+import os
+import tempfile
+import unittest
+
+import safetensors.torch
+import torch
+
+
+# (model_name, flavor) pairs that exercise distinct adapter code paths.
+# Every registered decoder-family adapter has a "debugmodel" flavor that
+# constructs a tiny config suitable for CPU unit tests. New models are
+# added here as their adapters are audited and any round-trip bugs they
+# expose are fixed in their own diffs.
+_MODEL_FLAVORS = [
+    # llama3: vanilla GQA, separate QKV. Baseline correct adapter.
+    ("llama3", "debugmodel"),
+    # llama3: fused-QKV path, exercises fused_to_separate_qkv /
+    # separate_to_fused_qkv.
+    ("llama3", "debugmodel_fused_qkv"),
+]
+
+
+def _build_model_and_adapter(model_name: str, flavor: str):
+    """Construct a CPU-initialized model and its state_dict adapter."""
+    model_module = importlib.import_module(f"torchtitan.models.{model_name}")
+    spec = model_module.model_registry(flavor)
+    model_config = spec.model
+    with torch.device("cpu"):
+        model = model_config.build()
+    model.to_empty(device="cpu")
+    model.init_weights(buffer_device=torch.device("cpu"))
+    adapter = spec.state_dict_adapter(model_config, hf_assets_path=None)
+    return model, adapter
+
+
+class TestHFCheckpointRoundtrip(unittest.TestCase):
+    """End-to-end HF checkpoint round-trip is bit-exact in both formats."""
+
+    def _assert_roundtrip(self, model_name: str, flavor: str) -> None:
+        model, adapter = _build_model_and_adapter(model_name, flavor)
+        tt_orig = model.state_dict()
+
+        # native -> HF
+        hf_first = adapter.to_hf(tt_orig)
+        # HF -> native
+        tt_back = adapter.from_hf(hf_first)
+
+        # ---- Native-side: tt_back must equal tt_orig key-for-key, bit-for-bit.
+        missing = tt_orig.keys() - tt_back.keys()
+        extra = tt_back.keys() - tt_orig.keys()
+        self.assertFalse(
+            missing or extra,
+            f"{model_name}/{flavor}: native key set diverged "
+            f"missing={sorted(missing)} extra={sorted(extra)}",
+        )
+        for fqn, orig_tensor in tt_orig.items():
+            back_tensor = tt_back[fqn]
+            self.assertEqual(
+                orig_tensor.shape,
+                back_tensor.shape,
+                f"{model_name}/{flavor}: native shape diverged for {fqn}: "
+                f"{tuple(orig_tensor.shape)} vs {tuple(back_tensor.shape)}",
+            )
+            self.assertEqual(
+                orig_tensor.dtype,
+                back_tensor.dtype,
+                f"{model_name}/{flavor}: native dtype diverged for {fqn}: "
+                f"{orig_tensor.dtype} vs {back_tensor.dtype}",
+            )
+            if not torch.equal(orig_tensor, back_tensor):
+                max_abs_diff = (
+                    (orig_tensor.to(torch.float64) - back_tensor.to(torch.float64))
+                    .abs()
+                    .max()
+                    .item()
+                )
+                self.fail(
+                    f"{model_name}/{flavor}: native bitwise mismatch at "
+                    f"{fqn} (max|Δ|={max_abs_diff:.3e}, "
+                    f"shape={tuple(orig_tensor.shape)})"
+                )
+
+        # ---- HF-side: the produced HF dict must be safetensors-serializable.
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "model.safetensors")
+            safetensors.torch.save_file(hf_first, path)
+
+    def test_roundtrip_is_bit_exact(self) -> None:
+        for model_name, flavor in _MODEL_FLAVORS:
+            with self.subTest(model_name=model_name, flavor=flavor):
+                self._assert_roundtrip(model_name, flavor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -36,8 +36,10 @@ Then two assertions:
 
 import importlib
 import os
+import re
 import tempfile
 import unittest
+from copy import deepcopy
 
 import safetensors.torch
 import torch
@@ -54,14 +56,43 @@ _MODEL_FLAVORS = [
     # llama3: fused-QKV path, exercises fused_to_separate_qkv /
     # separate_to_fused_qkv.
     ("llama3", "debugmodel_fused_qkv"),
+    # llama4: interleaved dense + MoE decoder. Exercises shape-suffix MoE keys
+    # (w1_EFD / w2_EDF / w3_EFD), dense FF mappings on non-MoE layers, and
+    # expert_bias_E reinit (see _NATIVE_EXCLUSIONS).
+    ("llama4", "debugmodel"),
+]
+
+# Native-side keys (or regex patterns) excluded from the bitwise comparison,
+# keyed by (model_name, flavor). Every exclusion MUST have a comment that
+# explains why the key cannot round-trip exactly through HF format — these
+# are intentional design carve-outs, not unexplained skips.
+_NATIVE_EXCLUSIONS: dict[tuple[str, str], list[str]] = {
+    # llama4: `moe.expert_bias_E` is auxiliary-loss-free load-balancing bias
+    # (DeepSeek paper, adapted for Qwen/Mixtral-style routers including
+    # llama4). HF transformers' Llama4 router has no equivalent buffer
+    # (Llama4Router is plain nn.Linear with bias=False), so there is no
+    # HF key to map to. The adapter intentionally drops it on to_hf
+    # (matches HF format) and reinitializes it to zeros on from_hf
+    # (preserves the key set). The bias therefore does not survive an HF
+    # round-trip by design; the optimizer pre-hook recomputes it during
+    # training. Resuming from an HF checkpoint loses any accumulated bias.
+    ("llama4", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
+}
+
+_MOE_LOAD_BALANCE_OPTIONAL_FLAVORS = [
+    ("llama4", "debugmodel"),
 ]
 
 
-def _build_model_and_adapter(model_name: str, flavor: str):
+def _build_model_and_adapter(model_name: str, flavor: str, *, load_balance: bool = True):
     """Construct a CPU-initialized model and its state_dict adapter."""
     model_module = importlib.import_module(f"torchtitan.models.{model_name}")
     spec = model_module.model_registry(flavor)
-    model_config = spec.model
+    model_config = deepcopy(spec.model)
+    if not load_balance:
+        for layer in model_config.layers:
+            if layer.moe is not None:
+                layer.moe.load_balance_coeff = None
     with torch.device("cpu"):
         model = model_config.build()
     model.to_empty(device="cpu")
@@ -81,6 +112,17 @@ class TestHFCheckpointRoundtrip(unittest.TestCase):
         hf_first = adapter.to_hf(tt_orig)
         # HF -> native
         tt_back = adapter.from_hf(hf_first)
+
+        # Native keys that are intentionally excluded from the bitwise tensor
+        # comparison (e.g. buffers that have no HF equivalent and get
+        # reinitialized to zeros on from_hf). The key set itself is still
+        # required to match — exclusions only apply to tensor-value comparison.
+        exclusion_patterns = [
+            re.compile(p) for p in _NATIVE_EXCLUSIONS.get((model_name, flavor), [])
+        ]
+
+        def _is_excluded(fqn: str) -> bool:
+            return any(p.search(fqn) for p in exclusion_patterns)
 
         # ---- Native-side: tt_back must equal tt_orig key-for-key, bit-for-bit.
         missing = tt_orig.keys() - tt_back.keys()
@@ -104,6 +146,8 @@ class TestHFCheckpointRoundtrip(unittest.TestCase):
                 f"{model_name}/{flavor}: native dtype diverged for {fqn}: "
                 f"{orig_tensor.dtype} vs {back_tensor.dtype}",
             )
+            if _is_excluded(fqn):
+                continue
             if not torch.equal(orig_tensor, back_tensor):
                 max_abs_diff = (
                     (orig_tensor.to(torch.float64) - back_tensor.to(torch.float64))
@@ -126,6 +170,16 @@ class TestHFCheckpointRoundtrip(unittest.TestCase):
         for model_name, flavor in _MODEL_FLAVORS:
             with self.subTest(model_name=model_name, flavor=flavor):
                 self._assert_roundtrip(model_name, flavor)
+
+    def test_disabled_load_balance_keeps_native_key_set(self) -> None:
+        for model_name, flavor in _MOE_LOAD_BALANCE_OPTIONAL_FLAVORS:
+            with self.subTest(model_name=model_name, flavor=flavor):
+                model, adapter = _build_model_and_adapter(
+                    model_name, flavor, load_balance=False
+                )
+                tt_orig = model.state_dict()
+                tt_back = adapter.from_hf(adapter.to_hf(tt_orig))
+                self.assertEqual(tt_orig.keys(), tt_back.keys())
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -64,6 +64,10 @@ _MODEL_FLAVORS = [
     # Different shape-suffix naming (mlp1_*_EGD/EG, mlp2_*_EDF/ED) but same
     # expert_bias_E semantics as llama4.
     ("gpt_oss", "debugmodel"),
+    # deepseek_v3: MLA attention + MoE with per-expert HF keys. Unique among
+    # MoE models here: HF DeepSeek has e_score_correction_bias as a real
+    # buffer, so expert_bias_E genuinely round-trips (no exclusion needed).
+    ("deepseek_v3", "debugmodel"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -68,6 +68,14 @@ _MODEL_FLAVORS = [
     # MoE models here: HF DeepSeek has e_score_correction_bias as a real
     # buffer, so expert_bias_E genuinely round-trips (no exclusion needed).
     ("deepseek_v3", "debugmodel"),
+    # qwen3: weight-tied lm_head + GQA. Exercises the from_hf input-copy
+    # contract and the tying-restore path.
+    ("qwen3", "debugmodel"),
+    # qwen3: fused-QKV variant of the above.
+    ("qwen3", "debugmodel_fused_qkv"),
+    # qwen3: MoE variant, exercises shape-suffix MoE keys
+    # (w1_EFD / w2_EDF / w3_EFD).
+    ("qwen3", "debugmodel_moe"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,
@@ -89,11 +97,14 @@ _NATIVE_EXCLUSIONS: dict[tuple[str, str], list[str]] = {
     # router has no equivalent buffer, so the round-trip resets the bias to
     # zeros by design.
     ("gpt_oss", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
+    # qwen3 MoE: same missing-HF-buffer story as llama4/gpt_oss.
+    ("qwen3", "debugmodel_moe"): [r".*\.moe\.expert_bias_E$"],
 }
 
 _MOE_LOAD_BALANCE_OPTIONAL_FLAVORS = [
     ("llama4", "debugmodel"),
     ("gpt_oss", "debugmodel"),
+    ("qwen3", "debugmodel_moe"),
 ]
 
 

--- a/tests/unit_tests/test_hf_checkpoint_roundtrip.py
+++ b/tests/unit_tests/test_hf_checkpoint_roundtrip.py
@@ -60,6 +60,10 @@ _MODEL_FLAVORS = [
     # (w1_EFD / w2_EDF / w3_EFD), dense FF mappings on non-MoE layers, and
     # expert_bias_E reinit (see _NATIVE_EXCLUSIONS).
     ("llama4", "debugmodel"),
+    # gpt_oss: gated MoE with gate_up_proj fused into a single mlp1 weight.
+    # Different shape-suffix naming (mlp1_*_EGD/EG, mlp2_*_EDF/ED) but same
+    # expert_bias_E semantics as llama4.
+    ("gpt_oss", "debugmodel"),
 ]
 
 # Native-side keys (or regex patterns) excluded from the bitwise comparison,
@@ -77,10 +81,15 @@ _NATIVE_EXCLUSIONS: dict[tuple[str, str], list[str]] = {
     # round-trip by design; the optimizer pre-hook recomputes it during
     # training. Resuming from an HF checkpoint loses any accumulated bias.
     ("llama4", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
+    # gpt_oss: same expert_bias_E story as llama4 — HF transformers' gpt_oss
+    # router has no equivalent buffer, so the round-trip resets the bias to
+    # zeros by design.
+    ("gpt_oss", "debugmodel"): [r".*\.moe\.expert_bias_E$"],
 }
 
 _MOE_LOAD_BALANCE_OPTIONAL_FLAVORS = [
     ("llama4", "debugmodel"),
+    ("gpt_oss", "debugmodel"),
 ]
 
 

--- a/torchtitan/models/deepseek_v3/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/state_dict_adapter.py
@@ -43,10 +43,11 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
             # Transformer Layer
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE Module
-            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1",
-            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3",
-            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2",
+            # MoE Module. The _EFD / _EDF suffixes are torchtitan's shape-suffix
+            # convention (E=experts, F=ffn, D=hidden) added in PR #3425.
+            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1_EFD",
+            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3_EFD",
+            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2_EDF",
             "model.layers.{}.mlp.gate.weight": "layers.{}.moe.router.gate.weight",
             "model.layers.{}.mlp.shared_experts.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "model.layers.{}.mlp.shared_experts.up_proj.weight": "layers.{}.moe.shared_experts.w3.weight",

--- a/torchtitan/models/gpt_oss/state_dict_adapter.py
+++ b/torchtitan/models/gpt_oss/state_dict_adapter.py
@@ -52,13 +52,22 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
             # Transformer layer
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE
-            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.experts.mlp1_weight",
-            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.experts.mlp1_bias",
-            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.experts.mlp2_weight",
-            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.experts.mlp2_bias",
+            # MoE. The _EGD / _EG / _EDF / _ED suffixes are torchtitan's
+            # shape-suffix convention (E=experts, G=gate, F=ffn, D=hidden)
+            # added in PR #3425.
+            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.experts.mlp1_weight_EGD",
+            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.experts.mlp1_bias_EG",
+            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.experts.mlp2_weight_EDF",
+            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.experts.mlp2_bias_ED",
             "model.layers.{}.mlp.router.weight": "layers.{}.moe.router.gate.weight",
             "model.layers.{}.mlp.router.bias": "layers.{}.moe.router.gate.bias",
+            # expert_bias_E is auxiliary-loss-free load-balancing state (DeepSeek
+            # paper, adapted for Qwen/Mixtral-style routers including gpt_oss).
+            # HF transformers' gpt_oss router has no equivalent buffer, so to_hf
+            # drops this key and from_hf reinitializes it to zeros. See
+            # test_hf_checkpoint_roundtrip exclusion for the matching test
+            # contract.
+            None: "layers.{}.moe.expert_bias_E",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "lm_head.weight",
         }
@@ -188,12 +197,17 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 if abstract_key not in to_hf_map:
                     continue
                 hf_key = to_hf_map[abstract_key]
+                if hf_key is None:
+                    # Intentionally dropped (e.g. expert_bias_E — see from_hf_map comment).
+                    continue
                 hf_key = hf_key.format(layer_num)
                 hf_state_dict[hf_key] = value
             else:
                 if key not in to_hf_map:
                     continue
                 hf_key = to_hf_map[key]
+                if hf_key is None:
+                    continue
                 hf_state_dict[hf_key] = value
 
         return hf_state_dict
@@ -277,5 +291,21 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
             raise ValueError(
                 f"Incomplete Q/K/V bias projections for layers: {list(pending_qkv_bias.keys())}"
             )
+
+        # Restore expert_bias_E (zeros) for every MoE layer. The HF format
+        # doesn't have a key for this auxiliary-loss-free load-balancing bias,
+        # so to_hf drops it; we reinitialize it to zeros so the native key set
+        # stays complete. The bias gets recomputed by the optimizer pre-hook
+        # during training; resuming from an HF checkpoint loses any
+        # accumulated bias state.
+        for layer_idx, layer_cfg in enumerate(self.model_config.layers):
+            if (
+                getattr(layer_cfg, "moe", None) is not None
+                and layer_cfg.moe.load_balance_coeff is not None
+            ):
+                state_dict[f"layers.{layer_idx}.moe.expert_bias_E"] = torch.zeros(
+                    layer_cfg.moe.num_experts,
+                    dtype=torch.float32,
+                )
 
         return state_dict

--- a/torchtitan/models/llama4/state_dict_adapter.py
+++ b/torchtitan/models/llama4/state_dict_adapter.py
@@ -49,8 +49,19 @@ class Llama4StateDictAdapter(StateDictAdapter):
             **qkv_map,
             "language_model.model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
             "language_model.model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
+            # Dense FF layers (non-MoE layers in llama4's interleaved MoE pattern).
+            "language_model.model.layers.{}.feed_forward.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
+            "language_model.model.layers.{}.feed_forward.up_proj.weight": "layers.{}.feed_forward.w3.weight",
+            "language_model.model.layers.{}.feed_forward.down_proj.weight": "layers.{}.feed_forward.w2.weight",
+            # MoE layers. The _EFD / _EDF suffixes are torchtitan's shape-suffix
+            # convention (E=experts, F=ffn, D=hidden) added in PR #3425.
             "language_model.model.layers.{}.feed_forward.router.weight": "layers.{}.moe.router.gate.weight",
-            "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2",
+            "language_model.model.layers.{}.feed_forward.experts.down_proj": "layers.{}.moe.experts.w2_EDF",
+            # expert_bias_E is auxiliary-loss-free load-balancing state (DeepSeek
+            # paper, adapted for Qwen/Mixtral-style routers). HF transformers'
+            # Llama4 router has no equivalent buffer (plain nn.Linear, bias=False),
+            # so to_hf drops this key and from_hf reinitializes it to zeros.
+            # See state_dict_adapter test exclusion for the matching test contract.
             None: "layers.{}.moe.expert_bias_E",
             "language_model.model.layers.{}.feed_forward.shared_expert.gate_proj.weight": "layers.{}.moe.shared_experts.w1.weight",
             "language_model.model.layers.{}.feed_forward.shared_expert.down_proj.weight": "layers.{}.moe.shared_experts.w2.weight",
@@ -108,27 +119,25 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 ] = wv
             elif key in to_hf_map:
                 # do direct mapping
-                if key in "layers.{}.moe.experts.w2":
-                    # we transpose the expert weights for torchtitan optimization purpose
-                    value = value.transpose(-1, -2)
+                if key == "layers.{}.moe.experts.w2_EDF":
+                    # safetensors rejects non-contiguous transposed views.
+                    value = value.transpose(-1, -2).contiguous()
 
                 new_key = to_hf_map[key]
                 if new_key is None:
+                    # Intentionally dropped (e.g. expert_bias_E — see from_hf_map comment).
                     continue
                 if layer_num:
                     new_key = new_key.format(layer_num)
                 hf_state_dict[new_key] = value
             elif key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
+                "layers.{}.moe.experts.w1_EFD",
+                "layers.{}.moe.experts.w3_EFD",
             ]:
                 # handle collecting values to combine
                 hf_abstract_key = (
                     "language_model.model.layers.{}.feed_forward.experts.gate_up_proj"
                 )
-                # pyrefly: ignore [unnecessary-comparison]
-                if hf_abstract_key is None:
-                    continue
                 to_combine[hf_abstract_key.format(layer_num)][
                     key.format(layer_num)
                 ] = value
@@ -140,8 +149,8 @@ class Llama4StateDictAdapter(StateDictAdapter):
             combine_values = []
             # put into correct order to combine
             for tt_abstract_key in [
-                "layers.{}.moe.experts.w1",
-                "layers.{}.moe.experts.w3",
+                "layers.{}.moe.experts.w1_EFD",
+                "layers.{}.moe.experts.w3_EFD",
             ]:
                 tt_key = tt_abstract_key.format(layer_num)
                 # we transpose the expert weights for torchtitan optimization purpose
@@ -217,12 +226,28 @@ class Llama4StateDictAdapter(StateDictAdapter):
                 w1, w3 = value.chunk(2, dim=-1)
                 # we transpose the expert weights for torchtitan optimization purpose
                 w1, w3 = w1.transpose(-1, -2), w3.transpose(-1, -2)
-                state_dict["layers.{}.moe.experts.w1".format(layer_num)] = w1
-                state_dict["layers.{}.moe.experts.w3".format(layer_num)] = w3
+                state_dict["layers.{}.moe.experts.w1_EFD".format(layer_num)] = w1
+                state_dict["layers.{}.moe.experts.w3_EFD".format(layer_num)] = w3
 
         if self.fuse_qkv and pending_qkv:
             raise ValueError(
                 f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
             )
+
+        # Restore expert_bias_E (zeros) for every MoE layer. The HF format
+        # doesn't have a key for this auxiliary-loss-free load-balancing bias,
+        # so to_hf drops it; we reinitialize it to zeros so the native key set
+        # stays complete. The bias gets recomputed by the optimizer pre-hook
+        # during training, but resuming from an HF checkpoint loses any
+        # accumulated bias state.
+        for layer_idx, layer_cfg in enumerate(self.model_config.layers):
+            if (
+                getattr(layer_cfg, "moe", None) is not None
+                and layer_cfg.moe.load_balance_coeff is not None
+            ):
+                state_dict[f"layers.{layer_idx}.moe.expert_bias_E"] = torch.zeros(
+                    layer_cfg.moe.num_experts,
+                    dtype=torch.float32,
+                )
 
         return state_dict

--- a/torchtitan/models/qwen3/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/state_dict_adapter.py
@@ -59,11 +59,16 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
             # Transformer layer
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-            # MoE
-            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1",
-            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3",
-            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2",
+            # MoE. The _EFD / _EDF suffixes are torchtitan's shape-suffix
+            # convention (E=experts, F=ffn, D=hidden) added in PR #3425.
+            "model.layers.{}.mlp.experts.{}.gate_proj.weight": "layers.{}.moe.experts.w1_EFD",
+            "model.layers.{}.mlp.experts.{}.up_proj.weight": "layers.{}.moe.experts.w3_EFD",
+            "model.layers.{}.mlp.experts.{}.down_proj.weight": "layers.{}.moe.experts.w2_EDF",
             "model.layers.{}.mlp.gate.weight": "layers.{}.moe.router.gate.weight",
+            # HF transformers' Qwen3 MoE router has no equivalent persisted
+            # load-balancing buffer, so to_hf drops this key and from_hf
+            # reinitializes it to zeros.
+            None: "layers.{}.moe.expert_bias_E",
             "model.norm.weight": "norm.weight",
             "lm_head.weight": "lm_head.weight",
         }
@@ -161,6 +166,8 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 if abstract_key not in to_hf_map:
                     continue
                 new_key = to_hf_map[abstract_key]
+                if new_key is None:
+                    continue
                 new_key = new_key.format(layer_num)
                 hf_state_dict[new_key] = value
 
@@ -180,6 +187,14 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
         1. Convert between the HF shape and the torchtitan shape.
         2. Concate separate expert's wegiht into GroupedExperts' weight.
         """
+
+        # Shallow-copy the input so we never mutate the caller's dict. The
+        # weight-tying restore below adds `lm_head.weight` to whichever dict
+        # we iterate; without this copy it leaks back into the caller and
+        # corrupts any later use of the HF dict (notably, makes the dict
+        # unserializable via safetensors because `lm_head.weight` and
+        # `model.embed_tokens.weight` would share storage).
+        hf_state_dict = dict(hf_state_dict)
 
         state_dict = {}
         expert_weights_by_layer = {}  # {layer: {abstract_key: {expert_id: tensor}}}
@@ -280,5 +295,19 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
             raise ValueError(
                 f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
             )
+
+        # Restore expert_bias_E (zeros) for every MoE layer. The HF format
+        # does not have a key for this auxiliary-loss-free load-balancing bias,
+        # so to_hf drops it; we reinitialize it to zeros so the native key set
+        # stays complete.
+        for layer_idx, layer_cfg in enumerate(self.model_config.layers):
+            if (
+                getattr(layer_cfg, "moe", None) is not None
+                and layer_cfg.moe.load_balance_coeff is not None
+            ):
+                state_dict[f"layers.{layer_idx}.moe.expert_bias_E"] = torch.zeros(
+                    layer_cfg.moe.num_experts,
+                    dtype=torch.float32,
+                )
 
         return state_dict


### PR DESCRIPTION

Summary: Qwen3StateDictAdapter.from_hf was mutating the caller's HF state dict while restoring lm_head.weight for tied-weight dense Qwen3 checkpoints. That leaked a shared-storage alias back into the HF dict, making later safetensors serialization fail.

Fix the tying path by shallow-copying the input before restoring lm_head.weight. Also include Qwen3 MoE in the HF round-trip coverage and bring its adapter in line with the shape-suffix GroupedExperts names (w1_EFD/w2_EDF/w3_EFD). Qwen3 MoE has the same auxiliary-loss-free expert_bias_E gap as llama4/gpt_oss: HF has no persisted buffer for it, so to_hf drops it and from_hf restores zeros to keep the native key set complete.

Test changes:
- Add qwen3/debugmodel, qwen3/debugmodel_fused_qkv, and qwen3/debugmodel_moe to test_hf_checkpoint_roundtrip.
- Add a Qwen3 MoE expert_bias_E native-value exclusion because the HF format cannot preserve that buffer.

Test Plan: python -m unittest tests.unit_tests.test_hf_checkpoint_roundtrip -v
python -m py_compile tests/unit_tests/test_hf_checkpoint_roundtrip.py torchtitan/models/qwen3/state_dict_adapter.py
flake8 tests/unit_tests/test_hf_checkpoint_roundtrip.py torchtitan/models/qwen3/state_dict_adapter.py

Reviewers:

Subscribers:

Tasks:

Tags:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/3557).
* __->__ #3557
* #3556
* #3555
* #3554
* #3553