### PR TITLE
Memory snapshot: python-only stacks for fast dumps + configurable max_entries

### DIFF
--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -14,7 +14,6 @@ from typing import Annotated
 
 import torch
 import tyro
-
 from torchtitan.config import Configurable
 from torchtitan.config.function import Function
 from torchtitan.observability import structured_logger as sl
@@ -35,9 +34,6 @@ MEMORY_FILE = (
     "{rank:06d}_step_{step}.pickle"  # MEMORY_DIR/MEMORY_STEP_DIR/{MEMORY_FILE}
 )
 
-# how much memory allocation/free ops to record in memory snapshots
-MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
-
 
 class MemoryProfiler:
     """Records periodic memory snapshots during training.
@@ -54,9 +50,15 @@ class MemoryProfiler:
         snapshot_dir: str,
         leaf_folder: str,
         rank: int,
+        max_entries: int,
     ) -> None:
         device_module.memory._record_memory_history(
-            max_entries=MEMORY_SNAPSHOT_MAX_ENTRIES
+            # stacks="python" records only Python frames (not C++), which is much
+            # cheaper to capture and serialize, keeping the snapshot dump from
+            # taking minutes -- the default stacks="all" symbolizes C++ frames,
+            # which is very slow for torchtitan workload.
+            stacks="python",
+            max_entries=max_entries,
         )
         # when resume training, we start from the last step
         self.step_num = step_num
@@ -167,6 +169,13 @@ class Profiler(Configurable):
 
         save_memory_snapshot_folder: str = MEMORY_DIR
         """Memory snapshot files location."""
+
+        memory_snapshot_max_entries: int = 1_000_000
+        """Max alloc/free events recorded per memory snapshot (ring buffer).
+
+        Caps the history passed to ``_record_memory_history``; the oldest events
+        are dropped once full. Bounds host memory and snapshot size / dump time.
+        """
 
         trace_post_processor: Annotated[
             Function.Config | None, tyro.conf.Suppress
@@ -353,5 +362,10 @@ class Profiler(Configurable):
 
         logger.info(f"Memory profiler active. Snapshot will be saved at {snapshot_dir}")
         return MemoryProfiler(
-            global_step, cfg.profile_freq, snapshot_dir, leaf_folder, rank
+            global_step,
+            cfg.profile_freq,
+            snapshot_dir,
+            leaf_folder,
+            rank,
+            cfg.memory_snapshot_max_entries,
         )


### PR DESCRIPTION
## What

`MemoryProfiler` calls `torch.cuda.memory._record_memory_history` with torch's
default `stacks="all"`, which captures and symbolizes **C++** frames.
Symbolization runs at dump time and is pathologically slow for this workload.

This PR:
1. Records **Python-only** stacks (`stacks="python"`) for memory snapshots.
2. Replaces the hardcoded `MEMORY_SNAPSHOT_MAX_ENTRIES = 100000` with a
   `Profiler.Config` field `memory_snapshot_max_entries` (default `1_000_000`),
   overridable via `--profiler.memory_snapshot_max_entries`.

## Why / evidence

On DeepSeek-v3 16B (8×H100, `--profiler.enable_memory_snapshot`), a single
`_snapshot()` dump:

| `stacks` | dump time |
|---|---|
| `"all"` (default) | **~461 s** |
| `"python"` (this PR) | **~4 s** |

~100× faster. With `stacks="all"` the dump dominated the run and made
`--profiler.enable_memory_snapshot` impractical; `stacks="python"` still produces
actionable per-allocation Python stacks in the PyTorch memory visualizer.

On `max_entries`: the old 100k ring buffer only retained the last ~2–3 steps of
history. With the much cheaper python-only stacks a larger buffer is affordable,
so the default is raised to 1M and exposed as config. (Torch's own default is
effectively unbounded — `sys.maxsize` — which is unsafe for long runs, so we keep
an explicit, configurable cap.)

## Test plan

deepseek_v3 16B, 8×H100, `--profiler.enable_memory_snapshot`:
- snapshot dump ~461 s (`stacks="all"`) → ~4 s (`stacks="python"`)
- the `.pickle` opens in the PyTorch memory visualizer with Python stacks
- snapshot ~10–12 MB at 1M `max_entries`
