### PR TITLE
Skip timeout updates for fake process groups

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -546,7 +546,10 @@ def set_pg_timeouts(
         for mesh in parallel_dims.get_all_one_dimensional_meshes().values()
     ] + [None]
     for group in groups:
-        torch.distributed.distributed_c10d._set_pg_timeout(timeout, group)
+        if torch.distributed.get_backend(group) == torch.distributed.Backend.FAKE:
+            logger.debug("Skipping timeout update for fake ProcessGroup")
+            continue
+        torch.distributed.set_timeout(timeout, group)
 
 
 @torch.no_grad()


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/187387 deprecated torch.distributed.distributed_c10d._set_pg_timeout in favor of torch.distributed.set_timeout and also reimplemented it on top of C++ setTimeout which now errors out, instead of warning, when setting a timeout on fake process groups.

Skip fake process groups while updating training timeouts and use the public set_timeout API for real process groups.

Error first seen in https://github.com/pytorch/torchtitan/actions/runs/27707627747