### PR TITLE
[Flex][RL] add custom mask support

### DIFF
--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -130,7 +130,6 @@ def spmd_validate_redistributions(sharding_config: Any) -> None:
         # from the innermost position. For example, (DP) -> (DP, CP) is valid
         # when CP is the changed axis, but (DP) -> (CP, DP) changes shard order.
         changed_axis = changed_axes[0] if changed_axes else None
-        # pyrefly: ignore [bad-argument-type]
         for dim, (src_entry, dst_entry) in enumerate(zip(src_spec, dst_spec)):
             src_axes = (
                 ()

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -260,7 +260,6 @@ def set_batch_invariance(enable: bool) -> None:
 
     # Register batch-invariant ATen overrides via upstream package
     # https://github.com/thinking-machines-lab/batch_invariant_ops
-    # pyrefly: ignore[missing-import]
     from batch_invariant_ops import enable_batch_invariant_mode as _upstream_enable
 
     _upstream_enable()

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -209,6 +209,9 @@ class VLLMGenerator(Actor, Configurable):
         debug: DebugConfig = field(default_factory=DebugConfig)
         """Debug and determinism settings."""
 
+        sliding_window: int | None = None
+        """sliding window size"""
+
         def __post_init__(self):
             # VLLMGenerator only supports TP. vLLM handles its own parallelism;
             # we only apply TP via the core parallelize function.
@@ -286,6 +289,7 @@ class VLLMGenerator(Actor, Configurable):
             parallelism=config.parallelism,
             compile_config=compile_config,
             checkpoint_config=config.checkpoint,
+            sliding_window=config.sliding_window,
         )
 
         # Set vLLM environment variables from config before any vLLM initialization

