### PR TITLE
[MoE] Fix expert bias update for mixed load balancing

### DIFF
--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -63,14 +63,13 @@ class FakeMoEBlock(nn.Module):
 
 
 class FakeMoEModel(nn.Module):
-    def __init__(self):
+    def __init__(self, load_balance_coeffs=(0.1, 0.2)):
         super().__init__()
         self.weight = nn.Parameter(torch.tensor([1.0]))
         self.layers = nn.ModuleDict(
             {
-                "0": FakeMoEBlock(0.1, [10, 0]),
-                "1": FakeMoEBlock(None, [3, 7]),
-                "2": FakeMoEBlock(0.2, [0, 10]),
+                "0": FakeMoEBlock(load_balance_coeffs[0], [10, 0]),
+                "1": FakeMoEBlock(load_balance_coeffs[1], [0, 10]),
             }
         )
 
@@ -145,8 +144,7 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(adam.param_groups[0]["lr"], 1e-2)
         self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
 
-    def test_moe_load_balancing_skips_disabled_layers(self):
-        """A disabled MoE layer should not stop later enabled layers from updating."""
+    def test_moe_load_balancing_updates_all_enabled_layers(self):
         model = FakeMoEModel()
         config = OptimizersContainer.Config(
             implementation="for-loop",
@@ -171,13 +169,8 @@ class TestParamGroupConfig(unittest.TestCase):
             model.layers["0"].moe.expert_bias_E,
             torch.tensor([-0.1, 0.1]),
         )
-        self.assertIsNone(model.layers["1"].moe.expert_bias_E)
         torch.testing.assert_close(
-            model.layers["1"].moe.tokens_per_expert_E,
-            torch.tensor([3, 7]),
-        )
-        torch.testing.assert_close(
-            model.layers["2"].moe.expert_bias_E,
+            model.layers["1"].moe.expert_bias_E,
             torch.tensor([0.2, -0.2]),
         )
         torch.testing.assert_close(
@@ -185,9 +178,31 @@ class TestParamGroupConfig(unittest.TestCase):
             torch.tensor([0, 0]),
         )
         torch.testing.assert_close(
-            model.layers["2"].moe.tokens_per_expert_E,
+            model.layers["1"].moe.tokens_per_expert_E,
             torch.tensor([0, 0]),
         )
+
+    def test_moe_load_balancing_rejects_inconsistent_coeffs(self):
+        model = FakeMoEModel(load_balance_coeffs=(None, 0.2))
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 0.0, "weight_decay": 0.0},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        with self.assertRaisesRegex(
+            ValueError, "load_balance_coeff must be configured consistently"
+        ):
+            register_moe_load_balancing_hook(
+                container,
+                [model],
+                FakeParallelDims(),
+            )
 
     def test_single_pattern_weight_decay_zero(self):
         """Pattern matching bias params with weight_decay=0."""

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -13,6 +13,7 @@ from torchtitan.components.optimizer import (
     default_adamw,
     OptimizersContainer,
     ParamGroupConfig,
+    register_moe_load_balancing_hook,
 )
 
 
@@ -41,6 +42,44 @@ class SimpleModel(nn.Module):
         x = self.layers["0"]["norm"](x)
         x = self.layers["0"]["ff"](x)
         return self.output(x)
+
+
+class FakeMoE(nn.Module):
+    def __init__(self, load_balance_coeff, tokens):
+        super().__init__()
+        self.load_balance_coeff = load_balance_coeff
+        self.register_buffer("tokens_per_expert_E", torch.tensor(tokens))
+        if load_balance_coeff is not None:
+            self.register_buffer("expert_bias_E", torch.zeros(len(tokens)))
+        else:
+            self.expert_bias_E = None
+
+
+class FakeMoEBlock(nn.Module):
+    def __init__(self, load_balance_coeff, tokens):
+        super().__init__()
+        self.moe_enabled = True
+        self.moe = FakeMoE(load_balance_coeff, tokens)
+
+
+class FakeMoEModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor([1.0]))
+        self.layers = nn.ModuleDict(
+            {
+                "0": FakeMoEBlock(0.1, [10, 0]),
+                "1": FakeMoEBlock(None, [3, 7]),
+                "2": FakeMoEBlock(0.2, [0, 10]),
+            }
+        )
+
+
+class FakeParallelDims:
+    spmd_backend = "none"
+
+    def get_optional_mesh(self, name):
+        return None
 
 
 # Default AdamW param group for catch-all
