### PR TITLE
Skip hybridEP test on ROCm since deep_ep isn't installed for ROCm

### DIFF
--- a/.github/scripts/run_8xgpu_integration_tests.sh
+++ b/.github/scripts/run_8xgpu_integration_tests.sh
@@ -76,5 +76,5 @@ fi
 # Disable Nvlink Sharp. The CI machine seems to be unstable state to support
 # NLVS according to several CI runs.
 # DeepEP needs CUDA_HOME specified to JIT kernels.
-CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --test_suite h100 "${ARTIFACTS}" --ngpu 8
+CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests --test_suite h100 --gpu_arch_type "${GPU_ARCH_TYPE}" "${ARTIFACTS}" --ngpu 8
 rm -rf "${ARTIFACTS}"/*/checkpoint

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -92,6 +92,8 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "DeepSeek V3 FSDP+HybridEP+compile",
             "deepseek_v3_fsdp+hybridep+compile",
             ngpu=4,
+            # deep_ep/NVSHMEM is CUDA-only, so skip on ROCm.
+            skip_rocm_test=True,
         ),
     ]
     return integration_tests_flavors


### PR DESCRIPTION
fix CI errors on rocm when running `deepseek_v3_fsdp+hybridep+compile`
example: https://github.com/pytorch/torchtitan/actions/runs/27108561047/job/80002013308
```
ImportError: HybridEP requires deep_ep library. Install from: https://github.com/deepseek-ai/DeepEP, branch: hybrid-ep
```

Claude summary:
  What happened:                                                                                                                                              
  - #3360 added the deepseek_v3_fsdp+hybridep+compile test to the h100 suite                                                                                  
  (tests/integration_tests/h100.py:82-95) and installed deep_ep in CUDA CI. That worked fine — at                                                             
  the time only the CUDA H100 job ran the h100 suite.                                                                                                         
  - #3562 made the ROCm runner also execute the same h100 suite via the new shared                                                                            
  run_8xgpu_integration_tests.sh. But deep_ep/NVSHMEM is CUDA-only, so the script deliberately skips                                                          
  installing it on ROCm (run_8xgpu_integration_tests.sh:71). The hybridep test still runs on ROCm →                                                           
  ModuleNotFoundError: No module named 'deep_ep'.  