### PR TITLE
FusedQKVLinear checkpoint interop via state_dict hooks

### DIFF
--- a/tests/unit_tests/test_fused_qkv.py
+++ b/tests/unit_tests/test_fused_qkv.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Checkpoint interop tests for FusedQKVLinear.
+
+FusedQKVLinear stores a single fused ``wqkv`` parameter but checkpoints in the
+stock ``QKVLinear`` layout (``wq.weight`` / ``wk.weight`` / ``wv.weight``) via
+state_dict hooks, so its checkpoints round-trip with the non-fused module.
+
+All tests run on CPU.
+"""
+
+import unittest
+
+import torch
+from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
+from torchtitan.models.common.nn_modules import Linear
+
+_DIM = 16
+_N_HEADS = 4
+_N_KV_HEADS = 2
+_HEAD_DIM = 8
+_HPK = _N_HEADS // _N_KV_HEADS  # heads_per_kv = 2
+_R_DIM = _HPK + 2  # 4
+_WQKV_OUT = (_N_HEADS + 2 * _N_KV_HEADS) * _HEAD_DIM  # 64
+_WQ_OUT = _N_HEADS * _HEAD_DIM  # 32
+_WK_OUT = _N_KV_HEADS * _HEAD_DIM  # 16
+
+
+def _build_fused(with_bias: bool = False) -> FusedQKVLinear:
+    fused = FusedQKVLinear.Config(
+        head_dim=_HEAD_DIM,
+        n_heads=_N_HEADS,
+        n_kv_heads=_N_KV_HEADS,
+        wqkv=Linear.Config(in_features=_DIM, out_features=_WQKV_OUT, bias=with_bias),
+    ).build()
+    with torch.no_grad():
+        fused.wqkv.weight.copy_(torch.randn(_WQKV_OUT, _DIM))
+        if with_bias:
+            fused.wqkv.bias.copy_(torch.randn(_WQKV_OUT))
+    return fused
+
+
+def _build_stock(with_bias: bool = False) -> QKVLinear:
+    stock = QKVLinear.Config(
+        head_dim=_HEAD_DIM,
+        wq=Linear.Config(in_features=_DIM, out_features=_WQ_OUT, bias=with_bias),
+        wkv=Linear.Config(in_features=_DIM, out_features=_WK_OUT, bias=with_bias),
+    ).build()
+    with torch.no_grad():
+        for p in stock.parameters():
+            p.copy_(torch.randn_like(p))
+    return stock
+
+
+class TestFusedQKVCheckpointInterop(unittest.TestCase):
+    def test_fused_checkpoint_loads_into_stock(self):
+        """Fused state_dict loads into stock QKVLinear with correct weights."""
+        fused = _build_fused(with_bias=True)
+        stock = _build_stock(with_bias=True)
+        stock.load_state_dict(fused.state_dict())
+
+        n_kv = _WQKV_OUT // (_R_DIM * _HEAD_DIM)
+        wqkv = fused.wqkv.weight.reshape(n_kv, _R_DIM, _HEAD_DIM, _DIM)
+        self.assertTrue(torch.equal(stock.wq.weight, wqkv[:, :_HPK].reshape(-1, _DIM)))
+        self.assertTrue(torch.equal(stock.wk.weight, wqkv[:, _HPK].reshape(-1, _DIM)))
+        self.assertTrue(
+            torch.equal(stock.wv.weight, wqkv[:, _HPK + 1].reshape(-1, _DIM))
+        )
+
+        b_3d = fused.wqkv.bias.reshape(n_kv, _R_DIM, _HEAD_DIM)
+        self.assertTrue(torch.equal(stock.wq.bias, b_3d[:, :_HPK].reshape(-1)))
+        self.assertTrue(torch.equal(stock.wk.bias, b_3d[:, _HPK].reshape(-1)))
+        self.assertTrue(torch.equal(stock.wv.bias, b_3d[:, _HPK + 1].reshape(-1)))
+
+    def test_stock_checkpoint_loads_into_fused(self):
+        """A stock checkpoint loads into FusedQKVLinear."""
+        stock = _build_stock(with_bias=True)
+        fused = _build_fused(with_bias=True)
+        fused.load_state_dict(stock.state_dict())
+
+        n_kv = _WQKV_OUT // (_R_DIM * _HEAD_DIM)
+        wqkv = fused.wqkv.weight.reshape(n_kv, _R_DIM, _HEAD_DIM, _DIM)
+        self.assertTrue(torch.equal(wqkv[:, :_HPK].reshape(-1, _DIM), stock.wq.weight))
+        self.assertTrue(torch.equal(wqkv[:, _HPK].reshape(-1, _DIM), stock.wk.weight))
+        self.assertTrue(
+            torch.equal(wqkv[:, _HPK + 1].reshape(-1, _DIM), stock.wv.weight)
+        )
+
+        wqkv_b = fused.wqkv.bias.reshape(n_kv, _R_DIM, _HEAD_DIM)
+        self.assertTrue(torch.equal(wqkv_b[:, :_HPK].reshape(-1), stock.wq.bias))
+        self.assertTrue(torch.equal(wqkv_b[:, _HPK].reshape(-1), stock.wk.bias))
+        self.assertTrue(torch.equal(wqkv_b[:, _HPK + 1].reshape(-1), stock.wv.bias))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -613,6 +613,10 @@ class FusedQKVLinear(BaseQKVLinear):
     Reduces kernel launch overhead compared to three separate projections.
 
     Compatible with ColwiseParallel on the ``wqkv`` linear layer.
+
+    Checkpoints in the stock ``QKVLinear`` layout (``wq.weight`` / ``wk.weight`` /
+    ``wv.weight``) via state_dict hooks, so checkpoints interoperate with the
+    non-fused module and the HF adapter.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -631,6 +635,8 @@ class FusedQKVLinear(BaseQKVLinear):
         self.wqkv = config.wqkv.build()
         self.heads_per_kv = config.n_heads // config.n_kv_heads
         self.r_dim = self.heads_per_kv + 2
+        self.register_state_dict_post_hook(self._split_qkv_on_save)
+        self.register_load_state_dict_pre_hook(self._merge_qkv_on_load)
 
     def forward(
         self, x: torch.Tensor
@@ -648,6 +654,68 @@ class FusedQKVLinear(BaseQKVLinear):
         xk = xk.reshape(bs, seqlen, -1, self.head_dim)
         xv = xv.reshape(bs, seqlen, -1, self.head_dim)
         return xq, xk, xv
+
+    @staticmethod
+    def _split_qkv_on_save(module, state_dict, prefix, local_metadata) -> None:
+        """Split fused ``wqkv`` into stock ``wq.weight``/``wk.weight``/``wv.weight``."""
+        hd, hpk, r = module.head_dim, module.heads_per_kv, module.r_dim
+
+        wqkv_w = state_dict.pop(f"{prefix}wqkv.weight")
+        n_kv, in_f = wqkv_w.shape[0] // (r * hd), wqkv_w.shape[1]
+        w = wqkv_w.reshape(n_kv, r, hd, in_f)
+        state_dict[f"{prefix}wq.weight"] = w[:, :hpk].reshape(-1, in_f).contiguous()
+        state_dict[f"{prefix}wk.weight"] = w[:, hpk].reshape(-1, in_f).contiguous()
+        state_dict[f"{prefix}wv.weight"] = w[:, hpk + 1].reshape(-1, in_f).contiguous()
+
+        b_key = f"{prefix}wqkv.bias"
+        if b_key in state_dict:
+            b = state_dict.pop(b_key).reshape(n_kv, r, hd)
+            state_dict[f"{prefix}wq.bias"] = b[:, :hpk].reshape(-1).contiguous()
+            state_dict[f"{prefix}wk.bias"] = b[:, hpk].reshape(-1).contiguous()
+            state_dict[f"{prefix}wv.bias"] = b[:, hpk + 1].reshape(-1).contiguous()
+
+    @staticmethod
+    def _merge_qkv_on_load(module, state_dict, prefix, *args) -> None:
+        """Merge stock ``wq.weight``/``wk.weight``/``wv.weight`` back into ``wqkv``."""
+        hd, hpk = module.head_dim, module.heads_per_kv
+        wq_key, wk_key, wv_key = (
+            f"{prefix}wq.weight",
+            f"{prefix}wk.weight",
+            f"{prefix}wv.weight",
+        )
+
+        if wq_key in state_dict and wk_key in state_dict and wv_key in state_dict:
+            wq, wk, wv = (
+                state_dict.pop(wq_key),
+                state_dict.pop(wk_key),
+                state_dict.pop(wv_key),
+            )
+            n_kv, in_f = wk.shape[0] // hd, wq.shape[1]
+            q = wq.reshape(n_kv, hpk, hd, in_f)
+            k = wk.reshape(n_kv, 1, hd, in_f)
+            v = wv.reshape(n_kv, 1, hd, in_f)
+            state_dict[f"{prefix}wqkv.weight"] = torch.cat([q, k, v], dim=1).reshape(
+                -1, in_f
+            )
+
+        bq_key, bk_key, bv_key = (
+            f"{prefix}wq.bias",
+            f"{prefix}wk.bias",
+            f"{prefix}wv.bias",
+        )
+        if bq_key in state_dict and bk_key in state_dict and bv_key in state_dict:
+            bq, bk, bv = (
+                state_dict.pop(bq_key),
+                state_dict.pop(bk_key),
+                state_dict.pop(bv_key),
+            )
+            n_kv = bk.shape[0] // hd
+            q_b = bq.reshape(n_kv, hpk, hd)
+            k_b = bk.reshape(n_kv, 1, hd)
+            v_b = bv.reshape(n_kv, 1, hd)
+            state_dict[f"{prefix}wqkv.bias"] = torch.cat(
+                [q_b, k_b, v_b], dim=1
+            ).reshape(-1)
 
 
 class GQAttention(BaseAttention):

--- a/torchtitan/models/gpt_oss/state_dict_adapter.py
+++ b/torchtitan/models/gpt_oss/state_dict_adapter.py
@@ -7,10 +7,8 @@
 import re
 from typing import Any
 
-import torch
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 
-from torchtitan.models.common.attention import FusedQKVLinear
 from torchtitan.models.common.rope import CosSinRoPE
 from torchtitan.models.utils import MoEStateDictAdapter
 from .model import GptOssModel
@@ -19,34 +17,16 @@ from .model import GptOssModel
 class GptOssStateDictAdapter(MoEStateDictAdapter):
     def __init__(self, model_config: GptOssModel.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
-        self.fuse_qkv = isinstance(
-            model_config.layers[0].attention.qkv_linear, FusedQKVLinear.Config
-        )
-
-        qkv_map: dict[str, str | None]
-        if self.fuse_qkv:
-            qkv_map = {
-                "model.layers.{}.self_attn.q_proj.weight": None,
-                "model.layers.{}.self_attn.q_proj.bias": None,
-                "model.layers.{}.self_attn.k_proj.weight": None,
-                "model.layers.{}.self_attn.k_proj.bias": None,
-                "model.layers.{}.self_attn.v_proj.weight": None,
-                "model.layers.{}.self_attn.v_proj.bias": None,
-            }
-        else:
-            qkv_map = {
-                "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
-                "model.layers.{}.self_attn.q_proj.bias": "layers.{}.attention.qkv_linear.wq.bias",
-                "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
-                "model.layers.{}.self_attn.k_proj.bias": "layers.{}.attention.qkv_linear.wk.bias",
-                "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
-                "model.layers.{}.self_attn.v_proj.bias": "layers.{}.attention.qkv_linear.wv.bias",
-            }
 
         self.from_hf_map = {
             "model.embed_tokens.weight": "tok_embeddings.weight",
             # Attention module
-            **qkv_map,
+            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
+            "model.layers.{}.self_attn.q_proj.bias": "layers.{}.attention.qkv_linear.wq.bias",
+            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
+            "model.layers.{}.self_attn.k_proj.bias": "layers.{}.attention.qkv_linear.wk.bias",
+            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
+            "model.layers.{}.self_attn.v_proj.bias": "layers.{}.attention.qkv_linear.wv.bias",
             "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
             "model.layers.{}.self_attn.o_proj.bias": "layers.{}.attention.wo.bias",
             "model.layers.{}.self_attn.sinks": "layers.{}.attention.sinks",
@@ -85,53 +65,6 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
         else:
             return HuggingFaceStorageReader(path)
 
-    def _get_attention_dims(self) -> tuple[int, int, int]:
-        """Return (n_heads, n_kv_heads, head_dim) from model config."""
-        # pyrefly: ignore [missing-attribute]
-        attn = self.model_config.layers[0].attention
-        n_heads = attn.n_heads
-        n_kv_heads = attn.n_kv_heads if attn.n_kv_heads is not None else n_heads
-        head_dim = (
-            attn.head_dim
-            if attn.head_dim is not None
-            else self.model_config.dim // n_heads  # pyrefly: ignore [missing-attribute]
-        )
-        return n_heads, n_kv_heads, head_dim
-
-    @staticmethod
-    def _fused_to_separate_qkv_bias(
-        fused_bias: torch.Tensor,
-        n_heads: int,
-        n_kv_heads: int,
-        head_dim: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Split fused wqkv bias [n_kv * R * hd] into separate Q, K, V biases."""
-        heads_per_kv = n_heads // n_kv_heads
-        r_dim = heads_per_kv + 2
-        b = fused_bias.view(n_kv_heads, r_dim, head_dim)
-        bq = b[:, :heads_per_kv, :].reshape(n_heads * head_dim)
-        bk = b[:, heads_per_kv, :].reshape(n_kv_heads * head_dim)
-        bv = b[:, heads_per_kv + 1, :].reshape(n_kv_heads * head_dim)
-        return bq, bk, bv
-
-    @staticmethod
-    def _separate_to_fused_qkv_bias(
-        bq: torch.Tensor,
-        bk: torch.Tensor,
-        bv: torch.Tensor,
-        n_heads: int,
-        n_kv_heads: int,
-        head_dim: int,
-    ) -> torch.Tensor:
-        """Combine separate Q, K, V biases into fused wqkv layout."""
-        heads_per_kv = n_heads // n_kv_heads
-        r_dim = heads_per_kv + 2
-        q = bq.view(n_kv_heads, heads_per_kv, head_dim)
-        k = bk.view(n_kv_heads, 1, head_dim)
-        v = bv.view(n_kv_heads, 1, head_dim)
-        fused = torch.cat([q, k, v], dim=1)
-        return fused.reshape(n_kv_heads * r_dim * head_dim)
-
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         """
         Convert from a tt model state dict to a hf format state dict.
@@ -144,11 +77,7 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                  One can save into unquantized hf checkpoints with last_save_in_hf = true.
         """
 
