### PR TITLE
[graph_trainer] hoist collective-PG reassignment into its own default pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -86,12 +86,6 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Maximum CPU memory budget (in GB per rank) for offloaded activations.
     Tensors are selected largest-first until the budget is exhausted."""
 
-    enable_fsdp_ag_rs_overlap: bool = False
-    """When True, run ``overlap_fsdp_ag_rs_pass``. The pass moves backward
-    FSDP all-gathers onto a separate CUDA stream from reduce-scatters so the
-    two collectives can overlap. It is a no-op when the graph contains no
-    FSDP all-gathers."""
-
     precompile_artifact_dir: str = ""
     """
     Directory for precompiled artifacts. Setting this enables precompile:

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -107,23 +107,17 @@ def _get_or_create_extra_fsdp_pg(source_pg_name: str) -> str:
     )
 
 
-def overlap_fsdp_ag_rs_pass(
+def reassign_collective_pgs_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
-    """
-    Reassign FSDP all-gathers to extra NCCL process groups.
+    """Reassign collectives to dedicated NCCL process groups.
 
-    Discovers all distinct FSDP PGs by inspecting the graph (e.g. one for
-    FSDP, another for expert-FSDP), creates an extra NCCL PG over the same
-    ranks for each (giving it a separate CUDA stream), and rewrites every
-    all-gather to the corresponding extra PG. This separates all-gathers
-    from reduce-scatters onto different streams, enabling AG/RS overlap in
-    backward. EP communicator isolation is handled by
-    ``isolate_ep_process_group_pass``.
-
-    No-op when the graph has no FSDP all-gathers. Must be applied BEFORE
-    bucketing passes so bucketed all-gathers inherit the new PG name.
+    Each PG runs on its own CUDA stream, so moving a collective to an extra PG
+    (same ranks) lets it overlap with the collectives left on the original PG --
+    e.g. all-gathers overlapping reduce-scatters in backward, or isolating EP
+    collectives. No-op without targeted collectives; run before bucketing so
+    bucketed collectives inherit the new PG.
     """
     source_pg_names: OrderedSet[str] = OrderedSet()
     for node in gm.graph.nodes:
@@ -386,7 +380,6 @@ def joint_transformer_block_bucketing_reordering_pass(
     module_bucket_plans: list[list[str] | str],
     insert_overlap_deps: bool = False,
     bucket_mode: BucketMode | None = None,
-    enable_fsdp_ag_rs_overlap: bool = False,
 ) -> torch.fx.GraphModule:
     """Run joint-graph manual bucketing and reordering.
 
@@ -394,6 +387,9 @@ def joint_transformer_block_bucketing_reordering_pass(
     ``torch._inductor.fx_passes.overlap_manual_scheduling.manual_overlap_bucketing``.
     Buckets forward all-gathers, backward all-gathers, and backward reduce-scatters
     of each module into separate buckets per transformer block and emits prefetching.
+
+    Run ``reassign_collective_pgs_pass`` first to put collectives on dedicated
+    streams; bucketed collectives inherit the new PGs.
 
     Args:
         gm: joint forward+backward graph module.
@@ -405,14 +401,7 @@ def joint_transformer_block_bucketing_reordering_pass(
             ``preserve_node_ordering`` after the topological sort.
         bucket_mode: bucket mode forwarded to the underlying bucketer;
             defaults to ``"custom_ops"`` via the parent class.
-        enable_fsdp_ag_rs_overlap: when ``True``, run ``overlap_fsdp_ag_rs_pass``
-            on ``gm`` before bucketing so that bucketed all-gathers inherit
-            the extra FSDP PG name and run on a separate CUDA stream from
-            reduce-scatters. No-op when the graph contains no FSDP
-            all-gathers.
     """
-    if enable_fsdp_ag_rs_overlap:
-        gm = overlap_fsdp_ag_rs_pass(gm, example_inputs)
 
     def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN)

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -43,6 +43,7 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
     joint_transformer_block_bucketing_reordering_pass,
+    reassign_collective_pgs_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
@@ -118,11 +119,10 @@ def compile_time_passes(
     cudagraph is excluded because it needs to re-capture the graph into
     an in-memory CUDA graph at runtime.
 
-    ``joint_transformer_block_bucketing_reordering_pass`` optionally runs
-    ``overlap_fsdp_ag_rs_pass`` first (gated by
-    ``compile.enable_fsdp_ag_rs_overlap``) so that forward+backward
-    all-gathers end up on a separate CUDA stream from reduce-scatters
-    (enabling AG/RS overlap in backward).
+    ``reassign_collective_pgs_pass`` runs just before bucketing to place
+    collectives on dedicated process groups / streams (bucketing then inherits
+    the new PGs). Disable with
+    ``--compile.disable_passes reassign_collective_pgs_pass``.
     """
     from torchtitan.experiments.graph_trainer.common_utils import (
         get_default_transformer_block_buckets,
@@ -143,10 +143,11 @@ def compile_time_passes(
             defer_n_layers=config.compile.cpu_offload_defer_n_layers,
         ),
         selective_activation_remat_pass,
+        # Run before bucketing so bucketed collectives inherit the dedicated PG.
+        reassign_collective_pgs_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
-            enable_fsdp_ag_rs_overlap=config.compile.enable_fsdp_ag_rs_overlap,
         ),
     ]
     if config.parallelism.enable_async_tensor_parallel:

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -51,7 +51,6 @@ def build_minimal_trainer(
                 inductor_compilation="regional",
                 numerics_changing_optim=compile_numerics_changing_optim,
                 disable_passes=[],
-                enable_fsdp_ag_rs_overlap=False,
                 debug_graph_passes=False,
                 cpu_offload_prefetch_n_layers=1,
                 cpu_offload_defer_n_layers=1,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -234,7 +234,6 @@ class BitwiseDeterministicBase(unittest.TestCase):
                     cpu_offload_prefetch_n_layers=1,
                     cpu_offload_defer_n_layers=1,
                     cpu_offload_budget_gb=100.0,
-                    enable_fsdp_ag_rs_overlap=False,
                 ),
                 parallelism=SimpleNamespace(
                     pipeline_parallel_degree=1,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -35,7 +35,9 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
 from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
 )
-from torchtitan.experiments.graph_trainer.fsdp_passes import overlap_fsdp_ag_rs_pass
+from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    reassign_collective_pgs_pass,
+)
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
 from torchtitan.experiments.graph_trainer.memory_policy import (
@@ -92,8 +94,8 @@ class ToyModel(Module):
         return x
 
 
-class TestOverlapFsdpAgRsPass(FSDPTest):
-    """Integration tests: toy model + simple_fsdp + export_joint + overlap_fsdp_ag_rs_pass."""
+class TestReassignCollectivePgsPass(FSDPTest):
+    """Integration tests: toy model + simple_fsdp + export_joint + reassign_collective_pgs_pass."""
 
     def _setup(self):
         """Set up ParallelDims and device mesh for FSDP."""
@@ -165,7 +167,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
         )
 
     def test_overlap_rewrites_ag_nodes(self):
-        """Apply overlap_fsdp_ag_rs_pass on the real backward graph and verify
+        """Apply reassign_collective_pgs_pass on the real backward graph and verify
         that FSDP AG nodes are rewritten to the auto-created extra PG."""
         from torchtitan.experiments.graph_trainer.fsdp_passes import (
             _EXTRA_FSDP_PG_REGISTRY,
@@ -183,7 +185,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
         self.assertGreater(ag_before, 0, "Expected AG nodes with FSDP PG name")
 
         _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
-        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
+        reassign_collective_pgs_pass(bw_gm, bw_example_inputs)
 
         extra_pg_name = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
         ag_with_old = self._count_ag_nodes_with_pg(bw_gm, fsdp_pg_name)
@@ -205,7 +207,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
         bw_gm, bw_example_inputs = self._export_and_get_bw_graph(model, inputs)
 
         total_before = self._count_all_ag_nodes(bw_gm)
-        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
+        reassign_collective_pgs_pass(bw_gm, bw_example_inputs)
         total_after = self._count_all_ag_nodes(bw_gm)
 
         self.assertEqual(total_before, total_after)
@@ -247,7 +249,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
 
         _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
         _EXTRA_FSDP_PG_REGISTRY.pop(second_pg_name, None)
-        overlap_fsdp_ag_rs_pass(bw_gm, bw_example_inputs)
+        reassign_collective_pgs_pass(bw_gm, bw_example_inputs)
 
         # Both source PGs should have their own extra PG
         self.assertIn(fsdp_pg_name, _EXTRA_FSDP_PG_REGISTRY)
@@ -296,7 +298,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
 
         _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
         _EXTRA_EP_PG_REGISTRY.pop(fsdp_pg_name, None)
-        overlap_fsdp_ag_rs_pass(gm, ())
+        reassign_collective_pgs_pass(gm, ())
         isolate_ep_process_group_pass(gm, ())
 
         fsdp_extra_pg = _EXTRA_FSDP_PG_REGISTRY[fsdp_pg_name]
@@ -343,7 +345,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
 
         _EXTRA_FSDP_PG_REGISTRY.pop(fsdp_pg_name, None)
         _EXTRA_EP_PG_REGISTRY.pop(ep_pg_name, None)
-        overlap_fsdp_ag_rs_pass(gm, ())
+        reassign_collective_pgs_pass(gm, ())
         isolate_ep_process_group_pass(gm, ())
 
         self.assertNotIn(ep_pg_name, _EXTRA_EP_PG_REGISTRY)
@@ -391,7 +393,7 @@ class TestOverlapFsdpAgRsPass(FSDPTest):
         # Plain (non-FSDP) module: a graph without FSDP all-gathers.
         gm = torch.fx.symbolic_trace(torch.nn.Linear(4, 4))
         ag_before = self._count_all_ag_nodes(gm)
-        overlap_fsdp_ag_rs_pass(gm, ())
+        reassign_collective_pgs_pass(gm, ())
         ag_after = self._count_all_ag_nodes(gm)
         self.assertEqual(ag_before, 0)
         self.assertEqual(ag_after, 0)


### PR DESCRIPTION
## What

Stream-separation of FSDP all-gathers used to run *inside*
`joint_transformer_block_bucketing_reordering_pass`, gated by the
`compile.enable_fsdp_ag_rs_overlap` config (default **off**). Reassigning
collectives to dedicated NCCL process groups — each PG runs on its own CUDA
stream — is a **general** primitive (reusable beyond FSDP, e.g. EP collectives),
so it shouldn't be buried in the FSDP bucketing pass.

This PR:
- Renames `overlap_fsdp_ag_rs_pass` → **`reassign_collective_pgs_pass`**.
- Makes it a standalone default pass that runs immediately before bucketing
  (identical execution order to before).
- Removes the `compile.enable_fsdp_ag_rs_overlap` config field. The pass is now
  **on by default** and can be turned off with
  `--compile.disable_passes reassign_collective_pgs_pass`.

## Why

- It's a general collective→PG/stream assignment primitive; gating it behind an
  FSDP-named config and nesting it in the bucketing pass hid that.
- `disable_passes` already provides the on/off knob, so the dedicated config was
  redundant.

It is a **no-op** when the graph has no targeted collectives, and is
**numerics-preserving**: it only reassigns all-gathers to an extra PG over the
same ranks; reduce-scatters are untouched.

## Perf

`deepseek_v3_16b`, 8×H100, `dp_shard=8 / tp=1 / ep=4`,
`--compile.memory_policy full`, `aot_fx_trace`, `c4_test`, 20 steps
(steady-state = steps 4–20). This is the config run by
`run_graph_trainer_llama3_8b.sh`.

| pass | tps | tflops | mfu | peak mem |
|---|---|---|---|---|
| off (before) | 8,185 | 148.20 | 14.99% | 51.22 GiB |
| on (after) | 8,280 | 149.92 | 15.16% | 51.30 GiB |
| **Δ** | **+1.16%** | **+1.16%** | +0.17pp | +0.08 GiB |

Wall-clock cross-check over the same steps: 2.018 s/step → 1.995 s/step (~1.1%
faster), consistent with the throughput delta.

## Test plan

- `pre-commit run --all-files` (flake8, ufmt, pydoclint, pyrefly): pass.
- `pytest torchtitan/experiments/graph_trainer/tests/test_passes.py`
  (`TestReassignCollectivePgsPass`).
- End-to-end: default run fires the pass (`Rewrote all-gather node(s)`);
  `--compile.disable_passes reassign_collective_pgs_pass` removes it
  (`Disabled 1 graph passes: ['reassign_collective_pgs_pass']`).