@@ -105,6 +144,50 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertIsInstance(adam, torch.optim.Adam)
         self.assertEqual(adam.param_groups[0]["lr"], 1e-2)
         self.assertEqual(adam.param_groups[0]["betas"], (0.9, 0.95))
+
+    def test_moe_load_balancing_skips_disabled_layers(self):
+        """A disabled MoE layer should not stop later enabled layers from updating."""
+        model = FakeMoEModel()
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 0.0, "weight_decay": 0.0},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        register_moe_load_balancing_hook(
+            container,
+            [model],
+            FakeParallelDims(),
+        )
+
+        container.step()
+
+        torch.testing.assert_close(
+            model.layers["0"].moe.expert_bias_E,
+            torch.tensor([-0.1, 0.1]),
+        )
+        self.assertIsNone(model.layers["1"].moe.expert_bias_E)
+        torch.testing.assert_close(
+            model.layers["1"].moe.tokens_per_expert_E,
+            torch.tensor([3, 7]),
+        )
+        torch.testing.assert_close(
+            model.layers["2"].moe.expert_bias_E,
+            torch.tensor([0.2, -0.2]),
+        )
+        torch.testing.assert_close(
+            model.layers["0"].moe.tokens_per_expert_E,
+            torch.tensor([0, 0]),
+        )
+        torch.testing.assert_close(
+            model.layers["2"].moe.tokens_per_expert_E,
+            torch.tensor([0, 0]),
+        )
 
     def test_single_pattern_weight_decay_zero(self):
         """Pattern matching bias params with weight_decay=0."""

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -393,16 +393,20 @@ def register_moe_load_balancing_hook(
         parallel_dims: Parallel dimensions for distributed communication.
     """
 
-    def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
+    def _iter_moe_layers(model_parts: list[nn.Module]) -> Iterator[nn.Module]:
         for model_part in model_parts:
             layers = model_part.get_submodule("layers")
             assert isinstance(layers, nn.ModuleDict)
             for transformer_block in layers.values():
-                if transformer_block.moe_enabled:
-                    # Assumption: load_balance_coeff is set universally on all moe blocks.
-                    # pyrefly: ignore [missing-attribute]
-                    return bool(transformer_block.moe.load_balance_coeff)
-        return False
+                if getattr(transformer_block, "moe_enabled", False):
+                    yield transformer_block
+
+    def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
+        return any(
+            # pyrefly: ignore [missing-attribute]
+            transformer_block.moe.load_balance_coeff is not None
+            for transformer_block in _iter_moe_layers(model_parts)
+        )
 
     # for MoE auxiliary-loss-free load balancing
     def _is_recomputation_enabled(module):
@@ -416,24 +420,22 @@ def register_moe_load_balancing_hook(
         # TODO: Currently this sync is blocking (thus exposed) and happens on the
         # default compute stream. Need to assess if this is OK performance-wise.
         tokens_per_expert_E_list = []
-        for model_part in model_parts:
-            layers = model_part.get_submodule("layers")
-            assert isinstance(layers, nn.ModuleDict)
-            for transformer_block in layers.values():
-                if not transformer_block.moe_enabled:
-                    continue
-                # pyrefly: ignore [missing-attribute]
-                if transformer_block.moe.load_balance_coeff is None:
-                    return
-                # pyrefly: ignore [missing-attribute]
-                tokens_per_expert_E = transformer_block.moe.tokens_per_expert_E
-                if _is_recomputation_enabled(transformer_block):
-                    # TODO: This is a hack, we assume with full AC, the tokens_per_expert_E is counted twice.
-                    # This does not affect to expert choice, but affects the experts usage metrics.
-                    # We divide by 2 to correct for this double-counting due to recomputation
-                    # TODO: new API to help determine if AC is enabled https://github.com/pytorch/pytorch/pull/160888
-                    tokens_per_expert_E = tokens_per_expert_E // 2
-                tokens_per_expert_E_list.append(tokens_per_expert_E)
+        for transformer_block in _iter_moe_layers(model_parts):
+            # pyrefly: ignore [missing-attribute]
+            if transformer_block.moe.load_balance_coeff is None:
+                continue
+            # pyrefly: ignore [missing-attribute]
+            tokens_per_expert_E = transformer_block.moe.tokens_per_expert_E
+            if _is_recomputation_enabled(transformer_block):
+                # TODO: This is a hack, we assume with full AC, the tokens_per_expert_E is counted twice.
+                # This does not affect to expert choice, but affects the experts usage metrics.
+                # We divide by 2 to correct for this double-counting due to recomputation
+                # TODO: new API to help determine if AC is enabled https://github.com/pytorch/pytorch/pull/160888
+                tokens_per_expert_E = tokens_per_expert_E // 2
+            tokens_per_expert_E_list.append(tokens_per_expert_E)
+
+        if not tokens_per_expert_E_list:
+            return
 
         tokens_per_expert_E_by_layer = torch.vstack(tokens_per_expert_E_list)
 
@@ -487,6 +489,8 @@ def register_moe_load_balancing_hook(
                     if not transformer_block.moe_enabled:
                         continue
                     moe = transformer_block.moe
+                    if moe.load_balance_coeff is None:
+                        continue
 
                     tokens_per_expert_E = tokens_per_expert_E_by_layer[
                         moe_layer_idx

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -8,7 +8,7 @@ import re
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, overload, TypeVar
+from typing import Any, Generic, Literal, Protocol, cast, overload, TypeVar
 
 import torch
 import torch.distributed.tensor
@@ -67,6 +67,12 @@ class ParamGroupConfig:
 
 
 T = TypeVar("T", bound=Optimizer)
+
+
+class _MoELike(Protocol):
+    load_balance_coeff: float | None
+    tokens_per_expert_E: torch.Tensor
+    expert_bias_E: torch.Tensor
 
 
 class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
@@ -393,19 +399,20 @@ def register_moe_load_balancing_hook(
         parallel_dims: Parallel dimensions for distributed communication.
     """
 
-    def _iter_moe_layers(model_parts: list[nn.Module]) -> Iterator[nn.Module]:
+    def _iter_moe_layers(
+        model_parts: list[nn.Module],
+    ) -> Iterator[tuple[nn.Module, _MoELike]]:
         for model_part in model_parts:
             layers = model_part.get_submodule("layers")
             assert isinstance(layers, nn.ModuleDict)
             for transformer_block in layers.values():
                 if getattr(transformer_block, "moe_enabled", False):
-                    yield transformer_block
+                    yield transformer_block, cast(_MoELike, transformer_block.moe)
 
     def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
         return any(
-            # pyrefly: ignore [missing-attribute]
-            transformer_block.moe.load_balance_coeff is not None
-            for transformer_block in _iter_moe_layers(model_parts)
+            moe.load_balance_coeff is not None
+            for _transformer_block, moe in _iter_moe_layers(model_parts)
         )
 
     # for MoE auxiliary-loss-free load balancing
@@ -420,12 +427,10 @@ def register_moe_load_balancing_hook(
         # TODO: Currently this sync is blocking (thus exposed) and happens on the
         # default compute stream. Need to assess if this is OK performance-wise.
         tokens_per_expert_E_list = []
-        for transformer_block in _iter_moe_layers(model_parts):
-            # pyrefly: ignore [missing-attribute]
-            if transformer_block.moe.load_balance_coeff is None:
+        for transformer_block, moe in _iter_moe_layers(model_parts):
+            if moe.load_balance_coeff is None:
                 continue
-            # pyrefly: ignore [missing-attribute]
-            tokens_per_expert_E = transformer_block.moe.tokens_per_expert_E
+            tokens_per_expert_E = moe.tokens_per_expert_E
             if _is_recomputation_enabled(transformer_block):
                 # TODO: This is a hack, we assume with full AC, the tokens_per_expert_E is counted twice.
                 # This does not affect to expert choice, but affects the experts usage metrics.
@@ -488,7 +493,7 @@ def register_moe_load_balancing_hook(
                 for transformer_block in layers.values():
                     if not transformer_block.moe_enabled:
                         continue
-                    moe = transformer_block.moe
+                    moe = cast(_MoELike, transformer_block.moe)
                     if moe.load_balance_coeff is None:
                         continue
 
@@ -499,16 +504,13 @@ def register_moe_load_balancing_hook(
 
                     # update the expert bias
                     # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
-                    # pyrefly: ignore [missing-attribute]
                     expert_bias_delta_E = moe.load_balance_coeff * torch.sign(
                         tokens_per_expert_E.mean() - tokens_per_expert_E
                     )
                     expert_bias_delta_E = (
                         expert_bias_delta_E - expert_bias_delta_E.mean()
                     )
-                    # pyrefly: ignore [missing-attribute]
                     moe.expert_bias_E.add_(expert_bias_delta_E)
-                    # pyrefly: ignore [missing-attribute]
                     moe.tokens_per_expert_E.zero_()
 
     if _should_register_moe_balancing_hook(model_parts):

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -8,7 +8,7 @@ import re
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, Protocol, cast, overload, TypeVar
+from typing import Any, cast, Generic, Literal, overload, Protocol, TypeVar
 
 import torch
 import torch.distributed.tensor
@@ -71,8 +71,8 @@ T = TypeVar("T", bound=Optimizer)
 
 class _MoELike(Protocol):
     load_balance_coeff: float | None
-    tokens_per_expert_E: torch.Tensor
-    expert_bias_E: torch.Tensor
+    tokens_per_expert_E: torch.Tensor  # noqa: N815
+    expert_bias_E: torch.Tensor  # noqa: N815
 
 
 class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):

--- a/torchtitan/components/optimizer.py
+++ b/torchtitan/components/optimizer.py
@@ -410,10 +410,19 @@ def register_moe_load_balancing_hook(
                     yield transformer_block, cast(_MoELike, transformer_block.moe)
 
     def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
-        return any(
-            moe.load_balance_coeff is not None
-            for _transformer_block, moe in _iter_moe_layers(model_parts)
-        )
+        moe_layers = list(_iter_moe_layers(model_parts))
+        if not moe_layers:
+            return False
+
+        load_balance_enabled = moe_layers[0][1].load_balance_coeff is not None
+        for _transformer_block, moe in moe_layers[1:]:
+            if (moe.load_balance_coeff is not None) != load_balance_enabled:
+                raise ValueError(
+                    "MoE load_balance_coeff must be configured consistently "
+                    "across all MoE layers. Either set it for every MoE layer "
+                    "or leave it unset for all MoE layers."
+                )
+        return load_balance_enabled
 
     # for MoE auxiliary-loss-free load balancing
     def _is_recomputation_enabled(module):
@@ -428,8 +437,6 @@ def register_moe_load_balancing_hook(
         # default compute stream. Need to assess if this is OK performance-wise.
         tokens_per_expert_E_list = []
         for transformer_block, moe in _iter_moe_layers(model_parts):
-            if moe.load_balance_coeff is None:
-                continue
             tokens_per_expert_E = moe.tokens_per_expert_E
             if _is_recomputation_enabled(transformer_block):
                 # TODO: This is a hack, we assume with full AC, the tokens_per_expert_E is counted twice.
@@ -494,8 +501,8 @@ def register_moe_load_balancing_hook(
                     if not transformer_block.moe_enabled:
                         continue
                     moe = cast(_MoELike, transformer_block.moe)
-                    if moe.load_balance_coeff is None:
-                        continue
+                    load_balance_coeff = moe.load_balance_coeff
+                    assert load_balance_coeff is not None
 
                     tokens_per_expert_E = tokens_per_expert_E_by_layer[
                         moe_layer_idx
@@ -504,7 +511,7 @@ def register_moe_load_balancing_hook(
 
                     # update the expert bias
                     # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
-                    expert_bias_delta_E = moe.load_balance_coeff * torch.sign(
+                    expert_bias_delta_E = load_balance_coeff * torch.sign(
                         tokens_per_expert_E.mean() - tokens_per_expert_E
                     )
                     expert_bias_delta_E = (


### PR DESCRIPTION
## Summary

Fix MoE load-balancing hook behavior when only a subset of MoE layers enables auxiliary-loss-free load balancing.

Previously, encountering a MoE layer with `load_balance_coeff is None` returned from the whole hook, so later enabled MoE layers would not update `expert_bias_E` or clear `tokens_per_expert_E`.

This change skips disabled MoE layers while continuing to update enabled ones.

## Test Plan

```bash
python -m pytest tests/unit_tests/test_optimizer_param_groups.py -q