### PR TITLE
Add MinimalAsyncEP + offset aware swiglu kernels (#3561)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,10 @@ You should NEVER use `--debug.deterministic_warn_only`.
    fields, distributed utilities), check and update every callsite. This includes all
    model variants: llama3, llama4, qwen3, deepseek_v3, gpt_oss, flux, etc.
 
+7. **No speculative defensive checks.** Don't add checks, casts, fallbacks, or
+   conversions "just in case." Only validate explicit contracts, user-facing
+   configuration, or invariants whose failure would otherwise be silent or unclear.
+
 ## Code Style
 
 ### Naming

--- a/dsv3_scaling_experiment_results.md
+++ b/dsv3_scaling_experiment_results.md
@@ -159,3 +159,85 @@ All 9 graph passes took **113.558 s** (cold-ish Inductor cache):
   transient spike tripped the OS OOM-killer. Capping
   `TORCHINDUCTOR_COMPILE_THREADS=8` and warming the Inductor cache let it
   complete. Consider baking the cap into the launcher for cold-start reliability.
+
+---
+
+## Run 3 — deepseek_v3 16B with MinimalAsyncEP (run script + #3419 + #3248 + #3561)
+
+**Date:** 2026-06-09
+**Branch:** `graph_trainer/dsv3_scaling`
+**Branch state at run:** run-script + #3419 + #3248 + #3561 (MinimalAsyncEP).
+#3590 / EP-overlap / #3548 **not yet applied**.
+**Launcher:** `TORCHINDUCTOR_COMPILE_THREADS=8 ./run_graph_trainer_dsv3.sh` with
+`CONFIG=graph_trainer_deepseek_v3_16b_minimal_async_ep` (the committed script's
+generic `graph_trainer_deepseek_v3_16b` was temporarily switched to the
+MinimalAsyncEP variant for this run).
+
+> ⚠️ **UNVERIFIED — numerics not validated.** Same loss-divergence concern as
+> Run 2, and MinimalAsyncEP is a **new sync-free MoE dispatcher** — its numerics
+> need an eager comparison (eager `deepseek_v3_16b_minimal_async_ep` via
+> `scripts/loss_compare.py`, ideally bitwise with `--debug.seed=42
+> --debug.deterministic`, loss *and* grad_norm) before this result can be
+> trusted. Treat the loss curve below as **provisional.**
+
+### MinimalAsyncEP confirmed in use
+Symmetric-memory buffer init logged at startup (proves the sync-free dispatcher
+is active, not a fallback):
+`Initializing MinimalAsyncEP buffer: hidden_dim=2048, tokens_per_rank=16384,
+top_k=6, num_local_experts=16, ep_size=4, max_routed_tokens=393216`.
+
+### Setup
+Same as Run 2 (8× H100, `dp_shard=8 ep=4`, `aot_fx_trace`, `memory_policy=full`,
+ChunkedCELoss, B=4 / seq 4096, 20 steps, c4_test) **except the MoE dispatcher**:
+
+| | |
+|---|---|
+| MoE dispatcher | **MinimalAsyncEPTokenDispatcher** (sync-free EP via symmetric memory) |
+| Config | `graph_trainer_deepseek_v3_16b_minimal_async_ep` |
+
+### Results
+| step | loss | grad_norm | memory | tps | tflops | mfu |
+|-----:|------|-----------|--------|-----|--------|-----|
+| 1 | 12.09197 | 1.6856 | 29.34 GiB (30.86%) | 95 | 1.72 | 0.17% |
+| 10 | 9.10410 | 6.9499 | 36.06 GiB (37.93%) | 8,221 | 148.84 | 15.05% |
+| 20 | 7.21462 | 8.1240 | 36.06 GiB (37.93%) | 5,504 | 99.66 | 10.08% |
+
+Loss converges; memory ~36 GiB (same band as Run 2). step-10 mfu 15.05%
+(vs Run 2's 13.04%). **Numerics unverified — see caveat above.**
+
+### Compile pipeline
+All 9 graph passes took **94.834 s** (`TORCHINDUCTOR_COMPILE_THREADS=8`; cold
+Inductor cache for the new MinimalAsyncEP / offset-aware swiglu kernels):
+- `joint_transformer_block_bucketing_reordering` 9.25 s
+- `regional_inductor` 74.05 s
+
+### Artifacts
+| artifact | link |
+|---|---|
+| run log (pastry) | https://www.internalfb.com/intern/paste/P2371964742/ |
+| profiler trace (perfetto, rank0 iter 10) | https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_de493592-0d3f-40da-9376-ab01153b39e9_rank0_trace.json.gz |
+| tlparse logs (manifold, **temporary** `.tmp` path) | https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpd3wvEW/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000 |
+
+#### Per-pass before/after graph diffs
+| pass | diff |
+|---|---|
+| eliminate_dead_code | https://www.internalfb.com/intern/diffing/?before_paste_number=2371964059&after_paste_number=2371964141&selected_tab=plain_diff |
+| canonicalize_graph | https://www.internalfb.com/intern/diffing/?before_paste_number=2371963719&after_paste_number=2371963790&selected_tab=plain_diff |
+| tag_with_memory_policy | https://www.internalfb.com/intern/diffing/?before_paste_number=2371964490&after_paste_number=2371964578&selected_tab=plain_diff |
+| selective_activation_remat | https://www.internalfb.com/intern/diffing/?before_paste_number=2371964352&after_paste_number=2371964417&selected_tab=plain_diff |
+| annotate_flex_attention_for_regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2371963554&after_paste_number=2371963641&selected_tab=plain_diff |
+| regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2371964223&after_paste_number=2371964281&selected_tab=plain_diff |
+
+#### Standalone artifacts
+| artifact | paste |
+|---|---|
+| activation_memory_policy | https://www.internalfb.com/intern/paste/P2371964600/ |
+
+### Notes
+- MinimalAsyncEP parallelism requirements satisfied: `ep=4>1`, `tp=1`,
+  `dp_shard=8 % ep=0`, no CP/PP/sequence-parallel, `memory_policy=full`, and
+  `spmd_backend=default` (MinimalAsyncEP rejects `full_dtensor`).
+- Cold-cache compile mitigation as in Run 2 (`TORCHINDUCTOR_COMPILE_THREADS=8`);
+  the MinimalAsyncEP / swiglu kernels are new, so their first compile is cold.
+- The committed launcher still uses `graph_trainer_deepseek_v3_16b`; the
+  MinimalAsyncEP config was set only for this run.

--- a/run_graph_trainer_dsv3.sh
+++ b/run_graph_trainer_dsv3.sh
@@ -99,8 +99,11 @@ tlp ()
 # logged automatically.
 {
 
-# --- DeepSeek-v3 16B (FSDP+TP+EP) ---
-NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b tlp ./run_train.sh \
+# --- DeepSeek-v3 16B MinimalAsyncEP (FSDP+EP, sync-free MoE) ---
+# TORCHINDUCTOR_COMPILE_THREADS caps Inductor compile-worker parallelism:
+# MinimalAsyncEP's kernels compile cold, and the default worker pool (this host
+# has 368 cores) spikes host RAM enough to OOM-kill regional_inductor without it.
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b_minimal_async_ep TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=8 \
     --parallelism.tensor_parallel_degree=1 \

--- a/torchtitan/distributed/minimal_async_ep.py
+++ b/torchtitan/distributed/minimal_async_ep.py
@@ -1,0 +1,1016 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MinimalAsyncEP primitives for constrained MoE expert parallel dispatch.
+
+This backend is intentionally narrow: it supports the launch shape where the
+EP process group is the data-parallel group and TP/CP/PP/SP are disabled.
+The symmetric-memory allocation is explicit and must happen before dispatch.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from torchtitan.distributed.minimal_async_ep_kernels import (
+    active_swiglu_backward_kernel,
+    active_swiglu_forward_kernel,
+    copy_full_counts_to_peers_kernel,
+    copy_rows_to_peers_kernel,
+    expand_topk_grad_kernel,
+    fill_combine_metadata_kernel,
+    fill_dispatch_metadata_kernel,
+    invert_flat_indices_kernel,
+    reduce_topk_slots_kernel,
+    topk_scores_grad_kernel,
+)
+from torchtitan.tools.logging import logger
+
+
+_HIDDEN_RECV_BUFFER_COUNT = 2
+
+_HIDDEN_READY_CHANNEL = 0
+_COUNTS_READY_CHANNEL = 0
+
+
+@dataclass
+class _MinimalAsyncEPBufferState:
+    """Process-local symmetric-memory state initialized as one unit."""
+
+    group: dist.ProcessGroup
+    tokens_per_rank: int
+    hidden_recv_buffers: list[torch.Tensor]
+    hidden_recv_handles: list[Any]
+    hidden_recv_peer_buffers: list[list[torch.Tensor]]
+    hidden_recv_peer_ptrs: list[torch.Tensor]
+    counts_recv_buffer: torch.Tensor
+    counts_recv_handle: Any
+    counts_recv_peer_buffers: list[torch.Tensor]
+    counts_recv_peer_ptrs: torch.Tensor
+    hidden_recv_buffer_index: int = 0
+
+
+_buffer_state: _MinimalAsyncEPBufferState | None = None
+
+
+@dataclass
+class MinimalAsyncEPDispatchMetadata:
+    """MinimalAsyncEP metadata from dispatch needed for combine.
+
+    Shape symbols match ``MinimalAsyncEPTokenDispatcher.dispatch`` and
+    ``AllToAllTokenDispatcher``: ``T`` local tokens, ``D`` model dimension,
+    ``N = T * K`` T-major routed rows before EP exchange, and ``R`` active rows
+    assigned to this rank's local experts. MinimalAsyncEP additionally keeps
+    a static receive capacity ``R_max >= R``.
+
+    Field shapes:
+        dispatch_dst_ranks, dispatch_dst_rows: ``(N,)``.
+        combine_dst_ranks, combine_dst_rows: ``(R_max,)``.
+        combine_num_valid_rows: ``(1,)`` active receive rows, where
+            ``combine_num_valid_rows[0] == R``.
+        E_row_to_T_row,
+            T_row_to_E_row,
+            routed_scores: ``(N,)``.
+        num_tokens: ``T``.
+        top_k: ``K``.
+    """
+
+    dispatch_dst_ranks: torch.Tensor
+    dispatch_dst_rows: torch.Tensor
+    combine_dst_ranks: torch.Tensor
+    combine_dst_rows: torch.Tensor
+    combine_num_valid_rows: torch.Tensor
+    E_row_to_T_row: torch.Tensor  # noqa: N815
+    T_row_to_E_row: torch.Tensor  # noqa: N815
+    routed_scores: torch.Tensor
+    num_tokens: int
+    top_k: int
+
+
+def init_buffer(
+    group: dist.ProcessGroup,
+    hidden_dim: int,
+    tokens_per_rank: int,
+    num_local_experts: int,
+    top_k: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Initialize the process-local MinimalAsyncEP symmetric-memory buffer."""
+    global _buffer_state
+
+    device = torch.device(device)
+    max_routed_tokens = group.size() * tokens_per_rank * min(top_k, num_local_experts)
+    num_experts = group.size() * num_local_experts
+    assert _buffer_state is None
+
+    logger.info(
+        "Initializing MinimalAsyncEP buffer: hidden_dim=%d, tokens_per_rank=%d, "
+        "top_k=%d, num_local_experts=%d, ep_size=%d, max_routed_tokens=%d",
+        hidden_dim,
+        tokens_per_rank,
+        top_k,
+        num_local_experts,
+        group.size(),
+        max_routed_tokens,
+    )
+    backend = symm_mem.get_backend(device)
+    if backend != "CUDA":
+        raise RuntimeError(
+            "MinimalAsyncEP custom all-to-allv requires the symmetric-memory CUDA "
+            f"backend, got {backend}."
+        )
+
+    hidden_recv_buffers = [
+        symm_mem.empty(
+            max_routed_tokens,
+            hidden_dim,
+            dtype=dtype,
+            device=device,
+        )
+        for _ in range(_HIDDEN_RECV_BUFFER_COUNT)
+    ]
+    counts_recv_buffer = symm_mem.empty(
+        group.size(),
+        num_experts,
+        dtype=torch.int64,
+        device=device,
+    )
+    hidden_recv_handles = [
+        symm_mem.rendezvous(hidden_recv_buffer, group)
+        for hidden_recv_buffer in hidden_recv_buffers
+    ]
+    counts_recv_handle = symm_mem.rendezvous(counts_recv_buffer, group)
+    hidden_recv_peer_buffers = [
+        [
+            hidden_recv_handle.get_buffer(
+                peer,
+                hidden_recv_buffer.shape,
+                hidden_recv_buffer.dtype,
+            )
+            for peer in range(group.size())
+        ]
+        for hidden_recv_buffer, hidden_recv_handle in zip(
+            hidden_recv_buffers,
+            hidden_recv_handles,
+        )
+    ]
+    hidden_recv_peer_ptrs = [
+        torch.tensor(
+            [peer_buffer.data_ptr() for peer_buffer in hidden_recv_peer_buffers],
+            dtype=torch.int64,
+            device=device,
+        )
+        for hidden_recv_peer_buffers in hidden_recv_peer_buffers
+    ]
+    counts_recv_peer_buffers = [
+        counts_recv_handle.get_buffer(
+            peer,
+            counts_recv_buffer.shape,
+            counts_recv_buffer.dtype,
+        )
+        for peer in range(group.size())
+    ]
+    counts_recv_peer_ptrs = torch.tensor(
+        [peer_buffer.data_ptr() for peer_buffer in counts_recv_peer_buffers],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    _buffer_state = _MinimalAsyncEPBufferState(
+        group=group,
+        tokens_per_rank=tokens_per_rank,
+        hidden_recv_buffers=hidden_recv_buffers,
+        hidden_recv_handles=hidden_recv_handles,
+        hidden_recv_peer_buffers=hidden_recv_peer_buffers,
+        hidden_recv_peer_ptrs=hidden_recv_peer_ptrs,
+        counts_recv_buffer=counts_recv_buffer,
+        counts_recv_handle=counts_recv_handle,
+        counts_recv_peer_buffers=counts_recv_peer_buffers,
+        counts_recv_peer_ptrs=counts_recv_peer_ptrs,
+    )
+
+
+def _copy_rows_to_peers_and_wait_cuda(
+    x: torch.Tensor,
+    dst_ranks: torch.Tensor,
+    dst_rows: torch.Tensor,
+    num_rows: int,
+    *,
+    block_m: int = 1,
+    num_warps: int = 4,
+    src_rows: torch.Tensor | None = None,
+    num_valid_rows: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Copy rows through symmetric memory and wait before returning.
+
+    MinimalAsyncEP exposes synchronous custom-op boundaries: callers receive a
+    readable buffer, not an async handle. This keeps the operator interface
+    simple for graph capture, but means this backend does not provide
+    microbatch communication overlap.
+    """
+    assert _buffer_state is not None
+
+    buffer_index = _buffer_state.hidden_recv_buffer_index
+    _buffer_state.hidden_recv_buffer_index = (
+        _buffer_state.hidden_recv_buffer_index + 1
+    ) % _HIDDEN_RECV_BUFFER_COUNT
+    hidden_recv_buffer = _buffer_state.hidden_recv_buffers[buffer_index]
+    hidden_recv_handle = _buffer_state.hidden_recv_handles[buffer_index]
+    hidden_recv_peer_buffers = _buffer_state.hidden_recv_peer_buffers[buffer_index]
+    hidden_recv_peer_ptrs = _buffer_state.hidden_recv_peer_ptrs[buffer_index]
+
+    copy_rows_to_peers_kernel(
+        x,
+        hidden_recv_peer_buffers,
+        dst_ranks,
+        dst_rows,
+        ep_size=_buffer_state.group.size(),
+        num_rows=num_rows,
+        num_cols=x.shape[1],
+        block_m=block_m,
+        num_warps=num_warps,
+        src_rows=src_rows,
+        dst_ptrs=hidden_recv_peer_ptrs,
+        num_valid_rows=num_valid_rows,
+    )
+    _wait_hidden_ready(hidden_recv_handle)
+    return hidden_recv_buffer
+
+
+def _wait_hidden_ready(hidden_recv_handle: Any) -> None:
+    _wait_ready(hidden_recv_handle, _HIDDEN_READY_CHANNEL)
+
+
+def _wait_counts_ready() -> None:
+    assert _buffer_state is not None
+    _wait_ready(_buffer_state.counts_recv_handle, _COUNTS_READY_CHANNEL)
+
+
+def _wait_ready(handle: Any, channel: int) -> None:
+    """EP-group barrier: ensure every peer has finished writing into this
+    rank's symmetric receive buffer before the buffer is read.
+
+    This wait intentionally happens before custom ops return tensors that are
+    consumed by later compute. MinimalAsyncEP is a synchronous, CUDA-graphable
+    backend and does not expose a separate async handle for microbatch overlap.
+
+    Issues a single fused ``barrier`` kernel that signals and polls all peers
+    concurrently. This was previously a Python loop of ``2 * (ep_size - 1)``
+    per-peer ``put_signal`` / ``wait_signal`` kernels, all serialized and fully
+    exposed on the critical path (each ``wait_signal`` its own spin-wait
+    kernel) -- the dominant MinimalAsyncEP comm cost once CPU-launch overhead
+    is removed by CUDA graphs / compiled steps.
+    """
+    handle.barrier(channel=channel)
+
+
+def _copy_all_counts_to_peers_and_wait_cuda(
+    num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
+    ep_size: int,
+) -> torch.Tensor:
+    """Copy this rank's expert counts to all peers and wait for peer counts."""
+    assert _buffer_state is not None
+
+    num_experts = num_local_tokens_per_expert_E.numel()
+    copy_full_counts_to_peers_kernel(
+        num_local_tokens_per_expert_E,
+        _buffer_state.counts_recv_peer_buffers,
+        rank=_buffer_state.group.rank(),
+        ep_size=ep_size,
+        num_experts=num_experts,
+        dst_ptrs=_buffer_state.counts_recv_peer_ptrs,
+    )
+    _wait_counts_ready()
+    return _buffer_state.counts_recv_buffer
+
+
+def _compute_direct_metadata(
+    num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
+    all_tokens_per_expert_RE: torch.Tensor,  # noqa: N803
+    num_routed_rows: int,
+    receive_capacity: int,
+    ep_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    assert _buffer_state is not None
+
+    rank = _buffer_state.group.rank()
+    num_experts = num_local_tokens_per_expert_E.numel()
+    num_local_experts = num_experts // ep_size
+
+    counts_sde = all_tokens_per_expert_RE.view(
+        ep_size,
+        ep_size,
+        num_local_experts,
+    )
+    source_prefix_sde = counts_sde.cumsum(0) - counts_sde
+    total_de = counts_sde.sum(0)
+    expert_starts_de = total_de.cumsum(1) - total_de
+    tokens_per_expert_e = total_de[rank]
+
+    local_dest_offsets_E = (  # noqa: N806
+        expert_starts_de + source_prefix_sde[rank]
+    ).reshape(num_experts)
+    local_count_ends_E = num_local_tokens_per_expert_E.cumsum(0)  # noqa: N806
+    local_count_starts_E = (  # noqa: N806
+        local_count_ends_E - num_local_tokens_per_expert_E
+    )
+    (
+        dispatch_dst_ranks_N,
+        dispatch_dst_rows_N,
+    ) = fill_dispatch_metadata_kernel(  # noqa: N806
+        num_local_tokens_per_expert_E,
+        local_dest_offsets_E,
+        local_count_starts_E,
+        num_routed_tokens=num_routed_rows,
+        num_local_experts=num_local_experts,
+        max_tokens_per_segment=_buffer_state.tokens_per_rank,
+    )
+
+    segment_lens = counts_sde[:, rank, :].t().reshape(-1)
+    output_ends = segment_lens.cumsum(0)
+    output_starts = output_ends - segment_lens
+    source_input_starts_RE = (  # noqa: N806
+        all_tokens_per_expert_RE.cumsum(1) - all_tokens_per_expert_RE
+    )
+    (
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+    ) = fill_combine_metadata_kernel(
+        segment_lens,
+        output_starts,
+        source_input_starts_RE,
+        ep_rank=rank,
+        ep_size=ep_size,
+        num_local_experts=num_local_experts,
+        receive_capacity=receive_capacity,
+        max_tokens_per_segment=_buffer_state.tokens_per_rank,
+    )
+
+    return (
+        dispatch_dst_ranks_N,
+        dispatch_dst_rows_N,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        tokens_per_expert_e,
+    )
+
+
+def _dispatch_to_experts(
+    x_ND: torch.Tensor,  # noqa: N803
+    dispatch_dst_ranks: torch.Tensor,
+    dispatch_dst_rows: torch.Tensor,
+    num_routed_rows: int,
+) -> torch.Tensor:
+    hidden_recv_buffer = _copy_rows_to_peers_and_wait_cuda(
+        x_ND,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        num_routed_rows,
+        block_m=4,
+        num_warps=8,
+    )
+    return hidden_recv_buffer
+
+
+def _combine_to_origin(
+    x_RD: torch.Tensor,  # noqa: N803
+    combine_dst_ranks: torch.Tensor,
+    combine_dst_rows: torch.Tensor,
+    combine_num_valid_rows: torch.Tensor,
+    num_routed_rows: int,
+) -> torch.Tensor:
+    """Copy active local rows back to origin ranks as logical ``(N, D)`` rows."""
+    origin_recv_buffer = _copy_rows_to_peers_and_wait_cuda(
+        x_RD,
+        combine_dst_ranks,
+        combine_dst_rows,
+        x_RD.shape[0],
+        block_m=4,
+        num_valid_rows=combine_num_valid_rows,
+    )
+    # The symmetric buffer is sized for the maximum receive capacity. Combine
+    # only writes origin-rank routed rows ``[0:N]`` and downstream reductions
+    # should not see capacity padding or unused trailing columns.
+    return origin_recv_buffer.narrow(0, 0, num_routed_rows).narrow(1, 0, x_RD.shape[1])
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::active_swiglu",
+    mutates_args=(),
+    device_types="cuda",
+)
+def active_swiglu_op(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` over active padded expert-buffer rows.
+
+    Args:
+        gate, up: ``(R_max, F)`` expert intermediate rows, where only the
+            first ``R`` rows are active and ``R_max`` is the static receive
+            capacity.
+        active_rows: ``(1,)`` device scalar containing ``R``.
+
+    Returns:
+        ``(R_max, F)`` output. Rows ``[:R]`` are defined; rows ``[R:]`` are
+        unspecified because grouped-mm offsets skip receive-capacity padding.
+    """
+    return active_swiglu_forward_kernel(gate, up, active_rows)
+
+
+@active_swiglu_op.register_fake
+def active_swiglu_op_fake(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(gate)
+
+
+def _dispatch_metadata(
+    num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
+    num_routed_rows: int,
+    receive_capacity: int,
+    ep_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Exchange per-expert local counts and build dispatch/combine metadata.
+
+    Args:
+        num_local_tokens_per_expert_E: ``(E,)`` int64 counts for this rank's
+            local token shard over all global experts.
+        num_routed_rows: ``N = T * K`` routed rows in local E-major order.
+        receive_capacity: ``R_max`` static receive-buffer row capacity.
+        ep_size: ``EP`` expert-parallel group size.
+
+    Returns:
+        ``dispatch_dst_ranks`` and ``dispatch_dst_rows``: ``(N,)`` maps local
+        E-major routed rows to destination EP rank and destination receive row.
+        ``combine_dst_ranks`` and ``combine_dst_rows``: ``(R_max,)`` maps
+        active received rows back to origin EP rank and origin E-major row.
+        ``combine_num_valid_rows``: ``(1,)`` device scalar active row count
+        ``R``. ``tokens_per_expert``: ``(E / EP,)`` active rows per local
+        expert on this rank.
+    """
+
+    # Mirrors AllToAllTokenDispatcher's count exchange: each rank starts with
+    # counts for its local tokens over all global experts, then learns how many
+    # tokens every peer will send to each of this rank's local experts.
+    all_tokens_per_expert_RE = _copy_all_counts_to_peers_and_wait_cuda(  # noqa: N806
+        num_local_tokens_per_expert_E,
+        ep_size,
+    )
+
+    # Instead of materializing an all-to-all rank-major receive tensor and then
+    # calling _permute(), compute the final E-major receive rows directly.
+    return _compute_direct_metadata(
+        num_local_tokens_per_expert_E,
+        all_tokens_per_expert_RE,
+        num_routed_rows,
+        receive_capacity,
+        ep_size,
+    )
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::dispatch",
+    mutates_args=(),
+    device_types="cuda",
+)
+def dispatch_op(
+    dispatch_input: torch.Tensor,
+    topk_expert_ids_TK: torch.Tensor,  # noqa: N803
+    num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
+    receive_capacity: int,
+    ep_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Build MinimalAsyncEP metadata and dispatch rows to expert-owner ranks.
+
+    Args:
+        dispatch_input: ``(T, D)`` local token rows.
+        topk_expert_ids_TK: ``(T, K)`` global expert ids.
+        num_local_tokens_per_expert_E: ``(E,)`` counts for this rank's token
+            shard over all global experts.
+        receive_capacity: ``R_max`` static receive-buffer row capacity.
+        ep_size: ``EP`` expert-parallel group size.
+
+    Returns:
+        ``hidden_states`` plus all tensor metadata needed by combine and
+        backward.
+    """
+    T_row_to_expert_N = topk_expert_ids_TK.reshape(-1)  # noqa: N806
+    num_routed_rows = T_row_to_expert_N.numel()
+    E_row_to_T_row_N = torch.argsort(  # noqa: N806
+        T_row_to_expert_N,
+        stable=True,
+    )
+    top_k = topk_expert_ids_TK.shape[1]
+    E_row_to_token_N = E_row_to_T_row_N // top_k  # noqa: N806
+    (
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        num_tokens_per_local_expert_e,
+    ) = _dispatch_metadata(
+        num_local_tokens_per_expert_E,
+        num_routed_rows,
+        receive_capacity,
+        ep_size,
+    )
+
+    # Invert the E-major permutation for combine. Example:
+    # E_row_to_T_row_N=[2, 0, 3, 1] means E-major row 0 came
+    # from T-major row 2, so T_row_to_E_row_N=[1, 3, 0, 2].
+    T_row_to_E_row_N = invert_flat_indices_kernel(  # noqa: N806
+        E_row_to_T_row_N,
+        num_rows=num_routed_rows,
+    )
+
+    # This direct copy corresponds to AllToAllTokenDispatcher's token all-to-all;
+    # dispatch_dst_rows already point at the post-_permute E-major layout.
+    hidden_states = _copy_rows_to_peers_and_wait_cuda(
+        dispatch_input,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        num_routed_rows,
+        block_m=4,
+        num_warps=8,
+        src_rows=E_row_to_token_N,
+    )
+    return (
+        hidden_states,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        E_row_to_T_row_N,
+        T_row_to_E_row_N,
+        num_tokens_per_local_expert_e,
+    )
+
+
+@dispatch_op.register_fake
+def dispatch_op_fake(
+    dispatch_input: torch.Tensor,
+    topk_expert_ids_TK: torch.Tensor,  # noqa: N803
+    num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
+    receive_capacity: int,
+    ep_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    num_routed_rows = topk_expert_ids_TK.numel()
+    num_local_experts = num_local_tokens_per_expert_E.shape[0] // ep_size
+    return (
+        dispatch_input.new_empty(receive_capacity, dispatch_input.shape[1]),
+        topk_expert_ids_TK.new_empty(num_routed_rows, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(num_routed_rows, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(receive_capacity, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(receive_capacity, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(1, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(num_routed_rows, dtype=torch.int64),
+        topk_expert_ids_TK.new_empty(num_routed_rows, dtype=torch.int64),
+        num_local_tokens_per_expert_E.new_empty(
+            num_local_experts,
+            dtype=torch.int64,
+        ),
+    )
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::combine",
+    mutates_args=(),
+    device_types="cuda",
+)
+def combine_op(
+    x: torch.Tensor,
+    dispatch_dst_ranks: torch.Tensor,
+    dispatch_dst_rows: torch.Tensor,
+    combine_dst_ranks: torch.Tensor,
+    combine_dst_rows: torch.Tensor,
+    combine_num_valid_rows: torch.Tensor,
+    T_row_to_E_row_N: torch.Tensor,  # noqa: N803
+    E_row_to_T_row_N: torch.Tensor,  # noqa: N803
+    routed_scores_N: torch.Tensor,  # noqa: N803
+    num_tokens: int,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Move expert outputs to origin ranks and reduce routed top-k rows.
+
+    Args:
+        x: ``(R_max, D)`` local expert output rows.
+        dispatch_dst_ranks, dispatch_dst_rows: ``(N,)`` forward dispatch
+            destinations, saved for backward.
+        combine_dst_ranks, combine_dst_rows: ``(R_max,)`` origin rank and
+            origin E-major row for each active received row.
+        combine_num_valid_rows: ``(1,)`` device scalar active row count ``R``.
+        T_row_to_E_row_N: ``(N,)`` maps T-major top-k slots to E-major routed
+            rows.
+        E_row_to_T_row_N: ``(N,)`` maps E-major routed rows to T-major top-k
+            slots.
+        routed_scores_N: ``(N,)`` T-major routed scores.
+        num_tokens: ``T`` local tokens.
+        top_k: ``K`` routed rows per token.
+
+    Returns:
+        ``out_TD``: ``(T, D)`` reduced token rows.
+        ``routed_output_ND``: ``(N, D)`` origin-rank E-major routed rows, saved
+        for routing-score gradients.
+    """
+    routed_output_ND = _combine_to_origin(  # noqa: N806
+        x,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        E_row_to_T_row_N.numel(),
+    )
+    out_TD = reduce_topk_slots_kernel(  # noqa: N806
+        routed_output_ND,
+        T_row_to_E_row_N,
+        routed_scores_N,
+        num_tokens=num_tokens,
+        top_k=top_k,
+        scores_are_slot_ordered=True,
+    )
+    return out_TD, routed_output_ND
+
+
+@combine_op.register_fake
+def combine_op_fake(
+    x: torch.Tensor,
+    dispatch_dst_ranks: torch.Tensor,
+    dispatch_dst_rows: torch.Tensor,
+    combine_dst_ranks: torch.Tensor,
+    combine_dst_rows: torch.Tensor,
+    combine_num_valid_rows: torch.Tensor,
+    T_row_to_E_row_N: torch.Tensor,  # noqa: N803
+    E_row_to_T_row_N: torch.Tensor,  # noqa: N803
+    routed_scores_N: torch.Tensor,  # noqa: N803
+    num_tokens: int,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        x.new_empty(num_tokens, x.shape[1]),
+        x.new_empty(
+            E_row_to_T_row_N.numel(),
+            x.shape[1],
+        ),
+    )
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::active_swiglu_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def active_swiglu_backward_op(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute active-row gradients for ``minimal_async_ep::active_swiglu``.
+
+    Args:
+        grad_out, gate, up: ``(R_max, F)`` tensors from the forward op.
+        active_rows: ``(1,)`` device scalar containing active row count ``R``.
+
+    Returns:
+        ``grad_gate`` and ``grad_up`` with shape ``(R_max, F)``. Rows ``[R:]``
+        are unspecified because receive-capacity padding is not consumed.
+    """
+    return active_swiglu_backward_kernel(grad_out, gate, up, active_rows)
+
+
+@active_swiglu_backward_op.register_fake
+def active_swiglu_backward_op_fake(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(gate), torch.empty_like(up)
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::dispatch_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def dispatch_backward_op(
+    grad_hidden: torch.Tensor,
+    combine_dst_ranks: torch.Tensor,
+    combine_dst_rows: torch.Tensor,
+    combine_num_valid_rows: torch.Tensor,
+    T_row_to_E_row_N: torch.Tensor,  # noqa: N803
+    num_routed_rows: int,
+    num_tokens: int,
+    top_k: int,
+) -> torch.Tensor:
+    """Move dispatched activation gradients back and reduce routed top-k rows.
+
+    Args:
+        grad_hidden: ``(R_max, D)`` gradient for expert-owner received rows.
+        combine_dst_ranks, combine_dst_rows: ``(R_max,)`` origin rank and
+            origin E-major row for each active received row.
+        combine_num_valid_rows: ``(1,)`` device scalar active row count ``R``.
+        T_row_to_E_row_N: ``(N,)`` maps T-major top-k slots to E-major routed
+            rows.
+        num_routed_rows: ``N`` routed rows.
+        num_tokens: ``T`` local tokens.
+        top_k: ``K`` routed rows per token.
+
+    Returns:
+        ``(T, D)`` gradient for the dispatch input token rows.
+    """
+    grad_routed_input = _combine_to_origin(
+        grad_hidden,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        num_routed_rows,
+    )
+    return reduce_topk_slots_kernel(
+        grad_routed_input,
+        T_row_to_E_row_N,
+        None,
+        num_tokens=num_tokens,
+        top_k=top_k,
+    )
+
+
+@dispatch_backward_op.register_fake
+def dispatch_backward_op_fake(
+    grad_hidden: torch.Tensor,
+    combine_dst_ranks: torch.Tensor,
+    combine_dst_rows: torch.Tensor,
+    combine_num_valid_rows: torch.Tensor,
+    T_row_to_E_row_N: torch.Tensor,  # noqa: N803
+    num_routed_rows: int,
+    num_tokens: int,
+    top_k: int,
+) -> torch.Tensor:
+    return grad_hidden.new_empty(num_tokens, grad_hidden.shape[1])
+
+
+@torch.library.custom_op(
+    "minimal_async_ep::combine_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def combine_backward_op(
+    grad_out: torch.Tensor,
+    dispatch_dst_ranks: torch.Tensor,
+    dispatch_dst_rows: torch.Tensor,
+    E_row_to_T_row_N: torch.Tensor,  # noqa: N803
+    routed_scores_N: torch.Tensor,  # noqa: N803
+    saved_routed_output_ND: torch.Tensor,  # noqa: N803
+    top_k: int,
+    receive_capacity: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Expand combine gradients and dispatch them back to expert-owner ranks.
+
+    Args:
+        grad_out: ``(T, D)`` gradient for reduced token rows.
+        dispatch_dst_ranks, dispatch_dst_rows: ``(N,)`` destination rank and
+            receive row for each E-major routed row.
+        E_row_to_T_row_N: ``(N,)`` maps E-major routed rows to T-major top-k
+            slots.
+        routed_scores_N: ``(N,)`` T-major routed scores.
+        saved_routed_output_ND: ``(N, D)`` origin-rank E-major routed output
+            rows from ``combine``.
+        top_k: ``K`` routed rows per token.
+        receive_capacity: ``R_max`` static receive-buffer row capacity.
+
+    Returns:
+        ``grad_x``: ``(R_max, D)`` gradient for expert output rows.
+        ``grad_scores``: ``(N,)`` gradient for routed scores.
+    """
+    grad_routed_output = expand_topk_grad_kernel(
+        grad_out,
+        E_row_to_T_row_N,
+        routed_scores_N,
+        top_k=top_k,
+        dtype=grad_out.dtype,
+        scores_are_slot_ordered=True,
+    )
+    grad_scores = topk_scores_grad_kernel(
+        saved_routed_output_ND,
+        grad_out,
+        E_row_to_T_row_N,
+        top_k=top_k,
+        dtype=routed_scores_N.dtype,
+        scores_are_slot_ordered=True,
+    )
+
+    grad_x = _dispatch_to_experts(
+        grad_routed_output,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        E_row_to_T_row_N.numel(),
+    )
+    return grad_x, grad_scores
+
+
+@combine_backward_op.register_fake
+def combine_backward_op_fake(
+    grad_out: torch.Tensor,
+    dispatch_dst_ranks: torch.Tensor,
+    dispatch_dst_rows: torch.Tensor,
+    E_row_to_T_row_N: torch.Tensor,  # noqa: N803
+    routed_scores_N: torch.Tensor,  # noqa: N803
+    saved_routed_output_ND: torch.Tensor,  # noqa: N803
+    top_k: int,
+    receive_capacity: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        grad_out.new_empty(receive_capacity, grad_out.shape[1]),
+        routed_scores_N.new_empty(routed_scores_N.shape),
+    )
+
+
+def active_swiglu_autograd_backward(ctx, grad_out):
+    gate, up, active_rows = ctx.saved_tensors
+    grad_gate, grad_up = active_swiglu_backward_op(
+        grad_out,
+        gate,
+        up,
+        active_rows,
+    )
+    return grad_gate, grad_up, None
+
+
+def active_swiglu_setup_context(ctx, inputs, output):
+    gate, up, active_rows = inputs
+    ctx.save_for_backward(gate, up, active_rows)
+
+
+def dispatch_setup_context(ctx, inputs, output):
+    dispatch_input, topk_expert_ids_TK, *_ = inputs  # noqa: N806
+    (
+        _hidden_states,
+        _dispatch_dst_ranks,
+        _dispatch_dst_rows,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        _E_row_to_T_row_N,
+        T_row_to_E_row_N,
+        _num_tokens_per_local_expert_e,
+    ) = output
+    ctx.num_routed_rows = topk_expert_ids_TK.numel()
+    ctx.num_tokens = dispatch_input.shape[0]
+    ctx.top_k = topk_expert_ids_TK.shape[1]
+    ctx.save_for_backward(
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        T_row_to_E_row_N,
+    )
+
+
+def dispatch_autograd_backward(ctx, grad_hidden, *unused_grads):
+    (
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        T_row_to_E_row_N,
+    ) = ctx.saved_tensors
+
+    grad_input = dispatch_backward_op(
+        grad_hidden,
+        combine_dst_ranks,
+        combine_dst_rows,
+        combine_num_valid_rows,
+        T_row_to_E_row_N,
+        ctx.num_routed_rows,
+        ctx.num_tokens,
+        ctx.top_k,
+    )
+
+    return grad_input, None, None, None, None
+
+
+def combine_setup_context(ctx, inputs, output):
+    (
+        hidden_states,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        _combine_dst_ranks,
+        _combine_dst_rows,
+        _combine_num_valid_rows,
+        _T_row_to_E_row_N,
+        E_row_to_T_row_N,
+        routed_scores_N,
+        _num_tokens,
+        top_k,
+    ) = inputs
+    _combined, routed_output_ND = output
+    ctx.top_k = top_k
+    ctx.receive_capacity = hidden_states.shape[0]
+    ctx.save_for_backward(
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        E_row_to_T_row_N,
+        routed_scores_N,
+        routed_output_ND,
+    )
+
+
+def combine_autograd_backward(ctx, grad_out, grad_routed_output):
+    (
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        E_row_to_T_row_N,
+        routed_scores_N,
+        routed_output_ND,
+    ) = ctx.saved_tensors
+    grad_x, grad_scores = combine_backward_op(
+        grad_out,
+        dispatch_dst_ranks,
+        dispatch_dst_rows,
+        E_row_to_T_row_N,
+        routed_scores_N,
+        routed_output_ND,
+        ctx.top_k,
+        ctx.receive_capacity,
+    )
+
+    return (
+        grad_x,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        grad_scores,
+        None,
+        None,
+    )
+
+
+active_swiglu_op.register_autograd(
+    active_swiglu_autograd_backward, setup_context=active_swiglu_setup_context
+)
+dispatch_op.register_autograd(
+    dispatch_autograd_backward,
+    setup_context=dispatch_setup_context,
+)
+combine_op.register_autograd(
+    combine_autograd_backward,
+    setup_context=combine_setup_context,
+)
+
+__all__ = [
+    "MinimalAsyncEPDispatchMetadata",
+    "active_swiglu_op",
+    "combine_op",
+    "dispatch_op",
+    "init_buffer",
+]

--- a/torchtitan/distributed/minimal_async_ep_kernels.py
+++ b/torchtitan/distributed/minimal_async_ep_kernels.py
@@ -1,0 +1,831 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import triton
+import triton.language as tl
+
+
+_COUNT_COPY_BLOCK_SIZE = 1024
+_METADATA_BLOCK_SIZE = 256
+_MAX_BLOCK_N = 2048
+_SWIGLU_BLOCK_M = 4
+
+# MinimalAsyncEP hidden buffers use TrainingConfig.mixed_precision_param,
+# currently restricted to bfloat16 or float32.
+_HIDDEN_ROW_DTYPES = {
+    torch.bfloat16: tl.bfloat16,
+    torch.float32: tl.float32,
+}
+
+
+@triton.jit(do_not_specialize=["rank"])
+def _copy_full_counts_to_peer_ptrs_kernel(
+    counts: tl.pointer_type(tl.int64),
+    dst_ptrs: tl.pointer_type(tl.int64),
+    rank: tl.int64,
+    EP_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    DST_ROW_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    """Copy this rank's global expert counts into every peer count buffer.
+
+    Each peer exposes its symmetric counts buffer through ``dst_ptrs``. This
+    kernel writes ``counts[:]`` into row ``rank`` of each peer's buffer.
+
+    Example:
+        With ``rank=1`` and ``counts=[2, 0, 1, 3]``, every peer buffer has
+        row 1 updated to ``[2, 0, 1, 3]`` after the kernel finishes.
+    """
+    peer = tl.program_id(0)
+    offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = (peer < EP_SIZE) & (offsets < NUM_EXPERTS)
+    base = tl.load(dst_ptrs + peer, mask=peer < EP_SIZE, other=0)
+    dst = base.to(tl.pointer_type(tl.int64)) + rank * DST_ROW_STRIDE + offsets
+    values = tl.load(counts + offsets, mask=mask, other=0)
+    tl.store(dst, values, mask=mask)
+
+
+@triton.jit
+def _fill_dispatch_metadata_kernel(
+    counts: tl.pointer_type(tl.int64),
+    local_dest_offsets: tl.pointer_type(tl.int64),
+    local_count_starts: tl.pointer_type(tl.int64),
+    dst_ranks: tl.pointer_type(tl.int64),
+    dst_rows: tl.pointer_type(tl.int64),
+    NUM_EXPERTS: tl.constexpr,
+    NUM_LOCAL_EXPERTS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    """Build per-routed-row peer destinations for the dispatch copy.
+
+    Rows are in this rank's expert-sorted routed-token order. ``dst_rows``
+    indexes the destination peer's expert-major receive buffer.
+
+    Example:
+        With ``NUM_LOCAL_EXPERTS=2``, ``counts=[2, 0, 1, 1]``,
+        ``local_count_starts=[0, 2, 2, 3]``, and
+        ``local_dest_offsets=[0, 0, 5, 9]``, the outputs are
+        ``dst_ranks=[0, 0, 1, 1]`` and ``dst_rows=[0, 1, 5, 9]``.
+    """
+    expert = tl.program_id(0)
+    block = tl.program_id(1)
+    offset = block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    count = tl.load(counts + expert)
+    mask = (expert < NUM_EXPERTS) & (offset < count)
+    row = tl.load(local_count_starts + expert) + offset
+    tl.store(dst_ranks + row, expert // NUM_LOCAL_EXPERTS, mask=mask)
+    tl.store(dst_rows + row, tl.load(local_dest_offsets + expert) + offset, mask=mask)
+
+
+@triton.jit(do_not_specialize=["ep_rank"])
+def _fill_combine_metadata_kernel(
+    segment_lens: tl.pointer_type(tl.int64),
+    output_starts: tl.pointer_type(tl.int64),
+    source_input_starts: tl.pointer_type(tl.int64),
+    dst_ranks: tl.pointer_type(tl.int64),
+    dst_rows: tl.pointer_type(tl.int64),
+    ep_rank: tl.int64,
+    EP_SIZE: tl.constexpr,
+    NUM_LOCAL_EXPERTS: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    """Build per-active-row peer destinations for the combine copy.
+
+    Rows are local expert-major rows in ``x_recv``. ``dst_rows`` maps each
+    active received row back to the source rank's expert-sorted routed rows.
+
+    Example:
+        With ``ep_rank=1``, ``EP_SIZE=2``, ``NUM_LOCAL_EXPERTS=2``,
+        ``segment_lens=[2, 1, 0, 1]``, ``output_starts=[0, 2, 3, 3]``,
+        and source starts for global experts 2 and 3 equal to
+        ``[[4, 6], [8, 10]]``, the active prefix is
+        ``dst_ranks=[0, 0, 1, 1]`` and ``dst_rows=[4, 5, 8, 10]``.
+    """
+    segment = tl.program_id(0)
+    block = tl.program_id(1)
+    offset = block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    count = tl.load(segment_lens + segment)
+    mask = offset < count
+
+    output_start = tl.load(output_starts + segment)
+    row = output_start + offset
+    src_rank = segment % EP_SIZE
+    local_expert = segment // EP_SIZE
+    global_expert = ep_rank * NUM_LOCAL_EXPERTS + local_expert
+    source_start = tl.load(source_input_starts + src_rank * NUM_EXPERTS + global_expert)
+
+    tl.store(dst_ranks + row, src_rank, mask=mask)
+    tl.store(dst_rows + row, source_start + offset, mask=mask)
+
+
+@triton.jit
+def _invert_flat_indices_kernel(
+    flat_indices: tl.pointer_type(tl.int64),
+    slot_to_row: tl.pointer_type(tl.int64),
+    NUM_ROWS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    """Invert routed-row to top-k-slot indices into top-k-slot to routed-row.
+
+    Example:
+        ``flat_indices=[2, 0, 3, 1]`` means rows 0..3 belong to slots
+        2, 0, 3, 1. The output is ``slot_to_row=[1, 3, 0, 2]``.
+    """
+    row = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = row < NUM_ROWS
+    slot = tl.load(flat_indices + row, mask=mask, other=0)
+    tl.store(slot_to_row + slot, row, mask=mask)
+
+
+@triton.jit
+def _reduce_topk_slots_kernel(
+    routed_output,
+    slot_to_row: tl.pointer_type(tl.int64),
+    scores,
+    out,
+    NUM_COLS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    HAS_SCORES: tl.constexpr,
+    SCORES_ARE_SLOT_ORDERED: tl.constexpr,
+    ROUTED_ROW_STRIDE: tl.constexpr,
+    ROUTED_COL_STRIDE: tl.constexpr,
+    OUT_ROW_STRIDE: tl.constexpr,
+    OUT_COL_STRIDE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Reduce expert-sorted routed rows back to origin token rows.
+
+    This runs over local origin tokens and their ``TOP_K`` routed slots, not
+    the worst-case receive-capacity buffer. Accumulation is done in fp32.
+
+    Example:
+        With ``TOP_K=2``, ``routed_output=[[10], [20], [30], [40]]``,
+        ``slot_to_row=[1, 3, 0, 2]``, and slot-ordered
+        ``scores=[0.1, 0.2, 0.3, 0.4]``, the output is
+        ``[[10], [15]]``.
+    """
+    token = tl.program_id(0)
+    col = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    col_mask = col < NUM_COLS
+    acc = tl.zeros((BLOCK_N,), tl.float32)
+
+    for slot in tl.static_range(0, TOP_K):
+        row = tl.load(slot_to_row + token * TOP_K + slot)
+        value = tl.load(
+            routed_output + row * ROUTED_ROW_STRIDE + col * ROUTED_COL_STRIDE,
+            mask=col_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if HAS_SCORES:
+            score_index = token * TOP_K + slot if SCORES_ARE_SLOT_ORDERED else row
+            value *= tl.load(scores + score_index).to(tl.float32)
+        acc += value
+
+    tl.store(
+        out + token * OUT_ROW_STRIDE + col * OUT_COL_STRIDE,
+        acc,
+        mask=col_mask,
+    )
+
+
+@triton.jit
+def _expand_topk_grad_kernel(
+    grad_out,
+    flat_indices: tl.pointer_type(tl.int64),
+    scores,
+    grad_routed,
+    NUM_ROWS: tl.constexpr,
+    NUM_COLS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    HAS_SCORES: tl.constexpr,
+    SCORES_ARE_SLOT_ORDERED: tl.constexpr,
+    GRAD_OUT_ROW_STRIDE: tl.constexpr,
+    GRAD_OUT_COL_STRIDE: tl.constexpr,
+    GRAD_ROUTED_ROW_STRIDE: tl.constexpr,
+    GRAD_ROUTED_COL_STRIDE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Expand token gradients into expert-sorted routed-row gradients.
+
+    This is the backward of ``_reduce_topk_slots_kernel`` with respect to the
+    routed rows. It covers the local routed rows described by ``flat_indices``.
+
+    Example:
+        With ``TOP_K=2``, ``grad_out=[[100], [200]]``,
+        ``flat_indices=[2, 0, 3, 1]``, and slot-ordered
+        ``scores=[0.1, 0.2, 0.3, 0.4]``, the output is
+        ``grad_routed=[[60], [10], [80], [20]]``.
+    """
+    row = tl.program_id(0)
+    col = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    col_mask = col < NUM_COLS
+    flat_index = tl.load(flat_indices + row)
+    token = flat_index // TOP_K
+    value = tl.load(
+        grad_out + token * GRAD_OUT_ROW_STRIDE + col * GRAD_OUT_COL_STRIDE,
+        mask=(row < NUM_ROWS) & col_mask,
+        other=0.0,
+    )
+    if HAS_SCORES:
+        score_index = flat_index if SCORES_ARE_SLOT_ORDERED else row
+        value = value.to(tl.float32) * tl.load(scores + score_index).to(tl.float32)
+    tl.store(
+        grad_routed + row * GRAD_ROUTED_ROW_STRIDE + col * GRAD_ROUTED_COL_STRIDE,
+        value,
+        mask=(row < NUM_ROWS) & col_mask,
+    )
+
+
+@triton.jit
+def _topk_scores_grad_kernel(
+    routed_output,
+    grad_out,
+    flat_indices: tl.pointer_type(tl.int64),
+    grad_scores,
+    NUM_COLS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    ROUTED_ROW_STRIDE: tl.constexpr,
+    ROUTED_COL_STRIDE: tl.constexpr,
+    GRAD_OUT_ROW_STRIDE: tl.constexpr,
+    GRAD_OUT_COL_STRIDE: tl.constexpr,
+    SCORES_ARE_SLOT_ORDERED: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Compute routing-score gradients for each local routed row.
+
+    The score gradient is the dot product of that routed row's output and the
+    gradient of its origin token output.
+
+    Example:
+        With ``TOP_K=2``, ``routed_output=[[10], [20], [30], [40]]``,
+        ``grad_out=[[100], [200]]``, and
+        ``flat_indices=[2, 0, 3, 1]``, the slot-ordered output is
+        ``grad_scores=[2000, 4000, 2000, 6000]``.
+    """
+    row = tl.program_id(0)
+    col = tl.arange(0, BLOCK_N)
+    col_mask = col < NUM_COLS
+    flat_index = tl.load(flat_indices + row)
+    token = flat_index // TOP_K
+    routed = tl.load(
+        routed_output + row * ROUTED_ROW_STRIDE + col * ROUTED_COL_STRIDE,
+        mask=col_mask,
+        other=0.0,
+    ).to(tl.float32)
+    grad = tl.load(
+        grad_out + token * GRAD_OUT_ROW_STRIDE + col * GRAD_OUT_COL_STRIDE,
+        mask=col_mask,
+        other=0.0,
+    ).to(tl.float32)
+    score_index = flat_index if SCORES_ARE_SLOT_ORDERED else row
+    tl.store(grad_scores + score_index, tl.sum(routed * grad, axis=0))
+
+
+@triton.jit
+def _active_swiglu_forward_kernel(
+    gate,
+    up,
+    out,
+    active_rows_ptr: tl.pointer_type(tl.int32),
+    NUM_COLS: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    OUT_ROW_STRIDE: tl.constexpr,
+    OUT_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Compute ``silu(gate) * up`` for active received rows only.
+
+    Rows at or after ``active_rows_ptr[0]`` are receive-capacity padding and
+    are intentionally left unspecified because grouped-mm offsets skip them.
+
+    Example:
+        With ``active_rows=2``, ``gate=[[0], [1], [9]]``, and
+        ``up=[[2], [3], [4]]``, the first two output rows are
+        approximately ``[[0.0], [2.193]]`` and row 2 is unspecified.
+    """
+    row_start = tl.program_id(0) * BLOCK_M
+    active_rows = tl.load(active_rows_ptr)
+    if row_start >= active_rows:
+        return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < active_rows) & (cols[None, :] < NUM_COLS)
+
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    silu = gate_values * tl.sigmoid(gate_values)
+    tl.store(
+        out + rows[:, None] * OUT_ROW_STRIDE + cols[None, :] * OUT_COL_STRIDE,
+        silu * up_values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _active_swiglu_backward_kernel(
+    grad_out,
+    gate,
+    up,
+    grad_gate,
+    grad_up,
+    active_rows_ptr: tl.pointer_type(tl.int32),
+    NUM_COLS: tl.constexpr,
+    GRAD_OUT_ROW_STRIDE: tl.constexpr,
+    GRAD_OUT_COL_STRIDE: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    GRAD_GATE_ROW_STRIDE: tl.constexpr,
+    GRAD_GATE_COL_STRIDE: tl.constexpr,
+    GRAD_UP_ROW_STRIDE: tl.constexpr,
+    GRAD_UP_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Backward for ``_active_swiglu_forward_kernel`` over active rows only.
+
+    Gradients for receive-capacity padding rows are intentionally left
+    unspecified because no later grouped-mm segment consumes them.
+
+    Example:
+        With ``active_rows=2``, ``grad_out=[[5], [7], [11]]``,
+        ``gate=[[0], [1], [9]]``, and ``up=[[2], [3], [4]]``, the first
+        two ``grad_gate`` rows are approximately ``[[5.0], [19.48]]``,
+        the first two ``grad_up`` rows are approximately
+        ``[[0.0], [5.118]]``, and row 2 is unspecified.
+    """
+    row_start = tl.program_id(0) * BLOCK_M
+    active_rows = tl.load(active_rows_ptr)
+    if row_start >= active_rows:
+        return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < active_rows) & (cols[None, :] < NUM_COLS)
+
+    grad_values = tl.load(
+        grad_out
+        + rows[:, None] * GRAD_OUT_ROW_STRIDE
+        + cols[None, :] * GRAD_OUT_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    sigmoid = tl.sigmoid(gate_values)
+    silu = gate_values * sigmoid
+    silu_grad = sigmoid * (1.0 + gate_values * (1.0 - sigmoid))
+
+    tl.store(
+        grad_gate
+        + rows[:, None] * GRAD_GATE_ROW_STRIDE
+        + cols[None, :] * GRAD_GATE_COL_STRIDE,
+        grad_values * up_values * silu_grad,
+        mask=mask,
+    )
+    tl.store(
+        grad_up
+        + rows[:, None] * GRAD_UP_ROW_STRIDE
+        + cols[None, :] * GRAD_UP_COL_STRIDE,
+        grad_values * silu,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _copy_rows_to_peer_ptrs_kernel(
+    src,
+    dst_ptrs: tl.pointer_type(tl.int64),
+    dst_ranks: tl.pointer_type(tl.int64),
+    dst_rows: tl.pointer_type(tl.int64),
+    num_valid_rows: tl.pointer_type(tl.int64),
+    src_rows: tl.pointer_type(tl.int64),
+    NUM_ROWS: tl.constexpr,
+    NUM_COLS: tl.constexpr,
+    SRC_ROW_STRIDE: tl.constexpr,
+    SRC_COL_STRIDE: tl.constexpr,
+    DST_ROW_STRIDE: tl.constexpr,
+    DST_DTYPE: tl.constexpr,
+    HAS_NUM_VALID_ROWS: tl.constexpr,
+    HAS_SRC_ROWS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Copy rows into peer symmetric hidden buffers through pointer tables.
+
+    ``dst_ranks`` selects the peer buffer, ``dst_rows`` selects the row within
+    that peer buffer, and ``src_rows`` optionally gathers rows from ``src``.
+    ``num_valid_rows`` optionally limits the copy to the active prefix.
+
+    Example:
+        With ``src=[[10], [20], [30]]``, ``dst_ranks=[1, 0]``,
+        ``dst_rows=[3, 4]``, and ``src_rows=[2, 0]``, peer 1 row 3 receives
+        ``[30]`` and peer 0 row 4 receives ``[10]``.
+    """
+    row_start = tl.program_id(0) * BLOCK_M
+    row_limit = NUM_ROWS
+    if HAS_NUM_VALID_ROWS:
+        row_limit = tl.load(num_valid_rows)
+        if row_start >= row_limit:
+            return
+    row = row_start + tl.arange(0, BLOCK_M)
+    col = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    row_mask = row < row_limit
+    col_mask = col < NUM_COLS
+    mask = row_mask[:, None] & col_mask[None, :]
+    src_row = row
+    if HAS_SRC_ROWS:
+        src_row = tl.load(src_rows + row, mask=row_mask, other=0)
+    dst_rank = tl.load(dst_ranks + row, mask=row_mask, other=-1)
+    dst_row = tl.load(dst_rows + row, mask=row_mask, other=0)
+    dst_rank_mask = row_mask & (dst_rank >= 0)
+    values = tl.load(
+        src + src_row[:, None] * SRC_ROW_STRIDE + col[None, :] * SRC_COL_STRIDE,
+        mask=mask,
+    )
+    dst_base = tl.load(dst_ptrs + dst_rank, mask=dst_rank_mask, other=0)
+    dst_ptr = (
+        dst_base.to(tl.pointer_type(DST_DTYPE))[:, None]
+        + dst_row[:, None] * DST_ROW_STRIDE
+        + col[None, :]
+    )
+    tl.store(dst_ptr, values, mask=mask & dst_rank_mask[:, None])
+
+
+def copy_full_counts_to_peers_kernel(
+    counts: torch.Tensor,
+    dsts: list[torch.Tensor],
+    *,
+    rank: int,
+    ep_size: int,
+    num_experts: int,
+    dst_ptrs: torch.Tensor,
+) -> None:
+    if counts.dtype != torch.int64:
+        raise ValueError(f"counts must be torch.int64, got {counts.dtype}.")
+    if len(dsts) != ep_size:
+        raise ValueError(f"expected {ep_size} count buffers, got {len(dsts)}.")
+    if dsts[0].dtype != torch.int64:
+        raise ValueError(
+            "destination count buffers must be torch.int64, " f"got {dsts[0].dtype}."
+        )
+
+    block_size = _COUNT_COPY_BLOCK_SIZE
+    grid = (ep_size, triton.cdiv(num_experts, block_size))
+    _copy_full_counts_to_peer_ptrs_kernel[grid](
+        counts,
+        dst_ptrs,
+        rank=rank,
+        EP_SIZE=ep_size,
+        NUM_EXPERTS=num_experts,
+        DST_ROW_STRIDE=dsts[0].stride(0),
+        BLOCK_SIZE=block_size,
+    )
+
+
+def active_swiglu_forward_kernel(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` only for rows before ``active_rows[0]``.
+
+    Rows at or after ``active_rows[0]`` in the returned tensor are unspecified.
+    MinimalAsyncEP only consumes rows covered by the same grouped-mm offsets.
+    """
+    out = torch.empty_like(gate)
+
+    block_m = _SWIGLU_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _active_swiglu_forward_kernel[grid](
+        gate,
+        up,
+        out,
+        active_rows,
+        NUM_COLS=gate.shape[1],
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        OUT_ROW_STRIDE=out.stride(0),
+        OUT_COL_STRIDE=out.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return out
+
+
+def active_swiglu_backward_kernel(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    grad_gate = torch.empty_like(gate)
+    grad_up = torch.empty_like(up)
+
+    block_m = _SWIGLU_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _active_swiglu_backward_kernel[grid](
+        grad_out,
+        gate,
+        up,
+        grad_gate,
+        grad_up,
+        active_rows,
+        NUM_COLS=gate.shape[1],
+        GRAD_OUT_ROW_STRIDE=grad_out.stride(0),
+        GRAD_OUT_COL_STRIDE=grad_out.stride(1),
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        GRAD_GATE_ROW_STRIDE=grad_gate.stride(0),
+        GRAD_GATE_COL_STRIDE=grad_gate.stride(1),
+        GRAD_UP_ROW_STRIDE=grad_up.stride(0),
+        GRAD_UP_COL_STRIDE=grad_up.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return grad_gate, grad_up
+
+
+def copy_rows_to_peers_kernel(
+    src: torch.Tensor,
+    dsts: list[torch.Tensor],
+    dst_ranks: torch.Tensor,
+    dst_rows: torch.Tensor,
+    *,
+    ep_size: int,
+    num_rows: int,
+    num_cols: int,
+    dst_ptrs: torch.Tensor,
+    block_m: int = 1,
+    num_warps: int = 4,
+    src_rows: torch.Tensor | None = None,
+    num_valid_rows: torch.Tensor | None = None,
+) -> None:
+    if len(dsts) != ep_size:
+        raise ValueError(f"expected {ep_size} destination buffers, got {len(dsts)}.")
+
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(num_cols))
+    grid = (triton.cdiv(num_rows, block_m), triton.cdiv(num_cols, block_n))
+    dst_dtype = _HIDDEN_ROW_DTYPES.get(src.dtype)
+    if dst_dtype is None:
+        raise ValueError(f"Unsupported MinimalAsyncEP row-copy dtype: {src.dtype}.")
+    _copy_rows_to_peer_ptrs_kernel[grid](
+        src,
+        dst_ptrs,
+        dst_ranks,
+        dst_rows,
+        num_valid_rows if num_valid_rows is not None else dst_rows[:1],
+        src_rows if src_rows is not None else dst_rows,
+        NUM_ROWS=num_rows,
+        NUM_COLS=num_cols,
+        SRC_ROW_STRIDE=src.stride(0),
+        SRC_COL_STRIDE=src.stride(1),
+        DST_ROW_STRIDE=dsts[0].stride(0),
+        DST_DTYPE=dst_dtype,
+        HAS_NUM_VALID_ROWS=num_valid_rows is not None,
+        HAS_SRC_ROWS=src_rows is not None,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=num_warps,
+    )
+
+
+def fill_dispatch_metadata_kernel(
+    counts: torch.Tensor,
+    local_dest_offsets: torch.Tensor,
+    local_count_starts: torch.Tensor,
+    *,
+    num_routed_tokens: int,
+    num_local_experts: int,
+    max_tokens_per_segment: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    dst_ranks = torch.empty(
+        num_routed_tokens,
+        device=counts.device,
+        dtype=torch.int64,
+    )
+    dst_rows = torch.empty_like(dst_ranks)
+    block_size = _METADATA_BLOCK_SIZE
+    grid = (
+        counts.numel(),
+        triton.cdiv(max_tokens_per_segment, block_size),
+    )
+    _fill_dispatch_metadata_kernel[grid](
+        counts,
+        local_dest_offsets,
+        local_count_starts,
+        dst_ranks,
+        dst_rows,
+        NUM_EXPERTS=counts.numel(),
+        NUM_LOCAL_EXPERTS=num_local_experts,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return dst_ranks, dst_rows
+
+
+def fill_combine_metadata_kernel(
+    segment_lens: torch.Tensor,
+    output_starts: torch.Tensor,
+    source_input_starts: torch.Tensor,
+    *,
+    ep_rank: int,
+    ep_size: int,
+    num_local_experts: int,
+    receive_capacity: int,
+    max_tokens_per_segment: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    dst_ranks = torch.empty(
+        receive_capacity,
+        device=segment_lens.device,
+        dtype=torch.int64,
+    )
+    dst_rows = torch.empty_like(dst_ranks)
+    block_size = _METADATA_BLOCK_SIZE
+    grid = (
+        segment_lens.numel(),
+        triton.cdiv(max_tokens_per_segment, block_size),
+    )
+    _fill_combine_metadata_kernel[grid](
+        segment_lens,
+        output_starts,
+        source_input_starts,
+        dst_ranks,
+        dst_rows,
+        ep_rank=ep_rank,
+        EP_SIZE=ep_size,
+        NUM_LOCAL_EXPERTS=num_local_experts,
+        NUM_EXPERTS=ep_size * num_local_experts,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return (
+        dst_ranks,
+        dst_rows,
+        (output_starts[-1:] + segment_lens[-1:]).to(torch.int64),
+    )
+
+
+def invert_flat_indices_kernel(
+    flat_indices: torch.Tensor,
+    *,
+    num_rows: int,
+) -> torch.Tensor:
+    slot_to_row = flat_indices.new_empty(num_rows)
+
+    block_size = _COUNT_COPY_BLOCK_SIZE
+    _invert_flat_indices_kernel[(triton.cdiv(num_rows, block_size),)](
+        flat_indices,
+        slot_to_row,
+        NUM_ROWS=num_rows,
+        BLOCK_SIZE=block_size,
+    )
+    return slot_to_row
+
+
+def reduce_topk_slots_kernel(
+    routed_output: torch.Tensor,
+    slot_to_row: torch.Tensor,
+    scores: torch.Tensor | None,
+    *,
+    num_tokens: int,
+    top_k: int,
+    scores_are_slot_ordered: bool = False,
+) -> torch.Tensor:
+    num_cols = routed_output.shape[1]
+    out = torch.empty(
+        num_tokens,
+        num_cols,
+        device=routed_output.device,
+        dtype=routed_output.dtype,
+    )
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(num_cols))
+    grid = (num_tokens, triton.cdiv(num_cols, block_n))
+    _reduce_topk_slots_kernel[grid](
+        routed_output,
+        slot_to_row,
+        scores if scores is not None else slot_to_row,
+        out,
+        NUM_COLS=num_cols,
+        TOP_K=top_k,
+        HAS_SCORES=scores is not None,
+        SCORES_ARE_SLOT_ORDERED=scores_are_slot_ordered,
+        ROUTED_ROW_STRIDE=routed_output.stride(0),
+        ROUTED_COL_STRIDE=routed_output.stride(1),
+        OUT_ROW_STRIDE=out.stride(0),
+        OUT_COL_STRIDE=out.stride(1),
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return out
+
+
+def expand_topk_grad_kernel(
+    grad_out: torch.Tensor,
+    flat_indices: torch.Tensor,
+    scores: torch.Tensor | None,
+    *,
+    top_k: int,
+    dtype: torch.dtype,
+    scores_are_slot_ordered: bool = False,
+) -> torch.Tensor:
+    num_rows = flat_indices.numel()
+    num_cols = grad_out.shape[1]
+
+    grad_routed = torch.empty(
+        num_rows,
+        num_cols,
+        device=grad_out.device,
+        dtype=dtype,
+    )
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(num_cols))
+    grid = (num_rows, triton.cdiv(num_cols, block_n))
+    _expand_topk_grad_kernel[grid](
+        grad_out,
+        flat_indices,
+        scores if scores is not None else flat_indices,
+        grad_routed,
+        NUM_ROWS=num_rows,
+        NUM_COLS=num_cols,
+        TOP_K=top_k,
+        HAS_SCORES=scores is not None,
+        SCORES_ARE_SLOT_ORDERED=scores_are_slot_ordered,
+        GRAD_OUT_ROW_STRIDE=grad_out.stride(0),
+        GRAD_OUT_COL_STRIDE=grad_out.stride(1),
+        GRAD_ROUTED_ROW_STRIDE=grad_routed.stride(0),
+        GRAD_ROUTED_COL_STRIDE=grad_routed.stride(1),
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return grad_routed
+
+
+def topk_scores_grad_kernel(
+    routed_output: torch.Tensor,
+    grad_out: torch.Tensor,
+    flat_indices: torch.Tensor,
+    *,
+    top_k: int,
+    dtype: torch.dtype,
+    scores_are_slot_ordered: bool = False,
+) -> torch.Tensor:
+    num_rows, num_cols = routed_output.shape
+    grad_scores = torch.empty(
+        num_rows,
+        device=routed_output.device,
+        dtype=dtype,
+    )
+    block_n = triton.next_power_of_2(num_cols)
+    _topk_scores_grad_kernel[(num_rows,)](
+        routed_output,
+        grad_out,
+        flat_indices,
+        grad_scores,
+        NUM_COLS=num_cols,
+        TOP_K=top_k,
+        ROUTED_ROW_STRIDE=routed_output.stride(0),
+        ROUTED_COL_STRIDE=routed_output.stride(1),
+        GRAD_OUT_ROW_STRIDE=grad_out.stride(0),
+        GRAD_OUT_COL_STRIDE=grad_out.stride(1),
+        SCORES_ARE_SLOT_ORDERED=scores_are_slot_ordered,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return grad_scores

--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -130,7 +130,6 @@ def spmd_validate_redistributions(sharding_config: Any) -> None:
         # from the innermost position. For example, (DP) -> (DP, CP) is valid
         # when CP is the changed axis, but (DP) -> (CP, DP) changes shard order.
         changed_axis = changed_axes[0] if changed_axes else None
-        # pyrefly: ignore [bad-argument-type]
         for dim, (src_entry, dst_entry) in enumerate(zip(src_spec, dst_spec)):
             src_axes = (
                 ()

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -11,14 +11,22 @@ from torchtitan.experiments.graph_trainer.configs import (
 from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
+    deepseek_v3_16b_minimal_async_ep,
     deepseek_v3_671b,
     deepseek_v3_debugmodel,
+    deepseek_v3_debugmodel_minimal_async_ep,
 )
 
 from . import model_registry
 
 
 def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_ep() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
@@ -35,9 +43,41 @@ def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_debugmodel_minimal_async_ep() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        deepseek_v3_debugmodel_minimal_async_ep(),
+        model_registry,
+    )
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> GraphTrainer.Config:
+    return graph_trainer_deepseek_v3_debugmodel()
+
+
+def graph_trainer_deepseek_v3_debugmodel_flex_attn_ep() -> GraphTrainer.Config:
+    return graph_trainer_deepseek_v3_debugmodel_ep()
+
+
 def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_16b(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_16b_minimal_async_ep() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        deepseek_v3_16b_minimal_async_ep(),
+        model_registry,
+    )
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_16b_sdpa() -> GraphTrainer.Config:
+    config = graph_trainer_deepseek_v3_16b()
+    config.model_spec = model_registry("16B", attn_backend="sdpa")
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -23,6 +23,9 @@ from torchtitan.experiments.graph_trainer.compile import apply_compile
 from torchtitan.experiments.graph_trainer.deepseek_v3.model import (
     GraphTrainerDeepSeekV3Model,
 )
+from torchtitan.models.deepseek_v3.parallelize import (
+    _maybe_init_minimal_async_ep_buffer,
+)
 from torchtitan.tools.logging import logger
 
 
@@ -68,6 +71,15 @@ def parallelize_deepseekv3(
         Sequence length {training.seq_len} must be divisible by the product of TP degree
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}), i.e. {parallel_dims.seq_len_divisor}.
         """
+
+    _maybe_init_minimal_async_ep_buffer(
+        model,
+        parallel_dims=parallel_dims,
+        training=training,
+        parallelism=parallelism,
+        ac_config=ac_config,
+        memory_policy=getattr(compile_config, "memory_policy", None),
+    )
 
     if parallel_dims.cp_enabled:
         apply_cp_to_attention(model, parallel_dims)

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -375,6 +375,23 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ngpu=4,
             disabled=True,
         ),
+        # MinimalAsyncEP avoids the standard all-to-all load-balancing path and
+        # is expected to remain CUDA-graphable under its constrained topology.
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel_minimal_async_ep",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.memory_policy full",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 4",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 MinimalAsyncEP",
+            "aot_fx_trace_deepseek_v3_minimal_async_ep",
+            ngpu=4,
+        ),
     ]
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
@@ -137,7 +137,7 @@ def test_autoparallel_graph_pass_selection_uses_regular_memory_policy():
     config = SimpleNamespace(
         compile=GraphTrainerCompileConfig(
             enable_autoparallel=True,
-            enable_cudagraph=False,
+            disable_passes=["cudagraph_pass"],
         ),
         model_spec=SimpleNamespace(model=SimpleNamespace(layers=[object()])),
         parallelism=SimpleNamespace(

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -335,6 +335,77 @@ class TestCudagraphPass(unittest.TestCase):
             self.assertIs(result, gm)
             self.assertIs(gm.forward, mock_instance)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+    def test_minimal_async_ep_custom_ops_are_wrapped_by_cudagraph_pass(self):
+        """MinimalAsyncEP custom ops should not force cudagraph_pass fallback."""
+        import torchtitan.distributed.minimal_async_ep  # noqa: F401
+        from torchtitan.experiments.graph_trainer.passes import cudagraph_pass
+
+        def cuda_i64(*shape):
+            return torch.empty(*shape, device="cuda", dtype=torch.int64)
+
+        def cuda_f32(*shape):
+            return torch.empty(*shape, device="cuda", dtype=torch.float32)
+
+        graph = torch.fx.Graph()
+        op_outputs = [
+            (
+                torch.ops.minimal_async_ep.dispatch.default,
+                (
+                    cuda_f32(16, 8),
+                    cuda_i64(12),
+                    cuda_i64(12),
+                    cuda_i64(16),
+                    cuda_i64(16),
+                    cuda_i64(1),
+                    cuda_i64(12),
+                    cuda_i64(12),
+                    cuda_i64(4),
+                ),
+            ),
+            (
+                torch.ops.minimal_async_ep.combine.default,
+                (cuda_f32(4, 8), cuda_f32(12, 8)),
+            ),
+            (
+                torch.ops.minimal_async_ep.active_swiglu.default,
+                cuda_f32(16, 8),
+            ),
+            (
+                torch.ops.minimal_async_ep.dispatch_backward.default,
+                cuda_f32(4, 8),
+            ),
+            (
+                torch.ops.minimal_async_ep.combine_backward.default,
+                (cuda_f32(16, 8), cuda_f32(12)),
+            ),
+            (
+                torch.ops.minimal_async_ep.active_swiglu_backward.default,
+                (cuda_f32(16, 8), cuda_f32(16, 8)),
+            ),
+        ]
+        nodes = []
+        for target, meta_val in op_outputs:
+            node = graph.call_function(target, args=())
+            node.meta["val"] = meta_val
+            nodes.append(node)
+        graph.output(tuple(nodes))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with patch(
+            "torchtitan.experiments.graph_trainer.cudagraph.CUDAGraphWrapper"
+        ) as MockWrapper:
+            mock_instance = MagicMock()
+            MockWrapper.return_value = mock_instance
+            result = cudagraph_pass(gm, (), static_input_indices=[])
+
+            self.assertIs(result, gm)
+            self.assertIs(gm.forward, mock_instance)
+            MockWrapper.assert_called_once()
+            _, example_inputs, static_input_indices = MockWrapper.call_args.args
+            self.assertEqual(example_inputs, ())
+            self.assertEqual(static_input_indices, [])
+
 
 class TestCudagraphFingerprintConsistency(unittest.TestCase):
     """Test that save and load paths produce the same fingerprint.

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -30,6 +30,7 @@ from torchtitan.models.common.token_dispatcher import (
     DeepEPTokenDispatcher,
     HybridEPTokenDispatcher,
     LocalTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher,
 )
 from torchtitan.protocols.module import Module
 
@@ -215,6 +216,7 @@ def make_token_dispatcher_config(
       dispatch when EP=1, i.e. ep_mesh is None at runtime)
     - "deepep": Uses DeepEP custom kernels for H100/NVLink Switch
     - "hybridep": Uses HybridEP with TMA optimization for GB200/NVLink72
+    - "minimal_async_ep": Uses MinimalAsyncEP for constrained DP>=EP
 
     DeepEP/HybridEP requires installation:
     https://github.com/deepseek-ai/DeepEP
@@ -236,6 +238,14 @@ def make_token_dispatcher_config(
             score_before_experts=score_before_experts,
             non_blocking_capacity_factor=non_blocking_capacity_factor,
         )
+    elif comm_backend == "minimal_async_ep":
+        if score_before_experts:
+            raise ValueError("minimal_async_ep requires score_before_experts=False.")
+        return MinimalAsyncEPTokenDispatcher.Config(
+            num_experts=num_experts,
+            top_k=top_k,
+            score_before_experts=score_before_experts,
+        )
     elif comm_backend == "standard":
         return AllToAllTokenDispatcher.Config(
             num_experts=num_experts,
@@ -245,7 +255,7 @@ def make_token_dispatcher_config(
     else:
         raise ValueError(
             f"Unknown comm_backend: '{comm_backend}'. "
-            "Must be one of 'standard', 'deepep', 'hybridep'."
+            "Must be one of 'standard', 'deepep', 'hybridep', 'minimal_async_ep'."
         )
 
 

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -135,6 +135,7 @@ class Decoder(BaseModel):
                     from torchtitan.models.common.token_dispatcher import (
                         DeepEPTokenDispatcher,
                         HybridEPTokenDispatcher,
+                        MinimalAsyncEPTokenDispatcher,
                     )
 
                     token_dispatcher_cfg = layer_cfg.moe.experts.token_dispatcher
@@ -143,6 +144,7 @@ class Decoder(BaseModel):
                             token_dispatcher_cfg,
                             (
                                 DeepEPTokenDispatcher.Config,
+                                MinimalAsyncEPTokenDispatcher.Config,
                                 HybridEPTokenDispatcher.Config,
                             ),
                         )

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -13,11 +13,16 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 
+from torchtitan.distributed.minimal_async_ep import active_swiglu_op
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
+from .token_dispatcher import (
+    DeepEPTokenDispatcher,
+    LocalTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher,
+)
 
 # Shape suffix legend
 # (https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd):
@@ -50,6 +55,10 @@ class GroupedExperts(Module):
             torch.empty(config.num_experts, config.hidden_dim, config.dim)
         )
         self.token_dispatcher = config.token_dispatcher.build()
+        self._use_active_swiglu = isinstance(
+            self.token_dispatcher,
+            MinimalAsyncEPTokenDispatcher,
+        )
 
     def _experts_forward(
         self,
@@ -79,18 +88,20 @@ class GroupedExperts(Module):
 
         offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
 
-        h_RF = F.silu(
-            torch._grouped_mm(
-                x_RD.bfloat16(),
-                w1_EFD.bfloat16().transpose(-2, -1),
-                offs=offsets_E,
-            )
+        gate_RF = torch._grouped_mm(
+            x_RD.bfloat16(),
+            w1_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
         )
-        h_RF = h_RF * torch._grouped_mm(
+        up_RF = torch._grouped_mm(
             x_RD.bfloat16(),
             w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
+        if self._use_active_swiglu:
+            h_RF = active_swiglu_op(gate_RF, up_RF, offsets_E[-1:])
+        else:
+            h_RF = F.silu(gate_RF) * up_RF
         return torch._grouped_mm(
             h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)
@@ -122,7 +133,8 @@ class GroupedExperts(Module):
             x_TD, topk_scores_TK, topk_expert_ids_TK, num_local_tokens_per_expert_E
         )
         routed_output_RD = self._experts_forward(
-            routed_input_RD, num_global_tokens_per_local_expert_e
+            routed_input_RD,
+            num_global_tokens_per_local_expert_e,
         )
         out_TD = self.token_dispatcher.combine(routed_output_RD, metadata, x_TD)
         # Un-flatten back to 3-D (B, *, D) so the local_map output sharding

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
+from typing import cast
 
 import torch
 from torch.distributed._functional_collectives import (
@@ -14,6 +15,11 @@ from torch.distributed._functional_collectives import (
 from torch.distributed.tensor import DeviceMesh
 
 from torchtitan.config import Configurable
+from torchtitan.distributed.minimal_async_ep import (
+    combine_op as minimal_async_ep_combine_op,
+    dispatch_op as minimal_async_ep_dispatch_op,
+    MinimalAsyncEPDispatchMetadata,
+)
 from torchtitan.ops.scatter_add import deterministic_scatter_add
 
 
@@ -39,8 +45,9 @@ class LocalTokenDispatcher(Configurable):
     """Token dispatcher for EP=1. Handles local token reordering only.
 
     Also serves as the base class for EP dispatchers (AllToAllTokenDispatcher,
-    DeepEPTokenDispatcher, HybridEPTokenDispatcher) which override
-    dispatch() and combine().
+    DeepEPTokenDispatcher, HybridEPTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher)
+    which override dispatch() and combine().
 
     Not an nn.Module — dispatchers have no learnable parameters or buffers.
     """
@@ -352,6 +359,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         ep_size = self.ep_mesh.size()
         e = num_global_tokens_per_local_expert_E.shape[0] // ep_size
         device = num_global_tokens_per_local_expert_E.device
+        total = routed_input_RD.shape[0]
 
         # (EP, e) matrix of token counts per (rank, local_expert)
         t_mat = num_global_tokens_per_local_expert_E.view(ep_size, e)
@@ -369,7 +377,7 @@ class AllToAllTokenDispatcher(LocalTokenDispatcher):
         # For each output position, find its input position:
         #   output[p] = input[input_starts[seg] + (p - output_starts[seg])]
         seg_ids = torch.arange(segment_lens.shape[0], device=device).repeat_interleave(
-            segment_lens
+            segment_lens, output_size=total
         )
         output_starts = segment_lens.cumsum(0) - segment_lens
         # seg_ids.shape[0] == segment_lens.sum(), but reuses the unbacked symint
@@ -546,9 +554,9 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
 
 @dataclass(frozen=True, kw_only=True)
 class DeepEPDispatchMetadata:
-    """Metadata for DeepEP and HybridEP token dispatch."""
+    """Metadata for DeepEP, HybridEP, and MinimalAsyncEP token dispatch."""
 
-    state: object  # deepep.DispatchState or hybridep.DispatchState
+    state: object  # Backend-specific dispatch state.
 
 
 class DeepEPTokenDispatcher(LocalTokenDispatcher):
@@ -788,4 +796,162 @@ class HybridEPTokenDispatcher(LocalTokenDispatcher):
             out_TD[offset : offset + combined_TD.shape[0]] = combined_TD
             return out_TD
 
+        return combined_TD
+
+
+class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
+    """Token dispatcher using MinimalAsyncEP for constrained EP communication.
+
+    This first integration supports EP with ``sp_size == 1`` and
+    ``score_before_experts=False`` only. TP/SP, CP, PP, padding, and async
+    combine overlap are intentionally out of scope.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(LocalTokenDispatcher.Config):
+        score_before_experts: bool = False
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        if self.score_before_experts:
+            raise ValueError(
+                "MinimalAsyncEPTokenDispatcher only supports "
+                "score_before_experts=False."
+            )
+        self.ep_mesh: DeviceMesh | None = None
+        self.sp_size: int = 1
+
+    def wire_meshes(
+        self,
+        *,
+        ep_mesh: DeviceMesh | None,
+        tp_mesh: DeviceMesh | None,
+    ) -> None:
+        """Install the EP mesh used by MinimalAsyncEP dispatch / combine."""
+        if ep_mesh is None:
+            raise ValueError(
+                "MinimalAsyncEPTokenDispatcher requires expert parallelism "
+                "(ep_mesh must be set)."
+            )
+        if tp_mesh is not None and tp_mesh.size() > 1:
+            raise ValueError(
+                "MinimalAsyncEPTokenDispatcher does not support tensor or sequence "
+                "parallelism."
+            )
+        self.ep_mesh = ep_mesh
+        self.sp_size = 1
+
+    # pyrefly: ignore [bad-override]
+    def dispatch(
+        self,
+        x_TD: torch.Tensor,
+        topk_scores_TK: torch.Tensor,
+        topk_expert_ids_TK: torch.Tensor,
+        num_local_tokens_per_expert_E: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, DeepEPDispatchMetadata]:
+        """Reorder tokens, then MinimalAsyncEP dispatch to expert-parallel ranks.
+
+        We abbreviate:
+            T-major: Token-major
+            E-major: Expert-major
+
+        Logical shapes match ``AllToAllTokenDispatcher``:
+            B = batch size before flattening, L = sequence length before
+                flattening, and T = B * L local tokens.
+            D = model dimension of each token row.
+            E = global number of experts, EP = expert-parallel group size,
+                and e = E / EP local experts per EP rank.
+            K = top-k router choices per token.
+            N = routed rows, T * K.
+            R = active rows assigned to this rank's local experts,
+                sum(num_tokens_per_local_expert_e).
+
+        MinimalAsyncEP stores ``routed_input_RD`` in a static-capacity receive
+        buffer with row capacity ``R_max = EP * T * min(K, e)``. Only the
+        first ``R`` rows are active; padding rows keep the launch shape static.
+
+        Args:
+            x_TD: ``(T, D)`` local token shard.
+            topk_scores_TK: ``(T, K)`` routing scores.
+            topk_expert_ids_TK: ``(T, K)`` expert indices.
+            num_local_tokens_per_expert_E: ``(E,)`` token counts for this local
+                token shard.
+
+        Returns:
+            routed_input_RD: logical
+                ``[R = sum(num_tokens_per_local_expert_e), input_dim(D)]``.
+                Tokens in E-major order for local experts, physically
+                padded to ``(R_max, D)`` for this backend.
+            num_tokens_per_local_expert_e: ``(num_local_experts,)`` token counts
+            metadata: dispatch metadata for combine()
+        """
+        assert self.ep_mesh is not None, "ep_mesh must be set before dispatch"
+        ep_group = self.ep_mesh.get_group()
+
+        top_k = self.top_k
+        routed_scores_N = topk_scores_TK.view(-1)
+
+        ep_size = ep_group.size()
+        num_tokens = x_TD.shape[0]
+        num_local_experts = num_local_tokens_per_expert_E.numel() // ep_size
+        # TODO(xmfan): make this capacity configurable by user
+        num_receive_rows_per_source_rank = num_tokens * min(top_k, num_local_experts)
+        receive_capacity = ep_size * num_receive_rows_per_source_rank
+
+        (
+            hidden_states_RD,
+            dispatch_dst_ranks,  # local E-major row -> destination EP rank
+            dispatch_dst_rows,  # local E-major row -> destination receive row
+            combine_dst_ranks,  # received row -> origin EP rank; length R_max
+            combine_dst_rows,  # received row -> origin E-major row; length R_max
+            combine_num_valid_rows,  # actual received rows, device-side scalar
+            E_row_to_T_row_N,  # local E-major row -> local T-major row
+            T_row_to_E_row_N,  # local T-major row -> local E-major row
+            num_tokens_per_local_expert_e,  # local expert -> active row count
+        ) = minimal_async_ep_dispatch_op(
+            x_TD,
+            topk_expert_ids_TK,
+            num_local_tokens_per_expert_E,
+            receive_capacity,
+            ep_size,
+        )
+
+        state = MinimalAsyncEPDispatchMetadata(
+            dispatch_dst_ranks=dispatch_dst_ranks,
+            dispatch_dst_rows=dispatch_dst_rows,
+            combine_dst_ranks=combine_dst_ranks,
+            combine_dst_rows=combine_dst_rows,
+            combine_num_valid_rows=combine_num_valid_rows,
+            E_row_to_T_row=E_row_to_T_row_N,
+            T_row_to_E_row=T_row_to_E_row_N,
+            routed_scores=routed_scores_N,
+            num_tokens=num_tokens,
+            top_k=top_k,
+        )
+
+        metadata = DeepEPDispatchMetadata(state=state)
+        return hidden_states_RD, num_tokens_per_local_expert_e, metadata
+
+    # pyrefly: ignore [bad-override]
+    def combine(
+        self,
+        routed_output_RD: torch.Tensor,
+        metadata: DeepEPDispatchMetadata,
+        x_TD: torch.Tensor,
+    ) -> torch.Tensor:
+        """Combine tokens via MinimalAsyncEP."""
+        state = cast(MinimalAsyncEPDispatchMetadata, metadata.state)
+        combined_TD, _routed_output_ND = minimal_async_ep_combine_op(  # noqa: N806
+            routed_output_RD,
+            state.dispatch_dst_ranks,
+            state.dispatch_dst_rows,
+            state.combine_dst_ranks,
+            state.combine_dst_rows,
+            state.combine_num_valid_rows,
+            state.T_row_to_E_row,
+            state.E_row_to_T_row,
+            state.routed_scores,
+            state.num_tokens,
+            state.top_k,
+        )
         return combined_TD

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -67,6 +67,24 @@ def deepseek_v3_debugmodel_hybridep() -> Trainer.Config:
     return config
 
 
+def deepseek_v3_debugmodel_minimal_async_ep() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.model_spec = model_registry(
+        "debugmodel",
+        moe_comm_backend="minimal_async_ep",
+    )
+    config.parallelism = ParallelismConfig(
+        data_parallel_replicate_degree=1,
+        data_parallel_shard_degree=1,
+        tensor_parallel_degree=1,
+        context_parallel_degree=1,
+        pipeline_parallel_degree=1,
+        expert_parallel_degree=1,
+        enable_sequence_parallel=False,
+    )
+    return config
+
+
 def deepseek_v3_16b() -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),
@@ -96,6 +114,36 @@ def deepseek_v3_16b() -> Trainer.Config:
         ),
         compile=CompileConfig(enable=True, components=["loss"]),
     )
