### PR TITLE
Add Helion fused cos/sin RoPE override

### DIFF
--- a/.ci/docker/requirements-dev.txt
+++ b/.ci/docker/requirements-dev.txt
@@ -1,4 +1,5 @@
 expecttest>=0.2.0
+helion==1.1.0
 pytest==7.3.2
 pytest-cov
 pre-commit

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -76,6 +76,13 @@ jobs:
         fi
 
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
+        # Helion is a PyPI-only pure-Python JIT package; install it after the
+        # nightly torch wheel and only on CUDA where the override integration runs.
+        if [[ "${{ matrix.gpu-arch-type }}" == "cuda" ]]; then
+          python -m pip install helion==1.1.0
+          python -c "import helion"
+          python -m pytest tests/unit_tests/test_helion_rope.py -v
+        fi
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
         sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -76,13 +76,6 @@ jobs:
         fi
 
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
-        # Helion is a PyPI-only pure-Python JIT package; install it after the
-        # nightly torch wheel and only on CUDA where the override integration runs.
-        if [[ "${{ matrix.gpu-arch-type }}" == "cuda" ]]; then
-          python -m pip install helion==1.1.0
-          python -c "import helion"
-          python -m pytest tests/unit_tests/test_helion_rope.py -v
-        fi
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
         sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ testpaths = ["tests"]
 
 [tool.pyrefly]
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
-replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "fla.*"]  # optional dependencies
+replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "fla.*", "helion", "helion.*"]  # optional dependencies
 search-path = ["../pytorch"]  # local built pytorch

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -94,6 +94,25 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "qwen3_fsdp+tp+cp_no_sp_fused_qkv",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module qwen3 --config qwen3_debugmodel_fused_qkv",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.context_parallel_degree 2",
+                    "--compile.enable",
+                    "--override.imports torchtitan.overrides.helion_rope",
+                ],
+            ],
+            "Qwen3 fused QKV FSDP+TP+CP + compile + Helion RoPE override",
+            "qwen3_fused_qkv_fsdp+tp+cp_compile_helion_rope",
+            ngpu=8,
+            # The Helion fused cos/sin RoPE kernel is CUDA-only and its autotuned
+            # configs are tuned for NVIDIA H100; skip on ROCm where it is
+            # unvalidated (see torchtitan/overrides/helion_rope.py).
+            skip_rocm_test=True,
+        ),
         # Integration Test Cases for Qwen3.5
         OverrideDefinitions(
             [

--- a/tests/unit_tests/test_helion_rope.py
+++ b/tests/unit_tests/test_helion_rope.py
@@ -1,0 +1,255 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from dataclasses import dataclass, field
+
+import torch
+from torchtitan.config import apply_overrides, Configurable, OverrideConfig
+from torchtitan.config.override import _REGISTRY
+from torchtitan.models.common.rope import ComplexRoPE, CosSinRoPE
+
+# Importing the override module registers the "helion_rope" override and is safe
+# even when helion is not installed (the kernel import is optional).
+from torchtitan.overrides.helion_rope import helion_rope, HelionRoPE
+
+try:
+    import helion  # noqa: F401
+
+    _HAS_HELION = True
+except ImportError:
+    _HAS_HELION = False
+
+_HAS_CUDA = torch.cuda.is_available()
+_HELION_GPU = _HAS_HELION and _HAS_CUDA
+
+# The override registers at import time. Capture it now so the registry-dependent
+# tests below stay robust if a sibling test (e.g. test_override.py) calls
+# clear_overrides() first; setUp restores it.
+_HELION_OVERRIDE = _REGISTRY.get("helion_rope")
+
+
+class _RoPEHolder(Configurable):
+    """Minimal config tree with one cos/sin and one complex RoPE node."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        cos_rope: CosSinRoPE.Config = field(
+            default_factory=lambda: CosSinRoPE.Config(dim=64, max_seq_len=128)
+        )
+        complex_rope: ComplexRoPE.Config = field(
+            default_factory=lambda: ComplexRoPE.Config(dim=64, max_seq_len=128)
+        )
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class _ContractSubclassRoPE(CosSinRoPE):
+    """CosSinRoPE subclass with a different cache contract, like MRoPE."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(CosSinRoPE.Config):
+        extra: int = 7
+
+
+class _SubclassRoPEHolder(Configurable):
+    """Config tree containing a CosSinRoPE subclass node."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        rope: CosSinRoPE.Config = field(
+            default_factory=lambda: _ContractSubclassRoPE.Config(
+                dim=64, max_seq_len=128
+            )
+        )
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class TestHelionRoPEOverride(unittest.TestCase):
+    """Registration, factory, and PyTorch-fallback parity (no GPU/helion needed)."""
+
+    def setUp(self):
+        # Restore the override if a previously run test cleared the registry.
+        if _HELION_OVERRIDE is not None:
+            _REGISTRY.setdefault("helion_rope", _HELION_OVERRIDE)
+
+    def test_registered_against_cossin(self):
+        self.assertIn("helion_rope", _REGISTRY)
+        self.assertIs(_REGISTRY["helion_rope"].target_cls, CosSinRoPE.Config)
+        self.assertTrue(_REGISTRY["helion_rope"].exact)
+
+    def test_factory_preserves_fields(self):
+        cfg = CosSinRoPE.Config(dim=64, max_seq_len=128, theta=5000.0, scaling="yarn")
+        replacement = helion_rope(cfg)
+        self.assertIsInstance(replacement, HelionRoPE.Config)
+        self.assertEqual(replacement.dim, 64)
+        self.assertEqual(replacement.max_seq_len, 128)
+        self.assertEqual(replacement.theta, 5000.0)
+        self.assertEqual(replacement.scaling, "yarn")
+
+    def test_override_claims_only_cossin(self):
+        root = _RoPEHolder.Config()
+        replacements = apply_overrides(
+            OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
+        )
+        self.assertEqual(len(replacements), 1)
+        # cos/sin node is swapped; complex node (Llama 3 / DeepSeek) is untouched.
+        self.assertIsInstance(root.cos_rope, HelionRoPE.Config)
+        self.assertIs(type(root.complex_rope), ComplexRoPE.Config)
+
+    def test_override_does_not_claim_cossin_subclass(self):
+        root = _SubclassRoPEHolder.Config()
+        replacements = apply_overrides(
+            OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
+        )
+        self.assertEqual(replacements, [])
+        self.assertIs(type(root.rope), _ContractSubclassRoPE.Config)
+        self.assertEqual(root.rope.extra, 7)
+
+    def test_cpu_falls_back_to_cossin(self):
+        """On CPU the module falls back to CosSinRoPE, bit-for-bit identical."""
+        torch.manual_seed(0)
+        dim, seqlen = 64, 16
+        cossin = CosSinRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        helion_module = HelionRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        self.assertIsInstance(helion_module, HelionRoPE)
+
+        xq = torch.randn(2, seqlen, 4, dim, dtype=torch.bfloat16)
+        xk = torch.randn(2, seqlen, 1, dim, dtype=torch.bfloat16)
+        positions = torch.arange(seqlen).unsqueeze(0).expand(2, -1)
+
+        ref_q, ref_k = cossin(xq, xk, positions)
+        out_q, out_k = helion_module(xq, xk, positions)
+        torch.testing.assert_close(out_q, ref_q, rtol=0, atol=0)
+        torch.testing.assert_close(out_k, ref_k, rtol=0, atol=0)
+
+
+@unittest.skipUnless(_HELION_GPU, "requires helion + CUDA")
+class TestHelionRoPEKernel(unittest.TestCase):
+    """Fused-kernel numerics vs the PyTorch cos/sin RoPE (helion + CUDA only)."""
+
+    def setUp(self):
+        torch.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dim = 128
+        self.seqlen = 64
+        self.cossin = CosSinRoPE.Config(dim=self.dim, max_seq_len=self.seqlen).build()
+        self.helion = HelionRoPE.Config(dim=self.dim, max_seq_len=self.seqlen).build()
+        self.cossin.to(self.device)
+        self.helion.to(self.device)
+
+    def _inputs(self, *, batch=2, n_heads=8, n_kv_heads=1, requires_grad=False):
+        xq = torch.randn(
+            batch,
+            self.seqlen,
+            n_heads,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=requires_grad,
+        )
+        xk = torch.randn(
+            batch,
+            self.seqlen,
+            n_kv_heads,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=requires_grad,
+        )
+        positions = (
+            torch.arange(self.seqlen, device=self.device)
+            .unsqueeze(0)
+            .expand(batch, -1)
+            .contiguous()
+        )
+        return xq, xk, positions
+
+    def test_forward_matches_cossin(self):
+        xq, xk, positions = self._inputs()
+        ref_q, ref_k = self.cossin(xq, xk, positions)
+        out_q, out_k = self.helion(xq, xk, positions)
+        self.assertEqual(out_q.shape, ref_q.shape)
+        self.assertEqual(out_q.dtype, ref_q.dtype)
+        torch.testing.assert_close(out_q, ref_q, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(out_k, ref_k, rtol=2e-2, atol=2e-2)
+
+    def test_forward_matches_with_implicit_positions(self):
+        # positions=None must match cache[0:seq_len] (the kernel synthesizes arange).
+        xq, xk, _ = self._inputs()
+        ref_q, ref_k = self.cossin(xq, xk, None)
+        out_q, out_k = self.helion(xq, xk, None)
+        torch.testing.assert_close(out_q, ref_q, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(out_k, ref_k, rtol=2e-2, atol=2e-2)
+
+    def test_backward_matches_cossin(self):
+        xq, xk, positions = self._inputs(requires_grad=True)
+        xq_ref = xq.detach().clone().requires_grad_(True)
+        xk_ref = xk.detach().clone().requires_grad_(True)
+
+        self.helion(xq, xk, positions)[0].sum().backward()
+        self.cossin(xq_ref, xk_ref, positions)[0].sum().backward()
+
+        torch.testing.assert_close(xq.grad, xq_ref.grad, rtol=2e-2, atol=2e-2)
+        # xk does not feed the summed output, so its grad is zero on both paths.
+        self.assertIsNotNone(xk.grad)
+
+        xq2, xk2, positions2 = self._inputs(requires_grad=True)
+        xk2_ref = xk2.detach().clone().requires_grad_(True)
+        xq2_ref = xq2.detach().clone().requires_grad_(True)
+        self.helion(xq2, xk2, positions2)[1].sum().backward()
+        self.cossin(xq2_ref, xk2_ref, positions2)[1].sum().backward()
+        torch.testing.assert_close(xk2.grad, xk2_ref.grad, rtol=2e-2, atol=2e-2)
+
+    def test_eligible_rejects_unsupported_inputs(self):
+        # The eligibility gate must reject inputs the kernel can't safely gather,
+        # so they fall back to PyTorch instead of failing inside the kernel.
+        from torchtitan.overrides.helion_rope import _eligible
+
+        d = self.device
+        xq = torch.randn(2, self.seqlen, 8, self.dim, device=d, dtype=torch.bfloat16)
+        xk = torch.randn(2, self.seqlen, 1, self.dim, device=d, dtype=torch.bfloat16)
+        cache = self.helion.cache  # (max_seq, 2 * dim) on CUDA
+        pos = (
+            torch.arange(self.seqlen, device=d, dtype=torch.int32)
+            .unsqueeze(0)
+            .expand(2, -1)
+            .contiguous()
+        )
+        wrong_width = torch.randn(self.seqlen, 2 * self.dim - 2, device=d)
+
+        self.assertTrue(_eligible(xq, xk, cache, pos))  # baseline is eligible
+        self.assertFalse(_eligible(xq, xk, cache.cpu(), pos))  # cache off-device
+        self.assertFalse(_eligible(xq, xk, cache, pos.cpu()))  # positions off-device
+        self.assertFalse(_eligible(xq, xk, cache, pos.float()))  # non-integer ids
+        self.assertFalse(_eligible(xq, xk, wrong_width, pos))  # wrong cache width
+        self.assertFalse(_eligible(xq, xk, cache, pos[:1]))  # positions shape mismatch
+
+        # q/k batch/seq must match: the kernel indexes xk with xq's (b, s) tiles.
+        xk_short = torch.randn(
+            2, self.seqlen // 2, 1, self.dim, device=d, dtype=torch.bfloat16
+        )
+        self.assertFalse(_eligible(xq, xk_short, cache, pos))
+        # non-4D q/k (kernel unpacks both as 4D).
+        self.assertFalse(_eligible(xq[:, :, 0, :], xk[:, :, 0, :], cache, pos))
+
+        if torch.cuda.device_count() >= 2:
+            # All-CUDA but split across devices: caught by the same-device check,
+            # not is_cuda (the kernel can't gather across devices).
+            self.assertFalse(_eligible(xq, xk, cache, pos.to("cuda:1")))
+
+    def test_custom_op_opcheck(self):
+        from torchtitan.overrides.helion_rope import _helion_rope_fwd
+
+        xq, xk, positions = self._inputs()
+        torch.library.opcheck(_helion_rope_fwd, (xq, xk, self.helion.cache, positions))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_helion_rope.py
+++ b/tests/unit_tests/test_helion_rope.py
@@ -6,25 +6,20 @@
 
 import unittest
 from dataclasses import dataclass, field
+from unittest.mock import patch
 
 import torch
+import torchtitan.overrides.helion_rope as helion_rope_module
 from torchtitan.config import apply_overrides, Configurable, OverrideConfig
 from torchtitan.config.override import _REGISTRY
 from torchtitan.models.common.rope import ComplexRoPE, CosSinRoPE
 
-# Importing the override module registers the "helion_rope" override and is safe
-# even when helion is not installed (the kernel import is optional).
+# Importing the override module registers the "helion_rope" override. The import
+# is safe without helion, but explicitly applying the override requires helion.
 from torchtitan.overrides.helion_rope import helion_rope, HelionRoPE
 
-try:
-    import helion  # noqa: F401
-
-    _HAS_HELION = True
-except ImportError:
-    _HAS_HELION = False
-
-_HAS_CUDA = torch.cuda.is_available()
-_HELION_GPU = _HAS_HELION and _HAS_CUDA
+_HELION_INSTALLED = helion_rope_module._HELION_IMPORT_ERROR is None
+_HELION_GPU = _HELION_INSTALLED and torch.cuda.is_available()
 
 # The override registers at import time. Capture it now so the registry-dependent
 # tests below stay robust if a sibling test (e.g. test_override.py) calls
@@ -72,7 +67,7 @@ class _SubclassRoPEHolder(Configurable):
 
 
 class TestHelionRoPEOverride(unittest.TestCase):
-    """Registration, factory, and PyTorch-fallback parity (no GPU/helion needed)."""
+    """Registration, factory, and PyTorch-fallback parity."""
 
     def setUp(self):
         # Restore the override if a previously run test cleared the registry.
@@ -86,18 +81,29 @@ class TestHelionRoPEOverride(unittest.TestCase):
 
     def test_factory_preserves_fields(self):
         cfg = CosSinRoPE.Config(dim=64, max_seq_len=128, theta=5000.0, scaling="yarn")
-        replacement = helion_rope(cfg)
+        with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", None):
+            replacement = helion_rope(cfg)
         self.assertIsInstance(replacement, HelionRoPE.Config)
         self.assertEqual(replacement.dim, 64)
         self.assertEqual(replacement.max_seq_len, 128)
         self.assertEqual(replacement.theta, 5000.0)
         self.assertEqual(replacement.scaling, "yarn")
 
+    def test_override_requires_helion_install(self):
+        root = _RoPEHolder.Config()
+        import_error = ImportError("No module named 'helion'")
+        with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", import_error):
+            with self.assertRaisesRegex(ImportError, "helion.*not installed"):
+                apply_overrides(
+                    OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
+                )
+
     def test_override_claims_only_cossin(self):
         root = _RoPEHolder.Config()
-        replacements = apply_overrides(
-            OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
-        )
+        with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", None):
+            replacements = apply_overrides(
+                OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
+            )
         self.assertEqual(len(replacements), 1)
         # cos/sin node is swapped; complex node (Llama 3 / DeepSeek) is untouched.
         self.assertIsInstance(root.cos_rope, HelionRoPE.Config)
@@ -112,6 +118,7 @@ class TestHelionRoPEOverride(unittest.TestCase):
         self.assertIs(type(root.rope), _ContractSubclassRoPE.Config)
         self.assertEqual(root.rope.extra, 7)
 
+    @unittest.skipUnless(_HELION_INSTALLED, "requires helion")
     def test_cpu_falls_back_to_cossin(self):
         """On CPU the module falls back to CosSinRoPE, bit-for-bit identical."""
         torch.manual_seed(0)
@@ -128,6 +135,19 @@ class TestHelionRoPEOverride(unittest.TestCase):
         out_q, out_k = helion_module(xq, xk, positions)
         torch.testing.assert_close(out_q, ref_q, rtol=0, atol=0)
         torch.testing.assert_close(out_k, ref_k, rtol=0, atol=0)
+
+    @unittest.skipIf(_HELION_INSTALLED, "requires helion to be missing")
+    def test_forward_errors_without_helion(self):
+        torch.manual_seed(0)
+        dim, seqlen = 64, 16
+        helion_module = HelionRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+
+        xq = torch.randn(2, seqlen, 4, dim, dtype=torch.bfloat16)
+        xk = torch.randn(2, seqlen, 1, dim, dtype=torch.bfloat16)
+        positions = torch.arange(seqlen).unsqueeze(0).expand(2, -1)
+
+        with self.assertRaisesRegex(ImportError, "helion.*not installed"):
+            helion_module(xq, xk, positions)
 
 
 @unittest.skipUnless(_HELION_GPU, "requires helion + CUDA")

--- a/tests/unit_tests/test_override.py
+++ b/tests/unit_tests/test_override.py
@@ -172,6 +172,49 @@ class TestOverride(unittest.TestCase):
         for child_cfg in parent_cfg.children:
             self.assertEqual(child_cfg.extra, 2)
 
+    def test_exact_target_skips_subclasses(self):
+        @override("exact_a", target=ComponentA.Config, exact=True)
+        def exact_a(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=10)
+
+        parent_cfg = ParentComponent.Config(
+            child=DerivedComponent.Config(dim=99),
+            children=[
+                ComponentA.Config(dim=32),
+                DerivedComponent.Config(dim=48),
+            ],
+        )
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(len(replacements), 1)
+        self.assertIs(type(parent_cfg.child), DerivedComponent.Config)
+        self.assertIsInstance(parent_cfg.children[0], ComponentB.Config)
+        self.assertEqual(parent_cfg.children[0].extra, 10)
+        self.assertIs(type(parent_cfg.children[1]), DerivedComponent.Config)
+
+    def test_exact_target_does_not_conflict_with_subclass_override(self):
+        @override("exact_a", target=ComponentA.Config, exact=True)
+        def exact_a(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=10)
+
+        @override("derived", target=DerivedComponent.Config)
+        def derived(cfg: DerivedComponent.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=20)
+
+        parent_cfg = ParentComponent.Config(
+            child=DerivedComponent.Config(dim=99),
+            children=[
+                ComponentA.Config(dim=32),
+                DerivedComponent.Config(dim=48),
+            ],
+        )
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(len(replacements), 3)
+        self.assertEqual(parent_cfg.child.extra, 20)
+        self.assertEqual(parent_cfg.children[0].extra, 10)
+        self.assertEqual(parent_cfg.children[1].extra, 20)
+
     def test_non_configurable_target_raises(self):
         # `target` must be a Configurable.Config subclass; a plain class (e.g.
         # ModelSpec) or non-type is rejected at registration.

--- a/torchtitan/config/override.py
+++ b/torchtitan/config/override.py
@@ -22,6 +22,10 @@ Per-instance targeting is first-class: ``@override(..., fqns=[...])`` selects
 Config class. This supports e.g. "fused MoE on these layers only" and A/B-ing a
 kernel across layers.
 
+By default, a target also matches subclasses of that Config class. Override
+authors can pass ``exact=True`` when the replacement is valid only for the
+target's concrete contract.
+
 See ``torchtitan/overrides/README.md`` for the full design document.
 """
 
@@ -65,7 +69,8 @@ class Override:
 
     ``factory`` constructs the replacement config from the matched config.
     ``fqns`` selects which matched nodes the override claims (see
-    :func:`override`).
+    :func:`override`). ``exact`` restricts the match to exactly ``target_cls``
+    rather than subclasses.
     """
 
     name: str
@@ -74,6 +79,7 @@ class Override:
     fqns: list[str] | None
     description: str
     origin_module: str
+    exact: bool = False
 
     def matches(self, fqn: str) -> bool:
         """Whether this override claims the node at ``fqn``.
@@ -96,6 +102,7 @@ def override(
     target: type[Configurable.Config],
     fqns: list[str] | None = None,
     description: str = "",
+    exact: bool = False,
 ) -> Callable:
     """Decorator to register an override factory.
 
@@ -109,6 +116,9 @@ def override(
             bare module FQN, e.g. ``"layers.0.feed_forward"``. (A general
             predicate selector may be added later if needed.)
         description: Human-readable description, surfaced in the override log.
+        exact: If ``True``, claim only configs whose concrete type is exactly
+            ``target``. The default ``False`` preserves subclass matching, useful
+            when a replacement is valid for the full target contract.
 
     The decorated function takes the matched config and returns its replacement.
 
@@ -145,6 +155,7 @@ def override(
             fqns=fqns,
             description=description,
             origin_module=fn.__module__,
+            exact=exact,
         )
         return fn
 
@@ -254,6 +265,8 @@ def _collect_claims(
     claims: list[_Claim] = []
     for ov in active:
         for fqn, cfg, parent, attr in config_root.traverse(ov.target_cls):
+            if ov.exact and type(cfg) is not ov.target_cls:
+                continue
             if ov.matches(fqn):
                 claims.append(_Claim(ov=ov, fqn=fqn, cfg=cfg, parent=parent, attr=attr))
     return claims

--- a/torchtitan/overrides/README.md
+++ b/torchtitan/overrides/README.md
@@ -244,6 +244,12 @@ declaratively — no field-sniffing inside the factory.
 - a list of FQN globs — `fnmatch` style, where `*` also crosses `.`; a node is
   claimed if any glob matches its FQN.
 
+By default, `target` matches instances of the target config class and its
+subclasses. If a replacement only implements the concrete target contract, pass
+`exact=True` to `@override`; subclass configs are then not claimed, so they are
+not logged as replacements and can still be handled by a subclass-specific
+override.
+
 The FQN is the full path from the `Trainer.Config` root, e.g. a model component
 is `model_spec.model.layers.0.feed_forward` and the optimizer is `optimizer`.
 Globs with `*` (which crosses `.`) keep selectors readable.
@@ -441,17 +447,23 @@ for the full recipe.
 
 ## Worked Examples
 
-- `torchtitan/overrides/fused_swiglu.py` — **the in-repo example.** A fused
-  SwiGLU feed-forward demonstrating custom `__init__` parametrization (one fused
-  `(hidden, 2, dim)` `w13` weight, one GEMM), `param_init`, and a `sharding_config`
-  that composes with both FSDP and TP (see "Fusion under TP" above). Needs no
-  prerequisite. See "Checkpoint Compatibility" for why it is not interoperable
-  with stock checkpoints.
+- `torchtitan/overrides/fused_swiglu.py` — **the parametrization example.** A
+  fused SwiGLU feed-forward demonstrating custom `__init__` parametrization (one
+  fused `(hidden, 2, dim)` `w13` weight, one GEMM), `param_init`, and a
+  `sharding_config` that composes with both FSDP and TP (see "Fusion under TP"
+  above). Needs no prerequisite. See "Checkpoint Compatibility" for why it is not
+  interoperable with stock checkpoints.
+- `torchtitan/overrides/helion_rope.py` — **the custom-kernel example.** Swaps
+  `CosSinRoPE` for a fused Helion kernel (forward + backward) wrapped in a
+  `torch.library.custom_op` (with `register_fake` / `register_autograd`), the
+  recipe from "Custom kernels and `torch.compile`". `helion` is an optional
+  dependency, so the module imports without it and falls back to the PyTorch RoPE
+  when it (or CUDA) is unavailable; it is checkpoint-compatible with stock.
 
 The `TritonRoPE` snippets above are illustrative — no `triton_rope.py` is
-shipped — but RoPE is a fully valid override target: each attention module owns a
-`rope` submodule (`RoPE.Config`), so a custom RoPE is an ordinary component
-override.
+shipped — but RoPE is a fully valid override target (`helion_rope.py` is a real
+one): each attention module owns a `rope` submodule (`RoPE.Config`), so a custom
+RoPE is an ordinary component override.
 
 ## Code map
 
@@ -461,8 +473,8 @@ override.
 | `torchtitan/config/__init__.py` | Re-exports the override API. |
 | `torchtitan/protocols/model_spec.py` | `ModelSpec.traverse` exposes the nested model config to the traversal. |
 | `torchtitan/trainer.py` | Holds the `override` config field; applies overrides after `update_from_config`, before builds. |
-| `torchtitan/overrides/` | In-repo example implementations (`fused_swiglu.py`). |
-| `tests/unit_tests/test_override.py` | Unit tests: registration, provenance, FQN targeting, per-node conflicts, `derive`. |
+| `torchtitan/overrides/` | In-repo example implementations (`fused_swiglu.py`, `helion_rope.py`). |
+| `tests/unit_tests/test_override.py` | Unit tests: registration, provenance, FQN / exact targeting, per-node conflicts, `derive`. |
 
 Overriding a component requires no changes to any model's `config_registry.py`
 or `__init__.py` — that is the point of the design.
@@ -476,6 +488,8 @@ or `__init__.py` — that is the point of the design.
   claims error.
 - **Per-instance targeting.** Via `fqns` (FQN globs) on `@override`; the factory
   is pure construction.
+- **Subclass matching.** Targets match subclasses by default; use `exact=True`
+  when a replacement only supports the concrete target config.
 - **Scope.** Any `Configurable` in the `Trainer.Config` tree.
 - **Config construction.** Use `derive(cfg, NewConfig, **deltas)` so factories
   don't silently drop fields added to the target later.

--- a/torchtitan/overrides/helion_rope.py
+++ b/torchtitan/overrides/helion_rope.py
@@ -18,13 +18,13 @@ Scope and fallbacks (the kernel is opt-in and never changes default behavior):
 * **Plain cos/sin only.** Targets exactly ``CosSinRoPE.Config``; the complex
   RoPE used by Llama 3 / DeepSeek V3 and subclasses with different cache
   contracts (e.g. Qwen3.5 ``MRoPE``) are untouched.
-* ``helion`` is an optional dependency. If it is not installed, or
-  the inputs are unsupported (any tensor on CPU or split across devices, a cache
-  that isn't a 2D ``(max_seq, 2 * head_dim)`` table, non-integer or oddly shaped
-  position ids, non-contiguous tensors), the module transparently falls back to
-  the PyTorch ``CosSinRoPE`` path. Position ids are bounds-checked exactly as the
-  PyTorch path does, so out-of-range ids fail cleanly rather than as an illegal
-  kernel access.
+* ``helion`` is an optional dependency, but explicitly selecting this override
+  requires it to be installed. Unsupported tensor inputs (any tensor on CPU or
+  split across devices, a cache that isn't a 2D ``(max_seq, 2 * head_dim)``
+  table, non-integer or oddly shaped position ids, non-contiguous tensors) fall
+  back to the PyTorch ``CosSinRoPE`` path. Position ids are bounds-checked
+  exactly as the PyTorch path does, so out-of-range ids fail cleanly rather than
+  as an illegal kernel access.
 * **CUDA only.** For now, the configs are tuned for NVIDIA H100, although this
   supports configs tuned for AMD, etc. Helion is a hardware agnostic DSL.
 
@@ -35,6 +35,7 @@ rotate-half convention), so it is interoperable with stock checkpoints.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache
 from typing import Any, TYPE_CHECKING
 
 import torch
@@ -46,25 +47,25 @@ from torchtitan.tools.logging import logger, warn_once
 
 if TYPE_CHECKING:
     # The type checker always sees helion as importable (resolved to Any via
-    # ``replace-imports-with-any`` in pyproject.toml); the runtime guard below is
-    # what makes it a genuine optional dependency.
+    # ``replace-imports-with-any`` in pyproject.toml); the runtime import-error
+    # sentinel below is what makes it a genuine optional dependency.
     import helion
     import helion.language as hl
 
-    _HAS_HELION = True
+    _HELION_IMPORT_ERROR: ImportError | None = None
 else:
     try:
         import helion
         import helion.language as hl
 
-        _HAS_HELION = True
-    except ImportError:
-        _HAS_HELION = False
+        _HELION_IMPORT_ERROR = None
+    except ImportError as e:
+        _HELION_IMPORT_ERROR = e
 
 __all__ = ["HelionRoPE"]
 
 
-if _HAS_HELION:
+if _HELION_IMPORT_ERROR is None:
     # A reasonable default config so a raw (unbound) kernel call is deterministic
     # rather than triggering autotune; production calls override it per shape via
     # ``_run_tuned`` below.
@@ -209,27 +210,86 @@ if _HAS_HELION:
 
         return grad_xq, grad_xk
 
+    @cache
+    def _config(
+        block_sizes: tuple[int, ...],
+        num_warps: int,
+        num_stages: int | None = None,
+        *,
+        l2_groupings: tuple[int, ...] | None = None,
+        load_eviction_policies: tuple[str, ...] | None = None,
+        pid_type: str | None = None,
+    ) -> helion.Config:
+        config_kwargs: dict[str, Any] = {
+            "block_sizes": list(block_sizes),
+            "num_warps": num_warps,
+            "load_eviction_policies": list(load_eviction_policies)
+            if load_eviction_policies is not None
+            else ["", "", "first", "first"],
+        }
+        if num_stages is not None:
+            config_kwargs["num_stages"] = num_stages
+        if l2_groupings is not None:
+            config_kwargs["l2_groupings"] = list(l2_groupings)
+        if pid_type is not None:
+            config_kwargs["pid_type"] = pid_type
+        return helion.Config(**config_kwargs)
+
     def _fwd_config(query: torch.Tensor) -> helion.Config:
         # Pick a forward config by token count (batch * seq_len), the dominant
-        # work size for this bandwidth-bound kernel. The final bucket is a
-        # catch-all so every supported shape has a deterministic config.
+        # work size for this bandwidth-bound kernel. These buckets are tuned on
+        # Qwen3 TP=8 local training shapes and still cover all supported shapes.
         num_tokens = query.shape[0] * query.shape[1]
-        if num_tokens <= 1024:  # decode / short prefill
-            return helion.Config(block_sizes=[1, 8, 8, 1], num_warps=4)
-        if num_tokens <= 2048:  # small prefill
-            return helion.Config(block_sizes=[1, 16, 8, 1], num_warps=8)
-        # large prefill / batch
-        return helion.Config(block_sizes=[1, 16, 4, 1], num_warps=2, num_stages=2)
+        seq_len = query.shape[1]
+        if seq_len >= 1024:
+            return _config(
+                (1, 4, 4, 1),
+                num_warps=2,
+                num_stages=1,
+                l2_groupings=(64,),
+                pid_type="flat",
+            )
+        if num_tokens <= 512:
+            return _config((1, 16, 4, 1), num_warps=2)
+        if num_tokens <= 1024:
+            return _config((1, 4, 4, 1), num_warps=4)
+        if num_tokens <= 2048:
+            return _config((1, 4, 8, 1), num_warps=8)
+        if num_tokens <= 4096:
+            return _config((1, 16, 2, 1), num_warps=8, num_stages=2)
+        if num_tokens <= 8192:
+            return _config((1, 16, 4, 1), num_warps=2, num_stages=2)
+        if num_tokens <= 16384:
+            return _config((1, 4, 4, 1), num_warps=2, num_stages=2)
+        return _config(
+            (1, 8, 4, 1),
+            num_warps=2,
+            num_stages=2,
+            load_eviction_policies=("", "", "last", "last"),
+        )
 
     def _bwd_config(grad_query: torch.Tensor) -> helion.Config:
-        # Backward uses the same token-count bucketing as forward, with a
-        # pipelined catch-all config for larger batches.
+        # Backward gets its own token-count buckets because the transposed
+        # rotation changes which tile shapes are best.
         num_tokens = grad_query.shape[0] * grad_query.shape[1]
+        if num_tokens <= 512:
+            return _config((1, 16, 4, 1), num_warps=2)
         if num_tokens <= 1024:
-            return helion.Config(block_sizes=[1, 8, 8, 1], num_warps=4)
+            return _config((1, 4, 8, 1), num_warps=2)
+        if num_tokens <= 2048:
+            return _config((1, 8, 2, 1), num_warps=8)
+        if num_tokens <= 4096:
+            return _config((1, 8, 4, 1), num_warps=2)
         if num_tokens <= 8192:
-            return helion.Config(block_sizes=[1, 16, 8, 1], num_warps=8)
-        return helion.Config(block_sizes=[1, 16, 4, 1], num_warps=2, num_stages=2)
+            return _config((1, 4, 4, 1), num_warps=2)
+        if num_tokens <= 16384:
+            return _config((1, 8, 4, 1), num_warps=2, num_stages=2)
+        return _config(
+            (1, 4, 4, 1),
+            num_warps=2,
+            num_stages=2,
+            load_eviction_policies=("", "last", "", ""),
+        )
 
     # Cache of bound kernels keyed by (kernel, shapes, dtypes, device). Re-binding
     # a config on every call costs ~20us of CPU dispatch; training/inference use a
@@ -399,7 +459,7 @@ def _eligible(
     )
 
 
-if _HAS_HELION:
+if _HELION_IMPORT_ERROR is None:
 
     def _apply_helion_rope(
         query: torch.Tensor,
@@ -444,13 +504,10 @@ else:
         rope_cache: torch.Tensor,
         positions: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
-        warn_once(
-            logger,
+        raise ImportError(
             "HelionRoPE override is active but `helion` is not installed; "
-            "falling back to the PyTorch cos/sin RoPE. Install helion to use "
-            "the fused kernel.",
+            "install helion to use torchtitan.overrides.helion_rope."
         )
-        return None
 
 
 class HelionRoPE(CosSinRoPE):
@@ -458,8 +515,8 @@ class HelionRoPE(CosSinRoPE):
 
     A drop-in for :class:`CosSinRoPE`: it reuses the same cache and rotate-half
     math, so it stays checkpoint-compatible, and transparently falls back to the
-    PyTorch implementation whenever the fused kernel cannot be used (see the
-    module docstring). Registered as an override on ``CosSinRoPE.Config``.
+    PyTorch implementation for unsupported tensor inputs (see the module
+    docstring). Registered as an override on ``CosSinRoPE.Config``.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -485,4 +542,9 @@ class HelionRoPE(CosSinRoPE):
     description="Fused Helion cos/sin rotary embedding (CUDA).",
 )
 def helion_rope(cfg: CosSinRoPE.Config) -> HelionRoPE.Config:
+    if _HELION_IMPORT_ERROR is not None:
+        raise ImportError(
+            "HelionRoPE override was requested but `helion` is not installed; "
+            "install helion to use torchtitan.overrides.helion_rope."
+        ) from _HELION_IMPORT_ERROR
     return derive(cfg, HelionRoPE.Config)

--- a/torchtitan/overrides/helion_rope.py
+++ b/torchtitan/overrides/helion_rope.py
@@ -1,0 +1,488 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Override: cos/sin rotary embeddings applied with a fused Helion kernel.
+
+This swaps :class:`CosSinRoPE` for a version that fuses the cos/sin gather and
+the rotate-half rotation into a single Helion kernel (forward and backward),
+without touching core.
+
+    torchtitan_train ... --override.imports torchtitan.overrides.helion_rope
+
+Scope and fallbacks (the kernel is opt-in and never changes default behavior):
+
+* **Plain cos/sin only.** Targets exactly ``CosSinRoPE.Config``; the complex
+  RoPE used by Llama 3 / DeepSeek V3 and subclasses with different cache
+  contracts (e.g. Qwen3.5 ``MRoPE``) are untouched.
+* ``helion`` is an optional dependency. If it is not installed, or
+  the inputs are unsupported (any tensor on CPU or split across devices, a cache
+  that isn't a 2D ``(max_seq, 2 * head_dim)`` table, non-integer or oddly shaped
+  position ids, non-contiguous tensors), the module transparently falls back to
+  the PyTorch ``CosSinRoPE`` path. Position ids are bounds-checked exactly as the
+  PyTorch path does, so out-of-range ids fail cleanly rather than as an illegal
+  kernel access.
+* **CUDA only.** For now, the configs are tuned for NVIDIA H100, although this
+  supports configs tuned for AMD, etc. Helion is a hardware agnostic DSL.
+
+The kernel matches ``CosSinRoPE`` numerically (both upcast to fp32 and use the
+rotate-half convention), so it is interoperable with stock checkpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import torch
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import derive, override
+from torchtitan.models.common.rope import _maybe_check_max_pos, CosSinRoPE
+from torchtitan.tools.logging import logger, warn_once
+
+if TYPE_CHECKING:
+    # The type checker always sees helion as importable (resolved to Any via
+    # ``replace-imports-with-any`` in pyproject.toml); the runtime guard below is
+    # what makes it a genuine optional dependency.
+    import helion
+    import helion.language as hl
+
+    _HAS_HELION = True
+else:
+    try:
+        import helion
+        import helion.language as hl
+
+        _HAS_HELION = True
+    except ImportError:
+        _HAS_HELION = False
+
+__all__ = ["HelionRoPE"]
+
+
+if _HAS_HELION:
+    # A reasonable default config so a raw (unbound) kernel call is deterministic
+    # rather than triggering autotune; production calls override it per shape via
+    # ``_run_tuned`` below.
+    _DEFAULT_CONFIG = helion.Config(block_sizes=[1, 16, 8, 1], num_warps=8)
+
+    @helion.kernel(config=_DEFAULT_CONFIG, static_shapes=True)
+    def _rope_cos_sin_fwd(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Fuses the per-position cos/sin gather (``rope_cache[positions]``) with
+        # the rotate-half rotation. ``rope_cache`` is ``(max_seq, 2 * head_dim)``
+        # (cos concatenated with sin); ``*_lo``/``*_hi`` are the first/second
+        # head-dim halves that rotate-half mixes.
+        _, seqlen, n_heads, head_dim = xq.size()
+        _, _, n_kv_heads, _ = xk.size()
+        head_dim = hl.specialize(head_dim)
+
+        xq_out = torch.empty_like(xq)
+        xk_out = torch.empty_like(xk)
+
+        for tile_b, tile_s in hl.tile([xq.size(0), seqlen]):
+            position = positions[tile_b, tile_s]
+            rope_tile = rope_cache[position, :].to(torch.float32)
+            cos, sin = hl.split(
+                rope_tile.reshape([tile_b, tile_s, 2, head_dim]).permute(0, 1, 3, 2)
+            )
+            cos_lo, cos_hi = hl.split(
+                cos.reshape([tile_b, tile_s, 2, head_dim // 2]).permute(0, 1, 3, 2)
+            )
+            sin_lo, sin_hi = hl.split(
+                sin.reshape([tile_b, tile_s, 2, head_dim // 2]).permute(0, 1, 3, 2)
+            )
+
+            cos_lo = cos_lo[:, :, None, :]
+            cos_hi = cos_hi[:, :, None, :]
+            sin_lo = sin_lo[:, :, None, :]
+            sin_hi = sin_hi[:, :, None, :]
+
+            for tile_h in hl.tile(n_heads):
+                xq_tile = xq[tile_b, tile_s, tile_h, :].to(torch.float32)
+                xq_lo, xq_hi = hl.split(
+                    xq_tile.reshape([tile_b, tile_s, tile_h, 2, head_dim // 2]).permute(
+                        0, 1, 2, 4, 3
+                    )
+                )
+                xq_out_lo = xq_lo * cos_lo - xq_hi * sin_lo
+                xq_out_hi = xq_hi * cos_hi + xq_lo * sin_hi
+                xq_out[tile_b, tile_s, tile_h, :] = (
+                    hl.join(xq_out_lo, xq_out_hi)
+                    .permute(0, 1, 2, 4, 3)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(xq.dtype)
+                )
+
+            for tile_h in hl.tile(n_kv_heads):
+                xk_tile = xk[tile_b, tile_s, tile_h, :].to(torch.float32)
+                xk_lo, xk_hi = hl.split(
+                    xk_tile.reshape([tile_b, tile_s, tile_h, 2, head_dim // 2]).permute(
+                        0, 1, 2, 4, 3
+                    )
+                )
+                xk_out_lo = xk_lo * cos_lo - xk_hi * sin_lo
+                xk_out_hi = xk_hi * cos_hi + xk_lo * sin_hi
+                xk_out[tile_b, tile_s, tile_h, :] = (
+                    hl.join(xk_out_lo, xk_out_hi)
+                    .permute(0, 1, 2, 4, 3)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(xk.dtype)
+                )
+
+        return xq_out, xk_out
+
+    @helion.kernel(config=_DEFAULT_CONFIG, static_shapes=True)
+    def _rope_cos_sin_bwd(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Backward of ``_rope_cos_sin_fwd``: same loop structure, with the
+        # rotation transposed (the sign pattern is mirrored across lo/hi).
+        _, seqlen, n_heads, head_dim = grad_xq_out.size()
+        _, _, n_kv_heads, _ = grad_xk_out.size()
+        head_dim = hl.specialize(head_dim)
+
+        grad_xq = torch.empty_like(grad_xq_out)
+        grad_xk = torch.empty_like(grad_xk_out)
+        half_head_dim = head_dim // 2
+
+        for tile_b, tile_s in hl.tile([grad_xq_out.size(0), seqlen]):
+            position = positions[tile_b, tile_s]
+            rope_tile = rope_cache[position, :].to(torch.float32)
+            cos, sin = hl.split(
+                rope_tile.reshape([tile_b, tile_s, 2, head_dim]).permute(0, 1, 3, 2)
+            )
+            cos_lo, cos_hi = hl.split(
+                cos.reshape([tile_b, tile_s, 2, half_head_dim]).permute(0, 1, 3, 2)
+            )
+            sin_lo, sin_hi = hl.split(
+                sin.reshape([tile_b, tile_s, 2, half_head_dim]).permute(0, 1, 3, 2)
+            )
+
+            cos_lo = cos_lo[:, :, None, :]
+            cos_hi = cos_hi[:, :, None, :]
+            sin_lo = sin_lo[:, :, None, :]
+            sin_hi = sin_hi[:, :, None, :]
+
+            for tile_h in hl.tile(n_heads):
+                grad_tile = grad_xq_out[tile_b, tile_s, tile_h, :].to(torch.float32)
+                grad_lo, grad_hi = hl.split(
+                    grad_tile.reshape(
+                        [tile_b, tile_s, tile_h, 2, half_head_dim]
+                    ).permute(0, 1, 2, 4, 3)
+                )
+                grad_xq_lo = grad_lo * cos_lo + grad_hi * sin_hi
+                grad_xq_hi = grad_hi * cos_hi - grad_lo * sin_lo
+                grad_xq[tile_b, tile_s, tile_h, :] = (
+                    hl.join(grad_xq_lo, grad_xq_hi)
+                    .permute(0, 1, 2, 4, 3)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(grad_xq.dtype)
+                )
+
+            for tile_h in hl.tile(n_kv_heads):
+                grad_tile = grad_xk_out[tile_b, tile_s, tile_h, :].to(torch.float32)
+                grad_lo, grad_hi = hl.split(
+                    grad_tile.reshape(
+                        [tile_b, tile_s, tile_h, 2, half_head_dim]
+                    ).permute(0, 1, 2, 4, 3)
+                )
+                grad_xk_lo = grad_lo * cos_lo + grad_hi * sin_hi
+                grad_xk_hi = grad_hi * cos_hi - grad_lo * sin_lo
+                grad_xk[tile_b, tile_s, tile_h, :] = (
+                    hl.join(grad_xk_lo, grad_xk_hi)
+                    .permute(0, 1, 2, 4, 3)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(grad_xk.dtype)
+                )
+
+        return grad_xq, grad_xk
+
+    def _fwd_config(query: torch.Tensor) -> helion.Config:
+        # Pick a forward config by token count (batch * seq_len), the dominant
+        # work size for this bandwidth-bound kernel. The final bucket is a
+        # catch-all so every supported shape has a deterministic config.
+        num_tokens = query.shape[0] * query.shape[1]
+        if num_tokens <= 1024:  # decode / short prefill
+            return helion.Config(block_sizes=[1, 8, 8, 1], num_warps=4)
+        if num_tokens <= 2048:  # small prefill
+            return helion.Config(block_sizes=[1, 16, 8, 1], num_warps=8)
+        # large prefill / batch
+        return helion.Config(block_sizes=[1, 16, 4, 1], num_warps=2, num_stages=2)
+
+    def _bwd_config(grad_query: torch.Tensor) -> helion.Config:
+        # Backward uses the same token-count bucketing as forward, with a
+        # pipelined catch-all config for larger batches.
+        num_tokens = grad_query.shape[0] * grad_query.shape[1]
+        if num_tokens <= 1024:
+            return helion.Config(block_sizes=[1, 8, 8, 1], num_warps=4)
+        if num_tokens <= 8192:
+            return helion.Config(block_sizes=[1, 16, 8, 1], num_warps=8)
+        return helion.Config(block_sizes=[1, 16, 4, 1], num_warps=2, num_stages=2)
+
+    # Cache of bound kernels keyed by (kernel, shapes, dtypes, device). Re-binding
+    # a config on every call costs ~20us of CPU dispatch; training/inference use a
+    # handful of shapes, so this stays tiny. Dict ops are atomic under the GIL, so
+    # the forward (main thread) and backward (autograd thread) sharing it is safe.
+    _BOUND_KERNELS: dict[tuple, Any] = {}
+
+    def _run_tuned(
+        kernel: Any, config: helion.Config, *args: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        key = (
+            id(kernel),
+            tuple(tuple(a.shape) for a in args),
+            tuple(a.dtype for a in args),
+            args[0].device,
+        )
+        bound = _BOUND_KERNELS.get(key)
+        if bound is None:
+            bound = kernel.bind(args)
+            bound.set_config(config)
+            _BOUND_KERNELS[key] = bound
+        return bound(*args)
+
+    @torch.library.custom_op(
+        "torchtitan::helion_rope_fwd", mutates_args=(), device_types="cuda"
+    )
+    def _helion_rope_fwd(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return _run_tuned(
+            _rope_cos_sin_fwd, _fwd_config(xq), xq, xk, rope_cache, positions
+        )
+
+    @_helion_rope_fwd.register_fake
+    def _helion_rope_fwd_fake(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.empty_like(xq), torch.empty_like(xk)
+
+    @torch.library.custom_op(
+        "torchtitan::helion_rope_bwd", mutates_args=(), device_types="cuda"
+    )
+    def _helion_rope_bwd(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The pointer-indexed kernel assumes contiguous gradients (static_shapes);
+        # autograd may hand us non-contiguous ones, so make them contiguous.
+        grad_xq_out = grad_xq_out.contiguous()
+        grad_xk_out = grad_xk_out.contiguous()
+        return _run_tuned(
+            _rope_cos_sin_bwd,
+            _bwd_config(grad_xq_out),
+            grad_xq_out,
+            grad_xk_out,
+            rope_cache,
+            positions,
+        )
+
+    @_helion_rope_bwd.register_fake
+    def _helion_rope_bwd_fake(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.empty_like(grad_xq_out), torch.empty_like(grad_xk_out)
+
+    def _fwd_setup_context(ctx, inputs, output) -> None:
+        xq, xk, rope_cache, positions = inputs
+        ctx.save_for_backward(rope_cache, positions)
+        ctx.xq_shape = xq.shape
+        ctx.xk_shape = xk.shape
+
+    def _fwd_backward(ctx, grad_xq_out, grad_xk_out):
+        rope_cache, positions = ctx.saved_tensors
+        # RoPE feeds both q and k into attention, so both grads are normally
+        # present; zero-fill defensively if autograd drops one.
+        if grad_xq_out is None:
+            grad_xq_out = torch.zeros(
+                ctx.xq_shape, device=grad_xk_out.device, dtype=grad_xk_out.dtype
+            )
+        if grad_xk_out is None:
+            grad_xk_out = torch.zeros(
+                ctx.xk_shape, device=grad_xq_out.device, dtype=grad_xq_out.dtype
+            )
+        grad_xq, grad_xk = _helion_rope_bwd(
+            grad_xq_out, grad_xk_out, rope_cache, positions
+        )
+        if not ctx.needs_input_grad[0]:
+            grad_xq = None
+        if not ctx.needs_input_grad[1]:
+            grad_xk = None
+        return grad_xq, grad_xk, None, None
+
+    _helion_rope_fwd.register_autograd(_fwd_backward, setup_context=_fwd_setup_context)
+
+
+def _to_local(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _from_local(local: torch.Tensor, spec: torch.Tensor) -> torch.Tensor:
+    if isinstance(spec, DTensor):
+        return DTensor.from_local(
+            local, spec.device_mesh, spec.placements, run_check=False
+        )
+    return local
+
+
+def _resolve_positions(
+    positions: torch.Tensor | None, query_local: torch.Tensor
+) -> torch.Tensor:
+    # ``positions=None`` means "0, 1, ..., seq_len-1" per row (what the PyTorch
+    # path does via ``cache[0:seq_len]``); the kernel gathers by index, so make
+    # those explicit, contiguous (batch, seq_len) ids.
+    if positions is not None:
+        return _to_local(positions)
+    batch, seqlen = query_local.shape[0], query_local.shape[1]
+    pos = torch.arange(seqlen, device=query_local.device, dtype=torch.int32)
+    return pos.unsqueeze(0).expand(batch, -1).contiguous()
+
+
+def _eligible(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> bool:
+    # The kernel gathers ``rope_cache[positions]`` and reshapes the row to
+    # ``[..., 2, head_dim]`` on device, so every tensor must be CUDA, the cache a
+    # 2D ``(max_seq, 2 * head_dim)`` table, and positions integer ids -- otherwise
+    # it would be an illegal access / shape error instead of a clean fallback.
+    # (Stock ``CosSinRoPE`` even moves a mismatched-device cache via ``.to``; we
+    # fall back rather than gather across devices.) q/k must both be 4D
+    # ``(batch, seq, heads, head_dim)`` sharing batch/seq: the kernel unpacks both
+    # as 4D and indexes ``xk`` with ``xq``'s batch/seq tiles, so a mismatch would
+    # read out of bounds.
+    return (
+        xq.is_cuda
+        and xk.is_cuda
+        and rope_cache.is_cuda
+        and positions.is_cuda
+        and xq.device == xk.device == rope_cache.device == positions.device
+        and xq.ndim == 4
+        and xk.ndim == 4
+        and rope_cache.ndim == 2
+        and rope_cache.shape[-1] == 2 * xq.shape[-1]
+        and positions.ndim == 2
+        and positions.dtype in (torch.int32, torch.int64)
+        and tuple(positions.shape) == tuple(xq.shape[:2])
+        and tuple(xk.shape[:2]) == tuple(xq.shape[:2])
+        and xq.is_contiguous()
+        and xk.is_contiguous()
+        and rope_cache.is_contiguous()
+        and positions.is_contiguous()
+        and xq.shape[-1] == xk.shape[-1]
+        and xq.shape[-1] % 2 == 0
+    )
+
+
+if _HAS_HELION:
+
+    def _apply_helion_rope(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        """Run the fused kernel, or return ``None`` if the inputs are unsupported.
+
+        The custom op is valid in eager and compiled execution. Fallback is
+        reserved for inputs the kernel cannot safely handle; the caller uses the
+        PyTorch path for those cases.
+        """
+        xq = _to_local(query)
+        xk = _to_local(key)
+        cache = _to_local(rope_cache)
+        pos = _resolve_positions(positions, xq)
+        if not _eligible(xq, xk, cache, pos):
+            warn_once(
+                logger,
+                "HelionRoPE: inputs unsupported by the fused kernel (need "
+                "contiguous CUDA q/k/cache/positions, a 2D cache of width "
+                "2 * head_dim, and integer (batch, seq_len) position ids); "
+                "falling back to the PyTorch cos/sin RoPE.",
+            )
+            return None
+
+        # Bounds parity with stock CosSinRoPE: async-assert position ids are in
+        # range so an out-of-range id fails cleanly instead of triggering an
+        # illegal memory access inside the kernel's cache gather. No host sync,
+        # and skipped under torch.compile -- same semantics as the PyTorch path.
+        _maybe_check_max_pos(pos, max_valid_pos=cache.shape[0] - 1)
+
+        xq_out, xk_out = _helion_rope_fwd(xq, xk, cache, pos)
+        return _from_local(xq_out, query), _from_local(xk_out, key)
+
+else:
+
+    def _apply_helion_rope(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        warn_once(
+            logger,
+            "HelionRoPE override is active but `helion` is not installed; "
+            "falling back to the PyTorch cos/sin RoPE. Install helion to use "
+            "the fused kernel.",
+        )
+        return None
+
+
+class HelionRoPE(CosSinRoPE):
+    """Cos/sin RoPE that applies the rotation with a fused Helion kernel.
+
+    A drop-in for :class:`CosSinRoPE`: it reuses the same cache and rotate-half
+    math, so it stays checkpoint-compatible, and transparently falls back to the
+    PyTorch implementation whenever the fused kernel cannot be used (see the
+    module docstring). Registered as an override on ``CosSinRoPE.Config``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(CosSinRoPE.Config):
+        pass
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        positions: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        out = _apply_helion_rope(query, key, self.cache, positions)
+        if out is None:
+            return super().forward(query, key, positions)
+        return out
+
+
+@override(
+    "helion_rope",
+    target=CosSinRoPE.Config,
+    exact=True,
+    description="Fused Helion cos/sin rotary embedding (CUDA).",
+)
+def helion_rope(cfg: CosSinRoPE.Config) -> HelionRoPE.Config:
+    return derive(cfg, HelionRoPE.Config)


### PR DESCRIPTION
Adds an opt-in override (`torchtitan/overrides/helion_rope.py`) that swaps `CosSinRoPE` for a version applying the cos/sin gather + rotate-half rotation in a single fused Helion kernel (forward and backward). Activated with `--override.imports torchtitan.overrides.helion_rope`; it never changes default behavior.

We have speedups for tok/s in a standard inference setting:

Qwen3-32B (TP-8) tok/s (higher is better)
Inference (vllm, eager + cudagraph) using https://github.com/pytorch/torchtitan/blob/main/torchtitan/experiments/rl/generate.py
| Prefix tokens | Input tokens | Output tokens | cos_sin tok/s | Helion tok/s | Speedup |
|---:|---:|---:|---:|---:|---:|
| 64 | 128 | 128 | 588.5 | 701.8 | **1.19x** |
| 64 | 1024 | 128 | 337.7 | 462.3 | **1.37x** |
| 64 | 128 | 512 | 661.4 | 755.3 | **1.14x** |

We see that the custom kernel improves eager fwd/bwd performance, but doesnt help performance under torch compile, due to inductor fusing the bwd kernel well + standard custom op overhead. We should think of this primarily as a inference/eager optimization.

Qwen3-32B (TP-8) end-to-end fwd_bwd timing (lower is better)

| B | S | Eager cos_sin ms | Eager helion ms | Eager speedup | Inductor cos_sin ms | Inductor helion ms | Inductor speedup |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 8 | 1024 | 1157.1 | 1102.6 | 1.049x | 678.0 | 678.2 | 1.000x |
| 16 | 1024 | 1588.9 | 1490.6 | 1.066x | 1307.7 | 1309.9 | 0.998x |
| 32 | 1024 | 3129.1 | 2924.8 | 1.070x | 2559.7 | 2561.4 | 0.999x |
| 64 | 1024 | 6169.4 | 5770.2 | 1.069x | 5043.0 | 5054.0 | 0.998x |
| 8 | 4096 | 3308.2 | 3115.7 | 1.062x | 2753.1 | 2753.6 | 1.000x |
| 16 | 4096 | 6526.5 | 6118.3 | 1.067x | 5420.3 | 5426.4 | 0.999x |
| 32 | 4096 | 13005.8 | 12223.7 | 1.064x | 10824.7 | 10837.5 | 0.999x |
| 64 | 4096 | 25908.3 | 24331.7 | 1.065x | 21544.2 | 21558.9 | 0.999x |

Isolated kernel benchmarks (lower is better)

FWD RoPE
| B | S | eager fwd ms | inductor fwd ms | helion fwd ms | helion speedup vs inductor |
|---:|---:|---:|---:|---:|---:|
| 1 | 1024 | 0.1393 | 0.0663 | 0.0610 | 1.087x |
| 1 | 4096 | 0.1614 | 0.0676 | 0.0625 | 1.081x |
| 2 | 1024 | 0.1394 | 0.0654 | 0.0630 | 1.038x |
| 2 | 4096 | 0.3183 | 0.0725 | 0.0663 | 1.093x |
| 4 | 1024 | 0.1624 | 0.0675 | 0.0630 | 1.070x |
| 4 | 4096 | 0.5789 | 0.0852 | 0.0780 | 1.091x |
| 8 | 1024 | 0.3177 | 0.0696 | 0.0636 | 1.094x |
| 8 | 4096 | 1.0891 | 0.1222 | 0.1153 | 1.060x |
| 16 | 1024 | 0.5760 | 0.0801 | 0.0770 | 1.039x |
| 16 | 4096 | 2.1220 | 0.2020 | 0.1836 | 1.100x |
| 32 | 1024 | 1.0830 | 0.1143 | 0.1128 | 1.013x |
| 32 | 4096 | 4.1607 | 0.3462 | 0.3269 | 1.059x |
| 64 | 1024 | 2.1176 | 0.1823 | 0.1817 | 1.003x |
| 64 | 4096 | 8.2326 | 0.6416 | 0.6210 | 1.033x |
| 128 | 1024 | 4.1597 | 0.3376 | 0.3256 | 1.037x |
| 128 | 4096 | 16.3864 | 1.2524 | 1.2087 | 1.036x |

BWD RoPE
| B | S | Bwd eager ms | Bwd inductor ms | Bwd helion ms | Bwd speedup vs inductor |
|---:|---:|---:|---:|---:|---:|
| 1 | 1024 | 0.3177 | 0.1573 | 0.0730 | 2.157x |
| 1 | 4096 | 0.2915 | 0.1721 | 0.0698 | 2.466x |
| 2 | 1024 | 0.3263 | 0.1741 | 0.0763 | 2.282x |
| 2 | 4096 | 0.4542 | 0.1568 | 0.0714 | 2.197x |
| 4 | 1024 | 0.3225 | 0.1888 | 0.0693 | 2.726x |
| 4 | 4096 | 0.7800 | 0.1791 | 0.0859 | 2.084x |
| 8 | 1024 | 0.4382 | 0.1629 | 0.0687 | 2.371x |
| 8 | 4096 | 1.4483 | 0.1837 | 0.1233 | 1.490x |
| 16 | 1024 | 0.7838 | 0.1760 | 0.0855 | 2.059x |
| 16 | 4096 | 2.7736 | 0.2413 | 0.1901 | 1.269x |
| 32 | 1024 | 1.4500 | 0.1814 | 0.1217 | 1.490x |
| 32 | 4096 | 5.4222 | 0.4102 | 0.3306 | 1.241x |
| 64 | 1024 | 2.7465 | 0.2167 | 0.1927 | 1.124x |
| 64 | 4096 | 10.6831 | 0.7142 | 0.6191 | 1.154x |
| 128 | 1024 | 5.4158 | 0.4159 | 0.3323 | 1.251x |
| 128 | 4096 | 21.0995 | 1.3449 | 1.1790 | 1.141x |


Scope and safety:
- Adds an `exact` flag to the `@override` mechanism (`torchtitan/config/override.py`): a target matches subclasses by default; `exact=True` restricts to the concrete target type, which this override needs. Thus, it replaces exactly `CosSinRoPE.Config` and leaves subclasses with a different cache contract (e.g. Qwen3.5 `MRoPE`) untouched.
- Optional dependency: imports cleanly without `helion` and falls back to the PyTorch `CosSinRoPE` path when helion is absent or inputs are unsupported (non-CUDA, cross-device, non-4D or mismatched q/k, a cache that isn't a 2D `(max_seq, 2*head_dim)` table, non-integer or out-of-range position ids). Position ids are bounds-checked exactly as the PyTorch path.
- Compile-safe: the kernel is wrapped in a `torch.library.custom_op` with `register_fake`/`register_autograd`. Under compiled *training* the opaque custom op blocks Inductor's neighbor-fusion, so model-level compile can be a wash; this is documented rather than hidden behind a fallback.