### PR TITLE
Add OLMo-3-style MoE config and Dolma3 Dolmino open dataset

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -1,5 +1,6 @@
 torchdata >= 0.8.0
 datasets >= 3.6.0, < 4.8.0
+zstandard  # decompress the Dolmino .jsonl.zst shards when streaming from the Hub
 tensorboard
 wandb
 tyro >= 1.0.5

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import partial
@@ -34,6 +35,26 @@ def _process_c4_text(sample: dict[str, Any]) -> str:
     return sample["text"]
 
 
+def _load_dolmino_dataset(dataset_path: str):
+    """Load the Dolma3 Dolmino mix (allenai/dolma3_dolmino_mix-100B-1025).
+
+    Reads a local directory of parquet shards when ``dataset_path`` is a
+    directory (offline use); otherwise streams the full mix (the ``default``
+    config) from the Hugging Face Hub. The Hub shards are .jsonl.zst, so the
+    Hub path needs the ``zstandard`` package (see requirements.txt).
+    """
+    if os.path.isdir(dataset_path):
+        return load_dataset(
+            "parquet", data_dir=dataset_path, split="train", streaming=True
+        )
+    return load_dataset(dataset_path, split="train", streaming=True)
+
+
+def _process_dolmino_text(sample: dict[str, Any]) -> str:
+    """Process a Dolmino sample: the document text lives in the 'text' column."""
+    return sample["text"]
+
+
 # Add your dataset here - more information at docs/datasets.md
 DATASETS = {
     "c4": DatasetConfig(
@@ -50,6 +71,13 @@ DATASETS = {
         path="allenai/c4",
         loader=partial(_load_c4_dataset, split="validation"),
         sample_processor=_process_c4_text,
+    ),
+    # OLMo-3's stage-2 annealing mix (fully open data). Streams from the Hub by
+    # default; pass --dataloader.dataset_path to read a local parquet copy.
+    "dolmino": DatasetConfig(
+        path="allenai/dolma3_dolmino_mix-100B-1025",
+        loader=_load_dolmino_dataset,
+        sample_processor=_process_dolmino_text,
     ),
 }
 

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -140,11 +140,28 @@ def _build_qwen3_moe_layers(
     moe_comm_backend: str,
     non_blocking_capacity_factor: float | None = None,
     rope: RoPE.Config,
+    shared_expert_hidden_dim: int | None = None,
+    use_qk_norm: bool = True,
 ) -> list[TransformerBlock.Config]:
-    """Build per-layer configs for MoE Qwen3 models with depth-scaled inits."""
+    """Build per-layer configs for MoE Qwen3 models with depth-scaled inits.
+
+    ``shared_expert_hidden_dim`` adds an always-on shared expert (a dense
+    SwiGLU FFN of that intermediate size) alongside the routed experts, as in
+    DeepSeek-V3 / OLMo-3 style MoE; stock Qwen3-MoE has no shared expert so it
+    defaults to None. ``use_qk_norm`` toggles per-head QK RMSNorm (Qwen3 uses
+    it; OLMo-3 style softmax attention does not).
+    """
     inner_attention = get_attention_config(attn_backend)
     layers = []
     for layer_id in range(n_layers):
+        shared_experts = None
+        if shared_expert_hidden_dim is not None:
+            shared_experts = make_ffn_config(
+                dim=dim,
+                hidden_dim=shared_expert_hidden_dim,
+                w1_param_init=_LINEAR_INIT,
+                w2w3_param_init=_depth_init(layer_id),
+            )
         layers.append(
             Qwen3TransformerBlock.Config(
                 attention_norm=_qwen3_norm(dim),
@@ -158,7 +175,7 @@ def _build_qwen3_moe_layers(
                     wo_param_init=_depth_init(layer_id),
                     inner_attention=inner_attention,
                     rope=rope,
-                    qk_norm=_qwen3_norm(head_dim),
+                    qk_norm=_qwen3_norm(head_dim) if use_qk_norm else None,
                 ),
                 moe=make_moe_config(
                     num_experts=num_experts,
@@ -179,6 +196,7 @@ def _build_qwen3_moe_layers(
                         comm_backend=moe_comm_backend,
                         non_blocking_capacity_factor=non_blocking_capacity_factor,
                     ),
+                    shared_experts=shared_experts,
                 ),
             )
         )
@@ -596,6 +614,64 @@ def _235b_a22b(
     )
 
 
+def _olmo3_moe_7b_a1b(
+    attn_backend: str,
+    moe_comm_backend: str = "standard",
+) -> Qwen3Model.Config:
+    """OLMo-3 style fine-grained MoE: ~6.9B total / ~1.1B active params.
+
+    A sparse MoE counterpart to AllenAI's open OLMo-3 1025 family, trained on
+    the OLMo-3 tokenizer + Dolma3 Dolmino data. dim 1536, 40 layers, plain MHA
+    (24 query heads == 24 kv heads, head_dim 64), an MoE block in every layer
+    with 128 routed experts (per-expert hidden 256), top-8 routing, plus one
+    always-on shared expert (hidden 1024). Shares the OLMo-3 family conventions
+    cross-checked against allenai/Olmo-3-1025-7B: vocab 100278, RMSNorm eps
+    1e-6, RoPE theta 500000, no attention bias, untied embeddings.
+
+    Built from torchtitan's shared Qwen3 MoE components, so it uses pre-norm and
+    omits two features of the released *dense* Olmo3ForCausalLM that don't affect
+    this training stage: OLMo-2/3 reordered post-norm + whole-projection QK-norm,
+    and the sliding/full attention interleave (sliding_window 4096 == seq_len
+    here, so attention is full either way).
+    """
+    dim = 1536
+    head_dim = 64
+    n_layers = 40
+    vocab_size = 100278
+    return Qwen3Model.Config(
+        vocab_size=vocab_size,
+        dim=dim,
+        norm=_qwen3_norm(dim),
+        tok_embeddings=Embedding.Config(
+            num_embeddings=vocab_size, embedding_dim=dim, param_init=_EMBEDDING_INIT
+        ),
+        lm_head=Linear.Config(
+            in_features=dim,
+            out_features=vocab_size,
+            param_init=_output_linear_init(dim),
+        ),
+        layers=_build_qwen3_moe_layers(
+            n_layers=n_layers,
+            dim=dim,
+            n_heads=24,
+            n_kv_heads=24,
+            head_dim=head_dim,
+            moe_hidden_dim=256,
+            num_experts=128,
+            top_k=8,
+            shared_expert_hidden_dim=1024,
+            use_qk_norm=False,
+            attn_backend=attn_backend,
+            rope=CosSinRoPE.Config(
+                dim=head_dim,
+                max_seq_len=4096,
+                theta=500000.0,
+            ),
+            moe_comm_backend=moe_comm_backend,
+        ),
+    )
+
+
 qwen3_configs = {
     "debugmodel": _debugmodel,
     "debugmodel_fused_qkv": _debugmodel_fused_qkv,
@@ -608,6 +684,7 @@ qwen3_configs = {
     "debugmodel_moe": _debugmodel_moe,
     "30B-A3B": _30b_a3b,
     "235B-A22B": _235b_a22b,
+    "olmo3-7B-A1B": _olmo3_moe_7b_a1b,
 }
 
 

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -221,6 +221,51 @@ def qwen3_30b_a3b() -> Trainer.Config:
     )
 
 
+def olmo3_7b_a1b() -> Trainer.Config:
+    """OLMo-3 style ~6.9B-total / ~1.1B-active MoE on the Dolma3 Dolmino mix.
+
+    Trains an OLMo-3-style MoE (see ``_olmo3_moe_7b_a1b``) on the fully open
+    ``allenai/dolma3_dolmino_mix-100B-1025`` data with the OLMo-3 tokenizer,
+    using torchtitan's shared Qwen3 MoE components. Pure FSDP/ZeRO-3, bf16,
+    local batch 6 x seq 4096. Enable ``--compile.enable``, and set
+    ``--parallelism.expert_parallel_degree > 1`` at scale so the large expert
+    weights are sharded across ranks instead of all-gathered every step.
+
+    Stage the OLMo-3 tokenizer once with
+    ``scripts/download_hf_assets.py --repo_id allenai/OLMo-3-1025-7B
+    --assets tokenizer --local_dir ./assets/hf`` (it lands at the default
+    ``hf_assets_path`` below).
+    """
+    return Trainer.Config(
+        loss=ChunkedCELoss.Config(),
+        hf_assets_path="./assets/hf/OLMo-3-1025-7B",
+        model_spec=model_registry("olmo3-7B-A1B"),
+        dataloader=HuggingFaceTextDataLoader.Config(dataset="dolmino"),
+        optimizer=default_adamw(lr=3e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=200,
+            decay_type="cosine",
+            min_lr_factor=0.1,
+        ),
+        training=TrainingConfig(
+            local_batch_size=6,
+            seq_len=4096,
+            steps=1000,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=-1,
+            tensor_parallel_degree=1,
+            expert_parallel_degree=1,
+            context_parallel_degree=1,
+            pipeline_parallel_degree=1,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=500,
+            last_save_model_only=False,
+        ),
+    )
+
+
 def qwen3_32b() -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),