--- a/torchtitan/experiments/rl/config_registry.py
+++ b/torchtitan/experiments/rl/config_registry.py
@@ -34,20 +34,29 @@ from torchtitan.experiments.rl.generator_router import (
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
 from torchtitan.experiments.rl.trainer import GRPOLoss, RLTrainer
-from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.attention import (
+    FlexAttention,
+    MaskMod,
+    SlidingWindowMaskMod,
+)
 from torchtitan.models.qwen3 import model_registry
 from torchtitan.protocols.model import ModelConfigConverter
 
 _BATCH_INVARIANT_DEBUG = DebugConfig(batch_invariant=True, deterministic=True)
 
 
-class BatchInvariantFlexConverter(ModelConfigConverter):
-    """Pin flex attention kernel options for batch-invariant mode.
+class FlexConverter(ModelConfigConverter):
+    """Configure FlexAttention layers for the RL loop, applied per flex layer.
 
-    Sets fixed BLOCK_M/BLOCK_N=16 and BACKEND=TRITON on all
-    FlexAttention layers.
+    - ``batch_invariant``: pin kernel options (BACKEND=TRITON, BLOCK_M/N=16) so
+      the trainer's flex kernel is batch-invariant and matches vLLM's tile size.
+      (BACKEND=TRITON avoids the flex_decode kernel.) This is only the
+      model-side piece of batch invariance; the trainer/generator debug flags
+      and batcher padding are applied by the config builder.
+    - ``mask_mod``: a ``MaskMod.Config``set as the within-sequence
+    ``mask_mod`` on every flex layer.
 
-    BACKEND=TRITON is to avoid flex_decode kernel.
+    Both are independent and may be combined.
     """
 
     # the triton BLOCK_N tile size needs to be pinned for stable numerics and
@@ -58,18 +67,24 @@ class BatchInvariantFlexConverter(ModelConfigConverter):
 
     @dataclass(kw_only=True, slots=True)
     class Config(ModelConfigConverter.Config):
-        pass
+        batch_invariant: bool = False
+        mask_mod: MaskMod.Config | None = None
 
     def __init__(self, config: Config):
-        pass
+        self.batch_invariant = config.batch_invariant
+        self.mask_mod = config.mask_mod
 
     def convert(self, model_config) -> None:
         for layer_cfg in model_config.layers:
             inner = layer_cfg.attention.inner_attention
-            if isinstance(inner, FlexAttention.Config):
+            if not isinstance(inner, FlexAttention.Config):
+                continue
+            if self.batch_invariant:
                 inner.kernel_options["BACKEND"] = "TRITON"
                 inner.kernel_options["BLOCK_M"] = self._BLOCK_M
                 inner.kernel_options["BLOCK_N"] = self._BLOCK_N
+            if self.mask_mod is not None:
+                inner.mask_mod = self.mask_mod
 
 
 def rl_grpo_qwen3_0_6b_varlen() -> RLTrainer.Config:
@@ -130,11 +145,43 @@ def rl_grpo_qwen3_0_6b_varlen() -> RLTrainer.Config:
     )
 
 
-def rl_grpo_qwen3_0_6b_flex() -> RLTrainer.Config:
-    """GRPO training config for Qwen3-0.6B with flex attention (4 GPUs: 2 gen + 2 train)."""
+def _rl_grpo_qwen3_0_6b_flex(
+    *,
+    batch_invariant: bool = False,
+    mask_mod: MaskMod.Config | None = None,
+    sliding_window: int | None = None,
+) -> RLTrainer.Config:
+    """Shared builder for the Qwen3-0.6B flex-attention configs (4 GPUs: 2 gen + 2 train).
+
+    ``mask_mod`` and ``sliding_window`` are two independent ways to apply a
+    within-sequence mask, and are mutually exclusive:
+
+    Args:
+        batch_invariant: Pin flex kernel options + enable deterministic /
+            batch-invariant debug on trainer and generator (bitwise parity).
+        mask_mod: Custom ``MaskMod.Config`` (e.g. ``SlidingWindowMaskMod.Config``)
+            applied on every flex layer
+        sliding_window: Native sliding-window size (tokens)
+    """
     group_size = 8
-    return RLTrainer.Config(
-        model_spec=model_registry("0.6B", attn_backend="flex"),
+    if mask_mod is not None:
+        trainer_mask_mod = mask_mod
+    elif sliding_window is not None:
+        trainer_mask_mod = SlidingWindowMaskMod.Config(window_size=sliding_window)
+    else:
+        raise ValueError("cannot pass in both mask_mod and sliding_window ")
+    model_spec = model_registry(
+        "0.6B",
+        attn_backend="flex",
+        converters=[
+            FlexConverter.Config(
+                batch_invariant=batch_invariant,
+                mask_mod=trainer_mask_mod,
+            )
+        ],
+    )
+    config = RLTrainer.Config(
+        model_spec=model_spec,
         hf_assets_path="torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B",
         num_steps=10,
         num_groups_per_rollout_batch=5,
@@ -181,35 +228,65 @@ def rl_grpo_qwen3_0_6b_flex() -> RLTrainer.Config:
                 top_p=0.95,
                 max_tokens=100,
             ),
+            sliding_window=sliding_window,
         ),
     )
+
+    if batch_invariant:
+        block_size = model_spec.model.layers[0].attention.inner_attention.block_size
+        config.batcher = dataclasses.replace(
+            config.batcher, per_sample_pad_multiple=block_size
+        )
+        config.trainer = dataclasses.replace(
+            config.trainer,
+            debug=_BATCH_INVARIANT_DEBUG,
+            parallelism=dataclasses.replace(
+                config.trainer.parallelism, enable_sequence_parallel=False
+            ),
+        )
+        config.generator = dataclasses.replace(
+            config.generator, debug=_BATCH_INVARIANT_DEBUG
+        )
+    return config
+
+
+def rl_grpo_qwen3_0_6b_flex() -> RLTrainer.Config:
+    """GRPO training config for Qwen3-0.6B with flex attention (4 GPUs: 2 gen + 2 train)."""
+    return _rl_grpo_qwen3_0_6b_flex()
 
 
 def rl_grpo_qwen3_0_6b_flex_batch_invariant() -> RLTrainer.Config:
-    """GRPO training config for Qwen3-0.6B with flex attention and batch invariance
-    for bitwise-identical numerics between trainer and generator (4 GPUs: 2 gen + 2 train).
+    """``rl_grpo_qwen3_0_6b_flex`` + batch invariance, for bitwise-identical
+    trainer/generator numerics (4 GPUs: 2 gen + 2 train)."""
+    return _rl_grpo_qwen3_0_6b_flex(batch_invariant=True)
+
+
+def rl_grpo_qwen3_0_6b_flex_custom_mask_mod() -> RLTrainer.Config:
+    """``rl_grpo_qwen3_0_6b_flex`` + a custom mask_mod (sliding window)"""
+    return _rl_grpo_qwen3_0_6b_flex(
+        mask_mod=SlidingWindowMaskMod.Config(window_size=64)
+    )
+
+
+def rl_grpo_qwen3_0_6b_flex_batch_invariant_custom_mask_mod() -> RLTrainer.Config:
+    """``rl_grpo_qwen3_0_6b_flex_batch_invariant`` + a custom mask_mod (sliding window)"""
+    return _rl_grpo_qwen3_0_6b_flex(
+        batch_invariant=True, mask_mod=SlidingWindowMaskMod.Config(window_size=64)
+    )
+
+
+def rl_grpo_qwen3_0_6b_flex_sliding_window() -> RLTrainer.Config:
+    """``rl_grpo_qwen3_0_6b_flex`` + a causal sliding window via vLLM's native
+    ``per_layer_sliding_window`` spec (SlidingWindowSpec + KV-block pruning).
     """
-    config = rl_grpo_qwen3_0_6b_flex()
-    config.model_spec = model_registry(
-        "0.6B",
-        attn_backend="flex",
-        converters=[BatchInvariantFlexConverter.Config()],
-    )
-    block_size = config.model_spec.model.layers[0].attention.inner_attention.block_size
-    config.batcher = dataclasses.replace(
-        config.batcher, per_sample_pad_multiple=block_size
-    )
-    config.trainer = dataclasses.replace(
-        config.trainer,
-        debug=_BATCH_INVARIANT_DEBUG,
-        parallelism=dataclasses.replace(
-            config.trainer.parallelism, enable_sequence_parallel=False
-        ),
-    )
-    config.generator = dataclasses.replace(
-        config.generator, debug=_BATCH_INVARIANT_DEBUG
-    )
-    return config
+    return _rl_grpo_qwen3_0_6b_flex(sliding_window=64)
+
+
+def rl_grpo_qwen3_0_6b_flex_batch_invariant_sliding_window() -> RLTrainer.Config:
+    """``rl_grpo_qwen3_0_6b_flex_batch_invariant`` + a causal sliding window via
+    vLLM's native ``per_layer_sliding_window`` spec (KV-block pruning
+    """
+    return _rl_grpo_qwen3_0_6b_flex(batch_invariant=True, sliding_window=64)
 
 
 def rl_grpo_qwen3_1_7b() -> RLTrainer.Config:

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -14,7 +14,7 @@ from torch.nn.attention import (
     current_flash_attention_impl,
 )
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
-from torchtitan.models.common.attention import AttentionMasksType
+from torchtitan.models.common.attention import AttentionMasksType, MaskMod
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import warn_once
 from torchtitan.tools.utils import has_cuda_capability
@@ -226,6 +226,9 @@ class VLLMAttentionWrapper(Module):
         num_kv_heads: int
         head_dim: int
         scale: float | None = None
+        mask_mod: MaskMod.Config | None = None
+        sliding_window: int | None = None
+        """Causal sliding-window size"""
 
     def __init__(self, config: Config) -> None:
         super().__init__()
@@ -269,6 +272,8 @@ class VLLMAttentionWrapper(Module):
             vllm_config.cache_config if hasattr(vllm_config, "cache_config") else None
         )
 