-        if self.fuse_qkv:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
-            n_heads, n_kv_heads, head_dim = self._get_attention_dims()
-        else:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+        to_hf_map = {v: k for k, v in self.from_hf_map.items()}
         hf_state_dict = {}
 
         for key, value in state_dict.items():
@@ -156,37 +85,6 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
                 # pyrefly: ignore
                 layer_num = re.search(r"\d+", key).group(0)
-
-                if self.fuse_qkv and abstract_key in (
-                    "layers.{}.attention.qkv_linear.wqkv.weight",
-                    "layers.{}.attention.qkv_linear.wqkv.bias",
-                ):
-                    is_bias = abstract_key.endswith("bias")
-                    if is_bias:
-                        bq, bk, bv = self._fused_to_separate_qkv_bias(
-                            value,
-                            n_heads,  # pyrefly: ignore [unbound-name]
-                            n_kv_heads,  # pyrefly: ignore [unbound-name]
-                            head_dim,  # pyrefly: ignore [unbound-name]
-                        )
-                    else:
-                        bq, bk, bv = self.fused_to_separate_qkv(
-                            value,
-                            n_heads,  # pyrefly: ignore [unbound-name]
-                            n_kv_heads,  # pyrefly: ignore [unbound-name]
-                            head_dim,  # pyrefly: ignore [unbound-name]
-                        )
-                    suffix = "bias" if is_bias else "weight"
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.q_proj.{suffix}"
-                    ] = bq
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.k_proj.{suffix}"
-                    ] = bk
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.v_proj.{suffix}"
-                    ] = bv
-                    continue
 
                 if abstract_key not in to_hf_map:
                     continue
