### PR TITLE
[RL] Enable regional_inductor in FlexAttention

### DIFF
--- a/tests/unit_tests/test_compile_regional_inductor.py
+++ b/tests/unit_tests/test_compile_regional_inductor.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import unittest
+
+import torch
+
+import torchtitan.distributed.compile as compile_mod
+from torchtitan.distributed.compile import (
+    _maybe_regional_inductor_backend,
+    maybe_regional_inductor,
+)
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.nn_modules import Linear
+
+
+class TestRegionalInductorBackend(unittest.TestCase):
+    """CPU tests for FlexAttention regional_inductor backend selection.
+
+    These exercise only the backend-selection decision and the resulting
+    annotation toggle; compilation is never run, so no GPU is required.
+    """
+
+    def setUp(self):
+        self._flex = FlexAttention(FlexAttention.Config())
+        self._dense = Linear.Config(in_features=4, out_features=4, bias=False).build()
+        compile_mod._regional_inductor_enabled = False
+
+    def tearDown(self):
+        compile_mod._regional_inductor_enabled = False
+
+    def test_inductor_backend_left_unchanged(self):
+        backend = _maybe_regional_inductor_backend(self._flex, "inductor")
+        self.assertEqual(backend, "inductor")
+        self.assertFalse(compile_mod._regional_inductor_enabled)
+
+    def test_aot_eager_with_flex_scoops(self):
+        backend = _maybe_regional_inductor_backend(self._flex, "aot_eager")
+        self.assertTrue(callable(backend))
+        self.assertTrue(compile_mod._regional_inductor_enabled)
+
+    def test_aot_eager_without_flex_left_unchanged(self):
+        backend = _maybe_regional_inductor_backend(self._dense, "aot_eager")
+        self.assertEqual(backend, "aot_eager")
+        self.assertFalse(compile_mod._regional_inductor_enabled)
+
+    def test_other_backend_with_flex_raises(self):
+        with self.assertRaises(ValueError):
+            _maybe_regional_inductor_backend(self._flex, "eager")
+        self.assertFalse(compile_mod._regional_inductor_enabled)
+
+    def test_region_annotation_follows_flag(self):
+        # Disabled -> null context, so no annotation metadata is emitted.
+        ctx = maybe_regional_inductor(FlexAttention.inductor_configs)
+        self.assertIsInstance(ctx, contextlib.nullcontext)
+        # Enabled -> a real annotation context manager.
+        compile_mod._regional_inductor_enabled = True
+        ctx = maybe_regional_inductor(FlexAttention.inductor_configs)
+        self.assertNotIsInstance(ctx, contextlib.nullcontext)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestRegionalInductorCodegen(unittest.TestCase):
+    """GPU test: the compiled program lowers FlexAttention to a triton kernel.
+
+    Compiles flex under aot_eager and inspects the generated code. With the
+    regional scoop the flex region produces a triton kernel; with plain
+    aot_eager it decomposes to eager aten (no triton flex kernel).
+    """
+
+    def setUp(self):
+        # Disable autotune so codegen is fast and deterministic; the regional
+        # annotation reads inductor_configs, so this also speeds up the scoop.
+        self._cfg_backup = dict(FlexAttention.inductor_configs)
+        FlexAttention.inductor_configs["max_autotune"] = False
+        FlexAttention.inductor_configs["coordinate_descent_tuning"] = False
+        compile_mod._regional_inductor_enabled = False
+
+    def tearDown(self):
+        FlexAttention.inductor_configs.clear()
+        FlexAttention.inductor_configs.update(self._cfg_backup)
+        compile_mod._regional_inductor_enabled = False
+        torch._dynamo.reset()
+
+    @staticmethod
+    def _triton_flex_kernel_count(backend) -> int:
+        from torch._inductor.utils import run_fw_bw_and_get_code
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        torch._dynamo.reset()
+        attn = FlexAttention(FlexAttention.Config())
+        bs, seq, heads, dim = 2, 256, 4, 64
+        shape = (bs, seq, heads, dim)
+        q, k, v = (
+            torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+            for _ in range(3)
+        )
+        block_mask = create_block_mask(
+            lambda b, h, q_idx, kv_idx: q_idx >= kv_idx,
+            B=None,
+            H=None,
+            Q_LEN=seq,
+            KV_LEN=seq,
+            device="cuda",
+        )
+
+        def fn(q, k, v):
+            return (attn(q, k, v, attention_masks=block_mask) ** 2).sum()
+
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        _, codes = run_fw_bw_and_get_code(lambda: compiled(q, k, v))
+        return sum(1 for c in codes if "triton" in c and "flex_attention" in c)
+
+    def test_plain_aot_eager_decomposes_flex(self):
+        # Flag stays False -> forward emits no annotation -> flex decomposes.
+        self.assertEqual(self._triton_flex_kernel_count("aot_eager"), 0)
+
+    def test_regional_scoop_lowers_flex_to_triton(self):
+        backend = _maybe_regional_inductor_backend(
+            FlexAttention(FlexAttention.Config()), "aot_eager"
+        )
+        # Forward + backward flex regions both lower to triton.
+        self.assertGreaterEqual(self._triton_flex_kernel_count(backend), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/compile.py
+++ b/torchtitan/distributed/compile.py
@@ -4,7 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
+from collections.abc import Callable
+
 import torch
+import torch.fx.traceback as fx_traceback
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorMode
 
@@ -18,6 +22,14 @@ from torchtitan.tools.logging import logger
 FakeTensorMode.__init__ = torch.compiler.disable(  # type: ignore[method-assign]
     FakeTensorMode.__init__, recursive=True
 )
+
+
+# Toggled on by ``_maybe_regional_inductor_backend`` when the model is compiled
+# with a non-inductor backend that needs inductor-only regions (e.g.
+# FlexAttention) scooped into an inductor sub-compile. Read by
+# ``maybe_regional_inductor`` at trace time; left False on the default inductor
+# / eager paths so no annotation metadata is emitted.
+_regional_inductor_enabled: bool = False
 
 
 def apply_compile(model: nn.Module, compile_config: CompileConfig) -> None:
@@ -37,8 +49,65 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig) -> None:
         True  # pyrefly: ignore [bad-assignment]
     )
 
