### PR TITLE
Add CUDA graph capture to the core Trainer

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -139,10 +139,13 @@ jobs:
         fi
 
         echo "Checking Qwen3 MoE FSDP+TP+EP loss parity against reference"
+        # qwen3_moe_debug uses EP=1, where CUDA graphs are supported. This test
+        # overrides EP to 4 without changing the AllToAll token dispatcher,
+        # whose CPU synchronization is incompatible with CUDA graph capture.
         python3 scripts/loss_compare.py . . \
           --baseline-module=qwen3 --baseline-config=qwen3_moe_debug \
-          --baseline-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
-          --test-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
+          --baseline-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4 --training.disable_cuda_graphs" \
+          --test-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4 --training.disable_cuda_graphs" \
           --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/moe_loss_comparison" \
           --import-result="${MOE_LOSS_FILE}" --assert-equal --steps=100
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -258,6 +258,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule 1F1B",
                     "--parallelism.data_parallel_shard_degree 1",
@@ -270,11 +271,13 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule 1F1B",
                     "--parallelism.data_parallel_shard_degree 2",
                 ],
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule 1F1B",
                     "--parallelism.pipeline_parallel_layers_per_stage 4",
@@ -287,6 +290,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule GPipe",
                     "--parallelism.tensor_parallel_degree 2",
@@ -298,12 +302,14 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--checkpoint.enable",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
                 ],
                 [
+                    "--training.disable_cuda_graphs",
                     "--training.steps 20",
                     "--checkpoint.enable",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -318,6 +324,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
@@ -331,10 +338,12 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 4",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
                 ],
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 4",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
                     "--parallelism.pipeline_parallel_layers_per_stage 1",
@@ -359,6 +368,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 4",
                     "--parallelism.pipeline_parallel_schedule InterleavedZeroBubble",
                     "activation-checkpoint:full",
@@ -372,6 +382,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
                     "activation-checkpoint:full",
@@ -389,6 +400,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule PipelineScheduleMulti",
                     "--parallelism.pipeline_parallel_schedule_csv ./tests/assets/custom_schedule.csv",
@@ -504,6 +516,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--parallelism.fsdp_reshard_after_forward always",
                 ],
             ],
@@ -547,6 +560,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--validator.enable",
                     "--validator.dataloader.dataset c4_test",
                     "--parallelism.tensor_parallel_degree=2",
@@ -573,6 +587,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module deepseek_v3 --config deepseek_v3_debugmodel",
                     "--override.imports torchtitan.overrides.fused_swiglu.fused_swiglu,"
                     "torchtitan.overrides.fused_swiglu.fused_grouped_experts",
@@ -590,6 +605,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module llama3 --config llama3_debugmodel_varlen_attn",
                     "--parallelism.data_parallel_shard_degree=4",
                     "activation-checkpoint:selective",
@@ -603,6 +619,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module llama3 --config llama3_debugmodel_float8_emulate_lora",
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -615,6 +632,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--comm.mode torchcomms",
                     "--parallelism.context_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -633,6 +651,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module llama3 --config llama3_debugmodel_ce_loss",
                     "--comm.mode torchcomms",
                     "--parallelism.tensor_parallel_degree 2",
@@ -661,6 +680,7 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--checkpoint.enable",
                     "--checkpoint.create_seed_checkpoint",
                 ],

--- a/tests/integration_tests/flux.py
+++ b/tests/integration_tests/flux.py
@@ -23,6 +23,7 @@ def build_flux_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module flux",
                     "--config flux_debugmodel",
                     "--parallelism.data_parallel_shard_degree 2",
@@ -41,6 +42,7 @@ def build_flux_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module flux",
                     "--config flux_debugmodel",
                     "--compile.enable",

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -54,6 +54,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module llama3 --config llama3_debugmodel_float8",
                     "--compile.enable",
                     "--parallelism.data_parallel_shard_degree 2",

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -65,6 +65,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module deepseek_v3 --config deepseek_v3_debugmodel_mtp",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.expert_parallel_degree 2",
@@ -83,6 +84,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module deepseek_v3 --config deepseek_v3_debugmodel",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
@@ -98,6 +100,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module deepseek_v3 --config deepseek_v3_debugmodel",
                     "--parallelism.data_parallel_replicate_degree 2",
                     "--parallelism.data_parallel_shard_degree 2",
@@ -112,6 +115,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module qwen3 --config qwen3_debugmodel_moe_param_groups",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
@@ -180,6 +184,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module qwen3_5 --config qwen35_debugmodel_moe",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",
@@ -194,6 +199,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module qwen3_5 --config qwen35_debugmodel_varlen_attn",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
@@ -212,6 +218,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module gpt_oss --config gpt_oss_debugmodel",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.tensor_parallel_degree 2",
@@ -226,6 +233,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module gpt_oss --config gpt_oss_debugmodel_flex",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.context_parallel_degree 2",
@@ -244,6 +252,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module gpt_oss --config gpt_oss_debugmodel",
                     "--training.global_batch_size 64",
                     "--parallelism.data_parallel_shard_degree 4",
@@ -261,6 +270,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     # Consolidate the former 2-GPU FSDP smoke and 8-GPU
                     # FSDP+TP+EP+PP test into one supported FSDP+EP path. Kimi
                     # DistributedMuon rejects TP because it produces _StridedShard
@@ -282,6 +292,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module muse_glimmer --config muse_glimmer_debugmodel_mm",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -244,7 +244,11 @@ def run_tests(
             )
             try:
                 run_single_test(
-                    test_flavor, args.output_dir, module, config, gpu_ids=gpus
+                    test_flavor,
+                    args.output_dir,
+                    module,
+                    config,
+                    gpu_ids=gpus,
                 )
             finally:
                 pool.release(gpus)

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import sys
 import unittest
 from unittest import mock
@@ -114,6 +115,87 @@ class TestConfigManager(unittest.TestCase):
                     "3",
                 ]
             )
