### PR TITLE
[full_dtensor] validate src sharding placements

### DIFF
--- a/tests/unit_tests/test_module.py
+++ b/tests/unit_tests/test_module.py
@@ -6,12 +6,22 @@
 
 import unittest
 from dataclasses import dataclass
+from unittest.mock import patch
 
+import spmd_types as spmd
 import torch
 import torch.nn as nn
+from expecttest import assert_expected_inline
+from torch.distributed.tensor import distribute_tensor, Shard
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
 
+from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims, SpmdLayout
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module, ModuleDict, ModuleList, Sequential
+from torchtitan.protocols.sharding import ShardingConfig
 
 
 class TestModuleInitStates(unittest.TestCase):
@@ -343,6 +353,65 @@ class TestConfigBuildPropagatesParamInit(unittest.TestCase):
         nn.init.zeros_(m.linear.weight)
         m.init_states()
         self.assertTrue(torch.all(m.linear.weight == 1))
+
+
+class TestModuleRedistributionDTensor(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 2
+
+    def _parallel_dims(self):
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=self.world_size,
+            pp=1,
+            ep=1,
+            world_size=self.world_size,
+        )
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            parallel_dims.build_mesh()
+        return parallel_dims
+
+    class Identity(Module):
+        def forward(self, x):
+            return x
+
+    @with_comms
+    def test_dtensor_must_match_declared_src_shardings(self):
+        parallel_dims = self._parallel_dims()
+        mesh = parallel_dims.get_mesh("tp")
+        module = self.Identity()
+        module._sharding_config = ShardingConfig()
+        module._sharding_config.in_src_shardings = {
+            "x": SpmdLayout({MeshAxisName.TP: spmd.R})
+        }
+        module._sharding_config.out_src_shardings = SpmdLayout(
+            {MeshAxisName.TP: spmd.R}
+        )
+        module._cache_pos_arg_names()
+        x = distribute_tensor(
+            torch.randn(4, 4, device=self.device_type),
+            mesh,
+            (Shard(0),),
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            module._redistribute_inputs(parallel_dims, (x,), {})
+        assert_expected_inline(
+            str(cm.exception),
+            """Identity.x: input DTensor has placements (Shard(dim=0),), but in_src_shardings expects (Replicate(),).""",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            module._redistribute_outputs(parallel_dims, x)
+        assert_expected_inline(
+            str(cm.exception),
+            """Identity: output DTensor has placements (Shard(dim=0),), but out_src_shardings expects (Replicate(),).""",
+        )
 
 
 class TestVerifyModuleProtocol(unittest.TestCase):

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -458,10 +458,9 @@ class ChunkedCELoss(BaseLoss):
         fires per-chunk, and FSDP2 accumulates the sharded gradients correctly.
 
     TP / SP composability:
-        Hidden states are redistributed to ``Replicate()`` on the TP mesh
-        before chunking, so each chunk enters the lm_head as ``Replicate()``
-        input regardless of whether SP is enabled. With SP, this is an
-        all-gather from ``Shard(1)``; without SP, it's a no-op.
+        The root decoder norm emits hidden states that are replicated on the
+        TP axis before chunking, so each chunk enters the lm_head as
+        ``Replicate()`` input regardless of whether SP is enabled.
 
         When loss parallel is applied, each TP rank
         computes partial CE on its ``V/tp`` slice, with an internal
@@ -517,18 +516,6 @@ class ChunkedCELoss(BaseLoss):
         lm_head = self.lm_head
         assert lm_head is not None, "Set lm_head before calling ChunkedCELoss"
         fsdp_enabled = isinstance(lm_head, FSDPModule)
-
-        # If SP is enabled, hidden states are Shard(1) on the TP mesh dim.
-        # Redistribute only the TP dim to Replicate before chunking so that
-        # the lm_head receives Replicate input on TP.
-        if isinstance(hidden_states, DTensor):
-            mesh = hidden_states.device_mesh
-            if mesh.mesh_dim_names is not None and "tp" in mesh.mesh_dim_names:
-                tp_dim = mesh.mesh_dim_names.index("tp")
-                placements = list(hidden_states.placements)
-                if not isinstance(placements[tp_dim], Replicate):
-                    placements[tp_dim] = Replicate()
-                    hidden_states = hidden_states.redistribute(mesh, tuple(placements))
 
         # Check if it's training model or validation mode
         requires_grad = hidden_states.requires_grad

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -23,6 +23,7 @@ from spmd_types.checker import typecheck as spmd_typecheck
 from torch import distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Placement, Shard
 
 from torchtitan.config import CommConfig, DebugConfig
 from torchtitan.tools.logging import logger
@@ -44,6 +45,34 @@ def set_spmd_backend(spmd_backend: str) -> None:
 def get_spmd_backend() -> str:
     """Return the active SPMD backend."""
     return _spmd_backend
+
+
+def check_dtensor_placements_match(
+    actual: tuple[Placement, ...],
+    expected: tuple[Placement, ...],
+    tensor_ndim: int,
+) -> bool:
+    """Compare DTensor placements, normalizing negative Shard dims to tensor rank."""
+    if len(actual) != len(expected):
+        return False
+
+    def normalize_dim(dim: int, ndim: int) -> int:
+        return dim + ndim if dim < 0 else dim
+
+    for actual_placement, expected_placement in zip(actual, expected, strict=True):
+        if isinstance(actual_placement, Shard) and isinstance(
+            expected_placement, Shard
+        ):
+            if normalize_dim(actual_placement.dim, tensor_ndim) != normalize_dim(
+                expected_placement.dim, tensor_ndim
+            ):
+                return False
+            continue
+
+        if actual_placement != expected_placement:
+            return False
+
+    return True
 
 
 def _dist_reduce(

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -111,6 +111,29 @@ def norm_config(*, enable_sp: bool) -> ShardingConfig:
     )
 
 
+def pre_lm_head_norm_config(*, enable_sp: bool) -> ShardingConfig:
+    """Root decoder norm sharding before ``lm_head`` / chunked CE loss.
+
+    Decoder blocks emit sequence-sharded hidden states when sequence
+    parallelism is enabled. The root norm is the last clean module boundary to
+    all-gather the TP sequence shard back to replicated hidden states before
+    either the model forward or ``ChunkedCELoss`` applies ``lm_head``.
+    """
+    activation = (
+        dense_sequence_parallel_placement()
+        if enable_sp
+        else dense_activation_placement(tp=spmd.I)
+    )
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.R if enable_sp else spmd.I)
+        },
+        in_src_shardings={"input": activation},
+        out_src_shardings=activation,
+        out_dst_shardings=dense_activation_placement(tp=spmd.R),
+    )
+
+
 def set_qkv_linear_sharding(qkv_linear_cfg) -> None:
     """Colwise-shard each Q/K/V projection of a ``BaseQKVLinear``.
 
@@ -266,11 +289,11 @@ def set_decoder_sharding_config(
         out_dst_shardings=activation_layout,
         local_map=LocalMapConfig(in_grad_placements=None),
     )
-    config.norm.sharding_config = norm_config(enable_sp=enable_sp)
+    config.norm.sharding_config = pre_lm_head_norm_config(enable_sp=enable_sp)
 
     config.lm_head.sharding_config = ShardingConfig(
         state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
-        in_src_shardings={"input": activation_layout},
+        in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
         in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
         out_src_shardings=dense_activation_placement(tp=spmd.S(-1)),
         out_dst_shardings=dense_activation_placement(tp=loss_tp),

--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -75,17 +75,12 @@ def _shared_expert_colwise_config(enable_ep: bool, enable_sp: bool) -> ShardingC
     to Replicate for the column-sharded matmul; output is Shard(2)
     (feature dim for 3-D activations from MoE).
     """
