### PR TITLE
ci: skip deepseek_v3_fsdp+hybridep+compile on ROCm leg of 8 GPU H100 integration tests

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -92,6 +92,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "DeepSeek V3 FSDP+HybridEP+compile",
             "deepseek_v3_fsdp+hybridep+compile",
             ngpu=4,
+            skip_rocm_test=True,
         ),
     ]
     return integration_tests_flavors


### PR DESCRIPTION
## What

Mark the `deepseek_v3_fsdp+hybridep+compile` integration test flavor `skip_rocm_test=True` so it does not run on the ROCm leg of the `8 GPU Integration Test on H100` workflow.

## Why

torchtitan's `HybridEP` imports `deep_ep` from the upstream `hybrid-ep` branch (deepseek-ai/DeepEP), which targets NVSHMEM + SM80/SM90. AMD maintains a ROCm port at github.com/ROCm/DeepEP using rocSHMEM, but it tracks `main` and does not yet expose the hybrid-EP API used by torchtitan's HybridEP code. The CI's `install_deepep.sh` builds the upstream NVIDIA package (it JITs against `CUDA_HOME=/usr/local/cuda`), so on the ROCm container nothing usable lands and the test fails at import time:

```
[deepseek_v3_fsdp+hybridep+compile] [rank0]: ImportError:
  HybridEP requires deep_ep library.
  Install from: https://github.com/deepseek-ai/DeepEP, branch: hybrid-ep
```

The flavor was added in #3360 without a ROCm guard; the CUDA leg passes, but the ROCm gfx950.8 leg has been red on every scheduled run since (it is the only failing flavor in the run — the other five complete with `rc=0`).

This uses the `skip_rocm_test` field on `OverrideDefinitions` already honored by `tests/integration_tests/run_tests.py`. The test can be re-enabled once ROCm/DeepEP supports hybrid-EP and the install script gains a ROCm path (`python3 setup.py --variant rocm --nic <cx7|thor2|io>`).

## Failing run

https://github.com/pytorch/torchtitan/actions/runs/27101057924/job/79981696190 (scheduled run on `main` at `21c77d16`, 2026-06-07).

