### PR TITLE
[graph_trainer] Device-hoist CooR artifacts (drop --virtual-local-rank)

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -104,9 +104,15 @@ def regional_inductor_pass(
     tracing_ctx = torch._guards.TracingContext(fake_mode)
 
     if serializable:
+        import torch.distributed.config as _dist_config
+
         with (
             torch._guards.tracing(tracing_ctx),
             torch._functorch.config.patch("force_autograd_cache", True),
+            # Serializable (precompile) artifacts may load on a different rank's
+            # device. Resolve the CUDA device at runtime so a one-rank-compiled
+            # artifact runs on cuda:{local_rank} without --virtual-local-rank.
+            ic.patch(runtime_device_index=_dist_config.compile_on_one_rank),
         ):
             result = regional_inductor(gm, example_inputs)
         from torch._inductor.output_code import RegionalOutputCode
@@ -284,7 +290,21 @@ def full_inductor_compilation_pass(
     # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
     # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
     # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.
-    with ic.patch(reorder_for_peak_memory=True):
+    #
+    # Under compile_on_one_rank (CooR precompile), make the generated wrapper
+    # resolve the CUDA device at runtime so the single artifact can load on any
+    # rank's real device (cuda:{local_rank}) without the --virtual-local-rank
+    # hack that masquerades every rank as cuda:0 (which breaks symm-mem).
+    import torch.distributed.config as _dist_config
+
+    with ic.patch(
+        reorder_for_peak_memory=True,
+        # Resolve the CUDA device at runtime so the one-rank-compiled artifact
+        # loads on any rank's real device (drops the --virtual-local-rank hack).
+        # This is baked into the artifact's inductor_meta and also makes inductor
+        # skip the static CUDA launcher (which would pin cubins to one device).
+        runtime_device_index=_dist_config.compile_on_one_rank,
+    ):
         result = regional_inductor_pass(gm, example_inputs)
 
     # Carry the pre-collapse cudagraph verdict forward via gm.meta. The

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -125,6 +125,64 @@ def _validate_config_fingerprint(
 _FX_TRACE_ARTIFACT_KEY = "fx_trace_default"
 
 
+def _hoist_graph_device_to_current(gm: torch.fx.GraphModule) -> None:
+    """Remap a precompiled graph's baked CUDA device to the current device.
+
+    The artifact is traced on one rank (cuda:0) but loaded on every rank's real
+    device (cuda:{local_rank}) when running without --virtual-local-rank. The
+    inductor-compiled regions already resolve the device at runtime
+    (config.runtime_device_index), but the eager FX graph still holds baked
+    references: constant ``get_attr`` tensors materialized on cuda:0 and
+    ``device=cuda:0`` kwargs/args on factory ops. Both must move to the current
+    device or eager ops mix tensors across devices (e.g. SDPA mask on cuda:0 vs
+    activations on cuda:1). Caller must have set the current device first.
+    """
+    if not torch.cuda.is_available():
+        return
+    target = torch.device("cuda", torch.cuda.current_device())
+
+    def _is_cuda_tensor(t: object) -> bool:
+        return isinstance(t, torch.Tensor) and t.device.type == "cuda"
+
+    def _remap_device(value: object) -> object:
+        # Handle both torch.device and string ("cuda" / "cuda:0") forms, and
+        # recurse into list/tuple args (e.g. factory ops with nested device).
+        if isinstance(value, torch.device) and value.type == "cuda":
+            return target
+        if isinstance(value, str) and value.startswith("cuda"):
+            return str(target)
+        if isinstance(value, (list, tuple)):
+            return type(value)(_remap_device(v) for v in value)
+        return value
+
+    for module in gm.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        # Move baked CUDA tensors onto the current device across all three
+        # stores: plain-attribute constants (make_fx setattr), registered
+        # buffers, and parameters.
+        for name, attr in list(module.__dict__.items()):
+            if _is_cuda_tensor(attr):
+                setattr(module, name, attr.to(target))
+        for name, buf in list(module._buffers.items()):
+            if _is_cuda_tensor(buf):
+                module._buffers[name] = buf.to(target)
+        for name, par in list(module._parameters.items()):
+            if _is_cuda_tensor(par):
+                module._parameters[name] = torch.nn.Parameter(
+                    par.data.to(target), requires_grad=par.requires_grad
+                )
+        # Rewrite device= literals on factory ops (kwargs and args).
+        for node in module.graph.nodes:
+            if node.kwargs and "device" in node.kwargs:
+                node.kwargs = {
+                    **node.kwargs,
+                    "device": _remap_device(node.kwargs["device"]),
+                }
+            if node.args:
+                node.args = tuple(_remap_device(a) for a in node.args)
+
+
 @dataclass
 class PrecompiledFxTraceArtifact:
     """Serialized form of a TracedResult for aot_fx_trace precompilation.
@@ -207,6 +265,7 @@ class PrecompiledFxTraceArtifact:
             shape_env=torch.fx.experimental.symbolic_shapes.ShapeEnv(),
         )
         gm = GraphPickler.loads(self.serialized_gm, fake_mode)
+        _hoist_graph_device_to_current(gm)
         gm.recompile()
 
         return TracedResult(

--- a/torchtitan/experiments/graph_trainer/run_train_precompile.sh
+++ b/torchtitan/experiments/graph_trainer/run_train_precompile.sh
@@ -6,11 +6,15 @@
 # LICENSE file in the root directory of this source tree.
 
 # Dedicated training script for graph_trainer with CooR precompile support.
-# Passes --virtual-local-rank to torchrun so that every worker sees
-# LOCAL_RANK=0 and uses cuda:0. torchrun isolates each worker's GPU via
-# CUDA_VISIBLE_DEVICES, so cuda:0 maps to a different physical GPU per
-# worker. This is required when loading a CooR-precompiled artifact,
-# because the artifact was compiled on a single process targeting cuda:0.
+#
+# Each worker runs on its real device (cuda:{local_rank}) with all GPUs
+# visible. A CooR artifact is compiled on one rank (cuda:0) but is device
+# hoisted: inductor regions resolve the device at runtime
+# (config.runtime_device_index) and the eager FX graph's baked constants are
+# remapped to the current device at load. This replaces the old
+# --virtual-local-rank hack (which masqueraded every rank as cuda:0 via
+# CUDA_VISIBLE_DEVICES) and is required for features like symmetric memory
+# that need peer GPUs visible.
 
 set -ex
 
@@ -21,6 +25,5 @@ CONFIG=${CONFIG:-"graph_trainer_llama3_debugmodel"}
 
 PYTORCH_ALLOC_CONF="expandable_segments:True" \
 torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
---virtual-local-rank \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
 -m torchtitan.train --module ${MODULE} --config ${CONFIG} "$@"

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -250,6 +250,63 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
                 )
 
 
+class TestHoistGraphDeviceToCurrent(unittest.TestCase):
+    """_hoist_graph_device_to_current moves baked devices to the current one."""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "needs >=2 CUDA devices to observe a cross-device move",
+    )
+    def test_moves_all_tensor_stores_and_device_literals(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            _hoist_graph_device_to_current,
+        )
+
+        prev = torch.cuda.current_device()
+        try:
+            torch.cuda.set_device(0)
+            target = torch.device("cuda", 0)
+            src = torch.device("cuda", 1)
+
+            g = torch.fx.Graph()
+            g.get_attr("_tensor_constant0")
+            g.call_function(
+                torch.ops.aten.empty.memory_format,
+                ([2],),
+                {"device": torch.device("cuda", 1)},
+            )
+            g.call_function(
+                torch.ops.aten.empty.memory_format, ([2],), {"device": "cuda:1"}
+            )
+            g.output(())
+            gm = torch.fx.GraphModule(
+                {"_tensor_constant0": torch.zeros(3, device=src)}, g
+            )
+            gm.register_buffer("buf", torch.ones(2, device=src))
+            gm.register_parameter(
+                "par", torch.nn.Parameter(torch.ones(2, device=src))
+            )
+
+            _hoist_graph_device_to_current(gm)
+
+            # All three tensor stores moved to the current device.
+            self.assertEqual(gm._tensor_constant0.device, target)
+            self.assertEqual(gm.buf.device, target)
+            self.assertEqual(gm.par.device, target)
+            # Both torch.device and string device kwargs remapped to current.
+            for node in gm.graph.nodes:
+                if node.op == "call_function" and "device" in (node.kwargs or {}):
+                    dev = node.kwargs["device"]
+                    idx = (
+                        dev.index
+                        if isinstance(dev, torch.device)
+                        else int(str(dev).split(":")[1])
+                    )
+                    self.assertEqual(idx, 0)
+        finally:
+            torch.cuda.set_device(prev)
+
+
 class TestCudagraphPass(unittest.TestCase):
     """Test cudagraph_pass behavior."""
 

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -173,6 +173,11 @@ class GraphTrainer(Trainer):
             model, compile_config, self.parallel_dims
         )
 
+        # Device correctness for the hoisted artifact comes from the base
+        # Trainer's set_device(self.device) at init plus the artifact's own
+        # runtime device resolution (config.runtime_device_index), which makes
+        # Triton kernel handles bind to the current device at first launch. No
+        # extra device context is needed here.
         self._traced_step = precompile_fx_trace_load(
             storage,
             expected_fingerprint=config_fingerprint,


### PR DESCRIPTION
## Summary

Device-hoists CooR precompile artifacts so each rank runs on its **real** device
(`cuda:{local_rank}`) with all GPUs visible, removing the `--virtual-local-rank`
hack. That hack set `CUDA_VISIBLE_DEVICES` so every worker saw its GPU as
`cuda:0` — which hides peer GPUs and breaks features that need them visible
(e.g. symmetric-memory expert parallelism, #3561).

> Depends on the inductor-side `runtime_device_index` support in PyTorch
> (separate PR). Stacked on #3596.

## How it works

A CooR artifact is compiled on one rank (cuda:0) but loaded on all ranks. Two
device-baked layers are hoisted:

1. **Inductor regions** — `inductor_passes.py` enables
   `torch._inductor.config.runtime_device_index` during precompile (gated on
   `compile_on_one_rank`), for full and regional inductor. The generated wrapper
   then derives the launch device from an **input tensor**
   (`_runtime_device = arg0_1.device.index`) instead of the baked compile-time
   index — an explicit, data-driven contract that stays correct regardless of
   ambient `torch.cuda.current_device()`.
2. **Eager FX graph** — `precompile._hoist_graph_device_to_current` remaps the
   deserialized graph's baked constants (plain attrs, registered buffers, params)
   and `device=` literals (`torch.device` and string forms, incl. nested args)
   onto the current device at load. This fixes eager ops (e.g. vocab-parallel
   embedding / SDPA) mixing a `cuda:0` constant with `cuda:{local_rank}`
   activations.

`run_train_precompile.sh` drops `--virtual-local-rank`. A unit test for the FX
remap is added.

## Validation (llama3 debugmodel, TP=2 × FSDP=4, no --virtual-local-rank)

| config | result | step-1/2 loss |
|---|---|---|
| full | ✅ | 8.13228 / 7.81150 |
| regional | ✅ | 8.13265 / 7.81226 |
| full, VLR (back-compat) | ✅ | 8.13228 / 7.81150 |

Full no-VLR is bitwise-identical to the canonical VLR path (`--debug.seed 42
--debug.deterministic`): 8.13228 / 7.81150 / 7.04731.

## Follow-ups before un-drafting
- [ ] Multi-rank integration test asserting `tensor.device.index == local_rank` mid-step.
- [ ] Full-precision loss+grad_norm parity (all ranks) via `scripts/loss_compare.py`.
- [ ] EP / CP configs to exercise peer/comm kernels under the input-derived device contract.
- [ ] Land the PyTorch `runtime_device_index` PR first.
