### PR TITLE
[graph_trainer] Fix full inductor + precompile crash at TP>1

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -212,6 +212,42 @@ def _migrate_cpu_get_attrs_to_cuda(gm: torch.fx.GraphModule) -> None:
                 _assign_attr(attr.cuda(), module, node.target)
 
 
+def _mark_nodes_for_full_inductor(gm: torch.fx.GraphModule) -> None:
+    """Tag nodes with ``compile_with_inductor`` so regional_inductor scoops the
+    whole graph as one region.
+
+    Tags every node except placeholders, outputs, and tensor-constant
+    ``get_attr``s. ``get_attr`` is overloaded:
+
+    - A tensor-constant get_attr (e.g. a TP-redistribution mesh/mask) must stay
+      UNtagged so it remains in the outer FX graph and crosses into
+      ``standalone_compile`` as an ordinary input; tagging it pulls the constant
+      into the region where AOTAutograd lifts it to an input the serialized CooR
+      artifact never re-supplies.
+    - FlexAttention stores its score/mask functions as GraphModule attrs
+      (``sdpa_score0``/``sdpa_mask0``). Those are executable subgraphs, not
+      tensor constants: they MUST stay tagged/in-region so regional_inductor
+      recurses through them rather than externalizing them as fake-tensor inputs
+      (which fails with "non fake tensor value" — a GraphModule has no
+      ``meta["val"]``).
+    """
+    from torch.fx.graph_module import _get_attr
+
+    for module in gm.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in module.graph.nodes:
+            if node.op in ("placeholder", "output"):
+                continue
+            if node.op == "get_attr" and not isinstance(
+                _get_attr(module, node.target), torch.fx.GraphModule
+            ):
+                continue
+            node.meta.setdefault("custom", {}).setdefault(
+                "compile_with_inductor", {"inductor_configs": {}}
+            )
+
+
 def full_inductor_compilation_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple
 ) -> torch.fx.GraphModule:
@@ -244,15 +280,7 @@ def full_inductor_compilation_pass(
     )
 
     _migrate_cpu_get_attrs_to_cuda(gm)
-    for module in gm.modules():
-        if not isinstance(module, torch.fx.GraphModule):
-            continue
-        for node in module.graph.nodes:
-            if node.op in ("placeholder", "output"):
-                continue
-            node.meta.setdefault("custom", {}).setdefault(
-                "compile_with_inductor", {"inductor_configs": {}}
-            )
+    _mark_nodes_for_full_inductor(gm)
     # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
     # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
     # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -2362,6 +2362,47 @@ class TestIsFullCudagraphable(TestCase):
         self.assertFalse(is_full_cudagraphable(gm))
 
 
