### PR TITLE
fix num_local_tokens_after_padding for full_dtensor

### DIFF
--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -102,7 +102,7 @@ class GroupedExperts(Module):
         topk_expert_ids_BLK: torch.Tensor,
         num_local_tokens_per_expert_E: torch.Tensor,
         *,
-        num_local_tokens_after_padding: int,
+        num_local_tokens_after_seq_dim_padding: int,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add.
 
@@ -113,7 +113,7 @@ class GroupedExperts(Module):
         B, L, D = x_BLD.shape
         K = topk_scores_BLK.size(-1)
         T = B * L
-        local_seq_len_after_padding = num_local_tokens_after_padding // B
+        local_seq_len_after_padding = num_local_tokens_after_seq_dim_padding // B
         x_TD = x_BLD.view(T, D)
 
         topk_scores_TK = topk_scores_BLK.view(T, K)
@@ -135,7 +135,7 @@ class GroupedExperts(Module):
             routed_output_RD,
             metadata,
             x_TD,
-            num_local_tokens_after_padding=num_local_tokens_after_padding,
+            num_local_tokens_after_padding=num_local_tokens_after_seq_dim_padding,
             local_seq_len_after_padding=local_seq_len_after_padding,
         )
         # Un-flatten back to 3-D (B, *, D) so the local_map output sharding
@@ -384,15 +384,19 @@ class MoE(Module):
         the GroupedExperts boundary.
         """
         B, L, D = x_BLD.shape
-        T = B * L
         sp_size = getattr(self.experts.token_dispatcher, "sp_size", 1)
-        pad_tokens = (-T) % sp_size
-        # Padding is logically appended to the flattened global sequence tail,
+        seq_dim_pad_tokens = (-L) % sp_size
+        # Padding is logically appended to the sequence tail of each batch,
         # not to a specific SP rank. This lets combine() infer each SP rank's
         # start/end offsets from the uniform padded shard length; for example,
-        # if T < sp_size, only the first T ranks have real tokens. No padded
+        # if L < sp_size, only the first L ranks have real tokens. No padded
         # token is materialized or routed.
-        num_local_tokens_after_padding = (T + pad_tokens) // sp_size
+        local_batch_size = (
+            x_BLD._local_tensor.shape[0] if isinstance(x_BLD, DTensor) else B
+        )
+        num_local_tokens_after_seq_dim_padding = (
+            local_batch_size * (L + seq_dim_pad_tokens) // sp_size
+        )
 
         # topk_scores_BLK and topk_expert_ids_BLK shape (B, L, K)
         # scores_BLE shape (B, L, E)
@@ -452,7 +456,7 @@ class MoE(Module):
             topk_scores_BLK,
             topk_expert_ids_BLK,
             num_local_tokens_per_expert_E,
-            num_local_tokens_after_padding=num_local_tokens_after_padding,
+            num_local_tokens_after_seq_dim_padding=num_local_tokens_after_seq_dim_padding,
         )
 
         # shared_experts runs in parallel with deepep combine communication.
@@ -471,13 +475,11 @@ class MoE(Module):
 
             sync_combine()
 
-        if pad_tokens:
-            # Combine constructs the full logically padded SP view so each rank
-            # uses the same stride for global token offsets. The input was not
-            # physically padded, so trim the logical tail padding before
-            # restoring the original (B, L, D) shape.
-            out_TD = out_BLD.view(-1, D)
-            out_BLD = out_TD[:T].view(B, L, D)
+        if seq_dim_pad_tokens:
+            # Combine constructs a sequence-dim padded SP view for each batch
+            # row. The input was not physically padded, so trim that logical
+            # sequence tail before adding the shared expert output.
+            out_BLD = out_BLD[:, :L, :]
 
         if shared_out_BLD is not None:
             out_BLD = out_BLD + shared_out_BLD

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -164,13 +164,13 @@ class GptOssGroupedExperts(Module):
         topk_expert_ids_BLK: torch.Tensor,
         num_local_tokens_per_expert_E: torch.Tensor,
         *,
-        num_local_tokens_after_padding: int,
+        num_local_tokens_after_seq_dim_padding: int,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add."""
         B, L, D = x_BLD.shape
         K = topk_scores_BLK.size(-1)
         T = B * L
-        local_seq_len_after_padding = num_local_tokens_after_padding // B
+        local_seq_len_after_padding = num_local_tokens_after_seq_dim_padding // B
         x_TD = x_BLD.view(T, D)
         topk_scores_TK = topk_scores_BLK.view(T, K)
         topk_expert_ids_TK = topk_expert_ids_BLK.view(T, K)
@@ -192,7 +192,7 @@ class GptOssGroupedExperts(Module):
             routed_output_RD,
             metadata,
             x_TD,
-            num_local_tokens_after_padding=num_local_tokens_after_padding,
+            num_local_tokens_after_padding=num_local_tokens_after_seq_dim_padding,
             local_seq_len_after_padding=local_seq_len_after_padding,
         )
         # Un-flatten back to 3-D (B, *, D) so the local_map output sharding


### PR DESCRIPTION
in full_dtensor backend, x_BLD is a dense-mesh DTensor, and num_local_tokens_after_padding is computed from global batch, instead of local batch. This means GroupedExperts.combine() constructs a larger output buffer than necessary (dp degree x), causing a shape mismatch w/ residual stream.

This checks local-tensor batch size instead. Smoke-tested qwen3 MoE debug on legacy and full_dtensor backends across FSDP+TP+EP, FSDP+EP, and no-EP 4-GPU configs.

Previous error:
`NGPU=4 LOG_RANK=0 ./run_train.sh --module=qwen3 --config=qwen3_moe_debug --parallelism.data_parallel_shard_degree=2 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=4 --training.steps=2 --debug.seed=42 --debug.deterministic --parallelism.spmd_backend=full_dtensor`

```
    File "/data/users/pianpwk/ttclone/torchtitan/torchtitan/models/qwen3/model.py", line 63, in forward
      x = x + self.moe(self.ffn_norm(x))
    File "/data/users/pianpwk/pytorch/torch/_compile.py", line 54, in inner
      return disable_fn(*args, **kwargs)
    File "/data/users/pianpwk/pytorch/torch/_dynamo/eval_frame.py", line 1446, in _fn
      return fn(*args, **kwargs)
    File "/data/users/pianpwk/pytorch/torch/utils/checkpoint.py", line 1386, in __torch_dispatch__
      out = func(*args, **kwargs)
    File "/data/users/pianpwk/pytorch/torch/_ops.py", line 875, in __call__
      return self._op(*args, **kwargs)
    File "/data/users/pianpwk/pytorch/torch/distributed/tensor/_dispatch.py", line 289, in _propagate_op_sharding_dispatch_slow_path
      raise RuntimeError(
  RuntimeError: Attempting to broadcast a dimension of length 8192 at -2! Mismatching argument at index 1 had torch.Size([8, 8192, 256]); but expected shape should be broadcastable to [8, 4096, 256]
  
  Sharding propagation failed for aten.add.Tensor(Spec(bf16[8, 4096, 256](S(0)S(1))), Spec(bf16[8, 8192, 256](S(0)S(1)))) on DeviceMesh((dp_shard=2, tp=2), 'cuda', stride=(2, 1)))
```