### PR TITLE
[fix]Allow initial_load_in_hf without initial_load_path

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -801,11 +801,12 @@ class TestConfigPostInit(unittest.TestCase):
 
     def test_dependency_assertions(self):
         """Test logic where one field requires another to be set."""
-        # HF load requires path and model_only
-        with self.assertRaisesRegex(
-            ValueError, "requires both initial_load_path and initial_load_model_only"
-        ):
-            CheckpointManager.Config(initial_load_in_hf=True, initial_load_path=None)
+        # HF load needs model_only=True; initial_load_path stays optional.
+        with self.assertRaisesRegex(ValueError, "requires initial_load_model_only"):
+            CheckpointManager.Config(
+                initial_load_in_hf=True, initial_load_model_only=False
+            )
+        CheckpointManager.Config(initial_load_in_hf=True, initial_load_path=None)
 
         # HF quantized requires HF enabled
         with self.assertRaisesRegex(ValueError, "requires initial_load_in_hf"):

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -241,6 +241,15 @@ class CheckpointManager(Configurable):
         transformation. `initial_load_model_only` must be true because safetensors
         doesn't support saving non-tensors. The default value is False.
         """
+        Enable the use of HuggingFace's safetensors format for checkpointing. This will 
+        load checkpoints in HF's model definition and safetensors format instead of the
+        default torchtitan model definition and DCP format, after necessary model state
+        dict transformation. 
+        If `initial_load_path` is not provided, this option will look for weights 
+        in `sd_adapter.hf_assets_path`. `initial_load_model_only` must be True 
+        because safetensors doesn't support saving non-tensors. 
+        The default value is False.
+        """
 
         initial_load_in_hf_quantized: bool = False
         """

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -372,13 +372,8 @@ class CheckpointManager(Configurable):
                     raise ValueError(
                         f"initial_load_path must be absolute: {self.initial_load_path}"
                     )
-            if self.initial_load_in_hf and not (
-                self.initial_load_path and self.initial_load_model_only
-            ):
-                raise ValueError(
-                    "initial_load_in_hf requires both initial_load_path "
-                    "and initial_load_model_only."
-                )
+            if self.initial_load_in_hf and not self.initial_load_model_only:
+                raise ValueError("initial_load_in_hf requires initial_load_model_only.")
             if self.initial_load_in_hf_quantized and not (
                 self.initial_load_in_hf and self.initial_load_path
             ):


### PR DESCRIPTION
RL configs crash at construction with `initial_load_in_hf requires both initial_load_path and initial_load_model_only`.

4 relevant args (3 on the checkpointer, plus `hf_assets_path` which is a model arg):

- **`initial_load_in_hf`** — should I use hf?
- **`hf_assets_path`** — if yes to `initial_load_in_hf`, what's the `hf_assets_path`? (also where the tokenizer comes from)
- **`initial_load_path`** — optional: if you have a specific ckpt **not** in `hf_assets_path`, what's the path?
- **`initial_load_model_only`** — if you provided a specific ckpt, load just the model or also optimizer state, etc? (forced True for hf — safetensors has no optimizer state)

PR [`#3393` (a readability-only cleanup)](https://github.com/pytorch/torchtitan/pull/3393) added a `__post_init__` check that *requires* `initial_load_path` whenever `initial_load_in_hf` is set. This is wrong. It should be optional. If not provided, it just uses `hf_assets_path`.

**Fix:** relax the constraint.

The logic in `load()`
<img width="815" height="790" alt="image" src="https://github.com/user-attachments/assets/4af9a95d-ed81-4da5-86a9-26eb215a670a" />
