### PR TITLE
[Checkpointer] Remove the dependencies on PyTorch distributed state_dict APIs

### DIFF
--- a/scripts/checkpoint_compat_test.py
+++ b/scripts/checkpoint_compat_test.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Checkpoint backward compatibility test.
+
+Verifies that checkpoints saved by one git commit can be loaded by another
+and produce bit-identical losses. Runs three training jobs:
+
+  1. Reference run at <load_commit>: train full --steps from scratch.
+  2. Save run at <save_commit>: train --resume-step steps, save checkpoint.
+  3. Resume run at <load_commit>: resume from save checkpoint to --steps.
+
+All use --debug.deterministic --debug.seed=42. Pass = identical losses.
+
+Examples:
+  python scripts/checkpoint_compat_test.py HEAD~1 HEAD
+  python scripts/checkpoint_compat_test.py HEAD~1 HEAD --steps=100 --resume-step=50
+  python scripts/checkpoint_compat_test.py HEAD~1 HEAD --assert-equal
+  python scripts/checkpoint_compat_test.py HEAD~1 . --assert-equal
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+FIXED_OPTIONS = (
+    "--debug.deterministic --debug.seed=42"
+    " --metrics.enable_tensorboard --metrics.log_freq=1"
+)
+TB_LOSS_TAG = "loss_metrics/global_avg_loss"
+
+
+def log(msg: str = "") -> None:
+    print(f"[CKPT_COMPAT] {msg}" if msg else "[CKPT_COMPAT]")
+
+
+def git_run(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def check_git_clean() -> None:
+    lines = git_run("status", "--porcelain").split("\n")
+    modified = [l for l in lines if l and not l.startswith("??")]
+    if modified:
+        log("Error: uncommitted changes to tracked files:")
+        for l in modified:
+            log(f"  {l}")
+        sys.exit(1)
+
+
+def get_current_ref() -> str:
+    ref = git_run("rev-parse", "--abbrev-ref", "HEAD")
+    return ref if ref != "HEAD" else git_run("rev-parse", "HEAD")
+
+
+def checkout(commit: str, label: str) -> None:
+    if commit != ".":
+        log(f"Checking out {label}: {commit}")
+        subprocess.run(["git", "checkout", commit], check=True)
+
+
+def run_cmd(cmd: str, logfile: str, ngpus: int) -> None:
+    """Run training command with real-time output and log capture."""
+    log(f"Executing: {cmd}")
+    env = {**os.environ, "NGPU": str(ngpus), "PYTHONUNBUFFERED": "1"}
+    with open(logfile, "w") as f:
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+        for line in proc.stdout:  # pyrefly: ignore [not-iterable]
+            print(line, end="")
+            f.write(line)
+        proc.wait()
+        if proc.returncode != 0:
+            raise subprocess.CalledProcessError(proc.returncode, cmd)
+
+
+def build_cmd(
+    module: str,
+    config: str,
+    options: str,
+    steps: int,
+    dump_folder: str,
+    *,
+    total_steps: int = 0,
+    checkpoint_enable: bool = False,
+    checkpoint_interval: int = 0,
+) -> str:
+    cmd = (
+        f"MODULE='{module}' CONFIG='{config}' ./run_train.sh"
+        f" --dump_folder={dump_folder} {FIXED_OPTIONS}"
+        f" --training.steps={steps} --metrics.save_tb_folder=tb"
+    )
+    if total_steps > 0:
+        # Pin LR schedule so the save run uses the same curve as the full run.
+        cmd += f" --lr_scheduler.total_steps={total_steps}"
+    if options:
+        cmd += f" {options}"
+    if checkpoint_enable:
+        cmd += f" --checkpoint.enable --checkpoint.interval={checkpoint_interval}"
+    return cmd
+
+
+def extract_tb_losses(tb_base: str) -> dict[int, float]:
+    """Extract full-precision losses from all TB subdirs under tb_base.
+
+    Unlike loss_compare.extract_losses_from_tensorboard (which expects a single
+    subdirectory), this merges events across multiple subdirs to handle the
+    resume case where save and resume runs write to the same TB folder.
+    """
+    from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+    losses: dict[int, float] = {}
+    for subdir in sorted(os.listdir(tb_base)):
+        path = os.path.join(tb_base, subdir)
+        if not os.path.isdir(path):
+            continue
+        acc = EventAccumulator(path)
+        acc.Reload()
+        tags = acc.Tags().get("scalars", [])
+        if TB_LOSS_TAG in tags:  # pyrefly: ignore [not-iterable]
+            for s in acc.Scalars(TB_LOSS_TAG):
+                losses[s.step] = s.value
+    log(f"Extracted {len(losses)} steps from {tb_base}")
+    return losses
+
+
+def compare_losses(
+    ref: dict[int, float],
+    resume: dict[int, float],
+    assert_equal: bool,
+) -> bool:
+    ref_steps = sorted(ref)
+    if ref_steps != sorted(resume):
+        log(f"Step count mismatch: ref={len(ref)}, resume={len(resume)}")
+        return False
+
+    log(f"{'Step':<8} {'Reference':<22} {'Resume':<22} {'Match'}")
+    log("-" * 60)
+
+    all_ok = True
+    for step in ref_steps:
+        ok = ref[step] == resume[step]
+        all_ok &= ok
+        log(
+            f"{step:<8} {ref[step]!r:<22} {resume[step]!r:<22} {'OK' if ok else 'MISMATCH'}"
+        )
+
+    log()
+    log(
+        "PASS: All losses are bit-identical."
+        if all_ok
+        else "FAIL: Loss mismatch detected!"
+    )
+
+    if assert_equal and not all_ok:
+        sys.exit(1)
+    return all_ok
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Test checkpoint backward compatibility between two git commits.",
+    )
+    p.add_argument("save_commit", help="Commit that saves the checkpoint (old code)")
+    p.add_argument("load_commit", help="Commit that loads the checkpoint (new code)")
+    p.add_argument("--steps", type=int, default=100, help="Total training steps")
+    p.add_argument("--resume-step", type=int, default=50, help="Checkpoint/resume step")
+    p.add_argument("--module", default="llama3")
+    p.add_argument("--config", default="llama3_debugmodel")
+    p.add_argument("--options", default="", help="Extra training CLI args")
+    p.add_argument("--ngpus", type=int, default=8)
+    p.add_argument("--output-folder", default="")
+    p.add_argument(
+        "--assert-equal", action="store_true", help="Exit non-zero on mismatch"
+    )
+    args = p.parse_args()
+
+    if args.resume_step >= args.steps:
+        p.error(f"--resume-step ({args.resume_step}) must be < --steps ({args.steps})")
+    if not args.output_folder:
+        args.output_folder = tempfile.mkdtemp(prefix="ckpt_compat_")
+
+    log("Checkpoint Backward Compatibility Test")
+    log(
+        f"  save={args.save_commit}  load={args.load_commit}  "
+        f"steps={args.steps}  resume_step={args.resume_step}  ngpus={args.ngpus}"
+    )
+    log(f"  output: {args.output_folder}")
+
+    # Resolve SHAs before any checkout
+    save_sha = (
+        git_run("rev-parse", args.save_commit) if args.save_commit != "." else "."
+    )
+    load_sha = (
+        git_run("rev-parse", args.load_commit) if args.load_commit != "." else "."
+    )
+
+    ref_dump = os.path.join(args.output_folder, "ref_outputs")
+    resume_dump = os.path.join(args.output_folder, "resume_outputs")
+    os.makedirs(ref_dump, exist_ok=True)
+    os.makedirs(resume_dump, exist_ok=True)
+
+    needs_checkout = save_sha != "." or load_sha != "."
+    original = get_current_ref() if needs_checkout else None
+    if needs_checkout:
+        check_git_clean()
+
+    common = dict(module=args.module, config=args.config, options=args.options)
+
+    try:
+        # Step 1: Reference run at load_commit (full training from scratch)
+        log()
+        log("=" * 60)
+        log("STEP 1: Reference run")
+        log("=" * 60)
+        checkout(load_sha, "load_commit")
+        cmd = build_cmd(**common, steps=args.steps, dump_folder=ref_dump)
+        run_cmd(cmd, os.path.join(args.output_folder, "reference.log"), args.ngpus)
+
+        # Step 2: Save run at save_commit (partial training + checkpoint)
+        log()
+        log("=" * 60)
+        log(f"STEP 2: Save run ({args.resume_step} steps)")
+        log("=" * 60)
+        checkout(save_sha, "save_commit")
+        cmd = build_cmd(
+            **common,
+            steps=args.resume_step,
+            dump_folder=resume_dump,
+            total_steps=args.steps,
+            checkpoint_enable=True,
+            checkpoint_interval=args.resume_step,
+        )
+        run_cmd(cmd, os.path.join(args.output_folder, "save.log"), args.ngpus)
+
+        # Step 3: Resume run at load_commit (load checkpoint, train to end)
+        log()
+        log("=" * 60)
+        log(f"STEP 3: Resume run (to step {args.steps})")
+        log("=" * 60)
+        checkout(load_sha, "load_commit")
+        cmd = build_cmd(
+            **common,
+            steps=args.steps,
+            dump_folder=resume_dump,
+            checkpoint_enable=True,
+            checkpoint_interval=args.resume_step,
+        )
+        run_cmd(cmd, os.path.join(args.output_folder, "resume.log"), args.ngpus)
+
+        # Step 4: Compare
+        log()
+        ref_losses = extract_tb_losses(os.path.join(ref_dump, "tb"))
+        resume_losses = extract_tb_losses(os.path.join(resume_dump, "tb"))
+        compare_losses(ref_losses, resume_losses, args.assert_equal)
+
+    finally:
+        if original:
+            log()
+            log(f"Restoring: {original}")
+            subprocess.run(["git", "checkout", original], check=True)
+
+    log(f"Logs saved in: {args.output_folder}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/test_lr_scheduler.py
+++ b/tests/unit_tests/test_lr_scheduler.py
@@ -29,8 +29,6 @@ class TestLRScheduler(unittest.TestCase):
         self.optimizer_container = MagicMock(spec=OptimizersContainer)
         self.optimizer_container.__iter__.return_value = iter([self.optimizer])
         self.optimizer_container.__len__.return_value = 1
-        # LRSchedulersContainer reads per-optimizer patterns for lr metric labels.
-        self.optimizer_container._param_group_patterns = [[".*"]]
 
     def create_trainer_config(
         self,

--- a/tests/unit_tests/test_lr_scheduler.py
+++ b/tests/unit_tests/test_lr_scheduler.py
@@ -29,6 +29,8 @@ class TestLRScheduler(unittest.TestCase):
         self.optimizer_container = MagicMock(spec=OptimizersContainer)
         self.optimizer_container.__iter__.return_value = iter([self.optimizer])
         self.optimizer_container.__len__.return_value = 1
+        # LRSchedulersContainer reads per-optimizer patterns for lr metric labels.
+        self.optimizer_container._param_group_patterns = [[".*"]]
 
     def create_trainer_config(
         self,

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -425,34 +425,8 @@ class TestMixedOptimizers(unittest.TestCase):
         self.assertEqual(adam.param_groups[0]["lr"], 5e-4)
         self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
 
-    def test_model_part_indices(self):
-        """_model_part_indices correctly maps optimizers to model parts."""
-        model1 = SimpleModel()
-        model2 = SimpleModel()
-        config = OptimizersContainer.Config(
-            implementation="for-loop",
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r"output\.",
-                    optimizer_name="Adam",
-                    optimizer_kwargs={"lr": 5e-4, "betas": (0.9, 0.95), "eps": 1e-8},
-                ),
-                ParamGroupConfig(
-                    pattern=r".*",
-                    optimizer_name="AdamW",
-                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
-                ),
-            ],
-        )
-        container = config.build(model_parts=[model1, model2])
-        self.assertEqual(len(container.optimizers), 4)
-        self.assertEqual(container._model_part_indices[0], 0)
-        self.assertEqual(container._model_part_indices[1], 0)
-        self.assertEqual(container._model_part_indices[2], 1)
-        self.assertEqual(container._model_part_indices[3], 1)
-
-    def test_param_group_patterns(self):
-        """Param groups have correct pattern for logging."""
+    def test_pattern_not_leaked_to_state_dict(self):
+        """Pattern is logging-only; it must not enter the optimizer or state dict."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
@@ -470,9 +444,12 @@ class TestMixedOptimizers(unittest.TestCase):
             ],
         )
         container = config.build(model_parts=[model])
-        adamw = container.optimizers[0]
-        self.assertEqual(adamw.param_groups[0]["pattern"], r"output\.")
-        self.assertEqual(adamw.param_groups[1]["pattern"], ".*")
+        # Pattern is popped before optimizer construction, so it never reaches
+        # the optimizer's param groups or the saved (flat) state dict.
+        for opt in container.optimizers:
+            for group in opt.param_groups:
+                self.assertNotIn("pattern", group)
+        self.assertFalse(any(".pattern" in key for key in container.state_dict()))
 
     def test_mixed_optimizer_state_dict_round_trip(self):
         """State dict save/load works with mixed optimizer types."""

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -66,7 +66,7 @@ def _get_default_groups(model, config):
     """Helper: build param groups and return the AdamW optimizer's groups."""
     impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
     param_groups = config.param_groups
-    groups_by_opt = OptimizersContainer._build_param_groups(
+    groups_by_opt, _ = OptimizersContainer._build_param_groups(
         model, param_groups, impl_kwargs
     )
     return groups_by_opt.get("AdamW", [])
@@ -276,7 +276,7 @@ class TestParamGroupConfig(unittest.TestCase):
             ],
         )
         impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