### PR DESCRIPTION
## What & why

OLMo-3 (AllenAI) is one of the few **fully open** frontier LM families: open
weights, the **open Dolma 3 training data**, and the open training recipe. That
makes it uniquely valuable for reproducible research, but torchtitan today has
no OLMo arch and none of the Dolma data registered.

This PR makes it turnkey to **pretrain an OLMo-3-style MoE on public data** in
torchtitan:

- **`dolmino` dataset** (`allenai/dolma3_dolmino_mix-100B-1025`, OLMo-3's stage-2
  annealing mix) registered in `hf_datasets/text_datasets.py`. Streams the full
  mix (the `default` config) from the Hub, or reads a local parquet dir for
  offline clusters. The Hub shards are `.jsonl.zst`, so `zstandard` is added to
  requirements.
- **`olmo3-7B-A1B` model flavor** (~6.9B total / ~1.1B active): dim 1536, 40
  layers, plain MHA (24 heads, head_dim 64), 128 routed experts top-8 + 1 shared
  expert. It **reuses the shared Qwen3 MoE components** rather than adding a new
  model: `_build_qwen3_moe_layers` gains an optional `shared_expert_hidden_dim`
  and a `use_qk_norm` toggle, with defaults that leave the existing
  `debugmodel_moe` / `30B-A3B` / `235B-A22B` callers byte-for-byte unchanged.