@@ -208,59 +106,12 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
         self._validate_hf_rope_config(CosSinRoPE.Config)
 
         state_dict = {}
-        # Collect Q/K/V per layer for fusing (only used when fuse_qkv=True)
-        # Separate dicts for weight and bias since they arrive independently
-        pending_qkv_weight: dict[str, dict[str, torch.Tensor]] = {}
-        pending_qkv_bias: dict[str, dict[str, torch.Tensor]] = {}
-
-        if self.fuse_qkv:
-            n_heads, n_kv_heads, head_dim = self._get_attention_dims()
 
         for key, value in hf_state_dict.items():
             if "layers" in key:
                 # pyrefly: ignore
                 layer_num = re.search(r"\d+", key).group(0)
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-
-                if self.fuse_qkv and abstract_key in (
-                    "model.layers.{}.self_attn.q_proj.weight",
-                    "model.layers.{}.self_attn.k_proj.weight",
-                    "model.layers.{}.self_attn.v_proj.weight",
-                    "model.layers.{}.self_attn.q_proj.bias",
-                    "model.layers.{}.self_attn.k_proj.bias",
-                    "model.layers.{}.self_attn.v_proj.bias",
-                ):
-                    is_bias = abstract_key.endswith("bias")
-                    pending = pending_qkv_bias if is_bias else pending_qkv_weight
-                    if layer_num not in pending:
-                        pending[layer_num] = {}
-                    proj = abstract_key.split(".")[-2]  # q_proj, k_proj, v_proj
-                    pending[layer_num][proj] = value
-                    if len(pending[layer_num]) == 3:
-                        if is_bias:
-                            fused = self._separate_to_fused_qkv_bias(
-                                pending[layer_num]["q_proj"],
-                                pending[layer_num]["k_proj"],
-                                pending[layer_num]["v_proj"],
-                                n_heads,  # pyrefly: ignore [unbound-name]
-                                n_kv_heads,  # pyrefly: ignore [unbound-name]
-                                head_dim,  # pyrefly: ignore [unbound-name]
-                            )
-                        else:
-                            fused = self.separate_to_fused_qkv(
-                                pending[layer_num]["q_proj"],
-                                pending[layer_num]["k_proj"],
-                                pending[layer_num]["v_proj"],
-                                n_heads,  # pyrefly: ignore [unbound-name]
-                                n_kv_heads,  # pyrefly: ignore [unbound-name]
-                                head_dim,  # pyrefly: ignore [unbound-name]
-                            )
-                        suffix = "bias" if is_bias else "weight"
-                        state_dict[
-                            f"layers.{layer_num}.attention.qkv_linear.wqkv.{suffix}"
-                        ] = fused
-                        del pending[layer_num]
-                    continue
 
                 tt_key = self.from_hf_map.get(abstract_key)
                 if tt_key is None:
