### PR TITLE
Add deterministic topk for MoE routing

### DIFF
--- a/tests/unit_tests/test_deterministic_ops.py
+++ b/tests/unit_tests/test_deterministic_ops.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from torchtitan.models.common.moe import TokenChoiceTopKRouter
+from torchtitan.models.common.nn_modules import Linear
+from torchtitan.ops.topk import deterministic_topk
+
+
+def _has_stable_deterministic_topk() -> bool:
+    prev = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    x = torch.tensor([[3.0, 3.0, 2.0, 3.0, 1.0], [1.0, 0.0, 0.0, 0.0, 2.0]])
+    try:
+        torch.use_deterministic_algorithms(True, warn_only=False)
+        _, indices = torch.topk(x, k=3, dim=-1, largest=True, sorted=True)
+        return torch.equal(indices, torch.tensor([[0, 1, 3], [4, 0, 1]]))
+    finally:
+        torch.use_deterministic_algorithms(prev, warn_only=prev_warn_only)
+
+
+_HAS_STABLE_DETERMINISTIC_TOPK = _has_stable_deterministic_topk()
+
+
+class TestDeterministicTopK(unittest.TestCase):
+    def tearDown(self) -> None:
+        torch.use_deterministic_algorithms(False)
+
+    def test_matches_topk(self):
+        x = torch.tensor([[1.0, 4.0, 2.0, 3.0], [5.0, 0.0, 5.0, 1.0]])
+
+        actual_values, actual_indices = deterministic_topk(
+            x, k=2, dim=-1, largest=True, sorted=True
+        )
+        expected_values, expected_indices = torch.topk(
+            x, k=2, dim=-1, largest=True, sorted=True
+        )
+
+        torch.testing.assert_close(actual_values, expected_values)
+        torch.testing.assert_close(actual_indices, expected_indices)
+
+    @unittest.skipUnless(
+        _HAS_STABLE_DETERMINISTIC_TOPK,
+        "requires PyTorch deterministic topk tie-breaking",
+    )
+    def test_ties_use_stable_indices(self):
+        x = torch.tensor([[3.0, 3.0, 2.0, 3.0, 1.0], [1.0, 0.0, 0.0, 0.0, 2.0]])
+
+        values, indices = deterministic_topk(x, k=3, dim=-1, largest=True, sorted=True)
+        torch.testing.assert_close(
+            values, torch.tensor([[3.0, 3.0, 3.0], [2.0, 1.0, 0.0]])
+        )
+        torch.testing.assert_close(indices, torch.tensor([[0, 1, 3], [4, 0, 1]]))
+
+        values, indices = deterministic_topk(x, k=4, dim=-1, largest=False, sorted=True)
+        torch.testing.assert_close(
+            values, torch.tensor([[1.0, 2.0, 3.0, 3.0], [0.0, 0.0, 0.0, 1.0]])
+        )
+        torch.testing.assert_close(indices, torch.tensor([[4, 2, 0, 1], [1, 2, 3, 0]]))
+
+    def test_restores_deterministic_state(self):
+        torch.use_deterministic_algorithms(False)
+        deterministic_topk(torch.randn(4), k=2)
+        self.assertFalse(torch.are_deterministic_algorithms_enabled())
+        self.assertFalse(torch.is_deterministic_algorithms_warn_only_enabled())
+
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        deterministic_topk(torch.randn(4), k=2)
+        self.assertTrue(torch.are_deterministic_algorithms_enabled())
+        self.assertTrue(torch.is_deterministic_algorithms_warn_only_enabled())
+
+    def test_backward_matches_topk(self):
+        x = torch.tensor([[1.0, 3.0, 2.0], [4.0, 4.0, 1.0]], requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+
+        values, _ = deterministic_topk(x, k=2, dim=-1, largest=True, sorted=True)
+        values_ref, _ = torch.topk(x_ref, k=2, dim=-1, largest=True, sorted=True)
+
+        values.sum().backward()
+        values_ref.sum().backward()
+
+        torch.testing.assert_close(x.grad, x_ref.grad)
+
+    def test_fake_tensor(self):
+        with FakeTensorMode():
+            x = torch.empty(2, 5, dtype=torch.bfloat16)
+            values, indices = deterministic_topk(x, k=3, dim=-1)
+
+        self.assertEqual(values.shape, torch.Size([2, 3]))
+        self.assertEqual(values.dtype, torch.bfloat16)
+        self.assertEqual(indices.shape, torch.Size([2, 3]))
+        self.assertEqual(indices.dtype, torch.long)
+
+
+class TestMoERouterDeterministicTopK(unittest.TestCase):
+    @unittest.skipUnless(
+        _HAS_STABLE_DETERMINISTIC_TOPK,
+        "requires PyTorch deterministic topk tie-breaking",
+    )
+    def test_router_uses_stable_tie_breaking(self):
+        router = TokenChoiceTopKRouter(
+            TokenChoiceTopKRouter.Config(
+                num_experts=4,
+                gate=Linear.Config(in_features=2, out_features=4, bias=True),
+                top_k=3,
+                score_func="sigmoid",
+            )
+        )
+        torch.nn.init.zeros_(router.gate.weight)
+        torch.nn.init.zeros_(router.gate.bias)
+
+        _, expert_ids, _ = router(torch.ones(1, 2, 2))
+
+        torch.testing.assert_close(
+            expert_ids.sort(dim=-1).values,
+            torch.tensor([[[0, 1, 2], [0, 1, 2]]]),
+        )
+
+    @unittest.skipUnless(
+        _HAS_STABLE_DETERMINISTIC_TOPK,
+        "requires PyTorch deterministic topk tie-breaking",
+    )
+    def test_node_limited_router_uses_stable_tie_breaking(self):
+        router = TokenChoiceTopKRouter(
+            TokenChoiceTopKRouter.Config(
+                num_experts=4,
+                gate=Linear.Config(in_features=2, out_features=4, bias=True),
+                num_expert_groups=2,
+                num_limited_groups=1,
+                top_k=2,
+                score_func="sigmoid",
+            )
+        )
+        torch.nn.init.zeros_(router.gate.weight)
+        torch.nn.init.zeros_(router.gate.bias)
+
+        _, expert_ids, _ = router(torch.ones(1, 2, 2))
+
+        torch.testing.assert_close(
+            expert_ids.sort(dim=-1).values,
+            torch.tensor([[[0, 1], [0, 1]]]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -44,9 +44,6 @@ def _get_save_ops() -> set:
         # FlexAttention (torch.ops.higher_order.flex_attention is the same object)
         torch._higher_order_ops.flex_attention,
         torch.ops.aten.linear.default,
-        # topk can be non-deterministic; save to keep MoE expert assignments
-        # stable between forward and recompute.
-        torch.ops.aten.topk.default,
         # Inductor compiled code (available when torch.compile is used)
         (torch._higher_order_ops, "inductor_compiled_code"),
         # torch_attn custom backend

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -15,6 +15,7 @@ from torch.distributed.tensor.experimental import local_map
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.nn_modules import Linear
+from torchtitan.ops.topk import deterministic_topk
 from torchtitan.protocols.module import Module
 
 from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
@@ -220,9 +221,9 @@ class TokenChoiceTopKRouter(Module):
         scores_grouped = scores_for_choice_BLE.unflatten(
             -1, (self.num_expert_groups, experts_per_group)
         )
-        top2_scores_in_group, _ = scores_grouped.topk(2, dim=-1)
+        top2_scores_in_group, _ = deterministic_topk(scores_grouped, 2, dim=-1)
         group_scores = top2_scores_in_group.sum(dim=-1)
-        _, group_idx = torch.topk(
+        _, group_idx = deterministic_topk(
             group_scores, k=self.num_limited_groups, dim=-1, sorted=False
         )
         group_mask = torch.ones_like(group_scores, dtype=torch.bool)
@@ -268,7 +269,7 @@ class TokenChoiceTopKRouter(Module):
             scores_for_choice_BLE = self._get_node_limited_routing_scores(
                 scores_for_choice_BLE
             )
-        _, topk_expert_ids_BLK = torch.topk(
+        _, topk_expert_ids_BLK = deterministic_topk(
             scores_for_choice_BLE, k=self.top_k, dim=-1, sorted=False
         )
 

--- a/torchtitan/ops/topk.py
+++ b/torchtitan/ops/topk.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+@torch.library.custom_op("torchtitan::deterministic_topk", mutates_args=())
+def deterministic_topk(
+    input: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    prev = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(True, warn_only=False)
+    try:
+        return torch.topk(input, k=k, dim=dim, largest=largest, sorted=sorted)
+    finally:
+        torch.use_deterministic_algorithms(prev, warn_only=prev_warn_only)
+
+
+@deterministic_topk.register_fake
+def _(
+    input: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    shape = list(input.shape)
+    shape[dim % input.dim()] = k
+    return input.new_empty(shape), input.new_empty(shape, dtype=torch.long)
+
+
+def _backward(
+    ctx: torch.autograd.function.FunctionCtx,
+    grad_values: torch.Tensor | None,
+    grad_indices: torch.Tensor | None,
+) -> tuple[torch.Tensor, None, None, None, None]:
+    (indices,) = ctx.saved_tensors  # pyrefly: ignore[missing-attribute]
+    if grad_values is None:
+        return (
+            torch.zeros(
+                ctx.input_shape,  # pyrefly: ignore[missing-attribute]
+                dtype=ctx.input_dtype,  # pyrefly: ignore[missing-attribute]
+                device=indices.device,
+            ),
+            None,
+            None,
+            None,
+            None,
+        )
+
+    grad_input = torch.zeros(
+        ctx.input_shape,  # pyrefly: ignore[missing-attribute]
+        dtype=grad_values.dtype,
+        device=grad_values.device,
+    )
+    grad_input.scatter_(
+        ctx.dim,  # pyrefly: ignore[missing-attribute]
+        indices,
+        grad_values,
+    )
+    return grad_input, None, None, None, None
+
+
+def _setup_context(
+    ctx: torch.autograd.function.FunctionCtx,
+    inputs: tuple[torch.Tensor, int, int, bool, bool],
+    output: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    input, _k, dim, _largest, _sorted = inputs
+    _values, indices = output
+    ctx.save_for_backward(indices)
+    ctx.input_shape = tuple(input.shape)  # pyrefly: ignore[missing-attribute]
+    ctx.input_dtype = input.dtype  # pyrefly: ignore[missing-attribute]
+    ctx.dim = dim % input.dim()  # pyrefly: ignore[missing-attribute]
+
+
+deterministic_topk.register_autograd(
+    _backward,
+    setup_context=_setup_context,
+)


### PR DESCRIPTION

Route MoE expert selection through a TorchTitan custom op that enables PyTorch's deterministic topk implementation locally and restores the caller's deterministic-algorithm state afterward. This gives activation-checkpoint recompute the same stable top-k tie-breaking behavior without saving raw aten.topk outputs in selective activation checkpointing.

The wrapper follows the deterministic_scatter_add pattern, includes fake tensor and autograd registrations, and relies on the PyTorch deterministic topk implementation when available.

Test Plan:

- python -m py_compile torchtitan/ops/topk.py torchtitan/models/common/moe.py torchtitan/distributed/activation_checkpoint.py tests/unit_tests/test_deterministic_ops.py

- pytest tests/unit_tests/test_deterministic_ops.py -q

- pytest tests/unit_tests/test_activation_checkpoint.py -q

- pytest tests/unit_tests/test_compile_moe.py -q

- pre-commit run --files torchtitan/ops/topk.py torchtitan/models/common/moe.py torchtitan/distributed/activation_checkpoint.py tests/unit_tests/test_deterministic_ops.py

- pre-commit run --all-files