### PR TITLE
[graph_trainer] Runs 9-10 MinimalAsyncEP perf matrix + EP toggle in benchmark script

### DIFF
--- a/dsv3_scaling_experiment_results.md
+++ b/dsv3_scaling_experiment_results.md
@@ -650,15 +650,17 @@ seq 4096, `--compile.memory_policy full`, **cudagraph ENABLED + FORCED**
 `< sm_100` gate), `ChunkedCELossWithParamGrads` (`num_chunks=8`),
 `TORCHINDUCTOR_COMPILE_THREADS=8`.
 
-> 🟡 **PERF run — MinimalAsyncEP + forced-cudagraph numerics NOT bitwise-verified.**
-> The `chunked_loss.py` fix is bitwise-verified for the **regular-EP** path
-> (Run 7 vs Run 8). This run swaps in the **MinimalAsyncEP** dispatcher and
-> **forces cudagraph past the `_grouped_mm` sm_90 safety gate** — both carry the
-> unverified-correctness caveats from Runs 4–6 (sync-free MoE numerics; possible
-> hidden CPU↔CUDA copies under cudagraph replay). Loss converges in the expected
-> band but is **not** seed-pinned/deterministic here, so it is not a numerical
-> proof. This is a throughput/memory comparison vs the eager MinimalAsyncEP
-> baseline (Run 10), not a numerics check.
+> ✅ **NUMERICS NOW VERIFIED (update).** When first run this was a perf-only
+> comparison; the seed-pinned `--debug.deterministic` check has since proven graph
+> ≡ eager **bitwise** for MinimalAsyncEP **with the forced cudagraph on** (loss +
+> grad_norm 0/20) — see the "MinimalAsyncEP numerics verification" subsection at
+> the end. The throughput/memory numbers below stand as a perf comparison vs the
+> eager MinimalAsyncEP baseline (Run 10); the steady-state MFU is re-measured
+> cleanly in Run 9′.
+>
+> *(original caveat, for context: MinimalAsyncEP is a new sync-free dispatcher and
+> the forced cudagraph bypasses the `_grouped_mm` sm_90 gate — both were unverified
+> at the time of this run; the deterministic check has now cleared both.)*
 
 ### Setup
 Same model / parallelism / batch / recompute as Run 7 (8× H100, `dp_shard=8 tp=1
@@ -683,7 +685,8 @@ num_local_experts=16, ep_size=4, max_routed_tokens=1572864`.
 
 Loss converges; peak ~57.3 GiB / 95 GiB. step-10/20 both carry the
 profiler+memory-snapshot dump (`profile_freq=10`), so MFU is best read as a
-~19–21% band. **Numerics unverified — see caveat.**
+~19–21% band (clean steady-state is **22.54%** — see Run 9′). **Numerics now
+bitwise-verified ✅** (see verification subsection).
 
 ### Compile pipeline
 All **11** graph passes took **97.213 s** (`regional_inductor` dominant; cold-ish
@@ -740,8 +743,10 @@ This is the eager reference for the MinimalAsyncEP row (the Run 9 counterpart).
 graph-only; eager never uses cudagraph. MinimalAsyncEP buffer init confirmed
 (`tokens_per_rank=65536, max_routed_tokens=1572864`, identical to Run 9).
 
-> 🟡 Eager MinimalAsyncEP numerics are themselves a new path (not bitwise-checked
-> vs regular-EP eager here); loss converges in the expected band. Not seed-pinned.
+> ✅ This eager MinimalAsyncEP path is now the **bitwise reference** for the graph
+> side: the seed-pinned deterministic check (verification subsection) shows graph ≡
+> this eager run, loss + grad_norm 0/20. (The numbers in this section are perf-only
+> and not seed-pinned, so the loss here just converges in the expected band.)
 
 ### Results (eager + MinimalAsyncEP, B=16)
 | step | loss | grad_norm | memory | tps | tflops | mfu |
@@ -778,7 +783,7 @@ All four runs are the **same model / parallelism / batch / seq / recompute**
 
 | | **regular EP** (no cudagraph) | **MinimalAsyncEP** (graph: forced cudagraph) |
 |---|---|---|
-| **graph_trainer** (the fix, `memory_policy=full`) | Run 7 — mfu 18.51%, 10,108 tps, peak **57.5 GiB** ✅ bitwise vs eager | Run 9 — mfu ~19–21%, 11,521 tps, peak **57.3 GiB** 🟡 |
+| **graph_trainer** (the fix, `memory_policy=full`) | Run 7 — mfu 18.51%, 10,108 tps, peak **57.5 GiB** ✅ bitwise vs eager | Run 9 — peak **57.3 GiB**, clean MFU 22.54% (Run 9′) **✅ bitwise vs eager (cudagraph on *and* off)** |
 | **eager** (FSDP2, full AC) | Run 8 — mfu 18.60%, 10,160 tps, peak 68.8 GiB | Run 10 — mfu ~18–23%, 12,537 tps, peak 65.7 GiB |
 
 (MFU/tps quoted at step 10; step 10 & 20 both carry the profiler/snapshot dump,
@@ -793,12 +798,187 @@ so treat single-step MFU as a band, not a point.)
   tensor-granularity `memory_policy=full` recompute is tighter than eager's
   module-level `checkpoint_wrapper`. Notably MinimalAsyncEP barely moves graph's
   peak (57.5 → 57.3 GiB).
-- **Throughput is comparable within each EP mode**; graph and eager trade the
-  step-10 vs step-20 readings (profiler noise). The fix lets graph_trainer match
-  eager throughput at materially lower memory — proven bitwise for regular EP
-  (Run 7 vs 8); the MinimalAsyncEP row (Runs 9/10) is a perf comparison only.
-- **Open numerics caveat (Runs 9/10):** the MinimalAsyncEP path + forced
-  cudagraph (`_grouped_mm` sm_90 gate bypass) is **not** bitwise-verified vs eager.
-  Verifying it (eager `deepseek_v3_16b_minimal_async_ep` vs graph, `--debug.seed=42
-  --debug.deterministic`, loss + grad_norm) is the next correctness milestone for
-  the sync-free MoE row.
+- **At steady state graph and eager are within ~2% throughput** (eager marginally
+  ahead) for the MinimalAsyncEP row — settled by a clean **50-step, profiler-off**
+  re-run (Runs 9′/10′ below): **graph 22.54% / eager 22.96% MFU** (steps 20–50
+  avg). The earlier single-step readings were *both* measurement artifacts pulling
+  opposite ways: (a) the profiled **step-10** MFU (eager 22.95% vs graph 21.09%)
+  over-penalized graph because its step-1 **cudagraph capture** is amortized into
+  the step-10 rolling average; (b) the profiled **trace** per-step (graph 5,336 vs
+  eager 5,639 ms) over-credited graph because the **profiler instruments every
+  host launch** — hammering eager's 7,267 launches/step while barely touching
+  graph's 596 (turning the profiler off sped eager's step 5.64→5.20 s, +8.5%, but
+  graph's only 5.34→5.32 s). At B=16 both are ~99% GPU-bound, so cudagraph's
+  launch-collapse buys **memory and host headroom, not throughput**. See the
+  trace-analysis and Runs 9′/10′ subsections below.
+- **Numerics caveat RESOLVED ✅ — MinimalAsyncEP is bitwise-verified, forced
+  cudagraph included.** eager `deepseek_v3_16b_minimal_async_ep` vs graph
+  `graph_trainer_..._minimal_async_ep` (`--debug.seed=42 --debug.deterministic
+  --no-seed-checkpoint`, 20 steps, dp8/tp1/ep4) is **bitwise-identical in loss AND
+  grad_norm (0/20, max|diff| 0.000e+00)** — both with cudagraph **disabled** and
+  with the **forced cudagraph** (312 `_grouped_mm` nodes captured past the sm_90
+  gate). This clears the unverified flags on the whole MinimalAsyncEP column
+  (Runs 3–6, 9) and shows the **forced-cudagraph hack is numerically safe** on
+  H100 for this config (the feared `_grouped_mm` hidden CPU↔CUDA copy does not
+  corrupt replay). See the verification subsection below.
+
+### Profiler-trace analysis — Run 9 vs Run 10 (rank0, iter-10 capture)
+
+> ⚠️ **These per-step numbers are from the *profiled* runs and are profiler-skewed
+> — the profiler over-penalizes the eager path (see below). For the throughput
+> verdict use the profiler-off Runs 9′/10′. The trace is still the right tool for
+> the *mechanism* (kernel mix, host-launch counts, recompute fragments).**
+
+Pulled both rank-0 traces (Run 9 from manifold, Run 10 local) and sliced one
+training step using the per-step loss marker (`num_chunks=8` → **8 loss-chunk
+kernels = 1 step**): Run 9's window held **2 steps** (16 `nll_loss_forward`),
+Run 10's held **1 step** (8 `log_softmax+nll`). Normalizing to **per-step**:
+
+| | graph (Run 9) | eager (Run 10) |
+|---|---|---|
+| **wall / step** (profiled) | **5,336 ms** | 5,639 ms |
+| **GPU-busy / step** (union) | **5,309 ms** | 5,598 ms |
+| GPU busy % | 99.5% | 99.3% |
+| cpu_op events (window) | 2,145 | 44,962 |
+| cuda launch/Memcpy calls | 596 | 7,267 |
+| launches per GPU kernel | **0.028** | 0.652 |
+
+**cudagraph signature:** graph issues ~0.03 host launches per kernel vs eager's
+0.65 — CPU-side launch/op overhead is essentially collapsed (the captured graph
+replays). Both are ~99% GPU-busy, so neither is launch-bound at this batch, but
+the graph path removes ~7k host calls/step.
+
+**Per-step GPU time by kernel category (ms/step; streams overlap so columns
+sum > wall):**
+
+| category | graph (Run 9) | eager (Run 10) | Δ (graph−eager) |
+|---|---:|---:|---:|
+| matmul (dense+MoE) | 2,260.8 | 2,544.8 | **−284.0** |
+| symm_mem (EP dispatch) | 1,345.4 | 1,268.8 | +76.6 |
+| elementwise | 641.7 | 621.9 | +19.8 |
+| comm (nccl) | 309.3 | 460.4 | **−151.0** |
+| reduce/norm/softmax | 229.2 | 180.4 | +48.8 |
+| other | 184.2 | 295.5 | −111.3 |
+| attn_bwd (flex) | 172.9 | 200.5 | −27.5 |
+| cat/concat | 162.4 | 180.5 | −18.1 |
+| moe_swiglu | 159.2 | 179.2 | −20.0 |
+| attn_fwd (flex) | 92.0 | 116.5 | −24.5 |
+
+**Mechanism (robust — kernel durations aren't profiler-inflated, only gaps are):**
+1. **Collapsed host overhead** — cudagraph issues 596 vs 7,267 launches/step
+   (0.03 vs 0.65 per kernel). This is why the profiler skews the comparison:
+   instrumentation cost scales with host launches, so it taxes eager far more.
+2. **Slightly less recompute** under `memory_policy=full` tensor-granularity remat
+   vs eager module-level full AC: **52 vs 56 flex-fwd fragments/step**, −284 ms
+   matmul; offset by +49 ms reduce/norm + ~+20 ms elementwise from more, smaller
+   remat kernels. Roughly a wash.
+3. **Less NCCL comm** in-trace (−151 ms) — cudagraph + simple_fsdp bucketing.
+
+> **Takeaway:** the per-step deltas here are dominated by the profiler's
+> asymmetric per-launch overhead, so they do **not** establish a throughput
+> winner. The clean profiler-off Runs 9′/10′ do: **graph and eager are within
+> ~2% MFU (eager marginally ahead)**, and graph_trainer's durable advantage is
+> **memory (~13% lower, 57.3 vs 65.7 GiB)**. Analyzer: `~/tmp/mfu_compare/analyze.py`.
+
+---
+
+## Runs 9′ / 10′ — clean 50-step MFU re-measure (profiler OFF), MinimalAsyncEP
+
+**Date:** 2026-06-11
+**Branch:** `graph_trainer/dsv3_scaling` (same tree as Runs 9/10)
+**Launcher:** `STEPS=50 PROFILE=0 MODE={graph,eager} EP=minimal ./run_graph_trainer_dsv3.sh`
+— new `STEPS` and `PROFILE` toggles. `PROFILE=0` is a **lean run**: no profiler,
+no memory snapshot, no tlparse/`tlp`, no uploads.
+
+Re-measure of the MinimalAsyncEP row at **50 steps with profiling disabled**, to
+remove the two artifacts that distorted Runs 9/10: the step-1 cudagraph capture
+amortized into the step-10 average, and the profiler's per-host-launch overhead
+(which taxes eager's ~7k launches/step far more than graph's ~600). With
+`log_freq=10` and the profiler off, **every logged interval past step 10 is a
+clean, capture-free steady state**.
+
+### Results — graph (Run 9′) vs eager (Run 10′), B=16, profiler off
+| step | graph mfu | graph tps | eager mfu | eager tps |
+|-----:|----------:|----------:|----------:|----------:|
+| 1  (capture/warmup) | 0.89% | 486 | 7.36% | 4,022 |
+| 10 (interval incl. capture) | 21.79% | 11,901 | 22.81% | 12,459 |
+| 20 | 22.52% | 12,303 | 23.08% | 12,606 |
+| 30 | 22.35% | 12,206 | 22.57% | 12,327 |
+| 40 | 22.43% | 12,250 | 23.00% | 12,564 |
+| 50 | 22.85% | 12,483 | 23.18% | 12,662 |
+| **avg steps 20–50** | **22.54%** | **12,310** | **22.96%** | **12,540** |
+| **peak memory** | **57.31 GiB** | | 65.67 GiB | |
+
+**Verdict:** **eager is ~1.9% faster** at steady state (22.96% vs 22.54% MFU;
+12,540 vs 12,310 tps); **graph uses ~13% less memory** (57.3 vs 65.7 GiB). At
+B=16 both are ~99% GPU-bound, so cudagraph's host-launch savings don't convert to
+throughput — they buy memory and CPU headroom. This supersedes the throughput
+reading from Runs 9/10 (the step-10 MFU and the profiled trace were both
+artifacts; see the matrix takeaways above).
+
+### Loss parity (incidental — these perf runs are NOT deterministic)
+These are throughput runs, launched **without** `--debug.seed/--debug.deterministic`,
+so the kernels use nondeterministic algorithms and the curves drift run-to-run:
+step-10 9.865/9.786, step-20 8.027/7.987, step-50 **5.95344 / 5.95386** (~4e-4
+apart). That ~4e-4 is **nondeterminism jitter, not a graph-vs-eager difference** —
+the seed-pinned `--debug.deterministic` comparison (see the "MinimalAsyncEP
+numerics verification" subsection below) proves graph and eager are **bitwise
+identical** (loss + grad_norm 0/20). Correctness milestone: **MET ✅.**
+
+### Notes
+- No artifacts (profiler off by design). Pure throughput/memory measurement.
+- `run_graph_trainer_dsv3.sh` gained `STEPS` (default 20) and `PROFILE` (default 1)
+  toggles, composing with `MODE`/`EP`. `PROFILE=0` skips `tlp` + profiler flags +
+  uploads.
+
+---
+
+## MinimalAsyncEP numerics verification — graph ≡ eager, BITWISE ✅ (cudagraph on & off)
+
+**Date:** 2026-06-11
+**Branch:** `graph_trainer/dsv3_scaling`
+**Launcher:** `CONFIG_SUFFIX=_minimal_async_ep [TEST_CUDAGRAPH=0|1] STEPS=20 ./run_loss_compare_dsv3.sh`
+(new `CONFIG_SUFFIX` + `TEST_CUDAGRAPH` toggles).
+
+The MinimalAsyncEP analog of the Run 7-vs-8 regular-EP bitwise check: eager
+`deepseek_v3_16b_minimal_async_ep` (FSDP2, full AC, `--compile.no-enable`) vs
+graph `graph_trainer_deepseek_v3_16b_minimal_async_ep` (simple_fsdp, aot_fx_trace,
+`memory_policy=full`), via `scripts/loss_compare.py` with `--debug.deterministic
+--debug.seed=42 --no-seed-checkpoint --assert-equal`, 20 steps, dp8/tp1/ep4, B=4
+(loss_compare default batch). Run **twice**: cudagraph disabled, and forced on.
+
+| variant | loss max\|diff\| | grad_norm max\|diff\| | verdict |
+|---|---|---|---|
+| graph (cudagraph **off**) vs eager | 0.000e+00 (0/20) | 0.000e+00 (0/20) | **BITWISE IDENTICAL ✅** |
+| graph (**forced cudagraph**) vs eager | 0.000e+00 (0/20) | 0.000e+00 (0/20) | **BITWISE IDENTICAL ✅** |
+
+Real full-precision values (identical across all three runs — eager, graph-off,
+graph-forced-cg): step 1 loss `11.98491382598877`, step 10 `9.099592208862305`,
+step 20 `7.229188442230225` / grad_norm `5.547492504119873`.
+
+**Two things this proves:**
+1. **MinimalAsyncEP is deterministic and numerically correct** — it runs cleanly
+   under `--debug.deterministic` (no missing-deterministic-kernel error), and
+   graph simple_fsdp matches eager FSDP2 to the last bit (the lm_head chunked-loss
+   fix + #3590 FSDP-order carry over to the sync-free MoE path).
+2. **The forced cudagraph is numerically safe** on H100 (sm_90) for this config —
+   capturing the 312 non-cudagraphable `_grouped_mm` nodes past the gate does
+   **not** corrupt replay (the hypothesized hidden `_grouped_mm` CPU↔CUDA copy
+   either doesn't occur here or is captured correctly). Resolves the ⛔/🟡
+   correctness caveats carried since Runs 4–6.
+
+Incidental perf at this deterministic B=4 (avg steps >10, graph/eager): cudagraph
+**off** 0.983× tps (graph slightly slower — launch overhead exposed at B=4);
+forced cudagraph **on** 1.016× tps (graph faster — cudagraph recovers the launch
+overhead). Consistent with the B=16 finding that cudagraph's benefit is
+launch-bound (a wash once GPU-bound at large batch).
+
+### Notes
+- Summaries: `~/tmp/loss_compare_dsv3_16b_minimal_async_ep/fullprec_summary.md`
+  (no-cg) and `..._minimal_async_ep_cg/fullprec_summary.md` (forced cg).
+- `run_loss_compare_dsv3.sh` gained `CONFIG_SUFFIX` (variant on both sides) and
+  `TEST_CUDAGRAPH` (default 0 = disable cudagraph on the graph side; 1 = keep the
+  forced cudagraph) toggles.
+- Scope: 20 steps / B=4 / dp8 tp1 ep4. The regular-EP divergence (pre-fix)
+  appeared by step 7, and a cudagraph stale-data bug would surface on the first
+  post-capture replay (step 2), so 20 steps is a decisive window.

--- a/dsv3_scaling_experiment_results.md
+++ b/dsv3_scaling_experiment_results.md
@@ -635,3 +635,170 @@ eager run. Eager peaks at ~72% of 95 GiB at B=16; graph has more headroom.
   baseline, default `graph` runs the graph_trainer path (Run 7).
 - No OOM at B=16 (peak ~68.8 GiB / 95 GiB), but eager is ~12 GiB closer to the
   limit than graph_trainer at the same batch.
+
+---
+
+## Run 9 — graph_trainer + MinimalAsyncEP + forced cudagraph (the fix, sync-free MoE row)
+
+**Date:** 2026-06-11
+**Branch:** `graph_trainer/dsv3_scaling` (same tree as Runs 7–8, with the
+`chunked_loss.py` fix and the `cudagraph.py` force-capture override)
+**Launcher:** `MODE=graph EP=minimal ./run_graph_trainer_dsv3.sh` —
+`graph_trainer_deepseek_v3_16b_minimal_async_ep`, `dp_shard=8 tp=1 ep=4`, B=16,
+seq 4096, `--compile.memory_policy full`, **cudagraph ENABLED + FORCED**
+(MinimalAsyncEP is sync-free / cudagraphable; the force bypasses the `_grouped_mm`
+`< sm_100` gate), `ChunkedCELossWithParamGrads` (`num_chunks=8`),
+`TORCHINDUCTOR_COMPILE_THREADS=8`.
+
+> 🟡 **PERF run — MinimalAsyncEP + forced-cudagraph numerics NOT bitwise-verified.**
+> The `chunked_loss.py` fix is bitwise-verified for the **regular-EP** path
+> (Run 7 vs Run 8). This run swaps in the **MinimalAsyncEP** dispatcher and
+> **forces cudagraph past the `_grouped_mm` sm_90 safety gate** — both carry the
+> unverified-correctness caveats from Runs 4–6 (sync-free MoE numerics; possible
+> hidden CPU↔CUDA copies under cudagraph replay). Loss converges in the expected
+> band but is **not** seed-pinned/deterministic here, so it is not a numerical
+> proof. This is a throughput/memory comparison vs the eager MinimalAsyncEP
+> baseline (Run 10), not a numerics check.
+
+### Setup
+Same model / parallelism / batch / recompute as Run 7 (8× H100, `dp_shard=8 tp=1
+ep=4`, `aot_fx_trace`, `memory_policy=full`, B=16 / seq 4096, 20 steps, c4_test,
+ChunkedCELoss) **except the MoE dispatcher + cudagraph**:
+
+| | |
+|---|---|
+| MoE dispatcher | **MinimalAsyncEPTokenDispatcher** (sync-free EP via symmetric memory) |
+| Config | `graph_trainer_deepseek_v3_16b_minimal_async_ep` |
+| cudagraph | **enabled + forced** (312 non-cudagraphable `_grouped_mm` nodes captured anyway) |
+
+MinimalAsyncEP buffer init confirmed: `tokens_per_rank=65536, top_k=6,
+num_local_experts=16, ep_size=4, max_routed_tokens=1572864`.
+
+### Results (graph + MinimalAsyncEP + forced cudagraph, B=16)
+| step | loss | grad_norm | memory | tps | tflops | mfu |
+|-----:|------|-----------|--------|-----|--------|-----|
+| 1 | 12.01981 | 1.6180 | 57.19 GiB (60.16%) | 452 | 8.19 | 0.83% |
+| 10 | 9.07173 | 5.7077 | 57.31 GiB (60.28%) | 11,521 | 208.60 | 21.09% |
+| 20 | 7.11517 | 2.5456 | 57.31 GiB (60.28%) | 10,411 | 188.50 | 19.06% |
+
+Loss converges; peak ~57.3 GiB / 95 GiB. step-10/20 both carry the
+profiler+memory-snapshot dump (`profile_freq=10`), so MFU is best read as a
+~19–21% band. **Numerics unverified — see caveat.**
+
+### Compile pipeline
+All **11** graph passes took **97.213 s** (`regional_inductor` dominant; cold-ish
+MinimalAsyncEP/swiglu kernels). `cudagraph_pass` logs `FORCING cudagraph despite
+312 non-cudagraphable node(s)` then `Applied cudagraph pass.`
+
+### Artifacts
+| artifact | link |
+|---|---|
+| run log (pastry) | https://www.internalfb.com/intern/paste/P2374809129/ |
+| profiler trace (perfetto, rank0 iter 10) | https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_b755e5ff-674e-48c9-b179-3593b36330b7_rank0_trace.json.gz |
+| CUDA memory snapshot (memory visualizer, step 20) | https://www.internalfb.com/pytorch_memory_visualizer/perfetto_internal_traces/tree/shared_trace/bahuang_9d5560ff-81d0-4f9a-8d54-e4d4eb72fdd2_000000_step_20.pickle |
+| tlparse logs (manifold, **temporary** `.tmp` path) | https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpNMsm5U/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000 |
+
+#### Per-pass before/after graph diffs
+| pass | diff |
+|---|---|
+| eliminate_dead_code | https://www.internalfb.com/intern/diffing/?before_paste_number=2374807228&after_paste_number=2374807311&selected_tab=plain_diff |
+| canonicalize_graph | https://www.internalfb.com/intern/diffing/?before_paste_number=2374807003&after_paste_number=2374807137&selected_tab=plain_diff |
+| tag_with_memory_policy | https://www.internalfb.com/intern/diffing/?before_paste_number=2374808470&after_paste_number=2374808585&selected_tab=plain_diff |
+| selective_activation_remat | https://www.internalfb.com/intern/diffing/?before_paste_number=2374808252&after_paste_number=2374808337&selected_tab=plain_diff |
+| reassign_collective_pgs | https://www.internalfb.com/intern/diffing/?before_paste_number=2374807801&after_paste_number=2374807924&selected_tab=plain_diff |
+| joint_transformer_block_bucketing_reordering | https://www.internalfb.com/intern/diffing/?before_paste_number=2374807450&after_paste_number=2374807632&selected_tab=plain_diff |
+| annotate_flex_attention_for_regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2374806825&after_paste_number=2374806916&selected_tab=plain_diff |
+| regional_inductor | https://www.internalfb.com/intern/diffing/?before_paste_number=2374808044&after_paste_number=2374808148&selected_tab=plain_diff |
+
+#### Standalone artifacts
+| artifact | paste |
+|---|---|
+| activation_memory_policy | https://www.internalfb.com/intern/paste/P2374808648/ |
+| fx_compute_nodes_runtime_estimation | https://www.internalfb.com/intern/paste/P2374808722/ |
+
+### Notes
+- `run_graph_trainer_dsv3.sh` gained an `EP` toggle: `EP=minimal` selects the
+  MinimalAsyncEP config + enables cudagraph; default `EP=regular` is the
+  eager-comparable, cudagraph-disabled path (Run 7). Composes with `MODE`.
+- Same forced-cudagraph override as Runs 4–6 (`cudagraph.py`, TODO: revert / gate).
+- Peak ~57.3 GiB — essentially identical to Run 7's regular-EP graph peak (~57.5),
+  i.e. MinimalAsyncEP doesn't cost extra steady-state memory here.
+
+---
+
+## Run 10 — eager `Trainer` + MinimalAsyncEP baseline (FSDP2 + full AC)
+
+**Date:** 2026-06-11
+**Branch:** `graph_trainer/dsv3_scaling` (same tree as Run 9)
+**Launcher:** `MODE=eager EP=minimal ./run_graph_trainer_dsv3.sh` — eager
+`Trainer`, `deepseek_v3_16b_minimal_async_ep`, `dp_shard=8 tp=1 ep=4`, B=16,
+seq 4096, `--activation_checkpoint.mode full`, loss compiled (config default),
+`ChunkedCELoss`.
+
+This is the eager reference for the MinimalAsyncEP row (the Run 9 counterpart).
+**MinimalAsyncEP runs in pure eager** — the sync-free dispatcher is not
+graph-only; eager never uses cudagraph. MinimalAsyncEP buffer init confirmed
+(`tokens_per_rank=65536, max_routed_tokens=1572864`, identical to Run 9).
+
+> 🟡 Eager MinimalAsyncEP numerics are themselves a new path (not bitwise-checked
+> vs regular-EP eager here); loss converges in the expected band. Not seed-pinned.
+
+### Results (eager + MinimalAsyncEP, B=16)
+| step | loss | grad_norm | memory | tps | tflops | mfu |
+|-----:|------|-----------|--------|-----|--------|-----|
+| 1 | 12.03384 | 1.6457 | 50.98 GiB (53.62%) | 4,026 | 72.89 | 7.37% |
+| 10 | 9.21959 | 7.5177 | 65.67 GiB (69.08%) | 12,537 | 226.99 | 22.95% |
+| 20 | 7.29374 | 2.3227 | 65.67 GiB (69.08%) | 9,847 | 178.29 | 18.03% |
+
+Loss converges; peak ~65.7 GiB / 95 GiB. Same profiler-dump perturbation at
+steps 10/20 → read MFU as an ~18–23% band.
+
+### Artifacts
+| artifact | link |
+|---|---|
+| run log (pastry) | https://www.internalfb.com/intern/paste/P2374813340/ |
+| profiler trace (perfetto, rank0 iter 10) | https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_bf74e873-3d0e-4eec-9694-f3aa16edcb40_rank0_trace.json.gz |
+| CUDA memory snapshot (memory visualizer, step 20) | https://www.internalfb.com/pytorch_memory_visualizer/perfetto_internal_traces/tree/shared_trace/bahuang_6f90084a-2ee2-4797-84e4-955bf741f92e_000000_step_20.pickle |
+| tlparse logs (manifold, **temporary** `.tmp` path) | https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/.tmpd0CHli/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000 |
+
+> eager has no aot_fx_trace graph → **no per-pass graph diffs**; the tlparse report
+> covers only the loss `torch.compile`. Perfetto trace + memory snapshot are the
+> meaningful eager artifacts.
+
+### Notes
+- MinimalAsyncEP works unchanged in eager — no cudagraph, no graph passes.
+- Peak ~65.7 GiB, ~1 GiB under the regular-EP eager peak (Run 8, ~68.8 GiB).
+
+---
+
+## Summary — 2×2 matrix (graph_trainer vs eager × regular EP vs MinimalAsyncEP), B=16
+
+All four runs are the **same model / parallelism / batch / seq / recompute**
+(`deepseek_v3 16B`, `dp_shard=8 tp=1 ep=4`, B=16, seq 4096, full recompute):
+
+| | **regular EP** (no cudagraph) | **MinimalAsyncEP** (graph: forced cudagraph) |
+|---|---|---|
+| **graph_trainer** (the fix, `memory_policy=full`) | Run 7 — mfu 18.51%, 10,108 tps, peak **57.5 GiB** ✅ bitwise vs eager | Run 9 — mfu ~19–21%, 11,521 tps, peak **57.3 GiB** 🟡 |
+| **eager** (FSDP2, full AC) | Run 8 — mfu 18.60%, 10,160 tps, peak 68.8 GiB | Run 10 — mfu ~18–23%, 12,537 tps, peak 65.7 GiB |
+
+(MFU/tps quoted at step 10; step 10 & 20 both carry the profiler/snapshot dump,
+so treat single-step MFU as a band, not a point.)
+
+**Takeaways:**
+- **MinimalAsyncEP is a real throughput win in both backends.** Step-10 tps:
+  graph 10,108 → 11,521 (+14%), eager 10,160 → 12,537 (+23%). The sync-free MoE
+  dispatcher beats all-to-all + `_grouped_mm` regular EP on this config.
+- **graph_trainer's structural advantage is memory, in both EP modes.** Peak
+  ~57 GiB (graph) vs ~66–69 GiB (eager) — **~11–16% lower** — because
+  tensor-granularity `memory_policy=full` recompute is tighter than eager's
+  module-level `checkpoint_wrapper`. Notably MinimalAsyncEP barely moves graph's
+  peak (57.5 → 57.3 GiB).
+- **Throughput is comparable within each EP mode**; graph and eager trade the
+  step-10 vs step-20 readings (profiler noise). The fix lets graph_trainer match
+  eager throughput at materially lower memory — proven bitwise for regular EP
+  (Run 7 vs 8); the MinimalAsyncEP row (Runs 9/10) is a perf comparison only.
+- **Open numerics caveat (Runs 9/10):** the MinimalAsyncEP path + forced
+  cudagraph (`_grouped_mm` sm_90 gate bypass) is **not** bitwise-verified vs eager.
+  Verifying it (eager `deepseek_v3_16b_minimal_async_ep` vs graph, `--debug.seed=42
+  --debug.deterministic`, loss + grad_norm) is the next correctness milestone for
+  the sync-free MoE row.

--- a/run_graph_trainer_dsv3.sh
+++ b/run_graph_trainer_dsv3.sh
@@ -99,19 +99,28 @@ tlp ()
 # logged automatically.
 {
 
-# Run mode: graph = graph_trainer (the fix); eager = eager Trainer baseline.
-# Both use the SAME model / parallelism / batch / recompute so the graph run
-# (Run 7) and the eager run (Run 8) are directly comparable. Select with
-# `MODE=eager ./run_graph_trainer_dsv3.sh` (default: graph).
+# Run selectors:
+#   MODE = graph (graph_trainer, the fix) | eager (eager Trainer baseline)
+#   EP   = regular (all-to-all + _grouped_mm) | minimal (MinimalAsyncEP, sync-free)
+# Same model / parallelism / batch / recompute across all four, so graph-vs-eager
+# and regular-vs-minimal are directly comparable:
+#   Run 7  MODE=graph EP=regular     Run 8  MODE=eager EP=regular
+#   Run 9  MODE=graph EP=minimal     Run 10 MODE=eager EP=minimal
+# graph+minimal enables cudagraph (MinimalAsyncEP is sync-free / cudagraphable);
+# graph+regular disables it (regular EP's _grouped_mm / all-to-all aren't
+# cudagraphable on H100). Eager never uses cudagraph.
+# TORCHINDUCTOR_COMPILE_THREADS caps Inductor compile workers so the cold MoE
+# kernel compile doesn't spike host RAM and OOM-kill regional_inductor.
 MODE="${MODE:-graph}"
+EP="${EP:-regular}"
+if [ "$EP" = "minimal" ]; then SUFFIX="_minimal_async_ep"; else SUFFIX=""; fi
 
 if [ "$MODE" = "eager" ]; then
 # --- DeepSeek-v3 16B EAGER baseline (FSDP2 + full activation checkpointing) ---
-# The eager Trainer reference that the graph_trainer path (Run 7) is bitwise-
-# matched to. There is no aot_fx_trace graph here, so there are no graph-pass
-# tlparse diffs -- tlparse captures only the loss torch.compile; the profiler
-# trace and CUDA memory snapshot are the meaningful artifacts.
-NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
+# Eager Trainer reference. No aot_fx_trace graph -> no graph-pass tlparse diffs
+# (tlparse covers only the loss torch.compile); the profiler trace and CUDA
+# memory snapshot are the meaningful artifacts.
+NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
     --parallelism.data_parallel_shard_degree=8 \
     --parallelism.tensor_parallel_degree=1 \
     --parallelism.expert_parallel_degree=4 \
@@ -125,14 +134,9 @@ NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b TORCHINDUCTOR_COMPILE_THREADS=8
     --dump_folder "$PROFILE_DIR" \
     --debug.print-config
 else
-# --- DeepSeek-v3 16B (regular EP, non-MinimalAsyncEP) graph_trainer ---
-# Benchmarks the eager-comparable graph_trainer path with the lm_head chunked-loss
-# coalescing fix (PR #3636), which makes this path bitwise-identical to the eager
-# Trainer. cudagraph is disabled: regular EP's _grouped_mm / all-to-all are not
-# cudagraphable on H100 (sm_90), and the bitwise verification ran cudagraph-off.
-# TORCHINDUCTOR_COMPILE_THREADS caps Inductor compile-worker parallelism so the
-# cold MoE-kernel compile doesn't spike host RAM and OOM-kill regional_inductor.
-NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
+# --- DeepSeek-v3 16B graph_trainer (lm_head chunked-loss fix, PR #3636) ---
+if [ "$EP" = "minimal" ]; then CUDAGRAPH_FLAG=""; else CUDAGRAPH_FLAG="--compile.disable_passes cudagraph_pass"; fi
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=8 \
     --parallelism.tensor_parallel_degree=1 \
@@ -141,7 +145,7 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b TOR
     --training.local_batch_size 16 \
     --dataloader.dataset c4_test \
     --compile.debug_graph_passes \
-    --compile.disable_passes cudagraph_pass \
+    $CUDAGRAPH_FLAG \
     --profiler.enable_profiling \
     --profiler.profile_freq 10 \
     --profiler.enable_memory_snapshot \

--- a/run_graph_trainer_dsv3.sh
+++ b/run_graph_trainer_dsv3.sh
@@ -115,47 +115,62 @@ MODE="${MODE:-graph}"
 EP="${EP:-regular}"
 if [ "$EP" = "minimal" ]; then SUFFIX="_minimal_async_ep"; else SUFFIX=""; fi
 
+# STEPS    = number of training steps (default 20).
+# PROFILE  = 1 (default) runs under `tlp` with the profiler + memory snapshot and
+#            uploads all artifacts; 0 is a LEAN throughput run -- no profiler, no
+#            memory snapshot, no tlparse, no uploads. Use PROFILE=0 with a larger
+#            STEPS for clean steady-state MFU: the profiler perturbs the cudagraph
+#            path asymmetrically, and step-1 graph capture pollutes the step-10
+#            rolling average, so MFU is only trustworthy from a profiler-free run
+#            read past the capture (step 20+).
+STEPS="${STEPS:-20}"
+PROFILE="${PROFILE:-1}"
+if [ "$PROFILE" = "1" ]; then
+    RUNNER=tlp
+    PROFILE_FLAGS="--profiler.enable_profiling --profiler.profile_freq 10 --profiler.enable_memory_snapshot --dump_folder $PROFILE_DIR"
+else
+    RUNNER=""
+    PROFILE_FLAGS=""
+fi
+
 if [ "$MODE" = "eager" ]; then
 # --- DeepSeek-v3 16B EAGER baseline (FSDP2 + full activation checkpointing) ---
 # Eager Trainer reference. No aot_fx_trace graph -> no graph-pass tlparse diffs
 # (tlparse covers only the loss torch.compile); the profiler trace and CUDA
 # memory snapshot are the meaningful artifacts.
-NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
+NGPU=8 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 $RUNNER ./run_train.sh \
     --parallelism.data_parallel_shard_degree=8 \
     --parallelism.tensor_parallel_degree=1 \
     --parallelism.expert_parallel_degree=4 \
-    --training.steps 20 \
+    --training.steps $STEPS \
     --training.local_batch_size 16 \
     --dataloader.dataset c4_test \
     --activation_checkpoint.mode full \
-    --profiler.enable_profiling \
-    --profiler.profile_freq 10 \
-    --profiler.enable_memory_snapshot \
-    --dump_folder "$PROFILE_DIR" \
+    $PROFILE_FLAGS \
     --debug.print-config
 else
 # --- DeepSeek-v3 16B graph_trainer (lm_head chunked-loss fix, PR #3636) ---
 if [ "$EP" = "minimal" ]; then CUDAGRAPH_FLAG=""; else CUDAGRAPH_FLAG="--compile.disable_passes cudagraph_pass"; fi
-NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 tlp ./run_train.sh \
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b${SUFFIX} TORCHINDUCTOR_COMPILE_THREADS=8 $RUNNER ./run_train.sh \
     --compile.mode aot_fx_trace \
     --parallelism.data_parallel_shard_degree=8 \
     --parallelism.tensor_parallel_degree=1 \
     --parallelism.expert_parallel_degree=4 \
-    --training.steps 20 \
+    --training.steps $STEPS \
     --training.local_batch_size 16 \
     --dataloader.dataset c4_test \
     --compile.debug_graph_passes \
     $CUDAGRAPH_FLAG \
-    --profiler.enable_profiling \
-    --profiler.profile_freq 10 \
-    --profiler.enable_memory_snapshot \
-    --dump_folder "$PROFILE_DIR" \
+    $PROFILE_FLAGS \
     --debug.print-config \
     --compile.memory_policy full
 fi
 
 echo "Run log saved to $LOG_FILE"
 
+# Artifact uploads only when profiling (PROFILE=1). A lean throughput run (PROFILE=0)
+# produces no trace/snapshot, so there is nothing to upload.
+if [ "$PROFILE" = "1" ]; then
 # Upload rank 0 trace to Perfetto
 TRACE_FILE=$(find "$PROFILE_DIR" -name "rank0_*" -type f | head -1)
 if [ -n "$TRACE_FILE" ]; then
@@ -174,6 +189,7 @@ if [ -n "$SNAPSHOT_FILE" ]; then
     python3 ~/local/fbsource/arvr/scripts/perfetto/share_trace.py --is-memory-snapshot "$SNAPSHOT_FILE"
 else
     echo "No rank0 memory snapshot found in $PROFILE_DIR"
+fi
 fi
 
 } 2>&1 | tee "$LOG_FILE"

--- a/run_loss_compare_dsv3.sh
+++ b/run_loss_compare_dsv3.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+#
+# Bitwise numerics verification (+ perf comparison) for DeepSeek-V3:
+#   eager Trainer   vs   graph_trainer (aot_fx_trace).
+#
+# Both sides use ChunkedLoss and FULL activation checkpointing:
+#   - eager : ChunkedCELoss               + --activation_checkpoint.mode full
+#   - graph : ChunkedCELossWithParamGrads + --compile.memory_policy full
+#             (memory_policy=full is documented as the mirror of eager full AC)
+#
+# The eager baseline is run PURE eager: the 16B config enables
+# `compile.components=["loss"]`, so we pass --compile.no-enable to keep the
+# reference unfused (inductor loss fusion can shift bits). The graph_trainer
+# side uses regional-inductor flex (required for bitwise flex match) and has
+# cudagraph DISABLED so the comparison isolates the ChunkedLoss + full-AC
+# numerics (and avoids the branch's force-cudagraph debug hack).
+#
+# loss_compare.py forces --debug.deterministic --debug.seed=42 and creates a
+# shared seed checkpoint (single-GPU init), so both runs start from identical
+# weights. --assert-equal makes it exit non-zero on any full-precision loss
+# mismatch. After the runs we re-read TensorBoard for FULL-PRECISION loss and
+# grad_norm (bitwise), plus memory / tps / tflops / mfu (perf, not expected to
+# match).
+#
+# Usage:
+#   ./run_loss_compare_dsv3.sh                 # 16b, 50 steps, dp8/tp1/ep4
+#   MODEL_SIZE=debugmodel STEPS=20 ./run_loss_compare_dsv3.sh
+#   STEPS=100 EP=8 ./run_loss_compare_dsv3.sh
+
+set -uo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+
+MODEL_SIZE="${MODEL_SIZE:-16b}"          # 16b | debugmodel | 671b
+STEPS="${STEPS:-50}"
+NGPU="${NGPU:-8}"
+DP_SHARD="${DP_SHARD:-8}"
+TP="${TP:-1}"
+EP="${EP:-4}"
+DATASET="${DATASET:-c4_test}"
+# CONFIG_SUFFIX selects a config variant on BOTH sides, e.g. "_minimal_async_ep"
+# to compare eager deepseek_v3_16b_minimal_async_ep vs graph_trainer_..._minimal_async_ep.
+CONFIG_SUFFIX="${CONFIG_SUFFIX:-}"
+# TEST_CUDAGRAPH=1 keeps cudagraph ENABLED on the graph side (tests the forced
+# cudagraph numerics); default 0 disables it (isolates ChunkedLoss+AC+EP numerics).
+TEST_CUDAGRAPH="${TEST_CUDAGRAPH:-0}"
+JOB_DIR="${JOB_DIR:-$HOME/tmp/loss_compare_dsv3_${MODEL_SIZE}${CONFIG_SUFFIX}}"
+
+# 16B's MoE kernels compile cold; cap inductor workers so the many-core host
+# does not spike host RAM and OOM-kill regional_inductor (same reason as
+# run_graph_trainer_dsv3.sh). loss_compare inherits this env into both runs.
+export TORCHINDUCTOR_COMPILE_THREADS="${TORCHINDUCTOR_COMPILE_THREADS:-8}"
+
+PARALLELISM="--parallelism.data_parallel_shard_degree=${DP_SHARD}"
+PARALLELISM="${PARALLELISM} --parallelism.tensor_parallel_degree=${TP}"
+PARALLELISM="${PARALLELISM} --parallelism.expert_parallel_degree=${EP}"
+COMMON="${PARALLELISM} --dataloader.dataset ${DATASET}"
+
+# No seed checkpoint: with identical parallelism + --debug.seed=42 +
+# --debug.deterministic, the eager and graph_trainer runs initialize to
+# byte-identical weights on their own (verified: the debugmodel matches
+# bitwise both with and without a seed checkpoint). This also avoids
+# loss_compare's single-GPU seed creation, which for 16B/671B forces an
+# unsharded CPU init of all params -- impractically slow.
+BASE_OPTS="${COMMON} --compile.no-enable --activation_checkpoint.mode full"
+TEST_OPTS="${COMMON} --compile.mode aot_fx_trace --compile.memory_policy full"
+if [ "$TEST_CUDAGRAPH" != "1" ]; then
+    TEST_OPTS="${TEST_OPTS} --compile.disable_passes cudagraph_pass"
+fi
+
+mkdir -p "${JOB_DIR}"
+LOG="${JOB_DIR}/compare.log"
+SUMMARY_MD="${JOB_DIR}/fullprec_summary.md"
+
+echo "=============================================================="
+echo " DSv3 numerics verification"
+echo "   model        : deepseek_v3_${MODEL_SIZE}${CONFIG_SUFFIX}  vs  graph_trainer_deepseek_v3_${MODEL_SIZE}${CONFIG_SUFFIX}"
+echo "   test cudagraph: ${TEST_CUDAGRAPH}"
+echo "   parallelism  : dp_shard=${DP_SHARD} tp=${TP} ep=${EP} (NGPU=${NGPU})"
+echo "   steps        : ${STEPS}    dataset: ${DATASET}"
+echo "   job dir      : ${JOB_DIR}"
+echo "   baseline opts: ${BASE_OPTS}"
+echo "   test opts    : ${TEST_OPTS}"
+echo "=============================================================="
+
+python scripts/loss_compare.py . . \
+  --baseline-module=deepseek_v3 --baseline-config="deepseek_v3_${MODEL_SIZE}${CONFIG_SUFFIX}" \
+  --test-module=graph_trainer.deepseek_v3 --test-config="graph_trainer_deepseek_v3_${MODEL_SIZE}${CONFIG_SUFFIX}" \
+  --baseline-options="${BASE_OPTS}" \
+  --test-options="${TEST_OPTS}" \
+  --assert-equal --steps="${STEPS}" --no-seed-checkpoint \
+  --baseline-ngpus="${NGPU}" --test-ngpus="${NGPU}" \
+  --job-dump-folder="${JOB_DIR}" 2>&1 | tee "${LOG}"
+COMPARE_EXIT=${PIPESTATUS[0]}
+echo "loss_compare exit code: ${COMPARE_EXIT}"
+
+# --- Full-precision re-read from TensorBoard (loss/grad_norm bitwise; perf) ---
+python - "${JOB_DIR}" "${MODEL_SIZE}" "${STEPS}" "${DP_SHARD}" "${TP}" "${EP}" "${SUMMARY_MD}" <<'PY'
+import os, sys
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+job, model, steps, dp, tp, ep, out_md = sys.argv[1:8]
+
+def load(folder, tag):
+    base = os.path.join(job, folder)
+    sub = [d for d in os.listdir(base) if os.path.isdir(os.path.join(base, d))]
+    ea = EventAccumulator(os.path.join(base, sub[0])); ea.Reload()
+    return {s.step: s.value for s in ea.Scalars(tag)}
+
+def both(tag):
+    return load("tb_baseline", tag), load("tb_test", tag)
+
+L = []
+L.append(f"## {model} — eager vs graph_trainer ({steps} steps, dp_shard={dp} tp={tp} ep={ep})\n")
+
+# ---- Bitwise metrics: loss + grad_norm ----
+L.append("### Bitwise (loss + grad_norm, full precision)\n")
+verdicts = []
+for tag, name in (("loss_metrics/global_avg_loss", "loss"), ("grad_norm", "grad_norm")):
+    b, t = both(tag)
+    st = sorted(set(b) & set(t))
+    maxd = max(abs(b[s] - t[s]) for s in st)
+    ne = sum(1 for s in st if b[s] != t[s])
+    verdicts.append((name, len(st), maxd, ne))
+    print(f"\n=== {name}: steps={len(st)}  max|diff|={maxd:.3e}  bitwise-unequal-steps={ne}")
+    for s in st:
+        print(f"  step {s:3d}  baseline={b[s]!r}  test={t[s]!r}  diff={b[s]-t[s]:+.3e}")
+
+L.append("| metric | steps | max \\|diff\\| | steps differing |")
+L.append("|---|---|---|---|")
+for name, n, maxd, ne in verdicts:
+    L.append(f"| {name} | {n} | {maxd:.3e} | {ne} / {n} |")
+allzero = all(v[2] == 0.0 and v[3] == 0 for v in verdicts)
+if allzero:
+    L.append("\n**Verdict: BITWISE IDENTICAL ✅** "
+             "(loss and grad_norm match to full precision at every step).\n")
+else:
+    onset = []
+    for tag, name in (("loss_metrics/global_avg_loss", "loss"), ("grad_norm", "grad_norm")):
+        b, t = both(tag); st = sorted(set(b) & set(t))
+        fd = next((s for s in st if b[s] != t[s]), None)
+        onset.append(f"{name} from step {fd}")
+    L.append("\n**Verdict: MISMATCH ❌** (first divergence: "
+             + "; ".join(onset) + ").\n")
+
+# Per-step full-precision table (sampled: first 3, every 10th, last)
+bl, tl = both("loss_metrics/global_avg_loss")
+bg, tg = both("grad_norm")
+st = sorted(set(bl) & set(tl))
+sample = sorted(set(st[:3]) | set(s for s in st if s % 10 == 0) | {st[-1]})
+L.append("Per-step (sampled), full precision:\n")
+L.append("| step | loss (both) | grad_norm (both) | loss Δ | grad Δ |")
+L.append("|---:|---|---|---|---|")
+for s in sample:
+    L.append(f"| {s} | {bl[s]!r} | {bg[s]!r} | {bl[s]-tl[s]:+.1e} | {bg[s]-tg[s]:+.1e} |")
+L.append("")
+
+# ---- Perf metrics: memory / tps / tflops / mfu (not expected to match) ----
+def peak(tag):
+    b, t = both(tag); return max(b.values()), max(t.values())
+def avg_after(tag, warmup):
+    b, t = both(tag)
+    bb = [v for s, v in b.items() if s > warmup]
+    tt = [v for s, v in t.items() if s > warmup]
+    return sum(bb)/len(bb), sum(tt)/len(tt)
+
+warmup = max(10, int(steps) // 5)
+mem_res_b, mem_res_t = peak("memory/max_reserved(GiB)")
+mem_act_b, mem_act_t = peak("memory/max_active(GiB)")
+tps_b, tps_t = avg_after("throughput(tps)", warmup)
+tfl_b, tfl_t = avg_after("tflops", warmup)
+mfu_b, mfu_t = avg_after("mfu(%)", warmup)
+
+print(f"\n=== perf (memory=peak; tps/tflops/mfu=avg of steps>{warmup}) ===")
+L.append(f"### Perf (memory = peak; tps/tflops/mfu = avg of steps > {warmup})\n")
+L.append("| metric | eager | graph_trainer | graph/eager |")
+L.append("|---|---:|---:|---:|")
+def row(label, be, te, fmt="{:.2f}", ratio=True):
+    r = f"{te/be:.3f}×" if (ratio and be) else ""
+    line = f"| {label} | {fmt.format(be)} | {fmt.format(te)} | {r} |"
+    L.append(line); print(line)
+row("peak reserved mem (GiB)", mem_res_b, mem_res_t)
+row("peak active mem (GiB)",   mem_act_b, mem_act_t)
+row("throughput (tps)",        tps_b, tps_t, "{:,.0f}")
+row("tflops",                  tfl_b, tfl_t)
+row("mfu (%)",                 mfu_b, mfu_t)
+L.append("")
+
+with open(out_md, "w") as f:
+    f.write("\n".join(L))
+print(f"\nWrote markdown summary -> {out_md}")
+PY
+
+# --- Artifact: upload the full run log to pastry (internal; skipped if absent) ---
+if command -v pastry >/dev/null 2>&1; then
+    echo "Pastry (run log): $(pastry < "${LOG}" 2>/dev/null)"
+fi
+echo "Markdown summary: ${SUMMARY_MD}"
+echo "COMPARE_EXIT=${COMPARE_EXIT}"
+exit "${COMPARE_EXIT}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3646
* __->__ #3640
* #3639
* #3637
* #3618
* #3617
* #3616
* #3615
* #3614
* #3613
* #3612

Add EP=regular|minimal toggle to run_graph_trainer_dsv3.sh (composes with MODE),
and record the MinimalAsyncEP row of the 2x2 matrix at B=16:
  Run 9  graph_trainer + MinimalAsyncEP + forced cudagraph  (mfu ~19-21%, peak 57.3 GiB)
  Run 10 eager Trainer + MinimalAsyncEP                     (mfu ~18-23%, peak 65.7 GiB)

MinimalAsyncEP is a real throughput win in both backends (+14% graph / +23% eager
tps vs regular EP). graph_trainer keeps its ~11-16% lower peak memory in both EP
modes. Regular-EP row (Runs 7/8) is bitwise-verified; the MinimalAsyncEP row +
forced cudagraph remains numerics-unverified (next correctness milestone).