### PR TITLE
[rl] Fix batch invariant logprob calculation  by forcing vllm use trainer's function

### DIFF
--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -47,7 +47,7 @@ jobs:
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 45
+      timeout: 60
       script: |
         set -eux
 

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -104,34 +104,35 @@ def _prepare_generation_request_metrics(
     ]
 
 
-def _force_torch_logprobs_for_batch_invariance() -> None:
+def _force_logprobs_fn_for_batch_invariance() -> None:
     """Make vLLM's v2 logprob path dispatch ``aten::_log_softmax``.
 
     The v2 GPU sampler computes per-token logprobs with a fused Triton kernel
     (``compute_token_logprobs`` -> ``_topk_log_softmax_kernel``) that inlines
-    ``log(softmax(logits))`` and never calls ``aten::_log_softmax``. The
-    batch-invariant overrides installed by ``set_batch_invariance`` therefore
-    never reach it, leaving a ~4e-7 logprob gap against the trainer's
-    ``-F.cross_entropy`` (which does dispatch ``aten::_log_softmax``).
+    ``log(softmax(logits))`` and never calls ``aten::_log_softmax``.
 
     Swapping the kernel for ``log_softmax`` + gather routes the generator and
     the trainer through the same overridden op, so logprobs match bit-for-bit.
-    We patch the module attribute (not the re-export in ``v1/sample/sampler``)
-    because the active v2 path resolves ``compute_token_logprobs`` as a global
-    inside ``compute_topk_logprobs``.
     """
     import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
 
