### PR TITLE
[graph_trainer] Match Eager FSDP bucket order

### DIFF
--- a/dsv3_scaling_experiment_results.md
+++ b/dsv3_scaling_experiment_results.md
@@ -332,3 +332,78 @@ non-cudagraphable node(s)` then `Applied cudagraph pass.`
   flag) — not a blanket bypass.
 - MinimalAsyncEP buffer init confirmed; `TORCHINDUCTOR_COMPILE_THREADS=8`
   cold-cache mitigation as before.
+
+---
+
+## Run 5 — + #3590 Match Eager FSDP bucket order (MinimalAsyncEP + forced cudagraph + #3590)
+
+**Date:** 2026-06-09
+**Branch:** `graph_trainer/dsv3_scaling`
+**Branch state at run:** run-script + #3419 + #3248 + #3561 + **#3590** + the
+`cudagraph.py` force. EP-overlap / #3548 not yet applied.
+**Launcher:** `./run_graph_trainer_dsv3.sh` (MinimalAsyncEP, cudagraph enabled +
+forced, `TORCHINDUCTOR_COMPILE_THREADS=8`).
+
+> ⛔ **CORRECTNESS UNVERIFIED.** Carries forward every prior caveat (chunked loss,
+> MinimalAsyncEP, forced cudagraph past the `_grouped_mm` gate). **#3590's whole
+> purpose is a *bitwise* match with eager FSDP2 reduce-scatter bucket order**, so
+> it specifically needs an eager `loss_compare` (`--debug.seed=42
+> --debug.deterministic`, loss + grad_norm) to confirm. Provisional.
+
+### What #3590 adds
+`joint_transformer_block_bucketing_reordering_pass` now packs FSDP buckets in
+**eager FSDP2 first-seen parameter order** (`FSDPParamOrderBucketer` +
+`get_fsdp_param_module_order(traced_result.state_fqns)`) instead of graph
+execution order. MinimalAsyncEP buffer init + forced cudagraph (312
+`_grouped_mm`) both confirmed, same as Run 4.
+
+### Setup
+Identical to Run 4 (MinimalAsyncEP + forced cudagraph, 8× H100, `dp_shard=8 ep=4`,
+`aot_fx_trace`, `memory_policy=full`, ChunkedCELoss, B=4 / seq 4096, 20 steps,
+c4_test) **plus #3590** (eager FSDP bucket ordering).
+
+### Results
+| step | loss | grad_norm | memory | tps | tflops | mfu |
+|-----:|------|-----------|--------|-----|--------|-----|
+| 1 | 12.02874 | 1.6549 | 36.22 GiB (38.10%) | 109 | 1.97 | 0.20% |
+| 10 | 9.17541 | 8.9794 | 36.28 GiB (38.16%) | 9,110 | 164.94 | 16.68% |
+| 20 | 7.15267 | 1.7885 | 36.28 GiB (38.16%) | 9,145 | 165.57 | 16.74% |
+
+Perf matches Run 4 (~16.7% mfu, tps ~9.1k) — expected, since #3590 changes bucket
+*order* (for eager bitwise match), not the amount of work. Loss in the same band.
+**Numerics unverified — see caveat.**
+
+### Compile pipeline
+All **11** graph passes took **95.061 s**. `regional_inductor` 72.35 s;
+`cudagraph_pass` forced + applied.
+
+### Artifacts
+| artifact | link |
+|---|---|
+| run log (pastry) | https://www.internalfb.com/intern/paste/P2372034462/ |
+| profiler trace (perfetto, rank0 iter 10) | https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_2361ec10-8c5b-4504-91b4-9d11d8501b34_rank0_trace.json.gz |
+| tlparse logs (manifold, **temporary** `.tmp` path) | https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpqSCN8V/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000 |
+
+#### Per-pass before/after graph diffs
+| pass | diff |
+|---|---|
+| eliminate_dead_code | https://www.internalfb.com/intern/diffing/?before_paste_number=2372033030&after_paste_number=2372033136&selected_tab=plain_diff |
+| canonicalize_graph | https://www.internalfb.com/intern/diffing/?before_paste_number=2372032890&after_paste_number=2372032965&selected_tab=plain_diff |
+| tag_with_memory_policy | https://www.internalfb.com/intern/diffing/?before_paste_number=2372034105&after_paste_number=2372034195&selected_tab=plain_diff |
+| selective_activation_remat | https://www.internalfb.com/intern/diffing/?before_paste_number=2372033826&after_paste_number=2372033969&selected_tab=plain_diff |
+| reassign_collective_pgs | https://www.internalfb.com/intern/diffing/?before_paste_number=2372033370&after_paste_number=2372033465&selected_tab=plain_diff |
+| joint_transformer_block_bucketing_reordering | https://www.internalfb.com/intern/diffing/?before_paste_number=2372033222&after_paste_number=2372033299&selected_tab=plain_diff |
+| annotate_flex_attention_for_regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2372032751&after_paste_number=2372032811&selected_tab=plain_diff |
+| regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2372033579&after_paste_number=2372033700&selected_tab=plain_diff |
+
+#### Standalone artifacts
+| artifact | paste |
+|---|---|
+| activation_memory_policy | https://www.internalfb.com/intern/paste/P2372034223/ |
+| fx_compute_nodes_runtime_estimation | https://www.internalfb.com/intern/paste/P2372034308/ |
+
+### Notes
+- #3590's `models/utils.py` hunk was a no-op here (main already has the
+  `_StridedShard` fix); the commit lands the `fsdp_passes.py` + `passes.py`
+  changes only.
+- Bitwise FSDP-order match is the explicit goal of #3590 — verify against eager.

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -28,6 +28,7 @@ from torch._inductor.fx_passes.bucketing import (
 from torch._inductor.fx_passes.overlap_manual_scheduling import (
     _move_overlap_nodes,
     manual_overlap_bucketing,
+    ManualOverlapPreservingBucketer,
     ManualOverlapScheduler,
 )
 from torch._inductor.fx_passes.overlap_scheduling import (
@@ -175,6 +176,40 @@ def transformer_block_bucketing_reordering_pass(
     return gm
 
 
+def get_fsdp_param_module_order(state_fqns: list[str]) -> dict[str, int]:
+    """Return module order matching FSDP2's first-seen parameter order."""
+    order: dict[str, int] = {}
+    for fqn in state_fqns:
+        if "." not in fqn:
+            continue
+        module_fqn = fqn.rsplit(".", 1)[0]
+        order.setdefault(module_fqn, len(order))
+    return order
+
+
+class FSDPParamOrderBucketer(ManualOverlapPreservingBucketer):
+    """Pack FSDP buckets in Eager FSDP2 parameter order."""
+
+    def __init__(
+        self,
+        *args: Any,
+        fsdp_param_module_order: dict[str, int] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.fsdp_param_module_order = fsdp_param_module_order or {}
+
+    def _param_order_key(self, node: fx.Node) -> tuple[int, int]:
+        module_fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
+        param_idx = self.fsdp_param_module_order.get(module_fqn, len(self.node_idx))
+        return (param_idx, self.node_idx[node])
+
+    def _bucket_group(self, coll_nodes: list[fx.Node]) -> None:
+        if self.fsdp_param_module_order:
+            coll_nodes = sorted(coll_nodes, key=self._param_order_key)
+        return super()._bucket_group(coll_nodes)
+
+
 class JointManualOverlapScheduler(ManualOverlapScheduler):
     """Manual overlap scheduler for joint forward+backward graphs.
 
@@ -210,6 +245,7 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         is_backward_fn: Callable[[fx.Node], bool],
         module_stack_fn: Callable[[fx.Node], list[tuple[str, type[Any]]]],
         bucket_mode: BucketMode | None = None,
+        fsdp_param_module_order: dict[str, int] | None = None,
     ) -> None:
         super().__init__(
             gm,
@@ -219,6 +255,14 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
             bucket_mode=bucket_mode,
         )
         self._is_backward_fn = is_backward_fn
+        effective_bucket_mode = self.bucketer.bucket_mode
+        self.bucketer = FSDPParamOrderBucketer(
+            graph=self.graph,
+            collective_info=self.collective_info,
+            scheduled=OrderedSet(self.graph.nodes),
+            bucket_mode=effective_bucket_mode,
+            fsdp_param_module_order=fsdp_param_module_order,
+        )
 
     def _manual_bucket_collectives(self) -> None:
         """Bucket per module, splitting by direction to keep fwd/bwd buckets disjoint."""
@@ -381,6 +425,7 @@ def joint_transformer_block_bucketing_reordering_pass(
     module_bucket_plans: list[list[str] | str],
     insert_overlap_deps: bool = False,
     bucket_mode: BucketMode | None = None,
+    fsdp_param_module_order: dict[str, int] | None = None,
 ) -> torch.fx.GraphModule:
     """Run joint-graph manual bucketing and reordering.
 
@@ -402,6 +447,8 @@ def joint_transformer_block_bucketing_reordering_pass(
             ``preserve_node_ordering`` after the topological sort.
         bucket_mode: bucket mode forwarded to the underlying bucketer;
             defaults to ``"custom_ops"`` via the parent class.
+        fsdp_param_module_order: module order derived from traced parameter
+            FQNs, used to pack FSDP buckets like Eager FSDP2.
     """
 
     def _stack_fn(node: torch.fx.Node) -> list[tuple[str, type]]:
@@ -417,6 +464,7 @@ def joint_transformer_block_bucketing_reordering_pass(
         is_backward_fn=_is_backward_node,
         module_stack_fn=_stack_fn,
         bucket_mode=bucket_mode,
+        fsdp_param_module_order=fsdp_param_module_order,
     ).run()
     overlapped_gm.recompile()
     return overlapped_gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -42,6 +42,7 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     tlparse_log_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    get_fsdp_param_module_order,
     joint_transformer_block_bucketing_reordering_pass,
     reassign_collective_pgs_pass,
 )
@@ -148,6 +149,11 @@ def compile_time_passes(
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
             module_bucket_plans=get_default_transformer_block_buckets(n_layers),
+            # FSDP2 packs buckets in managed parameter order. The traced state
+            # FQNs preserve that registration order, unlike graph execution order.
+            fsdp_param_module_order=get_fsdp_param_module_order(
+                traced_result.state_fqns
+            ),
         ),
     ]
     if config.parallelism.enable_async_tensor_parallel:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3646
* #3640
* #3639
* #3637
* #3618
* __->__ #3617
* #3616
* #3615
* #3614
* #3613
* #3612

GT Regional was packing FSDP collective buckets in graph execution order.
Eager FSDP2 packs bucket payloads in managed parameter registration order.
For reduce-scatter, changing the payload order changes byte offsets inside
NCCL buckets; on multinode FSDP groups NCCL may use different ring orders per
channel, so moving parameter elements between offsets can produce different
bf16 accumulation order.

Derive module order from traced state FQNs, which preserve FSDP2's first-seen
parameter order, and use it to order every FSDP bucket group before delegating
to the upstream manual overlap bucketer. This keeps the Torchtitan-specific
logic limited to choosing bucket payload order; upstream still owns merging,
insertion, wait remapping, and bucketed-node tagging.

This also updates the existing _StridedShard call in models/utils.py to pass
split_factor by keyword. CI pyrefly removes the stale suppression there and
then reports the second positional argument, while this form matches the typed
usage elsewhere in GraphTrainer.

Authored by Codex.

Test Plan:

```bash
python -m py_compile \
  torchtitan/experiments/graph_trainer/fsdp_passes.py \
  torchtitan/experiments/graph_trainer/passes.py \
  torchtitan/models/utils.py
