### PR TITLE
[muon] flexshard based muon with ep support

### DIFF
--- a/torchtitan/experiments/flex_shard/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/config_registry.py
@@ -5,7 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.components.loss import CrossEntropyLoss
-from torchtitan.config import ParallelismConfig
+from torchtitan.components.optimizer import default_adamw, ParamGroupConfig
+from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.experiments.flex_shard.muon import (
+    BenchInstrumentedOptimizers,
+    FlexShardGatherMuonOptimizers,
+    FlexShardMuonOptimizers,
+    FSDP2MuonOptimizers,
+)
+from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
     deepseek_v3_debugmodel,
@@ -13,8 +21,14 @@ from torchtitan.models.deepseek_v3.config_registry import (
 from torchtitan.trainer import Trainer
 
 from . import model_registry
+from .parallelize import make_gather_muon_parallelize_fn, parallelize_deepseekv3_muon
 
 
+# =====================================================================================
+# Plain FlexShard debug configs (no Muon) -- the existing FlexShard surface. These keep
+# the model registry's default parallelize_fn (``parallelize_deepseekv3``); the Muon
+# configs below opt in by setting ``model_spec.parallelize_fn`` explicitly.
+# =====================================================================================
 def flex_shard_deepseek_v3_debugmodel() -> Trainer.Config:
     config = deepseek_v3_debugmodel()
     config.model_spec = model_registry("debugmodel")
@@ -44,4 +58,337 @@ def flex_shard_deepseek_v3_16b_dp8() -> Trainer.Config:
     config.parallelism.expert_parallel_degree = 1
     config.activation_checkpoint.mode = "none"
     config.compile.enable = False
+    return config
+
+
+def _muon_optimizer(
+    *, muon_lr: float = 0.02, adamw_lr: float = 8e-4
+) -> FlexShardMuonOptimizers.Config:
+    """Full Muon: owned 2D dense -> Muon, 3D MoE experts -> GroupedMuon / GatherGroupedMuon,
+    everything else (norms, embeddings, LM head) -> AdamW.
+
+    Routing is by FlexShard placement (see :class:`FlexShardMuonOptimizers`), so the
+    ``pattern`` fields are placeholders. On a dense model (no 3D experts) this reduces to
+    dense Muon + AdamW. The ``_grouped_muon_optimizer`` below is the same recipe plus the
+    optional MuonClip QK-clip (``qk_clip_tau``).
+    """
+    return FlexShardMuonOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern="<owned 2D matrices>",
+                optimizer_name="Muon",
+                optimizer_kwargs={
+                    "lr": muon_lr,
+                    "weight_decay": 0.1,
+                    "momentum": 0.95,
+                    "nesterov": True,
+                },
+            ),
+            ParamGroupConfig(
+                pattern="<rest>",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": adamw_lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
+        ],
+        implementation="foreach",
+    )
+
+
+def flex_shard_deepseek_v3_debugmodel_muon() -> Trainer.Config:
+    """DeepSeek V3 debug model trained with FlexShard + communication-efficient Muon.
+
+    Keeps the core debug parallelism (``dp_shard`` inferred from world size,
+    ``dp_replicate=1``, ``expert_parallel_degree=1``). With ``ep=1`` FlexShard
+    shards the experts itself on the dp mesh (gathered for compute -- not true EP;
+    fine for the debug model). See ``..._ep2`` for real expert parallelism.
+
+    **Run with NGPU <= 6** (the debug model has 6 layers; comm-efficient ``Owned``
+    requires ``dp_shard <= num_layers`` so every dp rank owns a layer). No HSDP /
+    TP / PP.
+    """
+    config = deepseek_v3_debugmodel()
+    config.model_spec = model_registry("debugmodel")
+    # Opt in to comm-efficient Muon: the registry default is plain FlexShard
+    # (parallelize_deepseekv3), so set the Muon parallelizer explicitly here.
+    config.model_spec.parallelize_fn = parallelize_deepseekv3_muon
+    config.optimizer = _muon_optimizer()
+    # Activation checkpointing is disabled: AC recompute does not yet compose with
+    # FlexShard's Owned broadcast + FlexAttention's compiled HOP (the reshard-after-
+    # forward recompute path errors on the compiled op). Re-enabling AC is future work.
+    config.activation_checkpoint = None
+    # Leave parallelism at the core debug default: dp_shard=-1 (inferred = NGPU),
+    # dp_replicate=1, expert_parallel_degree=1.
+    return config
+
+
+def flex_shard_deepseek_v3_debugmodel_muon_ep2() -> Trainer.Config:
+    """Real expert parallelism: experts permanently partitioned across ``ep=2``.
+
+    The experts keep their EP partition (DTensor), are unwrapped to each rank's
+    local EP shard, and FlexShard then FSDP-shards that within the EP group; dense
+    weights run comm-efficient Muon on the dp mesh. ``ep`` must divide ``dp_shard`` and
+    ``dp_shard <= num_layers (6)``, so e.g. **run with NGPU=4** (-> dp_shard=4,
+    ep=2, efsdp=2).
+    """
+    config = flex_shard_deepseek_v3_debugmodel_muon()
+    config.parallelism = ParallelismConfig(expert_parallel_degree=2)
+    return config
+
+
+def flex_shard_deepseek_v3_debugmodel_adamw() -> Trainer.Config:
+    """AdamW baseline for comparison against the comm-efficient Muon config.
+
+    Identical model / FlexShard sharding / AC-off / parallelism to
+    ``flex_shard_deepseek_v3_debugmodel_muon`` -- only the optimizer differs: every
+    parameter is optimized by AdamW (``default_adamw``) instead of routing 2D
+    matrices to Muon. AdamW on ``Owned`` params is still comm-efficient (the owner holds
+    the full param + averaged grad; empty shards on other ranks are no-ops), and is
+    numerically standard AdamW, so it is a clean optimizer-only baseline.
+    """
+    config = flex_shard_deepseek_v3_debugmodel_muon()
+    config.optimizer = default_adamw(lr=8e-4)
+    return config
+
+
+def _gather_muon_optimizer(
+    *, muon_lr: float = 0.02, adamw_lr: float = 8e-4
+) -> FlexShardGatherMuonOptimizers.Config:
+    """Full Muon, gather dense distribution: sharded 2D dense -> GatherMuon, 3D experts ->
+    GroupedMuon / GatherGroupedMuon, everything else -> AdamW."""
+    return FlexShardGatherMuonOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern="<sharded 2D matrices>",
+                optimizer_name="Muon",
+                optimizer_kwargs={
+                    "lr": muon_lr,
+                    "weight_decay": 0.1,
+                    "momentum": 0.95,
+                    "nesterov": True,
+                },
+            ),
+            ParamGroupConfig(
+                pattern="<rest>",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": adamw_lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
+        ],
+        implementation="foreach",
+    )
+
+
+def flex_shard_deepseek_v3_debugmodel_gather_muon_shard() -> Trainer.Config:
+    """Gather-for-NS Muon baseline: dense 2D matrices use plain FSDP ``Shard(0)``.
+
+    Same model / AC-off as the comm-efficient Muon config, but dense matrices are
+    row-sharded and the optimizer all-gathers each matrix before Newton-Schulz (1
+    all-gather/bucket + redundant NS). Unlike comm-efficient ``Owned`` there is no
+    ``num_layers >= dp_shard`` limit (sharding is within-tensor). Compare against
+    ``flex_shard_deepseek_v3_debugmodel_muon`` to measure comm-efficient vs gather.
+    """
+    config = flex_shard_deepseek_v3_debugmodel_muon()
+    config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("shard")
+    config.optimizer = _gather_muon_optimizer()
+    return config
+
+
+def flex_shard_deepseek_v3_debugmodel_gather_muon_grouped() -> Trainer.Config:
+    """Gather-for-NS Muon baseline: dense 2D matrices use byte-perfect ``GroupedRaggedShard``.
+
+    Like ``..._gather_muon_shard`` but each layer's 2D matrices are packed into one
+    byte-balanced ``GroupedRaggedShard`` bucket (cut crosses matrix boundaries), so
+    every rank holds exactly ``1/world_size`` of the layer's matrices.
+    """
+    config = flex_shard_deepseek_v3_debugmodel_gather_muon_shard()
+    config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("grouped")
+    return config
+
+
+# =====================================================================================
+# DeepSeek V3 16B: owned + comm-efficient Muon, whole-layer placement, single-node
+# (8x95GB). dsv3-16B is 27 layers and runs on <= 27 ranks single-node (world_size <=
+# num_layers), so each rank owns whole layers (one Owned bucket per layer). Full Muon recipe:
+# dense 2D -> Muon, experts -> GroupedMuon, embeddings/lm_head/norms -> AdamW. Two EP regimes:
+# ep=1 ("flex_shard 1d") and ep=8 (+EP). (Finer per-matrix / two-level placements only differ
+# from whole-layer when world_size > num_layers, which this single-node regime is not.)
+# =====================================================================================
+def _grouped_muon_optimizer(
+    *, muon_lr: float = 0.005, adamw_lr: float = 2e-4, qk_clip_tau: float | None = None
+) -> FlexShardMuonOptimizers.Config:
+    """Full Muon recipe: owned 2D dense -> Muon, 3D experts -> GroupedMuon, rest -> AdamW.
+
+    ``qk_clip_tau`` (optional) enables MuonClip's QK-clip (Kimi K2) after each step.
+    """
+    base = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    return FlexShardMuonOptimizers.Config(
+        param_groups=base.param_groups,
+        implementation=base.implementation,
+        qk_clip_tau=qk_clip_tau,
+    )
+
+
+def _flex_shard_dsv3_16b(
+    *,
+    expert_parallel_degree: int = 8,
+    muon_lr: float = 0.005,
+    adamw_lr: float = 2e-4,
+    qk_clip_tau: float | None = None,
+) -> Trainer.Config:
+    """Build a DeepSeek V3 16B FlexShard + comm-efficient Muon config (whole-layer Owned).
+
+    Full Muon recipe: dense 2D -> Muon, 3D experts -> GroupedMuon, rest -> AdamW, with
+    optional ``qk_clip_tau`` for MuonClip. Whole-layer Owned placement: one Owned bucket per
+    layer (27 layers >= the single-node world_size, so each rank owns whole layers).
+    Test-friendly: bs=1 / seq=2048, c4_test + test tokenizer, AC off, eager (no compile), no PP.
+    """
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry("16B")
+    config.model_spec.parallelize_fn = parallelize_deepseekv3_muon
+    # eager + AC off (FlexShard Owned is eager-only; AC/compile do not compose yet).
+    config.activation_checkpoint = None
+    config.compile = CompileConfig(enable=False)
+    # 1D FSDP (+ optional EP); strip the 16B default's PP schedule.
+    config.parallelism = ParallelismConfig(
+        expert_parallel_degree=expert_parallel_degree
+    )
+    config.dataloader = HuggingFaceTextDataLoader.Config(dataset="c4_test")
+    config.hf_assets_path = "./tests/assets/tokenizer"
+    config.training = TrainingConfig(local_batch_size=1, seq_len=2048, steps=10)
+
+    config.optimizer = _grouped_muon_optimizer(
+        muon_lr=muon_lr, adamw_lr=adamw_lr, qk_clip_tau=qk_clip_tau
+    )
+    return config
+
+
+# Full Muon (experts -> GroupedMuon), whole-layer Owned. ep=8 (+EP) and ep=1 (flex_shard 1d).
+def flex_shard_deepseek_v3_16b_muon_grouped() -> Trainer.Config:
+    return _flex_shard_dsv3_16b(expert_parallel_degree=8)
+
+
+# Full MuonClip recipe: full Muon (grouped experts) + QK-clip (Kimi K2, tau=100).
+def flex_shard_deepseek_v3_16b_muonclip() -> Trainer.Config:
+    return _flex_shard_dsv3_16b(expert_parallel_degree=8, qk_clip_tau=100.0)
+
+
+def flex_shard_deepseek_v3_16b_muon_grouped_1d() -> Trainer.Config:
+    return _flex_shard_dsv3_16b(expert_parallel_degree=1)
+
+
+# =====================================================================================
+# DeepSeek V3 16B: MuonClip across the 4 distribution strategies. Full Muon + QK-clip in 3
+# dense distributions -- Owned (comm-efficient), gather_shard (Shard(0)), gather_grouped
+# (GroupedRaggedShard) -- plus fsdp2 + AdamW as the production reference. All ep=8, AC off,
+# eager, c4_test; sweep batch via --training.local_batch_size.
+# =====================================================================================
+def _dsv3_16b_test_base(*, expert_parallel_degree: int = 8) -> Trainer.Config:
+    """core deepseek_v3_16b + shared test settings (AC off, eager, EP, c4_test).
+
+    Keeps the CORE ``model_spec`` (``fully_shard`` parallelize); the FlexShard configs
+    (Owned / gather) override ``model_spec`` with the flex_shard wrapper themselves.
+    """
+    config = deepseek_v3_16b()
+    config.activation_checkpoint = None
+    config.compile = CompileConfig(enable=False)
+    config.parallelism = ParallelismConfig(
+        expert_parallel_degree=expert_parallel_degree
+    )
+    config.dataloader = HuggingFaceTextDataLoader.Config(dataset="c4_test")
+    config.hf_assets_path = "./tests/assets/tokenizer"
+    config.training = TrainingConfig(local_batch_size=1, seq_len=2048, steps=10)
+    return config
+
+
+def _gather_grouped_muon_optimizer(
+    *, muon_lr: float = 0.005, adamw_lr: float = 2e-4, qk_clip_tau: float | None = None
+) -> FlexShardGatherMuonOptimizers.Config:
+    """Gather full Muon: GatherMuon (sharded 2D dense) + GroupedMuon (experts) + AdamW; +QK-clip.
+
+    Same container as the plain gather optimizer (gather is now always full Muon -- experts
+    -> GroupedMuon / GatherGroupedMuon); this builder just adds the MuonClip ``qk_clip_tau``.
+    """
+    base = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    return FlexShardGatherMuonOptimizers.Config(
+        param_groups=base.param_groups,
+        implementation=base.implementation,
+        qk_clip_tau=qk_clip_tau,
+    )
+
+
+def flex_shard_deepseek_v3_16b_gather_shard_muonclip() -> Trainer.Config:
+    """gather_shard MuonClip: dense 2D -> Shard(0) GatherMuon, experts -> GroupedMuon, +QK-clip."""
+    config = _dsv3_16b_test_base()
+    config.model_spec = model_registry("16B")
+    config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("shard")
+    config.optimizer = _gather_grouped_muon_optimizer(qk_clip_tau=100.0)
+    return config
+
+
+def flex_shard_deepseek_v3_16b_gather_grouped_muonclip() -> Trainer.Config:
+    """gather_grouped MuonClip: dense 2D -> GroupedRaggedShard GatherMuon, experts -> GroupedMuon, +QK-clip."""
+    config = _dsv3_16b_test_base()
+    config.model_spec = model_registry("16B")
+    config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("grouped")
+    config.optimizer = _gather_grouped_muon_optimizer(qk_clip_tau=100.0)
+    return config
+
+
+def flex_shard_deepseek_v3_16b_fsdp2_adamw() -> Trainer.Config:
+    """fsdp2 + AdamW production reference (core fully_shard, no Muon / QK-clip).
+
+    Uses :class:`BenchInstrumentedOptimizers` (the stock AdamW container + the
+    ``[muon-bench]`` instrumentation) so its total_iter / opt_step / comm are reported
+    on the same axes as the Muon methods.
+    """
+    config = _dsv3_16b_test_base()
+    da = default_adamw(lr=2e-4)
+    config.optimizer = BenchInstrumentedOptimizers.Config(
+        param_groups=da.param_groups,
+        implementation=da.implementation,
+    )
+    return config
+
+
+# =====================================================================================
+# DeepSeek V3 16B: fsdp2 baseline -- core fully_shard (DTensor Shard(0)) + Muon
+# that lets DTensor do the all-gather in opt.step (vs comm-efficient Owned). Same full-Muon
+# recipe as Owned/gather: dense 2D + 3D experts -> DTensorMuon (single / batched NS),
+# everything else -> AdamW.
+# =====================================================================================
+def _fsdp2_muon_optimizer(
+    *, muon_lr: float = 0.005, adamw_lr: float = 2e-4
+) -> FSDP2MuonOptimizers.Config:
+    """DTensorMuon on dense 2D body matrices + 3D experts, AdamW on the rest (core fully_shard)."""
+    base = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    return FSDP2MuonOptimizers.Config(
+        param_groups=base.param_groups,
+        implementation=base.implementation,
+    )
+
+
+def flex_shard_deepseek_v3_16b_fsdp2_muon() -> Trainer.Config:
+    """fsdp2 Shard(0) + DTensor-all-gather Muon baseline for dsv3-16B (vs comm-efficient Owned).
+
+    Keeps the core ``deepseek_v3_16b`` model + ``fully_shard`` parallelize (DTensor params);
+    only the optimizer differs. Test-friendly: bs=1 / seq=2048, c4_test + test tokenizer, AC
+    off, eager (no compile), EP=8.
+    """
+    config = deepseek_v3_16b()
+    config.optimizer = _fsdp2_muon_optimizer()
+    config.activation_checkpoint = None
+    config.compile = CompileConfig(enable=False)
+    config.parallelism = ParallelismConfig(expert_parallel_degree=8)
+    config.dataloader = HuggingFaceTextDataLoader.Config(dataset="c4_test")
+    config.hf_assets_path = "./tests/assets/tokenizer"
+    config.training = TrainingConfig(local_batch_size=1, seq_len=2048, steps=10)
     return config

--- a/torchtitan/experiments/flex_shard/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/parallelize.py
@@ -4,6 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""FlexShard + communication-efficient Muon parallelizer for DeepSeek V3.
+
+A training test bed: shards DeepSeek V3 with FlexShard so the dense 2D weights run
+communication-efficient Muon (each transformer layer is one ``Owned`` bucket, owner
+balanced by Newton-Schulz FLOPs), while MoE expert stacks stay ``Shard``-ed (and
+run GroupedMuon / GatherGroupedMuon). The model-agnostic bucketing/parallelizer logic lives in
+``..muon.bucketing``; this module just binds it to DeepSeek V3 (EP-capable).
+"""
+
+from __future__ import annotations
+
 from collections.abc import Callable
 
 import torch
@@ -30,6 +41,12 @@ from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
     MixedPrecisionPolicy,
 )
 from torchtitan.experiments.flex_shard.flex_shard.placement_contract import Placement
+from torchtitan.experiments.flex_shard.muon.bucketing import (
+    build_gather_muon_buckets,
+    build_muon_buckets,
+    make_gather_muon_parallelize_fn as _make_gather_muon_parallelize_fn,
+    make_muon_parallelize_fn,
+)
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
 from torchtitan.models.llama4.parallelize import apply_moe_ep_tp
 from torchtitan.tools.logging import logger
@@ -144,9 +161,8 @@ def _placement_fn(dim: int) -> PlacementFn:
 
 
 def _is_grouped_expert_weight(fqn: str, param: nn.Parameter) -> bool:
-    return (
-        param.dim() == 3
-        and fqn.endswith((".moe.experts.w1", ".moe.experts.w2", ".moe.experts.w3"))
+    return param.dim() == 3 and fqn.endswith(
+        (".moe.experts.w1", ".moe.experts.w2", ".moe.experts.w3")
     )
 
 
@@ -176,7 +192,9 @@ def _make_expert_block_grouped_owned_segments(
     num_experts = named_params[0][1].shape[0]
     if any(param.shape[0] != num_experts for _, param in named_params):
         raise ValueError("GroupedOwned expert block requires matching expert counts.")
-    ordered_params = sorted(named_params, key=lambda item: _expert_block_order_key(item[0]))
+    ordered_params = sorted(
+        named_params, key=lambda item: _expert_block_order_key(item[0])
+    )
     segments_by_fqn: dict[str, list[GroupedOwnedSegmentSpec]] = {
         fqn: [] for fqn, _ in ordered_params
     }
@@ -291,3 +309,28 @@ def _apply_flex_shard(
     )
 
     flex_shard(model, buckets=buckets)
+
+
+# Comm-efficient Owned Muon (EP-capable: dense weights run Owned/Muon on the dp mesh,
+# MoE expert stacks Shard on the expert mesh).
+# Whole-layer allocation -- one Owned bucket per layer. dsv3-16B is 27 layers, run
+# single-node (world_size <= num_layers), so every rank owns whole layers. Finer per-matrix
+# / two-level allocations are available via ``make_muon_parallelize_fn(granularity=...)``
+# for the world_size > num_layers regimes; the dsv3 configs don't use them (on 8 GPUs both
+# would reduce to this whole-layer placement anyway).
+parallelize_deepseekv3_muon = make_muon_parallelize_fn(
+    model_name="DeepSeek V3", support_ep=True
+)
+
+
+def make_gather_muon_parallelize_fn(dense_kind: str):
+    """Gather-for-NS Muon baseline parallelize_fn for DeepSeek V3 (EP-capable)."""
+    return _make_gather_muon_parallelize_fn(dense_kind, model_name="DeepSeek V3")
+
+
+__all__ = [
+    "build_gather_muon_buckets",
+    "build_muon_buckets",
+    "make_gather_muon_parallelize_fn",
+    "parallelize_deepseekv3_muon",
+]

--- a/torchtitan/experiments/flex_shard/muon/__init__.py
+++ b/torchtitan/experiments/flex_shard/muon/__init__.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Distributed Muon + MuonClip test bed for FlexShard.
+
+Three distributed-Muon implementations for the dense 2D matrices, all bit-exact with
+single-device Muon -- they differ only in how the matrix is distributed and gathered:
+
+1. Owned Muon (the main result, communication-efficient): each whole 2D matrix lives on
+   one owner rank (``Owned`` placement), so its Newton-Schulz runs locally with **no
+   collectives in the step**. Owners are balanced across ranks by NS FLOPs.
+2. Gather Muon (baseline): each 2D matrix is sharded and all-gathered before NS, in two
+   sharding layouts -- ``Shard(0)`` (per-tensor row split) or ``GroupedRaggedShard``
+   (byte-balanced, the cut crosses matrix boundaries).
+3. fsdp2 / DTensor Muon (baseline): core ``fully_shard`` shards the matrices and DTensor
+   does the all-gather inside ``opt.step`` (``full_tensor()``).
+
+MoE expert stacks get Muon too, but only the whole-expert case is collective-free: when
+``efsdp <= num_local_experts`` (``world_size <= num_experts``) each rank holds whole
+experts (``Shard(0)``) -> ``GroupedMuon`` (local NS, no step collectives). When
+``efsdp > num_local_experts`` the experts are sharded *within* the matrix (``Shard(>=1)``)
+and **fall back to** ``GatherGroupedMuon``, which all-gathers each expert stack over the
+efsdp mesh before NS -- so in that regime the step is no longer fully collective-free (the
+dense 2D Owned Muon still is). MuonClip (Kimi K2) QK-clip (``qkclip``) layers on any
+recipe, rescaling per-head q/k rows after each step (this adds a small per-head
+``all_reduce(MAX)``) so the max attention logit stays ``<= tau``. Everything else (1D
+norms, embeddings, LM head) -> AdamW.
+
+The code is organized in three layers:
+
+| Layer | Concern | Modules |
+|---|---|---|
+| 1. Partition | tensor -> ranks (which slice each rank holds) | ``bucketing``, ``owned`` |
+| 2. Routing | placement -> optimizer (which param uses which) | ``containers`` |
+| 3. Optimizer step | the Newton-Schulz math | ``newton_schulz`` + ``{gather,grouped,dtensor}_muon`` + ``qkclip`` |
+
+Benchmarking: ``bench._BenchMixin`` (enabled by ``FLEX_SHARD_MUON_BENCH=1``) reports a
+per-step breakdown -- total_iter / opt_step / fwd_bwd and comm bytes (in-step vs fwd/bwd,
+via the ``comm_counter`` collective-byte counter) -- so the recipes above compare on the
+same axes (e.g. Owned's zero in-step comm vs the gather / DTensor all-gather cost).
+
+Built on the FlexShard engine and its ``example`` placement primitives (``Owned`` /
+``Shard`` / ``RaggedShard``); kept separate from ``example/`` so it does not collide with
+that folder's own muon. The public API is re-exported here (``from ...muon import X``).
+"""
+
+from .bench import _BenchMixin  # noqa: F401
+from .containers import (  # noqa: F401
+    _build_grouped_expert_optimizers,
+    _discover_dense_gather_buckets,
+    _discover_expert_buckets,
+    BenchInstrumentedOptimizers,
+    build_comm_efficient_muon_optimizer,
+    FlexShardGatherMuonOptimizers,
+    FlexShardMuonOptimizers,
+    FSDP2MuonOptimizers,
+)
+from .dtensor_muon import DTensorMuon  # noqa: F401
+from .gather_muon import GatherGroupedMuon, GatherMuon  # noqa: F401
+from .grouped_muon import GroupedMuon  # noqa: F401
+from .newton_schulz import (  # noqa: F401
+    _zeropower_via_newtonschulz_batched,
+    assign_layer_owners_lpt,
+    layer_newton_schulz_cost,
+    newton_schulz_flops,
+)
+from .owned import (  # noqa: F401
+    _group_params_by_layer,
+    comm_efficient_muon_buckets,
+    is_owned_2d,
+    make_owned_placement_fn,
+)
+from .qkclip import (  # noqa: F401
+    _is_mla_attention,
+    _max_logit_per_head,
+    _scale_rows,
+    QKClip,
+)

