### PR TITLE
Prefix amd-do- to ROCm ecosystem runner labels

### DIFF
--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runner-rocm:
-        description: 'Override default (linux.rocm.gpu.ecosystem.gfx950.8) ROCm runner label'
+        description: 'Override default (amd-do-linux.rocm.gpu.ecosystem.gfx950.8) ROCm runner label'
         required: false
         type: string
       runner-cuda:
@@ -44,7 +44,7 @@ jobs:
       TRIGGERED_8GPU_LABEL: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' }}
 
       # Default CUDA & ROCm runners
-      DEFAULT_ROCM_RUNNER: linux.rocm.gpu.ecosystem.gfx950.8
+      DEFAULT_ROCM_RUNNER: amd-do-linux.rocm.gpu.ecosystem.gfx950.8
       DEFAULT_CUDA_RUNNER: linux.g5.48xlarge.nvidia.gpu
 
       # Input CUDA & ROCm runners


### PR DESCRIPTION
## Summary

Prepends the literal prefix `amd-do-` to every runner label that starts with `linux.rocm.gpu.ecosystem`, so ROCm jobs target the migrated runner fleet. The suffix (e.g. `.gfx950.8`) is preserved.

Changes in `.github/workflows/set-matrix.yaml`:
- `DEFAULT_ROCM_RUNNER`: `linux.rocm.gpu.ecosystem.gfx950.8` -> `amd-do-linux.rocm.gpu.ecosystem.gfx950.8`
- `runner-rocm` input description default reference updated to match.

## Test plan

- [ ] Trigger the ROCm matrix (8gpu ciflow tag / label) and confirm jobs are scheduled on the `amd-do-linux.rocm.gpu.ecosystem.gfx950.8` runners.
- [ ] Confirm CUDA-only path is unaffected.

Made with Cursor