### PR TITLE
Use python -m torch.distributed.run instead of torchrun

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -41,7 +41,7 @@ else
     # Normal training with torchrun
     PYTORCH_ALLOC_CONF="expandable_segments:True" \
     TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
-    torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
+    python -m torch.distributed.run --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
     --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
     -m torchtitan.train --module ${MODULE} --config ${CONFIG} "$@"
 fi

--- a/tests/unit_tests/test_minimal_async_ep_kernels.py
+++ b/tests/unit_tests/test_minimal_async_ep_kernels.py
@@ -8,7 +8,10 @@ import unittest
 
 import torch
 
+from torchtitan.distributed.minimal_async_ep import active_swiglu_op
 from torchtitan.distributed.minimal_async_ep.kernels import (
+    active_swiglu_backward_kernel,
+    active_swiglu_forward_kernel,
     copy_full_counts_to_peers_kernel,
     copy_rows_to_peers_kernel,
     expand_topk_grad_kernel,
@@ -31,6 +34,72 @@ def assert_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestMinimalAsyncEPKernels(unittest.TestCase):
+    def test_active_swiglu_custom_op_matches_reference_on_active_rows(self):
+        gate = torch.randn(3, 2, device="cuda", requires_grad=True)
+        up = torch.randn(3, 2, device="cuda", requires_grad=True)
+        active_rows = torch.tensor([2], device="cuda", dtype=torch.int32)
+
+        out = active_swiglu_op(gate, up, active_rows)
+        out[:2].sum().backward()
+
+        ref_gate = gate.detach().clone().requires_grad_()
+        ref_up = up.detach().clone().requires_grad_()
+        expected = torch.nn.functional.silu(ref_gate) * ref_up
+        expected[:2].sum().backward()
+
+        assert gate.grad is not None
+        assert up.grad is not None
+        assert ref_gate.grad is not None
+        assert ref_up.grad is not None
+        torch.testing.assert_close(out[:2], expected[:2])
+        torch.testing.assert_close(gate.grad[:2], ref_gate.grad[:2])
+        torch.testing.assert_close(up.grad[:2], ref_up.grad[:2])
+
+    def test_active_swiglu_kernels_match_reference_on_active_rows(self):
+        gate = torch.tensor(
+            [
+                [0.0, 1.0],
+                [2.0, -3.0],
+                [4.0, 5.0],
+            ],
+            device="cuda",
+            requires_grad=True,
+        )
+        up = torch.tensor(
+            [
+                [2.0, 3.0],
+                [5.0, 7.0],
+                [11.0, 13.0],
+            ],
+            device="cuda",
+            requires_grad=True,
+        )
+        active_rows = torch.tensor([2], device="cuda", dtype=torch.int32)
+
+        out = active_swiglu_forward_kernel(gate, up, active_rows)
+        expected = torch.nn.functional.silu(gate) * up
+        torch.testing.assert_close(out[:2], expected[:2])
+
+        grad_out = torch.tensor(
+            [
+                [17.0, 19.0],
+                [23.0, 29.0],
+                [31.0, 37.0],
+            ],
+            device="cuda",
+        )
+        grad_gate, grad_up = active_swiglu_backward_kernel(
+            grad_out,
+            gate,
+            up,
+            active_rows,
+        )
+        expected[:2].backward(grad_out[:2])
+        assert gate.grad is not None
+        assert up.grad is not None
+        torch.testing.assert_close(grad_gate[:2], gate.grad[:2])
+        torch.testing.assert_close(grad_up[:2], up.grad[:2])
+
     def test_topk_index_kernels_match_reference(self):
         flat_indices = torch.tensor([2, 0, 3, 1], device="cuda", dtype=torch.int64)
         slot_to_row = invert_flat_indices_kernel(flat_indices, num_rows=4)

--- a/torchtitan/distributed/minimal_async_ep/__init__.py
+++ b/torchtitan/distributed/minimal_async_ep/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.distributed.minimal_async_ep.api import (
+    active_swiglu_op,
     combine_op,
     dispatch_op,
     init_buffer,
@@ -14,6 +15,7 @@ from torchtitan.distributed.minimal_async_ep.api import (
 
 __all__ = [
     "MinimalAsyncEPDispatchMetadata",
+    "active_swiglu_op",
     "combine_op",
     "dispatch_op",
     "init_buffer",

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -29,6 +29,8 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 
 from torchtitan.distributed.minimal_async_ep.kernels import (
+    active_swiglu_backward_kernel,
+    active_swiglu_forward_kernel,
     copy_full_counts_to_peers_kernel,
     copy_rows_to_peers_kernel,
     expand_topk_grad_kernel,
@@ -482,6 +484,40 @@ def _combine_to_origin(
     return origin_recv_buffer.narrow(0, 0, num_routed_rows).narrow(1, 0, x_RD.shape[1])
 
 
+@torch.library.custom_op(
+    "minimal_async_ep::active_swiglu",
+    mutates_args=(),
+    device_types="cuda",
+)
+def active_swiglu_op(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` over active padded expert-buffer rows.
+
+    Args:
+        gate, up: ``(R_max, F)`` expert intermediate rows, where only the
+            first ``R`` rows are active and ``R_max`` is the static receive
+            capacity.
+        active_rows: ``(1,)`` device scalar containing ``R``.
+
+    Returns:
+        ``(R_max, F)`` output. Rows ``[:R]`` are defined; rows ``[R:]`` are
+        unspecified because grouped-mm offsets skip receive-capacity padding.
+    """
+    return active_swiglu_forward_kernel(gate, up, active_rows)
+
+
+@active_swiglu_op.register_fake
+def active_swiglu_op_fake(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(gate)
+
+
 def _dispatch_metadata(
     num_local_tokens_per_expert_E: torch.Tensor,  # noqa: N803
     num_routed_rows: int,
@@ -741,6 +777,40 @@ def combine_op_fake(
 
 
 @torch.library.custom_op(
+    "minimal_async_ep::active_swiglu_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def active_swiglu_backward_op(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute active-row gradients for ``minimal_async_ep::active_swiglu``.
+
+    Args:
+        grad_out, gate, up: ``(R_max, F)`` tensors from the forward op.
+        active_rows: ``(1,)`` device scalar containing active row count ``R``.
+
+    Returns:
+        ``grad_gate`` and ``grad_up`` with shape ``(R_max, F)``. Rows ``[R:]``
+        are unspecified because receive-capacity padding is not consumed.
+    """
+    return active_swiglu_backward_kernel(grad_out, gate, up, active_rows)
+
+
+@active_swiglu_backward_op.register_fake
+def active_swiglu_backward_op_fake(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(gate), torch.empty_like(up)
+
+
+@torch.library.custom_op(
     "minimal_async_ep::dispatch_backward",
     mutates_args=(),
     device_types="cuda",
@@ -877,6 +947,22 @@ def combine_backward_op_fake(
     )
 
 
+def active_swiglu_autograd_backward(ctx, grad_out):
+    gate, up, active_rows = ctx.saved_tensors
+    grad_gate, grad_up = active_swiglu_backward_op(
+        grad_out,
+        gate,
+        up,
+        active_rows,
+    )
+    return grad_gate, grad_up, None
+
+
+def active_swiglu_setup_context(ctx, inputs, output):
+    gate, up, active_rows = inputs
+    ctx.save_for_backward(gate, up, active_rows)
+
+
 def dispatch_setup_context(ctx, inputs, output):
     dispatch_input, topk_expert_ids_TK, *_ = inputs  # noqa: N806
     (
@@ -983,6 +1069,9 @@ def combine_autograd_backward(ctx, grad_out, grad_routed_output):
     )
 
 
+active_swiglu_op.register_autograd(
+    active_swiglu_autograd_backward, setup_context=active_swiglu_setup_context
+)
 dispatch_op.register_autograd(
     dispatch_autograd_backward,
     setup_context=dispatch_setup_context,
@@ -994,6 +1083,7 @@ combine_op.register_autograd(
 
 __all__ = [
     "MinimalAsyncEPDispatchMetadata",
+    "active_swiglu_op",
     "combine_op",
     "dispatch_op",
     "init_buffer",

--- a/torchtitan/distributed/minimal_async_ep/kernels.py
+++ b/torchtitan/distributed/minimal_async_ep/kernels.py
@@ -14,6 +14,7 @@ import triton.language as tl
 _COUNT_COPY_BLOCK_SIZE = 1024
 _METADATA_BLOCK_SIZE = 256
 _MAX_BLOCK_N = 2048
+_SWIGLU_BLOCK_M = 4
 
 # MinimalAsyncEP hidden buffers use TrainingConfig.mixed_precision_param,
 # currently restricted to bfloat16 or float32.
@@ -289,6 +290,140 @@ def _topk_scores_grad_kernel(
 
 
 @triton.jit
+def _active_swiglu_forward_kernel(
+    gate,
+    up,
+    out,
+    active_rows_ptr: tl.pointer_type(tl.int32),
+    NUM_COLS: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    OUT_ROW_STRIDE: tl.constexpr,
+    OUT_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Compute ``silu(gate) * up`` for active received rows only.
+
+    Rows at or after ``active_rows_ptr[0]`` are receive-capacity padding and
+    are intentionally left unspecified because grouped-mm offsets skip them.
+
+    Example:
+        With ``active_rows=2``, ``gate=[[0], [1], [9]]``, and
+        ``up=[[2], [3], [4]]``, the first two output rows are
+        approximately ``[[0.0], [2.193]]`` and row 2 is unspecified.
+    """
+    row_start = tl.program_id(0) * BLOCK_M
+    active_rows = tl.load(active_rows_ptr)
+    if row_start >= active_rows:
+        return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < active_rows) & (cols[None, :] < NUM_COLS)
+
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    silu = gate_values * tl.sigmoid(gate_values)
+    tl.store(
+        out + rows[:, None] * OUT_ROW_STRIDE + cols[None, :] * OUT_COL_STRIDE,
+        silu * up_values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _active_swiglu_backward_kernel(
+    grad_out,
+    gate,
+    up,
+    grad_gate,
+    grad_up,
+    active_rows_ptr: tl.pointer_type(tl.int32),
+    NUM_COLS: tl.constexpr,
+    GRAD_OUT_ROW_STRIDE: tl.constexpr,
+    GRAD_OUT_COL_STRIDE: tl.constexpr,
+    GATE_ROW_STRIDE: tl.constexpr,
+    GATE_COL_STRIDE: tl.constexpr,
+    UP_ROW_STRIDE: tl.constexpr,
+    UP_COL_STRIDE: tl.constexpr,
+    GRAD_GATE_ROW_STRIDE: tl.constexpr,
+    GRAD_GATE_COL_STRIDE: tl.constexpr,
+    GRAD_UP_ROW_STRIDE: tl.constexpr,
+    GRAD_UP_COL_STRIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    """Backward for ``_active_swiglu_forward_kernel`` over active rows only.
+
+    Gradients for receive-capacity padding rows are intentionally left
+    unspecified because no later grouped-mm segment consumes them.
+
+    Example:
+        With ``active_rows=2``, ``grad_out=[[5], [7], [11]]``,
+        ``gate=[[0], [1], [9]]``, and ``up=[[2], [3], [4]]``, the first
+        two ``grad_gate`` rows are approximately ``[[5.0], [19.48]]``,
+        the first two ``grad_up`` rows are approximately
+        ``[[0.0], [5.118]]``, and row 2 is unspecified.
+    """
+    row_start = tl.program_id(0) * BLOCK_M
+    active_rows = tl.load(active_rows_ptr)
+    if row_start >= active_rows:
+        return
+
+    rows = row_start + tl.arange(0, BLOCK_M)
+    cols = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < active_rows) & (cols[None, :] < NUM_COLS)
+
+    grad_values = tl.load(
+        grad_out
+        + rows[:, None] * GRAD_OUT_ROW_STRIDE
+        + cols[None, :] * GRAD_OUT_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate_values = tl.load(
+        gate + rows[:, None] * GATE_ROW_STRIDE + cols[None, :] * GATE_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    up_values = tl.load(
+        up + rows[:, None] * UP_ROW_STRIDE + cols[None, :] * UP_COL_STRIDE,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    sigmoid = tl.sigmoid(gate_values)
+    silu = gate_values * sigmoid
+    silu_grad = sigmoid * (1.0 + gate_values * (1.0 - sigmoid))
+
+    tl.store(
+        grad_gate
+        + rows[:, None] * GRAD_GATE_ROW_STRIDE
+        + cols[None, :] * GRAD_GATE_COL_STRIDE,
+        grad_values * up_values * silu_grad,
+        mask=mask,
+    )
+    tl.store(
+        grad_up
+        + rows[:, None] * GRAD_UP_ROW_STRIDE
+        + cols[None, :] * GRAD_UP_COL_STRIDE,
+        grad_values * silu,
+        mask=mask,
+    )
+
+
+@triton.jit
 def _copy_rows_to_peer_ptrs_kernel(
     src,
     dst_ptrs: tl.pointer_type(tl.int64),
@@ -377,6 +512,77 @@ def copy_full_counts_to_peers_kernel(
         DST_ROW_STRIDE=dsts[0].stride(0),
         BLOCK_SIZE=block_size,
     )
+
+
+def active_swiglu_forward_kernel(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``silu(gate) * up`` only for rows before ``active_rows[0]``.
+
+    Rows at or after ``active_rows[0]`` in the returned tensor are unspecified.
+    MinimalAsyncEP only consumes rows covered by the same grouped-mm offsets.
+    """
+    out = torch.empty_like(gate)
+
+    block_m = _SWIGLU_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _active_swiglu_forward_kernel[grid](
+        gate,
+        up,
+        out,
+        active_rows,
+        NUM_COLS=gate.shape[1],
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        OUT_ROW_STRIDE=out.stride(0),
+        OUT_COL_STRIDE=out.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return out
+
+
+def active_swiglu_backward_kernel(
+    grad_out: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    active_rows: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    grad_gate = torch.empty_like(gate)
+    grad_up = torch.empty_like(up)
+
+    block_m = _SWIGLU_BLOCK_M
+    block_n = min(_MAX_BLOCK_N, triton.next_power_of_2(gate.shape[1]))
+    grid = (triton.cdiv(gate.shape[0], block_m), triton.cdiv(gate.shape[1], block_n))
+    _active_swiglu_backward_kernel[grid](
+        grad_out,
+        gate,
+        up,
+        grad_gate,
+        grad_up,
+        active_rows,
+        NUM_COLS=gate.shape[1],
+        GRAD_OUT_ROW_STRIDE=grad_out.stride(0),
+        GRAD_OUT_COL_STRIDE=grad_out.stride(1),
+        GATE_ROW_STRIDE=gate.stride(0),
+        GATE_COL_STRIDE=gate.stride(1),
+        UP_ROW_STRIDE=up.stride(0),
+        UP_COL_STRIDE=up.stride(1),
+        GRAD_GATE_ROW_STRIDE=grad_gate.stride(0),
+        GRAD_GATE_COL_STRIDE=grad_gate.stride(1),
+        GRAD_UP_ROW_STRIDE=grad_up.stride(0),
+        GRAD_UP_COL_STRIDE=grad_up.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return grad_gate, grad_up
 
 
 def copy_rows_to_peers_kernel(

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -368,12 +368,20 @@ class TestCudagraphPass(unittest.TestCase):
                 (cuda_f32(4, 8), cuda_f32(12, 8)),
             ),
             (
+                torch.ops.minimal_async_ep.active_swiglu.default,
+                cuda_f32(16, 8),
+            ),
+            (
                 torch.ops.minimal_async_ep.dispatch_backward.default,
                 cuda_f32(4, 8),
             ),
             (
                 torch.ops.minimal_async_ep.combine_backward.default,
                 (cuda_f32(16, 8), cuda_f32(12)),
+            ),
+            (
+                torch.ops.minimal_async_ep.active_swiglu_backward.default,
+                (cuda_f32(16, 8), cuda_f32(16, 8)),
             ),
         ]
         nodes = []

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -13,11 +13,17 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 
+from torchtitan.distributed.minimal_async_ep import active_swiglu_op
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher
+from .token_dispatcher import (
+    DeepEPTokenDispatcher,
+    HybridEPTokenDispatcher,
+    LocalTokenDispatcher,
+    MinimalAsyncEPTokenDispatcher,
+)
 
 # Shape suffix legend
 # (https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd):
@@ -50,6 +56,10 @@ class GroupedExperts(Module):
             torch.empty(config.num_experts, config.hidden_dim, config.dim)
         )
         self.token_dispatcher = config.token_dispatcher.build()
+        self._use_active_swiglu = isinstance(
+            self.token_dispatcher,
+            (HybridEPTokenDispatcher, MinimalAsyncEPTokenDispatcher),
+        )
 
     def _experts_forward(
         self,
@@ -79,18 +89,20 @@ class GroupedExperts(Module):
 
         offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
 
-        h_RF = F.silu(
-            torch._grouped_mm(
-                x_RD.bfloat16(),
-                w1_EFD.bfloat16().transpose(-2, -1),
-                offs=offsets_E,
-            )
+        gate_RF = torch._grouped_mm(
+            x_RD.bfloat16(),
+            w1_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
         )
-        h_RF = h_RF * torch._grouped_mm(
+        up_RF = torch._grouped_mm(
             x_RD.bfloat16(),
             w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
+        if self._use_active_swiglu:
+            h_RF = active_swiglu_op(gate_RF, up_RF, offsets_E[-1:])
+        else:
+            h_RF = F.silu(gate_RF) * up_RF
         return torch._grouped_mm(
             h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -1037,8 +1037,12 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
         routed_output_RD: torch.Tensor,
         metadata: DeepEPDispatchMetadata,
         x_TD: torch.Tensor,
+        *,
+        num_local_tokens_after_padding: int,
+        local_seq_len_after_padding: int,
     ) -> torch.Tensor:
         """Combine tokens via MinimalAsyncEP."""
+        del num_local_tokens_after_padding, local_seq_len_after_padding
         state = cast(MinimalAsyncEPDispatchMetadata, metadata.state)
         combined_TD, _routed_output_ND = minimal_async_ep_combine_op(  # noqa: N806
             routed_output_RD,


### PR DESCRIPTION
Stacked PRs:
 * __->__#3660
 * #3659
 * #3658


--- --- ---

Use python -m torch.distributed.run instead of torchrun

The installation of torchrun is unclear to me. It seems like when you install pytorch via nightly, it will add this script to your PATH.

For instance, I installed pytorch nightly on py310 to use the linter matching titan/pytorch CI, and torchrun file was added into `~/.local/bin/torchrun`.
```python
#!/home/xmfan/core/miniconda3/envs/py310/bin/python3.10
import sys
from torch.distributed.run import main
if __name__ == '__main__':
    sys.argv[0] = sys.argv[0].removesuffix('.exe')
    sys.exit(main())
~                            
```

But this python3.10 torchrun will be still be active in your PATH and used in other conda envs. This PR directly calls `torch.distributed.run` to use the available `python` binary (which is packaged inside the venv/conda env) as ground truth instead.