@@ -272,14 +123,5 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 if tt_key is None:
                     continue
                 state_dict[tt_key] = value
-
-        if self.fuse_qkv and pending_qkv_weight:
-            raise ValueError(
-                f"Incomplete Q/K/V weight projections for layers: {list(pending_qkv_weight.keys())}"
-            )
-        if self.fuse_qkv and pending_qkv_bias:
-            raise ValueError(
-                f"Incomplete Q/K/V bias projections for layers: {list(pending_qkv_bias.keys())}"
-            )
 
         return state_dict

--- a/torchtitan/models/llama3/state_dict_adapter.py
+++ b/torchtitan/models/llama3/state_dict_adapter.py
@@ -8,11 +8,8 @@ import logging
 import re
 from typing import Any
 
-import torch
-
 logger = logging.getLogger()
 
-from torchtitan.models.common.attention import FusedQKVLinear
 from torchtitan.models.common.rope import ComplexRoPE
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
 from .model import Llama3Model
@@ -28,42 +25,22 @@ class Llama3StateDictAdapter(StateDictAdapter):
 
         self.model_config = model_config
         self.hf_assets_path = hf_assets_path
-        self.fuse_qkv = isinstance(
-            model_config.layers[0].attention.qkv_linear, FusedQKVLinear.Config
-        )
 