```

```bash
git diff --check origin/main...HEAD -- \
  torchtitan/experiments/graph_trainer/fsdp_passes.py \
  torchtitan/experiments/graph_trainer/passes.py \
  torchtitan/models/utils.py
```

```bash
black --check \
  torchtitan/experiments/graph_trainer/fsdp_passes.py \
  torchtitan/experiments/graph_trainer/passes.py \
  torchtitan/models/utils.py
```

```bash
flake8 --config=.flake8 \
  torchtitan/experiments/graph_trainer/fsdp_passes.py \
  torchtitan/experiments/graph_trainer/passes.py \
  torchtitan/models/utils.py
```

```bash
PYTHONPATH=/data/users/ivankobzarev/f/torchtitan-orderfix-main \
  python torchtitan/experiments/graph_trainer/tests/test_passes.py \
    -k TestBucketingPrefetchOrder
```

```bash
lintrunner -a
```

This failed because Torchtitan has no `.lintrunner.toml` in this checkout.
`pre-commit`, `ufmt`, and `pyrefly` are also not installed in the local Python
environment.

MAST 64-GPU TP=1/BS=1 weight-hash validation matched Eager for all 25 steps:

```text
ORDERFIX_GT8B_TP1_BS1_WHASH_Eager_8b-64gpu-64-ivankobzarev-lhpsfjn4
ORDERFIX_GT8B_TP1_BS1_WHASH_GT_Reg_NoCG_8b-64gpu-64-ivankob-t06vk4kk
```

MAST 128-GPU TP=1/BS=1 weight-hash validation matched Eager for all 25 steps:

```text
ORDERFIX_GT8B_TP1_BS1_WHASH_Eager_8b-128gpu-128-ivankobzare-dvg55jz4
ORDERFIX_GT8B_TP1_BS1_WHASH_GT_Reg_NoCG_8b-128gpu-128-ivank-qtz1q3fk
```

MAST 256-GPU TP=1/BS=1 weight-hash validation matched Eager for all 25 steps:

```text
ORDERFIX_GT8B_TP1_BS1_WHASH_Eager_8b-256gpu-256-ivankobzare-jtmfxc4z
ORDERFIX_GT8B_TP1_BS1_WHASH_GT_Reg_NoCG_8b-256gpu-256-ivank-dhm7t4th
```

(cherry picked from commit bd56b388e31fe18c4cd404a1b71e7120d7d5ef1e)