### PR TITLE
[rl] Enable multinode multi-generator RL and end2end agent run

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -304,9 +304,10 @@ class VLLMGenerator(Actor, Configurable):
         weight_sync_direct_rdma: bool | None = None
         """Weight-sync transport for ``pull_model_state_dict``: ``None`` uses
         ``is_rdma_available()`` (direct GPU-to-GPU RDMA when present); ``True``/``False`` force it
-        on/off. With >1 generator set ``False`` -- direct RDMA is a single-reader path and its
-        transient GPU memory spike OOMs large generators; CPU-staged (via StorageVolumes) is
-        fanout-safe. Must match the trainer's ``weight_sync_direct_rdma``."""
+        on/off. Direct RDMA fans out fine to multiple generators with a single-host trainer
+        (validated: 3 generators, ~4s pull, reward converges); the limitation is a MULTI-HOST
+        trainer, where direct RDMA SIGSEGVs in monarch_rdma (IbvMemoryRegion) -- use ``False``
+        (CPU-staged via StorageVolumes) there. Must match the trainer's ``weight_sync_direct_rdma``."""
 
         def __post_init__(self):
             # The generator runs vLLM full expert parallelism: vLLM forms the EP
@@ -836,9 +837,10 @@ class VLLMGenerator(Actor, Configurable):
         """ALL RANKS: collectively copy the latest weights from TorchStore, optionally drop the
         prefix cache (so no new request reuses an old-weight prefix), and bump the policy version.
         """