+
+    def test_cuda_graphs_reject_pipeline_parallelism(self):
+        config_manager = ConfigManager()
+        with pytest.raises(ValueError, match="do not support pipeline parallelism"):
+            config_manager.parse_args(
+                [
+                    "--module",
+                    "llama3",
+                    "--config",
+                    "llama3_debugmodel",
+                    "--parallelism.pipeline_parallel_degree",
+                    "2",
+                ]
+            )
+
+    def test_cuda_graphs_enabled_by_default(self):
+        config = ConfigManager().parse_args(
+            ["--module", "llama3", "--config", "llama3_debugmodel"]
+        )
+        assert not config.training.disable_cuda_graphs
+
+    def test_cuda_graphs_reject_unsupported_expert_parallelism(self):
+        config_manager = ConfigManager()
+        with pytest.raises(ValueError, match="without CPU synchronization"):
+            config_manager.parse_args(
+                [
+                    "--module",
+                    "deepseek_v3",
+                    "--config",
+                    "deepseek_v3_debugmodel",
+                    "--parallelism.expert_parallel_degree",
+                    "2",
+                ]
+            )
+
+    def test_cuda_graphs_allow_non_blocking_hybridep(self):
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "deepseek_v3",
+                "--config",
+                "deepseek_v3_debugmodel_hybridep",
+                "--parallelism.expert_parallel_degree",
+                "2",
+            ]
+        )
+        assert not config.training.disable_cuda_graphs
+
+    def test_disable_cuda_graphs_allows_pipeline_parallelism(self):
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        assert config.training.disable_cuda_graphs
+
+    def test_cuda_graphs_reject_blocking_hybridep(self):
+        from torchtitan.models.common.token_dispatcher import HybridEPTokenDispatcher
+        from torchtitan.models.deepseek_v3.config_registry import (
+            deepseek_v3_debugmodel_hybridep,
+        )
+
+        config = deepseek_v3_debugmodel_hybridep()
+        dispatcher_configs = list(
+            config.model_spec.model.traverse(HybridEPTokenDispatcher.Config)
+        )
+        assert dispatcher_configs
+        for _, dispatcher_config, _, _ in dispatcher_configs:
+            dispatcher_config.non_blocking_capacity_factor = None
+        config.parallelism.expert_parallel_degree = 2
+
+        with pytest.raises(ValueError, match="non_blocking_capacity_factor"):
+            dataclasses.replace(config)
 
     def test_cli_override_dump_folder(self):
         """CLI args override config defaults for nested fields."""

