### PR TITLE
[rl] refactor alphabet-sort configs into examples/alphabet_sort

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -74,7 +74,7 @@ python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-1.7B --local_dir torch
 
 7. Run simple GRPO RL loop to learn sum digits task. This also serves as an end-to-end smoke test that your environment is set up correctly.
 ```bash
-python -m torchtitan.experiments.rl.train --module rl --config rl_grpo_qwen3_0_6b_varlen
+python -m torchtitan.experiments.rl.train --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen
 ```
 
 **NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
@@ -104,7 +104,7 @@ If you want to run true on-policy mode in TorchTitan RL and debug generator/trai
 Now we only support logprob bitwise parity when trainer and generator are under the same parallelism.
 Example:
 ```bash
-python -m torchtitan.experiments.rl.train --module rl --config rl_grpo_qwen3_0_6b_varlen_batch_invariant
+python -m torchtitan.experiments.rl.train --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen_batch_invariant
 ```
 
 This config sets `DebugConfig(batch_invariant=True, deterministic=True)` and `training.dtype="bfloat16"` (required so the trainer computes in the same precision as the generator, as a limitation because TP only doesn't naturally support mixed precision training).

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -27,6 +27,10 @@ from torchtitan.config import (
     ParallelismConfig,
 )
 from torchtitan.distributed.utils import set_batch_invariance
+from torchtitan.experiments.rl.batch_invariance import (
+    force_logprobs_fn_for_batch_invariance,
+    patch_bmm_for_batch_invariance,
+)
 from torchtitan.experiments.rl.models.vllm_registry import (
     registry_to_vllm,
     TORCHTITAN_CONFIG_FORMAT,
@@ -102,85 +106,6 @@ def _prepare_generation_request_metrics(
         for key, value in metric_values.items()
         for metric in (m.Metric(key, m.Mean(value)), m.Metric(key, m.Max(value)))
     ]
-
-
-_batch_invariant_bmm_lib: torch.library.Library | None = None
-
-
-def _patch_bmm_for_batch_invariance() -> None:
-    """Override ``aten::bmm`` with vLLM's batch-invariant bmm kernel.
-
-    torchtitan's batch-invariant mode (``batch_invariant_ops``, applied by
-    ``set_batch_invariance``) overrides ``mm``/``addmm``/``_log_softmax``/
-    ``mean.dim`` but not ``bmm``. The MoE router gate (3-D activation @ 2-D
-    weight) lowers to ``aten::bmm`` in the generator but ``aten::mm`` in the
-    trainer, so without this the generator's gate scores drift from the
-    trainer's and flip top-k expert routing, breaking on-policy logprob parity.
-
-    TODO: Investigate how to drop bmm batch invariant patch in generator.
-    """
-    global _batch_invariant_bmm_lib
-    if _batch_invariant_bmm_lib is not None:
-        return
-    from vllm.model_executor.layers.batch_invariant import bmm_batch_invariant
-
-    _batch_invariant_bmm_lib = torch.library.Library("aten", "IMPL")
-    _batch_invariant_bmm_lib.impl("bmm", bmm_batch_invariant, "CUDA")
-    # pyrefly: ignore[bad-assignment]
-    torch.bmm = bmm_batch_invariant
-
-
-def _force_logprobs_fn_for_batch_invariance() -> None:
-    """Make vLLM's v2 logprob path dispatch.
-
-    The v2 GPU sampler computes per-token logprobs with a fused Triton kernel
-    (``compute_token_logprobs`` -> ``_topk_log_softmax_kernel``) that inlines
-    ``log(softmax(logits))`` and never calls PyTorch ops.
-
-    Swapping the kernel to routes the generator and the trainer through
-    the same set of ops, so logprobs match bit-for-bit.
-    """
-    import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
-
-    from torchtitan.experiments.rl.actors.trainer import compute_logprobs
-
-    def generator_compute_token_logprobs(
-        logits: torch.Tensor, token_ids: torch.Tensor
-    ) -> torch.Tensor:
-        """Per-token logprobs for vLLM's v2 sampler (replaces its fused kernel).
-
-        Args:
-            logits: ``[N, V]`` next-token logits for N sampled positions
-                (V = vocab_size).
-            token_ids: ``[N, K]`` the K token ids to score per position (vLLM
-                passes the sampled token's logprob plus any top-k logprobs it requested).
-
-        Returns:
-            ``[N, K]`` logprob of each of the K token ids at each position.
-        """
-        # vLLM gives token_ids [N, K]. SamplingParams(logprobs=0) makes real
-        # requests K=1, but we can't assert that: vLLM's kernel warmup probes
-        # this patched fn with K>1 (e.g. K=6), so we must handle any K. Map the
-        # N positions to one sequence (B=1, S=N) and reuse the trainer's
-        # compute_logprobs (one token per position) once per column.
-        #
-        # NOTE: each element of token_ids is scored independently, after the
-        # whole generated sequence is marterialized. We iterate column-by-column
-        # purely because torchtitan's compute_logprobs takes one token id per
-        # position; it is not a cross-column/cross-position dependency.
-        logits = logits.unsqueeze(0)  # [1, N, V]  (B=1, S=N)
-        token_ids = token_ids.to(torch.int64)
-        per_column = [
-            compute_logprobs(logits, token_ids[:, k].unsqueeze(0))  # [1, N]
-            for k in range(token_ids.shape[1])
-        ]
-        return torch.stack(per_column, dim=-1).squeeze(0)  # [N, K]
-
-    vllm_logprob.compute_token_logprobs = generator_compute_token_logprobs
-    logger.info(
-        "Patched vLLM compute_token_logprobs with trainer's implementation "
-        "so generator and trainer share one logprob code path"
-    )
 
 
 @dataclass(kw_only=True, slots=True)
@@ -442,10 +367,10 @@ class VLLMGenerator(Actor, Configurable):
             # batch_invariant_ops (via set_batch_invariance) covers
             # mm/addmm/_log_softmax/mean but not bmm; the MoE router gate lowers
             # to bmm in the vLLM inference graph, so override it generator-side.
-            _patch_bmm_for_batch_invariance()
+            patch_bmm_for_batch_invariance()
             # The vLLM v2 logprob Triton kernel bypasses the aten overrides above;
             # route it through trainer's function to match the trainer exactly.
-            _force_logprobs_fn_for_batch_invariance()
+            force_logprobs_fn_for_batch_invariance()
 
         self._set_determinism(config.debug)
 

--- a/torchtitan/experiments/rl/batch_invariance.py
+++ b/torchtitan/experiments/rl/batch_invariance.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Batch-invariance helpers for bitwise trainer/generator numerics parity.
+
+Groups the pieces that make the vLLM generator match the trainer op-for-op under
+batch-invariant mode: a model-config converter that pins FlexAttention kernel
+options, plus two runtime patches (bmm and the v2 logprob kernel).
+"""
+
+import logging
+from dataclasses import dataclass
+
+import torch
+
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.protocols.model import ModelConfigConverter
+
+logger = logging.getLogger(__name__)
+
+
+class BatchInvariantFlexConverter(ModelConfigConverter):
+    """Pin flex attention kernel options for batch-invariant mode.
+
+    Sets fixed BLOCK_M/BLOCK_N=16 and BACKEND=TRITON on all
+    FlexAttention layers.
+
+    BACKEND=TRITON is to avoid flex_decode kernel.
+    """
+
+    # the triton BLOCK_N tile size needs to be pinned for stable numerics and
+    # needs to match vLLM's for identical results, today vLLM default is 16
+    # TODO: run some experiments to determine impact of small vs large tile sizes
+    _BLOCK_M = 16
+    _BLOCK_N = 16
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelConfigConverter.Config):
+        pass
+
+    def __init__(self, config: Config):
+        pass
+
+    def convert(self, model_config) -> None:
+        for layer_cfg in model_config.layers:
+            inner = layer_cfg.attention.inner_attention
+            if isinstance(inner, FlexAttention.Config):
+                inner.kernel_options["BACKEND"] = "TRITON"
+                inner.kernel_options["BLOCK_M"] = self._BLOCK_M
+                inner.kernel_options["BLOCK_N"] = self._BLOCK_N
+
+
+_batch_invariant_bmm_lib: torch.library.Library | None = None
+
+
+def patch_bmm_for_batch_invariance() -> None:
+    """Override ``aten::bmm`` with vLLM's batch-invariant bmm kernel.
+
+    torchtitan's batch-invariant mode (``batch_invariant_ops``, applied by
+    ``set_batch_invariance``) overrides ``mm``/``addmm``/``_log_softmax``/
+    ``mean.dim`` but not ``bmm``. The MoE router gate (3-D activation @ 2-D
+    weight) lowers to ``aten::bmm`` in the generator but ``aten::mm`` in the
+    trainer, so without this the generator's gate scores drift from the
+    trainer's and flip top-k expert routing, breaking on-policy logprob parity.
+
+    TODO: Investigate how to drop bmm batch invariant patch in generator.
+    """
+    global _batch_invariant_bmm_lib
+    if _batch_invariant_bmm_lib is not None:
+        return
+    from vllm.model_executor.layers.batch_invariant import bmm_batch_invariant
+
+    _batch_invariant_bmm_lib = torch.library.Library("aten", "IMPL")
+    _batch_invariant_bmm_lib.impl("bmm", bmm_batch_invariant, "CUDA")
+    # pyrefly: ignore[bad-assignment]
+    torch.bmm = bmm_batch_invariant
+
+
+def force_logprobs_fn_for_batch_invariance() -> None:
+    """Make vLLM's v2 logprob path dispatch.
+
+    The v2 GPU sampler computes per-token logprobs with a fused Triton kernel
+    (``compute_token_logprobs`` -> ``_topk_log_softmax_kernel``) that inlines
+    ``log(softmax(logits))`` and never calls PyTorch ops.
+
+    Swapping the kernel to routes the generator and the trainer through
+    the same set of ops, so logprobs match bit-for-bit.
+    """
+    import vllm.v1.worker.gpu.sample.logprob as vllm_logprob
+
+    from torchtitan.experiments.rl.actors.trainer import compute_logprobs
+
+    def generator_compute_token_logprobs(
+        logits: torch.Tensor, token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-token logprobs for vLLM's v2 sampler (replaces its fused kernel).
+
+        Args:
+            logits: ``[N, V]`` next-token logits for N sampled positions
+                (V = vocab_size).
+            token_ids: ``[N, K]`` the K token ids to score per position (vLLM
+                passes the sampled token's logprob plus any top-k logprobs it requested).
+
+        Returns:
+            ``[N, K]`` logprob of each of the K token ids at each position.
+        """
+        # vLLM gives token_ids [N, K]. SamplingParams(logprobs=0) makes real
+        # requests K=1, but we can't assert that: vLLM's kernel warmup probes
+        # this patched fn with K>1 (e.g. K=6), so we must handle any K. Map the
+        # N positions to one sequence (B=1, S=N) and reuse the trainer's
+        # compute_logprobs (one token per position) once per column.
+        #
+        # NOTE: each element of token_ids is scored independently, after the
+        # whole generated sequence is marterialized. We iterate column-by-column
+        # purely because torchtitan's compute_logprobs takes one token id per
+        # position; it is not a cross-column/cross-position dependency.
+        logits = logits.unsqueeze(0)  # [1, N, V]  (B=1, S=N)
+        token_ids = token_ids.to(torch.int64)
+        per_column = [
+            compute_logprobs(logits, token_ids[:, k].unsqueeze(0))  # [1, N]
+            for k in range(token_ids.shape[1])
+        ]
+        return torch.stack(per_column, dim=-1).squeeze(0)  # [N, K]
+
+    vllm_logprob.compute_token_logprobs = generator_compute_token_logprobs
+    logger.info(
+        "Patched vLLM compute_token_logprobs with trainer's implementation "
+        "so generator and trainer share one logprob code path"
+    )

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -4,15 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""
-Config entry points for the RL/unified experiment.
+"""Config entry points for the alphabet-sort example.
 
-Each function returns a complete ``RLTrainer.Config`` and is discoverable by
-``ConfigManager`` via ``--module rl --config <function_name>``.
+Each function returns a complete ``RLTrainer.Config``, discoverable by
+``ConfigManager`` via
+``--module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_*``.
 """
 
 import dataclasses
-from dataclasses import dataclass
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
@@ -29,6 +28,7 @@ from torchtitan.experiments.rl.actors.generator import (
     VLLMGenerator,
 )
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
+from torchtitan.experiments.rl.batch_invariance import BatchInvariantFlexConverter
 from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
 from torchtitan.experiments.rl.examples.alphabet_sort import AlphabetSortRollouter
 from torchtitan.experiments.rl.generator_router import (
@@ -40,42 +40,9 @@ from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
 from torchtitan.experiments.rl.trainer import RLTrainer
-from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.qwen3 import model_registry
-from torchtitan.protocols.model import ModelConfigConverter
 
 _BATCH_INVARIANT_DEBUG = DebugConfig(batch_invariant=True, deterministic=True)
-
-
-class BatchInvariantFlexConverter(ModelConfigConverter):
-    """Pin flex attention kernel options for batch-invariant mode.
-
-    Sets fixed BLOCK_M/BLOCK_N=16 and BACKEND=TRITON on all
-    FlexAttention layers.
-
-    BACKEND=TRITON is to avoid flex_decode kernel.
-    """
-
-    # the triton BLOCK_N tile size needs to be pinned for stable numerics and
-    # needs to match vLLM's for identical results, today vLLM default is 16
-    # TODO: run some experiments to determine impact of small vs large tile sizes
-    _BLOCK_M = 16
-    _BLOCK_N = 16
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(ModelConfigConverter.Config):
-        pass
-
-    def __init__(self, config: Config):
-        pass
-
-    def convert(self, model_config) -> None:
-        for layer_cfg in model_config.layers:
-            inner = layer_cfg.attention.inner_attention
-            if isinstance(inner, FlexAttention.Config):
-                inner.kernel_options["BACKEND"] = "TRITON"
-                inner.kernel_options["BLOCK_M"] = self._BLOCK_M
-                inner.kernel_options["BLOCK_N"] = self._BLOCK_N
 
 
 def rl_grpo_qwen3_0_6b_varlen() -> RLTrainer.Config:

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -32,7 +32,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.distributed.utils import set_batch_invariance
-from torchtitan.experiments.rl import config_registry
+from torchtitan.experiments.rl.examples.alphabet_sort import config_registry
 from torchtitan.experiments.rl.models.vllm_registry import (
     registry_to_vllm,
     TORCHTITAN_CONFIG_FORMAT,
@@ -107,11 +107,11 @@ def generate() -> None:
     if gen_config.debug.batch_invariant:
         # batch_invariant_ops doesn't cover bmm; the MoE router gate is a bmm in
         # the vLLM inference graph, so override it generator-side (not in core).
-        from torchtitan.experiments.rl.actors.generator import (
-            _patch_bmm_for_batch_invariance,
+        from torchtitan.experiments.rl.batch_invariance import (
+            patch_bmm_for_batch_invariance,
         )
 
-        _patch_bmm_for_batch_invariance()
+        patch_bmm_for_batch_invariance()
     enable_ep = gen_config.parallelism.expert_parallel_degree > 1
 
     logger.debug("Initializing vLLM LLMEngine with TorchTitan model")

--- a/torchtitan/experiments/rl/scripts/loss_compare.py
+++ b/torchtitan/experiments/rl/scripts/loss_compare.py
@@ -120,7 +120,7 @@ def run_training(
         "-m",
         "torchtitan.experiments.rl.train",
         "--module",
-        "rl",
+        "torchtitan.experiments.rl.examples.alphabet_sort",
         "--config",
         config,
         f"--hf_assets_path={hf_assets_path}",

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -33,7 +33,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module rl",
+                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 5",
                     "--trainer.parallelism.tensor_parallel_degree 2",
@@ -57,7 +57,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module rl",
+                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 5",
                     "--trainer.parallelism.tensor_parallel_degree 2",
@@ -78,7 +78,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module rl",
+                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
                     "--config rl_grpo_qwen3_moe_debug_varlen",
                     "--num_steps 5",
                     "--hf_assets_path tests/assets/tokenizer",
@@ -111,7 +111,7 @@ def build_rl_h100_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module rl",
+                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen_batch_invariant",
                     "--num_steps 5",
                     "--group_size 2",
@@ -128,7 +128,7 @@ def build_rl_h100_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module rl",
+                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
                     "--config rl_grpo_qwen3_moe_debug_varlen_batch_invariant",
                     "--num_steps 5",
                     "--hf_assets_path tests/assets/tokenizer",

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -59,7 +59,7 @@ from torchtitan.distributed.utils import (
     set_batch_invariance,
 )
 from torchtitan.experiments.rl.actors.trainer import compute_logprobs
-from torchtitan.experiments.rl.config_registry import (
+from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
     rl_grpo_qwen3_0_6b_flex_batch_invariant,
     rl_grpo_qwen3_0_6b_varlen_batch_invariant,
 )

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -226,7 +226,9 @@ def test_trainer_requires_prefix_cache_reset_when_hotswap_off():
     # Strict drain (hot_swap=False) needs the prefix cache reset so post-pull requests don't reuse old-weight KV.
     import dataclasses
 
-    from torchtitan.experiments.rl.config_registry import rl_grpo_qwen3_0_6b_varlen
+    from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
+        rl_grpo_qwen3_0_6b_varlen,
+    )
 
     config = rl_grpo_qwen3_0_6b_varlen()
     assert (

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -18,7 +18,7 @@ This demonstrates:
 
 Command to run:
 python3 -m torchtitan.experiments.rl.train \
-    --module rl --config rl_grpo_qwen3_0_6b_varlen \
+    --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen \
     --hf_assets_path=<path_to_model_checkpoint>
 """
 


### PR DESCRIPTION
Follow-up to Tianyu's note in https://github.com/pytorch/torchtitan/pull/3602#discussion_r3418169634.

`config_registry.py` had collected all the alphabet-sort smoke/debug configs — the 0.6b/1.7b/14b GRPO recipes, the two batch-invariant variants, and the `BatchInvariantFlexConverter` they share. That's example-specific code living in what's supposed to be a generic registry. search_r1 already keeps its configs under `examples/search_r1/config.py` and only re-imports them into `config_registry` so `ConfigManager` can find them via `--config`; this makes alphabet-sort do the same.

What changed:
- new `examples/alphabet_sort/config.py` holds the six config functions plus the converter/debug helpers
- `config_registry.py` is now just two re-import blocks (alphabet-sort + search_r1)
- the direct importers (`generate.py`, `test_generator.py`, `test_bitwise_parity.py`) pull the functions from the example module instead of `config_registry`

`--config` on the CLI is unchanged: `config_registry` still re-exports the names, so `getattr(config_registry, "rl_grpo_qwen3_0_6b_varlen")` keeps working and the integration tests (`tests/integration_tests.py`) that pass `--config` strings don't need touching.

Pure move, no behavior change. Confirmed all six configs are still discoverable through `config_registry` and `pre-commit` is clean.