+
+
+def deepseek_v3_16b_hybridep() -> Trainer.Config:
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry(
+        "16B",
+        attn_backend="flex",
+        moe_comm_backend="hybridep",
+        non_blocking_capacity_factor=1.0,
+    )
+    return config
+
+
+def deepseek_v3_16b_minimal_async_ep() -> Trainer.Config:
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry(
+        "16B",
+        attn_backend="flex",
+        moe_comm_backend="minimal_async_ep",
+    )
+    config.parallelism = ParallelismConfig(
+        data_parallel_replicate_degree=1,
+        data_parallel_shard_degree=1,
+        tensor_parallel_degree=1,
+        context_parallel_degree=1,
+        pipeline_parallel_degree=1,
+        expert_parallel_degree=1,
+        enable_sequence_parallel=False,
+    )
+    return config
 
 
 def deepseek_v3_671b() -> Trainer.Config:

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch
+
 from torchtitan.config import (
     ActivationCheckpointConfig,
     CompileConfig,
@@ -11,7 +13,7 @@ from torchtitan.config import (
     TORCH_DTYPE_MAP,
     TrainingConfig,
 )
-from torchtitan.distributed import ParallelDims
+from torchtitan.distributed import minimal_async_ep, ParallelDims
 from torchtitan.distributed.activation_checkpoint import apply_ac
 from torchtitan.distributed.compile import apply_compile
 from torchtitan.distributed.context_parallel import apply_cp_to_forward
@@ -22,9 +24,106 @@ from torchtitan.distributed.full_dtensor import (
     validate_config,
 )
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
+from torchtitan.tools.utils import device_module, device_type
 
 
+def _get_minimal_async_ep_dispatcher_config(
+    model: DeepSeekV3Model,
+) -> MinimalAsyncEPTokenDispatcher.Config | None:
+    """Return the MinimalAsyncEP config selected through the model spec.
+
+    ``model_registry(..., moe_comm_backend="minimal_async_ep")`` lowers the
+    backend choice into the MoE token-dispatcher config stored in
+    ``ModelSpec.model``. At parallelize time that config is the source of truth.
+    """
+    moe_config = next((l.moe for l in model.config.layers if l.moe is not None), None)
+    if moe_config is None:
+        return None
+
+    dispatcher_config = moe_config.experts.token_dispatcher
+    if isinstance(dispatcher_config, MinimalAsyncEPTokenDispatcher.Config):
+        return dispatcher_config
+    return None
+
+
+def _validate_minimal_async_ep_config(
+    dispatcher_config: MinimalAsyncEPTokenDispatcher.Config,
+    *,
+    parallel_dims: ParallelDims,
+    parallelism: ParallelismConfig,
+) -> None:
+    if parallelism.spmd_backend == "full_dtensor":
+        raise ValueError("MinimalAsyncEP does not support full_dtensor SPMD.")
+    if parallel_dims.ep <= 1:
+        raise ValueError("MinimalAsyncEP requires expert_parallel_degree > 1.")
+    if dispatcher_config.num_experts % parallel_dims.ep != 0:
+        raise ValueError(
+            f"MinimalAsyncEP num_experts ({dispatcher_config.num_experts}) must be "
+            f"divisible by expert_parallel_degree ({parallel_dims.ep})."
+        )
+    if parallel_dims.tp != 1:
+        raise ValueError(
+            "MinimalAsyncEP does not support tensor or sequence parallelism."
+        )
+    if parallelism.enable_sequence_parallel:
+        raise ValueError("MinimalAsyncEP does not support sequence parallelism.")
+    if parallel_dims.cp != 1:
+        raise ValueError("MinimalAsyncEP does not support context parallelism.")
+    if parallel_dims.pp != 1:
+        raise ValueError("MinimalAsyncEP does not support pipeline parallelism.")
+    if parallel_dims.dp_replicate != 1:
+        raise ValueError(
+            "MinimalAsyncEP requires data_parallel_replicate_degree == 1. Got "
+            f"{parallel_dims.dp_replicate}."
+        )
+    if parallel_dims.dp_shard % parallel_dims.ep != 0:
+        raise ValueError(
+            "MinimalAsyncEP requires data_parallel_shard_degree to be a multiple "
+            "of expert_parallel_degree. Got "
+            f"data_parallel_shard_degree={parallel_dims.dp_shard}, "
+            f"expert_parallel_degree={parallel_dims.ep}."
+        )
+
+
+def _maybe_init_minimal_async_ep_buffer(
+    model: DeepSeekV3Model,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    ac_config: ActivationCheckpointConfig,
+    memory_policy: str | None = None,
+) -> None:
+    dispatcher_config = _get_minimal_async_ep_dispatcher_config(model)
+    if dispatcher_config is None:
+        return
+
+    if ac_config.mode != "full" and memory_policy != "full":
+        raise ValueError(
+            "MinimalAsyncEP requires full recompute: set "
+            "--activation_checkpoint.mode full for eager training or "
+            "--compile.memory_policy full for graph_trainer."
+        )
+
+    _validate_minimal_async_ep_config(
+        dispatcher_config,
+        parallel_dims=parallel_dims,
+        parallelism=parallelism,
+    )
+    minimal_async_ep.init_buffer(
+        group=parallel_dims.get_mesh("ep").get_group(),
+        hidden_dim=model.config.dim,
+        tokens_per_rank=training.local_batch_size * training.seq_len,
+        num_local_experts=dispatcher_config.num_experts // parallel_dims.ep,
+        top_k=dispatcher_config.top_k,
+        dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        device=torch.device(device_type, device_module.current_device()),
+    )
+
+
+# Adapted from llama4/infra/parallelize.py
 def parallelize_deepseekv3(
     model: DeepSeekV3Model,
     *,
@@ -41,6 +140,13 @@ def parallelize_deepseekv3(
         Sequence length {training.seq_len} must be divisible by the product of TP degree
         ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
         """
+    _maybe_init_minimal_async_ep_buffer(
+        model,
+        parallel_dims=parallel_dims,
+        training=training,
+        parallelism=parallelism,
+        ac_config=ac_config,
+    )
 
     if parallelism.spmd_backend == "full_dtensor":
         validate_config(parallel_dims, model)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3611
* #3610
* __->__ #3609
* #3608
* #3607
* #3606

Squashed from PR #3561. Sync-free MoE token dispatcher (MinimalAsyncEP) +
offset-aware swiglu kernels, enabling full cudagraph for the MoE path.

Original: https://github.com/pytorch/torchtitan/pull/3561