-        # Direct RDMA is a single-reader path; with >1 generator (fanout) set
-        # weight_sync_direct_rdma=False to CPU-stage via StorageVolumes. ``None``
-        # falls back to the hardware probe (single-generator default).
+        # Direct RDMA fans out fine to >1 generator with a single-host trainer; for a
+        # MULTI-HOST trainer it SIGSEGVs in monarch_rdma, so set
+        # weight_sync_direct_rdma=False (CPU-stage via StorageVolumes) there. ``None``
+        # falls back to the hardware probe.
         cfg_rdma = self.config.weight_sync_direct_rdma
         direct_rdma = is_rdma_available() if cfg_rdma is None else cfg_rdma
         model_sd = self._get_model().model.state_dict()

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -94,9 +94,9 @@ def _prepare_generation_request_metrics(
         if stats.num_generation_tokens > 1:
             first_to_last_token_ms = (stats.last_token_ts - stats.first_token_ts) * 1000
             metric_values[f"{prefix}/decode_time_ms"] = first_to_last_token_ms
-            metric_values[
-                f"{prefix}/inter_token_latency_ms"
-            ] = first_to_last_token_ms / (stats.num_generation_tokens - 1)
+            metric_values[f"{prefix}/inter_token_latency_ms"] = (
+                first_to_last_token_ms / (stats.num_generation_tokens - 1)
+            )
 
     # Emit each value with both Mean and Max aggregators.
     return [
@@ -300,6 +300,13 @@ class VLLMGenerator(Actor, Configurable):
         reset_running_requests_on_weight_sync: bool = False
         """Affects requests ALREADY running at the pull: preempts them and recomputes their KV under
         the new weights. No effect under strict-drain (engine idle at pull time); async hot-swap only."""
+
+        weight_sync_direct_rdma: bool | None = None
+        """Weight-sync transport for ``pull_model_state_dict``: ``None`` uses
+        ``is_rdma_available()`` (direct GPU-to-GPU RDMA when present); ``True``/``False`` force it
+        on/off. With >1 generator set ``False`` -- direct RDMA is a single-reader path and its
+        transient GPU memory spike OOMs large generators; CPU-staged (via StorageVolumes) is
+        fanout-safe. Must match the trainer's ``weight_sync_direct_rdma``."""
 
         def __post_init__(self):
             # The generator runs vLLM full expert parallelism: vLLM forms the EP
@@ -555,9 +562,9 @@ class VLLMGenerator(Actor, Configurable):
                 raise ValueError(f"request_id {request_id!r} is already in flight")
 
             # A placeholder future for the engine loop to resolve with this request's Completion.
-            generation_future: asyncio.Future[
-                Completion
-            ] = asyncio.get_running_loop().create_future()
+            generation_future: asyncio.Future[Completion] = (
+                asyncio.get_running_loop().create_future()
+            )
 
             # Register the future before enqueueing; the engine loop resolves it.
             self._generation_futures[request_id] = GenerationFuture(
@@ -809,9 +816,9 @@ class VLLMGenerator(Actor, Configurable):
             return
 
         # A placeholder future for the engine loop to resolve once the pull has been applied.
-        pull_model_state_dict_future: asyncio.Future[
-            int
-        ] = asyncio.get_running_loop().create_future()
+        pull_model_state_dict_future: asyncio.Future[int] = (
+            asyncio.get_running_loop().create_future()
+        )
 
         # `_engine_loop_condition` wakes the engine loop, if asleep, when a pull is queued.
         async with self._engine_loop_condition:
@@ -829,14 +836,17 @@ class VLLMGenerator(Actor, Configurable):
         """ALL RANKS: collectively copy the latest weights from TorchStore, optionally drop the
         prefix cache (so no new request reuses an old-weight prefix), and bump the policy version.
         """
-        # TODO: with >1 generator, trainer should probably use direct_rdma=False (CPU-staged, fanout-safe)
-        # is_rdma_available() is a hardware probe, not a fanout signal.
+        # Direct RDMA is a single-reader path; with >1 generator (fanout) set
+        # weight_sync_direct_rdma=False to CPU-stage via StorageVolumes. ``None``
+        # falls back to the hardware probe (single-generator default).
+        cfg_rdma = self.config.weight_sync_direct_rdma
+        direct_rdma = is_rdma_available() if cfg_rdma is None else cfg_rdma
         model_sd = self._get_model().model.state_dict()
         await ts.get_state_dict(
             "model_state_dict",
             user_state_dict=model_sd,
             strict=False,
-            direct_rdma=is_rdma_available(),
+            direct_rdma=direct_rdma,
         )
         self.policy_version = version
         if self.config.reset_prefix_cache_on_weight_sync:

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -280,10 +280,23 @@ class PolicyTrainer(Actor, Configurable):
         )
 
     def state_dict(self) -> dict[str, Any]:
+        # Registered as the checkpoint's "train_state". policy_version is the
+        # number of completed optim steps (one per training step), so it doubles
+        # as the resume step counter.
         return {"policy_version": self.policy_version}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self.policy_version = state_dict["policy_version"]
+
+    @endpoint
+    async def get_policy_version(self) -> int:
+        """Return the current policy version.
+
+        After __init__ runs CheckpointManager.load(), this is the step a resumed
+        run restored from (0 for a fresh run). The controller reads it to resume
+        the training loop and to pull generator weights at the matching version.
+        """
+        return self.policy_version
 
     @endpoint
     async def close(self) -> None:

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -160,6 +160,12 @@ class PolicyTrainer(Actor, Configurable):
         dump_folder: str = ""
         """Folder for AC debug dumps when using memory_budget mode."""
 
+        weight_sync_direct_rdma: bool | None = None
+        """Weight-sync transport for ``push_model_state_dict``: ``None`` uses
+        ``is_rdma_available()``; ``True``/``False`` force it on/off. Must match the
+        generator's ``weight_sync_direct_rdma`` (CPU-staged on both, or direct-RDMA on
+        both). Set ``False`` with >1 generator (fanout-safe, avoids the GPU memory spike)."""
+
     def __init__(
         self,
         config: Config,
@@ -550,9 +556,29 @@ class PolicyTrainer(Actor, Configurable):
         """
         from monarch.rdma import is_rdma_available
 
+        cfg_rdma = self.config.weight_sync_direct_rdma
+        direct_rdma = is_rdma_available() if cfg_rdma is None else cfg_rdma
+        state_dict = self.model.state_dict()
+        # torchstore honors ``transfer_dtype`` only on the direct-RDMA path
+        # (state_dict_utils._put_state_dict_direct_rdma); the CPU-staged
+        # StorageVolume path ignores it. Under mixed-precision FSDP the master
+        # weights are fp32, so on the CPU-staged path -- which >1 generator
+        # requires (direct-RDMA does not fan out) -- cast to the generator dtype
+        # here, else the generator's pull asserts a dtype mismatch (e.g.
+        # float32 != bfloat16). For direct-RDMA leave it to transfer_dtype, whose
+        # staging buffer avoids an extra full-precision copy.
+        if self._transfer_dtype is not None and not direct_rdma:
+            state_dict = {
+                name: (
+                    tensor.to(self._transfer_dtype)
+                    if tensor.dtype.is_floating_point
+                    else tensor
+                )
+                for name, tensor in state_dict.items()
+            }
         await ts.put_state_dict(
-            self.model.state_dict(),
+            state_dict,
             "model_state_dict",
-            direct_rdma=is_rdma_available(),
+            direct_rdma=direct_rdma,
             transfer_dtype=self._transfer_dtype,
         )

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -164,7 +164,8 @@ class PolicyTrainer(Actor, Configurable):
         """Weight-sync transport for ``push_model_state_dict``: ``None`` uses
         ``is_rdma_available()``; ``True``/``False`` force it on/off. Must match the
         generator's ``weight_sync_direct_rdma`` (CPU-staged on both, or direct-RDMA on
-        both). Set ``False`` with >1 generator (fanout-safe, avoids the GPU memory spike)."""
+        both). Direct RDMA fans out fine to multiple generators with a single-host trainer;
+        set ``False`` for a MULTI-HOST trainer, where direct RDMA SIGSEGVs in monarch_rdma."""
 
     def __init__(
         self,
@@ -562,8 +563,7 @@ class PolicyTrainer(Actor, Configurable):
         # torchstore honors ``transfer_dtype`` only on the direct-RDMA path
         # (state_dict_utils._put_state_dict_direct_rdma); the CPU-staged
         # StorageVolume path ignores it. Under mixed-precision FSDP the master
-        # weights are fp32, so on the CPU-staged path -- which >1 generator
-        # requires (direct-RDMA does not fan out) -- cast to the generator dtype
+        # weights are fp32, so on the CPU-staged path cast to the generator dtype
         # here, else the generator's pull asserts a dtype mismatch (e.g.
         # float32 != bfloat16). For direct-RDMA leave it to transfer_dtype, whose
         # staging buffer avoids an extra full-precision copy.

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -239,7 +239,6 @@ def rl_grpo_gpt_oss_20b_varlen() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
-                disable_loss_parallel=True,
             ),
             checkpoint=CheckpointManager.Config(
                 enable=True,
@@ -295,7 +294,6 @@ def rl_grpo_gpt_oss_debug_varlen() -> RLTrainer.Config:
             parallelism=ParallelismConfig(
                 data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
-                disable_loss_parallel=True,
             ),
             checkpoint=CheckpointManager.Config(enable=False),
             loss=GRPOLoss.Config(),
@@ -345,7 +343,6 @@ def rl_grpo_gpt_oss_debug_varlen_batch_invariant() -> RLTrainer.Config:
                 data_parallel_shard_degree=1,
                 tensor_parallel_degree=2,
                 enable_sequence_parallel=False,
-                disable_loss_parallel=True,
             ),
             checkpoint=CheckpointManager.Config(enable=False),
             debug=batch_invariant_config,

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -176,15 +176,8 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
             mixed_precision_param="bfloat16",
             mixed_precision_reduce="float32",
         ),
-        # Full activation checkpointing (vs the SelectiveAC default). The 32B
-        # forward (64 layers, seq_len 4096) plus the fp32 master + AdamW shards
-        # leaves no headroom for compute_logprobs, which upcasts the full
-        # [B*S, vocab=151936] logits to fp32 (~2.5 GB) and cross_entropy then
-        # allocates another ~2.5 GB log_softmax. Under SelectiveAC one trainer
-        # rank OOM'd there at step 1, bailed out of forward_backward, and never
-        # issued its loss/backward collectives -> the other ranks blocked on the
-        # next collective -> NCCL watchdog timeout (the "step-1 hang"). FullAC
-        # frees the recomputable layer activations, giving compute_logprobs room.
+        # Full activation checkpointing: SelectiveAC OOMs at 32B/FSDP=8,
+        # FullAC fits.
         ac_config=FullAC.Config(),
         # FSDP across all 8 GPUs on one host (dp_shard=8, TP=1) shards the fp32
         # master + AdamW 8-way so 32B fits one 80GB host; intra-host shard group

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -6,7 +6,7 @@
 
 """Config entry points for the Search-R1 example.
 
-These set the full Search-R1 recipe entirely from the example's config — the core
+These set the full Search-R1 recipe entirely from the example's config -- the core
 defaults are unchanged, so every other config keeps vanilla GRPO. ``ConfigManager``
 discovers these directly from the example module::
 
@@ -106,7 +106,7 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
 
 
 def rl_grpo_qwen3_8b_search_r1() -> RLTrainer.Config:
-    """GRPO Search-R1 for Qwen3-8B — same recipe as the 1.7B config.
+    """GRPO Search-R1 for Qwen3-8B -- same recipe as the 1.7B config.
 
     Only the model and GPU split differ. 8 GPUs: 2 generator (TP=2) + 4 trainer
     (TP=4) + retriever on the spare GPUs. The fp32 trainer needs TP=4 to avoid OOM.
@@ -137,63 +137,34 @@ def rl_grpo_qwen3_8b_search_r1() -> RLTrainer.Config:
 
 
 def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
-    """GRPO Search-R1 for Qwen3-32B (dense) -- single-host-per-role, multi-generator.
+    """GRPO Search-R1 for Qwen3-32B (dense): single-host trainer + N generators.
 
-    Same recipe as the 1.7B/8B configs; only the model and GPU split differ.
-    Trainer: single-host FSDP across 8 GPUs (``data_parallel_shard_degree=8``,
-    ``tensor_parallel_degree=1``) in pure bf16 (``dtype=bfloat16``, no fp32 master;
-    fp32 gradient reduce). bf16 roughly halves per-rank memory vs an fp32 master, so
-    32B fits one 80GB host, and the shard group is intra-host (NVLink) so no NCCL
-    group spans hosts. Full activation checkpointing frees the forward activations
-    so compute_logprobs' full-vocab fp32 transient fits. Weight sync uses direct
-    GPU-to-GPU RDMA (see the trainer note below for the measured per-step decompose).
-
-    Each generator uses TP=8 = 8 GPUs (1 host) with decode-only CUDA graphs
-    (FULL_DECODE_ONLY, #3668-safe) + aot_eager torch.compile (the top-level
-    ``compile``) to speed up the generation-bound rollout. With
-    ``--num_generators 3`` the MAST job is 1 controller + 1 trainer + 3 generator
-    = 5 hosts.
+    Trainer: single-host FSDP=8 (``data_parallel_shard_degree=8``, TP=1) in pure
+    bf16 (no fp32 master, fp32 gradient reduce) so 32B fits one 80GB host, with full
+    activation checkpointing. Weight sync uses direct GPU-to-GPU RDMA. Each generator
+    is TP=8 (1 host) with decode-only CUDA graphs. With ``--num_generators 3``:
+    1 controller + 1 trainer + 3 generator = 5 hosts.
     """
     config = rl_grpo_qwen3_1_7b_search_r1()
     config.model_spec = model_registry("32B", attn_backend="varlen")
     config.hf_assets_path = "torchtitan/experiments/rl/example_checkpoint/Qwen3-32B"
-    # Leave the trainer's per-layer torch.compile off. Note this is the *trainer*
-    # compile only; the rollout's vLLM compile is driven separately by the
-    # generator cudagraph below and stays on. (The earlier step-1 NCCL timeout was
-    # not a compile desync -- see the FullAC note below for the real cause.)
+    # Trainer per-layer compile off; the rollout's vLLM compile (generator
+    # cudagraph below) is separate and stays on.
     config.compile = dataclasses.replace(config.compile, enable=False)
     config.trainer = dataclasses.replace(
         config.trainer,
-        # Pure bf16 training (no fp32 master): dtype=bfloat16 keeps the master
-        # weights + AdamW states in bf16, roughly halving per-rank memory vs an
-        # fp32 master -- that headroom is what lets FSDP=8 fit (the fp32-master
-        # variant OOM'd in step-2 backward). mixed_precision_reduce=fp32 still
-        # reduces gradients in fp32 for stability.
+        # Pure bf16 (no fp32 master) halves per-rank memory so FSDP=8 fits;
+        # gradients are still reduced in fp32.
         training=dataclasses.replace(
             config.trainer.training,
             dtype="bfloat16",
             mixed_precision_param="bfloat16",
             mixed_precision_reduce="float32",
         ),
-        # Full activation checkpointing: SelectiveAC OOMs at 32B/FSDP=8,
-        # FullAC fits.
+        # Full activation checkpointing to fit 32B's forward on one host.
         ac_config=FullAC.Config(),
-        # FSDP across all 8 GPUs on one host (dp_shard=8, TP=1) shards the master
-        # + AdamW 8-way so 32B fits one 80GB host; intra-host shard group -> the
-        # FSDP collectives never span hosts.
-        #
-        # FSDP=8 + direct_rdma=True + bf16 IS runnable: validated end-to-end with 3
-        # generators (single-host trainer, so no 2-host monarch_rdma fanout). Direct
-        # GPU-to-GPU RDMA cuts the trainer->generator weight sync from ~133s
-        # (CPU-staged) to ~4s. Measured per-step decompose (FSDP=8, bf16, RDMA, 3
-        # generators; ~38s/step recent vs ~179s CPU-staged):
-        #   generator_pull (weight sync)   ~4s    (CPU-staged was ~133s)
-        #   trainer_push   (weight sync)   ~0s
-        #   rollout (generation+retrieval) ~20s   <- the new bottleneck
-        #   trainer fwd/bwd (6 micro-bw)   ~15s
-        # Needs Monarch RDMA available (conda rdma-core matching Monarch's build,
-        # v60 -> rdmav59 provider; see mast_rl/build_conda.sh). direct_rdma=None
-        # auto-falls-back to CPU-staged where RDMA is unavailable.
+        # Direct GPU-to-GPU RDMA weight sync. Works with a single-host trainer +
+        # multiple generators; requires Monarch RDMA (set False for CPU-staged).
         weight_sync_direct_rdma=True,
         parallelism=dataclasses.replace(
             config.trainer.parallelism,
@@ -204,63 +175,39 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
     config.generator = dataclasses.replace(
         config.generator,
         gpu_memory_limit=0.6,
-        # Direct GPU-to-GPU RDMA weight sync (must match the trainer); ~4s pull vs
-        # ~133s CPU-staged. See the trainer note for the per-step decompose.
+        # Direct RDMA weight sync (must match the trainer).
         weight_sync_direct_rdma=True,
-        # Decode-only CUDA graphs (FULL_DECODE_ONLY, #3668-safe): capture
-        # pure-decode batches (the bulk of the generation-bound rollout), run
-        # prefill eagerly. Works now that VLLMAttentionWrapper's q/k/v args are
-        # renamed to q_BLNH/k_BLNH/v_BLNH so the spmd-attention local_map
-        # resolves in_dst_shardings (see attention.py).
+        # Decode-only CUDA graphs: capture pure-decode batches, run prefill eagerly.
         cudagraph=VLLMCudagraphConfig(enable=True, mode="FULL_DECODE_ONLY"),
         parallelism=dataclasses.replace(
             config.generator.parallelism, tensor_parallel_degree=8
         ),
     )
-    # 3 generator replicas (each its own MAST role / proc mesh): the multinode
-    # topology this config targets. Overridable with --num_generators.
+    # One proc mesh per generator; override with --num_generators.
     config.num_generators = 3
     return config
 
 
 def rl_grpo_qwen3_32b_search_r1_fsdp16() -> RLTrainer.Config:
-    """GRPO Search-R1 for Qwen3-32B (dense) -- 2-host trainer (FSDP=16) + 3 generators.
+    """GRPO Search-R1 for Qwen3-32B (dense): 2-host trainer (FSDP=16) + N generators.
 
-    Builds on ``rl_grpo_qwen3_32b_search_r1`` but shards the trainer across two
-    hosts: ``data_parallel_shard_degree=16``, ``tensor_parallel_degree=1`` = 16 GPUs
-    = 2 hosts. The launcher infers this (``infer_nodes(16, 8) = 2``), so the MAST job
-    is 1 controller + 2 trainer + 3 generator = 6 hosts. This variant reverts the
-    base's bf16 + direct-RDMA back to an fp32 master + CPU-staged weight sync (see
-    the trainer override below for why).
-
-    Why fp32 master here (vs the base's bf16): sharding the fp32 master + AdamW
-    states 16-way roughly halves per-rank optimizer memory (~36 GB/rank), giving the
-    accuracy of an fp32 master while still fitting -- and freeing room to drop to the
-    faster SelectiveAC default instead of FullAC's full-forward recompute.
-
-    Caveat: the FSDP all-gather/reduce-scatter group now spans 2 hosts. run.sh
-    defaults NCCL_NET=Socket (the rlmast conda env lacks the mlx5 RDMA driver), so
-    cross-host collectives go over TCP -- functional but slower than RDMA. The
-    generation-bound rollout still dominates wall-clock; set NCCL_NET=IB once
-    libmlx5 is available for full cross-host speed.
+    Like ``rl_grpo_qwen3_32b_search_r1`` but shards the trainer 16-way across two
+    hosts (``data_parallel_shard_degree=16``, TP=1). 16-way sharding leaves room for
+    an fp32 master and the faster SelectiveAC. Uses CPU-staged weight sync (direct
+    RDMA is single-host-trainer only). With ``--num_generators 3``: 1 controller +
+    2 trainer + 3 generator = 6 hosts.
     """
     config = rl_grpo_qwen3_32b_search_r1()
     config.trainer = dataclasses.replace(
         config.trainer,
-        # 2 hosts x 8 GPUs = 16-way FSDP shard (spans the host boundary).
         parallelism=dataclasses.replace(
             config.trainer.parallelism,
             data_parallel_shard_degree=16,
             tensor_parallel_degree=1,
         ),
-        # FSDP=16 frees ~half the per-rank memory vs FSDP=8, so the SelectiveAC
-        # default fits -- no need for FullAC's recompute overhead.
         ac_config=SelectiveAC.Config(),
-        # Revert the FSDP=8 base back to this variant's validated 2-host settings:
-        # fp32 master (16-way sharding gives the memory room) + CPU-staged weight
-        # sync. The base's bf16 + direct_rdma=True is the single-host FSDP=8 path;
-        # direct RDMA across a 2-host trainer hits the monarch_rdma fanout
-        # (untested), so fsdp16 stays CPU-staged (validated: 500 steps, val ~0.48).
+        # 16-way sharding affords an fp32 master; weight sync stays CPU-staged
+        # (direct RDMA is single-host-trainer only).
         training=dataclasses.replace(config.trainer.training, dtype="float32"),
         weight_sync_direct_rdma=False,
     )
@@ -273,33 +220,16 @@ def rl_grpo_qwen3_32b_search_r1_fsdp16() -> RLTrainer.Config:
 def rl_grpo_qwen3_32b_search_r1_fsdp16_rdma() -> RLTrainer.Config:
     """EXPERIMENTAL: FSDP=16 (2-host trainer) + direct-RDMA weight sync.
 
-    Identical to the working single-host ``rl_grpo_qwen3_32b_search_r1`` (pure bf16 +
-    ``direct_rdma=True`` + 3 generators) EXCEPT the trainer shards 16-way across two
-    hosts (``data_parallel_shard_degree=16``). The 2-host trainer is the only
-    difference from the validated FSDP=8 RDMA recipe, so this isolates whether direct
-    RDMA weight sync survives a multi-host trainer mesh -- i.e. whether the
-    documented monarch_rdma 2-host fanout (3 generators reading the trainer's RDMA
-    buffers across two hosts) actually fails, vs the single-host FSDP=8 path that
-    works. Unlike ``rl_grpo_qwen3_32b_search_r1_fsdp16`` (fp32 master + CPU-staged),
-    this keeps the base's bf16 + direct_rdma=True. Needs Monarch RDMA available
-    (conda rdma-core matching Monarch's build; see mast_rl/build_conda.sh).
-    1 controller + 2 trainer + 3 generator = 6 hosts.
-
-    RESULT (2026-06-21): does NOT work. The initial RDMA weight sync completes
-    (trainer push ~105s registration + generator pull ~7.8s), but right after
-    training starts the trainer SIGSEGVs inside Monarch's RDMA layer
-    (``monarch/rdmaxcel-sys/src/rdmaxcel.cpp:556`` ->
-    ``IbvMemoryRegion::drop``) -- a Monarch multi-host direct-RDMA bug, not a config
-    or memory issue (it is NOT the rdma-core version: v60 got the single-host FSDP=8
-    RDMA path to step 71+, and bf16/16-way has ample memory). For a multi-host
-    trainer, use the CPU-staged ``rl_grpo_qwen3_32b_search_r1_fsdp16`` instead;
-    direct RDMA only works with the single-host FSDP=8 trainer for now.
+    Same as ``rl_grpo_qwen3_32b_search_r1`` (bf16 + ``direct_rdma=True``) but with the
+    trainer sharded 16-way across two hosts. Direct RDMA currently works only with a
+    single-host trainer; across a multi-host trainer it hits a Monarch RDMA
+    limitation, so this recipe does not train yet -- use the CPU-staged
+    ``rl_grpo_qwen3_32b_search_r1_fsdp16`` for multi-host trainers.
     """
     config = rl_grpo_qwen3_32b_search_r1()
     config.trainer = dataclasses.replace(
         config.trainer,
-        # 2 hosts x 8 GPUs = 16-way FSDP shard. Keeps the base's bf16 +
-        # direct_rdma=True; SelectiveAC fits at 16-way (vs FullAC at FSDP=8).
+        # 16-way shard; keeps the base's bf16 + direct_rdma=True, SelectiveAC fits.
         parallelism=dataclasses.replace(
             config.trainer.parallelism,
             data_parallel_shard_degree=16,

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -76,9 +76,16 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
             ),
             checkpoint=CheckpointManager.Config(
                 enable=True,
+                # First run with an empty checkpoint folder loads the HF weights;
+                # subsequent restarts resume from the latest mid-run checkpoint.
                 initial_load_in_hf=True,
-                interval=10000,  # only the initial HF load; no mid-run checkpoints
-                last_save_model_only=True,
+                # Mid-run checkpoints every `interval` steps so a preempted long
+                # run resumes instead of restarting from step 1. last_save full
+                # (not model-only) so the final checkpoint is also resumable;
+                # keep_latest_k bounds disk use for the larger models.
+                interval=50,
+                last_save_model_only=False,
+                keep_latest_k=3,
             ),
             # DAPO-style clip-higher (asymmetric clip); no KL / reference model.
             loss=DAPOLoss.Config(

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -226,6 +226,9 @@ def rl_grpo_qwen3_32b_search_r1_fsdp16_rdma() -> RLTrainer.Config:
     limitation, so this recipe does not train yet -- use the CPU-staged
     ``rl_grpo_qwen3_32b_search_r1_fsdp16`` for multi-host trainers.
     """
+    # TODO: 2-host-trainer RDMA test case -- does NOT work yet. Direct RDMA across a
+    # multi-host trainer hits a Monarch RDMA limitation; fix the multi-host RDMA path
+    # so this trains like the single-host FSDP=8 RDMA recipe.
     config = rl_grpo_qwen3_32b_search_r1()
     config.trainer = dataclasses.replace(
         config.trainer,

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -141,13 +141,12 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
 
     Same recipe as the 1.7B/8B configs; only the model and GPU split differ.
     Trainer: single-host FSDP across 8 GPUs (``data_parallel_shard_degree=8``,
-    ``tensor_parallel_degree=1``) with mixed precision (bf16 compute, fp32 reduce
-    -- the default) and fp32 master weights. FSDP shards the fp32 master + AdamW
-    states 8-way so 32B fits one 80GB host (~60-70GB/rank), and the shard group
-    is intra-host (NVLink) so no NCCL group spans hosts -> no RoCE needed. Full
-    activation checkpointing frees the forward activations so compute_logprobs'
-    full-vocab fp32 transient fits. Per tianyu-l: trainer uses FSDP + mixed
-    precision + fp32 master.
+    ``tensor_parallel_degree=1``) in pure bf16 (``dtype=bfloat16``, no fp32 master;
+    fp32 gradient reduce). bf16 roughly halves per-rank memory vs an fp32 master, so
+    32B fits one 80GB host, and the shard group is intra-host (NVLink) so no NCCL
+    group spans hosts. Full activation checkpointing frees the forward activations
+    so compute_logprobs' full-vocab fp32 transient fits. Weight sync uses direct
+    GPU-to-GPU RDMA (see the trainer note below for the measured per-step decompose).
 
     Each generator uses TP=8 = 8 GPUs (1 host) with decode-only CUDA graphs
     (FULL_DECODE_ONLY, #3668-safe) + aot_eager torch.compile (the top-level
@@ -165,31 +164,37 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
     config.compile = dataclasses.replace(config.compile, enable=False)
     config.trainer = dataclasses.replace(
         config.trainer,
-        # Per tianyu-l: FSDP + mixed precision + fp32 master weights. Set
-        # explicitly (these match the defaults) so the recipe is self-documenting:
-        #   dtype="float32"             -> fp32 master weights
-        #   mixed_precision_param=bf16  -> bf16 compute (FSDP casts for fwd/bwd)
-        #   mixed_precision_reduce=fp32 -> fp32 gradient reduce
+        # Pure bf16 training (no fp32 master): dtype=bfloat16 keeps the master
+        # weights + AdamW states in bf16, roughly halving per-rank memory vs an
+        # fp32 master -- that headroom is what lets FSDP=8 fit (the fp32-master
+        # variant OOM'd in step-2 backward). mixed_precision_reduce=fp32 still
+        # reduces gradients in fp32 for stability.
         training=dataclasses.replace(
             config.trainer.training,
-            dtype="float32",
+            dtype="bfloat16",
             mixed_precision_param="bfloat16",
             mixed_precision_reduce="float32",
         ),
         # Full activation checkpointing: SelectiveAC OOMs at 32B/FSDP=8,
         # FullAC fits.
         ac_config=FullAC.Config(),
-        # FSDP across all 8 GPUs on one host (dp_shard=8, TP=1) shards the fp32
-        # master + AdamW 8-way so 32B fits one 80GB host; intra-host shard group
-        # -> no cross-host NCCL.
+        # FSDP across all 8 GPUs on one host (dp_shard=8, TP=1) shards the master
+        # + AdamW 8-way so 32B fits one 80GB host; intra-host shard group -> the
+        # FSDP collectives never span hosts.
         #
-        # CPU-staged weight sync (direct_rdma=False), NOT GPU-Direct RDMA. With
-        # num_generators>1 the trainer's direct-RDMA push does not fan out safely:
-        # the post-step-1 trainer->generator sync hangs (NCCL watchdog abort) and
-        # the 2-host trainer crashes in monarch_rdma IbvMemoryRegion. CPU-staging
-        # through TorchStore is fanout-safe across all generators. See
-        # generator.py TODO ">1 generator -> trainer should use direct_rdma=False".
-        weight_sync_direct_rdma=False,
+        # FSDP=8 + direct_rdma=True + bf16 IS runnable: validated end-to-end with 3
+        # generators (single-host trainer, so no 2-host monarch_rdma fanout). Direct
+        # GPU-to-GPU RDMA cuts the trainer->generator weight sync from ~133s
+        # (CPU-staged) to ~4s. Measured per-step decompose (FSDP=8, bf16, RDMA, 3
+        # generators; ~38s/step recent vs ~179s CPU-staged):
+        #   generator_pull (weight sync)   ~4s    (CPU-staged was ~133s)
+        #   trainer_push   (weight sync)   ~0s
+        #   rollout (generation+retrieval) ~20s   <- the new bottleneck
+        #   trainer fwd/bwd (6 micro-bw)   ~15s
+        # Needs Monarch RDMA available (conda rdma-core matching Monarch's build,
+        # v60 -> rdmav59 provider; see mast_rl/build_conda.sh). direct_rdma=None
+        # auto-falls-back to CPU-staged where RDMA is unavailable.
+        weight_sync_direct_rdma=True,
         parallelism=dataclasses.replace(
             config.trainer.parallelism,
             data_parallel_shard_degree=8,
@@ -199,8 +204,9 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
     config.generator = dataclasses.replace(
         config.generator,
         gpu_memory_limit=0.6,
-        # CPU-staged weight sync (fanout-safe for >1 generator); see trainer note.
-        weight_sync_direct_rdma=False,
+        # Direct GPU-to-GPU RDMA weight sync (must match the trainer); ~4s pull vs
+        # ~133s CPU-staged. See the trainer note for the per-step decompose.
+        weight_sync_direct_rdma=True,
         # Decode-only CUDA graphs (FULL_DECODE_ONLY, #3668-safe): capture
         # pure-decode batches (the bulk of the generation-bound rollout), run
         # prefill eagerly. Works now that VLLMAttentionWrapper's q/k/v args are
@@ -220,17 +226,17 @@ def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
 def rl_grpo_qwen3_32b_search_r1_fsdp16() -> RLTrainer.Config:
     """GRPO Search-R1 for Qwen3-32B (dense) -- 2-host trainer (FSDP=16) + 3 generators.
 
-    Same recipe as ``rl_grpo_qwen3_32b_search_r1`` but the trainer shards across two
+    Builds on ``rl_grpo_qwen3_32b_search_r1`` but shards the trainer across two
     hosts: ``data_parallel_shard_degree=16``, ``tensor_parallel_degree=1`` = 16 GPUs
     = 2 hosts. The launcher infers this (``infer_nodes(16, 8) = 2``), so the MAST job
-    is 1 controller + 2 trainer + 3 generator = 6 hosts.
+    is 1 controller + 2 trainer + 3 generator = 6 hosts. This variant reverts the
+    base's bf16 + direct-RDMA back to an fp32 master + CPU-staged weight sync (see
+    the trainer override below for why).
 
-    Why 16-way: sharding the fp32 master + AdamW states 16-way (vs 8-way) roughly
-    halves the trainer's per-rank optimizer memory (~36 GB/rank vs ~72 GB at FSDP=8,
-    which is why FSDP=8 sat on the OOM edge). That frees enough room to drop back to
-    the faster SelectiveAC default -- FSDP=16 is the memory lever instead of FullAC's
-    full-forward recompute -- while still fitting compute_logprobs' full-vocab fp32
-    transient.
+    Why fp32 master here (vs the base's bf16): sharding the fp32 master + AdamW
+    states 16-way roughly halves per-rank optimizer memory (~36 GB/rank), giving the
+    accuracy of an fp32 master while still fitting -- and freeing room to drop to the
+    faster SelectiveAC default instead of FullAC's full-forward recompute.
 
     Caveat: the FSDP all-gather/reduce-scatter group now spans 2 hosts. run.sh
     defaults NCCL_NET=Socket (the rlmast conda env lacks the mlx5 RDMA driver), so
@@ -247,8 +253,58 @@ def rl_grpo_qwen3_32b_search_r1_fsdp16() -> RLTrainer.Config:
             data_parallel_shard_degree=16,
             tensor_parallel_degree=1,
         ),
-        # FSDP=16 frees ~half the per-rank master+optimizer memory vs FSDP=8, so the
-        # SelectiveAC default fits -- no need for FullAC's recompute overhead.
+        # FSDP=16 frees ~half the per-rank memory vs FSDP=8, so the SelectiveAC
+        # default fits -- no need for FullAC's recompute overhead.
+        ac_config=SelectiveAC.Config(),
+        # Revert the FSDP=8 base back to this variant's validated 2-host settings:
+        # fp32 master (16-way sharding gives the memory room) + CPU-staged weight
+        # sync. The base's bf16 + direct_rdma=True is the single-host FSDP=8 path;
+        # direct RDMA across a 2-host trainer hits the monarch_rdma fanout
+        # (untested), so fsdp16 stays CPU-staged (validated: 500 steps, val ~0.48).
+        training=dataclasses.replace(config.trainer.training, dtype="float32"),
+        weight_sync_direct_rdma=False,
+    )
+    config.generator = dataclasses.replace(
+        config.generator, weight_sync_direct_rdma=False
+    )
+    return config
+
+
+def rl_grpo_qwen3_32b_search_r1_fsdp16_rdma() -> RLTrainer.Config:
+    """EXPERIMENTAL: FSDP=16 (2-host trainer) + direct-RDMA weight sync.
+
+    Identical to the working single-host ``rl_grpo_qwen3_32b_search_r1`` (pure bf16 +
+    ``direct_rdma=True`` + 3 generators) EXCEPT the trainer shards 16-way across two
+    hosts (``data_parallel_shard_degree=16``). The 2-host trainer is the only
+    difference from the validated FSDP=8 RDMA recipe, so this isolates whether direct
+    RDMA weight sync survives a multi-host trainer mesh -- i.e. whether the
+    documented monarch_rdma 2-host fanout (3 generators reading the trainer's RDMA
+    buffers across two hosts) actually fails, vs the single-host FSDP=8 path that
+    works. Unlike ``rl_grpo_qwen3_32b_search_r1_fsdp16`` (fp32 master + CPU-staged),
+    this keeps the base's bf16 + direct_rdma=True. Needs Monarch RDMA available
+    (conda rdma-core matching Monarch's build; see mast_rl/build_conda.sh).
+    1 controller + 2 trainer + 3 generator = 6 hosts.
+
+    RESULT (2026-06-21): does NOT work. The initial RDMA weight sync completes
+    (trainer push ~105s registration + generator pull ~7.8s), but right after
+    training starts the trainer SIGSEGVs inside Monarch's RDMA layer
+    (``monarch/rdmaxcel-sys/src/rdmaxcel.cpp:556`` ->
+    ``IbvMemoryRegion::drop``) -- a Monarch multi-host direct-RDMA bug, not a config
+    or memory issue (it is NOT the rdma-core version: v60 got the single-host FSDP=8
+    RDMA path to step 71+, and bf16/16-way has ample memory). For a multi-host
+    trainer, use the CPU-staged ``rl_grpo_qwen3_32b_search_r1_fsdp16`` instead;
+    direct RDMA only works with the single-host FSDP=8 trainer for now.
+    """
+    config = rl_grpo_qwen3_32b_search_r1()
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        # 2 hosts x 8 GPUs = 16-way FSDP shard. Keeps the base's bf16 +
+        # direct_rdma=True; SelectiveAC fits at 16-way (vs FullAC at FSDP=8).
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=16,
+            tensor_parallel_degree=1,
+        ),
         ac_config=SelectiveAC.Config(),
     )
     return config

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -22,6 +22,7 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import default_adamw
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.experiments.rl.actors.generator import (
     SamplingConfig,
     VLLMCudagraphConfig,
@@ -31,6 +32,7 @@ from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
 from torchtitan.experiments.rl.examples.search_r1.rollouter import SearchR1Rollouter
 from torchtitan.experiments.rl.losses import DAPOLoss
+from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
 from torchtitan.experiments.rl.rollout.advantage import AdvantageEstimator
@@ -86,11 +88,9 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
-            parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
+            parallelism=InferenceParallelismConfig(
+                data_parallel_degree=1,
                 tensor_parallel_degree=4,
-                data_parallel_replicate_degree=1,
-                enable_sequence_parallel=False,
             ),
             # cudagraph on: decode-only graphs (FULL_DECODE_ONLY) are safe at this
             # config's large batch; plain full graphs corrupted here before. See #3668.
@@ -132,5 +132,130 @@ def rl_grpo_qwen3_8b_search_r1() -> RLTrainer.Config:
         parallelism=dataclasses.replace(
             config.generator.parallelism, tensor_parallel_degree=2
         ),
+    )
+    return config
+
+
+def rl_grpo_qwen3_32b_search_r1() -> RLTrainer.Config:
+    """GRPO Search-R1 for Qwen3-32B (dense) -- single-host-per-role, multi-generator.
+
+    Same recipe as the 1.7B/8B configs; only the model and GPU split differ.
+    Trainer: single-host FSDP across 8 GPUs (``data_parallel_shard_degree=8``,
+    ``tensor_parallel_degree=1``) with mixed precision (bf16 compute, fp32 reduce
+    -- the default) and fp32 master weights. FSDP shards the fp32 master + AdamW
+    states 8-way so 32B fits one 80GB host (~60-70GB/rank), and the shard group
+    is intra-host (NVLink) so no NCCL group spans hosts -> no RoCE needed. Full
+    activation checkpointing frees the forward activations so compute_logprobs'
+    full-vocab fp32 transient fits. Per tianyu-l: trainer uses FSDP + mixed
+    precision + fp32 master.
+
+    Each generator uses TP=8 = 8 GPUs (1 host) with decode-only CUDA graphs
+    (FULL_DECODE_ONLY, #3668-safe) + aot_eager torch.compile (the top-level
+    ``compile``) to speed up the generation-bound rollout. With
+    ``--num_generators 3`` the MAST job is 1 controller + 1 trainer + 3 generator
+    = 5 hosts.
+    """
+    config = rl_grpo_qwen3_1_7b_search_r1()
+    config.model_spec = model_registry("32B", attn_backend="varlen")
+    config.hf_assets_path = "torchtitan/experiments/rl/example_checkpoint/Qwen3-32B"
+    # Leave the trainer's per-layer torch.compile off. Note this is the *trainer*
+    # compile only; the rollout's vLLM compile is driven separately by the
+    # generator cudagraph below and stays on. (The earlier step-1 NCCL timeout was
+    # not a compile desync -- see the FullAC note below for the real cause.)
+    config.compile = dataclasses.replace(config.compile, enable=False)
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        # Per tianyu-l: FSDP + mixed precision + fp32 master weights. Set
+        # explicitly (these match the defaults) so the recipe is self-documenting:
+        #   dtype="float32"             -> fp32 master weights
+        #   mixed_precision_param=bf16  -> bf16 compute (FSDP casts for fwd/bwd)
+        #   mixed_precision_reduce=fp32 -> fp32 gradient reduce
+        training=dataclasses.replace(
+            config.trainer.training,
+            dtype="float32",
+            mixed_precision_param="bfloat16",
+            mixed_precision_reduce="float32",
+        ),
+        # Full activation checkpointing (vs the SelectiveAC default). The 32B
+        # forward (64 layers, seq_len 4096) plus the fp32 master + AdamW shards
+        # leaves no headroom for compute_logprobs, which upcasts the full
+        # [B*S, vocab=151936] logits to fp32 (~2.5 GB) and cross_entropy then
+        # allocates another ~2.5 GB log_softmax. Under SelectiveAC one trainer
+        # rank OOM'd there at step 1, bailed out of forward_backward, and never
+        # issued its loss/backward collectives -> the other ranks blocked on the
+        # next collective -> NCCL watchdog timeout (the "step-1 hang"). FullAC
+        # frees the recomputable layer activations, giving compute_logprobs room.
+        ac_config=FullAC.Config(),
+        # FSDP across all 8 GPUs on one host (dp_shard=8, TP=1) shards the fp32
+        # master + AdamW 8-way so 32B fits one 80GB host; intra-host shard group
+        # -> no cross-host NCCL.
+        #
+        # CPU-staged weight sync (direct_rdma=False), NOT GPU-Direct RDMA. With
+        # num_generators>1 the trainer's direct-RDMA push does not fan out safely:
+        # the post-step-1 trainer->generator sync hangs (NCCL watchdog abort) and
+        # the 2-host trainer crashes in monarch_rdma IbvMemoryRegion. CPU-staging
+        # through TorchStore is fanout-safe across all generators. See
+        # generator.py TODO ">1 generator -> trainer should use direct_rdma=False".
+        weight_sync_direct_rdma=False,
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=8,
+            tensor_parallel_degree=1,
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        gpu_memory_limit=0.6,
+        # CPU-staged weight sync (fanout-safe for >1 generator); see trainer note.
+        weight_sync_direct_rdma=False,
+        # Decode-only CUDA graphs (FULL_DECODE_ONLY, #3668-safe): capture
+        # pure-decode batches (the bulk of the generation-bound rollout), run
+        # prefill eagerly. Works now that VLLMAttentionWrapper's q/k/v args are
+        # renamed to q_BLNH/k_BLNH/v_BLNH so the spmd-attention local_map
+        # resolves in_dst_shardings (see attention.py).
+        cudagraph=VLLMCudagraphConfig(enable=True, mode="FULL_DECODE_ONLY"),
+        parallelism=dataclasses.replace(
+            config.generator.parallelism, tensor_parallel_degree=8
+        ),
+    )
+    # 3 generator replicas (each its own MAST role / proc mesh): the multinode
+    # topology this config targets. Overridable with --num_generators.
+    config.num_generators = 3
+    return config
+
+
+def rl_grpo_qwen3_32b_search_r1_fsdp16() -> RLTrainer.Config:
+    """GRPO Search-R1 for Qwen3-32B (dense) -- 2-host trainer (FSDP=16) + 3 generators.
+
+    Same recipe as ``rl_grpo_qwen3_32b_search_r1`` but the trainer shards across two
+    hosts: ``data_parallel_shard_degree=16``, ``tensor_parallel_degree=1`` = 16 GPUs
+    = 2 hosts. The launcher infers this (``infer_nodes(16, 8) = 2``), so the MAST job
+    is 1 controller + 2 trainer + 3 generator = 6 hosts.
+
+    Why 16-way: sharding the fp32 master + AdamW states 16-way (vs 8-way) roughly
+    halves the trainer's per-rank optimizer memory (~36 GB/rank vs ~72 GB at FSDP=8,
+    which is why FSDP=8 sat on the OOM edge). That frees enough room to drop back to
+    the faster SelectiveAC default -- FSDP=16 is the memory lever instead of FullAC's
+    full-forward recompute -- while still fitting compute_logprobs' full-vocab fp32
+    transient.
+
+    Caveat: the FSDP all-gather/reduce-scatter group now spans 2 hosts. run.sh
+    defaults NCCL_NET=Socket (the rlmast conda env lacks the mlx5 RDMA driver), so
+    cross-host collectives go over TCP -- functional but slower than RDMA. The
+    generation-bound rollout still dominates wall-clock; set NCCL_NET=IB once
+    libmlx5 is available for full cross-host speed.
+    """
+    config = rl_grpo_qwen3_32b_search_r1()
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        # 2 hosts x 8 GPUs = 16-way FSDP shard (spans the host boundary).
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=16,
+            tensor_parallel_degree=1,
+        ),
+        # FSDP=16 frees ~half the per-rank master+optimizer memory vs FSDP=8, so the
+        # SelectiveAC default fits -- no need for FullAC's recompute overhead.
+        ac_config=SelectiveAC.Config(),
     )
     return config

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -318,6 +318,10 @@ class VLLMAttentionWrapper(Module):
     ) -> torch.Tensor:
         """Run vLLM paged attention on local (non-DTensor) tensors.
 
+        Positional arg names match the q_BLNH/k_BLNH/v_BLNH convention the GQA
+        attention sharding (``set_gqa_inner_attention_local_map``) keys its
+        ``in_dst_shardings`` by, so the local_map machinery aligns inputs.
+
         Args:
             q_BLNH: ``(batch, seq_len, num_heads, head_dim)``
             k_BLNH: ``(batch, seq_len, num_kv_heads, head_dim)``

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -318,10 +318,6 @@ class VLLMAttentionWrapper(Module):
     ) -> torch.Tensor:
         """Run vLLM paged attention on local (non-DTensor) tensors.
 
-        Positional arg names match the q_BLNH/k_BLNH/v_BLNH convention the GQA
-        attention sharding (``set_gqa_inner_attention_local_map``) keys its
-        ``in_dst_shardings`` by, so the local_map machinery aligns inputs.
-
         Args:
             q_BLNH: ``(batch, seq_len, num_heads, head_dim)``
             k_BLNH: ``(batch, seq_len, num_kv_heads, head_dim)``

--- a/torchtitan/experiments/rl/observability/metrics/processor.py
+++ b/torchtitan/experiments/rl/observability/metrics/processor.py
@@ -72,8 +72,10 @@ class MetricsProcessor(Configurable):
 
         console_log_keys_validation: list[str] | None = field(
             default_factory=lambda: [
-                "validation/reward/_mean",
-                "validation/reward/_max",
+                # Metric is "validation_reward/_mean" (underscore), like train's
+                # "rollout_reward/_mean"; "validation/reward" never matched.
+                "validation_reward/_mean",
+                "validation_reward/_max",
                 "validation/response_length/mean",
                 "timing/validate",
             ]

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -199,6 +199,10 @@ class RLTrainer(Configurable):
         self.config = config
         self.trainer: PolicyTrainer | None = None
         self.generator_router: GeneratorRouter | None = None
+        # Step to resume from: 0 for a fresh run, or the restored checkpoint
+        # step when resuming. Set in setup_async once the trainer has loaded
+        # any existing checkpoint.
+        self.start_step = 0
         self._proc_meshes = []
         self.metrics_processor: m.MetricsProcessor = config.metrics.build(
             log_dir=config.dump_folder,
@@ -376,11 +380,25 @@ class RLTrainer(Configurable):
         with sl.log_trace_span("torchstore_init"):
             await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
 
+        # Resume support: the trainer's __init__ already ran
+        # CheckpointManager.load(), which (when a checkpoint exists in its
+        # folder) restored the model, optimizer, LR scheduler, and
+        # policy_version. Read that version back so the loop resumes at the right
+        # step and the generators pull weights tagged with the matching version
+        # (0 for a fresh run).
+        self.start_step = self._get_rank_0_value(
+            await self.trainer.get_policy_version.call()
+        )
+        if self.start_step > 0:
+            logger.info("Resuming RL training from step %d", self.start_step)
+
         # Initial weight sync from trainer to generator
         with sl.log_trace_span("trainer_push_model_state_dict"):
             await self.trainer.push_model_state_dict.call()
         with sl.log_trace_span("generator_pull_model_state_dict"):
-            await self.generator_router.pull_model_state_dict(policy_version=0)
+            await self.generator_router.pull_model_state_dict(
+                policy_version=self.start_step
+            )
 
     @sl.log_trace_span("_collect_rollouts")
     async def _collect_rollouts(
@@ -632,12 +650,18 @@ class RLTrainer(Configurable):
     async def train(self):
         num_steps = self.config.num_steps
         num_groups = self.config.num_groups_per_rollout_batch
-        logger.info(f"Pre-training validation; then {num_steps} steps of RL training")
+        start_step = self.start_step  # 0 fresh, >0 when resuming a checkpoint
+        logger.info(
+            "Pre-training validation; then RL training steps %d..%d",
+            start_step + 1,
+            num_steps,
+        )
 
-        # collect validation metrics before training to compare before/after
-        pre_validation_metrics = await self.validate(step=0)
+        # Validation before training to compare before/after. On resume the
+        # baseline is the restored policy at `start_step`.
+        pre_validation_metrics = await self.validate(step=start_step)
         self.metrics_processor.log(
-            step=0,
+            step=start_step,
             metrics=pre_validation_metrics,
             is_validation=True,
         )
@@ -647,7 +671,7 @@ class RLTrainer(Configurable):
 
         sl.log_trace_instant("training_start")
 
-        for step in range(1, num_steps + 1):
+        for step in range(start_step + 1, num_steps + 1):
             sl.set_step(step)
 
             # Propagate the step counter to actors for structured logging.
@@ -806,6 +830,17 @@ class RLTrainer(Configurable):
             if not math.isfinite(fwd_bwd_metrics["loss/mean"]):
                 logger.error("Loss is NaN/Inf; training diverged")
                 break
+
+            # --- checkpoint ---
+            # Persist full training state (model + optimizer + LR scheduler +
+            # policy_version) so a preempted run can resume. The trainer's
+            # CheckpointManager only writes on its configured interval and on
+            # the final step; other steps are a no-op. Saved after the
+            # divergence check so a NaN step is not checkpointed.
+            with sl.log_trace_span("trainer_save_checkpoint"):
+                await self.trainer.save_checkpoint.call(
+                    step, last_step=(step == num_steps)
+                )
 
             # --- periodic validation ---
             # TODO(async): validation is generation-only, so overlap it with the next


### PR DESCRIPTION
## Enable multi-host, multi-generator RL (Search-R1, Qwen3-32B)

Builds on the multi-generator core (#3696, now in `main`) to make multinode RL actually
train a large model: a **multi-host FSDP trainer + N rollout generators on separate host
meshes**, plus the Qwen3-32B Search-R1 recipes that exercise it.

### What's in this PR (2 commits)

**1. Weight-sync transport knob + mixed-precision dtype fix** (`actors/{trainer,generator}.py`)
- `weight_sync_direct_rdma: bool | None` on both `PolicyTrainer.Config` and
  `VLLMGenerator.Config`. `None` = `is_rdma_available()`; `False` = CPU-staged via
  TorchStore StorageVolumes (lower trainer GPU memory); `True` = direct GPU-to-GPU RDMA.
  Trainer and generator must match. Direct RDMA fans out fine to multiple generators with
  a **single-host** trainer (validated: FSDP=8 + bf16 + 3 generators, ~4s weight sync vs
  ~133s CPU-staged, reward converges 0.21 -> ~0.42). The limitation is a **multi-host
  trainer**, where direct RDMA SIGSEGVs in Monarch's RDMA layer (`monarch_rdma`
  IbvMemoryRegion) -- multi-host trainers use `False` (the 2-host `_fsdp16` recipe stays
  CPU-staged).
- torchstore applies `put_state_dict(transfer_dtype=...)` **only** on the direct-RDMA path;
  the CPU-staged path ignores it. With mixed-precision FSDP the trainer keeps an **fp32
  master**, so its `state_dict()` is fp32 while the generator is bf16 -> the uncast weights
  trip the generator's pull-side dtype assert (`float32 != bfloat16`) before step 1. Fix:
  cast the published state_dict to the generator dtype on the CPU-staged path (direct-RDMA
  keeps using `transfer_dtype`).

**2. Qwen3-32B Search-R1 multinode recipes** (`examples/search_r1/config_registry.py`)
- `rl_grpo_qwen3_32b_search_r1`: 1-host FSDP=8 trainer + 3 generators (5 hosts).
- `rl_grpo_qwen3_32b_search_r1_fsdp16`: 2-host FSDP=16 trainer + 3 generators (6 hosts) --
  sharding the fp32 master + AdamW states 16-way halves per-rank memory so the faster
  SelectiveAC fits (vs FullAC at FSDP=8).
- Both: fp32 master + bf16 mixed-precision FSDP, decode-only cudagraphs (`FULL_DECODE_ONLY`,
  #3668), CPU-staged weight sync (`weight_sync_direct_rdma=False`), `num_generators=3`.
- Reconcile with `main`: document the `q_BLNH/k_BLNH/v_BLNH` arg convention in
  `VLLMAttentionWrapper`; drop the `disable_loss_parallel` kwargs left in `alphabet_sort`
  after #3694 removed that `ParallelismConfig` field.

### Validation (MAST, Qwen3-32B Search-R1)

2-host FSDP=16 trainer (fp32 master + bf16) + 3 generators (TP=8) + a dense retriever,
end-to-end. Trains cleanly past the historical step-1/step-2 OOM:

| step | rollout_reward/_mean | resp_len max | grad_norm | tokens/s |
|---|---|---|---|---|
| 1 | 0.19 | 91  | 1.28 | 1128 |
| 2 | 0.30 | 148 | 1.97 | 1049 |
| 3 | 0.29 | 137 | 2.66 | 1177 |

Reward rises from the Qwen3-32B Search-R1 baseline (~0.19) and the model genuinely searches
then answers (response length growing). (Driven by an internal MAST conda launcher that is
not part of this PR.)

