### PR TITLE
Remove unused MetricsProcessor.lr_schedulers

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
-from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable
 from torchtitan.distributed import ParallelDims
@@ -314,7 +313,6 @@ class MetricsProcessor(Configurable):
     num_flops_per_token: int
     has_quantization: bool
     optimizers: OptimizersContainer | None
-    lr_schedulers: LRSchedulersContainer | None
     model_parts: list[torch.nn.Module] | None
 
     def __init__(
@@ -359,7 +357,6 @@ class MetricsProcessor(Configurable):
         # These variables have to be set later as they depend on other components or model.
         self.num_flops_per_token = -1
         self.optimizers = None
-        self.lr_schedulers = None
         self.model_parts = None
 
     def should_log(self, step: int) -> bool:


### PR DESCRIPTION
Fixes #1677.

`MetricsProcessor.lr_schedulers` was declared and initialized to `None`, but nothing ever assigned or read it. Per review, this removes the unused attribute (declaration, `None`-initialization, and the now-unused `LRSchedulersContainer` import) instead of wiring it up in the trainer, given the planned `MetricsProcessor` refactoring.

Verified via grep that nothing else references the attribute (remaining `lr_schedulers` hits are the trainers' own attribute and checkpoint plumbing). `pytest tests/unit_tests/test_lr_scheduler.py tests/unit_tests/test_config_manager.py tests/unit_tests/observability/` passes (101 tests) and pre-commit is clean on the changed file.