### PR TITLE
ci: don't run scheduled workflows on forks

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -22,6 +22,8 @@ concurrency:
 
 jobs:
   docker-build:
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_test_4gpu_rl.yaml
+++ b/.github/workflows/integration_test_4gpu_rl.yaml
@@ -28,7 +28,10 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl')
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl'))
     uses: ./.github/workflows/set-matrix.yaml
     with:
       is-experimental: true

--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -30,6 +30,8 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     uses: ./.github/workflows/set-matrix.yaml
 
   # Step 2: Use the dynamic matrix in the build-test job

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -29,7 +29,10 @@ permissions:
 
 jobs:
   build-test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.g5.48xlarge.nvidia.gpu

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -30,7 +30,10 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8'))
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-cuda: mt-l-bx86iamx-176-1800-h100-8

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -29,7 +29,10 @@ permissions:
 jobs:
   # CUDA: run the suite on an H100 runner via linux_job_v3.
   set-matrix:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8'))
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-cuda: mt-l-bx86iamx-176-1800-h100-8
@@ -64,7 +67,10 @@ jobs:
   # (the pull fails with "no basic auth credentials"); the bare image name lets
   # v2 resolve and authenticate against ECR.
   set-matrix-rocm:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8'))
     uses: ./.github/workflows/set-matrix.yaml
     with:
       gpu-arch: rocm

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -31,6 +31,8 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     uses: ./.github/workflows/set-matrix.yaml
 
   # Step 2: Use the dynamic matrix in the build-test job

--- a/.github/workflows/integration_test_8gpu_rl_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_rl_h100.yaml
@@ -28,7 +28,10 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl')
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: >-
+      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl'))
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-cuda: mt-l-bx86iamx-176-1800-h100-8

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -31,6 +31,8 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     uses: ./.github/workflows/set-matrix.yaml
     with:
       is-experimental: true

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -30,6 +30,8 @@ permissions:
 jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     uses: ./.github/workflows/set-matrix.yaml
     with:
       is-experimental: true

--- a/.github/workflows/todo_debt_tracker.yaml
+++ b/.github/workflows/todo_debt_tracker.yaml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   check_todos:
     name: Generate Report
+    # Skip scheduled runs on forks, where they would only fail and email the fork owner
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes #2238.

The spam comes from the `schedule:` triggers: all 11 cron'd workflows (the 9
integration-test workflows plus `docker-builds` and the TODO debt tracker) run on
any fork where Actions is enabled, and always fail there for lack of pytorch's
self-hosted runners / ECR credentials (or, for the TODO tracker, write access to
an upstream issue). Cron fires from the workflow files on the fork's default
branch, which is why this only started after a fork sync — the sync brought the
newer scheduled workflows onto the fork's `main`.

This adds the repository guard already used by `build_whl_and_publish.yaml` to
the entry job of each scheduled workflow, restricted to schedule events:

```yaml
if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
```

Scheduled runs on forks are skipped (no failure emails), while push/PR CI on
forks and all behavior on pytorch/torchtitan are unchanged. Where an entry job
already had a ciflow-label or draft condition, the guard is `&&`-combined with
explicit parentheses; downstream `build-test` jobs skip automatically through
`needs`.

Validated locally with actionlint over the 11 modified workflows plus a script
asserting every schedule-triggered workflow now guards its entry jobs; the
expression covers all event/repo combinations (schedule+fork = skip, everything
else = run as before).