-    input_layout = (
-        dense_sequence_parallel_placement()
-        if enable_ep and enable_sp
-        else dense_activation_placement(tp=spmd.R)
-    )
     return ShardingConfig(
         state_shardings={
             "weight": dense_param_placement(tp=spmd.S(0)),
             "bias": dense_param_placement(tp=spmd.S(0)),
         },
-        in_src_shardings={"input": input_layout},
+        in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
         in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
         out_dst_shardings=dense_activation_placement(tp=spmd.S(2)),
     )

--- a/torchtitan/models/qwen3_5/sharding.py
+++ b/torchtitan/models/qwen3_5/sharding.py
@@ -32,7 +32,7 @@ from torchtitan.models.common.decoder_sharding import (
     set_gqa_inner_attention_local_map,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
-from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig, SpmdLayout
 
 if TYPE_CHECKING:
     from torchtitan.models.qwen3_5.model import (
@@ -67,6 +67,14 @@ def _qk_norm_sharding() -> ShardingConfig:
         in_src_shardings={"input": head_plc},
         in_dst_shardings={"input": head_plc},
         out_dst_shardings=head_plc,
+    )
+
+
+def _decoder_norm_sharding(activation_layout: SpmdLayout) -> ShardingConfig:
+    return ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.R)},
+        in_src_shardings={"input": activation_layout},
+        out_src_shardings=activation_layout,
     )
 
 