-        if self.fuse_qkv:
-            self.from_hf_map = {
-                "model.embed_tokens.weight": "tok_embeddings.weight",
-                "model.layers.{}.self_attn.q_proj.weight": None,
-                "model.layers.{}.self_attn.k_proj.weight": None,
-                "model.layers.{}.self_attn.v_proj.weight": None,
-                "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-                "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
-                "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
-                "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
-                "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
-                "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-                "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-                "model.norm.weight": "norm.weight",
-                "lm_head.weight": "lm_head.weight",
-            }
-        else:
-            self.from_hf_map = {
-                "model.embed_tokens.weight": "tok_embeddings.weight",
-                "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
-                "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
-                "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
-                "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
-                "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
-                "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
-                "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
-                "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
-                "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
-                "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
-                "model.norm.weight": "norm.weight",
-                "lm_head.weight": "lm_head.weight",
-            }
+        self.from_hf_map = {
+            "model.embed_tokens.weight": "tok_embeddings.weight",
+            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
+            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
+            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
+            "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
+            "model.layers.{}.self_attn.rotary_emb.inv_freq": None,
+            "model.layers.{}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
+            "model.layers.{}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
+            "model.layers.{}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
+            "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
+            "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
+            "model.norm.weight": "norm.weight",
+            "lm_head.weight": "lm_head.weight",
+        }
 
     # HuggingFace permutation function (exact copy from their conversion script)
     def _permute(self, w, n_heads_arg, dim1=None, dim2=None):
@@ -99,10 +76,7 @@ class Llama3StateDictAdapter(StateDictAdapter):
         head_dim = attn.head_dim or dim // n_heads
         hf_state_dict = {}
 
-        if self.fuse_qkv:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
-        else:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+        to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
 
         for key, value in state_dict.items():
             if "layers" in key:
@@ -110,40 +84,16 @@ class Llama3StateDictAdapter(StateDictAdapter):
                 # pyrefly: ignore [missing-attribute]
                 layer_num = re.search(r"\d+", key).group(0)
 
-                if (
-                    self.fuse_qkv
-                    and abstract_key == "layers.{}.attention.qkv_linear.wqkv.weight"
-                ):
-                    # Split fused weight into separate Q, K, V for HF format
-                    wq, wk, wv = self.fused_to_separate_qkv(
-                        value, n_heads, n_kv_heads, head_dim
-                    )
-                    # Apply HF permutation
-                    wq = self._permute(wq, n_heads)
-                    key_value_dim = head_dim * n_kv_heads
-                    wk = self._permute(wk, n_kv_heads, key_value_dim, dim)
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.q_proj.weight"
-                    ] = wq
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.k_proj.weight"
-                    ] = wk
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.v_proj.weight"
-                    ] = wv
-                    continue
-
                 new_key = to_hf_map.get(abstract_key)
                 if new_key is None:
                     continue
 