+    backend = _maybe_regional_inductor_backend(model, compile_config.backend)
+
     # pyrefly: ignore [missing-attribute]
     for layer_id, transformer_block in model.layers.named_children():
-        transformer_block.compile(backend=compile_config.backend, fullgraph=True)
+        transformer_block.compile(backend=backend, fullgraph=True)
 
     logger.info("Compiling each TransformerBlock with torch.compile")
+
+
+def _maybe_regional_inductor_backend(model: nn.Module, backend: str) -> str | Callable:
+    """Wrap the ``aot_eager`` backend so inductor-only flex regions are scooped out.
+
+    ``regional_inductor`` lowers just the regions annotated with ``compile_with_inductor`` (see
+    ``FlexAttention.forward``) to inductor while the rest stays in aot_eager.
+
+    Only applied for ``aot_eager`` on models that actually use FlexAttention, so
+    dense/non-flex aot_eager paths are left untouched. Other non-inductor backends
+    can't be scooped here and raise rather than silently degrading.
+    """
+    from torchtitan.models.common.attention import FlexAttention
+
+    uses_flex = any(isinstance(m, FlexAttention) for m in model.modules())
+    # Non-flex models never need the scoop; the default inductor backend already
+    # lowers the flex region directly. Both are left on the unmodified backend.
+    if not uses_flex or backend == "inductor":
+        return backend
+
+    # FlexAttention only has an inductor lowering. Under a non-inductor backend
+    # other than aot_eager it would decompose to eager aten ops (no Triton
+    # kernel), which we can't transparently scoop here -- fail loudly.
+    if backend != "aot_eager":
+        raise ValueError(
+            f"Model uses FlexAttention but compile backend {backend!r} is neither "
+            f"'inductor' nor 'aot_eager'; the flex region would decompose to eager "
+            f"aten ops (no Triton kernel). Use 'inductor' or 'aot_eager'."
+        )
+
+    from torch._dynamo.backends.common import aot_autograd
+    from torch.fx.passes.regional_inductor import regional_inductor
+
+    global _regional_inductor_enabled
+    _regional_inductor_enabled = True
+
+    logger.info("regional_inductor is enabled")
+    return aot_autograd(fw_compiler=regional_inductor, bw_compiler=regional_inductor)
+
+
+def maybe_regional_inductor(
+    inductor_configs: dict,
+) -> contextlib.AbstractContextManager:
+    """Context manager that marks the wrapped region for ``regional_inductor``.
+
+    Returns a null context unless regional inductor is enabled (see
+    ``_maybe_regional_inductor_backend``). When enabled, the region is tagged
+    with ``compile_with_inductor`` so a non-inductor outer compile lowers just
+    this region to inductor with ``inductor_configs``.
+    """
+    if not _regional_inductor_enabled:
+        return contextlib.nullcontext()
+    return fx_traceback.annotate(
+        {"compile_with_inductor": {"inductor_configs": inductor_configs}}
+    )

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -142,12 +142,19 @@ def set_determinism(
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
         # Ensure flex_attention is compiled without max-autotune. This is needed to ensure
-        # reproducibility, since the autotune results may not be deterministic.
+        # reproducibility, since the autotune results may not be deterministic. We disable
+        # autotune in-place on FlexAttention.inductor_configs (rather than recompiling with
+        # no options) so the regional-inductor scoop configs are preserved.
         from torch.nn.attention.flex_attention import flex_attention
 
         from torchtitan.models.common.attention import FlexAttention
 
-        FlexAttention._compiled_flex_attn = torch.compile(flex_attention)
+        FlexAttention.inductor_configs["max_autotune"] = False
+        FlexAttention.inductor_configs["coordinate_descent_tuning"] = False
+        # pyrefly: ignore [no-matching-overload]
+        FlexAttention._compiled_flex_attn = torch.compile(
+            flex_attention, options=FlexAttention.inductor_configs
+        )
 
     if debug_config.detect_anomaly:
         logger.warning(

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -132,8 +132,7 @@ def rl_grpo_qwen3_0_6b_flex() -> RLTrainer.Config:
         num_steps=10,
         num_groups_per_rollout_batch=5,
         num_validation_samples=20,
-        # TODO: add aot_eager compiling overall, today it doesn't work because
-        # we are missing mechanism to scoop Flex region to plug in inductor backend support
+        compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
         group_size=group_size,
         renderer=RendererConfig(name="qwen3", enable_thinking=False),

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -27,6 +27,7 @@ from torch.nn.attention.flex_attention import (
 )
 from torch.nn.attention.varlen import varlen_attn
 
+from torchtitan.distributed.compile import maybe_regional_inductor
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
 
 from torchtitan.models.common.nn_modules import Linear, RMSNorm
@@ -231,16 +232,21 @@ class FlexAttention(Module):
         # 2. `self._compiled_flex_attn` is not correct, `self` will be passed in
         #    as the first argument, which will cause an error.
         #    `FlexAttention._compiled_flex_attn` is correct.
-        out, aux = FlexAttention._compiled_flex_attn(
-            q,
-            k,
-            v,
-            block_mask=attention_masks,
-            scale=scale,
-            enable_gqa=enable_gqa,
-            return_aux=AuxRequest(lse=return_lse),
-            kernel_options=self.kernel_options,
-        )
+        # Mark the flex region so that, when the enclosing model is compiled with
+        # a non-inductor backend, regional_inductor scoops just this region into
+        # an inductor sub-compile (see distributed/compile.py). A null context on
+        # the default inductor / eager paths, so no dead metadata is emitted.
+        with maybe_regional_inductor(FlexAttention.inductor_configs):
+            out, aux = FlexAttention._compiled_flex_attn(
+                q,
+                k,
+                v,
+                block_mask=attention_masks,
+                scale=scale,
+                enable_gqa=enable_gqa,
+                return_aux=AuxRequest(lse=return_lse),
+                kernel_options=self.kernel_options,
+            )
         # Transpose back to (bs, seq, heads, dim)
         if return_lse:
             return out.transpose(1, 2), aux.lse.transpose(1, 2)


### PR DESCRIPTION
When backend is aot_eager, annotate FlexAttention with the regional_inductor metadata so that it gets inductor-compiled. Provided this as a generic context manager `regional_inductor_region` so that other regions could be similarly "scooped" in the future.

Testing: Adding unit tests that validate Triton kernel is emitted when flex is scooped. Also enabling compile with aot_eager for rl_grpo_qwen3_0_6b_flex, validated that the Step 1 mismatch goes down:

Before:
Train | Step:  1  loss/mean: 0.00002  bit_wise/logprob_diff/max: 0.44  reward/_mean: 0.51  reward/_max: 1.30  reward/zero_std_frac: 0  rollout/response_length/max: 100.0  train/grad_norm/mean: 0.73  train/lr: 1.0e-06  perf/tokens_per_second: 1238.6  timing/step: 16.15

After:
Train | Step:  1  loss/mean: 0  bit_wise/logprob_diff/max: 3.5e-07  reward/_mean: 0  rollout_reward/_mean: 0  reward/_max: 0  rollout_reward/_max: 0  reward/zero_std_frac: 1.0  rollout/response_length/max: 100.0  train/grad_norm/mean: 0  train/lr: 1.0e-06  perf/tokens_per_second: 2002.8  timing/step: 10.48

The After numbers line up with disabling compile.
Full paste: Before: P2365572434 ; After: P2365565813

Fixes: https://github.com/pytorch/torchtitan/issues/3497