### PR TITLE
ci: skip fsdp_symm_mem integration test on ROCm

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -49,6 +49,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "FSDP symmetric memory",
             "fsdp_symm_mem",
             ngpu=2,
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
## Summary

Skip the `fsdp_symm_mem` flavor on the ROCm leg of the **8 GPU Integration Test on H100** workflow. The CUDA/H100 leg continues to run it unchanged.

## Why

PyTorch's FSDP2 symmetric-memory path (`set_symm_mem_for_comm()` → `_SymmetricMemory.rendezvous`) selects the **NCCL symm-mem allocator**, which routes through RCCL on ROCm. I opened up a similar PR initially, but closed it because we have symmetric mem enabled through AMD, so we hoped to keep it enabled through #3485 . However, the test still fails at rendezvous:

```
NCCL host communicator for group 0 not found
  at nccl_devcomm_manager.hpp:106
```

torchtitan's code is correct here; the fix belongs upstream in PyTorch (correct allocator selection on ROCm). Disabling the ROCm leg now keeps the workflow green pending that upstream fix.

## How

Adds `skip_rocm_test=True` to the `fsdp_symm_mem` `OverrideDefinitions` in `tests/integration_tests/h100.py`. `run_tests.py` honors this when invoked with `--gpu_arch_type rocm`, which the `build-test-rocm` leg passes via `run_8xgpu_integration_tests.sh`. This is the same mechanism #3576 used to skip the hybridep flavor on ROCm.

## Test plan

- [ ] CUDA/H100 leg still runs `fsdp_symm_mem` (unchanged).
- [ ] ROCm `build-test-rocm` leg skips `fsdp_symm_mem`.