--- a/torchtitan/experiments/flex_shard/muon/bench.py
+++ b/torchtitan/experiments/flex_shard/muon/bench.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""Benchmark instrumentation mixin for the FlexShard Muon containers."""
+
+from __future__ import annotations
+
+import os
+import time
+
+import torch
+
+from torchtitan.tools.logging import logger
+
+from . import comm_counter
+
+
+class _BenchMixin:
+    """Opt-in systems instrumentation for the distributed-Muon benchmark.
+
+    Enabled by ``FLEX_SHARD_MUON_BENCH=1`` (otherwise ``step`` is the base method,
+    zero overhead). When on, each step reports the whole-lifecycle breakdown:
+
+    * ``total_iter`` -- wall-clock per iteration, measured directly as the time
+      between consecutive ``step()`` calls (the same ``perf_counter`` method the
+      trainer uses for ``time_metrics/end_to_end``); not derived from tps.
+    * ``opt_step`` -- isolated ``optimizer.step()`` GPU time (CUDA events).
+    * ``fwd_bwd`` -- ``total_iter - opt_step`` (forward + backward + overhead).
+    * ``step_comm`` / ``fwdbwd_comm`` -- comm bytes inside the step (NS all-gather
+      for the gather baselines; ~0 for ``Owned``) vs. during fwd/bwd (param unshard
+      + gradient reduce), from the comm-byte counter snapshot around the step.
+
+    ``opt_step``, ``step_comm`` and ``fwdbwd_comm`` are batch-independent (params /
+    matrices / gradients); ``total_iter``, ``fwd_bwd`` and peak memory scale with
+    batch. CUDA-event reads use the *previous* step (one-iteration lag) so they never
+    block the current iteration; the last step is unreported (negligible over a
+    >=10-step run). Peak memory and tps/mfu come from the trainer's metrics logger.
+
+    MuonClip caveat: when ``qk_clip_tau`` is set, QK-clip adds an extra per-forward
+    ``[B, H, S, S]`` attention-logit capture pass (see :func:`qkclip._max_logit_per_head`)
+    that lands in ``fwd_bwd``, and a small per-head ``all_reduce(MAX)`` plus the row
+    rescale in ``opt_step`` -> ``step_comm`` (so the step is collective-free only
+    *without* QK-clip). Both scale with QK-clip being on, not with the dense-Muon
+    strategy, so to isolate QKClip's cost compare a config against the same config with
+    ``qk_clip_tau=None`` rather than against AdamW.
+    """
+
+    def _bench_setup(self) -> None:
+        self._bench_on = os.environ.get("FLEX_SHARD_MUON_BENCH") == "1"
+        if not self._bench_on:
+            return
+        comm_counter.install()
+        comm_counter.reset()
+        self._bench_idx = 0
+        self._bench_warmup = int(os.environ.get("FLEX_SHARD_MUON_BENCH_WARMUP", "3"))
+        self._bench_last_comm = comm_counter.read()
+        self._bench_pending = None
+        self._bench_n = 0
+        self._bench_sum_iter_ms = 0.0
+        self._bench_sum_opt_ms = 0.0
+        self._bench_sum_step_mb = 0.0
+        self._bench_sum_fb_mb = 0.0
+
+    def _bench_flush(self, iter_end: float) -> None:
+        if self._bench_pending is None:
+            return
+        idx, entry_time, start, end, step_bytes, fwdbwd_bytes = self._bench_pending
+        self._bench_pending = None
+        if idx < self._bench_warmup:
+            return
+        # total_iter is measured directly (wall-clock between consecutive step()
+        # entries); opt_step is the GPU time of this step; fwd_bwd is the remainder.
+        total_iter_ms = (iter_end - entry_time) * 1e3
+        end.synchronize()  # previous step's event; already complete, ~0 wait
+        opt_ms = start.elapsed_time(end)
+        fwd_bwd_ms = total_iter_ms - opt_ms
+        step_mb = step_bytes / 1e6
+        fb_mb = fwdbwd_bytes / 1e6
+        self._bench_n += 1
+        self._bench_sum_iter_ms += total_iter_ms
+        self._bench_sum_opt_ms += opt_ms
+        self._bench_sum_step_mb += step_mb
+        self._bench_sum_fb_mb += fb_mb
+        n = self._bench_n
+        logger.info(
+            f"[muon-bench] step {idx}: total_iter={total_iter_ms:.3f} ms  "
+            f"opt_step={opt_ms:.3f} ms  fwd_bwd={fwd_bwd_ms:.3f} ms  "
+            f"step_comm={step_mb:.2f} MB  fwdbwd_comm={fb_mb:.2f} MB  | "
+            f"avg/{n}: total_iter={self._bench_sum_iter_ms / n:.3f} ms  "
+            f"opt_step={self._bench_sum_opt_ms / n:.3f} ms  "
+            f"fwd_bwd={(self._bench_sum_iter_ms - self._bench_sum_opt_ms) / n:.3f} ms  "
+            f"step_comm={self._bench_sum_step_mb / n:.2f} MB  "
+            f"fwdbwd_comm={self._bench_sum_fb_mb / n:.2f} MB"
+        )
+
+    def _post_step(self) -> None:
+        """Hook run after the wrapped optimizer step (e.g. MuonClip QK-clip).
+
+        No-op by default; Muon containers override it to apply :class:`QKClip`. Runs
+        inside the benched ``opt_step`` window so its cost is attributed to the step.
+        """
+
+    def step(self, closure=None):
+        if not hasattr(self, "_bench_on"):
+            self._bench_setup()
+        if not self._bench_on:
+            out = super().step(closure)
+            self._post_step()
+            return out
+        # Mark iteration boundary and flush the previous step (its iteration is now
+        # complete, and its CUDA events are done -> no live sync).
+        now = time.perf_counter()
+        self._bench_flush(now)
+        comm_at_entry = comm_counter.read()
+        fwdbwd_bytes = comm_at_entry - self._bench_last_comm
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        out = super().step(closure)
+        self._post_step()
+        end.record()
+        comm_at_exit = comm_counter.read()
+        self._bench_last_comm = comm_at_exit
+        self._bench_pending = (
+            self._bench_idx,
+            now,
+            start,
+            end,
+            comm_at_exit - comm_at_entry,
+            fwdbwd_bytes,
+        )
+        self._bench_idx += 1
+        return out

--- a/torchtitan/experiments/flex_shard/muon/bucketing.py
+++ b/torchtitan/experiments/flex_shard/muon/bucketing.py
@@ -1,0 +1,900 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Model-agnostic FlexShard bucket builders and parallelizers for distributed Muon.
+
+Shared by the per-model FlexShard test beds (``deepseek_v3``, ``qwen3``, ...). All
+torchtitan decoder models name the same top-level modules in
+``models/common/decoder.py`` (``tok_embeddings``, ``layers``, ``norm``,
+``lm_head``), and partition a layer's params by fully-qualified name, so the
+bucketing here is model-agnostic:
+
+- Each transformer layer's dense params form one communication-efficient ``Owned``
+  bucket on the dp mesh (Muon on the 2D matrices; the owner runs Newton-Schulz
+  locally, owners balanced by Newton-Schulz FLOPs over the layer's 2D matrices).
+- MoE expert stacks, identified by an FQN marker, form ``Shard`` buckets on the
+  expert mesh (the optimizer routes them to GroupedMuon / GatherGroupedMuon). Dense
+  models simply have none.
+- Embeddings, final norm, and the LM head are ``Shard`` buckets (AdamW).
+
+The gather-for-NS Muon baselines instead *shard* the dense 2D matrices and the
+optimizer all-gathers them before Newton-Schulz; see ``build_gather_muon_buckets``.
+
+Scope: 1D FSDP (+ optional expert parallelism for the expert stacks), eager only.
+The whole-layer ``Owned`` allocation (the default) requires ``num_layers >= dp_shard``;
+the per-matrix / two-level / auto allocations relax that to
+``num_2D_dense_matrices >= dp_shard`` so the comm-efficient path still fills every rank
+when ``num_layers < world_size``. No PP/TP/CP/HSDP/compile/offload/full_dtensor.
+"""
+
+from __future__ import annotations
+
+import heapq
+import os
+from collections.abc import Callable
+
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.config import (
+    CompileConfig,
+    ParallelismConfig,
+    TORCH_DTYPE_MAP,
+    TrainingConfig,
+)
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
+from torchtitan.experiments.flex_shard import BucketSpec, flex_shard
+from torchtitan.experiments.flex_shard.example.ragged_shard import (
+    make_grouped_ragged_placement_fn,
+)
+from torchtitan.experiments.flex_shard.example.shard import per_param_placements, Shard
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    MixedPrecisionPolicy,
+)
+from torchtitan.tools.logging import logger
+from .newton_schulz import (
+    assign_layer_owners_lpt,
+    layer_newton_schulz_cost,
+    newton_schulz_flops,
+)
+from .owned import make_owned_placement_fn
+
+
+# torchtitan decoder models name these top-level modules (models/common/decoder.py).
+_REST_PATTERNS = ("tok_embeddings.*", "norm.*", "lm_head.*")
+# MoE expert stacks (3D: [num_experts, out, in]) live under this FQN marker. They are
+# placed off the dense Owned bucket (on the EP/efsdp mesh) and run GroupedMuon /
+# GatherGroupedMuon -- not the dense per-matrix Owned Muon.
+_DEFAULT_EXPERT_MARKER = ".moe.experts."
+
+
+def shard0_placement_fn(
+    named_params: list[tuple[str, nn.Parameter]],
+    mesh: DeviceMesh,
+) -> dict[str, tuple[Shard, ...]]:
+    """Plain FSDP ``Shard(0)`` for every param (embeddings, norms, LM head)."""
+    return {fqn: (Shard(0),) for fqn, _ in named_params}
+
+
+def expert_placement_fn(
+    named_params: list[tuple[str, nn.Parameter]],
+    mesh: DeviceMesh,
+) -> dict[str, tuple[Shard, ...]]:
+    """Shard a 3D expert stack ``[E, F, D]`` across the expert mesh.
+
+    Splits the expert (leading) dim with ``Shard(0)`` when there are at least as many
+    experts as ranks (``E >= mesh.size()``), so each rank holds whole ``(F, D)`` expert
+    matrices -- the comm-efficient :class:`GroupedMuon` regime. When there are more ranks
+    than experts (``mesh.size() > E``), it falls back to ``Shard(1)``, which splits
+    *within* each matrix: every rank then holds only a ``(F/n, D)`` slice of every expert,
+    not whole matrices -- the incomplete-tensor regime that :class:`GatherGroupedMuon`
+    all-gathers before Newton-Schulz.
+    """
+    if not named_params:
+        return {}
+    num_local_experts = named_params[0][1].shape[0]
+    dim = 1 if mesh.size() > num_local_experts else 0
+    return {fqn: (Shard(dim),) for fqn, _ in named_params}
+
+
+def build_muon_buckets(
+    model: nn.Module,
+    *,
+    dp_mesh: DeviceMesh,
+    expert_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    reshard_last: bool,
+    expert_marker: str = _DEFAULT_EXPERT_MARKER,
+    allow_idle_ranks: bool = False,
+) -> list[BucketSpec]:
+    """Comm-efficient Muon buckets: dense layers ``Owned`` (Muon), experts ``Shard``.
+
+    Per transformer layer, the dense params (everything not under ``expert_marker``)
+    form one ``Owned`` bucket on ``dp_mesh`` so the owner runs Newton-Schulz locally;
+    the MoE expert stack, if any, is a separate ``Shard`` bucket on ``expert_mesh``.
+    Embeddings, final norm, and the LM head are ``Shard`` buckets (AdamW). Layer
+    owners are balanced by Newton-Schulz FLOPs over each layer's dense 2D matrices.
+
+    Dense models (no expert params) simply produce no expert buckets, and
+    ``expert_mesh`` is unused. By default requires ``num_layers >= dp_mesh.size()`` so
+    every dp rank owns a layer; ``allow_idle_ranks=True`` lifts that (LPT then leaves
+    ``world_size - num_layers`` ranks idle in the step) -- used only to *measure* the
+    whole-layer cost in the ``num_layers < world_size`` regime that per-matrix
+    ownership (:func:`build_permatrix_muon_buckets`) is meant to fix.
+    """
+    layer_ids = sorted(model.layers.keys(), key=int)
+    world_size = dp_mesh.size()
+    if len(layer_ids) < world_size and not allow_idle_ranks:
+        raise ValueError(
+            f"FlexShard Muon requires num_layers >= dp_shard, but got "
+            f"{len(layer_ids)} layers and dp_shard {world_size}. Use a smaller "
+            "data_parallel_shard_degree, a deeper model, or per-matrix ownership."
+        )
+
+    # Partition each layer's params into dense (Owned -> Muon) vs expert (Shard ->
+    # GroupedMuon) by fully-qualified name -- model-agnostic, no per-model glob patterns.
+    dense_named: dict[str, list[tuple[str, nn.Parameter]]] = {}
+    expert_fqns: dict[str, list[str]] = {}
+    for lid in layer_ids:
+        dense: list[tuple[str, nn.Parameter]] = []
+        experts: list[str] = []
+        for name, param in model.layers[lid].named_parameters():
+            fqn = f"layers.{lid}.{name}"
+            if expert_marker in fqn:
+                experts.append(fqn)
+            else:
+                dense.append((fqn, param))
+        dense_named[lid] = dense
+        expert_fqns[lid] = experts
+
+    costs = [layer_newton_schulz_cost(dense_named[lid]) for lid in layer_ids]
+    owners = assign_layer_owners_lpt(costs, world_size)
+
+    buckets: list[BucketSpec] = [
+        BucketSpec(
+            ["tok_embeddings.*"],
+            placement_fn=shard0_placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        )
+    ]
+    for lid, owner in zip(layer_ids, owners, strict=True):
+        # Dense params of this layer -> one Owned bucket (Muon for the 2D matrices).
+        buckets.append(
+            BucketSpec(
+                [fqn for fqn, _ in dense_named[lid]],
+                placement_fn=make_owned_placement_fn(owner),
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_after_forward,
+            )
+        )
+        # MoE expert stack (if this layer has one) -> Shard on the expert mesh.
+        if expert_fqns[lid]:
+            buckets.append(
+                BucketSpec(
+                    expert_fqns[lid],
+                    placement_fn=expert_placement_fn,
+                    mesh=expert_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=reshard_after_forward,
+                )
+            )
+    for pattern in ("norm.*", "lm_head.*"):
+        buckets.append(
+            BucketSpec(
+                [pattern],
+                placement_fn=shard0_placement_fn,
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_last,
+            )
+        )
+    return buckets
+
+
+def build_permatrix_muon_buckets(
+    model: nn.Module,
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    reshard_last: bool,
+    expert_mesh: DeviceMesh | None = None,
+    expert_reshard_after_forward: bool | None = None,
+    expert_marker: str = _DEFAULT_EXPERT_MARKER,
+) -> list[BucketSpec]:
+    """Per-2D-tensor comm-efficient Muon: each dense matrix is its own ``Owned`` bucket.
+
+    Generalizes :func:`build_muon_buckets` (whole-layer) by allocating *individual*
+    2D dense tensors to owners via greedy LPT over Newton-Schulz FLOPs across **all**
+    such matrices in the model. This balances the optimizer-step makespan at matrix
+    granularity, so it (a) fills every rank when ``num_layers < world_size`` (which
+    whole-layer cannot), and (b) balances better even when ``num_layers`` is not a
+    multiple of ``world_size``. Still comm-efficient (each matrix lives wholly on one
+    owner). Requires ``num_2D_dense_matrices >= world_size``.
+
+    MoE expert stacks (identified by ``expert_marker``) are kept off the Owned
+    allocation and placed as ``Shard`` buckets on ``expert_mesh`` (routed to GroupedMuon),
+    exactly as :func:`build_muon_buckets` does -- so this composes with expert parallelism. The
+    Owned dense buckets use ``reshard_after_forward`` (forced ``False`` by the caller --
+    the fine-Owned RAF engine bug), while the experts use
+    ``expert_reshard_after_forward`` (the configured policy), so the large expert state
+    can still reshard and the resident footprint stays bounded. Each layer's non-2D
+    dense params (norms) and embeddings / final norm / LM head are ``Shard(0)`` (AdamW).
+    Dense models have no expert params and ``expert_mesh`` is unused.
+
+    Cost vs whole-layer: more broadcasts (one per owned matrix vs one per layer);
+    per-(layer, owner) grouping (:func:`build_twolevel_muon_buckets`) reduces that.
+    """
+    if expert_mesh is None:
+        expert_mesh = dp_mesh
+    if expert_reshard_after_forward is None:
+        expert_reshard_after_forward = reshard_after_forward
+    world_size = dp_mesh.size()
+    layer_ids = sorted(model.layers.keys(), key=int)
+    matrices: list[tuple[str, nn.Parameter]] = []
+    other_fqns_by_layer: dict[str, list[str]] = {}
+    expert_fqns_by_layer: dict[str, list[str]] = {}
+    for lid in layer_ids:
+        others: list[str] = []
+        experts: list[str] = []
+        for name, param in model.layers[lid].named_parameters():
+            fqn = f"layers.{lid}.{name}"
+            if expert_marker in fqn:
+                experts.append(fqn)
+            elif param.ndim == 2:
+                matrices.append((fqn, param))
+            else:
+                others.append(fqn)
+        other_fqns_by_layer[lid] = others
+        expert_fqns_by_layer[lid] = experts
+
+    if len(matrices) < world_size:
+        raise ValueError(
+            f"Per-matrix Muon requires num_2D_dense_matrices >= dp_shard, but got "
+            f"{len(matrices)} matrices and dp_shard {world_size}."
+        )
+
+    costs = [newton_schulz_flops(param.shape) for _, param in matrices]
+    owners = assign_layer_owners_lpt(costs, world_size)
+
+    buckets: list[BucketSpec] = [
+        BucketSpec(
+            ["tok_embeddings.*"],
+            placement_fn=shard0_placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        )
+    ]
+    # One Owned bucket per 2D dense matrix (owner from LPT); each layer's non-2D dense
+    # params in their own Shard(0) bucket; each MoE expert stack Shard on expert_mesh.
+    for (fqn, _), owner in zip(matrices, owners, strict=True):
+        buckets.append(
+            BucketSpec(
+                [fqn],
+                placement_fn=make_owned_placement_fn(owner),
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_after_forward,
+            )
+        )
+    for lid in layer_ids:
+        # Each non-2D param in its own bucket (a bucket spanning different submodules'
+        # params crosses forward-unshard units and corrupts the unsharded-param slots).
+        for fqn in other_fqns_by_layer[lid]:
+            buckets.append(
+                BucketSpec(
+                    [fqn],
+                    placement_fn=shard0_placement_fn,
+                    mesh=dp_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=reshard_after_forward,
+                )
+            )
+        if expert_fqns_by_layer[lid]:
+            buckets.append(
+                BucketSpec(
+                    expert_fqns_by_layer[lid],
+                    placement_fn=expert_placement_fn,
+                    mesh=expert_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=expert_reshard_after_forward,
+                )
+            )
+    for pattern in ("norm.*", "lm_head.*"):
+        buckets.append(
+            BucketSpec(
+                [pattern],
+                placement_fn=shard0_placement_fn,
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_last,
+            )
+        )
+    return buckets
+
+
+def _cost_weighted_group_sizes(
+    layer_costs: list[int], layer_caps: list[int], world_size: int
+) -> list[int]:
+    """Apportion ``world_size`` ranks to layers (heterogeneous two-level level 1).
+
+    Each layer with >=1 matrix is seeded with 1 rank, then every remaining rank goes
+    greedily to the layer with the highest per-rank NS load (``cost / group_size``),
+    **capped at the layer's 2D-matrix count** (a layer cannot use more comm-efficient ranks
+    than it has whole tensors). Deterministic (ties by layer index) so every rank
+    computes the identical sizing. Returns sizes summing to ``min(world_size,
+    sum(caps))``; any shortfall (``world_size > num_matrices``) leaves ranks idle in the
+    step -- the L3 (slice) regime. Homogeneous layers -> ~uniform sizes (== the old
+    two-level); a heavy MoE layer with many matrices gets proportionally more ranks.
+    """
+    n = len(layer_costs)
+    sizes = [1 if layer_caps[i] >= 1 else 0 for i in range(n)]
+    placed = sum(sizes)
+    heap = [
+        (-(layer_costs[i] / sizes[i]), i)
+        for i in range(n)
+        if 0 < sizes[i] < layer_caps[i] and layer_costs[i] > 0
+    ]
+    heapq.heapify(heap)
+    while placed < world_size and heap:
+        _, i = heapq.heappop(heap)
+        sizes[i] += 1
+        placed += 1
+        if sizes[i] < layer_caps[i]:
+            heapq.heappush(heap, (-(layer_costs[i] / sizes[i]), i))
+    return sizes
+
+
+def build_twolevel_muon_buckets(
+    model: nn.Module,
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    reshard_last: bool,
+    expert_mesh: DeviceMesh | None = None,
+    expert_reshard_after_forward: bool | None = None,
+    expert_marker: str = _DEFAULT_EXPERT_MARKER,
+) -> list[BucketSpec]:
+    """Two-level comm-efficient Muon allocation (for ``world_size >= num_layers``).
+
+    Level 1: partition the ``world_size`` ranks into one contiguous group per layer,
+    **sized by the layer's NS-cost** (capped at its 2D-matrix count) via
+    :func:`_cost_weighted_group_sizes` -- so a heavy MoE layer gets more ranks than a
+    light dense one, and each layer independently lands at whole-layer (group size 1) or
+    per-tensor (group > 1). Level 2: within each layer, LPT the layer's 2D dense matrices
+    over its group. Homogeneous layers give ~uniform groups (the plain two-level).
+
+    This matches per-tensor LPT's makespan but **confines each layer's matrices to its
+    rank group**, so each rank owns matrices from only one layer -> one Owned broadcast
+    per rank (~``world_size`` total) instead of per-tensor's ~``num_matrices``. The
+    grouped, heterogeneous-aware middle ground between whole-layer (case 1) and flat
+    per-tensor (case 2). Falls back to whole-layer when ``world_size < num_layers``; when
+    ``world_size > num_matrices`` some ranks stay idle (the L3 / slice regime, warned).
+
+    MoE expert stacks (``expert_marker``) are kept off the Owned allocation and placed as
+    ``Shard`` buckets on ``expert_mesh`` (routed to GroupedMuon) with
+    ``expert_reshard_after_forward`` -- so this composes with expert parallelism, and the
+    large expert state can reshard while
+    the fine Owned dense buckets stay at ``reshard_after_forward`` (forced ``False``).
+    Other non-2D dense params and embeddings / final norm / LM head are ``Shard(0)``.
+    """
+    if expert_mesh is None:
+        expert_mesh = dp_mesh
+    if expert_reshard_after_forward is None:
+        expert_reshard_after_forward = reshard_after_forward
+    world_size = dp_mesh.size()
+    layer_ids = sorted(model.layers.keys(), key=int)
+    num_layers = len(layer_ids)
+    if world_size < num_layers:
+        # Fewer ranks than layers: two-level degenerates to whole-layer (each rank
+        # owns >=1 whole layer), which is exactly build_muon_buckets.
+        return build_muon_buckets(
+            model,
+            dp_mesh=dp_mesh,
+            expert_mesh=expert_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+            reshard_last=reshard_last,
+            expert_marker=expert_marker,
+        )
+
+    # Per-layer dense matrices / non-2D / experts / NS-cost / cap (= matrix count), then
+    # size each layer's rank group by cost (capped at its matrix count) -- the
+    # heterogeneous level-1 split (a heavy layer gets more ranks than a light one).
+    layer_matrices: dict[str, list[tuple[str, nn.Parameter]]] = {}
+    layer_others: dict[str, list[str]] = {}
+    layer_experts: dict[str, list[str]] = {}
+    costs: list[int] = []
+    caps: list[int] = []
+    for lid in layer_ids:
+        matrices: list[tuple[str, nn.Parameter]] = []
+        others: list[str] = []
+        experts: list[str] = []
+        for name, param in model.layers[lid].named_parameters():
+            fqn = f"layers.{lid}.{name}"
+            if expert_marker in fqn:
+                experts.append(fqn)
+            elif param.ndim == 2:
+                matrices.append((fqn, param))
+            else:
+                others.append(fqn)
+        layer_matrices[lid] = matrices
+        layer_others[lid] = others
+        layer_experts[lid] = experts
+        costs.append(sum(newton_schulz_flops(p.shape) for _, p in matrices))
+        caps.append(len(matrices))
+
+    group_sizes = _cost_weighted_group_sizes(costs, caps, world_size)
+    if sum(group_sizes) < world_size:
+        logger.warning(
+            "Two-level Muon: %d ranks > %d total 2D matrices; %d ranks will be idle "
+            "in the optimizer step (the L3 / slice regime is not yet implemented).",
+            world_size,
+            sum(caps),
+            world_size - sum(group_sizes),
+        )
+
+    buckets: list[BucketSpec] = [
+        BucketSpec(
+            ["tok_embeddings.*"],
+            placement_fn=shard0_placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        )
+    ]
+    next_rank = 0
+    for li, lid in enumerate(layer_ids):
+        group = list(range(next_rank, next_rank + group_sizes[li]))
+        next_rank += group_sizes[li]
+
+        # Level 2: LPT this layer's matrices over its rank group, by NS-FLOPs.
+        loads = [(0, g) for g in group]
+        heapq.heapify(loads)
+        owner_fqns: dict[int, list[str]] = {g: [] for g in group}
+        for fqn, param in sorted(
+            layer_matrices[lid],
+            key=lambda fp: newton_schulz_flops(fp[1].shape),
+            reverse=True,
+        ):
+            load, g = heapq.heappop(loads)
+            owner_fqns[g].append(fqn)
+            heapq.heappush(loads, (load + newton_schulz_flops(param.shape), g))
+
+        # One Owned bucket per rank-in-group that owns matrices of this layer.
+        for g in group:
+            if owner_fqns[g]:
+                buckets.append(
+                    BucketSpec(
+                        owner_fqns[g],
+                        placement_fn=make_owned_placement_fn(g),
+                        mesh=dp_mesh,
+                        mp_policy=mp_policy,
+                        reshard_after_forward=reshard_after_forward,
+                    )
+                )
+        for fqn in layer_others[lid]:
+            buckets.append(
+                BucketSpec(
+                    [fqn],
+                    placement_fn=shard0_placement_fn,
+                    mesh=dp_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=reshard_after_forward,
+                )
+            )
+        if layer_experts[lid]:
+            buckets.append(
+                BucketSpec(
+                    layer_experts[lid],
+                    placement_fn=expert_placement_fn,
+                    mesh=expert_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=expert_reshard_after_forward,
+                )
+            )
+    for pattern in ("norm.*", "lm_head.*"):
+        buckets.append(
+            BucketSpec(
+                [pattern],
+                placement_fn=shard0_placement_fn,
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_last,
+            )
+        )
+    return buckets
+
+
+def build_gather_muon_buckets(
+    model: nn.Module,
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    dense_placement_fn: Callable,
+    expert_mesh: DeviceMesh | None = None,
+    expert_reshard_after_forward: bool | None = None,
+    expert_marker: str = _DEFAULT_EXPERT_MARKER,
+) -> list[BucketSpec]:
+    """Buckets for gather-for-NS Muon: dense 2D matrices sharded, gathered at step.
+
+    Per layer, the dense 2D matrices (everything 2D not under ``expert_marker``) share one
+    bucket placed by ``dense_placement_fn`` (``Shard(0)`` or ``GroupedRaggedShard``) ->
+    ``GatherMuon`` all-gathers + NS. MoE expert stacks (``expert_marker``) go to ``Shard``
+    on ``expert_mesh`` (the EP mesh) -> GroupedMuon, exactly as the comm-efficient Owned path -- so the
+    gather baselines compose with EP and the experts are handled *identically* across
+    methods (only the dense-matrix distribution differs). Other non-2D dense params (1D
+    norms) and embeddings / final norm / LM head are ``Shard(0)`` -> AdamW. Dense models
+    have no expert params and ``expert_mesh`` is unused.
+    """
+    if expert_mesh is None:
+        expert_mesh = dp_mesh
+    if expert_reshard_after_forward is None:
+        expert_reshard_after_forward = reshard_after_forward
+    buckets: list[BucketSpec] = []
+    for lid in sorted(model.layers.keys(), key=int):
+        matrices: list[str] = []
+        other: list[str] = []
+        experts: list[str] = []
+        for name, param in model.layers[lid].named_parameters():
+            fqn = f"layers.{lid}.{name}"
+            if expert_marker in fqn:
+                experts.append(fqn)
+            elif param.ndim == 2:
+                matrices.append(fqn)
+            else:
+                other.append(fqn)
+        if matrices:
+            buckets.append(
+                BucketSpec(
+                    matrices,
+                    placement_fn=dense_placement_fn,
+                    mesh=dp_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=reshard_after_forward,
+                )
+            )
+        for fqn in other:
+            buckets.append(
+                BucketSpec(
+                    [fqn],
+                    placement_fn=shard0_placement_fn,
+                    mesh=dp_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=reshard_after_forward,
+                )
+            )
+        if experts:
+            buckets.append(
+                BucketSpec(
+                    experts,
+                    placement_fn=expert_placement_fn,
+                    mesh=expert_mesh,
+                    mp_policy=mp_policy,
+                    reshard_after_forward=expert_reshard_after_forward,
+                )
+            )
+    buckets += [
+        BucketSpec(
+            [pattern],
+            placement_fn=shard0_placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        )
+        for pattern in _REST_PATTERNS
+    ]
+    return buckets
+
+
+def validate_supported_parallelisms(
+    parallel_dims: ParallelDims,
+    parallelism: ParallelismConfig,
+    training: TrainingConfig,
+    compile_config: CompileConfig,
+) -> None:
+    """Reject parallelism configs the FlexShard Muon test beds do not support."""
+    if parallelism.spmd_backend == "full_dtensor":
+        raise NotImplementedError(
+            "FlexShard Muon does not support the full_dtensor backend."
+        )
+    if parallel_dims.pp_enabled:
+        raise NotImplementedError("FlexShard Muon does not support PP.")
+    if parallel_dims.tp_enabled:
+        raise NotImplementedError("FlexShard Muon does not support TP.")
+    if parallel_dims.cp_enabled:
+        raise NotImplementedError("FlexShard Muon does not support CP.")
+    if parallel_dims.dp_replicate_enabled:
+        raise NotImplementedError("FlexShard Muon does not support HSDP.")
+    if training.enable_cpu_offload:
+        raise NotImplementedError("FlexShard Muon does not support CPU offload.")
+    if compile_config.enable and "model" in compile_config.components:
+        raise NotImplementedError(
+            "FlexShard Muon is eager-only; disable model compile."
+        )
+
+
+def _mp_policy_from(training: TrainingConfig) -> MixedPrecisionPolicy:
+    return MixedPrecisionPolicy(
+        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
+    )
+
+
+def resolve_auto_granularity(model: nn.Module, world_size: int) -> str:
+    """Pick the shallowest comm-efficient allocation level for the recursive descent.
+
+    The unified system (see docs/muon.md "unified allocation system"):
+    ``layer`` when ``W <= num_layers`` (whole layers fill the ranks, fewest broadcasts);
+    ``matrix`` when ``num_layers < W < 2*num_layers`` (two-level groups would be size 1
+    and degrade, so flat per-tensor balances better); ``twolevel`` when ``2*num_layers <=
+    W <= num_matrices`` (clean rank groups: per-tensor balance at ~W broadcasts). Beyond
+    ``num_matrices`` needs L3 group-local slicing (not yet implemented). ``num_matrices``
+    counts the actual 2D dense matrices across all layers (heterogeneous-safe).
+    """
+    layer_ids = sorted(model.layers.keys(), key=int)
+    num_layers = len(layer_ids)
+    # Count the actual 2D dense matrices across all layers (heterogeneous-safe -- e.g. a
+    # dense first layer followed by MoE layers, as in DeepSeek V3), not a layer-0 multiplier.
+    num_matrices = sum(
+        1
+        for lid in layer_ids
+        for _, p in model.layers[lid].named_parameters()
+        if p.ndim == 2
+    )
+    if world_size <= num_layers:
+        return "layer"
+    if world_size < 2 * num_layers:
+        return "matrix"
+    if world_size <= num_matrices:
+        return "twolevel"
+    raise NotImplementedError(
+        f"world_size {world_size} > num_matrices ~{num_matrices}: needs L3 group-local "
+        "slicing (not yet implemented). Use a gather-for-NS config for this regime."
+    )
+
+
+def _install_mem_debug_hooks(model: nn.Module) -> None:
+    """Env-gated (``FLEX_SHARD_MEM_DEBUG=1``) per-layer CUDA memory trace.
+
+    Logs ``torch.cuda.memory_allocated/reserved`` before each transformer layer's forward
+    (rank 0 only). If the comm-efficient unshard frees per-layer, ``alloc`` stays ~flat across
+    layers; if the broadcast/unshard accumulates (RAF not freeing, or prefetch holding all
+    layers), ``alloc`` grows monotonically with layer index toward the full model size.
+    """
+    import torch
+
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    if rank != 0:
+        return
+    layer_ids = sorted(model.layers.keys(), key=int)
+
+    def make_hook(tag: str):
+        def hook(_mod, _args):
+            alloc = torch.cuda.memory_allocated() / 1e9
+            reserved = torch.cuda.memory_reserved() / 1e9
+            logger.info(
+                f"[mem-debug] {tag}: alloc={alloc:.2f} GB reserved={reserved:.2f} GB"
+            )
+
+        return hook
+
+    for lid in layer_ids:
+        model.layers[lid].register_forward_pre_hook(make_hook(f"layer {lid} pre-fwd"))
+
+
+def make_muon_parallelize_fn(
+    *,
+    model_name: str,
+    support_ep: bool,
+    granularity: str = "layer",
+    allow_idle_ranks: bool = False,
+):
+    """Return a parallelize_fn for the comm-efficient ``Owned`` Muon path.
+
+    ``support_ep`` enables expert parallelism (the experts become DTensors that the
+    engine unwraps to local EP shards, then FlexShard FSDP-shards on the ``efsdp``
+    mesh); dense-only models pass ``support_ep=False`` and reject EP.
+
+    ``granularity`` selects the comm-efficient allocation unit: ``"layer"`` (whole-layer
+    Owned), ``"matrix"`` (per-2D-tensor Owned), ``"twolevel"`` (per-layer rank groups +
+    within-layer LPT), or ``"auto"`` -- the unified selector that picks the shallowest
+    level for the regime (see :func:`resolve_auto_granularity`). ``allow_idle_ranks``
+    lifts the whole-layer ``num_layers >= world_size`` guard. All granularities compose
+    with EP when ``support_ep`` is set: the dense 2D matrices run comm-efficient Owned on the
+    dp mesh at the chosen granularity, and MoE expert stacks Shard on the EP mesh. This
+    is what lets MoE models run comm-efficient Muon at ``world_size > num_layers`` (where
+    whole-layer cannot fill the ranks but per-tensor / two-level can).
+    """
+    if granularity not in ("layer", "matrix", "twolevel", "auto"):
+        raise ValueError(
+            "granularity must be 'layer', 'matrix', 'twolevel', or 'auto', "
+            f"got {granularity!r}"
+        )
+
+    def parallelize_fn(
+        model: nn.Module,
+        *,
+        parallel_dims: ParallelDims,
+        training: TrainingConfig,
+        parallelism: ParallelismConfig,
+        compile_config: CompileConfig,
+        ac_config: ActivationCheckpointingConfig,
+        dump_folder: str,
+    ):
+        validate_supported_parallelisms(
+            parallel_dims, parallelism, training, compile_config
+        )
+        if parallel_dims.ep_enabled:
+            if not support_ep:
+                raise NotImplementedError(
+                    f"FlexShard Muon {model_name} ({granularity}) is dense-only; "
+                    "set expert_parallel_degree=1."
+                )
+            # EP is a permanent partition (each rank owns its expert subset; tokens
+            # are routed to it). Apply it first so the experts become DTensors that
+            # flex_shard() unwraps to each rank's local EP shard. The dense 2D matrices
+            # still run comm-efficient Owned on the full dp mesh at the selected granularity;
+            # only the expert stacks live on the EP (efsdp) mesh.
+            model.parallelize(parallel_dims)
+
+        if ac_config is not None:
+            ac_config.build(dump_folder=dump_folder).apply(model)
+
+        dp_mesh = parallel_dims.get_mesh("fsdp")
+        expert_mesh = dp_mesh
+        if support_ep and parallel_dims.ep_enabled:
+            expert_mesh = parallel_dims.get_optional_mesh("efsdp") or dp_mesh
+
+        # "auto" resolves to the shallowest level that fills the ranks (the system).
+        gran = (
+            resolve_auto_granularity(model, dp_mesh.size())
+            if granularity == "auto"
+            else granularity
+        )
+
+        mp_policy = _mp_policy_from(training)
+        reshard_after_forward = get_fsdp_reshard_after_forward_policy(
+            parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
+        )
+        reshard_last = parallelism.fsdp_reshard_after_forward == "always"
+        if gran in ("matrix", "twolevel"):
+            # Fine Owned buckets + RAF=True hit the engine's saved-tensor re-view bug
+            # (mis-materialize on backward -- same limitation as the gather RAF=True
+            # path), so the *Owned* dense buckets run RAF=False. opt_step (what the
+            # allocation controls) is RAF-independent, so the makespan comparison stays
+            # valid. MoE expert stacks are plain Shard buckets on the EP mesh, so they
+            # keep the configured RAF policy -- letting the large expert state reshard
+            # so the resident footprint stays bounded at scale.
+            builder = (
+                build_permatrix_muon_buckets
+                if gran == "matrix"
+                else build_twolevel_muon_buckets
+            )
+            buckets = builder(
+                model,
+                dp_mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=False,
+                reshard_last=False,
+                expert_mesh=expert_mesh,
+                expert_reshard_after_forward=reshard_after_forward,
+            )
+        else:
+            buckets = build_muon_buckets(
+                model,
+                dp_mesh=dp_mesh,
+                expert_mesh=expert_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_after_forward,
+                reshard_last=reshard_last,
+                allow_idle_ranks=allow_idle_ranks,
+            )
+        flex_shard(model, buckets=buckets)
+        if os.environ.get("FLEX_SHARD_MEM_DEBUG"):
+            _install_mem_debug_hooks(model)
+        label = gran if granularity != "auto" else f"auto->{gran}"
+        logger.info(
+            f"Applied FlexShard + comm-efficient Muon ({label}) to {model_name}"
+        )
+        return model
+
+    return parallelize_fn
+
+
+def make_gather_muon_parallelize_fn(
+    dense_kind: str, *, model_name: str, reshard_after_forward: bool = False
+):
+    """Return a parallelize_fn for gather-for-NS Muon with the given dense placement.
+
+    ``dense_kind`` selects how dense 2D matrices are sharded: ``"shard"`` (plain FSDP
+    ``Shard(0)``) or ``"grouped"`` (byte-perfect ``GroupedRaggedShard``). EP-capable
+    (experts -> EP mesh, like Owned); no TP/PP/HSDP. Unlike the comm-efficient ``Owned`` path
+    there is no ``num_layers >= dp_shard`` constraint (sharding is within-tensor, so any
+    dp_shard works).
+
+    ``reshard_after_forward`` enables RAF for the sharded gather buckets. The engine
+    supports RAF with ``Shard(0)`` (and the GatherMuon optimizer now maps bucket params by
+    *canonical* FQN, so the discovery survives the ``CheckpointWrapper`` FQN renaming that
+    RAF-with-AC introduces). When ``True`` the configured ``fsdp_reshard_after_forward``
+    policy is used; default ``False`` preserves the original full-model-resident behavior.
+    RAF reshards the sharded matrices after forward (recomputed in backward), so the gather
+    baselines no longer hold the full model resident -- the prerequisite for a fair
+    memory-vs-comm comparison vs comm-efficient ``Owned``.
+    """
+    if dense_kind not in ("shard", "grouped"):
+        raise ValueError(f"dense_kind must be 'shard' or 'grouped', got {dense_kind!r}")
+
+    def parallelize_fn(
+        model: nn.Module,
+        *,
+        parallel_dims: ParallelDims,
+        training: TrainingConfig,
+        parallelism: ParallelismConfig,
+        compile_config: CompileConfig,
+        ac_config: ActivationCheckpointingConfig,
+        dump_folder: str,
+    ):
+        validate_supported_parallelisms(
+            parallel_dims, parallelism, training, compile_config
+        )
+        if parallel_dims.ep_enabled:
+            # EP: apply it first so the experts become DTensors the engine unwraps to each
+            # rank's EP shard. The gather baselines then gather only the DENSE 2D matrices
+            # on the dp mesh; experts go to Shard on the EP mesh -- handled *identically* to
+            # the comm-efficient Owned path, so the only difference vs Owned is the dense-matrix
+            # distribution (the variable under test). This is what makes a fair fixed-config
+            # (dp/ep) comparison across all methods possible.
+            model.parallelize(parallel_dims)
+        if ac_config is not None:
+            ac_config.build(dump_folder=dump_folder).apply(model)
+
+        dp_mesh = parallel_dims.get_mesh("fsdp")
+        expert_mesh = dp_mesh
+        if parallel_dims.ep_enabled:
+            expert_mesh = parallel_dims.get_optional_mesh("efsdp") or dp_mesh
+        if dense_kind == "grouped":
+            dense_placement_fn = make_grouped_ragged_placement_fn(
+                dims=(0,), local_units=(1,) * dp_mesh.size()
+            )
+        else:
+            dense_placement_fn = per_param_placements  # Shard(0)
+
+        raf = (
+            get_fsdp_reshard_after_forward_policy(
+                parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
+            )
+            if reshard_after_forward
+            else False
+        )
+        buckets = build_gather_muon_buckets(
+            model,
+            dp_mesh=dp_mesh,
+            mp_policy=_mp_policy_from(training),
+            reshard_after_forward=raf,
+            dense_placement_fn=dense_placement_fn,
+            expert_mesh=expert_mesh,
+            expert_reshard_after_forward=get_fsdp_reshard_after_forward_policy(
+                parallelism.fsdp_reshard_after_forward, parallel_dims.pp_enabled
+            ),
+        )
+        flex_shard(model, buckets=buckets)
+        logger.info(
+            f"Applied FlexShard + gather-for-NS Muon ({dense_kind}, "
+            f"reshard_after_forward={raf}) to {model_name}"
+        )
+        return model
+
+    return parallelize_fn

