### PR TITLE
[rl] support short --module names for RL examples

### DIFF
--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -61,6 +61,18 @@ class TestConfigManager(unittest.TestCase):
         with pytest.raises(ValueError, match="Available config functions"):
             config_manager.parse_args(["--module", "llama3", "--config", "nonexistent"])
 
+    def test_rl_examples_registered_as_shorthands(self):
+        """RL examples are valid --module shorthands (resolved under rl/examples).
+
+        End-to-end resolution + build is covered by the RL integration tests
+        (they run ``--module alphabet_sort``); kept out of here since importing an
+        example's config_registry pulls in vLLM, which isn't available on CPU.
+        """
+        from torchtitan.experiments import _supported_experiments
+
+        assert "alphabet_sort" in _supported_experiments
+        assert "search_r1" in _supported_experiments
+
     def test_cli_overrides(self):
         """CLI args override config defaults."""
         config_manager = ConfigManager()

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -101,8 +101,13 @@ class ConfigManager:
 
         # Import config_registry from module based on module specification
         if module_name in all_supported:
-            # short module from supported module list  (search models first, then experiments)
-            for prefix in ("torchtitan.models", "torchtitan.experiments"):
+            # short module from supported module list (search models, then
+            # experiments, then RL examples for their per-example config_registry)
+            for prefix in (
+                "torchtitan.models",
+                "torchtitan.experiments",
+                "torchtitan.experiments.rl.examples",
+            ):
                 module_path = f"{prefix}.{module_name}.config_registry"
                 try:
                     module = importlib.import_module(module_path)
@@ -112,7 +117,8 @@ class ConfigManager:
             if module is None:
                 raise ImportError(
                     f"Cannot import config_registry for module '{module_name}' "
-                    f"from torchtitan.models or torchtitan.experiments"
+                    f"from torchtitan.models, torchtitan.experiments, or "
+                    f"torchtitan.experiments.rl.examples"
                 )
         else:
             # Fully qualified module path: try appending .config_registry first,

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -14,5 +14,9 @@ _supported_experiments = frozenset(
         "autoparallel.local_map_deepseek_v3",
         "torchft.llama3",
         "rl",
+        # RL examples own a per-example config_registry under rl/examples/<name>;
+        # listed here so `--module <name>` resolves (see ConfigManager).
+        "alphabet_sort",
+        "search_r1",
     ]
 )

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -74,7 +74,7 @@ python scripts/download_hf_assets.py --repo_id Qwen/Qwen3-1.7B --local_dir torch
 
 7. Run simple GRPO RL loop to learn sum digits task. This also serves as an end-to-end smoke test that your environment is set up correctly.
 ```bash
-python -m torchtitan.experiments.rl.train --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen
+python -m torchtitan.experiments.rl.train --module alphabet_sort --config rl_grpo_qwen3_0_6b_varlen
 ```
 
 **NOTE:** If you downloaded your HF model to a different path than the one in step 4, specify it in your command with `--hf_assets_path=<path_to_model_checkpoint>`.
