### PR TITLE
Fix GQAttention input redistribution disabled by x -> x_BLD rename

### DIFF
--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -141,12 +141,6 @@ def set_qkv_linear_sharding(qkv_linear_cfg) -> None:
     ``FusedQKVLinear`` (single ``wqkv``).
     """
     if isinstance(qkv_linear_cfg, FusedQKVLinear.Config):
-        qkv_output = dense_activation_placement(tp=spmd.S(2))
-        qkv_linear_cfg.sharding_config = ShardingConfig(
-            in_src_shardings={"x": dense_activation_placement(tp=spmd.R)},
-            in_dst_shardings={"x": dense_activation_placement(tp=spmd.R)},
-            out_src_shardings=(qkv_output, qkv_output, qkv_output),
-        )
         qkv_linear_cfg.wqkv.sharding_config = colwise_config()
     elif isinstance(qkv_linear_cfg, QKVLinear.Config):
         qkv_linear_cfg.wq.sharding_config = colwise_config()
@@ -162,8 +156,8 @@ def set_gqa_attention_sharding(attention_cfg, *, enable_sp: bool) -> None:
     """Standard GQA attention (``qkv_linear``/``wo``) TP sharding.
 
     Shared by llama3 and qwen3 -- both have a GQA block whose
-    ``forward(x, ...)`` takes ``x`` (per-SP layout, gathered to Replicate
-    internally) and uses the attention layer's local RoPE cache.
+    ``forward(x_BLD, ...)`` takes ``x_BLD`` (per-SP layout, gathered to
+    Replicate internally) and uses the attention layer's local RoPE cache.
 
     Callers that have additional attention sub-state (e.g. ``qk_norm``,
     ``sinks``) set those after calling this helper.
@@ -179,10 +173,10 @@ def set_gqa_attention_sharding(attention_cfg, *, enable_sp: bool) -> None:
     )
     attention_cfg.sharding_config = ShardingConfig(
         in_src_shardings={
-            "x": attn_x_layout,
+            "x_BLD": attn_x_layout,
         },
         in_dst_shardings={
-            "x": dense_activation_placement(tp=spmd.R),
+            "x_BLD": dense_activation_placement(tp=spmd.R),
         },
     )
     if attention_cfg.rope is not None:


### PR DESCRIPTION
## Summary

`set_gqa_attention_sharding` keyed the attention input redistribution under
`"x"`, but #3443 renamed `GQAttention.forward`'s first parameter to `x_BLD`.
The redistribution engine looks up `in_src`/`in_dst` by the actual forward
parameter name, so the lookup missed and the "gather x to Replicate on TP"
silently no-op'd. Under sequence parallelism the activation reached the QKV
projection still `Shard(1)`, which the fused path rejected:

```
ValueError: FusedQKVLinear.x: input DTensor has placements (Shard(dim=1),),
but in_src_shardings expects (Replicate(),).
```

## Changes

- Key the GQAttention input redistribution under `x_BLD` so the gather runs.
- Drop the now-redundant `FusedQKVLinear` wrapper config (its `in_dst` was a
  no-op and its tuple `out_src` does nothing in default/full_dtensor and
  raises under spmd_types); the fused branch now matches the non-fused one.