--- a/torchtitan/experiments/flex_shard/muon/comm_counter.py
+++ b/torchtitan/experiments/flex_shard/muon/comm_counter.py
@@ -1,0 +1,152 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Process-global communication-byte counter for the distributed-Muon benchmark.
+
+Monkeypatches two disjoint families of collectives so each call adds this rank's
+**send volume** (the input buffer's bytes) to a global accumulator:
+
+1. Eager ``torch.distributed`` collectives (``_VOLUME_ARG``) -- the all-gather /
+   reduce-scatter / broadcast / reduce variants the FlexShard engine and the raw
+   collective calls use.
+2. Functional collectives (``torch.ops._c10d_functional.*``, ``_FUNCTIONAL_COLLECTIVES``)
+   -- the ops core ``fully_shard`` (FSDP2) and **DTensor redistribute / full_tensor**
+   dispatch to. These do NOT route through the eager ``torch.distributed`` python
+   symbols above (they call straight into the c10d functional ops), so patching only
+   family (1) would register **zero** bytes for the DTensor / FSDP2 baselines -- e.g.
+   :class:`DTensorMuon`'s in-step ``update.full_tensor()`` all-gather -- making them
+   look as collective-free as comm-efficient ``Owned`` Muon. The two families dispatch
+   through separate namespaces (``c10d`` vs ``_c10d_functional``), so patching both does
+   not double-count. The op packet is the single chokepoint every functional-collective
+   python wrapper (eager, autograd, coalesced) funnels through, so patching it there --
+   rather than the many wrappers -- catches all paths and adds zero overhead to
+   non-collective ops (unlike a process-wide ``TorchDispatchMode``).
+
+Reading the accumulator before/after a region attributes comm bytes to that region
+(e.g. the optimizer step vs the rest of the iteration); see ``_BenchMixin`` in ``bench.py``.
+
+Counting this rank's send bytes (input tensor) gives a consistent per-rank metric
+across collectives: for ``all_gather`` / ``all_gather_single`` / ``reduce_scatter``
+that is the local contribution; for ``broadcast`` / ``reduce`` it is the buffer the
+root sends / each rank contributes. Absolute numbers are approximate (one rank, send
+side only) but the cross-config comparison -- the point of the benchmark -- is clean.
+
+Limitation: under ``torch.compile`` the collectives inside a compiled region are
+captured by Dynamo and do not call these python wrappers, so they are not counted.
+The metric the benchmark turns on -- ``step_comm``, dominated by the eager optimizer
+step (NS gather for the gather baselines, ``full_tensor()`` for DTensorMuon) -- runs
+outside compiled regions and is counted.
+
+This lives entirely in experiment code and patches only ``torch.distributed`` symbols
+and the ``_c10d_functional`` op packets; it does not modify the FlexShard engine or any
+core torchtitan code. ``install()`` is idempotent and a no-op until called, so importing
+this module changes nothing.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+
+# (positional index, keyword name) of the input/volume tensor for each collective.
+_VOLUME_ARG = {
+    "all_gather": (1, "tensor"),
+    "all_gather_single": (1, "input"),
+    "reduce_scatter_tensor": (1, "input"),
+    "broadcast": (0, "tensor"),
+    "reduce": (0, "tensor"),
+    # FSDP2 (fully_shard) collectives, so the same counter works for the
+    # vanilla-FSDP2 + AdamW reference baseline.
+    "all_gather_into_tensor": (1, "input_tensor"),
+    "_all_gather_base": (1, "input"),
+    "_reduce_scatter_base": (1, "input"),
+}
+
+# Functional collectives on ``torch.ops._c10d_functional``. Every one takes the local
+# send/input tensor as the first positional arg (coalesced variants pass a list of them),
+# so a single args[0] rule covers all of them.
+_FUNCTIONAL_COLLECTIVES = (
+    "all_gather_into_tensor",
+    "all_gather_into_tensor_coalesced",
+    "reduce_scatter_tensor",
+    "reduce_scatter_tensor_coalesced",
+    "all_reduce",
+    "all_reduce_coalesced",
+    "broadcast",
+    "all_to_all_single",
+)
+
+_state = {"bytes": 0, "installed": False}
+
+
+def reset() -> None:
+    """Zero the accumulated byte count."""
+    _state["bytes"] = 0
+
+
+def read() -> int:
+    """Return the bytes accumulated on this rank since the last ``reset()``."""
+    return _state["bytes"]
+
+
+def _volume_bytes(name: str, args: tuple, kwargs: dict) -> int:
+    idx, key = _VOLUME_ARG[name]
+    tensor = kwargs.get(key)
+    if tensor is None and len(args) > idx:
+        tensor = args[idx]
+    if isinstance(tensor, torch.Tensor):
+        return tensor.numel() * tensor.element_size()
+    return 0
+
+
+def _wrap(name: str, fn):
+    def wrapped(*args, **kwargs):
+        # Count before the call; a failed collective would raise anyway.
+        _state["bytes"] += _volume_bytes(name, args, kwargs)
+        return fn(*args, **kwargs)
+
+    return wrapped
+
+
+def _functional_volume_bytes(args: tuple) -> int:
+    """Send bytes for a ``_c10d_functional`` op: its first positional arg (a tensor, or
+    a list of tensors for the coalesced variants)."""
+    tensor = args[0] if args else None
+    if isinstance(tensor, (list, tuple)):
+        return sum(
+            t.numel() * t.element_size() for t in tensor if isinstance(t, torch.Tensor)
+        )
+    if isinstance(tensor, torch.Tensor):
+        return tensor.numel() * tensor.element_size()
+    return 0
+
+
+def _wrap_functional(fn):
+    def wrapped(*args, **kwargs):
+        _state["bytes"] += _functional_volume_bytes(args)
+        return fn(*args, **kwargs)
+
+    return wrapped
+
+
+def install() -> None:
+    """Patch the eager + functional collectives to accumulate send bytes (idempotent)."""
+    if _state["installed"]:
+        return
+    for name in _VOLUME_ARG:
+        fn = getattr(dist, name, None)
+        if fn is not None:
+            setattr(dist, name, _wrap(name, fn))
+    # Functional collectives: wrap the op packet on the namespace (the chokepoint all
+    # python wrappers funnel through). Touch the attribute first so it is materialized and
+    # cached on the namespace before we overwrite it.
+    functional = torch.ops._c10d_functional
+    for name in _FUNCTIONAL_COLLECTIVES:
+        fn = getattr(functional, name, None)
+        if fn is not None:
+            setattr(functional, name, _wrap_functional(fn))
+    _state["installed"] = True

--- a/torchtitan/experiments/flex_shard/muon/containers.py
+++ b/torchtitan/experiments/flex_shard/muon/containers.py
@@ -1,0 +1,605 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""Optimizer containers (placement -> optimizer routing) for FlexShard Muon.
+
+Layer-2 of the distributed-Muon stack: each container reads a model's FlexShard
+placements and routes every parameter to one of the layer-3 optimizer
+implementations (``owned``'s dense Muon via ``torch.optim.Muon``, ``grouped_muon.GroupedMuon``,
+``gather_muon.GatherMuon`` / ``gather_muon.GatherGroupedMuon``, ``dtensor_muon.DTensorMuon``) or AdamW,
+then presents them as one ``OptimizersContainer``. Sits downstream of all the
+implementation modules, so the routing helper and every container live here together.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.components.checkpoint_utils import canonical_fqn
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
+
+from ..example.ragged_shard import RaggedShard
+from ..example.shard import Shard
+from .bench import _BenchMixin
+from .bucketing import _DEFAULT_EXPERT_MARKER
+from .dtensor_muon import DTensorMuon
+from .gather_muon import GatherGroupedMuon, GatherMuon
+from .grouped_muon import GroupedMuon
+from .owned import is_owned_2d
+from .qkclip import QKClip
+
+
+_GATHER_PLACEMENTS = (Shard, RaggedShard)
+
+
+def _is_dense_gather_bucket(infos: list) -> bool:
+    """Whether a bucket holds sharded 2D dense-layer matrices (for :class:`GatherMuon`).
+
+    True iff every param is a 2D matrix under ``layers.<i>.`` with a gatherable placement
+    (``Shard`` / ``RaggedShard`` / ``GroupedRaggedShard``). The ``layers.`` check excludes
+    embeddings / output head (2D but not Muon by convention); the 2D check excludes norms
+    (1D) and MoE expert stacks (>=3D).
+    """
+    if not infos:
+        return False
+    if not all(len(info.global_shape) == 2 for info in infos):
+        return False
+    if not all(info.fqn.startswith("layers.") for info in infos):
+        return False
+    return isinstance(infos[0].placement, _GATHER_PLACEMENTS)
+
+
+def _is_expert_bucket(infos: list) -> bool:
+    """Whether a bucket holds 3D ``[E, m, n]`` MoE expert stacks.
+
+    Two semantic signals, both required: a 3D ``global_shape`` *and* an FQN under the
+    expert marker (``_DEFAULT_EXPERT_MARKER`` = ``.moe.experts.``, the same marker the
+    partition layer uses to bucket experts). Routing then reads the placement: ``Shard(0)``
+    (whole experts per rank) -> :class:`GroupedMuon`; ``Shard(dim>=1)`` ->
+    :class:`GatherGroupedMuon`. Gating on the marker (not raw 3D ``ndim``) means a future
+    3D non-expert param falls to AdamW rather than silently routing to expert Muon.
+    """
+    if not infos:
+        return False
+    if not all(len(info.global_shape) == 3 for info in infos):
+        return False
+    return all(_DEFAULT_EXPERT_MARKER in info.fqn for info in infos)
+
+
+def _discover_buckets(model: nn.Module, predicate) -> list[dict[str, Any]]:
+    """This rank's FlexShard buckets whose ``param_infos`` match ``predicate(infos)``.
+
+    Bucket-to-parameter mapping is by **canonical** FQN (wrapper segments such as
+    ``_checkpoint_wrapped_module`` stripped via :func:`canonical_fqn`), so it survives
+    reshard-after-forward composed with activation checkpointing (which inserts
+    ``CheckpointWrapper`` segments into ``model.named_parameters()`` names). The optimizers
+    hold the persistent sharded params, so RAF -- which only frees/recomputes the unsharded
+    forward views -- does not affect these references.
+    """
+    param_by_fqn = {
+        canonical_fqn(name): param for name, param in model.named_parameters()
+    }
+    buckets: list[dict[str, Any]] = []
+    for storage in getattr(model, "sharded_bucket_storages", []):
+        infos = list(storage.param_infos.values())
+        if not predicate(infos):
+            continue
+        params = [param_by_fqn.get(canonical_fqn(info.fqn)) for info in infos]
+        if any(p is None for p in params):
+            raise ValueError(
+                "Could not map a FlexShard bucket param FQN to a model parameter "
+                f"(canonical FQNs: {[canonical_fqn(i.fqn) for i in infos]})."
+            )
+        buckets.append(
+            {
+                "placement": infos[0].placement,
+                "infos": infos,
+                "params": params,
+                "storage": storage,
+            }
+        )
+    return buckets
+
+
+def _discover_dense_gather_buckets(model: nn.Module) -> list[dict[str, Any]]:
+    """This rank's sharded 2D dense-matrix buckets (for :class:`GatherMuon`)."""
+    return _discover_buckets(model, _is_dense_gather_bucket)
+
+
+def _discover_expert_buckets(model: nn.Module) -> list[dict[str, Any]]:
+    """This rank's 3D MoE expert buckets (for GroupedMuon / GatherGroupedMuon)."""
+    return _discover_buckets(model, _is_expert_bucket)
+
+
+def _build_grouped_expert_optimizers(
+    container,
+    model: nn.Module,
+    part_idx: int,
+    muon_kwargs: dict[str, Any],
+    claimed_ids: set[int],
+    all_params: list[nn.Parameter],
+) -> set[int]:
+    """Route this model part's 3D MoE expert buckets to Muon, by FlexShard placement.
+
+    Experts are identified by FlexShard bucket metadata -- the 3D ``[E, m, n]`` buckets the
+    parallelizer placed (see :func:`_discover_expert_buckets`), not raw ``ndim`` over every
+    parameter -- and routed by placement:
+    * ``Shard(dim>=1)`` (sharded within the matrix, ``world_size > num_experts``) ->
+      :class:`GatherGroupedMuon` (all-gather over the efsdp mesh + batched per-expert NS);
+    * ``Shard(0)`` (whole experts per rank, ``world_size <= num_experts``) -> comm-efficient
+      :class:`GroupedMuon` (local batched per-expert NS).
+
+    ``claimed_ids`` are params already assigned (e.g. dense). Extends ``all_params`` and
+    returns the set of expert param ids handled (so the caller routes the rest to AdamW).
+    """
+    handled: set[int] = set()
+    expert_buckets = _discover_expert_buckets(model)
+
+    # Within-matrix-sharded experts (Shard(dim>=1)) -> gather-before-NS.
+    gather_buckets = [
+        b
+        for b in expert_buckets
+        if isinstance(b["placement"], Shard) and b["placement"].dim >= 1
+    ]
+    if gather_buckets:
+        mesh = gather_buckets[0]["storage"]._mesh
+        gather_grouped = GatherGroupedMuon(gather_buckets, mesh, **muon_kwargs)
+        container.optimizers.append(gather_grouped)
+        container._log_optimizer(
+            gather_grouped, part_idx, ["<3D experts Shard(>=1) (gathered)>"]
+        )
+        all_params.extend(gather_grouped.param_groups[0]["params"])
+        handled |= {id(p) for b in gather_buckets for p in b["params"] if p.numel() > 0}
+
+    # Whole-per-rank experts (Shard(0)) -> comm-efficient local batched NS.
+    grouped_params: list[nn.Parameter] = []
+    grouped_names: list[str] = []
+    for bucket in expert_buckets:
+        pl = bucket["placement"]
+        if isinstance(pl, Shard) and pl.dim >= 1:
+            continue  # handled by GatherGroupedMuon above
+        for info, param in zip(bucket["infos"], bucket["params"], strict=True):
+            if param.numel() == 0 or id(param) in claimed_ids:
+                continue
+            grouped_params.append(param)
+            grouped_names.append(canonical_fqn(info.fqn))
+    if grouped_params:
+        grouped = GroupedMuon(
+            [{"params": grouped_params, "param_names": grouped_names, **muon_kwargs}]
+        )
+        container.optimizers.append(grouped)
+        container._log_optimizer(grouped, part_idx, ["<3D MoE expert stacks (whole)>"])
+        all_params.extend(grouped_params)
+        handled |= {id(p) for p in grouped_params}
+    return handled
+
+
+class FlexShardMuonOptimizers(_BenchMixin, OptimizersContainer):
+    """Full comm-efficient Muon for FlexShard: 2D dense -> Muon, 3D experts -> GroupedMuon.
+
+    Routes by FlexShard placement (not regex), reusing core's container for
+    ``step``/``zero_grad``/``state_dict``/checkpoint integration:
+
+    * owned 2D matrices -> ``torch.optim.Muon`` (comm-efficient on the owner; empty
+      ``Owned`` shards on non-owner ranks, ``numel == 0``, are skipped so Muon never
+      sees a zero-size matrix);
+    * 3D MoE expert stacks -> :class:`GroupedMuon` (whole experts, ``Shard(0)``) or
+      :class:`GatherGroupedMuon` (experts sharded within the matrix, ``Shard(dim>=1)``),
+      via :func:`_build_grouped_expert_optimizers` -- experts always get Muon;
+    * everything else (norms, embeddings, LM head) -> AdamW.
+
+    ``Config.param_groups`` supplies only the optimizer kwargs per name (one entry with
+    ``optimizer_name="Muon"`` -- reused for the experts -- and one ``"AdamW"``); their
+    regex ``pattern`` is ignored, since routing is by FlexShard placement, not FQN.
+
+    ``Config.qk_clip_tau`` (optional) enables MuonClip's QK-clip (:class:`QKClip`):
+    after each step, per-head q/k projection rows are rescaled so the max attention
+    logit stays ``<= tau``. ``None`` (default) -> off.
+
+    On a dense model (no 3D experts) this reduces to 2D dense -> Muon, rest -> AdamW.
+    Subclasses can swap the dense Muon class by overriding :meth:`_resolve_optimizer_cls`.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OptimizersContainer.Config):
+        qk_clip_tau: float | None = None
+
+    def __init__(self, config: OptimizersContainer.Config, *, model_parts) -> None:
+        impl_kwargs = self._build_impl_kwargs(config)
+        kwargs_by_name = {
+            pg.optimizer_name: pg.optimizer_kwargs for pg in config.param_groups
+        }
+        if "Muon" not in kwargs_by_name or "AdamW" not in kwargs_by_name:
+            raise ValueError(
+                "FlexShardMuonOptimizers requires param_groups with optimizer_name "
+                "'Muon' and 'AdamW'."
+            )
+        self.model_parts = model_parts
+        self.optimizers = []
+        all_params: list[nn.Parameter] = []
+        muon_cls = self._resolve_optimizer_cls("Muon")
+
+        for part_idx, model in enumerate(model_parts):
+            # Dense 2D Owned matrices -> comm-efficient Muon. numel == 0 -> an Owned
+            # shard belonging to another rank; nothing local.
+            muon_params: list[nn.Parameter] = []
+            muon_names: list[str] = []
+            for name, param in model.named_parameters():
+                if not param.requires_grad or param.numel() == 0:
+                    continue
+                if is_owned_2d(param):
+                    muon_params.append(param)
+                    muon_names.append(canonical_fqn(name))
+            claimed: set[int] = {id(p) for p in muon_params}
+            if muon_params:
+                # Muon does not accept fused/foreach impl_kwargs; pass only its kwargs.
+                muon = muon_cls(
+                    [
+                        {
+                            "params": muon_params,
+                            "param_names": muon_names,
+                            **kwargs_by_name["Muon"],
+                        }
+                    ]
+                )
+                self.optimizers.append(muon)
+                self._log_optimizer(muon, part_idx, ["<owned 2D matrices>"])
+                all_params.extend(muon_params)
+
+            # 3D MoE expert stacks -> GroupedMuon (whole) / GatherGroupedMuon (Shard(>=1)).
+            claimed |= _build_grouped_expert_optimizers(
+                self, model, part_idx, kwargs_by_name["Muon"], claimed, all_params
+            )
+
+            # Everything else (norms, embeddings, LM head) -> AdamW.
+            adamw_params: list[nn.Parameter] = []
+            adamw_names: list[str] = []
+            for name, param in model.named_parameters():
+                if not param.requires_grad or param.numel() == 0:
+                    continue
+                if id(param) in claimed:
+                    continue
+                adamw_params.append(param)
+                adamw_names.append(canonical_fqn(name))
+            if adamw_params:
+                adamw = torch.optim.AdamW(
+                    [
+                        {
+                            "params": adamw_params,
+                            "param_names": adamw_names,
+                            **impl_kwargs,
+                            **kwargs_by_name["AdamW"],
+                        }
+                    ]
+                )
+                self.optimizers.append(adamw)
+                self._log_optimizer(adamw, part_idx, ["<rest>"])
+                all_params.extend(adamw_params)
+
+        self._validate_params(all_params)
+        # Honor implementation=fused_opt_states_bf16 (bf16 Adam states) for the AdamW
+        # group, like the base container does -- this custom __init__ bypasses it.
+        if config.implementation == "fused_opt_states_bf16":
+            self._register_bf16_optimizer_state_hook()
+        self._post_init(all_params)
+        tau = getattr(config, "qk_clip_tau", None)
+        self._qkclip = QKClip(self.model_parts, tau=tau) if tau is not None else None
+
+    def _post_step(self) -> None:
+        if self._qkclip is not None:
+            self._qkclip.step()
+
+    @staticmethod
+    def _resolve_optimizer_cls(name: str) -> type:
+        if name == "Muon":
+            return torch.optim.Muon
+        return OptimizersContainer._resolve_optimizer_cls(name)
+
+    def _validate_params(self, all_params: list[nn.Parameter]) -> None:
+        """Every *non-empty* trainable param must be assigned to one optimizer.
+
+        Overrides the base check to exclude empty ``Owned`` shards (``numel == 0``)
+        that this rank does not own -- they are intentionally skipped, not optimized.
+        """
+        expected = {
+            id(p)
+            for model in self.model_parts
+            for p in model.parameters()
+            if p.requires_grad and p.numel() > 0
+        }
+        actual = {id(p) for p in all_params}
+        assert expected == actual, (
+            f"Parameter mismatch: {len(expected)} non-empty trainable params in "
+            f"model, {len(actual)} in optimizers"
+        )
+
+
+class BenchInstrumentedOptimizers(_BenchMixin, OptimizersContainer):
+    """Plain core ``OptimizersContainer`` plus the benchmark instrumentation.
+
+    No Muon / placement-aware routing -- it is the stock container (regex param
+    groups, standard optimizers) with :class:`_BenchMixin` so the vanilla
+    **FSDP2 + AdamW** reference reports the same ``[muon-bench]`` line (total_iter /
+    opt_step / fwd_bwd / comm) as the FlexShard paths. Used to measure the cost of
+    *adopting* Owned/Muon over the production FSDP2 + AdamW setup.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OptimizersContainer.Config):
+        pass
+
+
+def build_comm_efficient_muon_optimizer(
+    model: nn.Module,
+    mesh: DeviceMesh | None = None,
+    *,
+    muon_kwargs: dict[str, Any] | None = None,
+    adamw_kwargs: dict[str, Any] | None = None,
+    implementation: str = "for-loop",
+) -> FlexShardMuonOptimizers:
+    """Convenience builder: a :class:`FlexShardMuonOptimizers` for one model.
+
+    For standalone use (tests, notebooks) without the trainer's config machinery.
+    Routes owned 2D matrices to Muon and the rest to AdamW. ``mesh`` is unused
+    (ownership is read from FlexShard param metadata) and kept for call-site
+    compatibility.
+    """
+    del mesh  # ownership is derived from param placement, not the mesh
+    config = FlexShardMuonOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern="<owned 2D matrices>",
+                optimizer_name="Muon",
+                optimizer_kwargs=dict(muon_kwargs or {}),
+            ),
+            ParamGroupConfig(
+                pattern="<rest>",
+                optimizer_name="AdamW",
+                optimizer_kwargs=dict(adamw_kwargs or {}),
+            ),
+        ],
+        implementation=implementation,
+    )
+    return FlexShardMuonOptimizers(config, model_parts=[model])
+
+
+class FlexShardGatherMuonOptimizers(_BenchMixin, OptimizersContainer):
+    """Full Muon with the *gather* dense distribution (FSDP/RaggedShard backend) + AdamW.
+
+    The gather counterpart to :class:`FlexShardMuonOptimizers` (Owned): sharded 2D dense
+    matrices go to :class:`GatherMuon` (all-gather + NS), 3D MoE experts go to
+    :class:`GroupedMuon` (whole, ``Shard(0)``) / :class:`GatherGroupedMuon` (sharded,
+    ``Shard(>=1)``), and everything else (norms, embeddings, output) to AdamW. So it
+    differs from Owned full Muon *only* in how the dense 2D matrices are distributed
+    (gather vs Owned). On a dense model (no experts) it is just gather-Muon + AdamW.
+    ``Config.param_groups`` supplies the per-optimizer kwargs (one ``optimizer_name="Muon"``,
+    one ``"AdamW"``); routing is by FlexShard placement/shape, not regex.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OptimizersContainer.Config):
+        qk_clip_tau: float | None = None
+
+    def __init__(self, config: OptimizersContainer.Config, *, model_parts) -> None:
+        impl_kwargs = self._build_impl_kwargs(config)
+        kwargs_by_name = {
+            pg.optimizer_name: pg.optimizer_kwargs for pg in config.param_groups
+        }
+        if "Muon" not in kwargs_by_name or "AdamW" not in kwargs_by_name:
+            raise ValueError(
+                "FlexShardGatherMuonOptimizers requires param_groups with "
+                "optimizer_name 'Muon' and 'AdamW'."
+            )
+        self.model_parts = model_parts
+        self.optimizers = []
+        all_params: list[nn.Parameter] = []
+        all_buckets: list[dict[str, Any]] = []
+
+        for part_idx, model in enumerate(model_parts):
+            buckets = _discover_dense_gather_buckets(model)
+            all_buckets.extend(buckets)
+            muon_param_ids = {
+                id(p) for b in buckets for p in b["params"] if p.numel() > 0
+            }
+            if buckets:
+                mesh = buckets[0]["storage"]._mesh
+                muon = GatherMuon(buckets, mesh, **kwargs_by_name["Muon"])
+                self.optimizers.append(muon)
+                self._log_optimizer(muon, part_idx, ["<sharded 2D matrices>"])
+                all_params.extend(muon.param_groups[0]["params"])
+
+            # 3D MoE experts -> GroupedMuon (whole) / GatherGroupedMuon (Shard(>=1)).
+            claimed = muon_param_ids | _build_grouped_expert_optimizers(
+                self,
+                model,
+                part_idx,
+                kwargs_by_name["Muon"],
+                muon_param_ids,
+                all_params,
+            )
+
+            adamw_params: list[nn.Parameter] = []
+            adamw_names: list[str] = []
+            for name, param in model.named_parameters():
+                if not param.requires_grad or param.numel() == 0:
+                    continue
+                if id(param) in claimed:
+                    continue
+                adamw_params.append(param)
+                adamw_names.append(canonical_fqn(name))
+            if adamw_params:
+                adamw = torch.optim.AdamW(
+                    [
+                        {
+                            "params": adamw_params,
+                            "param_names": adamw_names,
+                            **impl_kwargs,
+                            **kwargs_by_name["AdamW"],
+                        }
+                    ]
+                )
+                self.optimizers.append(adamw)
+                self._log_optimizer(adamw, part_idx, ["<rest>"])
+                all_params.extend(adamw_params)
+
+        self._validate_params(all_params)
+        # Honor implementation=fused_opt_states_bf16 (bf16 Adam states) for the AdamW
+        # group, like the base container does -- this custom __init__ bypasses it.
+        if config.implementation == "fused_opt_states_bf16":
+            self._register_bf16_optimizer_state_hook()
+        self._post_init(all_params)
+        self._setup_qkclip(config, all_buckets)
+
+    def _setup_qkclip(
+        self, config: OptimizersContainer.Config, buckets: list[dict[str, Any]]
+    ) -> None:
+        """Build :class:`QKClip` with a shard_map from the gather buckets (MuonClip).
+
+        Maps each gathered 2D param to its ``(placement, info, mesh)`` so QK-clip can
+        scale per-head rows of the *sharded* q/k projections (``Shard(0)`` /
+        ``GroupedRaggedShard``); ``None`` tau -> off.
+        """
+        tau = getattr(config, "qk_clip_tau", None)
+        if tau is None:
+            self._qkclip = None
+            return
+        shard_map: dict[int, tuple] = {}
+        for bucket in buckets:
+            placement = bucket["placement"]
+            mesh = bucket["storage"]._mesh
+            for info, param in zip(bucket["infos"], bucket["params"], strict=True):
+                shard_map[id(param)] = (placement, info, mesh)
+        self._qkclip = QKClip(self.model_parts, tau=tau, shard_map=shard_map)
+
+    def _post_step(self) -> None:
+        if self._qkclip is not None:
+            self._qkclip.step()
+
+    def _validate_params(self, all_params: list[nn.Parameter]) -> None:
+        """Every *non-empty* trainable param must be assigned to one optimizer.
+
+        Skips empty shards (``numel == 0``), which a rank may hold but not optimize.
+        """
+        expected = {
+            id(p)
+            for model in self.model_parts
+            for p in model.parameters()
+            if p.requires_grad and p.numel() > 0
+        }
+        actual = {id(p) for p in all_params}
+        assert expected == actual, (
+            f"Parameter mismatch: {len(expected)} non-empty trainable params in "
+            f"model, {len(actual)} in optimizers"
+        )
+
+
+class FSDP2MuonOptimizers(_BenchMixin, OptimizersContainer):
+    """FSDP2 (core ``fully_shard``) full-Muon baseline: DTensorMuon on dense 2D + experts.
+
+    The "DTensor does the all-gather in opt.step" counterpart to comm-efficient ``Owned``
+    (:class:`FlexShardMuonOptimizers`). The model is sharded by core ``fully_shard`` (params
+    are ``Shard`` DTensors); 2D transformer-body matrices (under ``layers.``) and 3D MoE
+    expert stacks both go to :class:`DTensorMuon` (which all-gathers and runs single /
+    batched-per-expert NS); embeddings, LM head and 1D norms -> AdamW. So it matches the
+    Owned / gather full-Muon recipe, differing only in that DTensor does the gather in the
+    step. ``Config.param_groups`` supplies the per-optimizer kwargs; routing is by FQN + ndim.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OptimizersContainer.Config):
+        pass
+
+    def __init__(self, config: OptimizersContainer.Config, *, model_parts) -> None:
+        impl_kwargs = self._build_impl_kwargs(config)
+        kwargs_by_name = {
+            pg.optimizer_name: pg.optimizer_kwargs for pg in config.param_groups
+        }
+        if "Muon" not in kwargs_by_name or "AdamW" not in kwargs_by_name:
+            raise ValueError(
+                "FSDP2MuonOptimizers requires param_groups with optimizer_name "
+                "'Muon' and 'AdamW'."
+            )
+        self.model_parts = model_parts
+        self.optimizers = []
+        all_params: list[nn.Parameter] = []
+
+        for part_idx, model in enumerate(model_parts):
+            muon_params: list[nn.Parameter] = []
+            adamw_params: list[nn.Parameter] = []
+            adamw_names: list[str] = []
+            # TODO(checkpoint): we collect canonical FQNs for the AdamW group only. The
+            # Muon group below is built flat (no "param_names"), so DCP save/load fails --
+            # checkpoint_utils.py:140 (_optim_state_dict_to_fqn_keys) raises on any group
+            # without "param_names". To make the fsdp2 Muon baseline checkpointable, also
+            # accumulate a muon_names list here and pass it through to DTensorMuon.
+            for name, param in model.named_parameters():
+                if not param.requires_grad or param.numel() == 0:
+                    continue
+                cfqn = canonical_fqn(name)
+                # 2D transformer-body matrices and 3D MoE expert stacks (under the expert
+                # marker) -> DTensorMuon (it all-gathers via full_tensor() and runs single /
+                # batched-per-expert NS); embeddings/LM head (outside ``layers.``) and 1D
+                # norms -> AdamW. Gating experts on the marker (not raw 3D ndim) keeps a
+                # future 3D non-expert param off expert Muon.
+                is_body_2d = (
+                    param.ndim == 2
+                    and cfqn.startswith("layers.")
+                    and _DEFAULT_EXPERT_MARKER not in cfqn
+                )
+                is_expert = param.ndim == 3 and _DEFAULT_EXPERT_MARKER in cfqn
+                if is_body_2d or is_expert:
+                    muon_params.append(param)
+                else:
+                    adamw_params.append(param)
+                    adamw_names.append(cfqn)
+            if muon_params:
+                muon = DTensorMuon(muon_params, **kwargs_by_name["Muon"])
+                self.optimizers.append(muon)
+                self._log_optimizer(
+                    muon, part_idx, ["<dense 2D body + 3D experts (DTensor)>"]
+                )
+                all_params.extend(muon_params)
+            if adamw_params:
+                adamw = torch.optim.AdamW(
+                    [
+                        {
+                            "params": adamw_params,
+                            "param_names": adamw_names,
+                            **impl_kwargs,
+                            **kwargs_by_name["AdamW"],
+                        }
+                    ]
+                )
+                self.optimizers.append(adamw)
+                self._log_optimizer(adamw, part_idx, ["<rest>"])
+                all_params.extend(adamw_params)
+
+        self._validate_params(all_params)
+        # Honor implementation=fused_opt_states_bf16 (bf16 Adam states) for the AdamW
+        # group, like the base container does -- this custom __init__ bypasses it.
+        if config.implementation == "fused_opt_states_bf16":
+            self._register_bf16_optimizer_state_hook()
+        self._post_init(all_params)
+
+    def _validate_params(self, all_params: list[nn.Parameter]) -> None:
+        """Every non-empty trainable param must be assigned to exactly one optimizer."""
+        expected = {
+            id(p)
+            for model in self.model_parts
+            for p in model.parameters()
+            if p.requires_grad and p.numel() > 0
+        }
+        actual = {id(p) for p in all_params}
+        assert expected == actual, (
+            f"Parameter mismatch: {len(expected)} non-empty trainable params in "
+            f"model, {len(actual)} in optimizers"
+        )

