### PR TITLE
[graph_trainer] Enable ChunkedCELoss for deepseek_v3 and qwen3 (#3248)

### DIFF
--- a/dsv3_scaling_experiment_results.md
+++ b/dsv3_scaling_experiment_results.md
@@ -74,3 +74,88 @@ All 9 graph passes took **45.884 s**. Notable transforms:
   it fires during the eager/trace warmup before `regional_inductor` compiles flex.
 - tlparse manifold link is a temporary `.tmp...` path and will expire; the pastry
   log and perfetto trace are durable.
+
+---
+
+## Run 2 — deepseek_v3 16B with ChunkedCELoss (run script + #3419 + #3248)
+
+**Date:** 2026-06-09
+**Branch:** `graph_trainer/dsv3_scaling`
+**Branch state at run:** run-script commit + #3419 + #3248 (Enable ChunkedCELoss).
+#3590/#3561/EP-overlap/#3548 **not yet applied**.
+**Launcher:** `TORCHINDUCTOR_COMPILE_THREADS=8 ./run_graph_trainer_dsv3.sh`
+(thread cap set at launch — not in the committed script — to avoid a cold-cache
+compile OOM; see Notes).
+
+> ⚠️ **UNVERIFIED — possible loss divergence; needs further confirmation.**
+> I'm concerned the loss may be diverging. These numbers have **not** been
+> validated against an eager run, so the chunked-loss numerics are not yet
+> trusted. **TODO before relying on this result:** compare against an eager
+> `ChunkedCELoss` baseline via `scripts/loss_compare.py` (ideally bitwise with
+> `--debug.seed=42 --debug.deterministic`, checking loss *and* grad_norm from
+> TensorBoard, not just the 5-digit stdout). Treat the loss curve below as
+> **provisional** pending that confirmation.
+
+### Setup
+Same as Run 1 (8× H100, `dp_shard=8 ep=4`, `aot_fx_trace`, `memory_policy=full`,
+local batch 4 / seq 4096, 20 steps, c4_test) **except the loss**:
+
+| | |
+|---|---|
+| Loss | **ChunkedCELoss → `ChunkedCELossWithParamGrads`** (`num_chunks=8`) |
+
+#3248 makes `to_graph_trainer_config` swap `ChunkedCELoss` to the tracer-friendly
+`ChunkedCELossWithParamGrads` instead of the previous `CrossEntropyLoss` fallback.
+
+### Results
+| step | loss | grad_norm | memory | tps | tflops | mfu |
+|-----:|------|-----------|--------|-----|--------|-----|
+| 1 | 12.02673 | 1.6668 | 29.34 GiB (30.86%) | 88 | 1.59 | 0.16% |
+| 10 | 9.04778 | 5.0626 | 35.73 GiB (37.59%) | 7,123 | 128.97 | 13.04% |
+| 20 | 7.07054 | 1.4865 | 36.07 GiB (37.93%) | 5,423 | 98.19 | 9.93% |
+
+**Memory vs Run 1 (CrossEntropyLoss): ~36 GiB vs ~51 GiB — ChunkedCELoss saves
+~15 GiB**, the intended #3248 benefit (matching eager ChunkedLoss memory). Loss
+converges normally.
+
+### Compile pipeline
+All 9 graph passes took **113.558 s** (cold-ish Inductor cache):
+- `joint_transformer_block_bucketing_reordering` 9.28 s
+- `regional_inductor` 89.92 s
+
+### Artifacts
+| artifact | link |
+|---|---|
+| run log (pastry) | https://www.internalfb.com/intern/paste/P2371696211/ |
+| profiler trace (perfetto, rank0 iter 10) | https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_53437836-36e9-452c-80aa-f9a98b44e4d7_rank0_trace.json.gz |
+| tlparse logs (manifold, **temporary** `.tmp` path) | https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpNACnGq/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000 |
+
+#### Per-pass before/after graph diffs
+| pass | diff |
+|---|---|
+| eliminate_dead_code | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695016&after_paste_number=2371695095&selected_tab=plain_diff |
+| canonicalize_graph | https://www.internalfb.com/intern/diffing/?before_paste_number=2371694852&after_paste_number=2371694922&selected_tab=plain_diff |
+| tag_with_memory_policy | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695911&after_paste_number=2371695985&selected_tab=plain_diff |
+| selective_activation_remat | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695733&after_paste_number=2371695832&selected_tab=plain_diff |
+| reassign_collective_pgs | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695378&after_paste_number=2371695465&selected_tab=plain_diff |
+| joint_transformer_block_bucketing_reordering | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695203&after_paste_number=2371695291&selected_tab=plain_diff |
+| annotate_flex_attention_for_regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2371694655&after_paste_number=2371694746&selected_tab=plain_diff |
+| regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2371695568&after_paste_number=2371695645&selected_tab=plain_diff |
+
+#### Standalone artifacts
+| artifact | paste |
+|---|---|
+| activation_memory_policy | https://www.internalfb.com/intern/paste/P2371696021/ |
+| fx_compute_nodes_runtime_estimation | https://www.internalfb.com/intern/paste/P2371696070/ |
+
+### Notes
+- **ChunkedCELoss confirmed** via `--debug.print-config`: `loss.num_chunks = 8`
+  (`CrossEntropyLoss` has no `num_chunks`), and `compile.components` includes
+  `"loss"` so the chunked loss is compiled.
+- **Cold-cache compile OOM (workaround applied):** the first two attempts were
+  SIGKILL'd during `regional_inductor` on a cold Inductor cache. It was *not* a
+  steady host-RAM OOM (1 s sampling showed peak ~214 GiB / 2 TiB); fresh
+  compilation on this 368-core host spawned a large compile-worker pool whose
+  transient spike tripped the OS OOM-killer. Capping
+  `TORCHINDUCTOR_COMPILE_THREADS=8` and warming the Inductor cache let it
+  complete. Consider baking the cap into the launcher for cold-start reliability.

--- a/torchtitan/experiments/graph_trainer/chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/chunked_loss.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
+
 import torch
 import torch.nn as nn
 
@@ -21,6 +23,10 @@ class ChunkedCELossWithParamGrads(ChunkedCELoss):
     replay therefore produces all-zero param grads. Compatible with both
     outer ``loss.backward()`` and ``torch.autograd.grad`` consumers.
     """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ChunkedCELoss.Config):
+        pass
 
     @staticmethod
     def _gradient_backprop(

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -8,9 +8,12 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, fields, replace
 from typing import Literal
 
-from torchtitan.components.loss import ChunkedCELoss, CrossEntropyLoss
+from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.config import ActivationCheckpointConfig
 from torchtitan.config.configs import CompileConfig
+from torchtitan.experiments.graph_trainer.chunked_loss import (
+    ChunkedCELossWithParamGrads,
+)
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
 
@@ -147,9 +150,13 @@ def to_graph_trainer_config(
     if ac is not None and ac.mode != "none":
         d["activation_checkpoint"] = ActivationCheckpointConfig(mode="selective")
 
-    # TODO: graph_trainer doesn't yet support ChunkedCELoss
-    if isinstance(d.get("loss"), ChunkedCELoss.Config):
-        d["loss"] = CrossEntropyLoss.Config()
+    # graph_trainer's tracer requires explicit autograd outputs for lm_head
+    # params instead of relying on .grad side effects from chunk_loss.backward().
+    loss_cfg = d.get("loss")
+    if isinstance(loss_cfg, ChunkedCELoss.Config):
+        d["loss"] = ChunkedCELossWithParamGrads.Config(
+            **{f.name: getattr(loss_cfg, f.name) for f in fields(loss_cfg)}
+        )
 
     # Merge CUDA graph kernel annotations into profiler traces when profiling
     # is active.  No-op otherwise (and no-op when requirements aren't met).

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -15,7 +14,6 @@ from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_671b,
     deepseek_v3_debugmodel,
 )
-from torchtitan.trainer import Trainer
 
 from . import model_registry
 
@@ -46,15 +44,4 @@ def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:
 def graph_trainer_deepseek_v3_671b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_671b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
-    return config
-
-
-# CrossEntropyLoss baseline for graph_trainer numerics tests. graph_trainer
-# doesn't yet support ChunkedCELoss, so to_graph_trainer_config swaps it for
-# CrossEntropyLoss; this wrapper applies the same swap to the eager baseline
-# so loss_compare runs apples-to-apples.
-# TODO: Remove once graph_trainer supports ChunkedCELoss.
-def deepseek_v3_debugmodel_ce_loss() -> Trainer.Config:
-    config = deepseek_v3_debugmodel()
-    config.loss = CrossEntropyLoss.Config()
     return config

--- a/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -15,7 +14,6 @@ from torchtitan.models.qwen3.config_registry import (
     qwen3_debugmodel,
     qwen3_moe_debug,
 )
-from torchtitan.trainer import Trainer
 
 from . import model_registry
 
@@ -35,21 +33,4 @@ def graph_trainer_qwen3_debugmodel_moe() -> GraphTrainer.Config:
 def graph_trainer_qwen3_14b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(qwen3_14b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
-    return config
-
-
-# CrossEntropyLoss baselines for graph_trainer numerics tests. graph_trainer
-# doesn't yet support ChunkedCELoss, so to_graph_trainer_config swaps it for
-# CrossEntropyLoss; these wrappers apply the same swap to the eager baseline
-# so loss_compare runs apples-to-apples.
-# TODO: Remove once graph_trainer supports ChunkedCELoss.
-def qwen3_debugmodel_ce_loss() -> Trainer.Config:
-    config = qwen3_debugmodel()
-    config.loss = CrossEntropyLoss.Config()
-    return config
-
-
-def qwen3_moe_debug_ce_loss() -> Trainer.Config:
-    config = qwen3_moe_debug()
-    config.loss = CrossEntropyLoss.Config()
     return config

--- a/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
@@ -53,6 +53,11 @@ def _chunked_loss_and_grads(model, chunked_loss, hidden_states, labels, gvt):
 
 
 class TestChunkedCELossWithParamGrads(TestCase):
+    def test_config_builds_param_grads_loss(self):
+        loss = ChunkedCELossWithParamGrads.Config(num_chunks=4).build()
+        self.assertIsInstance(loss, ChunkedCELossWithParamGrads)
+        self.assertEqual(loss.num_chunks, 4)
+
     def test_bitwise_equal_with_chunked_celoss(self):
         torch.manual_seed(42)
         B, L, D, V = 2, 8, 32, 64

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -164,7 +164,7 @@ def _run_llama3_loss_compare(test_options_extra: str = "") -> bool:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
         baseline_module="llama3",
-        baseline_config="llama3_debugmodel_ce_loss",
+        baseline_config="llama3_debugmodel",
         test_module="graph_trainer.llama3",
         test_config="graph_trainer_llama3_debugmodel",
         baseline_options=LLAMA3_PARALLELISM,
@@ -185,8 +185,8 @@ def _run_deepseek_v3_loss_compare(test_options_extra: str = "") -> bool:
     if test_options_extra:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
-        baseline_module="graph_trainer.deepseek_v3",
-        baseline_config="deepseek_v3_debugmodel_ce_loss",
+        baseline_module="deepseek_v3",
+        baseline_config="deepseek_v3_debugmodel",
         test_module="graph_trainer.deepseek_v3",
         test_config="graph_trainer_deepseek_v3_debugmodel",
         baseline_options=DSV3_PARALLELISM,
@@ -206,8 +206,8 @@ def _run_qwen3_loss_compare(test_options_extra: str = "") -> bool:
     if test_options_extra:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
-        baseline_module="graph_trainer.qwen3",
-        baseline_config="qwen3_debugmodel_ce_loss",
+        baseline_module="qwen3",
+        baseline_config="qwen3_debugmodel",
         test_module="graph_trainer.qwen3",
         test_config="graph_trainer_qwen3_debugmodel",
         baseline_options=QWEN3_PARALLELISM,
@@ -228,8 +228,8 @@ def _run_qwen3_moe_loss_compare(test_options_extra: str = "") -> bool:
     if test_options_extra:
         test_options += f" {test_options_extra}"
     return run_loss_compare(
-        baseline_module="graph_trainer.qwen3",
-        baseline_config="qwen3_moe_debug_ce_loss",
+        baseline_module="qwen3",
+        baseline_config="qwen3_moe_debug",
         test_module="graph_trainer.qwen3",
         test_config="graph_trainer_qwen3_debugmodel_moe",
         baseline_options=QWEN3_MOE_PARALLELISM,
@@ -277,8 +277,8 @@ AUTOPARALLEL_DSV3_PARALLELISM = (
 def _run_autoparallel_deepseek_v3_loss_compare() -> bool:
     """Run loss_compare for eager DeepSeek V3 vs graph_trainer AutoParallel."""
     return run_loss_compare_close(
-        baseline_module="graph_trainer.deepseek_v3",
-        baseline_config="deepseek_v3_debugmodel_ce_loss",
+        baseline_module="deepseek_v3",
+        baseline_config="deepseek_v3_debugmodel",
         test_module="graph_trainer.deepseek_v3",
         test_config="graph_trainer_deepseek_v3_debugmodel",
         baseline_options=AUTOPARALLEL_DSV3_PARALLELISM,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3611
* #3610
* #3609
* __->__ #3608
* #3607
* #3606

Squashed from ghstack PR #3248. Turns on traceable ChunkedCELoss config for
deepseek_v3 and qwen3 to match eager ChunkedLoss memory. Requires #3419 (+
pytorch nightly w/ pytorch#184711) for bitwise loss parity.

Original: https://github.com/pytorch/torchtitan/pull/3248