### PR TITLE
Use the scatter pattern to send different microbatches to different trainer DP groups

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -258,8 +258,11 @@ class PolicyTrainer(Actor, Configurable):
 
         self.generator: Any | None = None
 
-        # Data parallelism: mesh is available after _build_model triggers build_mesh
-        self.dp_enabled = self.parallel_dims.dp_enabled
+        # Data parallelism: mesh is available after _build_model triggers
+        # build_mesh. Underscore-prefixed so the public ``dp_rank`` endpoint name
+        # does not collide with the instance attribute (Monarch dispatches
+        # endpoints via getattr on the instance).
+        self._dp_enabled = self.parallel_dims.dp_enabled
         batch_mesh = self.parallel_dims.get_optional_mesh("batch")
         if batch_mesh is not None:
             self.dp_size = batch_mesh.size()
@@ -357,21 +360,8 @@ class PolicyTrainer(Actor, Configurable):
         sl.set_step(step, relative_step=relative_step)
 
     @endpoint
-    async def verify_dp_rank(self, expected_dp_rank: int) -> int:
-        """Return this rank's actual data-parallel rank; log on mismatch.
-
-        The controller calls this on ``slice(batch=d)`` (passing ``d``) after
-        reshaping the trainer mesh into ("batch", "within_batch"), then raises
-        if any returned dp_rank differs from its batch slice. Returning the
-        actual dp_rank lets the controller report actual-vs-expected.
-        """
-        if self.dp_rank != expected_dp_rank:
-            logger.error(
-                "Trainer mesh rank %d reports dp_rank=%d but expected %d.",
-                current_rank().rank,
-                self.dp_rank,
-                expected_dp_rank,
-            )
+    async def get_dp_rank(self) -> int:
+        """Return this actor's DP rank."""
         return self.dp_rank
 
     def reduce_forward_backward_metrics(

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -356,6 +356,24 @@ class PolicyTrainer(Actor, Configurable):
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
 
+    @endpoint
+    async def verify_dp_rank(self, expected_dp_rank: int) -> int:
+        """Return this rank's actual data-parallel rank; log on mismatch.
+
+        The controller calls this on ``slice(batch=d)`` (passing ``d``) after
+        reshaping the trainer mesh into ("batch", "within_batch"), then raises
+        if any returned dp_rank differs from its batch slice. Returning the
+        actual dp_rank lets the controller report actual-vs-expected.
+        """
+        if self.dp_rank != expected_dp_rank:
+            logger.error(
+                "Trainer mesh rank %d reports dp_rank=%d but expected %d.",
+                current_rank().rank,
+                self.dp_rank,
+                expected_dp_rank,
+            )
+        return self.dp_rank
+
     def reduce_forward_backward_metrics(
         self,
         *,
@@ -397,14 +415,13 @@ class PolicyTrainer(Actor, Configurable):
     @sl.log_trace_span("forward_backward")
     async def forward_backward(
         self,
-        training_data: list[TrainingBatch],
+        local_batch: TrainingBatch,
         num_global_valid_tokens: int,
     ) -> dict[str, float]:
         """Run forward pass, compute loss, call backward, and reduce metrics.
 
         Args:
-            training_data: List of TrainingBatch, one per DP rank. Local rank
-                picks training_data[self.dp_rank].
+            local_batch: This rank's TrainingBatch.
             num_global_valid_tokens: Total response tokens across all DP
                 ranks for this step. The controller computes this before
                 sharding episodes.
@@ -427,7 +444,6 @@ class PolicyTrainer(Actor, Configurable):
             )
         model = self.model_parts[0]
 
-        local_batch = training_data[self.dp_rank]
         device = self.device
         token_ids = local_batch.token_ids.to(device)
         labels = local_batch.labels.to(device)

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -153,6 +153,20 @@ class RLTrainer(Configurable):
                     "Set generator.checkpoint.enable=False."
                 )
 
+            # The controller scatters microbatches by reshaping the trainer mesh
+            # into ("batch", "_") and slicing the "batch" axis. This assumes
+            # "batch" is the outermost mesh axis, which only holds when pipeline
+            # parallelism is off.
+            # TODO: support trainer PP by accounting for the outermost "pp" axis
+            # in the reshape and validating torchstore composability with PP.
+            if self.trainer.parallelism.pipeline_parallel_degree != 1:
+                raise ValueError(
+                    "RL trainer does not support pipeline parallelism yet; the "
+                    "microbatch scatter assumes 'batch' is the outermost mesh "
+                    "axis. Got pipeline_parallel_degree="
+                    f"{self.trainer.parallelism.pipeline_parallel_degree}."
+                )
+
             # RL policy inputs are shaped by BatchConfig, not TrainingConfig.
             if self.trainer.parallelism.enable_sequence_parallel:
                 sp_degree = self.trainer.parallelism.tensor_parallel_degree
@@ -368,25 +382,27 @@ class RLTrainer(Configurable):
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
 
-        # Reshape trainer mesh into ("batch", "within_batch") so controller can
-        # scatter microbatches by the DP dimension.
-        self.trainer = self.trainer.flatten("flat").split(
-            flat=("batch", "within_batch"), batch=self.trainer_dp_degree
+        # Reshape the trainer ProcMesh into ("batch", "_") so the controller can
+        # scatter microbatches across the DP "batch" axis via slice(batch=...).
+        self.trainer = self.trainer.flatten("rank").split(
+            rank=("batch", "_"), batch=self.trainer_dp_degree
         )
-        # Verify the reshape result against the actual dp rank on each trainer actor.
+        # One-time, cheap startup check: confirm that the DP layout assumed by
+        # controller agrees with the real DP layout used in trainer SPMD.
         with sl.log_trace_span("verify_trainer_dp_layout"):
-            verifications = await asyncio.gather(
+            reported_dp_ranks = await asyncio.gather(
                 *[
-                    self.trainer.slice(batch=dp_rank).verify_dp_rank.call(dp_rank)
+                    self.trainer.slice(batch=dp_rank).get_dp_rank.call()
                     for dp_rank in range(self.trainer_dp_degree)
                 ]
             )
-            for dp_rank, value_mesh in enumerate(verifications):
+            for dp_rank, value_mesh in enumerate(reported_dp_ranks):
                 actual = list(value_mesh.values())
                 if any(reported != dp_rank for reported in actual):
                     raise ValueError(
-                        "Trainer mesh reshape is inconsistent with the DeviceMesh "
-                        f"batch axis: expected all to be {dp_rank}, but got {actual}."
+                        "Trainer mesh reshape is inconsistent with the SPMD "
+                        f"DeviceMesh batch axis: actors in batch slice {dp_rank} "
+                        f"reported SPMD dp_ranks {actual}, expected all {dp_rank}."
                     )
 
         # Initialize TorchStore for weight sync between trainer and generator.
@@ -761,8 +777,9 @@ class RLTrainer(Configurable):
             fwd_bwd_metrics: dict[str, float] = {}
             for microbatch in microbatches:
                 with sl.log_trace_span("trainer_forward_backward_call"):
-                    # Scatter microbatches by the DP dimension.
-                    shard_results = await asyncio.gather(
+                    # Scatter this microbatch across the DP "batch" axis, so
+                    # each rank only gets its designated TrainingBatch.
+                    per_dp_rank_results = await asyncio.gather(
                         *[
                             self.trainer.slice(batch=dp_rank).forward_backward.call(
                                 microbatch[dp_rank], num_global_valid_tokens
@@ -770,7 +787,15 @@ class RLTrainer(Configurable):
                             for dp_rank in range(self.trainer_dp_degree)
                         ]
                     )
-                    mb_metrics = self._get_rank_0_value(shard_results[0])
+                    # The trainer mesh was sliced into N sub-meshes above, where
+                    # N = trainer_dp_degree, and each sub-mesh consists of ranks in
+                    # a DP rank. Subsequently, ``per_dp_rank_results`` consists of
+                    # results from those N sub-meshes.
+                    #
+                    # Since the results from all ranks are identical, we only
+                    # use the 1st sub-mesh's rank 0 result here. It is also the
+                    # rank 0 of the whole trainer mesh.
+                    mb_metrics = self._get_rank_0_value(per_dp_rank_results[0])
                     for k, v in mb_metrics.items():
                         if k not in fwd_bwd_metrics:
                             fwd_bwd_metrics[k] = v

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -280,13 +280,6 @@ class RLTrainer(Configurable):
         """
         return result.get(0)
 
-    def _shard_episodes(self, episodes: list[Episode]) -> list[list[Episode]]:
-        """Round-robin partition episodes across DP ranks."""
-        return [
-            [episodes[i] for i in range(rank, len(episodes), self.trainer_dp_degree)]
-            for rank in range(self.trainer_dp_degree)
-        ]
-
     @sl.log_trace_span("setup_async")
     async def setup_async(
         self,
@@ -374,6 +367,27 @@ class RLTrainer(Configurable):
                 )
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
+
+        # Reshape trainer mesh into ("batch", "within_batch") so controller can
+        # scatter microbatches by the DP dimension.
+        self.trainer = self.trainer.flatten("flat").split(
+            flat=("batch", "within_batch"), batch=self.trainer_dp_degree
+        )
+        # Verify the reshape result against the actual dp rank on each trainer actor.
+        with sl.log_trace_span("verify_trainer_dp_layout"):
+            verifications = await asyncio.gather(
+                *[
+                    self.trainer.slice(batch=dp_rank).verify_dp_rank.call(dp_rank)
+                    for dp_rank in range(self.trainer_dp_degree)
+                ]
+            )
+            for dp_rank, value_mesh in enumerate(verifications):
+                actual = list(value_mesh.values())
+                if any(reported != dp_rank for reported in actual):
+                    raise ValueError(
+                        "Trainer mesh reshape is inconsistent with the DeviceMesh "
+                        f"batch axis: expected all to be {dp_rank}, but got {actual}."
+                    )
 
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
@@ -747,11 +761,16 @@ class RLTrainer(Configurable):
             fwd_bwd_metrics: dict[str, float] = {}
             for microbatch in microbatches:
                 with sl.log_trace_span("trainer_forward_backward_call"):
-                    mb_metrics = self._get_rank_0_value(
-                        await self.trainer.forward_backward.call(
-                            microbatch, num_global_valid_tokens
-                        )
+                    # Scatter microbatches by the DP dimension.
+                    shard_results = await asyncio.gather(
+                        *[
+                            self.trainer.slice(batch=dp_rank).forward_backward.call(
+                                microbatch[dp_rank], num_global_valid_tokens
+                            )
+                            for dp_rank in range(self.trainer_dp_degree)
+                        ]
                     )
+                    mb_metrics = self._get_rank_0_value(shard_results[0])
                     for k, v in mb_metrics.items():
                         if k not in fwd_bwd_metrics:
                             fwd_bwd_metrics[k] = v


### PR DESCRIPTION
Currently controller sends all the microbatches to all trainer ranks, and let the rank keeps what it needs, and throw the rest away. This is not efficient. This diff introduces a scatter pattern so controller will send different microbatches to different DP groups.

I also plan to use how we reshape the mesh into ("batch", "within_batch") on generator, after generator is enabled with DP. With the reshaping, it would be easy to route among different DP groups within the same generator.

### Test plan


Run `rl_grpo_qwen3_1_7b` with DP=2 to confirm it is still working:

```
python -m torchtitan.experiments.rl.train --module rl --config rl_grpo_qwen3_1_7b --metrics.no-enable-wandb --trainer.parallelism.data_parallel_shard_degree=2 --trainer.parallelism.tensor_parallel_degree=2
```