### PR TITLE
[GraphTrainer] Fix test_deterministic: update model hash and calling update_from_config

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -25,8 +25,10 @@ from expecttest import assert_expected_inline
 from tests.utils import hash_gradient, hash_model
 from torch.nn.attention.flex_attention import flex_attention
 
+from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
+from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -107,6 +109,20 @@ class BitwiseDeterministicBase(unittest.TestCase):
             self.model_flavor, attn_backend=self.attn_backend
         )
         self.model_config = model_spec.model
+        # Match Trainer.__init__: model configs consume runtime settings before
+        # build. DSv3 uses the synced RoPE length to decide YaRN scaling.
+        runtime_config = Trainer.Config(
+            model_spec=model_spec,
+            training=TrainingConfig(
+                local_batch_size=BATCH_SIZE,
+                seq_len=SEQ_LEN,
+                steps=NUM_STEPS,
+            ),
+            parallelism=ParallelismConfig(),
+            checkpoint=CheckpointManager.Config(initial_load_model_only=False),
+            debug=DebugConfig(seed=SEED, deterministic=True),
+        )
+        self.model_config.update_from_config(config=runtime_config)
         vocab_size = self.model_config.vocab_size
         with torch.device("meta"):
             model = self.model_config.build()
@@ -342,7 +358,7 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757659912109""")
         assert_expected_inline(
             model_hash,
-            """d8c4495bc41d103e3864433002d31be0823567938729396c44eb2f2782a47a23""",
+            """4cf2bed8281dfcdf4a5e5ced666ccd65681fab5fcaf404e14e91b583fe21bd4c""",
         )
         assert_expected_inline(
             grad_hash,
@@ -407,14 +423,14 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
         loss, model_hash, grad_hash = self._run_steps(
             copy.deepcopy(self.model), Trainer
         )
-        assert_expected_inline(str(loss.item()), """7.4749956130981445""")
+        assert_expected_inline(str(loss.item()), """7.474959373474121""")
         assert_expected_inline(
             model_hash,
-            """edaec1177d073cf99a24433a6381b23282bfbfe306c40cefcea5d4efaf14cd0a""",
+            """99d414c98ec7de31e58ad41f3324a402dfa4f8fc4b3c57a406368af7360a2ec6""",
         )
         assert_expected_inline(
             grad_hash,
-            """ce80bf7a7186d63eb6231d684ecefe7a7846f1bc63c8fde794fefd462e9c2c5d""",
+            """7f38de9544b31d1161c4191987663e2e8cc7be8b83b6226ff72a349a71aa1afa""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -483,7 +499,7 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757183074951""")
         assert_expected_inline(
             model_hash,
-            """2cc38288f1641b058a56a1930af77dcb33c91fb12176cfdb59f436c9a2b3addd""",
+            """6884b7b1013badc769666dc1acc75db5a09dbcf1170e3bea2c35ae77d20a3896""",
         )
         assert_expected_inline(
             grad_hash,
@@ -552,14 +568,14 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         loss, model_hash, grad_hash = self._run_steps(
             copy.deepcopy(self.model), Trainer
         )
-        assert_expected_inline(str(loss.item()), """7.4749956130981445""")
+        assert_expected_inline(str(loss.item()), """7.474959373474121""")
         assert_expected_inline(
             model_hash,
-            """d2670e9bf949d83c446bcce1ca468a23eda98c83c0cac83eafb15ddebde3c234""",
+            """aff6268960d2b137a44756d322b72c0dc253ffbbc54077e4105fc3abed0fdd79""",
         )
         assert_expected_inline(
             grad_hash,
-            """e90a28b41bdae0de5d1db20de40998b0508866efed561cce4373e595626e8e7a""",
+            """86f1656c38fa1e23d6b29955889bd5c4ad0c363f9755e2c4ea8dee142cacfcfe""",
         )
 
     # TODO: FlexAttention compilation exceeds resource limits on pre-Hopper GPUs.
@@ -633,7 +649,7 @@ class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.297995567321777""")
         assert_expected_inline(
             model_hash,
-            """c4f3d5d6a4dacffc82a0845ef620dcbdb053d9785ce64b8dd5b5e181f4fe2d1b""",
+            """633e10071953205f68501138d4e7a907d42c8523320df205c737a30ee8aaa9d7""",
         )
         assert_expected_inline(
             grad_hash,
@@ -706,7 +722,7 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.297987461090088""")
         assert_expected_inline(
             model_hash,
-            """85240276507f93d2dbc8b09d5dad5f86623bcd49423abe64fba787b74d7f6d81""",
+            """8f3524a4b2d4c6144abbb570ef7309a80ed87dc37025fa449ec332201f02aaed""",
         )
         assert_expected_inline(
             grad_hash,

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -339,11 +339,6 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_llama)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -407,11 +402,6 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -480,11 +470,6 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_llama)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -552,11 +537,6 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_deepseekv3)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -630,11 +610,6 @@ class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
     model_flavor = "debugmodel_moe"
     annotate_model = staticmethod(annotate_qwen3)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )
@@ -703,11 +678,6 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
     attn_backend = "flex"
     annotate_model = staticmethod(annotate_qwen3)
 
-    @unittest.skip(
-        "Eager self-determinism hashes drift across nightly PyTorch updates; "
-        "skipped instead of re-baselining. The aot_fx_trace-vs-eager tests "
-        "still guard numerics."
-    )
     @unittest.skipUnless(
         has_cuda_capability(9, 0), "Numerics only match on H100 (sm_90+)"
     )


### PR DESCRIPTION
torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py::TestLlama3BitwiseDeterministic::test_eager_self_deterministic - AssertionError: Mismatch between actual and expect strings:
 
- Failed because of #3458 