--- a/torchtitan/experiments/flex_shard/muon/dtensor_muon.py
+++ b/torchtitan/experiments/flex_shard/muon/dtensor_muon.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""DTensorMuon: the fsdp2 (core ``fully_shard``) Muon optimizer (gather-in-step).
+
+Per param, lets DTensor do the all-gather (``full_tensor()``) inside ``step()``, runs
+Newton-Schulz on the full tensor (one NS for a 2D matrix; batched per-expert NS for a 3D
+``[E, m, n]`` MoE expert stack), and redistributes back to the param's sharding. The fsdp2
+baseline against comm-efficient ``Owned`` Muon; the container that routes to it
+(:class:`containers.FSDP2MuonOptimizers`) lives in :mod:`containers`.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.optim._muon import (
+    _adjust_lr,
+    _zeropower_via_newtonschulz,
+    DEFAULT_A,
+    DEFAULT_B,
+    DEFAULT_C,
+    DEFAULT_NS_STEPS,
+    EPS,
+)
+
+from .newton_schulz import _zeropower_via_newtonschulz_batched
+
+
+class DTensorMuon(torch.optim.Optimizer):
+    """Muon for core ``fully_shard`` (FSDP2) DTensor params: gather each tensor in step().
+
+    The "let DTensor do the all-gather in opt.step" baseline (vs comm-efficient ``Owned``):
+    params are ``Shard`` DTensors from ``fully_shard``. Per param, the element-wise
+    momentum update is computed on the local shard (still a DTensor), ``full_tensor()``
+    all-gathers it to the full tensor on every rank, Newton-Schulz runs on the full tensor
+    (redundant across ranks) -- one NS for a 2D matrix, batched per-expert NS for a 3D
+    ``[E, m, n]`` MoE expert stack -- and the result is redistributed back to the param's
+    sharding so only this rank's shard is written. Bit-exact with single-device Muon; cost
+    is one all-gather + redundant NS per tensor per step (the comm ``Owned`` avoids).
+
+    TODO(checkpoint): callers build this with a flat param list and no "param_names", so
+    DCP save/load is not yet supported (see FSDP2MuonOptimizers and checkpoint_utils.py:140).
+    """
+
+    def __init__(
+        self,
+        params,
+        *,
+        lr: float = 0.02,
+        weight_decay: float = 0.1,
+        momentum: float = 0.95,
+        nesterov: bool = True,
+        ns_coefficients: tuple[float, float, float] = (DEFAULT_A, DEFAULT_B, DEFAULT_C),
+        ns_steps: int = DEFAULT_NS_STEPS,
+        eps: float = EPS,
+        adjust_lr_fn: str | None = None,
+    ) -> None:
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            nesterov=nesterov,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+            adjust_lr_fn=adjust_lr_fn,
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        from torch.distributed.tensor import DTensor, Replicate
+
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            weight_decay = group["weight_decay"]
+            momentum = group["momentum"]
+            nesterov = group["nesterov"]
+            ns_coefficients = group["ns_coefficients"]
+            ns_steps = group["ns_steps"]
+            eps = group["eps"]
+            adjust_lr_fn = group["adjust_lr_fn"]
+
+            for param in group["params"]:
+                if param.grad is None:
+                    continue
+                grad = param.grad
+                if not isinstance(param.data, DTensor) or not isinstance(grad, DTensor):
+                    raise ValueError(
+                        "DTensorMuon requires DTensor params/grads (core fully_shard); "
+                        f"got param={type(param.data).__name__} "
+                        f"grad={type(grad).__name__}."
+                    )
+                state = self.state[param]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(grad)
+                buf = state["momentum_buffer"]
+                buf.lerp_(grad, 1 - momentum)
+                update = grad.lerp(buf, momentum) if nesterov else buf
+
+                # DTensor does the all-gather: reconstruct the full tensor on every rank.
+                # 2D matrix -> one NS; 3D [E, m, n] MoE expert stack -> batched per-expert
+                # NS, with the lr adjusted by the per-expert (m, n) shape.
+                full_pre = update.full_tensor()
+                if full_pre.ndim == 3:
+                    full_update = _zeropower_via_newtonschulz_batched(
+                        full_pre, ns_coefficients, ns_steps, eps
+                    )
+                    lr_shape = tuple(full_update.shape[1:])
+                else:
+                    full_update = _zeropower_via_newtonschulz(
+                        full_pre, ns_coefficients, ns_steps, eps
+                    )
+                    lr_shape = tuple(full_update.shape)
+                adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
+
+                # Scatter back to the param's sharding (local slice, no collective): the
+                # full update is identical on every rank, so treat it as Replicate and
+                # redistribute to the param's placements to keep only this rank's shard.
+                mesh = param.device_mesh
+                update_dt = DTensor.from_local(
+                    full_update,
+                    mesh,
+                    [Replicate()] * mesh.ndim,
+                    run_check=False,
+                ).redistribute(mesh, param.placements)
+
+                param.mul_(1 - lr * weight_decay)
+                param.add_(update_dt, alpha=-adjusted_lr)
+        return loss