-        groups_by_opt = OptimizersContainer._build_param_groups(
+        groups_by_opt, _ = OptimizersContainer._build_param_groups(
             model, config.param_groups, impl_kwargs
         )
 

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -521,8 +521,8 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         lr = scheduler.schedulers[0].optimizer.param_groups[0]["lr"]
         self.assertAlmostEqual(lr, 1e-3, places=6)
 
-    def test_get_metrics_labels_lr_by_pattern(self):
-        """get_metrics labels each lr by its param-group regex pattern."""
+    def test_get_metrics_reports_lr_per_group(self):
+        """get_metrics reports a learning rate per optimizer param group."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
@@ -542,9 +542,8 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         lr_config = LRSchedulersContainer.Config(warmup_steps=10, decay_type="linear")
         scheduler, _ = self._build_scheduler(config, lr_config, model)
         metrics = scheduler.get_metrics()
-        # Both patterns appear as labels; no reference to a missing 'pattern' key.
-        self.assertIn(r"lr/AdamW_output\.", metrics)
-        self.assertIn("lr/AdamW_.*", metrics)
+        # One AdamW optimizer with two param groups -> indexed lr keys.
+        self.assertEqual(set(metrics), {"lr/AdamW/0", "lr/AdamW/1"})
 
     def test_mixed_optimizer_gets_separate_schedulers(self):
         """Mixed optimizers should each get their own scheduler."""

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -521,6 +521,31 @@ class TestLRSchedulerWithMixedOptimizers(unittest.TestCase):
         lr = scheduler.schedulers[0].optimizer.param_groups[0]["lr"]
         self.assertAlmostEqual(lr, 1e-3, places=6)
 
+    def test_get_metrics_labels_lr_by_pattern(self):
+        """get_metrics labels each lr by its param-group regex pattern."""
+        model = SimpleModel()
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r"output\.",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 5e-4, "weight_decay": 0.0},
+                ),
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 1e-3, "weight_decay": 0.1},
+                ),
+            ],
+        )
+        lr_config = LRSchedulersContainer.Config(warmup_steps=10, decay_type="linear")
+        scheduler, _ = self._build_scheduler(config, lr_config, model)
+        metrics = scheduler.get_metrics()
+        # Both patterns appear as labels; no reference to a missing 'pattern' key.
+        self.assertIn(r"lr/AdamW_output\.", metrics)
+        self.assertIn("lr/AdamW_.*", metrics)
+
     def test_mixed_optimizer_gets_separate_schedulers(self):
         """Mixed optimizers should each get their own scheduler."""
         model = SimpleModel()

--- a/tests/unit_tests/test_state_dict_keys.py
+++ b/tests/unit_tests/test_state_dict_keys.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Contract test for model and optimizer state dict keys (llama3 debugmodel).
+
+Verifies the key contract that distributed checkpointing relies on:
+- ModelWrapper.state_dict() strips wrapper prefixes (_orig_mod,
+  _checkpoint_wrapped_module) so keys are canonical FQNs.
+- OptimizersContainer.state_dict() is keyed by FQN as state.{fqn}.{state_name}
+  and param_groups.{fqn}.{key}, matching the model's parameter FQNs.
+- The flatten/unflatten round-trip preserves optimizer state values exactly.
+
+Ground-truth keys are derived from the model itself (robust to model evolution),
+while a few hard-coded structural anchors catch unexpected model refactors. This
+runs on CPU using torch.compile(backend="eager") to introduce the _orig_mod.
+prefixes without needing a GPU.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.components.checkpoint import ModelWrapper
+from torchtitan.components.checkpoint_utils import (
+    get_flat_optim_state_dict,
+    init_optim_state,
+    load_flat_optim_state_dict,
+)
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
+from torchtitan.models.llama3 import llama3_configs
+from torchtitan.models.llama3.model import Llama3Model
+
+# AdamW creates these per-parameter state tensors (no amsgrad).
+_ADAMW_STATE_NAMES = ("step", "exp_avg", "exp_avg_sq")
+
+# Well-known llama3 debugmodel parameter FQNs used as structural anchors. These
+# are checked as a subset, so extra keys (biases, buffers) never cause a false
+# failure, but a rename in the model would.
+_TOP_LEVEL_ANCHORS = ("tok_embeddings.weight", "norm.weight", "lm_head.weight")
+_LAYER0_ANCHORS = (
+    "layers.0.attention.qkv_linear.wq.weight",
+    "layers.0.attention.qkv_linear.wk.weight",
+    "layers.0.attention.qkv_linear.wv.weight",
+    "layers.0.attention.wo.weight",
+    "layers.0.feed_forward.w1.weight",
+    "layers.0.feed_forward.w2.weight",
+    "layers.0.feed_forward.w3.weight",
+    "layers.0.attention_norm.weight",
+    "layers.0.ffn_norm.weight",
+)
+
+
+def _build_debugmodel() -> Llama3Model:
+    config = llama3_configs["debugmodel"](attn_backend="flex")
+    model = Llama3Model(config)
+    model.init_states()
+    return model
+
+
+def _debugmodel_optimizer_config() -> OptimizersContainer.Config:
+    # for-loop keeps the test on CPU (no fused/foreach CUDA path).
+    return OptimizersContainer.Config(
+        implementation="for-loop",
+        param_groups=[
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": 8e-4,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            )
+        ],
+    )
+
+
+class TestStateDictKeys(unittest.TestCase):
+    def setUp(self) -> None:
+        # Ground-truth canonical keys come from the uncompiled model.
+        model = _build_debugmodel()
+        self.clean_state_keys = set(model.state_dict().keys())
+        self.clean_param_fqns = {
+            name for name, p in model.named_parameters() if p.requires_grad
+        }
+        # torch.compile (eager backend, no GPU) introduces _orig_mod. prefixes.
+        self.compiled_parts = [torch.compile(model, backend="eager")]
+
+    def test_model_structure_anchors(self) -> None:
+        """The debugmodel exposes the expected, well-known parameter FQNs."""
+        for anchor in _TOP_LEVEL_ANCHORS + _LAYER0_ANCHORS:
+            self.assertIn(anchor, self.clean_param_fqns)
+
+    def test_model_state_dict_keys_are_canonical(self) -> None:
+        """ModelWrapper strips wrapper prefixes to recover canonical FQNs."""
+        keys = set(ModelWrapper(self.compiled_parts).state_dict().keys())
+        for key in keys:
+            self.assertNotIn("_orig_mod", key)
+            self.assertNotIn("_checkpoint_wrapped_module", key)
+        self.assertEqual(keys, self.clean_state_keys)
+
+    def test_optimizer_state_dict_keys(self) -> None:
+        optimizers = _debugmodel_optimizer_config().build(
+            model_parts=self.compiled_parts
+        )
+        optim_sd = optimizers.state_dict()
+
+        state_keys = {k for k in optim_sd if k.startswith("state.")}
+        expected_state_keys = {
+            f"state.{fqn}.{name}"
+            for fqn in self.clean_param_fqns
+            for name in _ADAMW_STATE_NAMES
+        }
+        self.assertEqual(state_keys, expected_state_keys)
+
+        # Every parameter FQN has param_groups entries, and pattern never leaks.
+        pg_keys = {k for k in optim_sd if k.startswith("param_groups.")}
+        for fqn in self.clean_param_fqns:
+            self.assertTrue(
+                any(k.startswith(f"param_groups.{fqn}.") for k in pg_keys),
+                f"missing param_groups entries for {fqn}",
+            )
+        self.assertFalse(any(k.endswith(".pattern") for k in pg_keys))
+
+    def test_optimizer_state_dict_roundtrip_keys(self) -> None:
+        optimizers = _debugmodel_optimizer_config().build(
+            model_parts=self.compiled_parts
+        )
+        optim_sd = optimizers.state_dict()
+        optimizers.load_state_dict(optim_sd)
+        self.assertEqual(set(optim_sd.keys()), set(optimizers.state_dict().keys()))
+
+    def test_flat_optim_roundtrip_values(self) -> None:
+        """get/load_flat_optim_state_dict preserve state values exactly."""
+        optimizers = _debugmodel_optimizer_config().build(
+            model_parts=self.compiled_parts
+        )
+        # Populate optimizer state with non-zero values via a real step.
+        for p in self.compiled_parts[0].parameters():
+            if p.requires_grad:
+                p.grad = torch.randn_like(p)
+        optimizers.step()
+
+        flat: dict = {}
+        for optim in optimizers.optimizers:
+            flat.update(get_flat_optim_state_dict(optim))
+
+        # Load into a fresh container (second model, matching FQNs).
+        optimizers2 = _debugmodel_optimizer_config().build(
+            model_parts=[_build_debugmodel()]
+        )
+        for optim in optimizers2.optimizers:
+            init_optim_state(optim)
+            load_flat_optim_state_dict(optim, flat)
+
+        flat2: dict = {}
+        for optim in optimizers2.optimizers:
+            flat2.update(get_flat_optim_state_dict(optim))
+
+        self.assertEqual(set(flat), set(flat2))
+        for key, v1 in flat.items():
+            v2 = flat2[key]
+            if isinstance(v1, torch.Tensor):
+                self.assertTrue(
+                    torch.equal(v1, v2),
+                    f"value mismatch at {key}: max diff {(v1 - v2).abs().max()}",
+                )
+            else:
+                self.assertEqual(v1, v2, f"value mismatch at {key}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_state_dict_keys.py
+++ b/tests/unit_tests/test_state_dict_keys.py
@@ -10,7 +10,7 @@ Verifies the key contract that distributed checkpointing relies on:
 - ModelWrapper.state_dict() is keyed by canonical FQNs. This holds without any
   key cleaning because model.state_dict() is already canonical: the activation
   checkpoint wrapper strips its own _checkpoint_wrapped_module prefix via a
-  state_dict hook, and torchtitan applies torch.compile in place (no _orig_mod).
+  state_dict hook, and torchtitan applies torch.compile in place (no segment).
 - OptimizersContainer.state_dict() is keyed as state.{fqn}.{state_name} and
   param_groups.{fqn}.{key}, matching the model FQNs. The optimizer is built from
   named_parameters(), which (unlike state_dict()) keeps the wrapper prefix, so
@@ -138,7 +138,6 @@ class TestStateDictKeys(unittest.TestCase):
         keys = set(ModelWrapper(self.model_parts).state_dict().keys())
         for key in keys:
             self.assertNotIn(_WRAPPER_PREFIX, key)
-            self.assertNotIn("_orig_mod", key)
         self.assertEqual(keys, self.clean_state_keys)
 
     def test_optimizer_state_dict_keys(self) -> None:

--- a/tests/unit_tests/test_state_dict_keys.py
+++ b/tests/unit_tests/test_state_dict_keys.py
@@ -7,21 +7,28 @@
 """Contract test for model and optimizer state dict keys (llama3 debugmodel).
 
 Verifies the key contract that distributed checkpointing relies on:
-- ModelWrapper.state_dict() strips wrapper prefixes (_orig_mod,
-  _checkpoint_wrapped_module) so keys are canonical FQNs.
-- OptimizersContainer.state_dict() is keyed by FQN as state.{fqn}.{state_name}
-  and param_groups.{fqn}.{key}, matching the model's parameter FQNs.
+- ModelWrapper.state_dict() is keyed by canonical FQNs. This holds without any
+  key cleaning because model.state_dict() is already canonical: the activation
+  checkpoint wrapper strips its own _checkpoint_wrapped_module prefix via a
+  state_dict hook, and torchtitan applies torch.compile in place (no _orig_mod).
+- OptimizersContainer.state_dict() is keyed as state.{fqn}.{state_name} and
+  param_groups.{fqn}.{key}, matching the model FQNs. The optimizer is built from
+  named_parameters(), which (unlike state_dict()) keeps the wrapper prefix, so
+  canonical_fqn must strip it during construction.
 - The flatten/unflatten round-trip preserves optimizer state values exactly.
 
-Ground-truth keys are derived from the model itself (robust to model evolution),
-while a few hard-coded structural anchors catch unexpected model refactors. This
-runs on CPU using torch.compile(backend="eager") to introduce the _orig_mod.
-prefixes without needing a GPU.
+The test wraps each layer with the activation checkpoint wrapper to reproduce the
+prefix asymmetry on CPU (named_parameters prefixed, state_dict clean), and derives
+ground-truth keys from the unwrapped model plus a few hard-coded structural
+anchors that catch unexpected model refactors.
 """
 
 import unittest
 
 import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    checkpoint_wrapper as ptd_checkpoint_wrapper,
+)
 
 from torchtitan.components.checkpoint import ModelWrapper
 from torchtitan.components.checkpoint_utils import (
@@ -32,6 +39,8 @@ from torchtitan.components.checkpoint_utils import (
 from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.model import Llama3Model
+
+_WRAPPER_PREFIX = "_checkpoint_wrapped_module"
 
 # AdamW creates these per-parameter state tensors (no amsgrad).
 _ADAMW_STATE_NAMES = ("step", "exp_avg", "exp_avg_sq")
@@ -60,6 +69,17 @@ def _build_debugmodel() -> Llama3Model:
     return model
 
 
+def _wrap_layers_with_ac(model: Llama3Model) -> None:
+    """Wrap each transformer block with the AC wrapper, in place (like apply_ac).
+
+    This makes named_parameters() carry the _checkpoint_wrapped_module prefix
+    while state_dict() stays clean (the wrapper strips it via a state_dict hook).
+    """
+    layers = model.get_submodule("layers")
+    for layer_id, block in list(layers.named_children()):
+        layers.register_module(layer_id, ptd_checkpoint_wrapper(block))
+
+
 def _debugmodel_optimizer_config() -> OptimizersContainer.Config:
     # for-loop keeps the test on CPU (no fused/foreach CUDA path).
     return OptimizersContainer.Config(
@@ -81,32 +101,48 @@ def _debugmodel_optimizer_config() -> OptimizersContainer.Config:
 
 class TestStateDictKeys(unittest.TestCase):
     def setUp(self) -> None:
-        # Ground-truth canonical keys come from the uncompiled model.
+        # Ground-truth canonical keys come from the unwrapped model.
         model = _build_debugmodel()
         self.clean_state_keys = set(model.state_dict().keys())
         self.clean_param_fqns = {
             name for name, p in model.named_parameters() if p.requires_grad
         }
-        # torch.compile (eager backend, no GPU) introduces _orig_mod. prefixes.
-        self.compiled_parts = [torch.compile(model, backend="eager")]
+        # Wrapping introduces the _checkpoint_wrapped_module prefix on
+        # named_parameters() but not on state_dict() (stripped by a hook).
+        _wrap_layers_with_ac(model)
+        self.model_parts = [model]
 
     def test_model_structure_anchors(self) -> None:
         """The debugmodel exposes the expected, well-known parameter FQNs."""
         for anchor in _TOP_LEVEL_ANCHORS + _LAYER0_ANCHORS:
             self.assertIn(anchor, self.clean_param_fqns)
 
+    def test_ac_prefix_only_on_named_parameters(self) -> None:
+        """named_parameters() keeps the AC prefix; state_dict() is already clean.
+
+        This is the asymmetry that justifies cleaning FQNs for the optimizer but
+        not for the model state dict.
+        """
+        model = self.model_parts[0]
+        self.assertTrue(
+            any(_WRAPPER_PREFIX in n for n, _ in model.named_parameters()),
+            "expected the AC wrapper prefix on named_parameters()",
+        )
+        self.assertFalse(
+            any(_WRAPPER_PREFIX in k for k in model.state_dict()),
+            "model.state_dict() should already be free of the AC wrapper prefix",
+        )
+
     def test_model_state_dict_keys_are_canonical(self) -> None:
-        """ModelWrapper strips wrapper prefixes to recover canonical FQNs."""
-        keys = set(ModelWrapper(self.compiled_parts).state_dict().keys())
+        """ModelWrapper.state_dict() yields canonical FQNs with no cleaning."""
+        keys = set(ModelWrapper(self.model_parts).state_dict().keys())
         for key in keys:
+            self.assertNotIn(_WRAPPER_PREFIX, key)
             self.assertNotIn("_orig_mod", key)
-            self.assertNotIn("_checkpoint_wrapped_module", key)
         self.assertEqual(keys, self.clean_state_keys)
 
     def test_optimizer_state_dict_keys(self) -> None:
-        optimizers = _debugmodel_optimizer_config().build(
-            model_parts=self.compiled_parts
-        )
+        optimizers = _debugmodel_optimizer_config().build(model_parts=self.model_parts)
         optim_sd = optimizers.state_dict()
 
         state_keys = {k for k in optim_sd if k.startswith("state.")}
@@ -127,20 +163,16 @@ class TestStateDictKeys(unittest.TestCase):
         self.assertFalse(any(k.endswith(".pattern") for k in pg_keys))
 
     def test_optimizer_state_dict_roundtrip_keys(self) -> None:
-        optimizers = _debugmodel_optimizer_config().build(
-            model_parts=self.compiled_parts
-        )
+        optimizers = _debugmodel_optimizer_config().build(model_parts=self.model_parts)
         optim_sd = optimizers.state_dict()
         optimizers.load_state_dict(optim_sd)
         self.assertEqual(set(optim_sd.keys()), set(optimizers.state_dict().keys()))
 
     def test_flat_optim_roundtrip_values(self) -> None:
         """get/load_flat_optim_state_dict preserve state values exactly."""
-        optimizers = _debugmodel_optimizer_config().build(
-            model_parts=self.compiled_parts
-        )
+        optimizers = _debugmodel_optimizer_config().build(model_parts=self.model_parts)
         # Populate optimizer state with non-zero values via a real step.
-        for p in self.compiled_parts[0].parameters():
+        for p in self.model_parts[0].parameters():
             if p.requires_grad:
                 p.grad = torch.randn_like(p)
         optimizers.step()
@@ -150,9 +182,9 @@ class TestStateDictKeys(unittest.TestCase):
             flat.update(get_flat_optim_state_dict(optim))
 
         # Load into a fresh container (second model, matching FQNs).
-        optimizers2 = _debugmodel_optimizer_config().build(
-            model_parts=[_build_debugmodel()]
-        )
+        model2 = _build_debugmodel()
+        _wrap_layers_with_ac(model2)
+        optimizers2 = _debugmodel_optimizer_config().build(model_parts=[model2])
         for optim in optimizers2.optimizers:
             init_optim_state(optim)
             load_flat_optim_state_dict(optim, flat)

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -31,10 +31,6 @@ from torch.distributed.checkpoint.state_dict_saver import (
     AsyncSaveResponse,
 )
 from torch.distributed.checkpoint.stateful import Stateful
-from torchtitan.components.checkpoint_utils import (
-    canonical_model_state_dict,
-    load_canonical_model_state_dict,
-)
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -86,11 +82,11 @@ class ModelWrapper(Stateful):
         self.cached_state_dict = self._get_state_dict()
 
     def _get_state_dict(self) -> dict[str, Any]:
-        return {
-            k: v
-            for model in self.model
-            for k, v in canonical_model_state_dict(model).items()
-        }
+        # model.state_dict() keys are already canonical FQNs: torchtitan compiles
+        # in place (no _orig_mod prefix) and the activation checkpoint wrapper
+        # strips its own _checkpoint_wrapped_module prefix via a state_dict hook,
+        # so no key cleaning is needed here.
+        return {k: v for model in self.model for k, v in model.state_dict().items()}
 
     def state_dict(self) -> dict[str, Any]:
         return self.cached_state_dict
@@ -98,8 +94,10 @@ class ModelWrapper(Stateful):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         # strict=False because state_dict is the flattened checkpoint dict, which
         # mixes model FQN keys with non-model keys (optimizer, lr_scheduler, ...).
+        # The activation checkpoint wrapper's load hook re-adds its prefix, so the
+        # canonical keys here match the live module keys.
         for model in self.model:
-            load_canonical_model_state_dict(model, state_dict, strict=False)
+            model.load_state_dict(state_dict, strict=False)
         # Refresh the cache so state_dict() reflects the freshly loaded values.
         self.cached_state_dict = self._get_state_dict()
 
@@ -152,10 +150,9 @@ class CheckpointManager(Configurable):
     Then when reloading, only one stage can restore its optimizer states, others will
     error.
 
-        The solution to this problem is optimizer flattening (see PR #127071
-        https://github.com/pytorch/pytorch/pull/127071). TorchTitan's
-        OptimizersContainer flattens optimizer state dicts to FQN-keyed flat dicts
-        using the utilities in torchtitan/components/checkpoint_utils.py.
+        The solution to this problem is optimizer flattening.
+        TorchTitan's OptimizersContainer flattens optimizer state dicts to FQN-keyed
+        flat dicts using the utilities in torchtitan/components/checkpoint_utils.py.
 
     2. With complex PP schedules, we have multiple model chunks per pp rank. This
     compounds challenge (1) by also requiring us to reason about multiple 'optim'

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -82,10 +82,7 @@ class ModelWrapper(Stateful):
         self.cached_state_dict = self._get_state_dict()
 
     def _get_state_dict(self) -> dict[str, Any]:
-        # model.state_dict() keys are already canonical FQNs: torchtitan applies
-        # torch.compile in place (it adds no wrapper segment) and the activation
-        # checkpoint wrapper strips its own _checkpoint_wrapped_module segment via a
-        # state_dict hook, so no key cleaning is needed here.
+        # TorchTitan already makes model state_dict keys canonical.
         return {k: v for model in self.model for k, v in model.state_dict().items()}
 
     def state_dict(self) -> dict[str, Any]:
@@ -94,8 +91,6 @@ class ModelWrapper(Stateful):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         # strict=False because state_dict is the flattened checkpoint dict, which
         # mixes model FQN keys with non-model keys (optimizer, lr_scheduler, ...).
-        # The activation checkpoint wrapper's load hook re-adds its prefix, so the
-        # canonical keys here match the live module keys.
         for model in self.model:
             model.load_state_dict(state_dict, strict=False)
         # Refresh the cache so state_dict() reflects the freshly loaded values.

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import enum
-import functools
 import os
 import queue
 import re
@@ -27,16 +26,15 @@ from torch.distributed.checkpoint._consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
-from torch.distributed.checkpoint.state_dict import (
-    get_model_state_dict,
-    set_model_state_dict,
-    StateDictOptions,
-)
 from torch.distributed.checkpoint.state_dict_saver import (
     AsyncCheckpointerType,
     AsyncSaveResponse,
 )
 from torch.distributed.checkpoint.stateful import Stateful
+from torchtitan.components.checkpoint_utils import (
+    canonical_model_state_dict,
+    load_canonical_model_state_dict,
+)
 from torchtitan.components.dataloader import BaseDataLoader
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -88,23 +86,21 @@ class ModelWrapper(Stateful):
         self.cached_state_dict = self._get_state_dict()
 
     def _get_state_dict(self) -> dict[str, Any]:
-        state_dict = {
-            k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()
+        return {
+            k: v
+            for model in self.model
+            for k, v in canonical_model_state_dict(model).items()
         }
-        return state_dict
 
     def state_dict(self) -> dict[str, Any]:
         return self.cached_state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        func = functools.partial(
-            set_model_state_dict,
-            model_state_dict=state_dict,
-            options=StateDictOptions(strict=False),
-        )
-        list(map(func, self.model))
-        # `set_model_state_dict()` does change the keys of the input state_dict,
-        # we will need to reinitialize the cache_state_dict.
+        # strict=False because state_dict is the flattened checkpoint dict, which
+        # mixes model FQN keys with non-model keys (optimizer, lr_scheduler, ...).
+        for model in self.model:
+            load_canonical_model_state_dict(model, state_dict, strict=False)
+        # Refresh the cache so state_dict() reflects the freshly loaded values.
         self.cached_state_dict = self._get_state_dict()
 
 
@@ -156,11 +152,10 @@ class CheckpointManager(Configurable):
     Then when reloading, only one stage can restore its optimizer states, others will
     error.
 
-        The solution to this problem is optimizer flattening: it landed in #127071 and
-        is enabled in TorchTitan by passing the 'flatten_optimizer_state_dict' kwarg to
-        DCP functions called in the OptimizerContainer. See PR #127071
-        (https://github.com/pytorch/pytorch/pull/127071) for the example of a flattening
-        state_dict.
+        The solution to this problem is optimizer flattening (see PR #127071
+        https://github.com/pytorch/pytorch/pull/127071). TorchTitan's
+        OptimizersContainer flattens optimizer state dicts to FQN-keyed flat dicts
+        using the utilities in torchtitan/components/checkpoint_utils.py.
 
     2. With complex PP schedules, we have multiple model chunks per pp rank. This
     compounds challenge (1) by also requiring us to reason about multiple 'optim'

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -82,10 +82,10 @@ class ModelWrapper(Stateful):
         self.cached_state_dict = self._get_state_dict()
 
     def _get_state_dict(self) -> dict[str, Any]:
-        # model.state_dict() keys are already canonical FQNs: torchtitan compiles
-        # in place (no _orig_mod prefix) and the activation checkpoint wrapper
-        # strips its own _checkpoint_wrapped_module prefix via a state_dict hook,
-        # so no key cleaning is needed here.
+        # model.state_dict() keys are already canonical FQNs: torchtitan applies
+        # torch.compile in place (it adds no wrapper segment) and the activation
+        # checkpoint wrapper strips its own _checkpoint_wrapped_module segment via a
+        # state_dict hook, so no key cleaning is needed here.
         return {k: v for model in self.model for k, v in model.state_dict().items()}
 
     def state_dict(self) -> dict[str, Any]:

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -1,0 +1,306 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Minimal state-dict helpers for distributed checkpointing.
+
+These utilities are a focused replacement for the parts of
+``torch.distributed.checkpoint.state_dict`` that TorchTitan actually needs.
+The upstream APIs (``get_model_state_dict``, ``set_optimizer_state_dict``, ...)
+carry a lot of complexity from legacy FSDP1/DDP support that does not apply to
+TorchTitan. The functions here operate directly on ``nn.Module`` and
+``torch.optim.Optimizer`` state dicts and only exist because of distributed
+checkpointing; they are model-agnostic and optimizer-agnostic, and are good
+candidates for upstreaming back to PyTorch.
+
+There are two groups of helpers:
+
+- Model: ``canonical_model_state_dict`` / ``load_canonical_model_state_dict``
+  strip wrapper prefixes (``_orig_mod``, ``_checkpoint_wrapped_module``) so the
+  saved keys match the original module FQNs regardless of compile/AC wrapping.
+- Optimizer: ``get_flat_optim_state_dict`` / ``load_flat_optim_state_dict``
+  convert between an optimizer's native (integer-indexed) state dict and a flat,
+  FQN-keyed dict that DCP can save and reshard. ``init_optim_state`` materializes
+  optimizer state and is a precondition for both.
+"""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+__all__ = [
+    "canonical_fqn",
+    "canonical_model_state_dict",
+    "load_canonical_model_state_dict",
+    "init_optim_state",
+    "get_flat_optim_state_dict",
+    "load_flat_optim_state_dict",
+]
+
+# Wrapper segments inserted by torch.compile (``_orig_mod``) and activation
+# checkpointing (``_checkpoint_wrapped_module``). They can appear at any level
+# of the FQN and are not part of the canonical model contract.
+_WRAPPER_PREFIXES: tuple[str, ...] = ("_orig_mod", "_checkpoint_wrapped_module")
+
+
+def canonical_fqn(name: str, prefixes: tuple[str, ...] = _WRAPPER_PREFIXES) -> str:
+    """Strip wrapper segments from a dotted FQN.
+
+    The segments may appear at any level, e.g.
+    ``layers.0._orig_mod.attention.wq.weight`` or
+    ``layers.0._checkpoint_wrapped_module.attention.wq.weight``.
+    """
+    return ".".join(p for p in name.split(".") if p not in prefixes)
+
+
+def canonical_model_state_dict(
+    model: nn.Module,
+    *,
+    prefixes: tuple[str, ...] = _WRAPPER_PREFIXES,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Return ``model.state_dict()`` with wrapper prefixes stripped from keys."""
+    return {
+        canonical_fqn(k, prefixes): v for k, v in model.state_dict(**kwargs).items()
+    }
+
+
+def load_canonical_model_state_dict(
+    model: nn.Module,
+    state_dict: dict[str, Any],
+    *,
+    prefixes: tuple[str, ...] = _WRAPPER_PREFIXES,
+    strict: bool = True,
+    **kwargs: Any,
+) -> None:
+    """Load a canonical-keyed state dict into a possibly-wrapped model.
+
+    The model's live keys may carry wrapper prefixes (``_orig_mod`` etc.), while
+    ``state_dict`` is keyed by canonical FQNs. This builds the
+    ``canonical -> live`` mapping from the model's own keys and remaps the
+    checkpoint before calling ``model.load_state_dict``.
+
+    When ``strict`` is True, mismatches are reported in canonical-key terms,
+    which is more readable than the wrapped keys PyTorch would otherwise report.
+    """
+    canonical_to_live: dict[str, str] = {
+        canonical_fqn(key, prefixes): key for key in model.state_dict(keep_vars=True)
+    }
+
+    remapped: dict[str, Any] = {}
+    unexpected_keys: list[str] = []
+    for key, value in state_dict.items():
+        if key in canonical_to_live:
+            remapped[canonical_to_live[key]] = value
+        else:
+            unexpected_keys.append(key)
+
+    if strict:
+        if unexpected_keys:
+            raise KeyError(
+                f"State dict has {len(unexpected_keys)} key(s) with no matching "
+                f"model parameter (after stripping {prefixes}): {unexpected_keys}"
+            )
+        missing_keys = sorted(k for k in canonical_to_live if k not in state_dict)
+        if missing_keys:
+            raise KeyError(
+                f"State dict is missing {len(missing_keys)} model parameter(s) "
+                f"(after stripping {prefixes}): {missing_keys}"
+            )
+
+    model.load_state_dict(remapped, strict=strict, **kwargs)
+
+
+def init_optim_state(optim: torch.optim.Optimizer) -> None:
+    """Materialize optimizer state by running one zero-gradient, zero-lr step.
+
+    Optimizers create their state (e.g. Adam's ``exp_avg``) lazily on the first
+    ``step()``. DCP needs the state tensors to exist before save (to read them)
+    and before load (to load into them). This runs a step with zero gradients
+    and ``lr=0`` so parameters are untouched, then restores ``lr``.
+
+    No-op if state already exists or any gradient is set, so it is safe to call
+    repeatedly and never disturbs an in-progress training step.
+
+    Adapted from ``torch.distributed.checkpoint.state_dict._init_optim_state`` to
+    drop the dependency on that private API.
+    """
+    if optim.state:
+        return
+
+    for param_group in optim.param_groups:
+        for param in param_group["params"]:
+            if param.grad is not None:
+                return
+
+    for param_group in optim.param_groups:
+        for param in param_group["params"]:
+            if param.requires_grad:
+                param.grad = torch.zeros_like(param)
+
+    # Some optimizers update parameters regardless of gradients due to lr, so set
+    # lr to zero before stepping to keep parameters unchanged.
+    saved_lrs = []
+    for param_group in optim.param_groups:
+        if "lr" in param_group:
+            saved_lrs.append(param_group["lr"])
+            param_group["lr"] = (
+                torch.tensor(0.0)
+                if isinstance(param_group["lr"], torch.Tensor)
+                else 0.0
+            )
+    optim.step(closure=None)
+    for param_group in optim.param_groups:
+        if "lr" in param_group:
+            param_group["lr"] = saved_lrs.pop(0)
+    optim.zero_grad(set_to_none=True)
+
+
+def get_flat_optim_state_dict(optim: torch.optim.Optimizer) -> dict[str, Any]:
+    """Return a flat, FQN-keyed optimizer state dict ready for DCP.
+
+    Output keys are ``state.{fqn}.{state_name}`` and ``param_groups.{fqn}.{key}``.
+    The flat layout avoids the integer ``param_group`` index collisions that break
+    pipeline-parallel checkpoints (multiple chunks reusing index 0).
+
+    The optimizer state must already exist; call ``init_optim_state`` first.
+    """
+    fqn_sd = _optim_state_dict_to_fqn_keys(optim.state_dict())
+
+    flat: dict[str, Any] = {}
+    for fqn, state in fqn_sd["state"].items():
+        _flatten_state_nested(state, f"state.{fqn}", flat)
+    for param_group in fqn_sd["param_groups"]:
+        for fqn in param_group["params"]:
+            for key, value in param_group.items():
+                if key != "params":
+                    flat[f"param_groups.{fqn}.{key}"] = value
+    return flat
+
+
+def load_flat_optim_state_dict(
+    optim: torch.optim.Optimizer, flat_sd: dict[str, Any]
+) -> None:
+    """Load a flat, FQN-keyed optimizer state dict into ``optim``.
+
+    Inverse of ``get_flat_optim_state_dict``. The optimizer state must already
+    exist (it tells us which state tensors to expect); call ``init_optim_state``
+    first. Keys in ``flat_sd`` that this optimizer does not own are ignored, so a
+    single flat dict covering several optimizers can be passed to each of them.
+    """
+    optim.load_state_dict(_unflatten_optim_state_dict(optim, flat_sd))
+
+
+def _optim_state_dict_to_fqn_keys(optim_sd: dict[str, Any]) -> dict[str, Any]:
+    """Re-key an optimizer state dict from integer param ids to FQNs.
+
+    Relies on ``param_names`` in each param group, which PyTorch populates when
+    the optimizer is built with ``(name, param)`` tuples. ``param_names`` is
+    dropped from the result.
+    """
+    id_to_fqn: dict[int, str] = {}
+    new_param_groups: list[dict[str, Any]] = []
+    for param_group in optim_sd["param_groups"]:
+        if "param_names" not in param_group:
+            raise ValueError(
+                "Optimizer must be built with (name, param) tuples so that "
+                "param_names is available for FQN-keyed state dicts."
+            )
+        fqns = param_group["param_names"]
+        for param_id, fqn in zip(param_group["params"], fqns):
+            id_to_fqn[param_id] = fqn
+        new_group = {k: v for k, v in param_group.items() if k != "param_names"}
+        new_group["params"] = list(fqns)
+        new_param_groups.append(new_group)
+
+    new_state: dict[str, Any] = {}
+    for param_id, state in optim_sd["state"].items():
+        if param_id not in id_to_fqn:
+            raise KeyError(
+                f"Optimizer state has param id {param_id} that is not in any "
+                f"param group. Known ids: {sorted(id_to_fqn)}"
+            )
+        new_state[id_to_fqn[param_id]] = state
+
+    return {"state": new_state, "param_groups": new_param_groups}
+
+
+def _unflatten_optim_state_dict(
+    optim: torch.optim.Optimizer, flat_sd: dict[str, Any]
+) -> dict[str, Any]:
+    """Rebuild an integer-keyed optimizer state dict from a flat, FQN-keyed one.
+
+    Walks the live optimizer's param groups to recover the FQN order and the set
+    of state tensors to expect, then pulls matching values out of ``flat_sd``.
+    """
+    state: dict[int, dict[str, Any]] = {}
+    param_groups: list[dict[str, Any]] = []
+    param_id = 0
+    for param_group in optim.param_groups:
+        fqns = param_group["param_names"]
+        params = param_group["params"]
+        ids: list[int] = []
+        for fqn, param in zip(fqns, params):
+            ids.append(param_id)
+            if param in optim.state:
+                param_state: dict[str, Any] = {}
+                for state_name in optim.state[param]:
+                    flat_key = f"state.{fqn}.{state_name}"
+                    if flat_key in flat_sd:
+                        param_state[state_name] = flat_sd[flat_key]
+                    else:
+                        # State value is itself a nested dict (e.g. Shampoo).
+                        nested = _reconstruct_nested(flat_sd, flat_key)
+                        if nested:
+                            param_state[state_name] = nested
+                if param_state:
+                    state[param_id] = param_state
+            param_id += 1
+
+        if not fqns:
+            param_groups.append({"params": ids})
+            continue
+        new_group: dict[str, Any] = {"params": ids}
+        for key in param_group:
+            if key in ("params", "param_names"):
+                continue
+            flat_key = f"param_groups.{fqns[0]}.{key}"
+            if flat_key not in flat_sd:
+                raise KeyError(
+                    f"Optimizer param group key {key!r} not found in checkpoint "
+                    f"(looked up via param {fqns[0]!r})."
+                )
+            new_group[key] = flat_sd[flat_key]
+        param_groups.append(new_group)
+
+    return {"state": state, "param_groups": param_groups}
+
+
+def _flatten_state_nested(
+    state: dict[str, Any], prefix: str, out: dict[str, Any]
+) -> None:
+    """Flatten a (possibly nested) per-param state dict into dotted keys."""
+    for key, value in state.items():
+        flat_key = f"{prefix}.{key}"
+        if isinstance(value, dict):
+            _flatten_state_nested(value, flat_key, out)
+        else:
+            out[flat_key] = value
+
+
+def _reconstruct_nested(flat_sd: dict[str, Any], prefix: str) -> dict[str, Any]:
+    """Rebuild the nested dict stored under ``prefix`` in a flat state dict."""
+    result: dict[str, Any] = {}
+    prefix_dot = prefix + "."
+    for key, value in flat_sd.items():
+        if not key.startswith(prefix_dot):
+            continue
+        current = result
+        parts = key[len(prefix_dot) :].split(".")
+        for part in parts[:-1]:
+            current = current.setdefault(part, {})
+        current[parts[-1]] = value
+    return result

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -9,32 +9,31 @@
 These utilities are a focused replacement for the parts of
 ``torch.distributed.checkpoint.state_dict`` that TorchTitan actually needs.
 The upstream APIs (``get_model_state_dict``, ``set_optimizer_state_dict``, ...)
-carry a lot of complexity from legacy FSDP1/DDP support that does not apply to
-TorchTitan. The functions here operate directly on ``nn.Module`` and
-``torch.optim.Optimizer`` state dicts and only exist because of distributed
-checkpointing; they are model-agnostic and optimizer-agnostic, and are good
-candidates for upstreaming back to PyTorch.
+carry a lot of complexity from legacy FSDP1/DDP support and many features
+that does not apply to TorchTitan. The functions here operate directly on
+``nn.Module`` and ``torch.optim.Optimizer`` state dicts and only exist because of
+distributed checkpointing; they are model-agnostic and optimizer-agnostic.
 
-There are two groups of helpers:
+The helpers are:
 
-- Model: ``canonical_model_state_dict`` / ``load_canonical_model_state_dict``
-  strip wrapper prefixes (``_orig_mod``, ``_checkpoint_wrapped_module``) so the
-  saved keys match the original module FQNs regardless of compile/AC wrapping.
-- Optimizer: ``get_flat_optim_state_dict`` / ``load_flat_optim_state_dict``
-  convert between an optimizer's native (integer-indexed) state dict and a flat,
-  FQN-keyed dict that DCP can save and reshard. ``init_optim_state`` materializes
-  optimizer state and is a precondition for both.
+- ``canonical_fqn`` strips wrapper prefixes (``_orig_mod``,
+  ``_checkpoint_wrapped_module``) from a single FQN. The model state dict is
+  already canonical -- in-place ``torch.compile`` adds no prefix and the
+  activation-checkpoint wrapper strips its own prefix via a state_dict hook -- but
+  ``nn.Module.named_parameters()`` is not, so optimizer construction uses this to
+  produce FQN-keyed optimizer state that matches the model keys.
+- ``get_flat_optim_state_dict`` / ``load_flat_optim_state_dict`` convert between
+  an optimizer's native (integer-indexed) state dict and a flat, FQN-keyed dict
+  that DCP can save and reshard. ``init_optim_state`` materializes optimizer
+  state and is a precondition for both.
 """
 
 from typing import Any
 
 import torch
-import torch.nn as nn
 
 __all__ = [
     "canonical_fqn",
-    "canonical_model_state_dict",
-    "load_canonical_model_state_dict",
     "init_optim_state",
     "get_flat_optim_state_dict",
     "load_flat_optim_state_dict",
@@ -54,64 +53,6 @@ def canonical_fqn(name: str, prefixes: tuple[str, ...] = _WRAPPER_PREFIXES) -> s
     ``layers.0._checkpoint_wrapped_module.attention.wq.weight``.
     """
     return ".".join(p for p in name.split(".") if p not in prefixes)
-
-
-def canonical_model_state_dict(
-    model: nn.Module,
-    *,
-    prefixes: tuple[str, ...] = _WRAPPER_PREFIXES,
-    **kwargs: Any,
-) -> dict[str, Any]:
-    """Return ``model.state_dict()`` with wrapper prefixes stripped from keys."""
-    return {
-        canonical_fqn(k, prefixes): v for k, v in model.state_dict(**kwargs).items()
-    }
-
-
-def load_canonical_model_state_dict(
-    model: nn.Module,
-    state_dict: dict[str, Any],
-    *,
-    prefixes: tuple[str, ...] = _WRAPPER_PREFIXES,
-    strict: bool = True,
-    **kwargs: Any,
-) -> None:
-    """Load a canonical-keyed state dict into a possibly-wrapped model.
-
-    The model's live keys may carry wrapper prefixes (``_orig_mod`` etc.), while
-    ``state_dict`` is keyed by canonical FQNs. This builds the
-    ``canonical -> live`` mapping from the model's own keys and remaps the
-    checkpoint before calling ``model.load_state_dict``.
-
-    When ``strict`` is True, mismatches are reported in canonical-key terms,
-    which is more readable than the wrapped keys PyTorch would otherwise report.
-    """
-    canonical_to_live: dict[str, str] = {
-        canonical_fqn(key, prefixes): key for key in model.state_dict(keep_vars=True)
-    }
-
-    remapped: dict[str, Any] = {}
-    unexpected_keys: list[str] = []
-    for key, value in state_dict.items():
-        if key in canonical_to_live:
-            remapped[canonical_to_live[key]] = value
-        else:
-            unexpected_keys.append(key)
-
-    if strict:
-        if unexpected_keys:
-            raise KeyError(
-                f"State dict has {len(unexpected_keys)} key(s) with no matching "
-                f"model parameter (after stripping {prefixes}): {unexpected_keys}"
-            )
-        missing_keys = sorted(k for k in canonical_to_live if k not in state_dict)
-        if missing_keys:
-            raise KeyError(
-                f"State dict is missing {len(missing_keys)} model parameter(s) "
-                f"(after stripping {prefixes}): {missing_keys}"
-            )
-
-    model.load_state_dict(remapped, strict=strict, **kwargs)
 
 
 def init_optim_state(optim: torch.optim.Optimizer) -> None:

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -4,13 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Minimal state-dict helpers for distributed checkpointing.
+"""State-dict helpers for distributed checkpointing.
 
-These utilities are a focused replacement for the parts of
-``torch.distributed.checkpoint.state_dict`` that TorchTitan actually needs.
-The upstream APIs (``get_model_state_dict``, ``set_optimizer_state_dict``, ...)
-carry a lot of complexity from legacy FSDP1/DDP support and many features
-that do not apply to TorchTitan.
+These utilities operate directly on ``nn.Module`` and ``torch.optim.Optimizer``
+state dicts; they are model-agnostic and optimizer-agnostic.
 
 The helpers are:
 
@@ -63,9 +60,6 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
 
     No-op if state already exists or any gradient is set, so it is safe to call
     repeatedly and never disturbs an in-progress training step.
-
-    Adapted from ``torch.distributed.checkpoint.state_dict._init_optim_state`` to
-    drop the dependency on that private API.
     """
     if optim.state:
         return

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -16,10 +16,10 @@ distributed checkpointing; they are model-agnostic and optimizer-agnostic.
 
 The helpers are:
 
-- ``canonical_fqn`` strips wrapper prefixes (``_orig_mod``,
-  ``_checkpoint_wrapped_module``) from a single FQN. The model state dict is
-  already canonical -- in-place ``torch.compile`` adds no prefix and the
-  activation-checkpoint wrapper strips its own prefix via a state_dict hook -- but
+- ``canonical_fqn`` strips the activation-checkpoint wrapper segment
+  (``_checkpoint_wrapped_module``) from a single FQN. The model state dict is
+  already canonical -- ``torch.compile`` is applied in place (no segment) and the
+  activation-checkpoint wrapper strips its own segment via a state_dict hook -- but
   ``nn.Module.named_parameters()`` is not, so optimizer construction uses this to
   produce FQN-keyed optimizer state that matches the model keys.
 - ``get_flat_optim_state_dict`` / ``load_flat_optim_state_dict`` convert between
@@ -39,18 +39,18 @@ __all__ = [
     "load_flat_optim_state_dict",
 ]
 
-# Wrapper segments inserted by torch.compile (``_orig_mod``) and activation
-# checkpointing (``_checkpoint_wrapped_module``). They can appear at any level
-# of the FQN and are not part of the canonical model contract.
-_WRAPPER_PREFIXES: tuple[str, ...] = ("_orig_mod", "_checkpoint_wrapped_module")
+# Segment inserted by the activation checkpoint wrapper (checkpoint_wrapper) in
+# named_parameters(). It can appear at any level of the FQN and is not part of the
+# canonical model contract. torch.compile is applied in place and adds no segment.
+_WRAPPER_PREFIXES: tuple[str, ...] = ("_checkpoint_wrapped_module",)
 
 
 def canonical_fqn(name: str, prefixes: tuple[str, ...] = _WRAPPER_PREFIXES) -> str:
     """Strip wrapper segments from a dotted FQN.
 
-    The segments may appear at any level, e.g.
-    ``layers.0._orig_mod.attention.wq.weight`` or
-    ``layers.0._checkpoint_wrapped_module.attention.wq.weight``.
+    A segment may appear at any level, e.g.
+    ``layers.0._checkpoint_wrapped_module.attention.wq.weight`` ->
+    ``layers.0.attention.wq.weight``.
     """
     return ".".join(p for p in name.split(".") if p not in prefixes)
 

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -10,9 +10,7 @@ These utilities are a focused replacement for the parts of
 ``torch.distributed.checkpoint.state_dict`` that TorchTitan actually needs.
 The upstream APIs (``get_model_state_dict``, ``set_optimizer_state_dict``, ...)
 carry a lot of complexity from legacy FSDP1/DDP support and many features
-that does not apply to TorchTitan. The functions here operate directly on
-``nn.Module`` and ``torch.optim.Optimizer`` state dicts and only exist because of
-distributed checkpointing; they are model-agnostic and optimizer-agnostic.
+that do not apply to TorchTitan.
 
 The helpers are:
 

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -201,10 +201,6 @@ class LRSchedulersContainer(Stateful, Configurable):
         ), "Must have at least one optimizer to create LRScheduler"
 
         self.schedulers = [LambdaLR(optimizer, lr_lambda) for optimizer in optimizers]
-        # Per-optimizer regex patterns (aligned with self.schedulers), used as lr
-        # metric labels. Sourced from the container so patterns stay off the
-        # optimizer param groups and out of the saved state dict.
-        self._param_group_patterns = optimizers._param_group_patterns
 
     def __iter__(self) -> Iterator[LRScheduler]:
         return iter(self.schedulers)
@@ -213,12 +209,14 @@ class LRSchedulersContainer(Stateful, Configurable):
         return len(self.schedulers)
 
     def get_metrics(self) -> dict[str, float]:
-        """Return per-param-group learning rates keyed for logging."""
+        """Return learning rates keyed by optimizer (and param-group index)."""
         metrics = {}
-        for scheduler, patterns in zip(self.schedulers, self._param_group_patterns):
+        for scheduler in self.schedulers:
             opt_name = type(scheduler.optimizer).__name__
-            for pattern, lr_val in zip(patterns, scheduler.get_last_lr()):
-                metrics[f"lr/{opt_name}_{pattern}"] = float(lr_val)
+            last_lrs = scheduler.get_last_lr()
+            for i, lr_val in enumerate(last_lrs):
+                key = f"lr/{opt_name}" if len(last_lrs) == 1 else f"lr/{opt_name}/{i}"
+                metrics[key] = float(lr_val)
         return metrics
 
     def step(self) -> None:

--- a/torchtitan/components/lr_scheduler.py
+++ b/torchtitan/components/lr_scheduler.py
@@ -201,6 +201,10 @@ class LRSchedulersContainer(Stateful, Configurable):
         ), "Must have at least one optimizer to create LRScheduler"
 
         self.schedulers = [LambdaLR(optimizer, lr_lambda) for optimizer in optimizers]
+        # Per-optimizer regex patterns (aligned with self.schedulers), used as lr
+        # metric labels. Sourced from the container so patterns stay off the
+        # optimizer param groups and out of the saved state dict.
+        self._param_group_patterns = optimizers._param_group_patterns
 
     def __iter__(self) -> Iterator[LRScheduler]:
         return iter(self.schedulers)
@@ -211,11 +215,10 @@ class LRSchedulersContainer(Stateful, Configurable):
     def get_metrics(self) -> dict[str, float]:
         """Return per-param-group learning rates keyed for logging."""
         metrics = {}
-        for scheduler in self.schedulers:
-            opt = scheduler.optimizer
-            opt_name = type(opt).__name__
-            for group, lr_val in zip(opt.param_groups, scheduler.get_last_lr()):
-                metrics[f"lr/{opt_name}_{group['pattern']}"] = float(lr_val)
+        for scheduler, patterns in zip(self.schedulers, self._param_group_patterns):
+            opt_name = type(scheduler.optimizer).__name__
+            for pattern, lr_val in zip(patterns, scheduler.get_last_lr()):
+                metrics[f"lr/{opt_name}_{pattern}"] = float(lr_val)
         return metrics
 
     def step(self) -> None:

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -119,6 +119,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     optimizers: list[T]
     model_parts: list[nn.Module]
+    # Regex patterns per optimizer (aligned with ``optimizers``); each entry is
+    # the list of patterns for that optimizer's param groups. Kept here, off the
+    # optimizer param groups, so they feed logging and lr metrics without leaking
+    # into the saved optimizer state dict.
+    _param_group_patterns: list[list[str]]
 
     @staticmethod
     def _resolve_optimizer_cls(name: str) -> type:
@@ -201,8 +206,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
-        # (optimizer, model_part_index, patterns) collected only for logging.
-        summary: list[tuple[Optimizer, int, list[str]]] = []
+        self._param_group_patterns = []
+        # Model-part index per optimizer, only for the construction-time summary
+        # log. Not persisted: state_dict no longer needs this mapping.
+        model_part_per_optimizer: list[int] = []
 
         for part_idx, model in enumerate(self.model_parts):
             groups_by_opt_name = self._build_param_groups(
@@ -214,7 +221,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                 patterns = [group.pop("pattern") for group in opt_param_groups]
                 optimizer = self._resolve_optimizer_cls(opt_name)(opt_param_groups)
                 self.optimizers.append(optimizer)
-                summary.append((optimizer, part_idx, patterns))
+                self._param_group_patterns.append(patterns)
+                model_part_per_optimizer.append(part_idx)
                 for group in opt_param_groups:
                     all_params.extend(group["params"])
 
@@ -223,14 +231,13 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
         self._post_init(all_params)
-        self._log_summary(summary)
+        self._log_summary(model_part_per_optimizer)
 
-    def _log_summary(self, summary: list[tuple[Optimizer, int, list[str]]]) -> None:
+    def _log_summary(self, model_part_per_optimizer: list[int]) -> None:
         """Log a summary of optimizer assignments.
 
-        ``summary`` carries the per-optimizer model-part index and regex patterns
-        gathered at construction time, so the container does not need to keep a
-        persistent optimizer-to-model-part mapping.
+        ``model_part_per_optimizer`` is gathered at construction time, so the
+        container does not need to persist an optimizer-to-model-part mapping.
         """
         _KEY_KWARGS = {
             "lr",
@@ -242,7 +249,9 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             "fused",
             "foreach",
         }
-        for optimizer, part_idx, patterns in summary:
+        for optimizer, part_idx, patterns in zip(
+            self.optimizers, model_part_per_optimizer, self._param_group_patterns
+        ):
             opt_name = type(optimizer).__name__
             for group, pattern in zip(optimizer.param_groups, patterns):
                 num_params = len(group["params"])

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import functools
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterator
@@ -15,14 +14,15 @@ import torch
 import torch.distributed.tensor
 import torch.nn as nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl
-from torch.distributed.checkpoint.state_dict import (
-    get_optimizer_state_dict,
-    set_optimizer_state_dict,
-    StateDictOptions,
-)
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.tensor import Replicate
 from torch.optim import Optimizer
+from torchtitan.components.checkpoint_utils import (
+    canonical_fqn,
+    get_flat_optim_state_dict,
+    init_optim_state,
+    load_flat_optim_state_dict,
+)
 from torchtitan.config import Configurable
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools.logging import logger
@@ -156,21 +156,28 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         Each parameter is assigned to the first matching ParamGroupConfig pattern.
         Returns a dict mapping optimizer name to a list of param group dicts.
 
-        Each param group dict includes a ``pattern`` key with the regex pattern
-        string for logging.
+        Each group also carries a ``param_names`` list (canonical FQNs aligned
+        with ``params``) so PyTorch records the names on the group; the checkpoint
+        utilities use those names to build FQN-keyed optimizer state dicts.
+
+        Each param group dict also carries a ``pattern`` key (the regex string)
+        for logging. The caller pops it before constructing the optimizer so it
+        does not leak into the saved optimizer state dict.
         """
         result: dict[str, list[dict[str, Any]]] = defaultdict(list)
         claimed: set[str] = set()  # first-match-wins
 
         for pg in param_group_configs:
             pattern = re.compile(pg.pattern)
-            matched = []
+            params: list[nn.Parameter] = []
+            param_names: list[str] = []
             for name, param in model.named_parameters():
                 if param.requires_grad and name not in claimed and pattern.search(name):
-                    matched.append(param)
+                    params.append(param)
+                    param_names.append(canonical_fqn(name))
                     claimed.add(name)
 
-            if not matched:
+            if not params:
                 raise ValueError(
                     f"Optimizer param_groups pattern '{pg.pattern}' "
                     f"matched no parameters"
@@ -178,7 +185,8 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
             result[pg.optimizer_name].append(
                 {
-                    "params": matched,
+                    "params": params,
+                    "param_names": param_names,
                     "pattern": pg.pattern,
                     **impl_kwargs,
                     **pg.optimizer_kwargs,
@@ -193,17 +201,20 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
-        # Maps each optimizer to its model part (for state_dict/load_state_dict)
-        self._model_part_indices: list[int] = []
+        # (optimizer, model_part_index, patterns) collected only for logging.
+        summary: list[tuple[Optimizer, int, list[str]]] = []
 
         for part_idx, model in enumerate(self.model_parts):
             groups_by_opt_name = self._build_param_groups(
                 model, param_group_configs, impl_kwargs
             )
             for opt_name, opt_param_groups in groups_by_opt_name.items():
-                opt_cls = self._resolve_optimizer_cls(opt_name)
-                self.optimizers.append(opt_cls(opt_param_groups))
-                self._model_part_indices.append(part_idx)
+                # Pattern is logging-only; pop it so the optimizer never stores
+                # it (which would put it in the saved optimizer state dict).
+                patterns = [group.pop("pattern") for group in opt_param_groups]
+                optimizer = self._resolve_optimizer_cls(opt_name)(opt_param_groups)
+                self.optimizers.append(optimizer)
+                summary.append((optimizer, part_idx, patterns))
                 for group in opt_param_groups:
                     all_params.extend(group["params"])
 
@@ -212,10 +223,15 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
         self._post_init(all_params)
-        self._log_summary()
+        self._log_summary(summary)
 
-    def _log_summary(self) -> None:
-        """Log a summary of optimizer assignments."""
+    def _log_summary(self, summary: list[tuple[Optimizer, int, list[str]]]) -> None:
+        """Log a summary of optimizer assignments.
+
+        ``summary`` carries the per-optimizer model-part index and regex patterns
+        gathered at construction time, so the container does not need to keep a
+        persistent optimizer-to-model-part mapping.
+        """
         _KEY_KWARGS = {
             "lr",
             "weight_decay",
@@ -226,13 +242,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             "fused",
             "foreach",
         }
-        for i, opt in enumerate(self.optimizers):
-            opt_name = type(opt).__name__
-            part_idx = self._model_part_indices[i]
-            for group in opt.param_groups:
+        for optimizer, part_idx, patterns in summary:
+            opt_name = type(optimizer).__name__
+            for group, pattern in zip(optimizer.param_groups, patterns):
                 num_params = len(group["params"])
                 kwargs = {k: v for k, v in group.items() if k in _KEY_KWARGS}
-                pattern = group["pattern"]
                 logger.info(
                     f"Optimizer {opt_name} (model_part={part_idx}): "
                     f"{num_params} params [{pattern}] {kwargs}"
@@ -277,24 +291,25 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             optimizer.zero_grad(set_to_none=set_to_none)
 
     def state_dict(self) -> dict[str, Any]:
-        func = functools.partial(
-            get_optimizer_state_dict,
-            options=StateDictOptions(flatten_optimizer_state_dict=True),
-        )
-        result = {}
-        for opt, part_idx in zip(self.optimizers, self._model_part_indices):
-            sd = func(self.model_parts[part_idx], opt)
-            result.update(sd)
+        """Return a flat, FQN-keyed optimizer state dict for all optimizers.
+
+        Side effect: if an optimizer's state has not been created yet (no training
+        step taken), ``init_optim_state`` materializes it with a zero-gradient,
+        zero-lr step before reading. The step leaves parameters unchanged, and the
+        call is a no-op once state exists.
+        """
+        result: dict[str, Any] = {}
+        for optim in self.optimizers:
+            init_optim_state(optim)
+            result.update(get_flat_optim_state_dict(optim))
         return result
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        func = functools.partial(
-            set_optimizer_state_dict,
-            optim_state_dict=state_dict,
-            options=StateDictOptions(flatten_optimizer_state_dict=True),
-        )
-        for opt, part_idx in zip(self.optimizers, self._model_part_indices):
-            func(self.model_parts[part_idx], opt)
+        # init_optim_state must run first: the unflatten step reads each
+        # optimizer's live state to learn which state tensors to expect.
+        for optim in self.optimizers:
+            init_optim_state(optim)
+            load_flat_optim_state_dict(optim, state_dict)
 
     def _post_init(self, all_params: list[nn.Parameter]) -> None:
         # We need to call Optimizer.__init__() to initialize some necessary optimizer

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -119,11 +119,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     optimizers: list[T]
     model_parts: list[nn.Module]
-    # Regex patterns per optimizer (aligned with ``optimizers``); each entry is
-    # the list of patterns for that optimizer's param groups. Kept here, off the
-    # optimizer param groups, so they feed logging and lr metrics without leaking
-    # into the saved optimizer state dict.
-    _param_group_patterns: list[list[str]]
 
     @staticmethod
     def _resolve_optimizer_cls(name: str) -> type:
@@ -207,10 +202,6 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         all_params = []
         self.optimizers = []
         self.model_parts = model_parts
-        self._param_group_patterns = []
-
-        # Model-part index per optimizer, only for the log summary.
-        model_part_per_optimizer: list[int] = []
 
         for part_idx, model in enumerate(self.model_parts):
             groups_by_opt_name, patterns_by_opt_name = self._build_param_groups(
@@ -219,8 +210,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             for opt_name, opt_param_groups in groups_by_opt_name.items():
                 optimizer = self._resolve_optimizer_cls(opt_name)(opt_param_groups)
                 self.optimizers.append(optimizer)
-                self._param_group_patterns.append(patterns_by_opt_name[opt_name])
-                model_part_per_optimizer.append(part_idx)
+                self._log_optimizer(optimizer, part_idx, patterns_by_opt_name[opt_name])
                 for group in opt_param_groups:
                     all_params.extend(group["params"])
 
@@ -229,10 +219,11 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
         self._post_init(all_params)
-        self._log_summary(model_part_per_optimizer)
 
-    def _log_summary(self, model_part_per_optimizer: list[int]) -> None:
-        """Log a summary of optimizer assignments."""
+    def _log_optimizer(
+        self, optimizer: Optimizer, part_idx: int, patterns: list[str]
+    ) -> None:
+        """Log one optimizer's param-group assignments (patterns are logging-only)."""
         _KEY_KWARGS = {
             "lr",
             "weight_decay",
@@ -243,17 +234,14 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             "fused",
             "foreach",
         }
-        for optimizer, part_idx, patterns in zip(
-            self.optimizers, model_part_per_optimizer, self._param_group_patterns
-        ):
-            opt_name = type(optimizer).__name__
-            for group, pattern in zip(optimizer.param_groups, patterns):
-                num_params = len(group["params"])
-                kwargs = {k: v for k, v in group.items() if k in _KEY_KWARGS}
-                logger.info(
-                    f"Optimizer {opt_name} (model_part={part_idx}): "
-                    f"{num_params} params [{pattern}] {kwargs}"
-                )
+        opt_name = type(optimizer).__name__
+        for group, pattern in zip(optimizer.param_groups, patterns):
+            num_params = len(group["params"])
+            kwargs = {k: v for k, v in group.items() if k in _KEY_KWARGS}
+            logger.info(
+                f"Optimizer {opt_name} (model_part={part_idx}): "
+                f"{num_params} params [{pattern}] {kwargs}"
+            )
 
     def _validate_params(self, all_params: list[nn.Parameter]) -> None:
         """Verify every trainable param is assigned to exactly one optimizer."""

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -155,21 +155,22 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         model: nn.Module,
         param_group_configs: list[ParamGroupConfig],
         impl_kwargs: dict[str, Any],
-    ) -> dict[str, list[dict[str, Any]]]:
+    ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[str]]]:
         """Build PyTorch param groups from model parameters, partitioned by optimizer.
 
         Each parameter is assigned to the first matching ParamGroupConfig pattern.
-        Returns a dict mapping optimizer name to a list of param group dicts.
 
-        Each group also carries a ``param_names`` list (canonical FQNs aligned
-        with ``params``) so PyTorch records the names on the group; the checkpoint
-        utilities use those names to build FQN-keyed optimizer state dicts.
+        Returns two dicts keyed by optimizer name and aligned by index: the param
+        group dicts to pass to the optimizer constructor, and the regex pattern of
+        each group. Patterns are returned separately (not stored on the group) so
+        they stay out of the saved optimizer state dict; they are logging-only.
 
-        Each param group dict also carries a ``pattern`` key (the regex string)
-        for logging. The caller pops it before constructing the optimizer so it
-        does not leak into the saved optimizer state dict.
+        Each param group dict carries a ``param_names`` list (canonical FQNs
+        aligned with ``params``) so PyTorch records the names on the group; the
+        checkpoint utilities use those names to build FQN-keyed optimizer state.
         """
-        result: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        patterns: dict[str, list[str]] = defaultdict(list)
         claimed: set[str] = set()  # first-match-wins
 
         for pg in param_group_configs:
@@ -188,17 +189,17 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                     f"matched no parameters"
                 )
 
-            result[pg.optimizer_name].append(
+            groups[pg.optimizer_name].append(
                 {
                     "params": params,
                     "param_names": param_names,
-                    "pattern": pg.pattern,
                     **impl_kwargs,
                     **pg.optimizer_kwargs,
                 }
             )
+            patterns[pg.optimizer_name].append(pg.pattern)
 
-        return result
+        return groups, patterns
 
     def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
@@ -207,21 +208,18 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         self.optimizers = []
         self.model_parts = model_parts
         self._param_group_patterns = []
-        # Model-part index per optimizer, only for the construction-time summary
-        # log. Not persisted: state_dict no longer needs this mapping.
+
+        # Model-part index per optimizer, only for the log summary.
         model_part_per_optimizer: list[int] = []
 
         for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt_name = self._build_param_groups(
+            groups_by_opt_name, patterns_by_opt_name = self._build_param_groups(
                 model, param_group_configs, impl_kwargs
             )
             for opt_name, opt_param_groups in groups_by_opt_name.items():
-                # Pattern is logging-only; pop it so the optimizer never stores
-                # it (which would put it in the saved optimizer state dict).
-                patterns = [group.pop("pattern") for group in opt_param_groups]
                 optimizer = self._resolve_optimizer_cls(opt_name)(opt_param_groups)
                 self.optimizers.append(optimizer)
-                self._param_group_patterns.append(patterns)
+                self._param_group_patterns.append(patterns_by_opt_name[opt_name])
                 model_part_per_optimizer.append(part_idx)
                 for group in opt_param_groups:
                     all_params.extend(group["params"])
@@ -234,11 +232,7 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         self._log_summary(model_part_per_optimizer)
 
     def _log_summary(self, model_part_per_optimizer: list[int]) -> None:
-        """Log a summary of optimizer assignments.
-
-        ``model_part_per_optimizer`` is gathered at construction time, so the
-        container does not need to persist an optimizer-to-model-part mapping.
-        """
+        """Log a summary of optimizer assignments."""
         _KEY_KWARGS = {
             "lr",
             "weight_decay",

--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -130,7 +130,6 @@ def spmd_validate_redistributions(sharding_config: Any) -> None:
         # from the innermost position. For example, (DP) -> (DP, CP) is valid
         # when CP is the changed axis, but (DP) -> (CP, DP) changes shard order.
         changed_axis = changed_axes[0] if changed_axes else None
-        # pyrefly: ignore [bad-argument-type]
         for dim, (src_entry, dst_entry) in enumerate(zip(src_spec, dst_spec)):
             src_axes = (
                 ()

--- a/torchtitan/experiments/torchft/optimizer.py
+++ b/torchtitan/experiments/torchft/optimizer.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
 import torch.nn as nn
-from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
 
+from torchtitan.components.checkpoint_utils import init_optim_state
 from torchtitan.components.optimizer import OptimizersContainer
 
 if TYPE_CHECKING:
@@ -39,11 +39,8 @@ class TorchFTOptimizersContainer(OptimizersContainer):
 
         # Force to initialize the optimizer state so that `optim.step()`
         # won't be called by state_dict() and load_state_dict().
-        _ = {
-            k: v
-            for sd in map(get_optimizer_state_dict, model_parts, self.optimizers)
-            for k, v in sd.items()
-        }
+        for optim in self.optimizers:
+            init_optim_state(optim)
         self.cache_state_dict: dict[str, Any] = {}
         self._ft_optimizer = torchft.Optimizer(ft_manager.manager, self)
         # Whether to determine quorum using FT.optimizer,

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -34,14 +34,15 @@ NOTE (checkpoint compatibility) — this module checkpoints its own ``w13``
 parameter (FQN ``...feed_forward.w13``); it is **not** interchangeable with stock
 ``FeedForward`` checkpoints (``w1.weight`` / ``w3.weight``). A checkpoint saved
 with this override only loads back into a run that also uses it, and vice-versa.
-torchtitan's checkpointing uses DCP ``get_model_state_dict`` /
-``set_model_state_dict``, which resolve every state-dict key back to a real
-module attribute for DTensor/FSDP handling. A module-level ``state_dict`` hook
-that fabricates ``w1``/``w3`` keys is therefore bypassed and in fact errors
-(``'FusedSwiGLU' object has no attribute 'w1'``). Cross-layout interop with stock
+torchtitan's checkpointing uses ``canonical_model_state_dict`` /
+``load_canonical_model_state_dict`` (thin wrappers over ``nn.Module.state_dict``
+and ``load_state_dict`` that strip compile/AC prefixes), so every state-dict key
+must map to a real module parameter. A module-level ``state_dict`` hook that
+fabricates ``w1``/``w3`` keys cannot round-trip: the load side has no
+``w1``/``w3`` parameter to write into. Cross-layout interop with stock
 checkpoints requires a model-level ``BaseStateDictAdapter`` (the same mechanism
 used for HF conversion), which operates on the flat key→tensor dict after
-``get_model_state_dict``. The override mechanism does not yet expose a hook to
+``canonical_model_state_dict``. The override mechanism does not yet expose a hook to
 contribute such an adapter; a candidate design (an optional
 ``state_dict_translator`` on ``@override`` feeding ``from_hf``/``to_hf``) is
 tracked in https://github.com/pytorch/torchtitan/issues/3569. See ``OVERRIDE.md``

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -34,15 +34,14 @@ NOTE (checkpoint compatibility) — this module checkpoints its own ``w13``
 parameter (FQN ``...feed_forward.w13``); it is **not** interchangeable with stock
 ``FeedForward`` checkpoints (``w1.weight`` / ``w3.weight``). A checkpoint saved
 with this override only loads back into a run that also uses it, and vice-versa.
-torchtitan's checkpointing uses ``canonical_model_state_dict`` /
-``load_canonical_model_state_dict`` (thin wrappers over ``nn.Module.state_dict``
-and ``load_state_dict`` that strip compile/AC prefixes), so every state-dict key
-must map to a real module parameter. A module-level ``state_dict`` hook that
-fabricates ``w1``/``w3`` keys cannot round-trip: the load side has no
-``w1``/``w3`` parameter to write into. Cross-layout interop with stock
-checkpoints requires a model-level ``BaseStateDictAdapter`` (the same mechanism
-used for HF conversion), which operates on the flat key→tensor dict after
-``canonical_model_state_dict``. The override mechanism does not yet expose a hook to
+torchtitan's checkpointing uses ``nn.Module.state_dict`` / ``load_state_dict``
+directly, so every state-dict key must map to a real module parameter. A
+module-level ``state_dict`` hook that fabricates ``w1``/``w3`` keys cannot
+round-trip: the load side has no ``w1``/``w3`` parameter to write into.
+Cross-layout interop with stock checkpoints requires a model-level
+``BaseStateDictAdapter`` (the same mechanism used for HF conversion), which
+operates on the flat key->tensor dict from ``nn.Module.state_dict``. The override
+mechanism does not yet expose a hook to
 contribute such an adapter; a candidate design (an optional
 ``state_dict_translator`` on ``@override`` feeding ``from_hf``/``to_hf``) is
 tracked in https://github.com/pytorch/torchtitan/issues/3569. See ``OVERRIDE.md``


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3638
* __->__ #3623

**Summary:**
Same as https://github.com/pytorch/torchtitan/pull/2441/ but with new implementation to be compatiblewith the latest OptimizerContainer

**Verification:**
  | Check | Result |
  |---|---|
  | Checkpoint compat, FSDP (old saves -> new loads, resume to step 100) | PASS - bit-identical all 100
  steps |
  | Checkpoint compat, PP=2 (old saves -> new loads) | PASS - bit-identical |
  | loss_compare, FSDP (old vs new, 100 steps, seed checkpoint) | PASS - identical loss |
  | CPU unit tests (lr_scheduler, optimizer_param_groups, state_dict_keys, checkpoint) | 51 passed |
  | Full unit suite | 411 passed (2 unrelated tokenizer-download failures) |
  | Lint (ufmt, flake8, pydoclint) | pass |