@@ -109,23 +117,42 @@ def set_qwen35_sharding_config(
         local_map=LocalMapConfig(in_grad_placements=None),
     )
     _set_vision_encoder_sharding(config.vision_encoder)
-    for layer_cfg in config.layers:
-        _set_qwen35_layer_sharding(layer_cfg, enable_ep=enable_ep)
+    # The embedding path stays replicated through multimodal vision scatter.
+    # The first attention block restores SP; later decoder block inputs are SP.
+    first_layer_input_layout = dense_activation_placement(tp=spmd.R)
+    layer_input_layout = dense_sequence_parallel_placement()
+    for layer_idx, layer_cfg in enumerate(config.layers):
+        _set_qwen35_layer_sharding(
+            layer_cfg,
+            attention_input_layout=(
+                first_layer_input_layout if layer_idx == 0 else layer_input_layout
+            ),
+            enable_ep=enable_ep,
+        )
 
 
 def _set_qwen35_layer_sharding(
     layer_cfg: "Qwen35TransformerBlock.Config",
     *,
+    attention_input_layout: SpmdLayout,
     enable_ep: bool,
 ) -> None:
-    layer_cfg.attention_norm.sharding_config = norm_config(enable_sp=True)
+    layer_cfg.attention_norm.sharding_config = _decoder_norm_sharding(
+        attention_input_layout
+    )
     layer_cfg.ffn_norm.sharding_config = norm_config(enable_sp=True)
 
     if layer_cfg.attention is not None:
-        _set_full_attention_sharding(layer_cfg.attention)
+        _set_full_attention_sharding(
+            layer_cfg.attention,
+            attention_input_layout=attention_input_layout,
+        )
     else:
         assert layer_cfg.delta_net is not None