@@ -104,7 +104,7 @@ If you want to run true on-policy mode in TorchTitan RL and debug generator/trai
 Now we only support logprob bitwise parity when trainer and generator are under the same parallelism.
 Example:
 ```bash
-python -m torchtitan.experiments.rl.train --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen_batch_invariant
+python -m torchtitan.experiments.rl.train --module alphabet_sort --config rl_grpo_qwen3_0_6b_varlen_batch_invariant
 ```
 
 This config sets `DebugConfig(batch_invariant=True, deterministic=True)` and `training.dtype="bfloat16"` (required so the trainer computes in the same precision as the generator, as a limitation because TP only doesn't naturally support mixed precision training).

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -8,7 +8,7 @@
 
 Each function returns a complete ``RLTrainer.Config``, discoverable by
 ``ConfigManager`` via
-``--module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_*``.
+``--module alphabet_sort --config rl_grpo_qwen3_*``.
 """
 
 import dataclasses

--- a/torchtitan/experiments/rl/examples/search_r1/README.md
+++ b/torchtitan/experiments/rl/examples/search_r1/README.md
@@ -58,7 +58,7 @@ Override `message_env.search_url` / `message_env.topk` in the config if needed.
 ```bash
 # example run (Qwen3-1.7B), W&B on
 python torchtitan/experiments/rl/train.py \
-  --module torchtitan.experiments.rl.examples.search_r1 \
+  --module search_r1 \
   --config rl_grpo_qwen3_1_7b_search_r1
 ```
 

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -10,7 +10,7 @@ These set the full Search-R1 recipe entirely from the example's config — the c
 defaults are unchanged, so every other config keeps vanilla GRPO. ``ConfigManager``
 discovers these directly from the example module::
 
-    --module torchtitan.experiments.rl.examples.search_r1 \\
+    --module search_r1 \\
         --config rl_grpo_qwen3_1_7b_search_r1
 """
 

--- a/torchtitan/experiments/rl/scripts/loss_compare.py
+++ b/torchtitan/experiments/rl/scripts/loss_compare.py
@@ -120,7 +120,7 @@ def run_training(
         "-m",
         "torchtitan.experiments.rl.train",
         "--module",
-        "torchtitan.experiments.rl.examples.alphabet_sort",
+        "alphabet_sort",
         "--config",
         config,
         f"--hf_assets_path={hf_assets_path}",

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -33,7 +33,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 5",
                     "--trainer.parallelism.tensor_parallel_degree 2",
@@ -57,7 +57,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 5",
                     "--trainer.parallelism.tensor_parallel_degree 2",
@@ -78,7 +78,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_moe_debug_varlen",
                     "--num_steps 5",
                     "--hf_assets_path tests/assets/tokenizer",
@@ -111,7 +111,7 @@ def build_rl_h100_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen_batch_invariant",
                     "--num_steps 5",
                     "--group_size 2",
@@ -128,7 +128,7 @@ def build_rl_h100_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module torchtitan.experiments.rl.examples.alphabet_sort",
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_moe_debug_varlen_batch_invariant",
                     "--num_steps 5",
                     "--hf_assets_path tests/assets/tokenizer",

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -18,7 +18,7 @@ This demonstrates:
 
 Command to run:
 python3 -m torchtitan.experiments.rl.train \
-    --module torchtitan.experiments.rl.examples.alphabet_sort --config rl_grpo_qwen3_0_6b_varlen \
+    --module alphabet_sort --config rl_grpo_qwen3_0_6b_varlen \
     --hf_assets_path=<path_to_model_checkpoint>
 """
 


### PR DESCRIPTION
Follow-up to #3684. Now that each RL example owns its `config_registry` under `rl/examples/<name>`, running one meant typing the full `--module torchtitan.experiments.rl.examples.alphabet_sort`. This lets `ConfigManager` resolve the short name like it does for models/experiments.

What changed:
- `config/manager.py`: when resolving a short `--module` name, also search `torchtitan.experiments.rl.examples.<name>.config_registry` (after `torchtitan.models` and `torchtitan.experiments`).
- `experiments/__init__.py`: register `alphabet_sort` and `search_r1` as supported shorthands.
- Switch the integration tests, READMEs, `train`/example docs and `loss_compare.py` back to the short names (e.g. `--module alphabet_sort`).

So `--module alphabet_sort --config rl_grpo_qwen3_0_6b_varlen` now works like `--module llama3`.

Verified locally:
- `--module llama3 --config llama3_debugmodel` still builds (no regression).
- `--module alphabet_sort --config rl_grpo_qwen3_0_6b_varlen` and `--module search_r1 --config rl_grpo_qwen3_1_7b_search_r1` resolve and build.
- unknown short name still errors, now listing the rl-examples search path.
- added a CPU unit test for the shorthand registration (full resolution is exercised by the RL integration tests, which run `--module alphabet_sort` and pull in vLLM).

cc @tianyu-l — this is the manager.py change you sketched.