-    def compute_token_logprobs(
+    from torchtitan.experiments.rl.actors.trainer import (
+        compute_logprobs as trainer_compute_logprobs_fn,
+    )
+
+    def generator_compute_token_logprobs(
         logits: torch.Tensor, token_ids: torch.Tensor
     ) -> torch.Tensor:
-        logprobs = torch.log_softmax(logits, dim=-1, dtype=torch.float32)
-        return logprobs.gather(-1, token_ids.to(torch.int64))
+        # Broadcast 2D logits over token_ids' num_logprobs columns so the
+        # trainer's compute_logprobs (one token per position) works unchanged.
+        token_ids = token_ids.to(torch.int64)  # int64 required by F.cross_entropy
+        logits = logits.unsqueeze(1).expand(-1, token_ids.shape[1], -1)
+        return trainer_compute_logprobs_fn(logits, token_ids)
 
-    vllm_logprob.compute_token_logprobs = compute_token_logprobs
+    vllm_logprob.compute_token_logprobs = generator_compute_token_logprobs
     logger.info(
-        "Patched vLLM compute_token_logprobs with log_softmax+gather so the "
-        "batch-invariant aten::_log_softmax override applies to generator logprobs"
+        "Patched vLLM compute_token_logprobs to reuse the trainer's "
+        "compute_logprobs so generator and trainer share one logprob code path"
     )
 
 
@@ -395,9 +396,9 @@ class VLLMGenerator(Actor, Configurable):
         os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
         set_batch_invariance(config.debug.batch_invariant)
         if config.debug.batch_invariant:
-            # The v2 logprob Triton kernel bypasses the aten overrides above;
-            # route it through aten::_log_softmax to match the trainer exactly.
-            _force_torch_logprobs_for_batch_invariance()
+            # The vLLM v2 logprob Triton kernel bypasses the aten overrides above;
+            # route it through trainer's function to match the trainer exactly.
+            _force_logprobs_fn_for_batch_invariance()
 
         self._set_determinism(config.debug)
 

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -105,14 +105,14 @@ def _prepare_generation_request_metrics(
 
 
 def _force_logprobs_fn_for_batch_invariance() -> None:
-    """Make vLLM's v2 logprob path dispatch ``aten::_log_softmax``.
+    """Make vLLM's v2 logprob path dispatch.
 
     The v2 GPU sampler computes per-token logprobs with a fused Triton kernel
     (``compute_token_logprobs`` -> ``_topk_log_softmax_kernel``) that inlines
-    ``log(softmax(logits))`` and never calls ``aten::_log_softmax``.
+    ``log(softmax(logits))`` and never calls PyTorch ops.
 
-    Swapping the kernel for ``log_softmax`` + gather routes the generator and
-    the trainer through the same overridden op, so logprobs match bit-for-bit.
+    Swapping the kernel to routes the generator and the trainer through
+    the same set of ops, so logprobs match bit-for-bit.
     """
     import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
 
@@ -132,10 +132,16 @@ def _force_logprobs_fn_for_batch_invariance() -> None:
         Returns:
             ``[N, K]`` logprob of each of the K token ids at each position.
         """
-        # Map the N positions to a single sequence (B=1, S=N) and reuse the
-        # trainer's compute_logprobs for each of the K target columns: it scores
-        # one token per position, so K calls are needed (K=1 for our logprobs=0
-        # requests; vLLM's warmup probes K>1).
+        # vLLM gives token_ids [N, K]. SamplingParams(logprobs=0) makes real
+        # requests K=1, but we can't assert that: vLLM's kernel warmup probes
+        # this patched fn with K>1 (e.g. K=6), so we must handle any K. Map the
+        # N positions to one sequence (B=1, S=N) and reuse the trainer's
+        # compute_logprobs (one token per position) once per column.
+        #
+        # NOTE: each element of token_ids is scored independently, after the
+        # whole generated sequence is marterialized. We iterate column-by-column
+        # purely because torchtitan's compute_logprobs takes one token id per
+        # position; it is not a cross-column/cross-position dependency.
         logits = logits.unsqueeze(0)  # [1, N, V]  (B=1, S=N)
         token_ids = token_ids.to(torch.int64)
         per_column = [

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -104,6 +104,37 @@ def _prepare_generation_request_metrics(
     ]
 
 
+def _force_torch_logprobs_for_batch_invariance() -> None:
+    """Make vLLM's v2 logprob path dispatch ``aten::_log_softmax``.
+
+    The v2 GPU sampler computes per-token logprobs with a fused Triton kernel
+    (``compute_token_logprobs`` -> ``_topk_log_softmax_kernel``) that inlines
+    ``log(softmax(logits))`` and never calls ``aten::_log_softmax``. The
+    batch-invariant overrides installed by ``set_batch_invariance`` therefore
+    never reach it, leaving a ~4e-7 logprob gap against the trainer's
+    ``-F.cross_entropy`` (which does dispatch ``aten::_log_softmax``).
+
+    Swapping the kernel for ``log_softmax`` + gather routes the generator and
+    the trainer through the same overridden op, so logprobs match bit-for-bit.
+    We patch the module attribute (not the re-export in ``v1/sample/sampler``)
+    because the active v2 path resolves ``compute_token_logprobs`` as a global
+    inside ``compute_topk_logprobs``.
+    """
+    import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
+
+    def compute_token_logprobs(
+        logits: torch.Tensor, token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        logprobs = torch.log_softmax(logits, dim=-1, dtype=torch.float32)
+        return logprobs.gather(-1, token_ids.to(torch.int64))
+
+    vllm_logprob.compute_token_logprobs = compute_token_logprobs
+    logger.info(
+        "Patched vLLM compute_token_logprobs with log_softmax+gather so the "
+        "batch-invariant aten::_log_softmax override applies to generator logprobs"
+    )
+
+
 @dataclass(kw_only=True, slots=True)
 class VLLMCudagraphConfig:
     """CUDA graph capture settings for the vLLM inference engine.
@@ -363,6 +394,10 @@ class VLLMGenerator(Actor, Configurable):
 
         os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
         set_batch_invariance(config.debug.batch_invariant)
+        if config.debug.batch_invariant:
+            # The v2 logprob Triton kernel bypasses the aten overrides above;
+            # route it through aten::_log_softmax to match the trainer exactly.
+            _force_torch_logprobs_for_batch_invariance()
 
         self._set_determinism(config.debug)
 

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -116,23 +116,38 @@ def _force_logprobs_fn_for_batch_invariance() -> None:
     """
     import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
 
-    from torchtitan.experiments.rl.actors.trainer import (
-        compute_logprobs as trainer_compute_logprobs_fn,
-    )
+    from torchtitan.experiments.rl.actors.trainer import compute_logprobs
 
     def generator_compute_token_logprobs(
         logits: torch.Tensor, token_ids: torch.Tensor
     ) -> torch.Tensor:
-        # Broadcast 2D logits over token_ids' num_logprobs columns so the
-        # trainer's compute_logprobs (one token per position) works unchanged.
-        token_ids = token_ids.to(torch.int64)  # int64 required by F.cross_entropy
-        logits = logits.unsqueeze(1).expand(-1, token_ids.shape[1], -1)
-        return trainer_compute_logprobs_fn(logits, token_ids)
+        """Per-token logprobs for vLLM's v2 sampler (replaces its fused kernel).
+
+        Args:
+            logits: ``[N, V]`` next-token logits for N sampled positions
+                (V = vocab_size).
+            token_ids: ``[N, K]`` the K token ids to score per position (vLLM
+                passes the sampled token's logprob plus any top-k logprobs it requested).
+
+        Returns:
+            ``[N, K]`` logprob of each of the K token ids at each position.
+        """
+        # Map the N positions to a single sequence (B=1, S=N) and reuse the
+        # trainer's compute_logprobs for each of the K target columns: it scores
+        # one token per position, so K calls are needed (K=1 for our logprobs=0
+        # requests; vLLM's warmup probes K>1).
+        logits = logits.unsqueeze(0)  # [1, N, V]  (B=1, S=N)
+        token_ids = token_ids.to(torch.int64)
+        per_column = [
+            compute_logprobs(logits, token_ids[:, k].unsqueeze(0))  # [1, N]
+            for k in range(token_ids.shape[1])
+        ]
+        return torch.stack(per_column, dim=-1).squeeze(0)  # [N, K]
 
     vllm_logprob.compute_token_logprobs = generator_compute_token_logprobs
     logger.info(
-        "Patched vLLM compute_token_logprobs to reuse the trainer's "
-        "compute_logprobs so generator and trainer share one logprob code path"
+        "Patched vLLM compute_token_logprobs with trainer's implementation "
+        "so generator and trainer share one logprob code path"
     )
 
 


### PR DESCRIPTION
Rational: The logp calculation should be more transparent to us