### PR TITLE
Fix GraphTrainer CI: deterministic_topk DTensor strategy + get_train_context keyword-only callsites

### DIFF
--- a/tests/unit_tests/test_topk_dtensor.py
+++ b/tests/unit_tests/test_topk_dtensor.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Replicate, Shard
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.ops.topk import deterministic_topk
+
+
+class TestDeterministicTopKDTensor(DTensorTestBase):
+    """deterministic_topk is a custom op, so it needs an explicit DTensor
+    sharding strategy (register_sharding) to run under TP/EP MoE routing.
+    Without it, DTensor dispatch raises "Operator torchtitan.deterministic_topk
+    .default does not have a sharding strategy registered."
+    """
+
+    @property
+    def world_size(self):
+        return 2
+
+    def _check(self, placements, *, topk_dim=-1):
+        torch.manual_seed(0)
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        # (rows, experts); topk along the expert dim, mirroring MoE routing.
+        global_x = torch.randn(8, 16, device=self.device_type)
+        ref_values, _ = torch.topk(global_x, k=4, dim=topk_dim, sorted=True)
+
+        x_dt = distribute_tensor(global_x.clone(), mesh, placements)
+        values_dt, indices_dt = deterministic_topk(x_dt, k=4, dim=topk_dim, sorted=True)
+
+        # Values and indices share the input's placement (after any redistribute
+        # off the topk dim), and the gathered values match plain torch.topk.
+        self.assertEqual(values_dt.placements, indices_dt.placements)
+        torch.testing.assert_close(values_dt.full_tensor(), ref_values)
+
+    @with_comms
+    def test_replicate(self):
+        # Input replicated on the topk dim: the MoE router's common case.
+        self._check([Replicate()])
+
+    @with_comms
+    def test_shard_non_topk_dim(self):
+        # Sharding a non-topk dim is allowed; outputs stay sharded the same way.
+        self._check([Shard(0)])
+
+    @with_comms
+    def test_shard_topk_dim_redistributes(self):
+        # Sharding the topk dim is not an acceptable input placement, so DTensor
+        # must redistribute it to replicate before the topk runs.
+        self._check([Shard(1)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -272,7 +272,9 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         loss_parallel_enabled = (
             parallel_dims.tp_enabled and not parallelism_config.disable_loss_parallel
         )
-        self.train_context = dist_utils.get_train_context(loss_parallel_enabled)
+        self.train_context = dist_utils.get_train_context(
+            enable_loss_parallel=loss_parallel_enabled
+        )
 
     def close(self) -> None:
         if self.checkpointer:

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -33,7 +33,7 @@ def build_minimal_trainer(
     trainer.model_parts = [model]
     trainer.loss_fn = CrossEntropyLoss.Config().build()
     trainer.parallel_dims = SimpleNamespace(pp_enabled=False, cp_enabled=False)
-    trainer.train_context = get_train_context(False)
+    trainer.train_context = get_train_context(enable_loss_parallel=False)
     trainer.model_config = model_config
     trainer.device = torch.device("cuda")
     trainer.tokenizer = tokenizer

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -300,7 +300,9 @@ class FaultTolerantTrainer(Trainer):
         loss_parallel_enabled = (
             parallel_dims.tp_enabled and not config.parallelism.disable_loss_parallel
         )
-        self.train_context = dist_utils.get_train_context(loss_parallel_enabled)
+        self.train_context = dist_utils.get_train_context(
+            enable_loss_parallel=loss_parallel_enabled
+        )
 
         # Build validator if validation is configured
         if config.validator.enable:

--- a/torchtitan/ops/topk.py
+++ b/torchtitan/ops/topk.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from torch.distributed.tensor import Placement, Replicate, Shard
+from torch.distributed.tensor.experimental import register_sharding
 
 
 @torch.library.custom_op("torchtitan::deterministic_topk", mutates_args=())
@@ -86,3 +88,32 @@ deterministic_topk.register_autograd(
     _backward,
     setup_context=_setup_context,
 )
+
+
+@register_sharding(torch.ops.torchtitan.deterministic_topk.default)
+def _deterministic_topk_sharding(
+    input: torch.Tensor,
+    k: int,
+    dim: int = -1,
+    largest: bool = True,
+    sorted: bool = True,
+):
+    # Custom ops get no DTensor sharding strategy by default, so the op breaks
+    # under DTensor (e.g. MoE routing with TP/EP). Mirror aten.topk's strategy
+    # (torch.distributed.tensor._ops._math_ops.sort_strategy): the topk dim must
+    # be replicated, any other dim may be sharded with both outputs sharded the
+    # same way. The two return lists are (output_specs, input_specs); input_specs
+    # has one entry per arg, with None for the non-tensor args (k/dim/largest/sorted).
+    topk_dim = dim if dim >= 0 else dim + input.ndim
+    acceptable_shardings: list[tuple[list[Placement], list[Placement | None]]] = [
+        ([Replicate(), Replicate()], [Replicate(), None, None, None, None]),
+    ]
+    for shard_dim in range(input.ndim):
+        if shard_dim != topk_dim:
+            acceptable_shardings.append(
+                (
+                    [Shard(shard_dim), Shard(shard_dim)],
+                    [Shard(shard_dim), None, None, None, None],
+                )
+            )
+    return acceptable_shardings


### PR DESCRIPTION
## Summary

Gets the **GraphTrainer 8 GPU** and **GraphTrainer 8 GPU H100** integration
suites green again. The two scheduled runs on 2026-06-12 were red for two
independent reasons, both un-audited callsites introduced by recent PRs (not
torch-nightly drift):

### 1. `deterministic_topk` has no DTensor sharding strategy (H100 suite)

`deterministic_topk` (#3600) is a `torch.library.custom_op`, which gets **no**
DTensor sharding strategy by default. Under MoE routing with TP/EP, DTensor
dispatch raised:

```
NotImplementedError: Operator torchtitan.deterministic_topk.default does not
have a sharding strategy registered.
```

This failed `aot_fx_trace_qwen3_moe_fsdp_tp_ep` and
`aot_fx_trace_deepseek_v3_fsdp_tp_ep` in the H100 workflow.

**Fix:** register a strategy via
`torch.distributed.tensor.experimental.register_sharding` that mirrors
`aten.topk` (`_math_ops.sort_strategy`): the topk dim must be replicated, any
other dim may be sharded with both outputs sharded the same way. Add a DTensor
unit test (`tests/unit_tests/test_topk_dtensor.py`) covering replicate,
non-topk-dim shard, and topk-dim shard (which DTensor redistributes to
replicate).

### 2. `get_train_context` callsites broke when it became keyword-only (default suite)

#3641 made `get_train_context` keyword-only
(`def get_train_context(*, enable_loss_parallel, ...)`) and updated the core
`trainer.py`, but three callsites still passed the flag positionally:

```
TypeError: get_train_context() takes 0 positional arguments but 1 was given
```

This failed `test_passes.py::TestBucketingPrefetchOrder` in the default
workflow and also breaks the forge and torchft trainers.

**Fix:** pass `enable_loss_parallel` by keyword at all three remaining
callsites (forge engine, torchft trainer, graph_trainer test util). All four
`get_train_context` callsites in the tree now use the keyword form.

## Test plan

Validated on 8×H100:

- `pytest tests/unit_tests/test_topk_dtensor.py` → **3 passed**
- `pytest test_passes.py::TestBucketingPrefetchOrder::test_allgather_prefetch_with_reshard_after_forward`
  → **passed** (the exact default-CI failure)
- `pre-commit run --files <changed>` → all hooks pass

Both are correctness/API fixes with no numerics impact: the topk strategy only
routes DTensor dispatch (values still match plain `torch.topk`, asserted in the
new test), and the `get_train_context` change is a pure keyword-vs-positional
call fix.