### PR TITLE
Add num_generators field to RLTrainer.Config

### DIFF
--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -38,6 +38,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--num_steps 5",
                     "--trainer.parallelism.tensor_parallel_degree 2",
                     "--generator.parallelism.tensor_parallel_degree 2",
+                    "--num_generators 3",
                     "--group_size 2",
                     "--batcher.batch.seq_len 1024",
                     "--renderer.enable-thinking False",
@@ -51,7 +52,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             ],
             "RL GRPO TP=2 no compile",
             "rl_grpo_tp2_no_compile",
-            ngpu=4,
+            ngpu=8,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -22,10 +22,14 @@ class _FakeRLTrainer:
     def __init__(self, config=None):
         self.config = config
         self.events = []
+        self.setup_trainer_mesh = None
+        self.setup_generator_meshes = None
         self.instances.append(self)
 
     async def setup_async(self, *, trainer_mesh=None, generator_meshes=None):
         self.events.append("setup")
+        self.setup_trainer_mesh = trainer_mesh
+        self.setup_generator_meshes = generator_meshes
         if getattr(self.config, "fail_setup", False):
             raise RuntimeError("setup failed")
 
@@ -59,6 +63,7 @@ class _FakeConfig:
     trainer = _FakeTrainerConfig()
     # main() also reads config.generator.parallelism (same stubbing applies).
     generator = SimpleNamespace(parallelism=None)
+    num_generators = 1
 
     @property
     def __class__(self):
@@ -117,9 +122,13 @@ def stub_mesh_provisioning(monkeypatch):
     both and let the test intercept at the ``_FakeRLTrainer`` boundary.
     """
     monkeypatch.setattr(train, "_compute_world_size", lambda p: 1)
-    monkeypatch.setattr(
-        train, "spawn_proc_mesh", lambda *args, **kwargs: (object(), object())
-    )
+
+    def _spawn_proc_mesh(*args, num_generators=1, **kwargs):
+        return "trainer_mesh", [
+            f"generator_mesh_{idx}" for idx in range(num_generators)
+        ]
+
+    monkeypatch.setattr(train, "spawn_proc_mesh", _spawn_proc_mesh)
 
 
 def test_main_shuts_down_after_success(monkeypatch, stub_mesh_provisioning):
@@ -129,7 +138,25 @@ def test_main_shuts_down_after_success(monkeypatch, stub_mesh_provisioning):
 
     asyncio.run(train.main())
 
-    assert _FakeRLTrainer.instances[0].events == ["setup", "train", "close"]
+    trainer = _FakeRLTrainer.instances[0]
+    assert trainer.events == ["setup", "train", "close"]
+    assert trainer.setup_trainer_mesh == "trainer_mesh"
+    assert trainer.setup_generator_meshes == ["generator_mesh_0"]
+
+
+def test_main_passes_configured_num_generators(monkeypatch, stub_mesh_provisioning):
+    _FakeConfigManager.config = _FakeConfig(num_generators=2)
+    _FakeRLTrainer.instances = []
+    monkeypatch.setattr(train, "ConfigManager", _FakeConfigManager)
+
+    asyncio.run(train.main())
+
+    trainer = _FakeRLTrainer.instances[0]
+    assert trainer.events == ["setup", "train", "close"]
+    assert trainer.setup_generator_meshes == [
+        "generator_mesh_0",
+        "generator_mesh_1",
+    ]
 
 
 def test_main_shuts_down_after_train_failure(monkeypatch, stub_mesh_provisioning):

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -101,27 +101,36 @@ def spawn_proc_mesh(
     trainer_world_size: int,
     generator_world_size: int,
     host_meshes: HostMeshes | None = None,
-) -> tuple[ProcMesh, ProcMesh]:
+    *,
+    num_generators: int = 1,
+) -> tuple[ProcMesh, list[ProcMesh]]:
     """Spawn the trainer and generator proc meshes.
 
     Args:
         trainer_world_size: Number of GPU procs to spawn for the trainer.
-        generator_world_size: Number of GPU procs to spawn for the generator.
+        generator_world_size: Number of GPU procs to spawn for each generator.
         host_meshes: Caller-provided trainer/generator host meshes. When
             provided, each role is spawned on its provided host mesh. None means
-            both roles are spawned on ``this_host()``by using non-overlapping
+            both roles are spawned on ``this_host()`` by using non-overlapping
             GPU ranges.
+        num_generators: Number of generator proc meshes to spawn.
 
     Returns:
