### PR TITLE
Add FusedGroupedExperts override and offset-aware kernels to skip async EP worst case padding

### DIFF
--- a/tests/unit_tests/test_fused_swiglu_override.py
+++ b/tests/unit_tests/test_fused_swiglu_override.py
@@ -1,0 +1,156 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.models.common.token_dispatcher import (
+    LocalTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher,
+)
+from torchtitan.models.deepseek_v3.config_registry import (
+    deepseek_v3_debugmodel_minimal_async_ep,
+)
+from torchtitan.overrides.fused_grouped_experts import (
+    fused_grouped_experts,
+    FusedGroupedExperts,
+    silu_and_mul_backward_kernel,
+    silu_and_mul_forward_kernel,
+    silu_and_mul_op,
+)
+
+
+class TestFusedSwiGLUOverride(unittest.TestCase):
+    def test_minimal_async_ep_config_imports_override(self):
+        config = deepseek_v3_debugmodel_minimal_async_ep()
+
+        self.assertIn(
+            "torchtitan.overrides.fused_grouped_experts",
+            config.override.imports,
+        )
+
+    def test_minimal_async_ep_grouped_experts_config_is_replaced(self):
+        cfg = GroupedExperts.Config(
+            dim=16,
+            hidden_dim=32,
+            num_experts=4,
+            token_dispatcher=MinimalAsyncEPTokenDispatcher.Config(
+                num_experts=4,
+                top_k=1,
+            ),
+        )
+
+        replacement = fused_grouped_experts(cfg)
+
+        self.assertIsInstance(replacement, FusedGroupedExperts.Config)
+        self.assertIs(replacement.token_dispatcher, cfg.token_dispatcher)
+
+    def test_local_grouped_experts_config_is_replaced(self):
+        cfg = GroupedExperts.Config(
+            dim=16,
+            hidden_dim=32,
+            num_experts=4,
+            token_dispatcher=LocalTokenDispatcher.Config(
+                num_experts=4,
+                top_k=1,
+            ),
+        )
+
+        replacement = fused_grouped_experts(cfg)
+
+        self.assertIsInstance(replacement, FusedGroupedExperts.Config)
+        self.assertIs(replacement.token_dispatcher, cfg.token_dispatcher)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestFusedSwiGLUOverrideKernels(unittest.TestCase):
+    def test_silu_and_mul_custom_op_matches_reference_with_offsets(self):
+        gate = torch.randn(3, 2, device="cuda", requires_grad=True)
+        up = torch.randn(3, 2, device="cuda", requires_grad=True)
+        offsets = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
+
+        out = silu_and_mul_op(gate, up, offsets)
+        out[:2].sum().backward()
+
+        ref_gate = gate.detach().clone().requires_grad_()
+        ref_up = up.detach().clone().requires_grad_()
+        expected = torch.nn.functional.silu(ref_gate) * ref_up
+        expected[:2].sum().backward()
+
+        assert gate.grad is not None
+        assert up.grad is not None
+        assert ref_gate.grad is not None
+        assert ref_up.grad is not None
+        torch.testing.assert_close(out[:2], expected[:2])
+        torch.testing.assert_close(gate.grad[:2], ref_gate.grad[:2])
+        torch.testing.assert_close(up.grad[:2], ref_up.grad[:2])
+
+    def test_silu_and_mul_custom_op_matches_reference_without_offsets(self):
+        gate = torch.randn(3, 2, device="cuda", requires_grad=True)
+        up = torch.randn(3, 2, device="cuda", requires_grad=True)
+
+        out = silu_and_mul_op(gate, up)
+        out.sum().backward()
+
+        ref_gate = gate.detach().clone().requires_grad_()
+        ref_up = up.detach().clone().requires_grad_()
+        expected = torch.nn.functional.silu(ref_gate) * ref_up
+        expected.sum().backward()
+
+        assert gate.grad is not None
+        assert up.grad is not None
+        assert ref_gate.grad is not None
+        assert ref_up.grad is not None
+        torch.testing.assert_close(out, expected)
+        torch.testing.assert_close(gate.grad, ref_gate.grad)
+        torch.testing.assert_close(up.grad, ref_up.grad)
+
+    def test_silu_and_mul_kernels_match_reference_with_offsets(self):
+        gate = torch.tensor(
+            [
+                [0.0, 1.0],
+                [2.0, -3.0],
+                [4.0, 5.0],
+            ],
+            device="cuda",
+            requires_grad=True,
+        )
+        up = torch.tensor(
+            [
+                [2.0, 3.0],
+                [5.0, 7.0],
+                [11.0, 13.0],
+            ],
+            device="cuda",
+            requires_grad=True,
+        )
+        offsets = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
+
+        out = silu_and_mul_forward_kernel(gate, up, offsets)
+        expected = torch.nn.functional.silu(gate) * up
+        torch.testing.assert_close(out[:2], expected[:2])
+
+        grad_out = torch.tensor(
+            [
+                [17.0, 19.0],
+                [23.0, 29.0],
+                [31.0, 37.0],
+            ],
+            device="cuda",
+        )
+        grad_gate, grad_up = silu_and_mul_backward_kernel(
+            grad_out,
+            gate,
+            up,
+            offsets,
+        )
+        expected[:2].backward(grad_out[:2])
+        assert gate.grad is not None
+        assert up.grad is not None
+        torch.testing.assert_close(grad_gate[:2], gate.grad[:2])
+        torch.testing.assert_close(grad_up[:2], up.grad[:2])

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -21,6 +21,12 @@ from torchtitan.trainer import Trainer
 from . import model_registry
 
 