-                if not self.fuse_qkv:
-                    # Apply HF permutation for unfused Q/K weights
-                    if abstract_key == "layers.{}.attention.qkv_linear.wq.weight":
-                        value = self._permute(value, n_heads)
-                    if abstract_key == "layers.{}.attention.qkv_linear.wk.weight":
-                        key_value_dim = head_dim * n_kv_heads
-                        value = self._permute(value, n_kv_heads, key_value_dim, dim)
+                # Apply HF permutation for Q/K weights
+                if abstract_key == "layers.{}.attention.qkv_linear.wq.weight":
+                    value = self._permute(value, n_heads)
+                if abstract_key == "layers.{}.attention.qkv_linear.wk.weight":
+                    key_value_dim = head_dim * n_kv_heads
+                    value = self._permute(value, n_kv_heads, key_value_dim, dim)
 
                 new_key = new_key.format(layer_num)
             else:
@@ -175,9 +125,6 @@ class Llama3StateDictAdapter(StateDictAdapter):
         head_dim = attn.head_dim or dim // n_heads
         state_dict = {}
 
-        # Collect Q/K/V per layer, then fuse (only used when fuse_qkv=True)
-        pending_qkv: dict[str, dict[str, torch.Tensor]] = {}
-
         for key, value in hf_state_dict.items():
             if "layers" in key:
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
@@ -191,44 +138,15 @@ class Llama3StateDictAdapter(StateDictAdapter):
                     key_value_dim = head_dim * n_kv_heads
                     value = self._reverse_permute(value, n_kv_heads, key_value_dim, dim)
 
-                if self.fuse_qkv and abstract_key in (
-                    "model.layers.{}.self_attn.q_proj.weight",
-                    "model.layers.{}.self_attn.k_proj.weight",
-                    "model.layers.{}.self_attn.v_proj.weight",
-                ):
-                    # Collect Q/K/V; fuse once all three are available
-                    if layer_num not in pending_qkv:
-                        pending_qkv[layer_num] = {}
-                    proj = abstract_key.split(".")[-2]  # q_proj, k_proj, v_proj
-                    pending_qkv[layer_num][proj] = value
-                    if len(pending_qkv[layer_num]) == 3:
-                        fused = self.separate_to_fused_qkv(
-                            pending_qkv[layer_num]["q_proj"],
-                            pending_qkv[layer_num]["k_proj"],
-                            pending_qkv[layer_num]["v_proj"],
-                            n_heads,
-                            n_kv_heads,
-                            head_dim,
-                        )
-                        state_dict[
-                            f"layers.{layer_num}.attention.qkv_linear.wqkv.weight"
-                        ] = fused
-                        del pending_qkv[layer_num]
-                    continue
-
                 new_key = self.from_hf_map[abstract_key]
                 if new_key is None:
                     continue
                 new_key = new_key.format(layer_num)
             else:
                 new_key = self.from_hf_map[key]
+                if new_key is None:
+                    continue
 
-            # pyrefly: ignore [unsupported-operation]
             state_dict[new_key] = value
-
-        if self.fuse_qkv and pending_qkv:
-            raise ValueError(
-                f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
-            )
 
         return state_dict

--- a/torchtitan/models/qwen3/state_dict_adapter.py
+++ b/torchtitan/models/qwen3/state_dict_adapter.py
@@ -16,10 +16,8 @@ aligned with the HF implementation.
 import re
 from typing import Any
 
-import torch
 from torch.distributed.tensor import DTensor
 
-from torchtitan.models.common.attention import FusedQKVLinear
 from torchtitan.models.common.rope import CosSinRoPE
 from torchtitan.models.utils import MoEStateDictAdapter
 from .model import Qwen3Model
