### PR TITLE
[graph_trainer] Apply full inductor fuse regions

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -14,6 +14,7 @@ regional_inductor.
 from __future__ import annotations
 
 import torch
+from torch._inductor.fx_passes.fuse_regions import FUSE_REGION
 from torch.fx.passes.regional_inductor import regional_inductor
 
 from torchtitan.tools.logging import logger
@@ -212,6 +213,20 @@ def _migrate_cpu_get_attrs_to_cuda(gm: torch.fx.GraphModule) -> None:
                 _assign_attr(attr.cuda(), module, node.target)
 
 
+def _strip_nested_fuse_region_metadata(gm: torch.fx.GraphModule) -> None:
+    for module in gm.modules():
+        if module is gm or not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in module.graph.nodes:
+            custom = node.meta.get("custom")
+            if not isinstance(custom, dict):
+                continue
+            custom.pop(FUSE_REGION, None)
+            compile_with_inductor = custom.get("compile_with_inductor")
+            if isinstance(compile_with_inductor, dict):
+                compile_with_inductor.pop(FUSE_REGION, None)
+
+
 def full_inductor_compilation_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple
 ) -> torch.fx.GraphModule:
@@ -243,6 +258,12 @@ def full_inductor_compilation_pass(
         gm, skip_flex_attention_check=True
     )
 
+    full_inductor_configs = {
+        # Keep large fuse-region boundary buffers near their next consumer.
+        "size_threshold_for_succ_based_strategy": 1,
+    }
+
+    _strip_nested_fuse_region_metadata(gm)
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():
         if not isinstance(module, torch.fx.GraphModule):
@@ -250,13 +271,13 @@ def full_inductor_compilation_pass(
         for node in module.graph.nodes:
             if node.op in ("placeholder", "output"):
                 continue
-            node.meta.setdefault("custom", {}).setdefault(
-                "compile_with_inductor", {"inductor_configs": {}}
-            )
-    # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
-    # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
-    # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.
-    with ic.patch(reorder_for_peak_memory=True):
+            custom = node.meta.setdefault("custom", {})
+            compile_annotation = {"inductor_configs": full_inductor_configs}
+            region = custom.get(FUSE_REGION)
+            if isinstance(region, str):
+                compile_annotation[FUSE_REGION] = region
+            custom["compile_with_inductor"] = compile_annotation
+    with ic.patch(full_inductor_configs):
         result = regional_inductor_pass(gm, example_inputs)
 
     # Carry the pre-collapse cudagraph verdict forward via gm.meta. The

--- a/torchtitan/experiments/graph_trainer/tests/test_performance_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_performance_passes.py
@@ -5,10 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
+from unittest.mock import patch
 
 import torch
+from torch._inductor.fx_passes.fuse_regions import FUSE_REGION
 from torch.testing._internal.common_utils import TestCase
 
+from torchtitan.experiments.graph_trainer.inductor_passes import (
+    full_inductor_compilation_pass,
+)
 from torchtitan.experiments.graph_trainer.performance_passes import (
     annotate_rmsnorm_for_regional_inductor_pass,
 )
@@ -118,6 +123,36 @@ class TestAnnotateRMSNormForRegionalInductorPass(TestCase):
             annotation = node.meta.get("custom", {}).get("compile_with_inductor")
             if annotation is not None:
                 self.assertEqual(annotation["inductor_configs"], config)
+
+
+class TestFullInductorCompilationPass(TestCase):
+    def test_preserves_fuse_region_metadata(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, args=(x, x))
+        graph.output(add)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        add.meta["custom"] = {FUSE_REGION: "source_region"}
+
+        with (
+            patch(
+                "torchtitan.experiments.graph_trainer.cudagraph.is_cudagraph_compatible",
+                return_value=True,
+            ),
+            patch(
+                "torchtitan.experiments.graph_trainer.inductor_passes.regional_inductor_pass",
+                side_effect=lambda gm, example_inputs: gm,
+            ),
+        ):
+            result = full_inductor_compilation_pass(gm, ())
+
+        annotation = add.meta["custom"]["compile_with_inductor"]
+        self.assertEqual(annotation[FUSE_REGION], "source_region")
+        self.assertEqual(
+            annotation["inductor_configs"],
+            {"size_threshold_for_succ_based_strategy": 1},
+        )
+        self.assertTrue(result.meta["cudagraph_compatible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
GraphTrainer full-Inductor compilation collapses the traced graph into one Inductor compile. That removes the graph-break-like scheduling shape that the compile baseline gets for source-level regions, so source annotations are preserved through compile_with_inductor and left for Inductor's default post-grad fuse-region pass to materialize.

The TorchTitan side is now source driven and intentionally small. It preserves explicit FUSE_REGION annotations when tagging nodes for full Inductor, strips inherited fuse-region metadata from nested GraphModules before tagging compile_with_inductor, and avoids owning grouping or mark_fuse_region mechanics locally.

The full-Inductor application also sets size_threshold_for_succ_based_strategy=1. Once fuse regions recreate the compile-like boundaries, successor-based memory ordering keeps large boundary buffers moving to their next consumer instead of extending lifetimes through local LPMF choices.

Draft of integration Draft for inductor :) :

https://github.com/pytorch/pytorch/pull/187675

Authored with assistance from Codex (AI assistant).