- **`olmo3_7b_a1b` config** (`config_registry.py`): pure FSDP/ZeRO-3, bf16,
  local batch 6 x seq 4096, recipe lr 3e-4 cosine.

### Architecture fidelity

Cross-checked against `allenai/Olmo-3-1025-7B`: matches the OLMo-3 family
conventions (vocab 100278, RMSNorm eps 1e-6, RoPE theta 500000, no attention
bias, untied embeddings). There is **no released OLMo-3 MoE** (all released
OLMo-3 models are dense), so this flavor is a sparse counterpart following the
OLMo-3 recipe. Built on the Qwen3 MoE block, it uses pre-norm and omits the
released *dense* `Olmo3ForCausalLM`'s reordered post-norm, whole-projection
QK-norm, and sliding/full attention interleave -- none of which affect
seq-4096 training (sliding_window 4096 == seq_len).

## Results (8/16/32x H100, FSDP/ZeRO-3 + torch.compile, bf16)

| GPUs | tps/device | MFU | tokens/day |
|------|-----------:|----:|-----------:|
| 8  (1 node) | 25,227 | 24.6% | 17.4 B |
| 16 (2 node) | 24,880 | 24.3% | 34.4 B |
| 32 (4 node) | 23,821 | 23.3% | 65.9 B |

Near-linear FSDP scaling (98.6% per-device efficiency at 16 GPU, 94.4% at 32).
Loss decreases cleanly. 9.654 GFLOP/token.

## Analysis: the MoE dispatch is still a bottleneck

A one-step profiler trace (GPU kernel self-time) shows where the ~24% MFU goes:

| Category | % GPU time |
|----------|-----------:|
| GEMM (MoE experts + q/k/v/o proj) | 38.2% |
| FSDP comm (ReduceScatter + AllGather) | 27.4% |
| **MoE token-dispatch (gather / scatter / index_put)** | **15.5%** |
| elementwise / norm | 13.5% |
| attention (flash scores) | **3.7%** |

Two takeaways:

1. **Attention is not the bottleneck.** `flex`, `varlen` (FA3), and `flex_flash`
   (FA4/CUTE) all give identical MFU -- attention scores are only 3.7% of
   wall-clock despite being ~55% of the FLOP count.
2. **MoE dispatch is still a bottleneck.** torchtitan computes experts with
   `torch._grouped_mm` but the token routing (permute / gather / `scatter_add` /
   `index_put`) is **unfused** -- 15.5% of GPU time at zero FLOPs. A fused MoE
   kernel (sonicMoE / scatterMoE style) would reclaim most of it. Separately,
   under `expert_parallel_degree=1` the large expert weights are all-gathered by
   FSDP every step (much of the 27% comm); enabling expert parallelism trades
   that for a much smaller token all-to-all.

## Test plan

- `model_registry("olmo3-7B-A1B")` builds: 6.922B params, 9.654 GFLOP/token.
- `olmo3_7b_a1b()` builds; `dolmino` streams the full mix from the Hub and reads
  a local parquet dir.
- End-to-end training verified on 1/2/4 nodes (8/16/32x H100) above.
- `pre-commit` (ufmt / flake8 / codespell / pydoclint / license) passes on the
  changed files; existing MoE callers unaffected.