@@ -28,28 +26,13 @@ from .model import Qwen3Model
 class Qwen3StateDictAdapter(MoEStateDictAdapter):
     def __init__(self, model_config: Qwen3Model.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
-        self.fuse_qkv = isinstance(
-            model_config.layers[0].attention.qkv_linear, FusedQKVLinear.Config
-        )
-
-        qkv_map: dict[str, str | None]
-        if self.fuse_qkv:
-            qkv_map = {
-                "model.layers.{}.self_attn.q_proj.weight": None,
-                "model.layers.{}.self_attn.k_proj.weight": None,
-                "model.layers.{}.self_attn.v_proj.weight": None,
-            }
-        else:
-            qkv_map = {
-                "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
-                "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
-                "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
-            }
 
         self.from_hf_map = {
             "model.embed_tokens.weight": "tok_embeddings.weight",
             # Attention module
-            **qkv_map,
+            "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
+            "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
+            "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
             "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
             "model.layers.{}.self_attn.q_norm.weight": "layers.{}.attention.q_norm.weight",
             "model.layers.{}.self_attn.k_norm.weight": "layers.{}.attention.k_norm.weight",
@@ -70,30 +53,13 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
             "lm_head.weight": "lm_head.weight",
         }
 
-    def _get_attention_dims(self) -> tuple[int, int, int]:
-        """Return (n_heads, n_kv_heads, head_dim) from model config."""
-        # pyrefly: ignore [missing-attribute]
-        attn = self.model_config.layers[0].attention
-        n_heads = attn.n_heads
-        n_kv_heads = attn.n_kv_heads if attn.n_kv_heads is not None else n_heads
-        head_dim = (
-            attn.head_dim
-            if attn.head_dim is not None
-            else self.model_config.dim // n_heads  # pyrefly: ignore [missing-attribute]
-        )
-        return n_heads, n_kv_heads, head_dim
-
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         """
         1. Convert between the HF shape and the torchtitan shape.
         2. Split the GroupedExperts' weight into separate expert's wegiht.
         """
 
-        if self.fuse_qkv:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
-            n_heads, n_kv_heads, head_dim = self._get_attention_dims()
-        else:
-            to_hf_map = {v: k for k, v in self.from_hf_map.items()}
+        to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
         hf_state_dict = {}
 
         for key, value in state_dict.items():
@@ -143,27 +109,6 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 # pyrefly: ignore [missing-attribute]
                 layer_num = re.search(r"\d+", key).group(0)
 
-                if (
-                    self.fuse_qkv
-                    and abstract_key == "layers.{}.attention.qkv_linear.wqkv.weight"
-                ):
-                    wq, wk, wv = self.fused_to_separate_qkv(
-                        value,
-                        n_heads,  # pyrefly: ignore [unbound-name]
-                        n_kv_heads,  # pyrefly: ignore [unbound-name]
-                        head_dim,  # pyrefly: ignore [unbound-name]
-                    )
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.q_proj.weight"
-                    ] = wq
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.k_proj.weight"
-                    ] = wk
-                    hf_state_dict[
-                        f"model.layers.{layer_num}.self_attn.v_proj.weight"
-                    ] = wv
-                    continue
-
                 if abstract_key not in to_hf_map:
                     continue
                 new_key = to_hf_map[abstract_key]
@@ -190,11 +135,6 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
 
         state_dict = {}
         expert_weights_by_layer = {}  # {layer: {abstract_key: {expert_id: tensor}}}
-        # Collect Q/K/V per layer for fusing (only used when fuse_qkv=True)
-        pending_qkv: dict[str, dict[str, torch.Tensor]] = {}
-
-        if self.fuse_qkv:
-            n_heads, n_kv_heads, head_dim = self._get_attention_dims()
 
         if (
             # pyrefly: ignore [missing-attribute]
@@ -249,30 +189,6 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 # pyrefly: ignore [missing-attribute]
                 layer_num = re.search(r"\d+", key).group(0)
 
-                if self.fuse_qkv and abstract_key in (
-                    "model.layers.{}.self_attn.q_proj.weight",
-                    "model.layers.{}.self_attn.k_proj.weight",
-                    "model.layers.{}.self_attn.v_proj.weight",
-                ):
-                    if layer_num not in pending_qkv:
-                        pending_qkv[layer_num] = {}
-                    proj = abstract_key.split(".")[-2]  # q_proj, k_proj, v_proj
-                    pending_qkv[layer_num][proj] = value
-                    if len(pending_qkv[layer_num]) == 3:
-                        fused = self.separate_to_fused_qkv(
-                            pending_qkv[layer_num]["q_proj"],
-                            pending_qkv[layer_num]["k_proj"],
-                            pending_qkv[layer_num]["v_proj"],
-                            n_heads,  # pyrefly: ignore [unbound-name]
-                            n_kv_heads,  # pyrefly: ignore [unbound-name]
-                            head_dim,  # pyrefly: ignore [unbound-name]
-                        )
-                        state_dict[
-                            f"layers.{layer_num}.attention.qkv_linear.wqkv.weight"
-                        ] = fused
-                        del pending_qkv[layer_num]
-                    continue
-
                 new_key = self.from_hf_map[abstract_key]
                 if new_key is None:
                     continue
@@ -284,10 +200,5 @@ class Qwen3StateDictAdapter(MoEStateDictAdapter):
                 if new_key is None:
                     continue
                 state_dict[new_key] = value
-
-        if self.fuse_qkv and pending_qkv:
-            raise ValueError(
-                f"Incomplete Q/K/V projections for layers: {list(pending_qkv.keys())}"
-            )
 
         return state_dict

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -10,7 +10,6 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any
 
-import torch
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 
 from torchtitan.tools.logging import logger
@@ -132,42 +131,3 @@ class StateDictAdapter(BaseStateDictAdapter):
                 "Loading from quantized checkpoint format is not supported for this model."
             )
         return HuggingFaceStorageReader(path)