-        The ``(trainer_mesh, generator_mesh)`` proc meshes.
+        The ``(trainer_mesh, generator_meshes)`` proc meshes.
     """
-    total_gpus = trainer_world_size + generator_world_size
+    total_generator_gpus = num_generators * generator_world_size
+    total_gpus = trainer_world_size + total_generator_gpus
     logger.info(
-        f"{generator_world_size} generator GPUs + "
+        f"{num_generators} generator(s) * {generator_world_size} GPUs + "
         f"{trainer_world_size} trainer GPUs = {total_gpus} total"
     )
 
     if host_meshes is not None:
+        if num_generators > 1:
+            raise NotImplementedError(
+                "multi-host multi-generator topology is not yet supported"
+            )
+
         trainer_host_mesh = host_meshes.trainer
         generator_host_mesh = host_meshes.generator
         gpus_per_node = host_meshes.gpus_per_node
@@ -157,20 +166,25 @@ def spawn_proc_mesh(
             per_host={"gpus": generator_gpus_per_node},
             bootstrap=generator_provisioner.allocate(generator_gpus_per_node),
         )
+        generator_meshes = [generator_mesh]
     else:
         # Single-node mode: partition GPUs on this_host() via
         # CUDA_VISIBLE_DEVICES
+        host_mesh = this_host()
         provisioner = PerHostProvisioner(total_gpus=total_gpus)
-        trainer_mesh = this_host().spawn_procs(
+        trainer_mesh = host_mesh.spawn_procs(
             per_host={"gpus": trainer_world_size},
             bootstrap=provisioner.allocate(trainer_world_size),
         )
-        generator_mesh = this_host().spawn_procs(
-            per_host={"gpus": generator_world_size},
-            bootstrap=provisioner.allocate(generator_world_size),
-        )
+        generator_meshes = [
+            host_mesh.spawn_procs(
+                per_host={"gpus": generator_world_size},
+                bootstrap=provisioner.allocate(generator_world_size),
+            )
+            for _ in range(num_generators)
+        ]
 
-    return trainer_mesh, generator_mesh
+    return trainer_mesh, generator_meshes
 
 
 async def main():
@@ -188,14 +202,15 @@ async def main():
     try:
         trainer_world_size = _compute_world_size(config.trainer.parallelism)
         generator_world_size = _compute_world_size(config.generator.parallelism)
-        trainer_mesh, generator_mesh = spawn_proc_mesh(
+        trainer_mesh, generator_meshes = spawn_proc_mesh(
             trainer_world_size,
             generator_world_size,
             host_meshes=None,
+            num_generators=config.num_generators,
         )
         await rl_trainer.setup_async(
             trainer_mesh=trainer_mesh,
-            generator_meshes=[generator_mesh],
+            generator_meshes=generator_meshes,
         )
         await rl_trainer.train()
     except (KeyboardInterrupt, asyncio.CancelledError):

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -201,6 +201,14 @@ class RLTrainer(Configurable):
         generator: VLLMGenerator.Config = field(default_factory=VLLMGenerator.Config)
         """VLLMGenerator actor configuration (vLLM engine, sampling)."""
 
+        num_generators: int = 1
+        """Number of generator replicas to spawn as separate proc meshes.
+
+        This is distinct from intra-generator parallelism controlled by
+        ``generator.parallelism``. Total generator GPU/process usage is
+        ``num_generators * generator_world_size``.
+        """
+
         generator_router: GeneratorRouter.Config = field(
             default_factory=GeneratorRouter.Config
         )
@@ -211,6 +219,10 @@ class RLTrainer(Configurable):
         )
 
         def __post_init__(self):
+            if self.num_generators < 1:
+                raise ValueError(
+                    f"num_generators must be at least 1, got {self.num_generators}"
+                )
             if self.generator.checkpoint.enable:
                 raise ValueError(
                     "Generator checkpoint must be disabled in the RL loop "


### PR DESCRIPTION
`GeneratorRouter` was added in https://github.com/pytorch/torchtitan/pull/3583, but we currently do not have a way to spawn multiple generators. Subsequently router cannot be tested in CI with an integration test.

In order to unblock, this PR adds a `num_generators` field to `RLTrainer.Config`. This field can only be used in the single-host mode.

This field is meant to be temporary just to unblock the integration test (suggested by [this comment](https://github.com/pytorch/torchtitan/pull/3583#discussion_r3384471828)). For the long run, we need to have a "placement" config, which contains the information regarding how to map gpus/hosts to different RL roles, such as trainer and generators. The  `num_generators` should be there too. Hopefully we can get that done in the next few weeks.