### PR TITLE
[Override] Add loader/sample_processor to HuggingFaceTextDataLoader

### DIFF
--- a/tests/unit_tests/test_dataloader.py
+++ b/tests/unit_tests/test_dataloader.py
@@ -6,6 +6,8 @@
 
 import unittest
 
+from datasets import Dataset
+
 from torch.utils.data import IterableDataset
 
 from torchtitan.components.dataloader import ParallelAwareDataloader
@@ -284,6 +286,66 @@ class TestInterleavedHuggingFaceTextDataLoader(unittest.TestCase):
             single_batch_input["positions"].shape,
             interleaved_batch_input["positions"].shape,
         )
+
+
+class TestCustomDatasetConfig(unittest.TestCase):
+    """Tests for loader / sample_processor on HuggingFaceTextDataLoader.Config."""
+
+    _TEXT = "the quick brown fox jumps over the lazy dog "
+
+    def test_dataloader_with_custom_loader_and_processor(self):
+        loader = lambda path: Dataset.from_dict({"text": [self._TEXT]})
+        proc = lambda s: s["text"].upper()
+        tokenizer = DummyTokenizer()
+        cfg = HuggingFaceTextDataLoader.Config(
+            dataset="custom",
+            loader=loader,
+            sample_processor=proc,
+            num_workers=0,
+            infinite=False,
+        )
+        dl = HuggingFaceTextDataLoader(
+            cfg, dp_world_size=1, dp_rank=0,
+            tokenizer=tokenizer, seq_len=16, local_batch_size=1,
+        )
+        batch_input, batch_label = next(iter(dl))
+        decoded = tokenizer.decode(batch_input["input"].squeeze(0).tolist())
+        self.assertIn("THE QUICK BROWN", decoded)
+
+    def test_interleaved_with_custom_loader_and_processor(self):
+        tokenizer = DummyTokenizer()
+        cfg = InterleavedHuggingFaceTextDataLoader.Config(
+            sources=[
+                HFDataSource(
+                    dataset="upper",
+                    loader=lambda path: Dataset.from_dict({"text": [self._TEXT]}),
+                    sample_processor=lambda s: s["text"].upper(),
+                    infinite=False,
+                    weight=1.0,
+                ),
+                HFDataSource(
+                    dataset="lower",
+                    loader=lambda path: Dataset.from_dict({"text": [self._TEXT]}),
+                    sample_processor=lambda s: s["text"].lower(),
+                    infinite=False,
+                    weight=1.0,
+                ),
+            ],
+            seed=42,
+            num_workers=0,
+        )
+        dl = InterleavedHuggingFaceTextDataLoader(
+            cfg, dp_world_size=1, dp_rank=0,
+            tokenizer=tokenizer, seq_len=16, local_batch_size=1,
+        )
+        all_decoded = []
+        for batch_input, batch_label in dl:
+            all_decoded.append(
+                tokenizer.decode(batch_input["input"].squeeze(0).tolist())
+            )
+        combined = " ".join(all_decoded)
+        self.assertIn("THE QUICK BROWN", combined)
+        self.assertIn("the quick brown", combined)
 
 
 if __name__ == "__main__":

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -80,14 +80,26 @@ class HuggingFaceTextDataset(IterableDataset, Stateful):
         dp_rank: int = 0,
         dp_world_size: int = 1,
         infinite: bool = False,
+        *,
+        loader: Callable | None = None,
+        sample_processor: Callable | None = None,
     ) -> None:
         # Force lowercase for consistent comparison
         dataset_name = dataset_name.lower()
 
-        path, dataset_loader, text_processor = _validate_dataset(
-            dataset_name, dataset_path
-        )
-        ds = dataset_loader(path)
+        if loader is None and sample_processor is None:
+            path, dataset_loader, text_processor = _validate_dataset(
+                dataset_name, dataset_path
+            )
+            ds = dataset_loader(path)
+        elif loader is not None and sample_processor is not None:
+            ds = loader(dataset_path)
+            text_processor = sample_processor
+        else:
+            raise ValueError(
+                "Both loader and sample_processor must be provided together "
+                "(or neither, to use the DATASETS dict lookup)."
+            )
 
         self.dataset_name = dataset_name
         # Keep an unshuffled reference so map-style datasets can be re-shuffled
@@ -247,6 +259,14 @@ class HuggingFaceTextDataLoader(ParallelAwareDataloader):
         infinite: bool = True
         """Whether to loop the dataset infinitely"""
 
+        loader: Annotated[Callable | None, tyro.conf.Suppress] = None
+        """Optional ``Callable[[str], Dataset]``. Set alongside
+        ``sample_processor`` to bypass the DATASETS dict lookup."""
+
+        sample_processor: Annotated[Callable | None, tyro.conf.Suppress] = None
+        """Optional ``Callable[[dict], str]``. Set alongside
+        ``loader`` to bypass the DATASETS dict lookup."""
+
     def __init__(
         self,
         config: Config,
@@ -267,6 +287,8 @@ class HuggingFaceTextDataLoader(ParallelAwareDataloader):
             dp_rank=dp_rank,
             dp_world_size=dp_world_size,
             infinite=config.infinite,
+            loader=config.loader,
+            sample_processor=config.sample_processor,
         )
 
         dataloader_kwargs = {
@@ -344,6 +366,8 @@ class InterleavedHuggingFaceTextDataLoader(ParallelAwareDataloader):
                     dp_rank=dp_rank,
                     dp_world_size=dp_world_size,
                     infinite=source.infinite,
+                    loader=source.loader,
+                    sample_processor=source.sample_processor,
                 )
                 for source in config.sources
             ],


### PR DESCRIPTION
The override system enables external packages to extend torchtitan without touching core code. But dataset selection was locked behind the module-level `DATASETS` dict — the only way to add a custom dataset was to monkeypatch it, defeating the non-touch goal.

Add `loader` and `sample_processor` fields to `HuggingFaceTextDataLoader.Config` (mirroring `ChatDataLoader.Config`'s pattern). When both are set, `HuggingFaceTextDataset.__init__` bypasses `_validate_dataset()` and the `DATASETS` dict entirely.

An external package can now inject a custom dataset with a one-shot `@override`. Training and validation dataloaders are separate config nodes (`dataloader` vs `validator.dataloader`) and can be overridden independently via `fqns`. 

Besides, custom datasets can also be defined directly in `config_registry.py` by setting these fields.