### PR TITLE
Add GraphTrainer CI trigger label

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,5 +1,6 @@
 ciflow_push_tags:
   - ciflow/8gpu
   - ciflow/h100.8
+  - ciflow/graph-trainer
   - ciflow/rl
 labeler_config: labeler.yml

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -3,6 +3,8 @@ name: GraphTrainer 8 GPU Integration Tests
 on:
   push:
     branches: [ main ]
+    tags:
+      - ciflow/graph-trainer/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer.yaml'

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -3,6 +3,8 @@ name: GraphTrainer 8 GPU H100 Integration Tests
 on:
   push:
     branches: [ main ]
+    tags:
+      - ciflow/graph-trainer/*
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'


### PR DESCRIPTION
Register ciflow/graph-trainer with pytorch-probot and teach both GraphTrainer 8 GPU workflows to run on the generated ciflow/graph-trainer push tags. This lets PRs that touch shared TorchTitan code request the GraphTrainer suites without relying on graph-trainer path filters.