-        _set_deltanet_sharding(layer_cfg.delta_net)
+        _set_deltanet_sharding(
+            layer_cfg.delta_net,
+            attention_input_layout=attention_input_layout,
+        )
 
     if layer_cfg.feed_forward is not None:
         set_dense_ffn_sharding(
@@ -218,10 +245,12 @@ def _set_vision_encoder_sharding(ve_cfg: "Qwen35VisionEncoder.Config") -> None:
 
 def _set_full_attention_sharding(
     attention_cfg: "Qwen35Attention.Config",
+    *,
+    attention_input_layout: SpmdLayout,
 ) -> None:
     """TP sharding for Qwen35Attention (output gating + partial RoPE)."""
     attention_cfg.sharding_config = ShardingConfig(
-        in_src_shardings={"x": dense_sequence_parallel_placement()},
+        in_src_shardings={"x": attention_input_layout},
         in_dst_shardings={"x": dense_activation_placement(tp=spmd.R)},
     )
     # The per-layer rope ``cache`` buffer is a Replicate DTensor; MRoPE builds the
@@ -240,7 +269,11 @@ def _set_full_attention_sharding(
     set_gqa_inner_attention_local_map(attention_cfg.inner_attention)
 
 
-def _set_deltanet_sharding(deltanet_cfg: "GatedDeltaNet.Config") -> None:
+def _set_deltanet_sharding(
+    deltanet_cfg: "GatedDeltaNet.Config",
+    *,
+    attention_input_layout: SpmdLayout,
+) -> None:
     """Sharding for GatedDeltaNet: head-sharded TP on projections.
 
     Input is allgathered (Shard(1)→Replicate) so that the recurrence
@@ -301,7 +334,7 @@ def _set_deltanet_sharding(deltanet_cfg: "GatedDeltaNet.Config") -> None:
             "A_log": dense_param_placement(tp=spmd.S(0)),
             "dt_bias": dense_param_placement(tp=spmd.S(0)),
         },
-        in_src_shardings={"x": dense_sequence_parallel_placement()},
+        in_src_shardings={"x": attention_input_layout},
         in_dst_shardings={"x": dense_activation_placement(tp=spmd.R)},
         out_dst_shardings=dense_sequence_parallel_placement(),
     )

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -30,7 +30,10 @@ from torchtitan.distributed.spmd_types import (
     spmd_redistribute_per_axis,
     spmd_validate_redistributions,
 )
-from torchtitan.distributed.utils import get_spmd_backend
+from torchtitan.distributed.utils import (
+    check_dtensor_placements_match,
+    get_spmd_backend,
+)
 from torchtitan.protocols.sharding import resolve_placements, ShardingConfig
 
 
@@ -600,9 +603,22 @@ class Module(nn.Module, Configurable):
                     run_check=False,
                 )
 
+            if isinstance(value, DTensor) and src_spmd_layout is not None:
+                expected = resolve_placements(src_spmd_layout, mesh)
+                if not check_dtensor_placements_match(
+                    value.placements, expected, value.ndim
+                ):
+                    raise ValueError(
+                        f"{type(self).__name__}.{name}: input DTensor has "
+                        f"placements {value.placements}, but in_src_shardings "
+                        f"expects {expected}."
+                    )
+
             if dst_spmd_layout is not None and isinstance(value, DTensor):
                 desired = resolve_placements(dst_spmd_layout, mesh)
-                if value.placements != desired:
+                if not check_dtensor_placements_match(
+                    value.placements, desired, value.ndim
+                ):
                     value = value.redistribute(placements=desired, async_op=True)
 
             new_kwargs[name] = value
@@ -622,14 +638,14 @@ class Module(nn.Module, Configurable):
         sharding_config = self._sharding_config
         assert sharding_config is not None
 
-        out_spmd_layout = sharding_config.out_dst_shardings
+        out_src = sharding_config.out_src_shardings
+        out_dst = sharding_config.out_dst_shardings
         if parallel_dims.spmd_backend == "spmd_types":
             if not isinstance(outputs, torch.Tensor):
                 return outputs
 
-            out_src = sharding_config.out_src_shardings
             if out_src is None:
-                if sharding_config.out_dst_shardings is not None:
+                if out_dst is not None:
                     raise ValueError(
                         f"{type(self).__name__}: SPMD output redistribution "
                         "requires explicit out_src_shardings."
@@ -648,7 +664,6 @@ class Module(nn.Module, Configurable):
                 out_src.partition_spec,
             )
 
-            out_dst = sharding_config.out_dst_shardings
             if out_dst is None:
                 return outputs
             return spmd_redistribute_per_axis(
@@ -660,13 +675,29 @@ class Module(nn.Module, Configurable):
                 out_dst.per_axis_spmd_types(),
             )
 
-        mesh = parallel_dims.resolve_shared_mesh([out_spmd_layout])
+        if isinstance(out_src, tuple):
+            return outputs
+
+        mesh = parallel_dims.resolve_shared_mesh([out_src, out_dst])
         if mesh is None:
             return outputs
 
-        if out_spmd_layout is not None:
-            desired = resolve_placements(out_spmd_layout, mesh)
-            if isinstance(outputs, DTensor) and outputs.placements != desired:
+        if isinstance(outputs, DTensor) and out_src is not None:
+            expected = resolve_placements(out_src, mesh)
+            if not check_dtensor_placements_match(
+                outputs.placements, expected, outputs.ndim
+            ):
+                raise ValueError(
+                    f"{type(self).__name__}: output DTensor has placements "
+                    f"{outputs.placements}, but out_src_shardings expects "
+                    f"{expected}."
+                )
+
+        if out_dst is not None:
+            desired = resolve_placements(out_dst, mesh)
+            if isinstance(outputs, DTensor) and not check_dtensor_placements_match(
+                outputs.placements, desired, outputs.ndim
+            ):
                 outputs = outputs.redistribute(placements=desired, async_op=True)
 
         return outputs


### PR DESCRIPTION
Changes sharding config based input/output redistributions to check DTensor in_src, out_src placements, not loosely passthrough. Beneficial for spmd_types where that info is used for redistribution.

Caught 2 failures
- https://github.com/pytorch/torchtitan/pull/3371 updated shared experts in shardings, but didn't update shared experts colwise config (redundant redistribution)
- ChunkedCELoss does seq-dim allgather manually, so lm_head in is conditional. Moves this to norm config, ahead of https://github.com/pytorch/torchtitan/pull/3472/
- There seems to be other qwen3.5 src placement changes - e.g. first layer attention input isn't seq-sharded from embedding?