--- a/torchtitan/experiments/flex_shard/muon/gather_muon.py
+++ b/torchtitan/experiments/flex_shard/muon/gather_muon.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""Gather-for-NS Muon optimizers (2D dense + 3D Shard(>=1) experts).
+
+The Muon optimizers for the "this rank holds only a slice -> all-gather the full tensor
+before Newton-Schulz" case: :class:`GatherMuon` (sharded 2D dense matrices) and its
+subclass :class:`GatherGroupedMuon` (3D expert stacks sharded within the matrix). The
+routing that selects them lives in :mod:`containers`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.optim._muon import (
+    _adjust_lr,
+    _zeropower_via_newtonschulz,
+    DEFAULT_A,
+    DEFAULT_B,
+    DEFAULT_C,
+    DEFAULT_NS_STEPS,
+    EPS,
+)
+
+from ..example.ragged_shard import GroupedRaggedShard
+from .newton_schulz import _zeropower_via_newtonschulz_batched
+
+
+class GatherMuon(torch.optim.Optimizer):
+    """Muon for FSDP/RaggedShard-sharded 2D matrices via all-gather before NS.
+
+    Each step, per bucket: update the sharded momentum (element-wise), all-gather the
+    pre-NS update to reconstruct each full matrix, run Newton-Schulz on the full
+    matrix, and write back only this rank's shard. Bit-exact with single-device Muon;
+    cost is one all-gather/bucket plus redundant NS on every rank.
+    """
+
+    def __init__(
+        self,
+        buckets: list[dict[str, Any]],
+        mesh: DeviceMesh,
+        *,
+        lr: float = 0.02,
+        weight_decay: float = 0.1,
+        momentum: float = 0.95,
+        nesterov: bool = True,
+        ns_coefficients: tuple[float, float, float] = (DEFAULT_A, DEFAULT_B, DEFAULT_C),
+        eps: float = EPS,
+        ns_steps: int = DEFAULT_NS_STEPS,
+        adjust_lr_fn: str | None = None,
+    ) -> None:
+        self._mesh = mesh
+        self._buckets = buckets
+        params: list[nn.Parameter] = []
+        seen: set[int] = set()
+        for bucket in buckets:
+            for param in bucket["params"]:
+                if param.numel() > 0 and id(param) not in seen:
+                    seen.add(id(param))
+                    params.append(param)
+        if not params:
+            raise ValueError("GatherMuon found no sharded 2D matrices on this rank.")
+        # TODO(checkpoint): this builds a flat param group with no "param_names" key, so
+        # DCP save/load fails -- torchtitan/components/checkpoint_utils.py:140
+        # (_optim_state_dict_to_fqn_keys) raises when a group lacks "param_names". To make
+        # GatherMuon checkpointable, thread the per-param canonical FQNs through here and
+        # add them as a "param_names" entry (see how FlexShardGatherMuonOptimizers builds
+        # adamw_names for the AdamW group).
+        super().__init__(
+            params,
+            {
+                "lr": lr,
+                "weight_decay": weight_decay,
+                "momentum": momentum,
+                "nesterov": nesterov,
+                "ns_coefficients": ns_coefficients,
+                "eps": eps,
+                "ns_steps": ns_steps,
+                "adjust_lr_fn": adjust_lr_fn,
+            },
+        )
+
+    @staticmethod
+    def _local_update_shard(full_update, placement, info, rank, world_size):
+        """This rank's shard of the full Newton-Schulz update."""
+        if isinstance(placement, GroupedRaggedShard):
+            # Byte-balanced cut crosses param boundaries: slice the flat full matrix
+            # at this rank's offset within the param.
+            layout = info.bucket_layout.param_layouts[info.fqn]
+            start = layout.local_global_offset - layout.param_offset
+            return full_update.reshape(-1)[start : start + info.local_numel].view(
+                info.local_shape
+            )
+        return placement.extract_local_shard(full_update, rank, world_size)
+
+    @staticmethod
+    def _orthogonalize_full(full_pre, ns_coefficients, ns_steps, eps, global_shape):
+        """Orthogonalize one reconstructed full 2D matrix; returns (ortho, lr_shape).
+
+        Overridden by :class:`GatherGroupedMuon` for 3D ``[E, m, n]`` expert stacks
+        (batched per-expert NS, lr scaled by the per-expert ``(m, n)`` shape).
+        """
+        return (
+            _zeropower_via_newtonschulz(full_pre, ns_coefficients, ns_steps, eps),
+            global_shape,
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        group = self.param_groups[0]
+        lr = group["lr"]
+        weight_decay = group["weight_decay"]
+        momentum = group["momentum"]
+        nesterov = group["nesterov"]
+        ns_coefficients = group["ns_coefficients"]
+        eps = group["eps"]
+        ns_steps = group["ns_steps"]
+        adjust_lr_fn = group["adjust_lr_fn"]
+        rank = self._mesh.get_local_rank()
+        world_size = self._mesh.size()
+
+        for bucket in self._buckets:
+            placement = bucket["placement"]
+            infos = bucket["infos"]
+            params = bucket["params"]
+            storage = bucket["storage"]
+
+            # Stage each local shard's pre-NS update into one bucket-shaped scratch
+            # buffer so the placement can view it as a contiguous bucket slice; the
+            # momentum buffer stays sharded (its update is element-wise).
+            scratch = torch.zeros(
+                storage.total_bytes,
+                dtype=torch.uint8,
+                device=storage.byte_storage.device,
+            )
+            pre_views = [
+                placement.make_local_storage_view(scratch, info) for info in infos
+            ]
+            active: list[bool] = []
+            for info, param, pre_view in zip(infos, params, pre_views, strict=True):
+                has_update = info.local_numel > 0 and param.grad is not None
+                active.append(has_update)
+                if not has_update:
+                    continue
+                grad = param.grad
+                if grad.is_sparse:
+                    raise RuntimeError("GatherMuon does not support sparse gradients")
+                state = self.state[param]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(
+                        grad, memory_format=torch.preserve_format
+                    )
+                buf = state["momentum_buffer"]
+                buf.lerp_(grad, 1 - momentum)
+                pre_view.copy_(grad.lerp(buf, momentum) if nesterov else buf)
+
+            # One collective per bucket: all-gather the staged pre-NS shards and
+            # reconstruct each full matrix on every rank.
+            prepared = placement.prepare_unshard_bucket(
+                pre_views, infos, self._mesh, None
+            )
+            placement.run_prepared_unshard(prepared)
+            full_pre_updates = placement.finish_prepared_unshard(prepared).full_params
+
+            for info, param, full_pre, has_update in zip(
+                infos, params, full_pre_updates, active, strict=True
+            ):
+                if not has_update:
+                    continue
+                full_update, lr_shape = self._orthogonalize_full(
+                    full_pre, ns_coefficients, ns_steps, eps, info.global_shape
+                )
+                adjusted_lr = _adjust_lr(lr, adjust_lr_fn, lr_shape)
+                update_shard = self._local_update_shard(
+                    full_update, placement, info, rank, world_size
+                )
+                param.mul_(1 - lr * weight_decay)
+                param.add_(update_shard, alpha=-adjusted_lr)
+        return loss
+
+
+class GatherGroupedMuon(GatherMuon):
+    """GatherMuon for 3D MoE expert stacks sharded *within* the matrix (``Shard(dim>=1)``).
+
+    The ``Shard(1)`` counterpart to comm-efficient :class:`GroupedMuon`: when ``world_size >
+    num_experts`` each rank holds only a slice of every expert matrix, so per-expert
+    Newton-Schulz needs the full matrix. Reuses GatherMuon's gather/scatter unchanged
+    (all-gather each expert stack to ``[E, m, n]`` over the efsdp mesh, write back this
+    rank's ``[E, m_local, n]`` shard); only the orthogonalization differs -- one *batched*
+    NS over the reconstructed ``[E, m, n]`` (per-expert), with lr scaled by the per-expert
+    ``(m, n)`` shape. Cost: one all-gather/bucket + redundant batched NS per rank -- the
+    communication comm-efficient GroupedMuon avoids when experts are whole (``Shard(0)``).
+    """
+
+    @staticmethod
+    def _orthogonalize_full(full_pre, ns_coefficients, ns_steps, eps, global_shape):
+        # full_pre is the reconstructed [E, m, n]; batched per-expert NS; lr uses (m, n).
+        return (
+            _zeropower_via_newtonschulz_batched(
+                full_pre, ns_coefficients, ns_steps, eps
+            ),
+            global_shape[1:],
+        )

--- a/torchtitan/experiments/flex_shard/muon/grouped_muon.py
+++ b/torchtitan/experiments/flex_shard/muon/grouped_muon.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""GroupedMuon: a communication-efficient per-expert Muon optimizer for MoE experts.
+
+The Muon optimizer for "whole experts on this rank (``Shard(0)``) -> run per-expert
+Newton-Schulz locally, no gather" over 3D ``[E, m, n]`` expert stacks. The within-matrix-sharded
+counterpart (``Shard(>=1)``) is :class:`gather_muon.GatherGroupedMuon`; the routing that
+chooses between them lives in :mod:`containers`.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.optim._muon import (
+    _adjust_lr,
+    DEFAULT_A,
+    DEFAULT_B,
+    DEFAULT_C,
+    DEFAULT_NS_STEPS,
+    EPS,
+)
+
+from ..example.shard import Shard
+
+from ..flex_shard.sharded_param import get_placements
+from .newton_schulz import _zeropower_via_newtonschulz_batched
+
+
+class GroupedMuon(torch.optim.Optimizer):
+    """Muon for 3D MoE expert stacks via per-expert (batched) Newton-Schulz.
+
+    A rank's local expert parameter is ``[local_E, m, n]``. When expert parallelism shards
+    the expert (leading) dim -- ``Shard(0)``, which holds whenever ``efsdp <=
+    num_local_experts`` (equivalently world_size <= num_experts) -- every ``[m, n]`` is a
+    *whole* expert matrix, so Newton-Schulz runs per expert **locally and comm-efficient** (NS is
+    per-matrix and a rank's experts are disjoint from other ranks'). One batched ``baddbmm``
+    NS (:func:`_zeropower_via_newtonschulz_batched`) orthogonalizes the whole local stack at
+    once -- same FLOPs as per-expert NS, far fewer launches.
+
+    If an expert matrix is itself sharded (``Shard(dim>=1)``, i.e. ``efsdp >
+    num_local_experts``), NS on a partial matrix is invalid; that needs a gather over the
+    expert mesh before NS (as :class:`gather_muon.GatherMuon` does for 2D) and is not handled
+    here -- such a placement raises with guidance to use :class:`gather_muon.GatherGroupedMuon`.
+    """
+
+    def __init__(
+        self,
+        params,
+        *,
+        lr: float = 1e-3,
+        weight_decay: float = 0.1,
+        momentum: float = 0.95,
+        nesterov: bool = True,
+        ns_coefficients: tuple[float, float, float] = (DEFAULT_A, DEFAULT_B, DEFAULT_C),
+        ns_steps: int = DEFAULT_NS_STEPS,
+        eps: float = EPS,
+        adjust_lr_fn: str | None = None,
+    ) -> None:
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            nesterov=nesterov,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+            adjust_lr_fn=adjust_lr_fn,
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            weight_decay = group["weight_decay"]
+            momentum = group["momentum"]
+            nesterov = group["nesterov"]
+            coeffs = group["ns_coefficients"]
+            ns_steps = group["ns_steps"]
+            eps = group["eps"]
+            adjust_lr_fn = group["adjust_lr_fn"]
+            for p in group["params"]:
+                if p.grad is None or p.numel() == 0:
+                    continue
+                if p.grad.ndim != 3:
+                    raise ValueError(
+                        "GroupedMuon expects 3D [num_experts, m, n] expert stacks, got "
+                        f"ndim={p.grad.ndim}."
+                    )
+                placements = get_placements(p)
+                if placements is not None and any(
+                    isinstance(pl, Shard) and pl.dim >= 1 for pl in placements
+                ):
+                    raise NotImplementedError(
+                        "GroupedMuon: experts are sharded within the matrix (efsdp > "
+                        "num_local_experts, i.e. world_size > num_experts). NS on a partial "
+                        "matrix is invalid -- use GatherGroupedMuon (gather-before-NS over "
+                        "the expert mesh) for these; the FlexShard gather/owned Muon "
+                        "containers route Shard(dim>=1) experts there automatically."
+                    )
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(
+                        p.grad, memory_format=torch.preserve_format
+                    )
+                buf = state["momentum_buffer"]
+                buf.lerp_(p.grad, 1 - momentum)
+                update = p.grad.lerp(buf, momentum) if nesterov else buf
+                # One batched NS over the local [local_E, m, n] stack (per-expert ortho).
+                ortho = _zeropower_via_newtonschulz_batched(
+                    update, coeffs, ns_steps, eps
+                )
+                # lr adjustment uses the per-expert matrix shape (whole here).
+                adjusted_lr = _adjust_lr(lr, adjust_lr_fn, p.shape[1:])
+                p.mul_(1 - lr * weight_decay)
+                p.add_(ortho, alpha=-adjusted_lr)
+        return loss

--- a/torchtitan/experiments/flex_shard/muon/newton_schulz.py
+++ b/torchtitan/experiments/flex_shard/muon/newton_schulz.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""Newton-Schulz primitives + ownership cost model (NS FLOPs, LPT balancing)."""
+
+from __future__ import annotations
+
+import heapq
+
+import torch
+import torch.nn as nn
+
+
+def newton_schulz_flops(global_shape: torch.Size) -> int:
+    """Relative Newton-Schulz cost of one 2D matrix: ``m * n * min(m, n)``.
+
+    Each Newton-Schulz iteration forms the Gram matrix ``X @ X.T`` (an ``[m, m]``
+    product contracting all ``n`` columns), so cost scales with
+    ``m * n * min(m, n)`` rather than the parameter count ``m * n``. This is the
+    quantity to balance across owner ranks, since an owner runs NS only on the
+    matrices it owns. The constant factor (iteration count) is shared by all
+    matrices and irrelevant to balancing, so it is dropped.
+    """
+    m, n = int(global_shape[-2]), int(global_shape[-1])
+    return m * n * min(m, n)
+
+
+def layer_newton_schulz_cost(named_params: list[tuple[str, nn.Parameter]]) -> int:
+    """Total Newton-Schulz cost of a layer's 2D (Muon-eligible) matrices.
+
+    Non-2D params (norms, biases) carry no NS cost; they ride along on the
+    owner under AdamW and contribute negligible step time.
+    """
+    return sum(
+        newton_schulz_flops(param.shape) for _, param in named_params if param.ndim == 2
+    )
+
+
+def assign_layer_owners_lpt(layer_costs: list[int], world_size: int) -> list[int]:
+    """Assign one owner rank per layer, balancing total cost via greedy LPT.
+
+    Sorts layers by cost descending and repeatedly gives the heaviest remaining
+    layer to the least-loaded rank (a min-heap over ``(load, rank)``; ties broken
+    by rank index, so every rank computes the identical assignment -- required so
+    broadcast sources agree). The makespan is within 4/3 of optimal; residual
+    imbalance is bounded by the largest single layer, which cannot be split while
+    it stays one ``Owned`` bucket.
+
+    Returns ``owners`` where ``owners[i]`` is the owner rank of the ``i``-th layer
+    (same order as ``layer_costs``).
+    """
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, but got {world_size}.")
+    loads = [(0, rank) for rank in range(world_size)]
+    heapq.heapify(loads)
+    owners = [0] * len(layer_costs)
+    for layer_idx in sorted(
+        range(len(layer_costs)),
+        key=lambda i: layer_costs[i],
+        reverse=True,
+    ):
+        load, rank = heapq.heappop(loads)
+        owners[layer_idx] = rank
+        heapq.heappush(loads, (load + layer_costs[layer_idx], rank))
+    return owners
+
+
+def _zeropower_via_newtonschulz_batched(
+    grad: torch.Tensor,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> torch.Tensor:
+    """Batched Newton-Schulz over a stack of same-shape matrices ``[K, m, n]``.
+
+    Mathematically identical to applying :func:`_zeropower_via_newtonschulz` to each
+    ``[m, n]`` matrix independently, but replaces the per-matrix ``addmm`` with one
+    ``baddbmm`` over the batch -- the same FLOPs in far fewer kernel launches. Since
+    the batch dimension is independent, each slice's result matches the per-matrix
+    computation (same bf16 path, same coefficients).
+    """
+    if grad.ndim != 3:
+        raise ValueError("Batched Newton-Schulz expects a 3D [K, m, n] stack.")
+    a, b, c = ns_coefficients
+    ortho = grad.bfloat16()
+    # Same-shape group -> the transpose decision is uniform across the batch.
+    transposed = ortho.size(-2) > ortho.size(-1)
+    if transposed:
+        ortho = ortho.transpose(-2, -1)
+    # Per-matrix spectral-norm bound (Frobenius >= spectral norm).
+    norm = ortho.norm(dim=(-2, -1), keepdim=True).clamp(min=eps)
+    ortho = ortho / norm
+    for _ in range(ns_steps):
+        gram = ortho @ ortho.transpose(-2, -1)
+        gram_update = torch.baddbmm(gram, gram, gram, beta=b, alpha=c)
+        ortho = torch.baddbmm(ortho, gram_update, ortho, beta=a)
+    if transposed:
+        ortho = ortho.transpose(-2, -1)
+    return ortho

--- a/torchtitan/experiments/flex_shard/muon/owned.py
+++ b/torchtitan/experiments/flex_shard/muon/owned.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""Owned placement helpers + bucket builder for communication-efficient Muon.
+
+The ``Owned`` distribution for the dense 2D matrices: each whole matrix lives on one
+owner rank (so its Newton-Schulz runs locally, no all-gather in the step), with owners
+balanced across ranks by Newton-Schulz FLOPs. The dense Muon optimizer itself is
+``torch.optim.Muon`` (external); the routing that sends owned 2D matrices to it lives
+in :mod:`containers`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+
+from ..example.owned import Owned
+from ..example.shard import per_param_placements
+
+from ..flex_shard.bucket_storage import BucketSpec, PlacementFn
+from ..flex_shard.sharded_param import get_global_shape, get_placements
+from .newton_schulz import assign_layer_owners_lpt, layer_newton_schulz_cost
+
+
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+
+
+def make_owned_placement_fn(owner_rank: int) -> PlacementFn:
+    """Return a ``placement_fn`` assigning every param in the bucket to one owner.
+
+    FlexShard requires all params in a bucket to share one placement, so a whole
+    layer owned by one rank is a single uniform ``Owned`` bucket. (Contrast with
+    ``param_boundary_placements``, which assigns each param an independent owner
+    and therefore needs one-param buckets.)
+    """
+
+    def placement_fn(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Owned, ...]]:
+        return {fqn: (Owned(owner_rank),) for fqn, _ in named_params}
+
+    return placement_fn
+
+
+def _group_params_by_layer(
+    model: nn.Module,
+) -> tuple[dict[int, list[tuple[str, nn.Parameter]]], list[str]]:
+    """Split named params into per-layer groups and the rest (by top-level name).
+
+    Returns ``(layer_params, rest_top_names)`` where ``layer_params[i]`` lists the
+    ``(fqn, param)`` of layer ``i``, and ``rest_top_names`` is the sorted set of
+    top-level module names for params not under ``layers.<i>.`` (e.g.
+    ``tok_embeddings``, ``norm``, ``output``).
+    """
+    layer_params: dict[int, list[tuple[str, nn.Parameter]]] = defaultdict(list)
+    rest_top_names: set[str] = set()
+    for fqn, param in model.named_parameters():
+        match = _LAYER_RE.match(fqn)
+        if match:
+            layer_params[int(match.group(1))].append((fqn, param))
+        else:
+            rest_top_names.add(fqn.split(".")[0])
+    return layer_params, sorted(rest_top_names)
+
+
+def comm_efficient_muon_buckets(
+    model: nn.Module,
+    mesh: DeviceMesh,
+    *,
+    reshard_after_forward: bool = True,
+) -> list[BucketSpec]:
+    """Build FlexShard buckets for communication-efficient Muon.
+
+    Produces one ``Owned`` bucket per transformer layer (owner balanced by
+    Newton-Schulz FLOPs via :func:`assign_layer_owners_lpt`), plus one
+    ``Shard(0)`` bucket per non-layer top-level module (embeddings, final norm,
+    output head) -- those go to AdamW.
+
+    Must be called before :func:`flex_shard` (parameters are still full). Requires
+    ``num_layers >= world_size`` so every rank owns at least one layer.
+    """
+    world_size = mesh.size()
+    layer_params, rest_top_names = _group_params_by_layer(model)
+    if not layer_params:
+        raise ValueError(
+            "comm_efficient_muon_buckets found no `layers.<i>.*` parameters; the model "
+            "does not match the expected transformer layout."
+        )
+
+    layer_indices = sorted(layer_params)
+    num_layers = len(layer_indices)
+    if num_layers < world_size:
+        raise ValueError(
+            f"comm_efficient_muon_buckets requires num_layers >= world_size, but got "
+            f"{num_layers} layers and world_size {world_size}. Below this "
+            "threshold some ranks would own no layer and idle during the step; "
+            "finer-grained (per-matrix) ownership is needed there (out of scope)."
+        )
+
+    layer_costs = [layer_newton_schulz_cost(layer_params[i]) for i in layer_indices]
+    owners = assign_layer_owners_lpt(layer_costs, world_size)
+
+    buckets = [
+        BucketSpec(
+            [f"layers.{idx}.*"],
+            placement_fn=make_owned_placement_fn(owner),
+            mesh=mesh,
+            reshard_after_forward=reshard_after_forward,
+        )
+        for idx, owner in zip(layer_indices, owners, strict=True)
+    ]
+    # Non-layer params (embeddings / final norm / output head) stay Shard(0) and
+    # are optimized by AdamW. One bucket per top-level module keeps each bucket's
+    # forward hook on a real execution unit (a grouped root-level bucket is
+    # rejected when reshard-after-forward composes with activation checkpointing).
+    for top in rest_top_names:
+        buckets.append(
+            BucketSpec(
+                [f"{top}.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            )
+        )
+    return buckets
+
+
+def is_owned_2d(param: nn.Parameter) -> bool:
+    """Whether this rank owns the full 2D matrix backing ``param`` (Muon-eligible).
+
+    Under ``Owned`` a non-owner rank holds an empty ``(0, 0)`` shard, so
+    "owned-by-this-rank" is exactly "``Owned`` placement and ``numel > 0``" -- no
+    rank lookup needed. Sharded params (embeddings/output) and this rank's owned
+    non-2D params (norms) return False and fall through to AdamW.
+    """
+    if param.numel() == 0:
+        return False
+    placements = get_placements(param)
+    global_shape = get_global_shape(param)
+    if placements is None or global_shape is None:
+        return False
+    if len(placements) != 1 or not isinstance(placements[0], Owned):
+        return False
+    return len(global_shape) == 2

--- a/torchtitan/experiments/flex_shard/muon/qkclip.py
+++ b/torchtitan/experiments/flex_shard/muon/qkclip.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+"""MuonClip (Kimi K2) QK-clip for DeepSeek V3 MLA attention."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from torchtitan.tools.logging import logger
+
+
+def _is_mla_attention(module: nn.Module) -> bool:
+    """A DeepSeek V3 MLA attention module (has the wkv_b proj + the head-dim split)."""
+    return (
+        hasattr(module, "wkv_b")
+        and hasattr(module, "inner_attention")
+        and hasattr(module, "n_heads")
+        and hasattr(module, "qk_nope_head_dim")
+        and hasattr(module, "qk_rope_head_dim")
+    )
+
+
+def _max_logit_per_head(
+    q: torch.Tensor, k: torch.Tensor, scale: float, mask=None
+) -> torch.Tensor:
+    """Per-head max pre-softmax attention logit over the *attended* positions.
+
+    ``q``/``k`` are ``[bsz, seqlen, n_heads, qk_head_dim]`` (the layout passed to the
+    inner attention). Returns ``[n_heads]`` = max over batch and over the kept (i, j)
+    positions of ``scale * (q_i . k_j)``. This is the "cheap separate pass" that
+    materializes the score matrix the fused FlexAttention kernel does not expose.
+
+    ``mask`` is the masking the real kernel applies, so the max is taken over exactly
+    the positions the kernel attends to (not cross-document pairs it never sees, which
+    would make ``tau`` a guarantee about the wrong score set). A FlexAttention
+    ``BlockMask`` (causal + any document/packed masking) is materialized to a dense
+    ``[B, 1, S, S]`` keep-mask via its ``mask_mod``; without one (e.g. plain SDPA) it
+    falls back to a causal lower-triangular mask.
+    """
+    from torch.nn.attention.flex_attention import BlockMask, create_mask
+
+    scores = torch.einsum("bihd,bjhd->bhij", q.float(), k.float()).mul_(scale)
+    bsz, _, seqlen, _ = scores.shape
+    if isinstance(mask, BlockMask):
+        # Dense [B, 1, S, S] keep-mask from the kernel's own mask_mod (head-broadcast).
+        keep = create_mask(mask.mask_mod, bsz, 1, seqlen, seqlen, device=scores.device)
+    else:
+        keep = torch.ones(
+            seqlen, seqlen, dtype=torch.bool, device=scores.device
+        ).tril_()
+    scores.masked_fill_(~keep, float("-inf"))
+    return scores.amax(dim=(0, 2, 3))
+
+
+def _scale_rows(
+    linear: nn.Module,
+    row_scale: torch.Tensor,
+    shard_map: dict[int, tuple] | None = None,
+) -> None:
+    """Scale output rows (dim 0) of a Linear's weight in place, sharding-aware.
+
+    Reads the *persistent* parameter from ``module._parameters`` rather than the
+    ``module.weight`` attribute: under FlexShard eager mode ``module.weight`` is a
+    property backed by the bucket unshard hook and only materializes inside the module
+    forward (it raises at optimizer-step time), whereas ``_parameters`` holds the
+    persistent (owner-full / sharded) tensor the optimizer also operates on.
+
+    Three placement regimes:
+
+    * ``shard_map`` entry (gather methods -- ``Shard(0)`` / ``GroupedRaggedShard``): the
+      weight is row- or byte-sharded across ranks. Build the full ``[out, in]`` scale
+      matrix and extract this rank's local slice with
+      :meth:`GatherMuon._local_update_shard` (the same full->local map the gather
+      optimizer uses), then scale the local shard -- correct even when a byte cut splits
+      a row across ranks.
+    * ``Owned`` (no ``shard_map`` entry): the persistent weight is the full matrix on the
+      owner (full row count) and empty on others -- scale all rows on the owner, skip
+      empty shards.
+    * Plain ``DTensor`` (row-sharded, no shard_map): skipped -- needs the global->local
+      head-row mapping (fsdp2 QK-clip is a follow-up).
+
+    DeepSeek V3 q/k projections have no bias (Linear ``bias=False``), so only the weight
+    is scaled; a bias under sharding would need separate handling and raises.
+    """
+    from torch.distributed.tensor import DTensor
+
+    weight = linear._parameters["weight"]
+    bias = linear._parameters.get("bias")
+
+    entry = shard_map.get(id(weight)) if shard_map is not None else None
+    if entry is not None:
+        placement, info, mesh = entry
+        out_f, in_f = int(info.global_shape[0]), int(info.global_shape[1])
+        if out_f != row_scale.shape[0]:
+            return
+        local = weight.data
+        if local.numel() == 0:
+            return
+        if bias is not None:
+            raise NotImplementedError("QK-clip on a sharded biased projection")
+        full_scale = (
+            row_scale.to(local.dtype).unsqueeze(1).expand(out_f, in_f).contiguous()
+        )
+        # Lazy import to avoid a qkclip <-> gather import cycle (gather imports QKClip).
+        from .gather_muon import GatherMuon
+
+        local_scale = GatherMuon._local_update_shard(
+            full_scale, placement, info, mesh.get_local_rank(), mesh.size()
+        )
+        local.mul_(local_scale)
+        return
+
+    local = weight.to_local() if isinstance(weight, DTensor) else weight.data
+    if local.shape[0] != row_scale.shape[0]:
+        return
+    local.mul_(row_scale.to(local.dtype).unsqueeze(1))
+    if bias is not None:
+        b_local = bias.to_local() if isinstance(bias, DTensor) else bias.data
+        if b_local.shape[0] == row_scale.shape[0]:
+            b_local.mul_(row_scale.to(b_local.dtype))
+
+
+class QKClip:
+    """MuonClip QK-clip (Kimi K2) for DeepSeek V3 MLA attention.
+
+    After each optimizer step, rescales per-head query/key projection rows so the next
+    forward's max attention logit is pulled back to ``tau``. The attention logit is
+    bilinear in (Wq, Wk), so scaling both by ``gamma`` scales the logit by ``gamma``;
+    with ``gamma_h = tau / S_max^h`` (only for heads whose observed max logit
+    ``S_max^h > tau``, else 1) the head's max logit becomes ``tau``.
+
+    For MLA only the *unshared* components are scaled (Kimi K2): the head-specific
+    ``qC`` and ``kC`` (no-position) each by ``sqrt(gamma_h)`` and the head-specific
+    ``qR`` (rotary query) by ``gamma_h``, while the *shared* rotary key ``kR`` (from
+    ``wkv_a``) is left untouched to avoid coupling heads. So ``qC.kC`` scales by
+    ``gamma_h`` and ``qR.kR`` scales by ``gamma_h`` -- both terms, hence the whole
+    logit, scale by ``gamma_h``.
+
+    ``S_max^h`` is captured each forward by wrapping the module's ``inner_attention``
+    with an eager ``[B, H, S, S]`` score-materialization pass (:func:`_max_logit_per_head`,
+    masked by the real ``BlockMask``); the wrapper stores it on the attention module, and
+    :meth:`step` consumes the most recent value (reducing it across data-parallel ranks).
+    The capture runs in the forward, so its cost is attributed to ``fwd_bwd`` in the
+    benchmark, not ``opt_step`` (see :class:`bench._BenchMixin`); enabling QK-clip is the
+    tax, independent of the dense-Muon distribution strategy.
+    """
+
+    def __init__(
+        self,
+        model_parts: list[nn.Module],
+        *,
+        tau: float,
+        shard_map: dict[int, tuple] | None = None,
+    ) -> None:
+        self.tau = float(tau)
+        # shard_map: {id(persistent weight) -> (placement, info, mesh)} for gather
+        # methods whose q/k projections are row-/byte-sharded; None for Owned (full on
+        # owner). See :func:`_scale_rows`.
+        self._shard_map = shard_map
+        self._attns: list[nn.Module] = []
+        for model in model_parts:
+            for module in model.modules():
+                if _is_mla_attention(module):
+                    self._attns.append(module)
+                    self._install_capture(module)
+
+    @staticmethod
+    def _install_capture(attn: nn.Module) -> None:
+        inner = attn.inner_attention
+        orig_forward = inner.forward
+
+        def capture_forward(q, k, v, *args, **kwargs):
+            scale = kwargs.get("scale", None)
+            if scale is None:
+                scale = attn.softmax_scale
+            mask = kwargs.get("attention_masks", None)
+            with torch.no_grad():
+                attn._qkclip_smax = _max_logit_per_head(
+                    q.detach(), k.detach(), scale, mask
+                )
+            return orig_forward(q, k, v, *args, **kwargs)
+
+        inner.forward = capture_forward
+
+    @torch.no_grad()
+    def step(self) -> None:
+        debug = os.environ.get("QKCLIP_DEBUG") == "1"
+        max_logit = 0.0
+        heads_clipped = 0
+        for attn in self._attns:
+            smax = getattr(attn, "_qkclip_smax", None)
+            if smax is None:
+                continue
+            # Data-parallel correctness: each rank captured S_max from its own local
+            # batch, so reduce to the global-batch per-head max before clipping --
+            # otherwise the owner (Owned) clips on only its rank's logits, and sharded
+            # rows would be scaled from different local maxima. MAX over the default
+            # (world) group equals the data-parallel max when attention is not split by
+            # head/sequence (tp=cp=1, the regime these configs run in); every rank runs
+            # the full (replicated) attention on a distinct data slice, including under
+            # EP (which partitions only experts).
+            # TODO: with TP/CP, reduce only over the data-parallel axes -- heads/sequence
+            # are partitioned there, so a plain world MAX would mix unrelated heads.
+            if (
+                dist.is_available()
+                and dist.is_initialized()
+                and dist.get_world_size() > 1
+            ):
+                dist.all_reduce(smax, op=dist.ReduceOp.MAX)
+            if debug:
+                max_logit = max(max_logit, float(smax.max()))
+                heads_clipped += int((smax > self.tau).sum())
+            gamma = torch.where(smax > self.tau, self.tau / smax, torch.ones_like(smax))
+            if bool((gamma < 1.0).any()):
+                self._rescale(attn, gamma)
+        if debug:
+            logger.info(
+                f"[qkclip] pre-clip max_logit={max_logit:.2f} "
+                f"heads_clipped={heads_clipped} tau={self.tau:.1f}"
+            )
+
+    def _rescale(self, attn: nn.Module, gamma: torch.Tensor) -> None:
+        n_heads = attn.n_heads
+        nope = attn.qk_nope_head_dim
+        qk_head_dim = nope + attn.qk_rope_head_dim
+        v_head_dim = attn.v_head_dim
+        sqrt_gamma = gamma.sqrt()
+
+        # Query projection rows per head: qC (nope) -> sqrt(gamma), qR (rope) -> gamma.
+        qproj = attn.wq if attn.q_lora_rank == 0 else attn.wq_b
+        q_scale = gamma.new_ones(n_heads * qk_head_dim)
+        for h in range(n_heads):
+            base = h * qk_head_dim
+            q_scale[base : base + nope] = sqrt_gamma[h]
+            q_scale[base + nope : base + qk_head_dim] = gamma[h]
+        _scale_rows(qproj, q_scale, self._shard_map)
+
+        # wkv_b rows per head: kC (nope) -> sqrt(gamma), v -> 1 (untouched). kR (shared
+        # rotary key, from wkv_a) is never scaled.
+        kvb = nope + v_head_dim
+        kv_scale = gamma.new_ones(n_heads * kvb)
+        for h in range(n_heads):
+            base = h * kvb
+            kv_scale[base : base + nope] = sqrt_gamma[h]
+        _scale_rows(attn.wkv_b, kv_scale, self._shard_map)

--- a/torchtitan/experiments/flex_shard/qwen3/__init__.py
+++ b/torchtitan/experiments/flex_shard/qwen3/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.qwen3 import model_registry as qwen3_model_registry
+
+from .parallelize import parallelize_qwen3_muon
+
+
+def model_registry(*args, **kwargs):
+    """Qwen3 model spec using the FlexShard + Muon parallelizer.
+
+    Reuses the core Qwen3 model unchanged; only swaps the parallelize_fn for the
+    experimental eager FlexShard + communication-efficient Muon path.
+    """
+    spec = qwen3_model_registry(*args, **kwargs)
+    spec.name = "flex_shard.qwen3"
+    spec.parallelize_fn = parallelize_qwen3_muon
+    spec.pipelining_fn = None
+    return spec
+
+
+__all__ = ["model_registry", "parallelize_qwen3_muon"]

--- a/torchtitan/experiments/flex_shard/qwen3/config_registry.py
+++ b/torchtitan/experiments/flex_shard/qwen3/config_registry.py
@@ -1,0 +1,382 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FlexShard + Muon benchmark configs for the dense Qwen3 ladder.
+
+Built for the distributed-Muon **systems** benchmark (see
+``docs/muon.md``): the comm-efficient ``Owned`` Muon path across model sizes
+(``..._muon`` for every flavor -> model-size / GPU-count scaling), plus the
+gather-for-NS baselines and an AdamW reference at a couple of sizes (the fixed-config
+optimizer-step breakdown).
+
+Notes:
+- **Weight tying is disabled** (``enable_weight_tying=False``). FlexShard assigns each
+  parameter FQN to exactly one bucket, so a tied ``lm_head.weight`` /
+  ``tok_embeddings.weight`` (one shared storage under two FQNs) would be sharded twice;
+  untying makes them separate sharded params. Qwen3's tied flavors (0.6B/1.7B/4B)
+  *skip-init* the embedding (it normally aliases the initialized LM head), so once
+  untied the embedding must be initialized itself -- we set it to ``normal_(std=1.0)``,
+  matching the natively-untied flavors (8B/14B/32B). This slightly inflates the small
+  flavors' param count (a separate LM head); the systems metrics (``opt_step`` scales
+  with NS work, ``step_comm`` with sharding) are unaffected by tying.
+- **Activation checkpointing is disabled** (AC recompute does not yet compose with
+  FlexShard's ``Owned`` broadcast + FlexAttention's compiled HOP; re-enabling is Stage 2).
+- The test tokenizer + ``c4_test`` are used so configs run without HF asset downloads;
+  token content does not affect the step-time measurements. Override batch/seq/steps on
+  the CLI per size as needed.
+"""
+
+from functools import partial
+
+import torch.nn as nn
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.loss import ChunkedCELoss
+from torchtitan.components.lr_scheduler import LRSchedulersContainer
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw, ParamGroupConfig
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.experiments.flex_shard.muon import (
+    BenchInstrumentedOptimizers,
+    FlexShardGatherMuonOptimizers,
+    FlexShardMuonOptimizers,
+)
+from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.qwen3 import model_registry as core_qwen3_model_registry
+from torchtitan.trainer import Trainer
+
+from . import model_registry
+from .parallelize import (
+    make_gather_muon_parallelize_fn,
+    parallelize_qwen3_moe_muon,
+    parallelize_qwen3_moe_muon_auto,
+    parallelize_qwen3_moe_muon_twolevel,
+    parallelize_qwen3_muon_auto,
+    parallelize_qwen3_muon_idle,
+    parallelize_qwen3_muon_permatrix,
+    parallelize_qwen3_muon_twolevel,
+)
+
+
+def _muon_optimizer(
+    *, muon_lr: float = 0.02, adamw_lr: float = 8e-4
+) -> FlexShardMuonOptimizers.Config:
+    """Full Muon (placement-routed): owned 2D dense -> Muon, 3D MoE experts ->
+    GroupedMuon / GatherGroupedMuon, everything else -> AdamW. On a dense model (no 3D
+    experts) this reduces to dense Muon + AdamW.
+    """
+    return FlexShardMuonOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern="<owned 2D matrices>",
+                optimizer_name="Muon",
+                optimizer_kwargs={
+                    "lr": muon_lr,
+                    "weight_decay": 0.1,
+                    "momentum": 0.95,
+                    "nesterov": True,
+                },
+            ),
+            ParamGroupConfig(
+                pattern="<rest>",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": adamw_lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
+        ],
+        implementation="foreach",
+    )
+
+
+def _gather_muon_optimizer(
+    *, muon_lr: float = 0.02, adamw_lr: float = 8e-4
+) -> FlexShardGatherMuonOptimizers.Config:
+    """Full Muon, gather dense distribution: sharded 2D dense -> GatherMuon (all-gather +
+    NS), 3D experts -> GroupedMuon / GatherGroupedMuon, everything else -> AdamW. On a
+    dense model (no experts) this is just gather-Muon + AdamW."""
+    return FlexShardGatherMuonOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern="<sharded 2D matrices>",
+                optimizer_name="Muon",
+                optimizer_kwargs={
+                    "lr": muon_lr,
+                    "weight_decay": 0.1,
+                    "momentum": 0.95,
+                    "nesterov": True,
+                },
+            ),
+            ParamGroupConfig(
+                pattern="<rest>",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": adamw_lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
+        ],
+        implementation="foreach",
+    )
+
+
+def _bench_adamw_optimizer(lr: float = 8e-4) -> BenchInstrumentedOptimizers.Config:
+    """AdamW with benchmark instrumentation (for the vanilla FSDP2 + AdamW reference)."""
+    return BenchInstrumentedOptimizers.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern=".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={
+                    "lr": lr,
+                    "betas": (0.9, 0.95),
+                    "eps": 1e-8,
+                    "weight_decay": 0.1,
+                },
+            ),
+        ],
+        implementation="foreach",
+    )
+
+
+def _flex_shard_qwen3(
+    flavor: str, *, variant: str, truncate_layers: int | None = None
+) -> Trainer.Config:
+    """Build a Qwen3 benchmark config for ``flavor`` and optimizer ``variant``.
+
+    ``variant`` is one of ``"muon"`` (FlexShard comm-efficient ``Owned``, whole-layer
+    allocation -- case 1), ``"muon_permatrix"`` (per-2D-tensor allocation -- case 2,
+    finer LPT balance), ``"adamw"`` (FlexShard ``Owned`` +
+    AdamW; isolates the optimizer at fixed sharding), ``"gather_shard"`` /
+    ``"gather_grouped"`` (FlexShard gather-for-NS Muon baselines), or ``"fsdp2_adamw"``
+    (**vanilla FSDP2 + AdamW** -- the production reference; measures the cost of *adopting*
+    Owned/Muon, engine + optimizer). All share the same model/batch/seq/AC-off so only the
+    sharding+optimizer differ.
+    """
+    # The fsdp2_adamw reference uses the core FSDP2 (fully_shard) parallelizer; every
+    # other variant uses the FlexShard parallelizer (Owned by default).
+    if variant == "fsdp2_adamw":
+        spec = core_qwen3_model_registry(flavor)
+    else:
+        spec = model_registry(flavor)
+    # Untie lm_head from tok_embeddings (FlexShard shards each FQN once) and re-init the
+    # now-separate embedding; applied to every variant so they compare the same model.
+    spec.model.enable_weight_tying = False
+    spec.model.tok_embeddings.param_init = {"weight": partial(nn.init.normal_, std=1.0)}
+    # Optional depth truncation -- to study the num_layers < world_size regime (where
+    # two-level / per-tensor allocation differs from whole-layer) on a fixed GPU count.
+    if truncate_layers is not None:
+        spec.model.layers = spec.model.layers[:truncate_layers]
+
+    config = Trainer.Config(
+        loss=ChunkedCELoss.Config(),
+        hf_assets_path="./tests/assets/tokenizer",
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=spec,
+        dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
+        optimizer=_muon_optimizer(),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
+        training=TrainingConfig(local_batch_size=4, seq_len=2048, steps=10),
+        checkpoint=CheckpointManager.Config(interval=1000),
+        # AC off for all variants: AC does not yet compose with Owned broadcast +
+        # FlexAttention's HOP, and keeping it off everywhere makes the comparison fair.
+        activation_checkpoint=None,
+    )
+
+    if variant == "muon":
+        config.optimizer = _muon_optimizer()
+    elif variant == "muon_permatrix":
+        # Per-2D-tensor Owned allocation (case 2): same Muon optimizer, finer LPT.
+        config.model_spec.parallelize_fn = parallelize_qwen3_muon_permatrix
+        config.optimizer = _muon_optimizer()
+    elif variant == "muon_twolevel":
+        # Two-level allocation: per-layer rank groups + within-layer LPT.
+        config.model_spec.parallelize_fn = parallelize_qwen3_muon_twolevel
+        config.optimizer = _muon_optimizer()
+    elif variant == "muon_idle":
+        # Whole-layer (case 1) allowing idle ranks -- reference at num_layers<world_size.
+        config.model_spec.parallelize_fn = parallelize_qwen3_muon_idle
+        config.optimizer = _muon_optimizer()
+    elif variant == "muon_auto":
+        # Unified system: auto-select the allocation level for this regime.
+        config.model_spec.parallelize_fn = parallelize_qwen3_muon_auto
+        config.optimizer = _muon_optimizer()
+    elif variant == "adamw":
+        config.optimizer = default_adamw(lr=8e-4)
+    elif variant == "fsdp2_adamw":
+        config.optimizer = _bench_adamw_optimizer()
+    elif variant == "gather_shard":
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("shard")
+        config.optimizer = _gather_muon_optimizer()
+    elif variant == "gather_grouped":
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("grouped")
+        config.optimizer = _gather_muon_optimizer()
+    elif variant == "gather_shard_raf":
+        # gather-for-NS Muon with reshard-after-forward ON (Shard(0) supports RAF; the
+        # sharded matrices reshard after forward instead of staying resident).
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn(
+            "shard", reshard_after_forward=True
+        )
+        config.optimizer = _gather_muon_optimizer()
+    elif variant == "gather_grouped_raf":
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn(
+            "grouped", reshard_after_forward=True
+        )
+        config.optimizer = _gather_muon_optimizer()
+    else:
+        raise ValueError(f"unknown variant {variant!r}")
+    return config
+
+
+# =====================================================================================
+# Representative example configs (one per capability). The full set used for Experiments
+# A/B (every model size x method x granularity/batched variant) lives in the local-only
+# ``config_registry_local.py``; this submitted file keeps just a few examples that show the
+# pattern -- add more by following the same ``_flex_shard_qwen3`` / ``_flex_shard_qwen3_moe``
+# factory calls.
+# =====================================================================================
+# --- Dense: comm-efficient Owned Muon (debug + 4B); add other sizes via the same factory ---
+def flex_shard_qwen3_debugmodel_muon() -> Trainer.Config:
+    return _flex_shard_qwen3("debugmodel", variant="muon")
+
+
+def flex_shard_qwen3_4b_muon() -> Trainer.Config:
+    return _flex_shard_qwen3("4B", variant="muon")
+
+
+def flex_shard_qwen3_4b_muon_permatrix() -> Trainer.Config:
+    return _flex_shard_qwen3("4B", variant="muon_permatrix")
+
+
+def flex_shard_qwen3_4b_muon_auto() -> Trainer.Config:
+    # 36 layers, 8 GPUs -> auto resolves to "layer" (W <= num_layers).
+    return _flex_shard_qwen3("4B", variant="muon_auto")
+
+
+# --- Vanilla FSDP2 + AdamW reference (production baseline: cost of adopting Owned/Muon) ---
+def flex_shard_qwen3_4b_fsdp2_adamw() -> Trainer.Config:
+    return _flex_shard_qwen3("4B", variant="fsdp2_adamw")
+
+
+def flex_shard_qwen3_4b_gather_muon_shard() -> Trainer.Config:
+    return _flex_shard_qwen3("4B", variant="gather_shard")
+
+
+def flex_shard_qwen3_4b_gather_muon_grouped() -> Trainer.Config:
+    return _flex_shard_qwen3("4B", variant="gather_grouped")
+
+
+def _flex_shard_qwen3_moe(
+    flavor: str,
+    *,
+    variant: str,
+    expert_parallel_degree: int = 8,
+    truncate_layers: int | None = None,
+    muon_lr: float = 0.005,
+    adamw_lr: float = 2e-4,
+) -> Trainer.Config:
+    """Build a Qwen3-MoE benchmark config for ``flavor`` and optimizer ``variant``.
+
+    ``variant`` is one of ``"muon"`` (comm-efficient Owned whole-layer + EP),
+    ``"muon_auto"`` (Owned with the auto allocation level -- per-tensor / two-level when
+    ``num_layers < world_size`` -- + EP), ``"muon_twolevel"`` (Owned two-level + EP),
+    ``"adamw"`` (Owned + AdamW at the same EP sharding -- optimizer-only baseline),
+    ``"gather_shard"`` / ``"gather_grouped"`` (gather-for-NS Muon baselines; EP-capable --
+    experts go to the EP mesh, only the dense 2D matrices are gathered), or
+    ``"fsdp2_adamw"`` (vanilla FSDP2 + AdamW + EP, the
+    production reference). The comm-efficient (Owned) variants are full Muon: dense 2D
+    matrices -> Owned Muon, 3D experts -> GroupedMuon / GatherGroupedMuon; norms,
+    embeddings and the LM head -> AdamW.
+    """
+    if variant == "fsdp2_adamw":
+        spec = core_qwen3_model_registry(flavor)
+    else:
+        spec = model_registry(flavor)
+    # FlexShard assigns each FQN to one bucket; untie lm_head/embedding so they are
+    # separate sharded params (both are natively initialized in the MoE flavors).
+    spec.model.enable_weight_tying = False
+    # Optional depth truncation -- to exercise the num_layers < world_size regime (where
+    # the auto/two-level dense allocation differs from whole-layer) on a fixed GPU count.
+    if truncate_layers is not None:
+        spec.model.layers = spec.model.layers[:truncate_layers]
+
+    # All methods use the same EP degree so the comparison is fixed-config (dp/ep): the
+    # gather baselines now route experts to the EP mesh (gathering only the dense 2D
+    # matrices), so only the dense-matrix distribution differs across methods.
+    ep = expert_parallel_degree
+
+    config = Trainer.Config(
+        loss=ChunkedCELoss.Config(),
+        hf_assets_path="./tests/assets/tokenizer",
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=spec,
+        dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
+        optimizer=_muon_optimizer(),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
+        # MoE models are large: default to bs=1 / seq=2048 so the targets fit; override
+        # on the CLI. opt_step / step_comm are batch-independent anyway.
+        training=TrainingConfig(local_batch_size=1, seq_len=2048, steps=10),
+        checkpoint=CheckpointManager.Config(interval=1000),
+        activation_checkpoint=None,
+        parallelism=ParallelismConfig(expert_parallel_degree=ep),
+    )
+
+    if variant == "muon":
+        config.model_spec.parallelize_fn = parallelize_qwen3_moe_muon
+        config.optimizer = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "muon_auto":
+        config.model_spec.parallelize_fn = parallelize_qwen3_moe_muon_auto
+        config.optimizer = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "muon_twolevel":
+        config.model_spec.parallelize_fn = parallelize_qwen3_moe_muon_twolevel
+        config.optimizer = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "muon_grouped":
+        # Full Muon: dense 2D -> Owned Muon, experts -> GroupedMuon (per-expert NS).
+        # FlexShardMuonOptimizers always routes experts to GroupedMuon, so the optimizer
+        # is just the Owned full-Muon one (``_muon_optimizer``).
+        config.model_spec.parallelize_fn = parallelize_qwen3_moe_muon_auto
+        config.optimizer = _muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "adamw":
+        config.model_spec.parallelize_fn = parallelize_qwen3_moe_muon
+        config.optimizer = default_adamw(lr=adamw_lr)
+    elif variant == "gather_shard":
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("shard")
+        config.optimizer = _gather_muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "gather_grouped":
+        config.model_spec.parallelize_fn = make_gather_muon_parallelize_fn("grouped")
+        config.optimizer = _gather_muon_optimizer(muon_lr=muon_lr, adamw_lr=adamw_lr)
+    elif variant == "fsdp2_adamw":
+        config.optimizer = _bench_adamw_optimizer(adamw_lr)
+    else:
+        raise ValueError(f"unknown MoE variant {variant!r}")
+    return config
+
+
+# --- debugmodel_moe (8 layers, 64 experts): local EP + finer-allocation validation ---
+def flex_shard_qwen3_debugmodel_moe_muon() -> Trainer.Config:
+    return _flex_shard_qwen3_moe(
+        "debugmodel_moe", variant="muon", expert_parallel_degree=2
+    )
+
+
+def flex_shard_qwen3_30b_a3b_muon_grouped() -> Trainer.Config:
+    # Full Muon: dense 2D -> Owned Muon, experts -> GroupedMuon (per-expert batched NS).
+    return _flex_shard_qwen3_moe("30B-A3B", variant="muon_grouped")
+
+
+# Full Muon with the gather dense distribution (GroupedRaggedShard) -- the gather
+# counterpart to muon_grouped for the dense-distribution comparison (Owned vs gather).
+def flex_shard_qwen3_30b_a3b_gather_grouped() -> Trainer.Config:
+    return _flex_shard_qwen3_moe("30B-A3B", variant="gather_grouped")
+
+
+def flex_shard_qwen3_30b_a3b_fsdp2_adamw() -> Trainer.Config:
+    return _flex_shard_qwen3_moe("30B-A3B", variant="fsdp2_adamw")

--- a/torchtitan/experiments/flex_shard/qwen3/parallelize.py
+++ b/torchtitan/experiments/flex_shard/qwen3/parallelize.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FlexShard + communication-efficient Muon parallelizers for Qwen3 (dense + MoE).
+
+A training test bed for benchmarking distributed Muon across model sizes: shards the
+Qwen3 ladder with FlexShard so every transformer layer's 2D weights run communication-
+efficient Muon (one ``Owned`` bucket per layer, owner balanced by Newton-Schulz FLOPs).
+The model-agnostic bucketing/parallelizer logic lives in ``..muon.bucketing``; this module
+just binds it to Qwen3. Two families:
+
+- Dense Qwen3 (0.6B .. 32B): the ``parallelize_qwen3_muon*`` parallelizers. Qwen3's deep
+  layer counts (28..64) keep ``num_layers >= dp_shard`` for large world sizes -- a clean
+  vehicle for the model-size / GPU-count scaling studies.
+- Qwen3-MoE (30B-A3B): the ``parallelize_qwen3_moe_muon*`` parallelizers are EP-capable --
+  dense 2D matrices run Owned/Muon on the dp mesh; MoE expert stacks Shard on the EP
+  (efsdp) mesh and run GroupedMuon / GatherGroupedMuon.
+"""
+
+from __future__ import annotations
+
+from torchtitan.experiments.flex_shard.muon.bucketing import (
+    build_gather_muon_buckets,
+    build_muon_buckets,
+    build_permatrix_muon_buckets,
+    build_twolevel_muon_buckets,
+    make_gather_muon_parallelize_fn as _make_gather_muon_parallelize_fn,
+    make_muon_parallelize_fn,
+)
+
+# Comm-efficient Owned Muon. Dense-only: EP is rejected (support_ep=False).
+# whole-layer allocation (case 1) -- the default.
+parallelize_qwen3_muon = make_muon_parallelize_fn(model_name="Qwen3", support_ep=False)
+# per-2D-tensor allocation (case 2): finer LPT balance, fills more ranks.
+parallelize_qwen3_muon_permatrix = make_muon_parallelize_fn(
+    model_name="Qwen3", support_ep=False, granularity="matrix"
+)
+# two-level allocation: per-layer rank groups, LPT within each (fewer broadcasts).
+parallelize_qwen3_muon_twolevel = make_muon_parallelize_fn(
+    model_name="Qwen3", support_ep=False, granularity="twolevel"
+)
+# whole-layer but allowing idle ranks -- the case-1 reference when num_layers < world_size.
+parallelize_qwen3_muon_idle = make_muon_parallelize_fn(
+    model_name="Qwen3", support_ep=False, allow_idle_ranks=True
+)
+# unified system: auto-select the shallowest allocation level for the regime.
+parallelize_qwen3_muon_auto = make_muon_parallelize_fn(
+    model_name="Qwen3", support_ep=False, granularity="auto"
+)
+
+# --- Qwen3-MoE (EP-capable): dense 2D matrices run comm-efficient Owned/Muon on the dp
+# mesh; MoE expert stacks Shard on the EP (efsdp) mesh -> GroupedMuon. ---
+# Whole-layer allocation: one Owned dense bucket per layer (requires num_layers >=
+# world_size, e.g. 235B's 94 layers on 64 GPUs).
+parallelize_qwen3_moe_muon = make_muon_parallelize_fn(
+    model_name="Qwen3-MoE", support_ep=True
+)
+# Auto allocation: per-tensor / two-level for the dense matrices when num_layers <
+# world_size (e.g. 30B-A3B's 48 layers on 64 GPUs, 235B's 94 on 128) -- fills every
+# rank that whole-layer cannot. Experts still on the EP mesh.
+parallelize_qwen3_moe_muon_auto = make_muon_parallelize_fn(
+    model_name="Qwen3-MoE", support_ep=True, granularity="auto"
+)
+# Two-level allocation (per-layer rank groups), EP-capable.
+parallelize_qwen3_moe_muon_twolevel = make_muon_parallelize_fn(
+    model_name="Qwen3-MoE", support_ep=True, granularity="twolevel"
+)
+
+
+def make_gather_muon_parallelize_fn(
+    dense_kind: str, *, reshard_after_forward: bool = False
+):
+    """Gather-for-NS Muon baseline parallelize_fn for Qwen3 (EP-capable: experts on the EP mesh).
+
+    ``reshard_after_forward=True`` enables RAF for the sharded gather buckets (the engine
+    supports it for ``Shard(0)``; GatherMuon maps params by canonical FQN), so the gather
+    baselines stop holding the full model resident.
+    """
+    return _make_gather_muon_parallelize_fn(
+        dense_kind, model_name="Qwen3", reshard_after_forward=reshard_after_forward
+    )
+
+
+__all__ = [
+    "build_gather_muon_buckets",
+    "build_muon_buckets",
+    "build_permatrix_muon_buckets",
+    "build_twolevel_muon_buckets",
+    "make_gather_muon_parallelize_fn",
+    "parallelize_qwen3_moe_muon",
+    "parallelize_qwen3_moe_muon_auto",
+    "parallelize_qwen3_moe_muon_twolevel",
+    "parallelize_qwen3_muon",
+    "parallelize_qwen3_muon_auto",
+    "parallelize_qwen3_muon_idle",
+    "parallelize_qwen3_muon_permatrix",
+    "parallelize_qwen3_muon_twolevel",
+]

