### PR TITLE
Make GraphTrainer overlap scheduling work with current nightlies

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -20,13 +20,18 @@ from typing import Any
 
 import torch
 import torch.fx as fx
+from torch._dynamo.graph_deduplication import _stable_topological_sort
 from torch._inductor.fx_passes.bucketing import (
     BucketMode,
     is_all_gather_into_tensor as is_all_gather,
     is_wait_tensor,
 )
+
+try:
+    from torch._inductor.fx_passes.overlap_manual_scheduling import _move_overlap_nodes
+except ImportError:
+    _move_overlap_nodes = None
 from torch._inductor.fx_passes.overlap_manual_scheduling import (
-    _move_overlap_nodes,
     manual_overlap_bucketing,
     ManualOverlapScheduler,
 )
@@ -62,6 +67,19 @@ def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
 # Each NCCL PG gets its own CUDA stream, so the extra PG is what enables
 # AG/RS overlap in backward.
 _EXTRA_FSDP_PG_REGISTRY: dict[str, str] = {}
+
+
+def _reorder_overlap_nodes(
+    graph: fx.Graph,
+    overlap_deps: dict[fx.Node, OrderedSet[fx.Node]],
+    bucketed_node_types: dict[fx.Node, str],
+) -> None:
+    if _move_overlap_nodes is None:
+        # TODO(ivankobzarev): Remove this fallback once the PyTorch nightly wheel
+        # includes _move_overlap_nodes.
+        _stable_topological_sort(graph, overlap_deps)
+    else:
+        _move_overlap_nodes(graph, overlap_deps, bucketed_node_types)
 
 
 def _get_or_create_extra_pg(
@@ -231,6 +249,9 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
             if bwd_nodes:
                 self.bucketer.manual_bucket_collectives(nodes=bwd_nodes)
 
+        if _move_overlap_nodes is None:
+            _stable_topological_sort(self.graph, {})
+
         self.graph.lint()
         self.nodes = list(self.graph.nodes)
         self.in_degree = Counter(user for node in self.nodes for user in node.users)
@@ -245,7 +266,9 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
         self._schedule_rs_prefetch(overlap_deps)
         self._schedule_ag_prefetch(overlap_deps)
 
-        _move_overlap_nodes(self.graph, overlap_deps, self.bucketer.bucketed_node_types)
+        _reorder_overlap_nodes(
+            self.graph, overlap_deps, self.bucketer.bucketed_node_types
+        )
         self.graph.lint()
 
         if self.insert_overlap_deps:


### PR DESCRIPTION
The current CUDA 13 nightly can be cut before torch._inductor exposes _move_overlap_nodes. GraphTrainer imported that helper unconditionally, so importing graph_trainer model configs failed before the integration tests could run.\n\nKeep using _move_overlap_nodes when it is available, and fall back to the older stable topological sort path while nightlies without the helper are still in circulation. This preserves compatibility for both wheel states and leaves a TODO to remove the fallback once the nightly consistently includes the helper.\n\nTest Plan:\n\n```\npre-commit run --all-files\n```\n\n```\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 python - <<'PY'\nfrom torch._inductor.fx_passes import overlap_manual_scheduling as oms\nprint(hasattr(oms, '_move_overlap_nodes'))\nfor mod in ['graph_trainer.llama3', 'graph_trainer.deepseek_v3', 'graph_trainer.qwen3']:\n    __import__(f'torchtitan.experiments.{mod}.config_registry')\nPY\n```\n\n```\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_default --gpu_arch_type cuda /tmp/torchtitan_graph_ci_verify.UUo2OU/default --ngpu 8\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 python -m torchtitan.experiments.graph_trainer.tests.integration_tests --test_suite graph_trainer_autoparallel --gpu_arch_type cuda /tmp/torchtitan_graph_ci_verify.UUo2OU/autoparallel --ngpu 4\n```\n\n```\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestSimpleFSDP -v\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k dense\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerAutoParallelNumerics::test_llama3_aot_fx_trace_autoparallel_vs_eager -v\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 pytest torchtitan/experiments/graph_trainer/tests/test_passes.py -v\nLD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64 pytest torchtitan/experiments/graph_trainer/tests/test_profiler.py -v\n```\n\nAuthored with assistance from an AI assistant.