-
-    @staticmethod
-    def fused_to_separate_qkv(
-        fused_weight: torch.Tensor,
-        n_heads: int,
-        n_kv_heads: int,
-        head_dim: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Split fused wqkv weight [n_kv * R * hd, dim] into separate Q, K, V."""
-        heads_per_kv = n_heads // n_kv_heads
-        r_dim = heads_per_kv + 2
-        dim = fused_weight.shape[1]
-        # [n_kv_heads, R, head_dim, dim]
-        w = fused_weight.view(n_kv_heads, r_dim, head_dim, dim)
-        wq = w[:, :heads_per_kv, :, :].reshape(n_heads * head_dim, dim)
-        wk = w[:, heads_per_kv, :, :].reshape(n_kv_heads * head_dim, dim)
-        wv = w[:, heads_per_kv + 1, :, :].reshape(n_kv_heads * head_dim, dim)
-        return wq, wk, wv
-
-    @staticmethod
-    def separate_to_fused_qkv(
-        wq: torch.Tensor,
-        wk: torch.Tensor,
-        wv: torch.Tensor,
-        n_heads: int,
-        n_kv_heads: int,
-        head_dim: int,
-    ) -> torch.Tensor:
-        """Combine separate Q, K, V weights into fused wqkv layout."""
-        heads_per_kv = n_heads // n_kv_heads
-        r_dim = heads_per_kv + 2
-        dim = wq.shape[1]
-        # Reshape to per-KV-group: [n_kv_heads, heads_per_kv, head_dim, dim]
-        q = wq.view(n_kv_heads, heads_per_kv, head_dim, dim)
-        k = wk.view(n_kv_heads, 1, head_dim, dim)
-        v = wv.view(n_kv_heads, 1, head_dim, dim)
-        # [n_kv_heads, R, head_dim, dim]
-        fused = torch.cat([q, k, v], dim=1)
-        return fused.reshape(n_kv_heads * r_dim * head_dim, dim)


### PR DESCRIPTION
### Summary

This PR makes `FusedQKVLinear` checkpoints interoperable with stock `QKVLinear` by saving in the `wq.weight`/`wk.weight`/`wv.weight` layout via module-level state_dict hooks.

Adds `register_state_dict_post_hook` and `register_load_state_dict_pre_hook` to `FusedQKVLinear` so that:
- On save: fused `wqkv.weight` is split into `wq.weight`/`wk.weight`/`wv.weight`
- On load: stock `wq`/`wk`/`wv` keys are merged back into `wqkv.weight`

### Verification

Bit-identical loss across 20 training steps (straight-through vs save-at-10/resume) using `scripts/checkpoint_compat_test.py` with `--debug.deterministic --debug.seed=42`:

```
python scripts/checkpoint_compat_test.py . . \
    --module llama3 --config llama3_debugmodel_fused_qkv \
    --steps 20 --resume-step 10 --ngpus 2 --assert-equal \
    --options "--parallelism.spmd_backend full_dtensor"
```

| Step | Reference | Resume | Match |
|------|-----------|--------|-------|
| 1-10 | (identical) | (identical) | OK |
| 11 | 3.59175968170166 | 3.59175968170166 | OK |
| 12 | 3.5357553958892822 | 3.5357553958892822 | OK |
| 13 | 3.4192099571228027 | 3.4192099571228027 | OK |
| 14 | 3.3772449493408203 | 3.3772449493408203 | OK |
| 15 | 3.3474314212799072 | 3.3474314212799072 | OK |
| 16 | 3.3615636825561523 | 3.3615636825561523 | OK |
| 17 | 3.215083599090576 | 3.215083599090576 | OK |
| 18 | 3.1624622344970703 | 3.1624622344970703 | OK |
| 19 | 3.313873529434204 | 3.313873529434204 | OK |
| 20 | 3.1608173847198486 | 3.1608173847198486 | OK |

**PASS: All losses are bit-identical.**

---