### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add DualPipeV scheduling placeholder

### DIFF
--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
@@ -44,6 +44,8 @@ def _copy_prefixed_get_attrs(
 def multiplex_fw_bw_graph(
     fw_gm: fx.GraphModule,
     bw_gm: fx.GraphModule,
+    *,
+    overlap: bool = False,
 ) -> fx.GraphModule:
     """Concatenate backward and forward graphs into one boxed GraphPP callable.
 
@@ -62,6 +64,9 @@ def multiplex_fw_bw_graph(
       copy backward compute nodes before the forward compute nodes
       replace the output tuple with backward outputs followed by forward outputs
 
+    ``overlap`` is reserved for future DualPipeV scheduling work; the current
+    placeholder does not change graph construction.
+
     The forward graph remains the destination module because its ShapeEnv owns
     the dynamic collective-size constraints needed by full Inductor for MoE
     all-to-all outputs.  The backward graph is inserted in topological order
@@ -76,6 +81,8 @@ def multiplex_fw_bw_graph(
             namespace become the destination for the multiplexed graph.
         bw_gm (fx.GraphModule): Backward graph copied before the forward graph
             inside the multiplexed callable.
+        overlap (bool): Reserved placeholder for future DualPipeV scheduling
+            work. Defaults to ``False`` and currently has no behavior.
 
     Returns:
         fx.GraphModule: One graph module with placeholders ordered as

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -877,6 +877,7 @@ class GraphPipelineRuntimeTraceTest(unittest.TestCase):
         multiplexed = multiplex_fw_bw_graph(
             stage.graphs.modules.fw,
             stage.graphs.modules.full_bw,
+            overlap=True,
         )
 
         multiplexed_outputs = _boxed_run(


### PR DESCRIPTION

Reserve an optional keyword on the GraphPP forward/backward multiplexing helper for future DualPipeV scheduling work. The flag defaults to False and intentionally has no behavior in this commit, leaving the current multiplexed graph construction unchanged.

This replaces the previous fused-edge FSDP experiment with a small placeholder surface for the next scheduling iteration.