+        mask_mod_cfg = config.mask_mod
+
         # TODO: This need to be compatible with Pipeline Parallelism
         layer_id = next(VLLMAttentionWrapper._layer_counter)
         self.vllm_attn = Attention(
@@ -278,8 +283,12 @@ class VLLMAttentionWrapper(Module):
             num_kv_heads=num_kv_heads,
             cache_config=cache_config,
             quant_config=None,
+            per_layer_sliding_window=config.sliding_window,
             prefix=f"model.layers.{layer_id}.attention.inner_attention",
         )
+
+        if mask_mod_cfg is not None and config.sliding_window is None:
+            self.vllm_attn.logical_mask_mod = mask_mod_cfg.build().get_mask_mod()
 
     def forward(
         self,

--- a/torchtitan/experiments/rl/models/vllm_registry.py
+++ b/torchtitan/experiments/rl/models/vllm_registry.py
@@ -131,6 +131,7 @@ def registry_to_vllm(
     parallelism: ParallelismConfig,
     compile_config: CompileConfig,
     checkpoint_config: CheckpointManager.Config,
+    sliding_window: int | None = None,
 ) -> None:
     """Register the TorchTitan model class and the TorchTitan config parser with vLLM.
 
@@ -187,6 +188,7 @@ def registry_to_vllm(
                 compile_config=compile_config,
                 checkpoint_config=checkpoint_config,
                 vllm_config=vllm_config,
+                sliding_window=sliding_window,
                 prefix=prefix,
             )
 

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -118,6 +118,7 @@ class VLLMModelWrapper(Module):
         compile_config: CompileConfig,
         checkpoint_config: CheckpointManager.Config,
         vllm_config: VllmConfig,
+        sliding_window: int | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -151,21 +152,25 @@ class VLLMModelWrapper(Module):
             if attn_config.head_dim is not None
             else model_config.dim // n_heads
         )
-        vllm_backend = VLLMAttentionWrapper.Config(
-            hidden_size=model_config.dim,
-            num_heads=n_heads,
-            num_kv_heads=n_kv_heads,
-            head_dim=head_dim,
-        )
-        new_layers = [
-            dataclasses.replace(
-                layer_cfg,
-                attention=dataclasses.replace(
-                    layer_cfg.attention, inner_attention=vllm_backend
-                ),
+        new_layers = []
+        for layer_cfg in model_config.layers:
+            inner = layer_cfg.attention.inner_attention
+            vllm_backend = VLLMAttentionWrapper.Config(
+                hidden_size=model_config.dim,
+                num_heads=n_heads,
+                num_kv_heads=n_kv_heads,
+                head_dim=head_dim,
+                mask_mod=getattr(inner, "mask_mod", None),
+                sliding_window=sliding_window,
             )
-            for layer_cfg in model_config.layers
-        ]
+            new_layers.append(
+                dataclasses.replace(
+                    layer_cfg,
+                    attention=dataclasses.replace(
+                        layer_cfg.attention, inner_attention=vllm_backend
+                    ),
+                )
+            )
         self.config = dataclasses.replace(model_config, layers=new_layers)
         logger.debug(f"Creating model with config: {self.config.to_dict()}")
 

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -61,6 +61,8 @@ from torchtitan.distributed.utils import (
 from torchtitan.experiments.rl.actors.trainer import compute_logprobs
 from torchtitan.experiments.rl.config_registry import (
     rl_grpo_qwen3_0_6b_flex_batch_invariant,
+    rl_grpo_qwen3_0_6b_flex_batch_invariant_custom_mask_mod,
+    rl_grpo_qwen3_0_6b_flex_batch_invariant_sliding_window,
     rl_grpo_qwen3_0_6b_varlen_batch_invariant,
 )
 from torchtitan.experiments.rl.models.vllm_registry import (
@@ -284,9 +286,12 @@ def _flex_prefill_logprobs(model, input_tensors, seq_lens, device):
     packed_ids = torch.cat(parts).unsqueeze(0)
     positions = torch.cat(pos_parts).unsqueeze(0)
 
-    mask_mod = and_masks(get_causal_mask_mod(), get_document_mask_mod(positions))
+    mask_mods = [get_causal_mask_mod(), get_document_mask_mod(positions)]
+
+    if inner_attn.mask_mod is not None:
+        mask_mods.append(inner_attn.mask_mod.build().get_mask_mod())
     attention_masks = create_attention_mask(
-        mask_mod,
+        and_masks(*mask_mods),
         1,
         None,
         positions.shape[1],
@@ -528,6 +533,9 @@ class BitwiseParityTestBase(unittest.TestCase):
         hf_path = os.environ.get("HF_ASSETS_PATH")
         if hf_path:
             config.hf_assets_path = hf_path
+        # CheckpointManager.Config.initial_load_path must be absolute; the
+        # config_registry default is relative to the repo root, so resolve it.
+        config.hf_assets_path = os.path.abspath(config.hf_assets_path)
 
         from torchtitan.tools.utils import has_cuda_capability
 
@@ -702,6 +710,26 @@ class TestBitwiseParityFlex(BitwiseParityTestBase):
 
     __test__ = True
     config_fn = staticmethod(rl_grpo_qwen3_0_6b_flex_batch_invariant)
+    attn_backend = "flex"
+
+
+class TestBitwiseParityFlexCustomMaskMod(BitwiseParityTestBase):
+    """Bitwise parity with a sliding window applied via the generic
+    ``logical_mask_mod`` hook (no KV-block pruning).
+    """
+
+    __test__ = True
+    config_fn = staticmethod(rl_grpo_qwen3_0_6b_flex_batch_invariant_custom_mask_mod)
+    attn_backend = "flex"
+
+
+class TestBitwiseParityFlexSlidingWindow(BitwiseParityTestBase):
+    """Bitwise parity with a sliding window applied via vLLM's native
+    ``per_layer_sliding_window`` spec (KV-block pruning).
+    """
+
+    __test__ = True
+    config_fn = staticmethod(rl_grpo_qwen3_0_6b_flex_batch_invariant_sliding_window)
     attn_backend = "flex"
 
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import ClassVar, NamedTuple
 
 import torch
@@ -27,6 +30,8 @@ from torch.nn.attention.flex_attention import (
 )
 from torch.nn.attention.varlen import varlen_attn
 
+from torchtitan.config import Configurable
+
 from torchtitan.distributed.compile import maybe_regional_inductor
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
 
@@ -41,8 +46,10 @@ __all__ = [
     "BaseQKVLinear",
     "FusedQKVLinear",
     "GQAttention",
+    "MaskMod",
     "QKVLinear",
     "ScaledDotProductAttention",
+    "SlidingWindowMaskMod",
     "VarlenAttention",
     "VarlenMetadata",
     "create_attention_mask",
@@ -180,6 +187,7 @@ class FlexAttention(Module):
     class Config(Module.Config):
         block_size: int | tuple[int, int] = _DEFAULT_SPARSE_BLOCK_SIZE
         kernel_options: dict = field(default_factory=dict)
+        mask_mod: MaskMod.Config | None = None
 
     inductor_configs: ClassVar[dict[str, bool]] = {
         "wrap_inductor_compiled_regions": True,
@@ -450,6 +458,10 @@ def get_fixed_block_mask_mod(fixed_block_size: int) -> _mask_mod_signature:
     return blocked_mask_mod
 
 
+# need to cache so that the mask mod object is the same for each layer
+# vLLM determines whether or not mask mods need to be rebuilt by comparing the object
+# and if block mask gets rebuilt inside the full-graph captured region, it cannot be fully cudagraph-safe
+@lru_cache(maxsize=None)
 def get_sliding_window_mask_mod(window_size: int) -> _mask_mod_signature:
     """Creates a sliding window mask that only attends to tokens within a fixed window size.
 
@@ -479,6 +491,29 @@ def get_sliding_window_mask_mod(window_size: int) -> _mask_mod_signature:
     sliding_window_mod.__name__ = f"sliding_window_mod_window_size_{window_size}"
 
     return sliding_window_mod
+
+
+class MaskMod(Configurable):
+    """A composable, serializable attention mask modifier for flex attention."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        pass
+
+    def get_mask_mod(self) -> _mask_mod_signature:
+        raise NotImplementedError
+
+
+class SlidingWindowMaskMod(MaskMod):
+    @dataclass(kw_only=True, slots=True)
+    class Config(MaskMod.Config):
+        window_size: int
+
+    def __init__(self, config: Config) -> None:
+        self.window_size = config.window_size
+
+    def get_mask_mod(self) -> _mask_mod_signature:
+        return get_sliding_window_mask_mod(self.window_size)
 
 
 _compiled_create_block_mask = torch.compile(create_block_mask)

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -269,13 +269,16 @@ class Decoder(BaseModel):
         positions: torch.Tensor,
         attn_config: BaseAttention.Config,
     ) -> AttentionMasksType:
+        assert isinstance(attn_config.inner_attention, FlexAttention.Config)
         mask_mods = [
             get_causal_mask_mod(),
             get_efficient_causal_mask_mod_for_packed_document(positions),
         ]
+        inner_attention = attn_config.inner_attention
+        if inner_attention.mask_mod is not None:
+            mask_mods.append(inner_attention.mask_mod.build().get_mask_mod())
         B = positions.shape[0]
         seq_len = positions.shape[1]
-        assert isinstance(attn_config.inner_attention, FlexAttention.Config)
         return create_attention_mask(
             and_masks(*mask_mods),
             B,


### PR DESCRIPTION
adding custom mask support (ie sliding window attention) for Flex Attention RL loop.

- vLLM takes in custom mask mod via `self.vllm_attn.logical_mask_mod` so we just need to pass this through
- in order to work with cuda graphs, we need to cache mask mod generation on generator side in titan so that vLLM recognizes it as the same object and doesn't rebuild
- on vLLM side, we need to move custom mask handling out of the fwd https://github.com/vllm-project/vllm/pull/45232
- unified flex configs to be more clean 

batch invariant grpo script
<img width="1503" height="762" alt="Screenshot 2026-06-11 at 12 57 56 AM" src="https://github.com/user-attachments/assets/a60e5d9b-3bb4-4c06-9e2e-b0012131d0e5" />

sliding window unit test 
<img width="1503" height="423" alt="Screenshot 2026-06-11 at 12 55 10 AM" src="https://github.com/user-attachments/assets/2789cc7e-823d-4fe8-8a62-feb160fcec64" />

custom mask mod unit test
<img width="1504" height="470" alt="Screenshot 2026-06-11 at 12 38 40 PM" src="https://github.com/user-attachments/assets/bbadb810-d79d-4c82-b3ed-a1d488b6adee" />


