### PR TITLE
enable graph trainer + mxfp8 composability

### DIFF
--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -104,8 +104,12 @@ _mxfp8_experts_cache: dict[type, type] = {}
 def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
     """Get or create an MXFP8-quantized subclass of *parent_cls*.
 
-    Works for any ``GroupedExperts`` subclass (e.g. gpt-oss variants).
-    The returned class has a proper ``_owner`` set by ``__init_subclass__``.
+    Works for any experts module exposing the ``_grouped_mm`` seam (the common
+    ``GroupedExperts`` and ``GptOssGroupedExperts``). The returned class has a
+    proper ``_owner`` set by ``__init_subclass__``.
+
+    The subclass overrides ``_grouped_mm`` to call torchao's
+    ``_quantize_then_scaled_grouped_mm``.
     """
     if parent_cls in _mxfp8_experts_cache:
         return _mxfp8_experts_cache[parent_cls]
@@ -123,14 +127,17 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
                 MXFP8TrainingOpConfig,
                 MXFP8TrainingRecipe,
             )
-            from torchao.quantization.quant_api import quantize_
 
             recipe = MXFP8TrainingRecipe(config.recipe_name)
-            mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-            quantize_(
-                self,
-                config=mxfp8_op_config,
-                filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
+            self._mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
+
+        def _grouped_mm(self, *, A, B_t, offs):
+            from torchao.prototype.moe_training.utils import (
+                _quantize_then_scaled_grouped_mm,
+            )
+
+            return _quantize_then_scaled_grouped_mm(
+                A, B_t, config=self._mxfp8_op_config, offs=offs
             )
 
     MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -6,12 +6,17 @@
 
 from dataclasses import replace
 
+from torchtitan.components.quantization import (
+    MXFP8GroupedExpertsConverter,
+    MXFP8LinearConverter,
+)
 from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+from torchtitan.models.deepseek_v3 import model_registry as deepseek_v3_model_registry
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
     deepseek_v3_16b_minimal_async_ep,
@@ -25,6 +30,27 @@ from . import model_registry
 
 def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
+    base = deepseek_v3_debugmodel()
+    # Quantize dense and moe gemms to mxfp8
+    base.model_spec = deepseek_v3_model_registry(
+        "debugmodel",
+        converters=[
+            MXFP8LinearConverter.Config(
+                model_compile_enabled=True,
+                fqns=["attention", "shared_experts", "feed_forward"],
+            ),
+            MXFP8GroupedExpertsConverter.Config(
+                model_compile_enabled=True,
+                pad_multiple=128,
+            ),
+        ],
+    )
+    config = to_graph_trainer_config(base, model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.components.loss import CrossEntropyLoss
+from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.llama3 import model_registry as llama3_model_registry
 from torchtitan.models.llama3.config_registry import (
     llama3_405b,
     llama3_70b,
@@ -69,6 +71,20 @@ def graph_trainer_llama3_debugmodel_sdpa_eager() -> GraphTrainer.Config:
 
 def graph_trainer_llama3_8b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_8b(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_8b_mxfp8() -> GraphTrainer.Config:
+    base = llama3_8b()
+    # Swap dense Linear layers for MXFP8Linear before wrapping in the
+    # graph_trainer config. graph_trainer always compiles the model, so the
+    # MXFP8 converter's compile requirement is satisfied.
+    base.model_spec = llama3_model_registry(
+        "8B",
+        converters=[MXFP8LinearConverter.Config(model_compile_enabled=True)],
+    )
+    config = to_graph_trainer_config(base, model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -92,20 +92,32 @@ class GroupedExperts(Module):
                 spmd.mutate_type(offsets_E, axis, src=spmd.P, dst=spmd.V)
 
         h_RF = F.silu(
-            torch._grouped_mm(
-                x_RD.bfloat16(),
-                w1_EFD.bfloat16().transpose(-2, -1),
+            self._grouped_mm(
+                A=x_RD.bfloat16(),
+                B_t=w1_EFD.bfloat16().transpose(-2, -1),
                 offs=offsets_E,
             )
         )
-        h_RF = h_RF * torch._grouped_mm(
-            x_RD.bfloat16(),
-            w3_EFD.bfloat16().transpose(-2, -1),
+        h_RF = h_RF * self._grouped_mm(
+            A=x_RD.bfloat16(),
+            B_t=w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
-        return torch._grouped_mm(
-            h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
+        return self._grouped_mm(
+            A=h_RF, B_t=w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)
+
+    def _grouped_mm(
+        self, *, A: torch.Tensor, B_t: torch.Tensor, offs: torch.Tensor
+    ) -> torch.Tensor:
+        """Grouped matmul of ``A @ B_t`` with per-expert token offsets.
+
+        Overridable seam for low-precision variants (e.g. the MXFP8 converter
+        swaps this for a dynamically-quantized scaled grouped GEMM). Keeping the
+        op here -- rather than behind a tensor-subclass ``__torch_function__`` --
+        means it is captured by FX tracers such as graph_trainer's make_fx path.
+        """
+        return torch._grouped_mm(A, B_t, offs=offs)
 
 
 class RoutedExperts(Module):

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -158,9 +158,9 @@ class GptOssGroupedExperts(GroupedExperts):
         ).long()
 
         # G = gate+up dimension (2*F)
-        h_RG = torch._grouped_mm(
-            x_RD.bfloat16(),
-            mlp1_weight_EGD.transpose(-2, -1).bfloat16(),
+        h_RG = self._grouped_mm(
+            A=x_RD.bfloat16(),
+            B_t=mlp1_weight_EGD.transpose(-2, -1).bfloat16(),
             offs=offsets_E,
         )
 
@@ -173,8 +173,8 @@ class GptOssGroupedExperts(GroupedExperts):
         h_RG = h_RG + b1_RG.to(h_RG.dtype)
 
         h_RF = swiglu(h_RG, limit=self.swiglu_limit)
-        h_RD = torch._grouped_mm(
-            h_RF, mlp2_weight_EDF.transpose(-2, -1).bfloat16(), offs=offsets_E
+        h_RD = self._grouped_mm(
+            A=h_RF, B_t=mlp2_weight_EDF.transpose(-2, -1).bfloat16(), offs=offsets_E
         )
 
         # Apply custom autograd function to scale bias in forward but not in backward

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -9,7 +9,10 @@ from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import default_adamw
-from torchtitan.components.quantization import Float8LinearConverter
+from torchtitan.components.quantization import (
+    Float8LinearConverter,
+    MXFP8LinearConverter,
+)
 from torchtitan.components.validate import Validator
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
@@ -145,6 +148,21 @@ def llama3_8b() -> Trainer.Config:
             steps=1200,
         ),
     )
+
+
+def llama3_8b_mxfp8() -> Trainer.Config:
+    config = llama3_8b()
+    # Swap dense Linear layers for MXFP8Linear. compile is enabled so the
+    # converter's compile requirement is satisfied. This is the regular-Trainer
+    # (torch.compile) baseline counterpart to graph_trainer_llama3_8b_mxfp8.
+    config.compile = CompileConfig(enable=True, components=["model"])
+    config.model_spec = model_registry(
+        "8B",
+        converters=[
+            MXFP8LinearConverter.Config(model_compile_enabled=True),
+        ],
+    )
+    return config
 
 
 def llama3_70b() -> Trainer.Config:

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -555,11 +555,13 @@ class FusedGroupedExperts(GroupedExperts):
         offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
 
         w13_E_D_2F = w13.bfloat16().reshape(E, F * 2, D).transpose(-2, -1)
-        gate_up_R2F = torch._grouped_mm(x_RD.bfloat16(), w13_E_D_2F, offs=offsets_E)
+        gate_up_R2F = self._grouped_mm(
+            A=x_RD.bfloat16(), B_t=w13_E_D_2F, offs=offsets_E
+        )
         gate_RF, up_RF = gate_up_R2F.reshape(-1, F, 2).unbind(-1)
         h_RF = silu_and_mul_op(gate_RF, up_RF, offsets_E)
-        return torch._grouped_mm(
-            h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
+        return self._grouped_mm(
+            A=h_RF, B_t=w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)
 
     @staticmethod


### PR DESCRIPTION
Summary:

1. add a config for graph trainer llama3 + mxfp8
2. add a config for graph trainer deepseek debug + mxfp8
3. make 2 actually call mxfp8 kernels (instead of silently falling back to bfloat16) by removing torchao's tensor subclass weight wrapper and calling the underlying `torch.autograd.Function` with the mxfp8 logic directly. This is needed because `GraphTrainer` uses SimpleFSDP, that uses DTensorized weight, and that does not compose with torchao's previous usage of `__torch_function__`.

An explanation of 3:

```code
# before
* `foo.bar.expert_weight` is a tensor subclass with a `__torch_function__` override that calls the mxfp8 logic
* the parent calls `torch._grouped_mm`, and we dispatch to the mxfp8 logic via the subclass override above

# after
* `foo.bar.expert_weight` is a regular parameter
* the parent calls `self._grouped_mm`
* model configuration controls whether `self._grouped_mm` dispatches to the default `torch._grouped_mm` or an override.  The mxfp8 modeling classes set the override to call the mxfp8 logic.
```

Same result in the end, but more direct and no longer depends on `__torch_function__`.


Test Plan:

```
// on 1 B200 GPU

// graph trainer + dense model + mxfp8
// verify the chrome trace contains mxfp8 casts + gemm
NGPU=1 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b_mxfp8 ./run_train.sh

// graph trainer + moe debug model + mxfp8
// verify the chrome trace contains mxfp8 casts + gemm
NGPU=1 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_mxfp8 ./run_train.sh

// EP 2
NGPU=2 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_mxfp8 ./run_train.sh --parallelism.expert_parallel_degree=2
...
 step:  1  loss:  8.16138  grad_norm:  3.6610  memory:  2.98GiB(1.67%)  tps: 414  tflops: 0.23  mfu: N/A
 Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
 step:  2  loss:  6.18522  grad_norm:  4.6098  memory:  3.07GiB(1.72%)  tps: 17,394  tflops: 9.44  mfu: N/A
 step:  3  loss:  4.88102  grad_norm:  2.8651  memory:  3.07GiB(1.72%)  tps: 109,666  tflops: 59.54  mfu: N/A
 step:  4  loss:  4.76242  grad_norm:  2.6567  memory:  3.07GiB(1.72%)  tps: 131,115  tflops: 71.19  mfu: N/A
 step:  5  loss:  4.42710  grad_norm:  2.4591  memory:  3.07GiB(1.72%)  tps: 135,408  tflops: 73.52  mfu: N/A
 step:  6  loss:  4.20295  grad_norm:  2.0352  memory:  3.07GiB(1.72%)  tps: 122,923  tflops: 66.74  mfu: N/A
 step:  7  loss:  4.10372  grad_norm:  1.9203  memory:  3.09GiB(1.73%)  tps: 123,222  tflops: 66.90  mfu: N/A
 step:  8  loss:  4.01469  grad_norm:  2.0419  memory:  3.09GiB(1.73%)  tps: 135,611  tflops: 73.63  mfu: N/A
 step:  9  loss:  4.26402  grad_norm:  1.7035  memory:  3.09GiB(1.73%)  tps: 126,333  tflops: 68.59  mfu: N/A
 step: 10  loss:  3.89563  grad_norm:  1.5778  memory:  3.09GiB(1.73%)  tps: 100,589  tflops: 54.61  mfu: N/A

// tlparse of above: https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpZnVSv0/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000


// verify eager mxfp8 did not change
> python3 scripts/loss_compare.py HEAD~1 HEAD --baseline-module=deepseek_v3 --baseline-config=deepseek_v3_debugmodel_mxfp8 --baseline-ngpus=1 --test-ngpus=1 --steps=100 --assert-equal --no-seed-checkpoint
...
[LOSS_COMPARE] 98      3.16805100440979    3.16805100440979   0.000000
[LOSS_COMPARE] 99      2.819762706756592    2.819762706756592   0.000000
[LOSS_COMPARE] 100     2.7529165744781494    2.7529165744781494   0.000000
[LOSS_COMPARE]
[LOSS_COMPARE] Summary statistics:
[LOSS_COMPARE] Average baseline loss:  3.1106575202941893
[LOSS_COMPARE] Average test loss: 3.1106575202941893
[LOSS_COMPARE] Average difference:     0.000000


// 8 GPU test: https://www.internalfb.com/phabricator/paste/view/P2422670858
// more single GPU tests: https://www.internalfb.com/intern/paste/P2422673885/
```

Verified the traces manually to see mxfp8 MoE kernels being called in GraphTrainer runs