+def enable_fused_grouped_experts(config: Trainer.Config) -> None:
+    override = "torchtitan.overrides.fused_grouped_experts"
+    assert override not in config.override.imports
+    config.override.imports.append(override)
+
+
 def deepseek_v3_debugmodel() -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),
@@ -67,6 +73,7 @@ def deepseek_v3_debugmodel_minimal_async_ep() -> Trainer.Config:
         "debugmodel",
         moe_comm_backend="minimal_async_ep",
     )
+    enable_fused_grouped_experts(config)
     config.parallelism = ParallelismConfig(
         data_parallel_replicate_degree=1,
         data_parallel_shard_degree=1,
@@ -126,6 +133,7 @@ def deepseek_v3_16b_minimal_async_ep() -> Trainer.Config:
         attn_backend="flex",
         moe_comm_backend="minimal_async_ep",
     )
+    enable_fused_grouped_experts(config)
     config.parallelism = ParallelismConfig(
         data_parallel_replicate_degree=1,
         data_parallel_shard_degree=1,

--- a/torchtitan/overrides/fused_grouped_experts.py
+++ b/torchtitan/overrides/fused_grouped_experts.py
@@ -1,0 +1,375 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyrefly: ignore-errors
+
+"""
+Fused grouped-experts override.
+
+Importing this module registers a ``GroupedExperts`` override and the
+``torchtitan::silu_and_mul`` custom CUDA op it uses.
+"""
+
+from dataclasses import dataclass
+
+import torch
+import triton
+import triton.language as tl
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import derive, override
+from torchtitan.models.common.moe import GroupedExperts
+
+__all__ = [
+    "FusedGroupedExperts",
+    "fused_grouped_experts",
+    "silu_and_mul_backward_kernel",
+    "silu_and_mul_forward_kernel",
+    "silu_and_mul_op",
+]
+
+
+_MAX_BLOCK_N = 2048
+_SILU_AND_MUL_BLOCK_M = 4
+
+
+@triton.jit
+def _silu_and_mul_forward_kernel(
+    gate,
+    up,
+    out,
+    offsets,
+    NUM_ROWS: tl.constexpr,
+    NUM_COLS: tl.constexpr,
+    NUM_OFFSETS: tl.constexpr,
+    HAS_OFFSETS: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    OUT_ROW_STRIDE: tl.constexpr,
+    OUT_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Compute ``silu(gate) * up`` for optionally offset-limited rows."""
+    row_start = tl.program_id(0) * BLOCK_M
+    row_limit = NUM_ROWS
+    if HAS_OFFSETS:
+        row_limit = tl.load(offsets + NUM_OFFSETS - 1)
+        if row_start >= row_limit:
+            return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < row_limit) & (cols[None, :] < NUM_COLS)
+
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    silu = gate_values * tl.sigmoid(gate_values)
+    tl.store(
+        out + rows[:, None] * OUT_ROW_STRIDE + cols[None, :] * OUT_COL_STRIDE,
+        silu * up_values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _silu_and_mul_backward_kernel(
+    grad_out,
+    gate,
+    up,
+    grad_gate,
+    grad_up,
+    offsets,
+    NUM_ROWS: tl.constexpr,
+    NUM_COLS: tl.constexpr,
+    NUM_OFFSETS: tl.constexpr,
+    HAS_OFFSETS: tl.constexpr,
+    GRAD_OUT_ROW_STRIDE: tl.constexpr,
+    GRAD_OUT_COL_STRIDE: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    GRAD_GATE_ROW_STRIDE: tl.constexpr,
+    GRAD_GATE_COL_STRIDE: tl.constexpr,
+    GRAD_UP_ROW_STRIDE: tl.constexpr,
+    GRAD_UP_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Backward for ``_silu_and_mul_forward_kernel`` over defined rows."""
+    row_start = tl.program_id(0) * BLOCK_M
+    row_limit = NUM_ROWS
+    if HAS_OFFSETS:
+        row_limit = tl.load(offsets + NUM_OFFSETS - 1)
+        if row_start >= row_limit:
+            return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < row_limit) & (cols[None, :] < NUM_COLS)
+
+    grad_values = tl.load(
+        grad_out
+        + rows[:, None] * GRAD_OUT_ROW_STRIDE
+        + cols[None, :] * GRAD_OUT_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    sigmoid = tl.sigmoid(gate_values)
+    silu = gate_values * sigmoid
+    silu_grad = sigmoid * (1.0 + gate_values * (1.0 - sigmoid))
+
+    tl.store(
+        grad_gate
+        + rows[:, None] * GRAD_GATE_ROW_STRIDE
+        + cols[None, :] * GRAD_GATE_COL_STRIDE,
+        grad_values * up_values * silu_grad,
+        mask=mask,
+    )
+    tl.store(
+        grad_up
+        + rows[:, None] * GRAD_UP_ROW_STRIDE
+        + cols[None, :] * GRAD_UP_COL_STRIDE,
+        grad_values * silu,
+        mask=mask,
+    )
+
+
+def silu_and_mul_forward_kernel(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` with optional grouped_mm row offsets."""
+    if offsets is not None and offsets.numel() == 0:
+        raise ValueError("offsets must be non-empty when provided.")
+    out = torch.empty_like(gate)
+
+    block_m = _SILU_AND_MUL_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _silu_and_mul_forward_kernel[grid](
+        gate,
+        up,
+        out,
+        offsets if offsets is not None else gate,
+        NUM_ROWS=gate.shape[0],
+        NUM_COLS=gate.shape[1],
+        NUM_OFFSETS=offsets.numel() if offsets is not None else 0,
+        HAS_OFFSETS=offsets is not None,
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        OUT_ROW_STRIDE=out.stride(0),
+        OUT_COL_STRIDE=out.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return out
+
+
+def silu_and_mul_backward_kernel(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if offsets is not None and offsets.numel() == 0:
+        raise ValueError("offsets must be non-empty when provided.")
+    grad_gate = torch.empty_like(gate)
+    grad_up = torch.empty_like(up)
+
+    block_m = _SILU_AND_MUL_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _silu_and_mul_backward_kernel[grid](
+        grad_out,
+        gate,
+        up,
+        grad_gate,
+        grad_up,
+        offsets if offsets is not None else gate,
+        NUM_ROWS=gate.shape[0],
+        NUM_COLS=gate.shape[1],
+        NUM_OFFSETS=offsets.numel() if offsets is not None else 0,
+        HAS_OFFSETS=offsets is not None,
+        GRAD_OUT_ROW_STRIDE=grad_out.stride(0),
+        GRAD_OUT_COL_STRIDE=grad_out.stride(1),
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        GRAD_GATE_ROW_STRIDE=grad_gate.stride(0),
+        GRAD_GATE_COL_STRIDE=grad_gate.stride(1),
+        GRAD_UP_ROW_STRIDE=grad_up.stride(0),
+        GRAD_UP_COL_STRIDE=grad_up.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return grad_gate, grad_up
+
+
+@torch.library.custom_op(
+    "torchtitan::silu_and_mul",
+    mutates_args=(),
+    device_types="cuda",
+)
+def silu_and_mul_op(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` over optionally offset-limited rows."""
+    return silu_and_mul_forward_kernel(gate, up, offsets)
+
+
+@silu_and_mul_op.register_fake
+def silu_and_mul_op_fake(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty_like(gate)
+
+
+@torch.library.custom_op(
+    "torchtitan::silu_and_mul_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def silu_and_mul_backward_op(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute gradients for ``torchtitan::silu_and_mul``."""
+    return silu_and_mul_backward_kernel(grad_out, gate, up, offsets)
+
+
+@silu_and_mul_backward_op.register_fake
+def silu_and_mul_backward_op_fake(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(gate), torch.empty_like(up)
+
+
+def silu_and_mul_autograd_backward(ctx, grad_out):
+    if ctx.has_offsets:
+        gate, up, offsets = ctx.saved_tensors
+    else:
+        gate, up = ctx.saved_tensors
+        offsets = None
+    grad_gate, grad_up = silu_and_mul_backward_op(
+        grad_out,
+        gate,
+        up,
+        offsets,
+    )
+    return grad_gate, grad_up, None
+
+
+def silu_and_mul_setup_context(ctx, inputs, output):
+    gate, up = inputs[:2]
+    offsets = inputs[2] if len(inputs) > 2 else None
+    ctx.has_offsets = offsets is not None
+    if offsets is None:
+        ctx.save_for_backward(gate, up)
+    else:
+        ctx.save_for_backward(gate, up, offsets)
+
+
+silu_and_mul_op.register_autograd(
+    silu_and_mul_autograd_backward, setup_context=silu_and_mul_setup_context
+)
+
+
+class FusedGroupedExperts(GroupedExperts):
+    """Grouped experts variant that uses ``torchtitan::silu_and_mul``.
+
+    The fused activation accepts optional grouped_mm offsets, so it can compute
+    all rows for dense expert buffers or skip inactive capacity-padding rows
+    when a dispatcher produces them.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config):
+        pass
+
+    def _experts_forward(
+        self,
+        x_RD: torch.Tensor,
+        num_tokens_per_expert_E: torch.Tensor,
+    ) -> torch.Tensor:
+        if isinstance(self.w1_EFD, DTensor):
+            w1_EFD = self.w1_EFD.to_local()
+            assert isinstance(self.w2_EDF, DTensor)
+            w2_EDF = self.w2_EDF.to_local()
+            assert isinstance(self.w3_EFD, DTensor)
+            w3_EFD = self.w3_EFD.to_local()
+        else:
+            w1_EFD = self.w1_EFD
+            w2_EDF = self.w2_EDF
+            w3_EFD = self.w3_EFD
+
+        offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
+
+        gate_RF = torch._grouped_mm(
+            x_RD.bfloat16(),
+            w1_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
+        )
+        up_RF = torch._grouped_mm(
+            x_RD.bfloat16(),
+            w3_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
+        )
+        h_RF = silu_and_mul_op(gate_RF, up_RF, offsets_E)
+        return torch._grouped_mm(
+            h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
+        ).type_as(x_RD)
+
+
+@override(
+    "fused_grouped_experts",
+    target=GroupedExperts.Config,
+    description="Use fused SiLU-and-mul activation for grouped experts.",
+)
+def fused_grouped_experts(
+    cfg: GroupedExperts.Config,
+) -> GroupedExperts.Config:
+    if type(cfg) is not GroupedExperts.Config:
+        return cfg
+
+    return derive(cfg, FusedGroupedExperts.Config)


### PR DESCRIPTION
Add offset-aware SwiGLU kernels to avoid processing overallocated routed tokens buffer

For syncless EP approaches like MinimalAsyncEP and HybridEP

```python
NCCL_DEBUG=WARN  NGPU=4 MODULE=deepseek_v3 CONFIG=deepseek_v3_16b_hybridep wp ./run_train.sh      --parallelism.pipeline_parallel_degree 1       --parallelism.data_parallel_shard_degree 4   --parallelism.expert_parallel_degree 4  --activation_checkpoint.mode full

[rank0]:[titan] 2026-06-13 11:38:47,670 - root - INFO - Initializing HybridEP buffer: hidden_dim=2048, max_tokens_per_rank=16384, num_local_experts=16, ep_size=4
[rank0]:[titan] 2026-06-13 11:39:06,696 - root - INFO - step:  1  loss: 12.04959  grad_norm:  1.7336  memory: 59.90GiB(21.65%)  tps: 441  tflops: 7.98  mfu: 0.32%
[rank0]:[titan] 2026-06-13 11:39:06,697 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2026-06-13 11:39:16,113 - root - INFO - step: 10  loss: 11.20896  grad_norm:  2.5372  memory: 74.71GiB(27.01%)  tps: 15,660  tflops: 283.54  mfu: 11.34%
[rank0]:[titan] 2026-06-13 11:39:24,369 - root - INFO - step: 20  loss:  9.54478  grad_norm:  4.8683  memory: 74.71GiB(27.01%)  tps: 19,847  tflops: 359.36  mfu: 14.37%
[rank0]:[titan] 2026-06-13 11:39:32,798 - root - INFO - step: 30  loss:  8.54311  grad_norm:  2.8289  memory: 74.71GiB(27.01%)  tps: 19,438  tflops: 351.94  mfu: 14.08%
[rank0]:[titan] 2026-06-13 11:39:41,176 - root - INFO - step: 40  loss:  7.89478  grad_norm:  1.2303  memory: 74.71GiB(27.01%)  tps: 19,558  tflops: 354.11  mfu: 14.16%
```