--- a/tests/unit_tests/test_trainer.py
+++ b/tests/unit_tests/test_trainer.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
+from torchtitan.trainer import Trainer
+
+
+def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=False,
+            pp_has_last_stage=False,
+            pp_schedule=SimpleNamespace(step=lambda **kwargs: None),
+            train_context=nullcontext,
+            post_dataloading_process=lambda input_dict, labels: (
+                input_dict["input"],
+                labels,
+                {},
+            ),
+            device=torch.device("cpu"),
+        ),
+    )
+
+    loss = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[{"input": torch.ones(1)}],
+        label_mbs=[torch.ones(1)],
+        global_valid_tokens=torch.tensor(1),
+    )
+
+    torch.testing.assert_close(loss, torch.tensor([-1.0]))
+
+
+def test_cuda_graph_wrapper_decorates_fwd_bwd_and_clones_reused_output():
+    class PassthroughCUDAGraphWrapper:
+        def __init__(self, fn, example_inputs):
+            self.fn = fn
+
+        def __call__(self, *args):
+            return self.fn(*args)
+
+    graph_loss = torch.tensor(0.0)
+    fwd_bwd = MagicMock(return_value=graph_loss)
+
+    accumulated_losses = []
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch(
+            "torchtitan.distributed.cudagraph.CUDAGraphWrapper",
+            PassthroughCUDAGraphWrapper,
+        ),
+    ):
+        runner = wrap_with_cuda_graph(fwd_bwd)
+        for value in (1.0, 2.0, 3.0):
+            graph_loss.fill_(value)
+            loss = runner(
+                torch.ones(1),
+                torch.ones(1),
+                torch.tensor(1),
+                {"position": torch.ones(1)},
+            )
+            accumulated_losses.append(loss.detach())
+
+    torch.testing.assert_close(
+        torch.sum(torch.stack(accumulated_losses)), torch.tensor(6.0)
+    )
+    assert fwd_bwd.call_count == 3
+    _, _, global_valid_tokens, extra_kwargs = fwd_bwd.call_args.args
+    torch.testing.assert_close(global_valid_tokens, torch.tensor(1))
+    assert global_valid_tokens.dtype == torch.int64
+    torch.testing.assert_close(extra_kwargs["position"], torch.ones(1))
+
+
+@pytest.mark.parametrize(
+    ("device_type", "cuda_available", "hip_version"),
+    [
+        ("cpu", False, None),
+        ("cuda", False, None),
+        ("cuda", True, "6.3"),
+        ("xpu", False, None),
+    ],
+)
+def test_cuda_graph_wrapper_is_noop_without_nvidia_cuda(
+    device_type: str,
+    cuda_available: bool,
+    hip_version: str | None,
+) -> None:
+    fwd_bwd = MagicMock()
+
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", device_type),
+        patch("torch.cuda.is_available", return_value=cuda_available),
+        patch.object(torch.version, "hip", hip_version),
+        patch("torchtitan.distributed.cudagraph.logger.warning") as warning,
+    ):
+        runner = wrap_with_cuda_graph(fwd_bwd)
+
+    assert runner is fwd_bwd
+    warning.assert_called_once()

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -48,6 +48,13 @@ class TrainingConfig:
     Whether to apply CPU offloading of parameters, gradients, and optimizer states in FSDP
     """
 
+    enable_cuda_graphs: bool = False
+    """
+    Wrap the forward+backward step with CUDA graph capture and replay.
+    Requires fixed-shape inputs and no CPU↔GPU synchronization during the
+    captured region. Incompatible with pipeline parallelism.
+    """
+
     dtype: Literal["bfloat16", "float32"] = "float32"
     """
     torch dtype for training. In contrast to mixed precision training, setting training_dtype=bfloat16 will

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -55,6 +55,18 @@ class TrainingConfig:
     Whether to apply CPU offloading of parameters, gradients, and optimizer states in FSDP
     """
 
+    disable_cuda_graphs: bool = False
+    """
+    Disable CUDA graph capture and replay for the forward+backward step. CUDA
+    graphs require fixed-shape inputs and no CPU<->GPU synchronization during
+    the captured region. Expert parallelism is supported only with HybridEP
+    when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
+    EP backends synchronize with the host during dispatch. Pipeline parallelism
+    is not supported yet. CUDA graphs are independent of
+    ``torch.compile(mode="reduce-overhead")``, which performs its own CUDA graph
+    capture.
+    """
+
     dtype: Literal["bfloat16", "float32"] = "float32"
     """
     torch dtype for training. In contrast to mixed precision training, setting training_dtype=bfloat16 will

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Lightweight CUDA graph wrapper for eager-mode training steps.
+
+Adapted from ``torchtitan/experiments/graph_trainer/cudagraph.py``.
+"""
+
+import warnings
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import torch
+from torch._inductor.cudagraph_trees import _use_cuda_memory_pool_manager
+
+from torchtitan.tools.logging import logger
+
+
+class _CUDAGraphManager:
+    """Singleton that owns a shared graph pool and stream."""
+
+    def __init__(self) -> None:
+        self._initialized = False
+        self._wrappers: list["CUDAGraphWrapper"] = []
+
+    def maybe_initialize(self) -> None:
+        if self._initialized:
+            return
+        self._initialized = True
+        self.graph_pool = torch.cuda.graph_pool_handle()
+        self.stream = torch.cuda.Stream()
+        self._dummy_graph = torch.cuda.CUDAGraph()
+        with (
+            warnings.catch_warnings(record=True),
+            torch.cuda.graph(
+                self._dummy_graph,
+                pool=self.graph_pool,
+                stream=self.stream,
+                capture_error_mode="thread_local",
+            ),
+        ):
+            pass
+
+    def register(self, wrapper: "CUDAGraphWrapper") -> None:
+        self._wrappers.append(wrapper)
+
+    def teardown(self) -> None:
+        if not self._initialized:
+            return
+        for w in self._wrappers:
+            w.teardown()
+        self._wrappers.clear()
+        self._dummy_graph = None
+        self.stream = None
+        self.graph_pool = None
+
+
+_manager = _CUDAGraphManager()
+
+
+def cudagraph_teardown() -> None:
+    """Destroy all CUDA graphs and release the shared memory pool."""
+    _manager.teardown()
+
+
+class CUDAGraphWrapper:
+    """Wrap a callable with CUDA graph capture and replay.
+
+    Args:
+        fn: The callable (forward+backward step) to wrap.
+        static_input_indices: Indices of inputs whose tensor addresses
+            are stable across calls (e.g. model weights/buffers).
+    """
+
+    def __init__(
+        self,
+        fn: Callable,
+        example_inputs: Sequence[Any],
+        static_input_indices: tuple[int, ...] | None = None,
+    ):
+        _manager.maybe_initialize()
+        _manager.register(self)
+
+        self._fn = fn
+        self._static = set(static_input_indices or ())
+        self._copy_indices = [
+            i
+            for i, inp in enumerate(example_inputs)
+            if isinstance(inp, torch.Tensor) and i not in self._static
+        ]
+        self._graph: torch.cuda.CUDAGraph | None = None
+        self._warmup_remaining = 1
+        self._args: tuple | None = None
+        self._output: Any = None
+
+    def __call__(self, *args):
+        if self._warmup_remaining > 0:
+            self._warmup_remaining -= 1
+            device = torch.cuda.current_device()
+            with _use_cuda_memory_pool_manager(
+                device, _manager.graph_pool, _manager.stream
+            ):
+                return self._fn(*args)
+
+        if self._graph is None:
+            self._args = args
+            self._graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(
+                self._graph,
+                pool=_manager.graph_pool,
+                stream=_manager.stream,
+                capture_error_mode="thread_local",
+            ):
+                self._output = self._fn(*args)
+            logger.info("Recorded CUDA graph")
+
+        for i in self._copy_indices:
+            self._args[i].copy_(args[i])
+        self._graph.replay()
+        return self._output
+
+    def teardown(self) -> None:
+        self._graph = None
+        self._args = None
+        self._output = None

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -1,0 +1,414 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Lightweight CUDA graph wrapper for eager-mode training steps.
+
+Adapted from ``torchtitan/experiments/graph_trainer/cudagraph.py``.
+"""
+
+import warnings
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+from torch.nn.attention.flex_attention import BlockMask
+from torch.utils import _pytree as pytree
+
+from torchtitan.tools import utils
+from torchtitan.tools.logging import logger
+
+
+ForwardBackwardFn = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor, dict[str, Any]],
+    torch.Tensor,
+]
+
+
+@dataclass(frozen=True)
+class _BlockMaskInputSpec:
+    num_leaves: int
+    context: tuple[Any, ...]
+
+
+# TODO(@jinsooihm): Remove this class and use standard pytree flattening after
+# attention mask creation moves into model code and BlockMask is no longer an input.
+class CUDAGraphInputSpec:
+    """Flatten structured inputs while exposing tensors stored in ``BlockMask``."""
+
+    def __init__(self, tree: Any) -> None:
+        outer_leaves, self._tree_spec = pytree.tree_flatten(
+            tree,
+            is_leaf=lambda value: isinstance(value, BlockMask),
+        )
+        self._leaf_specs: list[_BlockMaskInputSpec | None] = []
+        self._num_flat_leaves = 0
+        for leaf in outer_leaves:
+            if isinstance(leaf, BlockMask):
+                block_mask_leaves, context = leaf._flatten()
+                self._leaf_specs.append(
+                    _BlockMaskInputSpec(len(block_mask_leaves), context)
+                )
+                self._num_flat_leaves += len(block_mask_leaves)
+            else:
+                self._leaf_specs.append(None)
+                self._num_flat_leaves += 1
+
+    def flatten(self, tree: Any) -> list[Any]:
+        outer_leaves, tree_spec = pytree.tree_flatten(
+            tree,
+            is_leaf=lambda value: isinstance(value, BlockMask),
+        )
+        if tree_spec != self._tree_spec or len(outer_leaves) != len(self._leaf_specs):
+            raise ValueError(
+                "CUDA graph auxiliary input structure must remain constant across "
+                "training steps."
+            )
+
+        flat_leaves: list[Any] = []
+        for leaf, leaf_spec in zip(outer_leaves, self._leaf_specs, strict=True):
+            if leaf_spec is None:
+                if isinstance(leaf, BlockMask):
+                    raise ValueError(
+                        "CUDA graph auxiliary input structure must remain constant "
+                        "across training steps."
+                    )
+                flat_leaves.append(leaf)
+                continue
+
+            if not isinstance(leaf, BlockMask):
+                raise ValueError(
+                    "CUDA graph auxiliary input structure must remain constant "
+                    "across training steps."
+                )
+            block_mask_leaves, context = leaf._flatten()
+            if (
+                len(block_mask_leaves) != leaf_spec.num_leaves
+                or context != leaf_spec.context
+            ):
+                raise ValueError(
+                    "CUDA graph BlockMask structure must remain constant across "
+                    "training steps."
+                )
+            flat_leaves.extend(block_mask_leaves)
+
+        return flat_leaves
+
+    def unflatten(self, flat_leaves: Sequence[Any]) -> Any:
+        if len(flat_leaves) != self._num_flat_leaves:
+            raise ValueError(
+                f"CUDA graph expected {self._num_flat_leaves} auxiliary inputs, "
+                f"got {len(flat_leaves)}."
+            )
+
+        outer_leaves: list[Any] = []
+        flat_index = 0
+        for leaf_spec in self._leaf_specs:
+            if leaf_spec is None:
+                outer_leaves.append(flat_leaves[flat_index])
+                flat_index += 1
+                continue
+
+            block_mask_end = flat_index + leaf_spec.num_leaves
+            block_mask_leaves = tuple(flat_leaves[flat_index:block_mask_end])
+            outer_leaves.append(
+                BlockMask._unflatten(block_mask_leaves, leaf_spec.context)
+            )
+            flat_index = block_mask_end
+
+        return pytree.tree_unflatten(outer_leaves, self._tree_spec)
+
+
+class _CUDAGraphManager:
+    """Singleton that owns a shared graph pool and stream."""
+
+    def __init__(self) -> None:
+        self._initialized = False
+        self._wrappers: list["CUDAGraphWrapper"] = []
+        self._graph_pool: Any = None
+        self._stream: torch.cuda.Stream | None = None
+        self._dummy_graph: torch.cuda.CUDAGraph | None = None
+
+    @property
+    def graph_pool(self) -> Any:
+        assert self._graph_pool is not None
+        return self._graph_pool
+
+    @property
+    def stream(self) -> torch.cuda.Stream:
+        assert self._stream is not None
+        return self._stream
+
+    def maybe_initialize(self) -> None:
+        if self._initialized:
+            return
+        graph_pool = torch.cuda.graph_pool_handle()
+        stream = torch.cuda.Stream()
+        dummy_graph = torch.cuda.CUDAGraph()
+        self._graph_pool = graph_pool
+        self._stream = stream
+        self._dummy_graph = dummy_graph
+        with (
+            warnings.catch_warnings(record=True),
+            torch.cuda.graph(
+                dummy_graph,
+                pool=graph_pool,
+                stream=stream,
+                capture_error_mode="thread_local",
+            ),
+        ):
+            pass
+        self._initialized = True
+
+    def register(self, wrapper: "CUDAGraphWrapper") -> None:
+        self._wrappers.append(wrapper)
+
+    def teardown(self) -> None:
+        if not self._initialized:
+            return
+        for wrapper in self._wrappers:
+            wrapper.teardown()
+        self._wrappers.clear()
+        self._dummy_graph = None
+        self._stream = None
+        self._graph_pool = None
+        self._initialized = False
+
+
+_manager = _CUDAGraphManager()
+
+
+def cudagraph_teardown() -> None:
+    """Destroy all CUDA graphs and release the shared memory pool."""
+    _manager.teardown()
+
+
+class CUDAGraphWrapper:
+    """Wrap a callable with CUDA graph capture and replay.
+
+    Args:
+        fn: The callable (forward+backward step) to wrap.
+        example_inputs: Inputs that define the fixed input structure and tensor
+            metadata for capture and replay.
+        static_input_indices: Indices of inputs whose tensor addresses
+            are stable across calls (e.g. model weights/buffers).
+        should_check_address: Whether to verify static input tensor addresses
+            before each replay. This should only be enabled for debugging.
+    """
+
+    def __init__(
+        self,
+        fn: Callable,
+        example_inputs: Sequence[Any],
+        static_input_indices: tuple[int, ...] | None = None,
+        should_check_address: bool = False,
+    ):
+        self._fn = fn
+        self._num_inputs = len(example_inputs)
+        self._static_input_indices = set(static_input_indices or ())
+        invalid_static_indices = {
+            i for i in self._static_input_indices if i < 0 or i >= self._num_inputs
+        }
+        if invalid_static_indices:
+            raise ValueError(
+                "CUDA graph static input indices are out of range: "
+                f"{sorted(invalid_static_indices)}"
+            )
+
+        self._input_indices_to_copy = [
+            i
+            for i, inp in enumerate(example_inputs)
+            if isinstance(inp, torch.Tensor) and i not in self._static_input_indices
+        ]
+        self._tensor_metadata = {
+            i: (inp.shape, inp.dtype, inp.device)
+            for i, inp in enumerate(example_inputs)
+            if isinstance(inp, torch.Tensor)
+        }
+        self._non_tensor_inputs = {
+            i: inp
+            for i, inp in enumerate(example_inputs)
+            if not isinstance(inp, torch.Tensor)
+        }
+        self._graph: torch.cuda.CUDAGraph | None = None
+        self._warmup_remaining = 1
+        self._args: tuple | None = None
+        self._output: Any = None
+        self._should_check_address = should_check_address
+        self._static_input_addresses: dict[int, int] = {}
+
+        _manager.maybe_initialize()
+        _manager.register(self)
+
+    def _record_static_input_addresses(self, args: tuple[Any, ...]) -> None:
+        for i in self._static_input_indices:
+            arg = args[i]
+            if isinstance(arg, torch.Tensor):
+                self._static_input_addresses[i] = arg.data_ptr()
+
+    def _check_static_input_addresses(self, args: tuple[Any, ...]) -> None:
+        for i, expected in self._static_input_addresses.items():
+            arg = args[i]
+            assert isinstance(
+                arg, torch.Tensor
+            ), f"Static input at index {i} changed from a tensor to {type(arg)}"
+            actual = arg.data_ptr()
+            assert expected == actual, (
+                "Expected the same static tensor address at index "
+                f"{i}, but found {expected} != {actual}"
+            )
+
+    def _validate_inputs(self, args: tuple[Any, ...]) -> None:
+        if len(args) != self._num_inputs:
+            raise ValueError(
+                f"CUDA graph expected {self._num_inputs} inputs, got {len(args)}"
+            )
+
+        for i, expected_metadata in self._tensor_metadata.items():
+            arg = args[i]
+            if not isinstance(arg, torch.Tensor):
+                raise ValueError(
+                    f"CUDA graph input {i} changed from a tensor to {type(arg)}"
+                )
+            actual_metadata = (arg.shape, arg.dtype, arg.device)
+            if actual_metadata != expected_metadata:
+                raise ValueError(
+                    "CUDA graph tensor inputs must keep the same shape, dtype, "
+                    f"and device, but input {i} changed from "
+                    f"{expected_metadata} to {actual_metadata}"
+                )
+
+        for i, expected in self._non_tensor_inputs.items():
+            actual = args[i]
+            if type(actual) is not type(expected) or actual != expected:
+                raise ValueError(
+                    "CUDA graph non-tensor inputs must remain constant, but input "
+                    f"{i} changed from {expected!r} to {actual!r}"
+                )
+
+    def __call__(self, *args):
+        self._validate_inputs(args)
+
+        if self._warmup_remaining > 0:
+            self._warmup_remaining -= 1
+            current_stream = torch.cuda.current_stream()
+            _manager.stream.wait_stream(current_stream)
+            with torch.cuda.stream(_manager.stream):
+                output = self._fn(*args)
+            current_stream.wait_stream(_manager.stream)
+            return output
+
+        if self._graph is None:
+            self._args = args
+            self._record_static_input_addresses(args)
+            self._graph = torch.cuda.CUDAGraph()
+            # TODO: Investigate why FSDP reshard_after_forward="always" leaves
+            # an all-gather event from warmup that causes
+            # CUDA_ERROR_STREAM_CAPTURE_ISOLATION when capture begins. The
+            # "default" and "never" policies work.
+            with torch.cuda.graph(
+                self._graph,
+                pool=_manager.graph_pool,
+                stream=_manager.stream,
+                capture_error_mode="thread_local",
+            ):
+                self._output = self._fn(*args)
+            logger.info("Recorded CUDA graph")
+
+        if self._should_check_address:
+            self._check_static_input_addresses(args)
+
+        assert self._args is not None
+        assert self._graph is not None
+        for i in self._input_indices_to_copy:
+            self._args[i].copy_(args[i])
+        self._graph.replay()
+        return self._output
+
+    def teardown(self) -> None:
+        self._graph = None
+        self._args = None
+        self._output = None
+        self._static_input_addresses.clear()
+        self._non_tensor_inputs.clear()
+
+
+def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
+    """Decorate a callable with CUDA graph capture/replay."""
+
+    if not (
+        utils.device_type == "cuda"
+        and torch.cuda.is_available()
+        and torch.version.hip is None
+    ):
+        logger.warning(
+            "CUDA graph capture is only supported on NVIDIA CUDA; "
+            "using eager execution."
+        )
+        return fwd_bwd_fn
+
+    # Every wrapper is registered to the manager in this module and persists
+    # until cudagraph_teardown is called.
+    graph_wrapper: CUDAGraphWrapper | None = None
+    # Input handling for dynamic custom type inputs like BlockMask.
+    extra_input_spec: CUDAGraphInputSpec | None = None
+
+    def run(
+        inputs: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        extra_kwargs: dict[str, Any],
+    ) -> torch.Tensor:
+        nonlocal graph_wrapper, extra_input_spec
+
+        if graph_wrapper is None:
+            extra_input_spec = CUDAGraphInputSpec(extra_kwargs)
+
+            def flat_fwd_bwd(
+                step_inputs: torch.Tensor,
+                step_labels: torch.Tensor,
+                step_global_valid_tokens: torch.Tensor,
+                *flat_extra_inputs: Any,
+            ) -> torch.Tensor:
+                assert extra_input_spec is not None
+                step_extra_kwargs = cast(
+                    dict[str, Any],
+                    extra_input_spec.unflatten(flat_extra_inputs),
+                )
+                return fwd_bwd_fn(
+                    step_inputs,
+                    step_labels,
+                    step_global_valid_tokens,
+                    step_extra_kwargs,
+                )
+
+            extra_flat = extra_input_spec.flatten(extra_kwargs)
+            example_inputs = [
+                inputs,
+                labels,
+                global_valid_tokens,
+                *extra_flat,
+            ]
+            graph_wrapper = CUDAGraphWrapper(
+                flat_fwd_bwd,
+                example_inputs,
+            )
+        else:
+            assert extra_input_spec is not None
+            extra_flat = extra_input_spec.flatten(extra_kwargs)
+
+        loss = graph_wrapper(
+            inputs,
+            labels,
+            global_valid_tokens,
+            *extra_flat,
+        )
+        # CUDA graph outputs are overwritten by each replay.
+        # TODO: Avoid this clone by migrating loss accumulation to a persistent
+        # tensor updated with add_().
+        return loss.clone()
+
+    return run

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -45,6 +45,7 @@ def build_minimal_trainer(
     trainer.loss_fn = CrossEntropyLoss.Config().build()
     trainer.parallel_dims = SimpleNamespace(pp_enabled=False, cp_enabled=False)
     trainer.train_context = get_spmd_context()
+    trainer.fwd_bwd_fn = trainer._forward_backward_body
     trainer.model_config = model_config
     trainer.device = torch.device("cuda")
     trainer.tokenizer = tokenizer

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -19,6 +19,7 @@ from torchtitan.components.dataloader import DataloaderExhaustedError
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.experiments.torchft.config.job_config import FaultTolerance
 from torchtitan.experiments.torchft.manager import (
     maybe_semi_sync_training,
@@ -311,6 +312,9 @@ class FaultTolerantTrainer(Trainer):
         self.train_context = dist_utils.get_spmd_context(
             parallel_dims=parallel_dims,
         )
+        self.fwd_bwd_fn = self._forward_backward_body
+        if not config.training.disable_cuda_graphs:
+            self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -382,7 +386,7 @@ class FaultTolerantTrainer(Trainer):
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
-        self.optimizers.zero_grad()
+        self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
 

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -110,6 +110,17 @@ def deepseek_v3_16b() -> Trainer.Config:
     )
 
 
+def deepseek_v3_16b_hybridep() -> Trainer.Config:
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry(
+        "16B",
+        attn_backend="flex",
+        moe_comm_backend="hybridep",
+        non_blocking_capacity_factor=1.0,
+    )
+    return config
+
+
 def deepseek_v3_671b() -> Trainer.Config:
     compile_config = CompileConfig(enable=True, components=["loss"])
     model_compile_enabled = (

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -159,6 +159,7 @@ def deepseek_v3_16b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=1000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             pipeline_parallel_schedule="Interleaved1F1B",
@@ -178,6 +179,7 @@ def deepseek_v3_16b_hybridep() -> Trainer.Config:
         moe_comm_backend="hybridep",
         non_blocking_capacity_factor=1.0,
     )
+    config.training.disable_cuda_graphs = False
     return config
 
 
@@ -198,6 +200,7 @@ def deepseek_v3_16b_minimal_async_ep() -> Trainer.Config:
         expert_parallel_degree=1,
         enable_sequence_parallel=False,
     )