+class TestFullInductorMarking(TestCase):
+    """_mark_nodes_for_full_inductor tags by get_attr value type."""
+
+    def test_graphmodule_attr_tagged_tensor_attr_not(self):
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            _mark_nodes_for_full_inductor,
+        )
+
+        class Score(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        class Outer(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        gm = torch.fx.symbolic_trace(Outer())
+        # A FlexAttention-style executable subgraph attr and a tensor constant.
+        gm.sdpa_score0 = torch.fx.symbolic_trace(Score())
+        gm._tp_mask = torch.zeros(4)
+        graph = gm.graph
+        ph = next(n for n in graph.nodes if n.op == "placeholder")
+        with graph.inserting_after(ph):
+            graph.get_attr("_tp_mask")
+            graph.get_attr("sdpa_score0")
+        gm.recompile()
+
+        _mark_nodes_for_full_inductor(gm)
+
+        def tagged(name):
+            node = next(n for n in graph.nodes if n.name == name)
+            return "compile_with_inductor" in node.meta.get("custom", {})
+
+        # GraphModule attr (flex score) must stay in-region; tensor constant must not.
+        self.assertTrue(tagged("sdpa_score0"))
+        self.assertFalse(tagged("_tp_mask"))
+        # Regular compute nodes are still tagged.
+        add = next(n for n in graph.nodes if n.op == "call_function")
+        self.assertIn("compile_with_inductor", add.meta.get("custom", {}))
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 


### PR DESCRIPTION
## Summary

Full inductor compilation (`--compile.inductor_compilation full`) combined with
CooR precompile crashes on step 1 of training whenever tensor parallelism is
enabled (TP ≥ 2):

```
ValueError: not enough values to unpack (expected 93, got 68)
```

The compiled inductor `call` expects more flat inputs than the runtime provides.
The gap is exactly the number of baked tensor constants that TP redistribution
introduces (25 for debugmodel, 33 for llama3 8B). The fix is a one-line change
in `full_inductor_compilation_pass`: stop tagging `get_attr` nodes for inductor
compilation, so those constants stay in the serializable part of the precompile
artifact instead of being absorbed into a part that doesn't carry them.

## Symptom / repro (debugmodel, ~30s)

```bash
# Build artifact (single process)
python -m torchtitan.experiments.graph_trainer.precompile_main \
  --module graph_trainer.llama3 --config graph_trainer_llama3_debugmodel \
  --parallelism.tensor_parallel_degree 2 \
  --parallelism.data_parallel_shard_degree 4 \
  --compile.inductor_compilation full \
  --compile.precompile_artifact_dir /tmp/repro \
  --activation_checkpoint.mode none

# Run training (crashes on step 1 before this fix)
NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
  bash torchtitan/experiments/graph_trainer/run_train_precompile.sh \
  --parallelism.tensor_parallel_degree 2 \
  --compile.inductor_compilation full \
  --compile.precompile_artifact_dir /tmp/repro \
  --compile.disable_passes cudagraph_pass \
  --activation_checkpoint.mode none --training.steps 3
```

Ablation: TP=1 always works; TP≥2 always fails with full inductor + precompile;
regional inductor works at any TP; full inductor without precompile works.

## Background: the precompile artifact has two nested layers

The CooR artifact (`fx_trace_default.bin`) is just `GraphPickler.dumps(gm)` —
the whole traced FX `GraphModule`. Inside that graph, a full-inductor region is
represented by a node that calls an `AOTCompiledArtifact`, which wraps an
"AOT bundle" (`BundledAOTAutogradCache`):

```
fx_trace_default.bin                          # CooR artifact = GraphPickler.dumps(gm)
└── FX GraphModule (gm)
    ├── get_attr constants (_tensor_constant0 …)     # GraphPickler serializes these ✅
    └── call node → AOTCompiledArtifact              # the compiled full-inductor region
                    └── AOT bundle                   # compiled code + metadata,
                                                     #   but NOT input/param values
```

Key property: GraphPickler **does** serialize `get_attr` tensor attributes on the
gm. The AOT bundle, by design, carries compiled code but treats lifted tensors
(params/buffers/constants) as **caller-supplied at load time** — it does not
store their values. This split is what the bug hinges on.

## Root cause

### 1. TP redistribution bakes rank-invariant tensor constants into the graph

With TP, parameters are sharded along a tensor dimension, so local computation
must know *which slice this rank owns*. The vocab-parallel embedding is the
clearest example — each rank holds vocab rows `[1024·u0, 1024·u0+1024)` and must
mask/offset tokens by its own mesh coordinate `u0`:

```python
_tensor_constant0: i32[8]                       # global mesh layout [0..7] (rank-invariant)
as_strided: i32[4,2]                            # reshaped to the (fsdp=4, tp=2) mesh
u0 = device_mesh._runtime_compute_coordinate_on_dim(as_strided, 0)   # this rank's coord
mul = 1024 * u0
mask = (tokens < 1024*u0) | (tokens >= 1024*u0 + 1024)
local_idx = tokens - 1024*u0
index_put_(local_idx, mask, _tensor_constant1)  # i64 0 fill for masked indices
embedding(local_weight, local_idx)
index_put_(out, mask, _tensor_constant2)         # bf16 0 to zero out-of-range rows
```

This is the `compile_on_one_rank` design, split deliberately:

- **Rank-invariant → baked as `get_attr` constants.** The mesh layout `[0..7]` is
  the global topology (identical on every rank); the mask-fill values are
  literals.
- **Rank-varying → computed at runtime.** The only rank-dependent value, "which
  coordinate am I", is computed inside `_runtime_compute_coordinate_on_dim` via
  `torch.distributed.get_rank()` — never baked. This is what lets one compiled
  artifact run on every rank.

FSDP (`dp_shard`) only ever does `Shard → Replicate` via all_gather: every rank
ends up with the identical full tensor, so it needs no coordinate, no masking,
and no constants. That is why TP=1 is unaffected — there is no slice to select.

### 2. `full_inductor` moves the constants out of the serializable layer

`full_inductor_compilation_pass` tags every non-placeholder/output node —
including `get_attr` — and hands the whole graph to `standalone_compile`
(AOTAutograd + inductor) as a single region. AOTAutograd compiles a region into
a pure function of every tensor it reads: `full_args = [*params, *buffers, *args]`
(`torch/_functorch/aot_autograd.py`). So the baked `get_attr` constants get
**lifted to inputs** of the compiled region and absorbed into the AOT bundle.
The generated inductor `call` now expects `66 data tensors + 25 lifted
constants = 93` flat inputs.

(This is *input lifting*, not functionalization. The `lift_fresh_copy` ops in the
graph are a separate functionalization artifact — they make a private copy of a
`torch.tensor(...)` constant — and are not what turns a constant into an input.)

### 3. The AOT bundle doesn't carry the constants → runtime crash

Once the constants live inside the AOT bundle as lifted inputs, they fall into
the layer that does **not** serialize tensor values (those are normally model
weights supplied by the caller at load). But these are graph-internal constants
that no caller knows about, so nobody supplies them. At runtime the outer
make_fx graph calls the artifact with only the 68 boundary values; the inner
`call` unpacks `arg0_1 … arg92_1 = args` against 68 args → `expected 93, got 68`.

### Why regional inductor is fine

Regional only compiles the small tagged regions (e.g. flex_attention). The
vocab-parallel embedding and TP redistribution — and their constants — stay in
the outer FX graph as `get_attr` attributes, which GraphPickler serializes and
`run_traced` reads at runtime. The constants only become a problem once they are
absorbed into an AOT bundle, which only full inductor does.

### Why full inductor *without* precompile is fine

Without precompile the compiled region is never serialized: `standalone_compile`
returns a **live** `AOTCompiledArtifact` that holds references to the lifted
constant tensors (in inductor's `CompiledFxGraph.constants` / grabbed from the
live GraphModule, and AOTAutograd's captured `params_buffers_flat`). Its wrapper
injects those 25 constants ahead of the inner `call` on every step, so the caller
only ever passes the 68 real inputs. It is the *same live object* across steps —
the constants stay in memory, so there is no "have to supply them again" problem;
step 1, step 2, step N all have the full 93.

Precompile is different only because it serializes the artifact to disk and
reloads it in fresh worker processes (compile once on rank 0, load on all ranks).
Serialization keeps the compiled code and metadata but **not** the in-memory
constant tensors, so the reloaded artifact's wrapper has nothing to inject. The
crash is therefore unique to the serialized path — it is not "first call vs
second call", it is "live in-memory object vs object reconstructed from disk".

## The fix

Leave `get_attr` nodes untagged in `full_inductor_compilation_pass`. The
constants then stay in the FX-graph layer of the artifact and cross into the
region as ordinary inputs (region inputs go `68 → 93`).

This is, concretely, "serialize the constants into the precompile artifact":
the whole artifact is `GraphPickler.dumps(gm)`, and GraphPickler serializes
`get_attr` tensors. Verified by loading the fixed artifact:

```
get_attr tensor constants on gm = 25, mesh[0..7] found in get_attr = True
```

All 25 constants (including the mesh layout) are embedded in the artifact and
supplied to the region by `run_traced` at load — exactly how the regional/eager
path already works.

This is safe specifically because the constants are **rank-invariant**:
GraphPickler bakes rank-0's values, which are valid on every rank. (If any baked
constant were rank-varying this would be wrong — but `compile_on_one_rank`
structurally guarantees all rank-varying values go through a runtime op, not a
constant; `from_traced_result` likewise uses GraphPickler precisely to keep the
rank-varying `u0` offset symbolic rather than baking it.)

## Validation

debugmodel, TP=2 + FSDP=4, full inductor, precompile, cudagraph disabled,
no flex/SAC — previously crashed on step 1, now trains:

```
step: 1  loss: 7.96265  grad_norm: 1.3340
step: 2  loss: 7.68565  grad_norm: 1.3973
step: 3  loss: 6.99437  grad_norm: 1.7940
Training completed
```

Converging loss and sane grad_norm indicate the constants flow with correct
values (a wrong rank-coordinate would corrupt the vocab-parallel embedding).

## Remaining validation before un-drafting

- [ ] Numerics parity via `scripts/loss_compare.py` (compare against
      full-inductor in-process, since full inductor changes numerics vs eager).
- [ ] Re-run with `cudagraph_pass` enabled (repro disabled it; constants-as-inputs
      may interact with cudagraph static-input handling).
- [ ] Confirm the original llama3 8B + flex-attn full repro (`expected 339, got 306`).

