### PR TITLE
Use CE loss for AutoParallel Llama SDPA

### DIFF
--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -38,6 +39,13 @@ def graph_trainer_llama3_debugmodel_sdpa() -> GraphTrainer.Config:
     base.model_spec = model_registry("debugmodel", attn_backend="sdpa")
     config = to_graph_trainer_config(base, model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_sdpa_cross_entropy_loss() -> GraphTrainer.Config:
+    """SDPA debug model with standard cross-entropy loss."""
+    config = graph_trainer_llama3_debugmodel_sdpa()
+    config.loss = CrossEntropyLoss.Config()
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 import torch
 import torch.distributed as dist
 
+from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
@@ -164,6 +165,22 @@ def _common_setup(config):
     )
 
 
+def _prepare_loss_for_precompile(model, loss_fn, parallel_dims, parallelism) -> None:
+    """Match Trainer's post-parallelization loss setup for precompile tracing."""
+    if not isinstance(loss_fn, ChunkedCELoss):
+        return
+
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is None:
+        raise ValueError("Model must have lm_head for ChunkedCELoss precompile")
+
+    loss_fn.loss_parallel = (
+        parallel_dims.tp_enabled and not parallelism.disable_loss_parallel
+    )
+    loss_fn.set_lm_head(lm_head)
+    model._skip_lm_head = True
+
+
 def _precompile_aot_fx_trace(
     config,
     model,
@@ -183,6 +200,7 @@ def _precompile_aot_fx_trace(
     from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
 
     loss_fn = config.loss.build(compile_config=compile_config)
+    _prepare_loss_for_precompile(model, loss_fn, parallel_dims, config.parallelism)
 
     fwd_bwd_fn = make_fwd_bwd_step(model, loss_fn)
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -515,7 +515,7 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
             [
                 [
                     "--module graph_trainer.llama3",
-                    "--config graph_trainer_llama3_debugmodel_sdpa",
+                    "--config graph_trainer_llama3_debugmodel_sdpa_cross_entropy_loss",
                     "--compile.mode aot_fx_trace",
                     "--compile.enable_autoparallel",
                     "--parallelism.data_parallel_shard_degree 2",

--- a/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
@@ -132,7 +132,8 @@ def test_autoparallel_graph_pass_selection_uses_regular_memory_policy():
     from torchtitan.experiments.graph_trainer import passes
 
     traced_result = SimpleNamespace(
-        gm=torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
+        gm=torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph()),
+        state_fqns=[],
     )
     config = SimpleNamespace(
         compile=GraphTrainerCompileConfig(

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -255,7 +255,7 @@ def _run_autoparallel_llama3_loss_compare() -> bool:
         baseline_module="graph_trainer.llama3",
         baseline_config="graph_trainer_llama3_debugmodel_sdpa_eager",
         test_module="graph_trainer.llama3",
-        test_config="graph_trainer_llama3_debugmodel_sdpa",
+        test_config="graph_trainer_llama3_debugmodel_sdpa_cross_entropy_loss",
         baseline_options=AUTOPARALLEL_LLAMA3_PARALLELISM,
         test_options=(
             f"{AUTOPARALLEL_LLAMA3_PARALLELISM}"

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -9,6 +9,7 @@ import pickle
 import tempfile
 import unittest
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -183,6 +184,28 @@ class TestConfigFingerprint(unittest.TestCase):
         fp_ab = compute_config_fingerprint(_make_stub_model(), cfg_ab, dims)
         fp_ba = compute_config_fingerprint(_make_stub_model(), cfg_ba, dims)
         self.assertNotEqual(fp_ab, fp_ba)
+
+
+class TestPrecompileLossSetup(unittest.TestCase):
+    def test_chunked_loss_setup_matches_trainer_boundary(self):
+        from torchtitan.experiments.graph_trainer.chunked_loss import (
+            ChunkedCELossWithParamGrads,
+        )
+        from torchtitan.experiments.graph_trainer.precompile_main import (
+            _prepare_loss_for_precompile,
+        )
+
+        lm_head = torch.nn.Linear(2, 3)
+        model = SimpleNamespace(lm_head=lm_head, _skip_lm_head=False)
+        loss_fn = ChunkedCELossWithParamGrads.Config().build()
+        parallel_dims = SimpleNamespace(tp_enabled=True)
+        parallelism = SimpleNamespace(disable_loss_parallel=False)
+
+        _prepare_loss_for_precompile(model, loss_fn, parallel_dims, parallelism)
+
+        self.assertIs(loss_fn.lm_head, lm_head)
+        self.assertTrue(loss_fn.loss_parallel)
+        self.assertTrue(model._skip_lm_head)
 
 
 class TestPrecompiledFxTraceArtifact(unittest.TestCase):


### PR DESCRIPTION
Add a Graph Trainer Llama SDPA config that keeps the existing SDPA config intact and only overrides the loss to CrossEntropyLoss. Point AutoParallel coverage at that config so the model graph continues to return logits and avoids ChunkedCELoss applying lm_head again.

Follow-up fixes are tracked by https://github.com/pytorch/torchtitan/issues/3699.