+    config.training.disable_cuda_graphs = False
     return config
 
 
@@ -228,6 +231,7 @@ def deepseek_v3_671b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=10000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             pipeline_parallel_schedule="Interleaved1F1B",

--- a/torchtitan/models/flux/config_registry.py
+++ b/torchtitan/models/flux/config_registry.py
@@ -45,6 +45,7 @@ def flux_debugmodel() -> FluxTrainer.Config:
             local_batch_size=4,
             max_norm=2.0,
             steps=10,
+            disable_cuda_graphs=True,
         ),
         dataloader=FluxDataLoader.Config(
             prompt_dropout_prob=0.447,
@@ -106,6 +107,7 @@ def flux_dev() -> FluxTrainer.Config:
         training=TrainingConfig(
             local_batch_size=32,
             steps=30000,
+            disable_cuda_graphs=True,
         ),
         dataloader=FluxDataLoader.Config(
             dataset="cc12m-wds",
@@ -156,6 +158,7 @@ def flux_schnell() -> FluxTrainer.Config:
         training=TrainingConfig(
             local_batch_size=64,
             steps=30000,
+            disable_cuda_graphs=True,
         ),
         dataloader=FluxDataLoader.Config(
             dataset="cc12m-wds",

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -79,6 +79,7 @@ def kimi_k2_5_debugmodel() -> Trainer.Config:
             local_batch_size=1,
             seq_len=512,
             steps=10,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(spmd_backend="spmd_types"),
         checkpoint=CheckpointManager.Config(
@@ -112,6 +113,7 @@ def moonlight_16b_a3b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=10000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             expert_parallel_degree=8,
@@ -152,6 +154,7 @@ def kimi_vl_a3b() -> Trainer.Config:
             local_batch_size=1,
             seq_len=4096,
             steps=10000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             expert_parallel_degree=8,
@@ -187,6 +190,7 @@ def kimi_k2_5() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=10000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             pipeline_parallel_schedule="Interleaved1F1B",

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -74,6 +74,7 @@ def llama3_debugmodel() -> Trainer.Config:
 def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     config = llama3_debugmodel()
     config.model_spec = model_registry("debugmodel", attn_backend="varlen")
+    config.training.disable_cuda_graphs = True
     return config
 
 

--- a/torchtitan/models/muse_glimmer/config_registry.py
+++ b/torchtitan/models/muse_glimmer/config_registry.py
@@ -143,6 +143,7 @@ def muse_glimmer_debugmodel_mm() -> Trainer.Config:
             local_batch_size=4,
             seq_len=512,
             steps=10,
+            disable_cuda_graphs=True,
         ),
         checkpoint=CheckpointManager.Config(
             interval=10,
@@ -208,6 +209,7 @@ def muse_glimmer_30b_mm() -> Trainer.Config:
             local_batch_size=1,
             seq_len=8192,
             steps=1000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -432,7 +432,12 @@ def qwen3_moe_deepep() -> Trainer.Config:
         dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
         optimizer=default_adamw(lr=3e-4),
         lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
-        training=TrainingConfig(local_batch_size=2, seq_len=512, steps=10),
+        training=TrainingConfig(
+            local_batch_size=2,
+            seq_len=512,
+            steps=10,
+            disable_cuda_graphs=True,
+        ),
         parallelism=ParallelismConfig(expert_parallel_degree=4),
         checkpoint=CheckpointManager.Config(
             interval=1000, last_save_model_only=False, export_dtype="float16"

--- a/torchtitan/models/qwen3_5/config_registry.py
+++ b/torchtitan/models/qwen3_5/config_registry.py
@@ -72,6 +72,7 @@ def qwen35_debugmodel() -> Trainer.Config:
 def qwen35_debugmodel_varlen_attn() -> Trainer.Config:
     config = qwen35_debugmodel()
     config.model_spec = model_registry("debugmodel", attn_backend="varlen")
+    config.training.disable_cuda_graphs = True
     return config
 
 
@@ -94,6 +95,7 @@ def qwen35_debugmodel_moe() -> Trainer.Config:
             local_batch_size=2,
             seq_len=512,
             steps=10,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=2,
@@ -278,6 +280,7 @@ def qwen35_35b_a3b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=1000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
@@ -310,6 +313,7 @@ def qwen35_122b_a10b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=1000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
@@ -342,6 +346,7 @@ def qwen35_397b_a17b() -> Trainer.Config:
             local_batch_size=4,
             seq_len=4096,
             steps=1000,
+            disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -683,28 +683,93 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         else:
             # Non-PP forward / backward
             assert len(model_parts) == 1
-            with self.train_context():
-                pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
-                # Under non-full_dtensor, labels stay as plain tensors. See
-                # ``cross_entropy_loss`` for why pred must also be plain.
-                # Remove once non-full_dtensor is no longer supported.
-                if (
-                    isinstance(pred, DTensor)
-                    and not self.config.parallelism.full_dtensor
-                    and self.config.parallelism.disable_loss_parallel
-                ):
-                    pred = pred.to_local()
-                loss = self.loss_fn(pred, labels, global_valid_tokens)
-                del pred
-                loss.backward()
+
+            if self.config.training.enable_cuda_graphs:
+                loss = self._cuda_graph_fwd_bwd(
+                    inputs, labels, global_valid_tokens, extra_inputs, extra_kwargs
+                )
+            else:
+                with self.train_context():
+                    pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
+                    # Under non-full_dtensor, labels stay as plain tensors. See
+                    # ``cross_entropy_loss`` for why pred must also be plain.
+                    # Remove once non-full_dtensor is no longer supported.
+                    if (
+                        isinstance(pred, DTensor)
+                        and not self.config.parallelism.full_dtensor
+                        and self.config.parallelism.disable_loss_parallel
+                    ):
+                        pred = pred.to_local()
+                    loss = self.loss_fn(pred, labels, global_valid_tokens)
+                    del pred
+                    loss.backward()
 
         # The returned loss here is local SUM loss / global_valid_tokens
         return loss
 
+    def _cuda_graph_fwd_bwd(
+        self,
+        inputs: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        extra_inputs: dict[str, torch.Tensor],
+        extra_kwargs: dict[str, Any],
+    ) -> torch.Tensor:
+        """Forward+backward wrapped with CUDA graph capture/replay."""
+        from torchtitan.distributed.cudagraph import CUDAGraphWrapper
+
+        if not hasattr(self, "_cg_wrapper"):
+            model = self.model_parts[0]
+            train_context = self.train_context
+            loss_fn = self.loss_fn
+            full_dtensor_enabled = self.config.parallelism.full_dtensor
+            disable_loss_parallel = self.config.parallelism.disable_loss_parallel
+
+            def _step(inp, lab, gvt, *extra_flat):
+                with train_context():
+                    pred = model(inp, **extra_inputs, **extra_kwargs)
+                    if (
+                        isinstance(pred, DTensor)
+                        and not full_dtensor_enabled
+                        and disable_loss_parallel
+                    ):
+                        pred = pred.to_local()
+                    loss = loss_fn(pred, lab, gvt)
+                    del pred
+                    loss.backward()
+                return loss
+
+            extra_flat = []
+            for v in extra_inputs.values():
+                if isinstance(v, torch.Tensor):
+                    extra_flat.append(v)
+            for v in extra_kwargs.values():
+                if isinstance(v, torch.Tensor):
+                    extra_flat.append(v)
+
+            example_inputs = [inputs, labels, global_valid_tokens] + extra_flat
+            static_indices = tuple(range(3, len(example_inputs)))
+            self._cg_wrapper = CUDAGraphWrapper(
+                _step, example_inputs, static_input_indices=static_indices
+            )
+            self._cg_extra_flat_count = len(extra_flat)
+
+        extra_flat = []
+        for v in extra_inputs.values():
+            if isinstance(v, torch.Tensor):
+                extra_flat.append(v)
+        for v in extra_kwargs.values():
+            if isinstance(v, torch.Tensor):
+                extra_flat.append(v)
+
+        return self._cg_wrapper(inputs, labels, global_valid_tokens, *extra_flat)
+
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
-        self.optimizers.zero_grad()
+        self.optimizers.zero_grad(
+            set_to_none=not self.config.training.enable_cuda_graphs
+        )
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
 
@@ -885,6 +950,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.ntokens_seen = state_dict["ntokens_seen"]
 
     def close(self) -> None:
+        if hasattr(self, "_cg_wrapper"):
+            from torchtitan.distributed.cudagraph import cudagraph_teardown
+
+            cudagraph_teardown()
         if hasattr(self, "checkpointer") and self.checkpointer:
             self.checkpointer.close()
         if hasattr(self, "metrics_processor") and self.metrics_processor:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -45,9 +45,19 @@ from torchtitan.distributed.activation_checkpoint import (
     SelectiveAC,
 )
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
+from torchtitan.distributed.cudagraph import (
+    cudagraph_teardown,
+    ForwardBackwardFn,
+    wrap_with_cuda_graph,
+)
 from torchtitan.distributed.spmd_types import annotate_input_spmd_types
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.token_dispatcher import (
+    HybridEPTokenDispatcher,
+    LocalTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher,
+)
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
@@ -129,6 +139,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     f"({pp_microbatch_size}) when pipeline parallelism is enabled."
                 )
 
+            self._validate_cuda_graphs()
+
             if (
                 self.parallelism.spmd_backend == "spmd_types"
                 and self.debug.spmd_typechecking
@@ -163,6 +175,39 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     "Memory budget activation checkpointing requires the model to be "
                     "compiled: set --compile.enable and include 'model' in "
                     "--compile.components."
+                )
+
+        def _validate_cuda_graphs(self) -> None:
+            if self.training.disable_cuda_graphs:
+                return
+
+            if self.parallelism.pipeline_parallel_degree > 1:
+                raise ValueError(
+                    "CUDA graphs do not support pipeline parallelism yet. "
+                    "Set --training.disable_cuda_graphs."
+                )
+
+            if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
+                return
+
+            for _, dispatcher_config, _, _ in self.model_spec.model.traverse(
+                LocalTokenDispatcher.Config
+            ):
+                if isinstance(
+                    dispatcher_config, MinimalAsyncEPTokenDispatcher.Config
+                ) or (
+                    isinstance(dispatcher_config, HybridEPTokenDispatcher.Config)
+                    and dispatcher_config.non_blocking_capacity_factor is not None
+                ):
+                    continue
+
+                raise ValueError(
+                    "CUDA graphs support only expert parallel token dispatcher "
+                    "configurations without CPU synchronization. "
+                    "Set HybridEP non_blocking_capacity_factor, or use "
+                    "MinimalAsyncEP, or set --training.disable_cuda_graphs. "
+                    "Unsupported token "
+                    f"dispatcher: {type(dispatcher_config).__qualname__}."
                 )
 
         def to_dict(self) -> dict[str, Any]:
@@ -229,6 +274,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     device: torch.device
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
+    fwd_bwd_fn: ForwardBackwardFn
     gradient_accumulation_steps: int
     num_pipeline_parallel_microbatches: int
     pp_has_first_stage: bool
@@ -311,6 +357,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # loss, dataloader, …) are built later in __init__.
         if config.override.imports:
             apply_overrides(config.override, config)
+        config._validate_cuda_graphs()
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")
 
@@ -563,6 +610,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 and config.debug.spmd_typechecking
             ),
         )
+        self.fwd_bwd_fn = self._forward_backward_body
+        if not config.training.disable_cuda_graphs:
+            self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -752,8 +802,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
 
         assert len(model_parts) == 1
+        return self.fwd_bwd_fn(inputs, labels, global_valid_tokens, extra_kwargs)
+
+    def _forward_backward_body(
+        self,
+        inputs: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        extra_kwargs: dict[str, Any],
+    ) -> torch.Tensor:
         with self.train_context():
-            pred = model_parts[0](inputs, **extra_kwargs)
+            pred = self.model_parts[0](inputs, **extra_kwargs)
             loss_kwargs = {}
             if "positions" in extra_kwargs:
                 loss_kwargs["positions"] = extra_kwargs["positions"]
@@ -813,7 +872,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
-        self.optimizers.zero_grad()
+        self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
 
@@ -1017,6 +1076,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.ntokens_seen = state_dict["ntokens_seen"]
 
     def close(self) -> None:
+        if not self.config.training.disable_cuda_graphs:
+            cudagraph_teardown()
         if hasattr(self, "checkpointer") and self.checkpointer:
             self.checkpointer.close()
         if hasattr(self, "metrics_processor") and self.metrics_processor:


### PR DESCRIPTION
Stacked PRs:
 * __->__#3559


--- --- ---

### Add eager CUDA graph capture to the core Trainer


#### Known limitations
- Pipeline parallelism primarily needs a different capture boundary rather than different model semantics: capture each stage forward/backward action with its static microbatch state while leaving the Python schedule and P2P handoff eager, instead of capturing the current combined forward+loss+backward callable.
- Any captured path that synchronizes with the CPU is unsupported. This includes blocking AllToAll expert parallelism; CUDA graph EP currently requires nonblocking HybridEP or MinimalAsyncEP.
- FSDP reshard_after_forward=always is unsupported. Its all-gather work uses hidden FSDP streams, and capture can encounter a dependency on an event produced by uncaptured work, resulting in CUDA_ERROR_STREAM_CAPTURE_ISOLATION. The default and never policies work.

#### No warmup needed
Numerics already match without warmup iteration.
1st iteration: record
2nd+ iteration: replay

#### Copy-in
Some tensors need to be copied each iteration due to the dataloader's sequence packing. For DSV3 16B these are:
  - Input token IDs
  - Labels
  - global_valid_tokens scalar
  - Position IDs
  - FlexAttention BlockMask tensors:
      - block counts and indices
      - full-block metadata
      - backward/query ordering metadata
      - tensors captured by the packed-document mask function

#### Test Plan
- Llama 3 debug model, 1 GPU, 10 deterministic steps: eager and CUDA graph TensorBoard loss and grad norm were exactly equal at every step.
- DeepSeek v3 debug model, 1 GPU, balanced MoE routing, 10 deterministic steps: eager and CUDA graph TensorBoard loss and grad norm were exactly equal at every step. This GB300 SM103 build required a temporary bmm test shim because native torch._grouped_mm fails to launch; the shim is not included in this commit.
- 8x H100, 10 deterministic steps: compared raw TensorBoard float32 loss and grad norm values with CUDA graphs disabled and enabled. All 60 scalar pairs matched bitwise (maximum absolute difference 0):
  - Llama 3 70B, FSDP=4 + TP=2
  - DeepSeek v3 16B HybridEP, FSDP=4 + EP=2 + TP=2
  - DeepSeek v3 16B HybridEP, FSDP=8 + EP=8, Full AC/SAC/No AC
  - DeepSeek v3 16B MinimalAsyncEP, FSDP=8 + EP=8, Full AC

Profile w/ CG: https://interncache-all.fbcdn.net/manifold/perfetto-artifacts/tree/ui/index.html#!/?url=https://interncache-all.fbcdn.net/manifold/perfetto_internal_traces/tree/shared_trace/xmfan_9ba1b77a-f72b-4e7d-b7ad-716941df298c_rank0_trace.json.gz

can see the cg launch from cpu thread
<img width="730" height="154" alt="image" src="https://github.com/user-attachments/assets/1bc40f8b-6007-46c4-89bb-f9df5760587b" />

#### Next steps

There still remains some sync (loss accumulation) after the optimizer to eliminate in the trainer, to be removed soon.
PP uses a different fwd bwd entrypoint.

Disabled cudagraph configs:
  - Pipeline-parallel configs
  - Standard host-synchronizing EP
  - Varlen attention
  - Flux/Kimi/Muse multimodal configs