### PR TITLE
[CP] Fix SDPA context-parallel shard placement

### DIFF
--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -78,7 +78,7 @@ def apply_cp_to_forward(
             original_forward = mod.forward
 
             def _make_cp_forward(orig_fn, mesh):
-                placement = [Shard(2)]
+                placement = [Shard(1)]
 
                 def cp_forward(q, k, v, **kwargs):
                     if not isinstance(q, DTensor):


### PR DESCRIPTION
ScaledDotProductAttention.forward receives q/k/v in model layout (B, L, H, D), then transposes them to SDPA layout (B, H, L, D). The CP wrapper annotates q/k/v before that transpose, so the shard dimension must be expressed in the model layout. CP splits the sequence axis, which is dim 1 in (B, L, H, D). The old code used Shard(2), annotating the head axis instead. After the transpose, PyTorch saw Shard(1) at the SDPA op, i.e. head sharding in (B, H, L, D), instead of the required Shard(2) sequence sharding.

This was latent because PyTorch's old CP SDPA sharding rule appended the CP sequence strategy to the normal SDPA base strategies, so the wrong head-sharded metadata could match a non-CP/base head-sharded strategy and pass propagation. https://github.com/pytorch/pytorch/pull/186667 migrated these rules to single-dim strategies and the CP override now only accepts the CP sequence strategy. That correctly exposes the bad TorchTitan annotation as needs_redistribute=True, which triggers the CP SDPA handler's assertion.

Use Shard(1) when wrapping the pre-transpose q/k/v tensors, so the transpose presents Shard(2) at the actual SDPA op.

Error seen in Graph Trainer CI test "aot_fx_trace llama3 FSDP+TP+CP" failed in torch/distributed/tensor/experimental/_context_parallel/_attention.py with AssertionError: "inputs need to be redistributed".