--- a/torchtitan/experiments/flex_shard/tests/test_muon.py
+++ b/torchtitan/experiments/flex_shard/tests/test_muon.py
@@ -1,0 +1,1397 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import copy
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.components.optimizer import ParamGroupConfig
+from torchtitan.experiments.flex_shard import flex_shard
+from torchtitan.experiments.flex_shard.example.owned import Owned
+from torchtitan.experiments.flex_shard.example.shard import Shard
+from torchtitan.experiments.flex_shard.flex_shard.sharded_param import (
+    get_placements,
+    set_sharding_info,
+)
+from torchtitan.experiments.flex_shard.muon import (
+    _discover_expert_buckets,
+    assign_layer_owners_lpt,
+    build_comm_efficient_muon_optimizer,
+    comm_efficient_muon_buckets,
+    FlexShardMuonOptimizers,
+    GatherGroupedMuon,
+    GroupedMuon,
+    is_owned_2d,
+    layer_newton_schulz_cost,
+    make_owned_placement_fn,
+    newton_schulz_flops,
+)
+from torchtitan.experiments.flex_shard.tests.common import (
+    expected_shard,
+    make_transformer_model,
+    transformer_inputs,
+)
+
+
+device_type = torch.device(get_devtype())
+
+
+class _StubMesh:
+    """Minimal stand-in for a DeviceMesh in non-distributed bucket-builder tests."""
+
+    def __init__(self, size: int, rank: int = 0) -> None:
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        return self._size
+
+    def get_local_rank(self) -> int:
+        return self._rank
+
+
+def _reference_muon_param_groups(
+    model: nn.Module,
+) -> tuple[list[nn.Parameter], list[nn.Parameter]]:
+    """Partition a full (single-device) model: 2D layer weights vs the rest.
+
+    Mirrors the distributed rule (only ``layers.<i>.*`` are ``Owned``, and 2D
+    owned matrices go to Muon) so the reference optimizer matches.
+    """
+    muon, adamw = [], []
+    for name, param in model.named_parameters():
+        if name.startswith("layers.") and param.ndim == 2:
+            muon.append(param)
+        else:
+            adamw.append(param)
+    return muon, adamw
+
+
+# ---------------------------------------------------------------------------
+# CPU unit tests: cost model + LPT assignment + bucket structure (no GPU/dist).
+# ---------------------------------------------------------------------------
+class TestCommEfficientMuonAssignment(TestCase):
+    def test_newton_schulz_flops_uses_min_dim(self):
+        # m * n * min(m, n); transpose-symmetric.
+        self.assertEqual(newton_schulz_flops(torch.Size([4, 8])), 4 * 8 * 4)
+        self.assertEqual(newton_schulz_flops(torch.Size([8, 4])), 8 * 4 * 4)
+        self.assertEqual(newton_schulz_flops(torch.Size([16, 4])), 16 * 4 * 4)
+
+    def test_layer_cost_sums_only_2d_matrices(self):
+        named = [
+            ("attn.wq.weight", nn.Parameter(torch.empty(8, 8))),
+            ("attn.norm.weight", nn.Parameter(torch.empty(8))),  # 1D ignored
+            ("mlp.w1.weight", nn.Parameter(torch.empty(16, 8))),
+        ]
+        expected = newton_schulz_flops(torch.Size([8, 8])) + newton_schulz_flops(
+            torch.Size([16, 8])
+        )
+        self.assertEqual(layer_newton_schulz_cost(named), expected)
+
+    def test_lpt_homogeneous_is_balanced(self):
+        owners = assign_layer_owners_lpt([10, 10, 10, 10], world_size=2)
+        # Equal layers -> each rank owns two, perfectly balanced.
+        loads = [0, 0]
+        for cost, owner in zip([10, 10, 10, 10], owners):
+            loads[owner] += cost
+        self.assertEqual(loads, [20, 20])
+
+    def test_lpt_heterogeneous_makespan(self):
+        costs = [10, 8, 6, 5, 4, 2]
+        owners = assign_layer_owners_lpt(costs, world_size=3)
+        loads = [0, 0, 0]
+        for cost, owner in zip(costs, owners):
+            loads[owner] += cost
+        # Greedy LPT lands at {12, 12, 11}; max is within 4/3 of the 35/3 ideal.
+        self.assertEqual(sorted(loads), [11, 12, 12])
+        self.assertLessEqual(max(loads), (4 * sum(costs)) // (3 * 3) + 1)
+
+    def test_lpt_is_deterministic(self):
+        costs = [7, 3, 9, 1, 5, 5, 2]
+        self.assertEqual(
+            assign_layer_owners_lpt(costs, 4),
+            assign_layer_owners_lpt(costs, 4),
+        )
+
+    def test_lpt_rejects_nonpositive_world_size(self):
+        with self.assertRaisesRegex(ValueError, "world_size must be positive"):
+            assign_layer_owners_lpt([1, 2], world_size=0)
+
+    def test_make_owned_placement_fn_assigns_single_owner(self):
+        placement_fn = make_owned_placement_fn(owner_rank=2)
+        named = [("a.weight", nn.Parameter(torch.empty(2, 2)))]
+        placements = placement_fn(named, _StubMesh(4))
+        self.assertEqual(placements, {"a.weight": (Owned(2),)})
+
+    def test_buckets_structure(self):
+        args, model = make_transformer_model(n_layers=4)
+        buckets = comm_efficient_muon_buckets(model, _StubMesh(2))
+
+        layer_buckets = [b for b in buckets if b.patterns[0].startswith("layers.")]
+        self.assertEqual(len(layer_buckets), args.n_layers)
+        for bucket in layer_buckets:
+            # Each layer bucket is a single-owner Owned bucket.
+            placements = bucket.placement_fn(
+                list(model.named_parameters()), _StubMesh(2)
+            )
+            owners = {p[0].owner_rank for p in placements.values()}
+            self.assertEqual(len(owners), 1)
+            self.assertIsInstance(next(iter(placements.values()))[0], Owned)
+
+        # Non-layer params (tok/pos embeddings, norm, output) get their own buckets.
+        rest_patterns = {
+            b.patterns[0] for b in buckets if not b.patterns[0].startswith("layers.")
+        }
+        self.assertIn("output.*", rest_patterns)
+        self.assertIn("norm.*", rest_patterns)
+
+    def test_buckets_require_num_layers_ge_world_size(self):
+        _, model = make_transformer_model(n_layers=2)
+        with self.assertRaisesRegex(ValueError, "num_layers >= world_size"):
+            comm_efficient_muon_buckets(model, _StubMesh(8))
+
+    def test_param_routing_skips_empty_and_routes_by_placement(self):
+        # Annotate params as FlexShard would, without needing CUDA/flex_shard.
+        class Tiny(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.w = nn.Parameter(torch.empty(4, 4))  # owned 2D -> Muon
+                self.norm = nn.Parameter(torch.empty(4))  # owned 1D -> AdamW
+                self.other = nn.Parameter(torch.empty(0, 0))  # other rank's empty
+                self.emb = nn.Parameter(torch.empty(8, 4))  # sharded 2D -> AdamW
+
+        model = Tiny()
+        set_sharding_info(model.w, (Owned(0),), torch.Size([4, 4]), (4, 1), None)
+        set_sharding_info(model.norm, (Owned(0),), torch.Size([4]), (1,), None)
+        set_sharding_info(model.other, (Owned(1),), torch.Size([4, 4]), (4, 1), None)
+        set_sharding_info(model.emb, (Shard(0),), torch.Size([8, 4]), (4, 1), None)
+
+        self.assertTrue(is_owned_2d(model.w))
+        self.assertFalse(is_owned_2d(model.norm))  # 1D
+        self.assertFalse(is_owned_2d(model.other))  # empty (numel == 0)
+        self.assertFalse(is_owned_2d(model.emb))  # not Owned
+
+        # Routing is inline in __init__ (no standalone _build_param_groups): build the
+        # container and check which optimizer each param landed in.
+        config = FlexShardMuonOptimizers.Config(
+            param_groups=[
+                ParamGroupConfig(
+                    pattern="x", optimizer_name="Muon", optimizer_kwargs={}
+                ),
+                ParamGroupConfig(
+                    pattern="y", optimizer_name="AdamW", optimizer_kwargs={}
+                ),
+            ],
+            implementation="for-loop",
+        )
+        container = FlexShardMuonOptimizers(config, model_parts=[model])
+        muon_ids: set[int] = set()
+        adamw_ids: set[int] = set()
+        for opt in container.optimizers:
+            ids = {id(p) for g in opt.param_groups for p in g["params"]}
+            if isinstance(opt, torch.optim.AdamW):
+                adamw_ids |= ids
+            else:
+                muon_ids |= ids
+        self.assertEqual(muon_ids, {id(model.w)})
+        self.assertEqual(adamw_ids, {id(model.norm), id(model.emb)})
+        # The other rank's empty (0, 0) shard is skipped entirely.
+        self.assertNotIn(id(model.other), muon_ids | adamw_ids)
+
+
+# ---------------------------------------------------------------------------
+# GPU parity test: communication-efficient Muon vs single-device Muon.
+# ---------------------------------------------------------------------------
+def _init_params_deterministically(model: nn.Module) -> None:
+    with torch.no_grad():
+        for idx, param in enumerate(model.parameters()):
+            values = torch.arange(
+                param.numel(), dtype=param.dtype, device=param.device
+            ).view_as(param)
+            param.copy_(values.div(max(param.numel(), 1)).add_(idx))
+
+
+def _average_reference_grads(model: nn.Module) -> None:
+    for param in model.parameters():
+        if param.grad is not None:
+            dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+
+
+@contextlib.contextmanager
+def _assert_no_collectives():
+    """Fail if any eager collective fires inside the block (comm-efficient step check)."""
+    names = [
+        "all_reduce",
+        "all_gather",
+        "all_gather_into_tensor",
+        "reduce_scatter_tensor",
+        "broadcast",
+        "reduce",
+    ]
+    saved = {}
+
+    def _raiser(name):
+        def _fn(*args, **kwargs):
+            raise AssertionError(f"unexpected collective '{name}' during step")
+
+        return _fn
+
+    for name in names:
+        if hasattr(dist, name):
+            saved[name] = getattr(dist, name)
+            setattr(dist, name, _raiser(name))
+    try:
+        yield
+    finally:
+        for name, fn in saved.items():
+            setattr(dist, name, fn)
+
+
+class TestCommEfficientMuon(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _check_param_parity(self, reference, model):
+        """Assert each local param equals its placement-expected slice of reference."""
+        for (ref_name, ref_param), (name, param) in zip(
+            reference.named_parameters(),
+            model.named_parameters(),
+            strict=True,
+        ):
+            self.assertEqual(ref_name, name)
+            placements = get_placements(param)
+            if placements is not None and isinstance(placements[0], Owned):
+                owner = placements[0].owner_rank
+                if self.rank == owner:
+                    expected = ref_param.detach()
+                else:
+                    expected = ref_param.detach().new_empty([0] * ref_param.ndim)
+            else:
+                expected = expected_shard(
+                    ref_param.detach(), rank=self.rank, world_size=self.world_size
+                )
+            self.assertEqual(param.detach(), expected, msg=f"param {name} mismatch")
+
+    @skip_if_lt_x_gpu(2)
+    def test_matches_single_device_muon(self):
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+        )
+        args, model = make_transformer_model(device=device_type.type, n_layers=4)
+        _init_params_deterministically(model)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=comm_efficient_muon_buckets(
+                model, mesh, reshard_after_forward=False
+            ),
+        )
+
+        muon_kwargs = {"lr": 0.02, "weight_decay": 0.0, "momentum": 0.9}
+        adamw_kwargs = {"lr": 0.01, "weight_decay": 0.0}
+        optim = build_comm_efficient_muon_optimizer(
+            model, mesh, muon_kwargs=muon_kwargs, adamw_kwargs=adamw_kwargs
+        )
+        ref_muon_params, ref_adamw_params = _reference_muon_param_groups(reference)
+        # Match the container's AdamW kernel (for-loop) so parity isn't masked by a
+        # foreach-vs-for-loop fusion difference unrelated to comm-efficient Muon.
+        ref_optims = [
+            torch.optim.Muon(ref_muon_params, **muon_kwargs),
+            torch.optim.AdamW(ref_adamw_params, **adamw_kwargs, foreach=False),
+        ]
+
+        # Distinct per-rank batches -> data-parallel; reference averages grads.
+        torch.manual_seed(42 + self.rank + 1)
+        x = transformer_inputs(args, batch_size=3, device=device_type)
+
+        for _ in range(3):
+            optim.zero_grad(set_to_none=True)
+            for ref_optim in ref_optims:
+                ref_optim.zero_grad(set_to_none=True)
+
+            loss = model(x).sum()
+            ref_loss = reference(x).sum()
+            loss.backward()
+            ref_loss.backward()
+            _average_reference_grads(reference)
+
+            # The optimizer step must be communication-efficient.
+            with _assert_no_collectives():
+                optim.step()
+            for ref_optim in ref_optims:
+                ref_optim.step()
+
+            self._check_param_parity(reference, model)
+
+    @skip_if_lt_x_gpu(2)
+    def test_owned_2d_go_to_muon_rest_to_adamw(self):
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+        )
+        _, model = make_transformer_model(device=device_type.type, n_layers=4)
+        flex_shard(
+            model,
+            buckets=comm_efficient_muon_buckets(
+                model, mesh, reshard_after_forward=False
+            ),
+        )
+        optim = build_comm_efficient_muon_optimizer(
+            model, mesh, muon_kwargs={"lr": 0.01}, adamw_kwargs={"lr": 0.01}
+        )
+
+        muon_opt = next(
+            (o for o in optim.optimizers if isinstance(o, torch.optim.Muon)), None
+        )
+        muon_params = set()
+        if muon_opt is not None:
+            for group in muon_opt.param_groups:
+                muon_params.update(id(p) for p in group["params"])
+
+        for name, param in model.named_parameters():
+            if param.numel() == 0:
+                continue
+            placements = get_placements(param)
+            owned_2d_here = (
+                placements is not None
+                and isinstance(placements[0], Owned)
+                and placements[0].owner_rank == self.rank
+                and param.ndim == 2
+            )
+            self.assertEqual(id(param) in muon_params, owned_2d_here, msg=name)
+
+
+class TestCommEfficientMuonTraining(FSDPTest):
+    """End-to-end: train torchtitan's real llama3 debug model with comm-efficient Muon."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_llama3_debugmodel_loss_decreases(self):
+        from torchtitan.models.llama3 import llama3_configs
+
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+        )
+        # Same seed on every rank -> identical init and identical (overfit) batch,
+        # so the data-parallel reduce is well-defined and the loss signal is clean.
+        torch.manual_seed(0)
+        model = llama3_configs["debugmodel"](attn_backend="flex").build()
+        model = model.to(device_type)
+
+        batch_size, seq_len, vocab_size = 4, 256, 2048
+        positions = torch.arange(seq_len, device=device_type).repeat(batch_size, 1)
+        # The masked attention backends (Flex/Varlen) need a torch whose
+        # flex_attention API matches torchtitan; skip cleanly if this environment's
+        # is incompatible (e.g. missing FA3, or an older create_block_mask) rather
+        # than reporting a failure unrelated to Muon.
+        try:
+            attention_masks = model.get_attention_masks(positions)
+        except (ImportError, TypeError) as exc:
+            raise unittest.SkipTest(
+                f"attention backend unavailable in this environment: {exc}"
+            ) from exc
+
+        # 6-layer dense model, world_size 2 -> num_layers >= world_size holds.
+        flex_shard(
+            model,
+            buckets=comm_efficient_muon_buckets(
+                model, mesh, reshard_after_forward=False
+            ),
+        )
+        optim = build_comm_efficient_muon_optimizer(
+            model,
+            mesh,
+            muon_kwargs={"lr": 0.02, "weight_decay": 0.0, "momentum": 0.9},
+            adamw_kwargs={"lr": 0.01, "weight_decay": 0.0},
+        )
+
+        tokens = torch.randint(0, vocab_size, (batch_size, seq_len), device=device_type)
+        labels = torch.randint(0, vocab_size, (batch_size, seq_len), device=device_type)
+
+        losses = []
+        for _ in range(15):
+            optim.zero_grad(set_to_none=True)
+            logits = model(tokens, positions, attention_masks)
+            loss = F.cross_entropy(logits.flatten(0, 1), labels.flatten())
+            loss.backward()
+            optim.step()
+            losses.append(loss.detach().item())
+
+        self.assertTrue(all(torch.isfinite(torch.tensor(losses))), msg=str(losses))
+        # Overfitting a fixed batch: the loss should drop clearly over the run.
+        early = sum(losses[:3]) / 3
+        late = sum(losses[-3:]) / 3
+        self.assertLess(late, 0.9 * early, msg=f"loss did not decrease: {losses}")
+
+
+class TestDeepSeekV3MuonBuckets(TestCase):
+    """CPU structural tests for the DeepSeek V3 FlexShard + Muon bucket builder."""
+
+    def _build_debug_model(self) -> nn.Module:
+        from torchtitan.models.deepseek_v3 import model_registry
+
+        return model_registry("debugmodel").model.build()
+
+    def _mp_policy(self):
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+
+        return MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+        )
+
+    def test_bucket_structure(self):
+        from torchtitan.experiments.flex_shard.deepseek_v3.parallelize import (
+            build_muon_buckets,
+        )
+
+        model = self._build_debug_model()
+        num_layers = len(model.layers)
+        mesh = _StubMesh(2)
+        buckets = build_muon_buckets(
+            model,
+            dp_mesh=mesh,
+            expert_mesh=mesh,
+            mp_policy=self._mp_policy(),
+            reshard_after_forward=True,
+            reshard_last=True,
+        )
+        flat_patterns = [p for b in buckets for p in b.patterns]
+        self.assertIn("tok_embeddings.*", flat_patterns)
+        self.assertIn("norm.*", flat_patterns)
+        self.assertIn("lm_head.*", flat_patterns)
+
+        # Layer buckets carry explicit FQNs (not globs); split dense vs expert.
+        params = dict(model.named_parameters())
+        layer_buckets = [
+            b for b in buckets if all(p.startswith("layers.") for p in b.patterns)
+        ]
+        expert_buckets = [
+            b for b in layer_buckets if any(".moe.experts." in p for p in b.patterns)
+        ]
+        dense_buckets = [b for b in layer_buckets if b not in expert_buckets]
+
+        # One Owned dense bucket per layer; each maps its FQNs to a single owner.
+        self.assertEqual(len(dense_buckets), num_layers)
+        for bucket in dense_buckets:
+            named = [(p, params[p]) for p in bucket.patterns]
+            placements = bucket.placement_fn(named, mesh)
+            owners = {pl[0].owner_rank for pl in placements.values()}
+            self.assertEqual(len(owners), 1)
+            self.assertIsInstance(next(iter(placements.values()))[0], Owned)
+
+        # MoE layers get a separate Shard expert bucket (layer 0 is dense -> none).
+        self.assertEqual(len(expert_buckets), num_layers - 1)
+        named = [(p, params[p]) for p in expert_buckets[0].patterns]
+        placement = expert_buckets[0].placement_fn(named, mesh)
+        self.assertIsInstance(next(iter(placement.values()))[0], Shard)
+
+    def test_requires_num_layers_ge_dp_shard(self):
+        from torchtitan.experiments.flex_shard.deepseek_v3.parallelize import (
+            build_muon_buckets,
+        )
+
+        model = self._build_debug_model()
+        big = _StubMesh(len(model.layers) + 1)
+        with self.assertRaisesRegex(ValueError, "num_layers >= dp_shard"):
+            build_muon_buckets(
+                model,
+                dp_mesh=big,
+                expert_mesh=big,
+                mp_policy=self._mp_policy(),
+                reshard_after_forward=True,
+                reshard_last=True,
+            )
+
+    def test_gather_muon_bucket_structure(self):
+        # Gather-for-NS baseline: per-layer 2D matrices in one dense bucket, non-2D
+        # params (norms) in their own buckets, embeddings/norm/lm_head as rest buckets.
+        from torchtitan.experiments.flex_shard.deepseek_v3.parallelize import (
+            build_gather_muon_buckets,
+        )
+        from torchtitan.experiments.flex_shard.example.shard import per_param_placements
+
+        model = self._build_debug_model()
+        buckets = build_gather_muon_buckets(
+            model,
+            dp_mesh=_StubMesh(2),
+            mp_policy=self._mp_policy(),
+            reshard_after_forward=False,
+            dense_placement_fn=per_param_placements,
+        )
+        flat = [p for b in buckets for p in b.patterns]
+        self.assertIn("tok_embeddings.*", flat)
+        self.assertIn("lm_head.*", flat)
+        self.assertIn("norm.*", flat)
+
+        # The layer-0 dense bucket: a multi-pattern bucket of exact 2D-matrix FQNs.
+        layer0_dense = [
+            b
+            for b in buckets
+            if len(b.patterns) > 1
+            and all(p.startswith("layers.0.") for p in b.patterns)
+        ]
+        self.assertEqual(len(layer0_dense), 1)
+        self.assertIn("layers.0.attention.wq.weight", layer0_dense[0].patterns)
+        # 1D norms are NOT in the dense (Muon) bucket.
+        self.assertNotIn("layers.0.attention_norm.weight", layer0_dense[0].patterns)
+
+
+class TestQwen3MuonBuckets(TestCase):
+    """CPU structural tests for the dense Qwen3 FlexShard + Muon bucket builder.
+
+    Qwen3 is dense (no MoE), so the shared builder should produce one Owned bucket
+    per layer and *no* expert buckets -- the model-agnostic path exercised by the
+    benchmark ladder.
+    """
+
+    def _build_debug_model(self) -> nn.Module:
+        from torchtitan.models.qwen3 import model_registry
+
+        spec = model_registry("debugmodel")
+        # Untie lm_head from tok_embeddings (as the benchmark configs do) so the LM
+        # head is its own param/bucket rather than an alias of the embedding.
+        spec.model.enable_weight_tying = False
+        return spec.model.build()
+
+    def _mp_policy(self):
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+
+        return MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+        )
+
+    def test_dense_bucket_structure(self):
+        from torchtitan.experiments.flex_shard.qwen3.parallelize import (
+            build_muon_buckets,
+        )
+
+        model = self._build_debug_model()
+        num_layers = len(model.layers)
+        mesh = _StubMesh(2)
+        buckets = build_muon_buckets(
+            model,
+            dp_mesh=mesh,
+            expert_mesh=mesh,
+            mp_policy=self._mp_policy(),
+            reshard_after_forward=True,
+            reshard_last=True,
+        )
+        flat = [p for b in buckets for p in b.patterns]
+        self.assertIn("tok_embeddings.*", flat)
+        self.assertIn("norm.*", flat)
+        self.assertIn("lm_head.*", flat)
+
+        params = dict(model.named_parameters())
+        layer_buckets = [
+            b for b in buckets if all(p.startswith("layers.") for p in b.patterns)
+        ]
+        # Dense model: one Owned bucket per layer, and zero expert buckets.
+        self.assertEqual(len(layer_buckets), num_layers)
+        self.assertFalse(
+            any(".moe.experts." in p for b in layer_buckets for p in b.patterns)
+        )
+        for bucket in layer_buckets:
+            named = [(p, params[p]) for p in bucket.patterns]
+            placements = bucket.placement_fn(named, mesh)
+            owners = {pl[0].owner_rank for pl in placements.values()}
+            self.assertEqual(len(owners), 1)
+            self.assertIsInstance(next(iter(placements.values()))[0], Owned)
+
+        # The owner bucket holds all of a layer's dense params (2D matrices + 1D norms);
+        # Muon-vs-AdamW routing happens later in the optimizer, not the bucket.
+        layer0 = next(b for b in layer_buckets if b.patterns[0].startswith("layers.0."))
+        self.assertIn("layers.0.attention.qkv_linear.wq.weight", layer0.patterns)
+        self.assertIn("layers.0.attention_norm.weight", layer0.patterns)
+
+    def test_permatrix_bucket_structure(self):
+        # Per-2D-tensor allocation (case 2): one single-FQN Owned bucket per matrix,
+        # owners from LPT over all matrices -> uses more distinct owners than layers.
+        from torchtitan.experiments.flex_shard.muon.bucketing import (
+            build_permatrix_muon_buckets,
+        )
+
+        model = self._build_debug_model()
+        mesh = _StubMesh(2)
+        buckets = build_permatrix_muon_buckets(
+            model,
+            dp_mesh=mesh,
+            mp_policy=self._mp_policy(),
+            reshard_after_forward=True,
+            reshard_last=True,
+        )
+        params = dict(model.named_parameters())
+        # Each 2D matrix is its own single-pattern Owned bucket.
+        owned_2d = [
+            b
+            for b in buckets
+            if len(b.patterns) == 1
+            and b.patterns[0] in params
+            and params[b.patterns[0]].ndim == 2
+        ]
+        num_2d = sum(
+            1 for n, p in params.items() if n.startswith("layers.") and p.ndim == 2
+        )
+        self.assertEqual(len(owned_2d), num_2d)
+        for bucket in owned_2d:
+            placements = bucket.placement_fn(
+                [(bucket.patterns[0], params[bucket.patterns[0]])], mesh
+            )
+            self.assertIsInstance(next(iter(placements.values()))[0], Owned)
+        # rest patterns present
+        flat = [p for b in buckets for p in b.patterns]
+        self.assertIn("tok_embeddings.*", flat)
+        self.assertIn("lm_head.*", flat)
+
+    def test_auto_granularity_thresholds(self):
+        # Unified selector: layer (W<=L) -> matrix (L<W<2L) -> twolevel (2L<=W<=L*M).
+        from torchtitan.experiments.flex_shard.muon.bucketing import (
+            resolve_auto_granularity,
+        )
+
+        model = self._build_debug_model()  # 8 layers, 7 matrices/layer = 56 matrices
+        num_layers = len(model.layers)  # 8
+        self.assertEqual(resolve_auto_granularity(model, 4), "layer")
+        self.assertEqual(resolve_auto_granularity(model, num_layers), "layer")
+        self.assertEqual(resolve_auto_granularity(model, 12), "matrix")  # 8 < 12 < 16
+        self.assertEqual(resolve_auto_granularity(model, 16), "twolevel")  # >= 2*8
+        self.assertEqual(resolve_auto_granularity(model, 56), "twolevel")  # == num_mats
+        with self.assertRaises(NotImplementedError):
+            resolve_auto_granularity(model, 64)  # > num_matrices -> needs L3
+
+    def test_cost_weighted_group_sizes(self):
+        # Heterogeneous two-level level-1 apportionment.
+        from torchtitan.experiments.flex_shard.muon.bucketing import (
+            _cost_weighted_group_sizes,
+        )
+
+        # Homogeneous -> ~uniform (== plain two-level).
+        self.assertEqual(
+            _cost_weighted_group_sizes([10, 10, 10, 10], [7, 7, 7, 7], 8),
+            [2, 2, 2, 2],
+        )
+        # Heavy layer gets proportionally more ranks (cost 100 vs 10/10).
+        self.assertEqual(
+            _cost_weighted_group_sizes([100, 10, 10], [7, 7, 7], 8), [6, 1, 1]
+        )
+        # Cap at matrix count: a cost-dominant layer can't exceed its 2 matrices.
+        self.assertEqual(_cost_weighted_group_sizes([1000, 10], [2, 7], 8), [2, 6])
+        # world_size > num_matrices: only sum(caps) ranks placed (rest idle -> L3).
+        self.assertEqual(_cost_weighted_group_sizes([10, 10], [2, 2], 8), [2, 2])
+
+
+class TestQwen3MoeMuonBuckets(TestCase):
+    """CPU structural test for the public Qwen3-MoE FlexShard + Muon surface.
+
+    The Qwen3-MoE configs (``debugmodel_moe`` / ``30B-A3B``) place dense 2D matrices as
+    ``Owned`` buckets on the dp mesh and the 3D MoE expert stacks as ``Shard`` buckets on
+    the (EP) expert mesh. Each expert bucket is a 3D ``.moe.experts.`` stack -- exactly what
+    the optimizer routing identifies (:func:`_is_expert_bucket`) and sends to full Muon
+    (GroupedMuon / GatherGroupedMuon), not AdamW.
+    """
+
+    def test_moe_expert_buckets_land_on_expert_mesh(self):
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+        from torchtitan.experiments.flex_shard.qwen3.parallelize import (
+            build_muon_buckets,
+        )
+        from torchtitan.models.qwen3 import model_registry
+
+        model = model_registry("debugmodel_moe").model.build()
+        params = dict(model.named_parameters())
+        # Distinct dp vs expert mesh objects so we can assert experts land on the EP mesh.
+        dp_mesh, expert_mesh = _StubMesh(2), _StubMesh(2)
+        buckets = build_muon_buckets(
+            model,
+            dp_mesh=dp_mesh,
+            expert_mesh=expert_mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+            ),
+            reshard_after_forward=True,
+            reshard_last=True,
+        )
+        layer_buckets = [
+            b for b in buckets if all(p.startswith("layers.") for p in b.patterns)
+        ]
+        expert_buckets = [
+            b for b in layer_buckets if any(".moe.experts." in p for p in b.patterns)
+        ]
+        dense_buckets = [b for b in layer_buckets if b not in expert_buckets]
+        self.assertTrue(expert_buckets, "Qwen3-MoE should produce expert buckets")
+
+        # Dense 2D matrices -> Owned bucket on the dp mesh.
+        for bucket in dense_buckets:
+            self.assertIs(bucket.mesh, dp_mesh)
+            placements = bucket.placement_fn(
+                [(p, params[p]) for p in bucket.patterns], dp_mesh
+            )
+            self.assertIsInstance(next(iter(placements.values()))[0], Owned)
+
+        # Expert stacks -> Shard bucket on the EP (expert) mesh; each is a 3D
+        # ``.moe.experts.`` stack, so the optimizer routes it to full Muon.
+        for bucket in expert_buckets:
+            self.assertIs(bucket.mesh, expert_mesh)
+            for p in bucket.patterns:
+                self.assertIn(".moe.experts.", p)
+                self.assertEqual(params[p].ndim, 3)
+            placements = bucket.placement_fn(
+                [(p, params[p]) for p in bucket.patterns], expert_mesh
+            )
+            self.assertIsInstance(next(iter(placements.values()))[0], Shard)
+
+    def test_expert_routing_requires_both_3d_and_marker(self):
+        """A 3D *non-expert* stack must NOT route to grouped Muon (falls to AdamW).
+
+        :func:`_is_expert_bucket` gates on two signals -- 3D ``global_shape`` AND the
+        ``.moe.experts.`` marker -- so it is only true when both hold. The positive
+        (marker + 3D) case is covered above; this pins the negative boundary: a 3D
+        parameter without the marker, and a 2D parameter under the marker, are both
+        rejected, so neither is misrouted to GroupedMuon / GatherGroupedMuon (they fall
+        through to AdamW). Without the marker gate a future 3D non-expert param would
+        silently take the expert path.
+        """
+        from types import SimpleNamespace
+
+        from torchtitan.experiments.flex_shard.muon.containers import _is_expert_bucket
+
+        def info(shape, fqn):
+            return SimpleNamespace(global_shape=shape, fqn=fqn)
+
+        # Both signals -> expert.
+        self.assertTrue(_is_expert_bucket([info((4, 16, 8), "layers.0.moe.experts.w")]))
+        # 3D but no marker (e.g. a hypothetical batched non-expert weight) -> NOT expert.
+        self.assertFalse(_is_expert_bucket([info((4, 16, 8), "layers.0.attn.w_3d")]))
+        # Marker but 2D (a per-matrix expert projection, not the stacked [E, m, n]) -> NOT.
+        self.assertFalse(_is_expert_bucket([info((16, 8), "layers.0.moe.experts.w")]))
+        # Mixed bucket (one 3D non-expert) -> NOT (requires all params to qualify).
+        self.assertFalse(
+            _is_expert_bucket(
+                [
+                    info((4, 16, 8), "layers.0.moe.experts.w"),
+                    info((4, 16, 8), "layers.0.other.w_3d"),
+                ]
+            )
+        )
+        self.assertFalse(_is_expert_bucket([]))
+
+
+class TestCommByteCounter(TestCase):
+    """CPU tests for the benchmark comm-byte counter's tensor extraction."""
+
+    def test_volume_bytes_picks_send_tensor(self):
+        from torchtitan.experiments.flex_shard.muon import comm_counter
+
+        send = torch.empty(4, 8, dtype=torch.float32)  # 32 elems * 4 B = 128
+        # all_gather(output_list, input): the input tensor is args[1].
+        self.assertEqual(comm_counter._volume_bytes("all_gather", ([], send), {}), 128)
+        # reduce_scatter_tensor(output=, input=): keyword input.
+        self.assertEqual(
+            comm_counter._volume_bytes("reduce_scatter_tensor", (), {"input": send}),
+            128,
+        )
+        # broadcast(tensor, src=): the tensor is args[0].
+        self.assertEqual(
+            comm_counter._volume_bytes("broadcast", (send,), {"src": 0}), 128
+        )
+
+    def test_functional_volume_bytes_picks_first_arg(self):
+        from torchtitan.experiments.flex_shard.muon import comm_counter
+
+        send = torch.empty(4, 8, dtype=torch.float32)  # 32 elems * 4 B = 128
+        # _c10d_functional.all_gather_into_tensor(input, group_size, group_name): args[0].
+        self.assertEqual(comm_counter._functional_volume_bytes((send, 2, "group")), 128)
+        # Coalesced variants pass a list of input tensors -> summed.
+        self.assertEqual(
+            comm_counter._functional_volume_bytes(([send, send], 2, "group")), 256
+        )
+        self.assertEqual(comm_counter._functional_volume_bytes(()), 0)
+
+    def test_reset_and_read(self):
+        from torchtitan.experiments.flex_shard.muon import comm_counter
+
+        comm_counter.reset()
+        self.assertEqual(comm_counter.read(), 0)
+        comm_counter._state["bytes"] += 100
+        self.assertEqual(comm_counter.read(), 100)
+        comm_counter.reset()
+        self.assertEqual(comm_counter.read(), 0)
+
+
+class TestCommByteCounterFunctional(FSDPTest):
+    """The counter must count DTensor / functional-collective sends, not just eager ones.
+
+    DTensor redistribute / ``full_tensor()`` (e.g. :class:`DTensorMuon`'s in-step
+    all-gather) dispatch to ``torch.ops._c10d_functional.*`` ops, which do NOT route
+    through the eager ``torch.distributed.*`` python symbols. If only the eager symbols
+    were patched, the DTensor / FSDP2 baselines would register **zero** step comm and look
+    as collective-free as comm-efficient ``Owned`` Muon -- the measurement bug this guards
+    against. Verifies ``full_tensor()`` counts exactly this rank's send shard, and that the
+    eager path still counts exactly once (disjoint namespaces -> no double-count).
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_functional_collectives_are_counted(self):
+        from torch.distributed.tensor import distribute_tensor, Shard as DTShard
+
+        from torchtitan.experiments.flex_shard.muon import comm_counter
+
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("dp",)
+        )
+        comm_counter.install()
+
+        m, n = 8, 16  # m divisible by world_size(2): even Shard(0) split.
+        dt = distribute_tensor(
+            torch.randn(m, n, device=device_type.type), mesh, [DTShard(0)]
+        )
+        local = dt.to_local()
+        send_bytes = local.numel() * local.element_size()  # this rank's [m/ws, n] shard
+
+        # full_tensor() all-gathers each rank's shard -> a functional collective. Counted
+        # bytes must equal this rank's send shard (and be > 0: the bug would read 0).
+        comm_counter.reset()
+        _ = dt.full_tensor()
+        torch.cuda.synchronize()
+        self.assertGreater(comm_counter.read(), 0)
+        self.assertEqual(comm_counter.read(), send_bytes)
+
+        # The eager symbol still counts, exactly once (no double-count from the functional
+        # patch: eager dispatches through c10d::, functional through _c10d_functional::).
+        comm_counter.reset()
+        eager_send = torch.randn(n, device=device_type.type)
+        out = torch.empty(n * self.world_size, device=device_type.type)
+        dist.all_gather_into_tensor(out, eager_send)
+        torch.cuda.synchronize()
+        self.assertEqual(
+            comm_counter.read(), eager_send.numel() * eager_send.element_size()
+        )
+
+
+class TestGatherGroupedMuonShard1(FSDPTest):
+    """3D MoE experts sharded *within* the matrix -- ``Shard(1)``, world_size > num_experts.
+
+    When ``efsdp > num_local_experts`` each rank holds only a slice of every expert matrix,
+    so :class:`GroupedMuon`'s local per-expert Newton-Schulz is invalid. ``GatherGroupedMuon``
+    must all-gather each expert stack over the efsdp mesh, run per-expert (batched) NS on the
+    reconstructed ``[E, m, n]``, and write back this rank's ``[E, m_local, n]`` slice. This
+    checks it matches a single-device :class:`GroupedMuon` on the whole expert stack
+    (bit-exact: same gathered NS input -> same per-expert update -> same local slice).
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @skip_if_lt_x_gpu(4)
+    def test_matches_single_device_grouped_muon(self):
+        from torchtitan.experiments.flex_shard import BucketSpec
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+        from torchtitan.experiments.flex_shard.muon.bucketing import expert_placement_fn
+
+        # num_experts(2) < world_size(4) => expert_placement_fn picks Shard(1)
+        # (each rank holds m/4 rows of both experts -- the incomplete-tensor regime).
+        num_experts, m, n = 2, 16, 8
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("efsdp",)
+        )
+
+        # Realistic expert FQN "layers.0.moe.experts.weight" so the expert marker
+        # (".moe.experts.") matches -- routing identifies experts by marker, not raw ndim.
+        class _Experts(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.empty(num_experts, m, n, device=device_type.type)
+                )
+
+        class _MoE(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.experts = _Experts()
+
+        class _Layer(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.moe = _MoE()
+
+        class _ExpertModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layers = nn.ModuleList([_Layer()])
+
+        torch.manual_seed(0)
+        model = _ExpertModel()
+        with torch.no_grad():
+            model.layers[0].moe.experts.weight.normal_()
+        reference = copy.deepcopy(model)  # full, unsharded experts
+        ref_experts = reference.layers[0].moe.experts.weight
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["*.moe.experts.*"],
+                    placement_fn=expert_placement_fn,
+                    mesh=mesh,
+                    mp_policy=MixedPrecisionPolicy(
+                        param_dtype=torch.float32, reduce_dtype=torch.float32
+                    ),
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+
+        buckets = _discover_expert_buckets(model)
+        self.assertEqual(len(buckets), 1)
+        placement = buckets[0]["placement"]
+        expert_param = buckets[0]["params"][0]  # this rank's persistent shard
+
+        # Confirm we actually hit the Shard(1) (incomplete-tensor) regime. (Read the
+        # placement off the persistent param/bucket, not model.experts -- the latter is
+        # the FlexShard unsharded-param property and raises outside the forward hook.)
+        self.assertIsInstance(placement, Shard)
+        self.assertGreaterEqual(placement.dim, 1)
+
+        kwargs = {"lr": 0.02, "weight_decay": 0.0, "momentum": 0.9}
+        optim = GatherGroupedMuon(buckets, mesh, **kwargs)
+        ref_optim = GroupedMuon([ref_experts], **kwargs)
+
+        for step in range(3):
+            # Same deterministic full grad on every rank; the sharded model gets only its
+            # local slice (what autograd would hand each rank), the reference the whole grad.
+            torch.manual_seed(100 + step)
+            full_grad = torch.randn(num_experts, m, n, device=device_type.type)
+            ref_experts.grad = full_grad.clone()
+            expert_param.grad = placement.extract_local_shard(
+                full_grad, self.rank, self.world_size
+            ).clone()
+
+            optim.step()
+            ref_optim.step()
+
+            expected = placement.extract_local_shard(
+                ref_experts.detach(), self.rank, self.world_size
+            )
+            torch.testing.assert_close(expert_param.detach(), expected, rtol=0, atol=0)
+
+
+class TestGatherMuonVsFSDP2Muon(FSDPTest):
+    """Gather Muon (FlexShard ``Shard``) and fsdp2 Muon (``DTensorMuon``) are identical.
+
+    Both reconstruct the full 2D matrix (one all-gather per step) and run the *same*
+    ``_zeropower_via_newtonschulz`` with the same momentum update, then write back only
+    this rank's shard. They differ only in *how* the gather happens (FlexShard bucket
+    unshard vs ``DTensor.full_tensor``), not in the math -- so given the same weight and
+    gradient they must produce bit-identical updates. Shown by both matching a
+    single-device ``torch.optim.Muon`` (hence each other), step after step.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_gather_and_dtensor_muon_match_single_device(self):
+        from torch.distributed.fsdp import fully_shard
+        from torch.distributed.tensor import distribute_tensor
+
+        from torchtitan.experiments.flex_shard import BucketSpec
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+        from torchtitan.experiments.flex_shard.muon import (
+            _discover_dense_gather_buckets,
+            DTensorMuon,
+            GatherMuon,
+        )
+        from torchtitan.experiments.flex_shard.muon.bucketing import shard0_placement_fn
+
+        m, n = 16, 8  # divisible by world_size(2): even row split, no padding
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+        )
+
+        class _BodyModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                # named param "layers.0.weight" -> the gather-Muon "2D under layers." rule.
+                self.layers = nn.ModuleList([nn.Linear(n, m, bias=False)])
+
+        torch.manual_seed(0)
+        reference = _BodyModel().to(device_type.type)  # full, single device
+        model_gather = copy.deepcopy(reference)
+        model_dtensor = copy.deepcopy(reference)
+
+        # Gather Muon path: FlexShard Shard(0) on the 2D body matrix.
+        flex_shard(
+            model_gather,
+            buckets=[
+                BucketSpec(
+                    ["layers.0.weight"],
+                    placement_fn=shard0_placement_fn,
+                    mesh=mesh,
+                    mp_policy=MixedPrecisionPolicy(
+                        param_dtype=torch.float32, reduce_dtype=torch.float32
+                    ),
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+        gbuckets = _discover_dense_gather_buckets(model_gather)
+        self.assertEqual(len(gbuckets), 1)
+        g_placement = gbuckets[0]["placement"]
+        g_param = gbuckets[0]["params"][0]  # this rank's persistent shard
+        self.assertIsInstance(g_placement, Shard)
+
+        # fsdp2 Muon path: core fully_shard -> DTensor Shard(0).
+        fully_shard(model_dtensor.layers[0], mesh=mesh)
+        d_param = model_dtensor.layers[0].weight
+
+        kwargs = {"lr": 0.02, "weight_decay": 0.1, "momentum": 0.95, "nesterov": True}
+        gather_optim = GatherMuon(gbuckets, mesh, **kwargs)
+        dtensor_optim = DTensorMuon([d_param], **kwargs)
+        ref_optim = torch.optim.Muon([reference.layers[0].weight], **kwargs)
+
+        for step in range(4):
+            # Same deterministic full grad on every rank; each sharded model gets only its
+            # local slice (what autograd would hand each rank), the reference the whole grad.
+            torch.manual_seed(100 + step)
+            full_grad = torch.randn(m, n, device=device_type.type)
+
+            reference.layers[0].weight.grad = full_grad.clone()
+            g_param.grad = g_placement.extract_local_shard(
+                full_grad, self.rank, self.world_size
+            ).clone()
+            d_param.grad = distribute_tensor(full_grad, mesh, d_param.placements)
+
+            ref_optim.step()
+            gather_optim.step()
+            dtensor_optim.step()
+
+            ref_full = reference.layers[0].weight.detach()
+            # Gather Muon: local shard equals the reference's same-placement slice.
+            torch.testing.assert_close(
+                g_param.detach(),
+                g_placement.extract_local_shard(ref_full, self.rank, self.world_size),
+                rtol=0,
+                atol=0,
+            )
+            # fsdp2 Muon: local DTensor shard equals the reference's same-placement slice.
+            torch.testing.assert_close(
+                d_param.to_local(),
+                distribute_tensor(ref_full, mesh, d_param.placements).to_local(),
+                rtol=0,
+                atol=0,
+            )
+
+
+class TestQKClipMaskAware(TestCase):
+    """MuonClip captures S_max over the *attended* positions (real mask), not causal-only.
+
+    A document/packed mask makes attention block cross-document pairs; clipping must be
+    based on the logits the kernel actually attends to, or ``tau`` bounds the wrong score
+    set. ``_max_logit_per_head`` materializes the FlexAttention ``BlockMask``'s own
+    ``mask_mod`` rather than a hand-rolled causal mask.
+    """
+
+    @skip_if_lt_x_gpu(1)
+    def test_document_mask_excludes_cross_document_logits(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        from torchtitan.experiments.flex_shard.muon import _max_logit_per_head
+
+        torch.manual_seed(0)
+        bsz, seqlen, n_heads, head_dim = 1, 8, 2, 4
+        q = torch.randn(bsz, seqlen, n_heads, head_dim, device=device_type.type)
+        k = torch.randn(bsz, seqlen, n_heads, head_dim, device=device_type.type)
+
+        # Plant a huge logit between query pos 7 (doc 1) and key pos 0 (doc 0): causal
+        # attends it (7 >= 0), a document mask must not.
+        q[0, 7] = 10.0
+        k[0, 0] = 10.0  # dot = 10 * 10 * head_dim = 400
+
+        doc = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], device=device_type.type)
+
+        def causal(b, h, qi, kv):
+            return qi >= kv
+
+        def doc_causal(b, h, qi, kv):
+            return (qi >= kv) & (doc[qi] == doc[kv])
+
+        bm_causal = create_block_mask(
+            causal, bsz, 1, seqlen, seqlen, device=device_type.type
+        )
+        bm_doc = create_block_mask(
+            doc_causal, bsz, 1, seqlen, seqlen, device=device_type.type
+        )
+
+        smax_causal = _max_logit_per_head(q, k, 1.0, bm_causal)
+        smax_doc = _max_logit_per_head(q, k, 1.0, bm_doc)
+        smax_fallback = _max_logit_per_head(q, k, 1.0, None)
+
+        # Causal sees the planted cross-doc logit; the document mask excludes it.
+        self.assertGreater(float(smax_causal.max()), 100.0)
+        self.assertLess(float(smax_doc.max()), float(smax_causal.max()))
+        # No-mask fallback (hand-rolled causal) matches the BlockMask causal exactly.
+        torch.testing.assert_close(smax_fallback, smax_causal)
+
+
+class TestQKClipDataParallel(FSDPTest):
+    """MuonClip reduces S_max across data-parallel ranks before clipping (global batch).
+
+    Each rank captures S_max from its own microbatch; the clip must use the global-batch
+    per-head max (``all_reduce(MAX)``) or the owner would clip on only its rank's logits
+    and sharded rows would scale from divergent local maxima.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_smax_reduced_to_global_batch_max(self):
+        import math
+
+        from torchtitan.experiments.flex_shard.muon import QKClip
+
+        n_heads, nope, rope, v_head_dim, in_dim = 2, 4, 2, 4, 8
+        qk_head_dim = nope + rope
+
+        class _StubMLA(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.n_heads = n_heads
+                self.qk_nope_head_dim = nope
+                self.qk_rope_head_dim = rope
+                self.v_head_dim = v_head_dim
+                self.q_lora_rank = 0
+                self.softmax_scale = 1.0
+                self.wq = nn.Linear(in_dim, n_heads * qk_head_dim, bias=False)
+                self.wkv_b = nn.Linear(
+                    in_dim, n_heads * (nope + v_head_dim), bias=False
+                )
+                self.inner_attention = nn.Identity()  # capture target (never called)
+
+        torch.manual_seed(0)  # identical init on every rank
+        attn = _StubMLA().to(device_type.type)
+        wq_init = attn.wq.weight.detach().clone()
+
+        tau = 100.0
+        qkclip = QKClip([attn], tau=tau)  # shard_map=None -> Owned/plain row-scale path
+
+        # Per-rank LOCAL maxima: each rank sees the large logit for a DIFFERENT head, so
+        # the global per-head max is [200, 200] and BOTH heads must clip (gamma = 0.5).
+        if self.rank == 0:
+            attn._qkclip_smax = torch.tensor([200.0, 50.0], device=device_type.type)
+        else:
+            attn._qkclip_smax = torch.tensor([50.0, 200.0], device=device_type.type)
+
+        qkclip.step()
+
+        # Head 1's nope rows: rank 0's local S_max[1]=50 < tau would NOT clip on its own;
+        # only the DP-reduced global max (200) does -> scaled by sqrt(tau / 200).
+        h1_nope = slice(qk_head_dim, qk_head_dim + nope)
+        torch.testing.assert_close(
+            attn.wq.weight.detach()[h1_nope],
+            wq_init[h1_nope] * math.sqrt(tau / 200.0),
+        )
+
+        # Both ranks must end bit-identical (clipped on the same global max).
+        gathered = [torch.empty_like(attn.wq.weight) for _ in range(self.world_size)]
+        dist.all_gather(gathered, attn.wq.weight.detach().contiguous())
+        torch.testing.assert_close(gathered[0], gathered[1])
+
+
+class TestQKClipShardedProjection(FSDPTest):
+    """MuonClip scales a real FlexShard-sharded q/k projection, not just a full nn.Linear.
+
+    For the gather methods the q/k projections are row-sharded (``Shard(0)``), and the
+    container wires the buckets' ``(placement, info, mesh)`` into :class:`QKClip` via
+    ``shard_map`` (see ``_setup_qkclip``). The sharded branch of ``_scale_rows`` slices the
+    full per-head row-scale down to this rank's rows -- a path the plain data-parallel
+    nn.Linear test never exercises (it has no shard_map). This checks the sharded local
+    shard ends bit-exact with the same-placement slice of a single-device full QK-clip,
+    so the row-count/slice arithmetic is correct rather than a silent no-op.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_sharded_projection_matches_full_clip_slice(self):
+        from torchtitan.experiments.flex_shard import BucketSpec
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            MixedPrecisionPolicy,
+        )
+        from torchtitan.experiments.flex_shard.muon import (
+            _discover_dense_gather_buckets,
+            QKClip,
+        )
+        from torchtitan.experiments.flex_shard.muon.bucketing import shard0_placement_fn
+
+        n_heads, nope, rope, v_head_dim, in_dim = 2, 4, 2, 4, 8
+        qk_head_dim = nope + rope
+
+        class _StubMLA(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.n_heads = n_heads
+                self.qk_nope_head_dim = nope
+                self.qk_rope_head_dim = rope
+                self.v_head_dim = v_head_dim
+                self.q_lora_rank = 0
+                self.softmax_scale = 1.0
+                # Rows = n_heads * head_dim, divisible by world_size(2) -> even Shard(0).
+                self.wq = nn.Linear(in_dim, n_heads * qk_head_dim, bias=False)
+                self.wkv_b = nn.Linear(
+                    in_dim, n_heads * (nope + v_head_dim), bias=False
+                )
+                self.inner_attention = nn.Identity()
+
+        class _Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                # Under "layers." so the q/k projections form dense gather buckets.
+                self.layers = nn.ModuleList([_StubMLA()])
+
+        torch.manual_seed(0)  # identical init on every rank
+        reference = _Model().to(device_type.type)  # full, single device
+        model = copy.deepcopy(reference)
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["layers.0.wq.weight", "layers.0.wkv_b.weight"],
+                    placement_fn=shard0_placement_fn,
+                    mesh=init_device_mesh(
+                        device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+                    ),
+                    mp_policy=MixedPrecisionPolicy(
+                        param_dtype=torch.float32, reduce_dtype=torch.float32
+                    ),
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+
+        # Build the shard_map exactly as the container's _setup_qkclip does: each gathered
+        # 2D param -> its (placement, info, mesh).
+        buckets = _discover_dense_gather_buckets(model)
+        shard_map: dict[int, tuple] = {}
+        for bucket in buckets:
+            placement, storage = bucket["placement"], bucket["storage"]
+            for info, param in zip(bucket["infos"], bucket["params"], strict=True):
+                shard_map[id(param)] = (placement, info, storage._mesh)
+        self.assertEqual(len(shard_map), 2)  # wq + wkv_b both sharded
+
+        sharded_attn = model.layers[0]
+        ref_attn = reference.layers[0]
+        tau = 100.0
+        sharded_clip = QKClip([model], tau=tau, shard_map=shard_map)
+        ref_clip = QKClip([reference], tau=tau)  # shard_map=None -> full row-scale
+
+        # Head 0 over tau (clips, gamma=0.5), head 1 under (no clip). Identical on every
+        # rank so the step()'s all_reduce(MAX) is a no-op and both ranks clip the same.
+        smax = torch.tensor([200.0, 50.0], device=device_type.type)
+        sharded_attn._qkclip_smax = smax.clone()
+        ref_attn._qkclip_smax = smax.clone()
+
+        sharded_clip.step()
+        ref_clip.step()
+
+        persistent = dict(model.named_parameters())
+        for name in ("layers.0.wq.weight", "layers.0.wkv_b.weight"):
+            placement, info, mesh = shard_map[id(persistent[name])]
+            ref_full = dict(reference.named_parameters())[name].detach()
+            expected = placement.extract_local_shard(
+                ref_full, self.rank, self.world_size
+            )
+            torch.testing.assert_close(
+                persistent[name].detach(), expected, rtol=0, atol=0
+            )
+
+
+class TestDTensorMuonExperts(FSDPTest):
+    """fsdp2 DTensorMuon optimizes 3D MoE expert stacks with Muon (batched per-expert NS).
+
+    The fsdp2 baseline routes experts to DTensorMuon (not AdamW), matching the Owned/gather
+    full-Muon recipe. DTensorMuon all-gathers the ``[E, m, n]`` stack via ``full_tensor()``,
+    runs one batched per-expert NS, and writes back this rank's expert shard -- bit-exact
+    with a single-device :class:`GroupedMuon` over the whole stack.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_3d_experts_match_single_device_grouped(self):
+        from torch.distributed.tensor import distribute_tensor, Shard as DTShard
+
+        from torchtitan.experiments.flex_shard.muon import DTensorMuon, GroupedMuon
+
+        num_experts, m, n = 4, 16, 8  # experts divisible by world_size(2)
+        mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("dp",)
+        )
+        torch.manual_seed(0)
+        full = torch.randn(num_experts, m, n, device=device_type.type)
+        reference = nn.Parameter(full.clone())  # full stack, single device
+        # Core fully_shard shards experts as Shard(0) DTensors over the dp mesh.
+        dt = nn.Parameter(distribute_tensor(full.clone(), mesh, [DTShard(0)]))
+
+        kw = {"lr": 0.02, "weight_decay": 0.1, "momentum": 0.95, "nesterov": True}
+        d_opt = DTensorMuon([dt], **kw)
+        ref_opt = GroupedMuon([reference], **kw)
+
+        for step in range(3):
+            torch.manual_seed(100 + step)
+            grad = torch.randn(num_experts, m, n, device=device_type.type)
+            reference.grad = grad.clone()
+            dt.grad = distribute_tensor(grad.clone(), mesh, [DTShard(0)])
+
+            ref_opt.step()
+            d_opt.step()
+
+            # This rank's expert shard must equal the reference's Shard(0) slice. Both run
+            # the same batched NS on the same gathered [E, m, n] (full_tensor is a pure
+            # gather, momentum is element-wise over disjoint experts), so require bit-wise
+            # equality (rtol=0, atol=0), not just closeness.
+            expected = distribute_tensor(
+                reference.detach(), mesh, [DTShard(0)]
+            ).to_local()
+            torch.testing.assert_close(dt.to_local(), expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
A FlexShard-based test bed for distributed Muon / MuonClip, with expert-parallel
(EP) support for MoE models. Three Muon implementations share one routing layer so
the same recipe runs across dense and MoE models.

Stated tightly:
- Single node; FlexShard sharding engine; eager only.
- Expert parallelism (EP) supported (dense + MoE models).
- No tensor / pipeline / context parallelism (TP/PP/CP), no HSDP, no
  compile / offload / full_dtensor.
- The whole-layer Owned allocation (the default) requires num_layers >= dp_shard;
  the per-matrix / two-level / auto allocations relax that to
  num_2D_dense_matrices >= dp_shard, so the comm-efficient path still fills every
  rank when num_layers < world_size.

Out of scope:
- Checkpointing. The Muon optimizers are built flat (no "param_names"), so DCP
  save/load is not supported yet; the limitation is marked with TODO(checkpoint)
  at the GatherMuon / DTensorMuon construction sites.

1. Partition -- how params are bucketed and placed on the mesh.
   - muon/bucketing.py     : model-agnostic FlexShard bucket builders + parallelizers.
   - muon/owned.py         : Owned placement helpers + LPT layer->owner assignment.
2. Routing -- map each FlexShard bucket to an optimizer by its placement (not FQN regex).
   - muon/containers.py    : FlexShardMuonOptimizers / FlexShardGatherMuonOptimizers /
     FSDP2MuonOptimizers, the bucket-discovery predicates, and the MuonClip wiring.
3. Optimizer step -- the actual update math.
   - muon/newton_schulz.py : the NS kernel (single + batched per-expert) and the
     NS-FLOP cost model that balances layer owners.
   - muon/gather_muon.py   : GatherMuon / GatherGroupedMuon (all-gather, then NS).
   - muon/grouped_muon.py  : GroupedMuon (per-expert NS on whole local experts).
   - muon/dtensor_muon.py  : DTensorMuon (the core fully_shard / FSDP2 baseline).
   - muon/qkclip.py        : MuonClip QK-clip for MLA attention.

The three Muon implementations:
- Owned Muon (comm-efficient): the owner holds the whole matrix, runs NS locally,
  broadcasts the update. Collective-free in the step, except MoE experts when
  efsdp > num_local_experts (they fall back to a GroupedRaggedShard gather).
- Gather Muon: the matrix is Shard(0) / GroupedRaggedShard; the step all-gathers it,
  runs the same NS, and writes back this rank's shard.
- FSDP2 / DTensor Muon (baseline): core fully_shard shards params as DTensors;
  DTensorMuon does the gather in the step via full_tensor().

- muon/bench.py        : opt-in per-step instrumentation (FLEX_SHARD_MUON_BENCH=1):
  total_iter / opt_step / fwd_bwd timing and step_comm / fwdbwd_comm bytes.
- muon/comm_counter.py : process-global send-byte counter over BOTH eager
  (torch.distributed.*) and functional (torch.ops._c10d_functional.*) collectives,
  so the DTensor / FSDP2 baseline's in-step all-gather is counted, not just Owned's.

- qwen3/       : the model-size / GPU-count validation ladder -- dense Qwen3
  (0.6B .. 32B) and Qwen3-MoE (30B-A3B). Qwen3's deep layer counts keep
  num_layers >= dp_shard at large world sizes, the clean vehicle for scaling studies.
- deepseek_v3/ : the MuonClip optimizer recipe (MLA QK-clip) on dsv3-16B, with
  whole-layer Owned placement.

- tests/test_muon.py passing: CPU structural tests (cost model, LPT, bucket
  structure, routing predicates) plus GPU parity tests (gather vs FSDP2 vs
  single-device Muon, bit-exact), MuonClip mask / DP-reduce / sharded-projection
  tests, and a comm-counter test asserting functional collectives are counted.
- Model-folder structural tests for Qwen3-MoE and DeepSeek-V3 bucket placement.
- The Qwen3 experiment ladder is the planned end-to-end scaling validation.



---
**Stacking:** Based on #3603 (`gh/weifengpy/32/head`). CI stays red until #3603 is rebased onto current `main` -- that brings `torchtitan/components/checkpoint_utils.py` (`canonical_fqn`), which this PR imports. It will go green automatically after that rebase.
