### PR TITLE
Fix weight-init truncation bounds and FFN depth-scaling target (#3334)

### DIFF
--- a/tests/unit_tests/test_feed_forward_init.py
+++ b/tests/unit_tests/test_feed_forward_init.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from functools import partial
+
+import torch
+import torch.nn as nn
+
+from torchtitan.models.common.config_utils import make_ffn_config
+
+
+class TestFeedForwardInit(unittest.TestCase):
+    """Weight-init wiring for the shared SwiGLU FeedForward (``make_ffn_config``)."""
+
+    def _build(self, w1w3_init, w2_init):
+        cfg = make_ffn_config(
+            dim=64,
+            hidden_dim=128,
+            w1w3_param_init=w1w3_init,
+            w2_param_init=w2_init,
+        )
+        ff = cfg.build()
+        ff.to_empty(device="cpu")
+        ff.init_states()
+        return ff
+
+    def test_w1_and_w3_share_input_init_not_w2(self):
+        """w1 and w3 use ``w1w3_param_init``; only w2 gets ``w2_param_init``."""
+        wide = {"weight": partial(nn.init.trunc_normal_, std=0.02, a=-0.06, b=0.06)}
+        narrow = {
+            "weight": partial(nn.init.trunc_normal_, std=0.005, a=-0.015, b=0.015)
+        }
+
+        torch.manual_seed(0)
+        ff = self._build(w1w3_init=wide, w2_init=narrow)
+
+        # w1/w3 follow the wide bound, not the narrow (depth-scaled) w2 bound.
+        for name in ("w1", "w3"):
+            w = getattr(ff, name).weight
+            self.assertLessEqual(w.abs().max().item(), 0.06 + 1e-6)
+            self.assertGreater(w.abs().max().item(), 0.015)
+
+        self.assertLessEqual(ff.w2.weight.abs().max().item(), 0.015 + 1e-6)
+
+    def test_truncation_bounds_are_effective(self):
+        """Explicit +-3 sigma bounds actually clip samples (default a/b do not)."""
+        std = 0.02
+        init = {
+            "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std)
+        }
+        torch.manual_seed(0)
+        ff = self._build(w1w3_init=init, w2_init=init)
+        for name in ("w1", "w2", "w3"):
+            self.assertLessEqual(
+                getattr(ff, name).weight.abs().max().item(), 3 * std + 1e-6
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -135,19 +135,23 @@ def make_ffn_config(
     *,
     dim: int,
     hidden_dim: int,
-    w1_param_init: dict[str, Callable],
-    w2w3_param_init: dict[str, Callable],
+    w1w3_param_init: dict[str, Callable],
+    w2_param_init: dict[str, Callable],
 ) -> FeedForward.Config:
-    """Build a fully-specified FeedForward.Config."""
+    """Build a fully-specified FeedForward.Config.
+
+    Forward is ``w2(silu(w1(x)) * w3(x))``, so ``w1``/``w3`` are input
+    projections and ``w2`` is the output projection.
+    """
     return FeedForward.Config(
         w1=Linear.Config(
-            in_features=dim, out_features=hidden_dim, param_init=w1_param_init
+            in_features=dim, out_features=hidden_dim, param_init=w1w3_param_init
         ),
         w2=Linear.Config(
-            in_features=hidden_dim, out_features=dim, param_init=w2w3_param_init
+            in_features=hidden_dim, out_features=dim, param_init=w2_param_init
         ),
         w3=Linear.Config(
-            in_features=dim, out_features=hidden_dim, param_init=w2w3_param_init
+            in_features=dim, out_features=hidden_dim, param_init=w1w3_param_init
         ),
     )
 

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
 
 
 _LINEAR_INIT = {
-    "weight": partial(nn.init.trunc_normal_, std=0.02),
+    "weight": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     "bias": nn.init.zeros_,
 }
 _NORM_INIT = {"weight": nn.init.ones_}
@@ -61,17 +61,20 @@ def _output_linear_init(dim: int) -> dict[str, Callable]:
 
 
 def _depth_init(layer_id: int) -> dict[str, Callable]:
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "weight": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
         "bias": nn.init.zeros_,
     }
 
 
 def _depth_experts_init(layer_id: int) -> dict[str, Callable]:
+    # Only w2 (output projection) gets the depth-scaled std; w1/w3 are inputs.
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02),
-        "w2_EDF": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
-        "w3_EFD": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
+        "w2_EDF": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
+        "w3_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     }
 
 
@@ -212,8 +215,8 @@ def _build_dsv3_layers(
             ffn_cfg = make_ffn_config(
                 dim=dim,
                 hidden_dim=dense_hidden_dim,
-                w1_param_init=_LINEAR_INIT,
-                w2w3_param_init=_depth_init(layer_id),
+                w1w3_param_init=_LINEAR_INIT,
+                w2_param_init=_depth_init(layer_id),
             )
             moe_cfg = None
         else:
@@ -243,8 +246,8 @@ def _build_dsv3_layers(
                 shared_experts=make_ffn_config(
                     dim=dim,
                     hidden_dim=moe_hidden_dim * num_shared_experts,
-                    w1_param_init=_LINEAR_INIT,
-                    w2w3_param_init=_depth_init(layer_id),
+                    w1w3_param_init=_LINEAR_INIT,
+                    w2_param_init=_depth_init(layer_id),
                 ),
             )
 

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -59,8 +59,9 @@ def _output_linear_init(dim: int) -> dict[str, Callable]:
 
 
 def _depth_init(layer_id: int) -> dict[str, Callable]:
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "weight": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
         "bias": nn.init.zeros_,
     }
 
@@ -93,8 +94,11 @@ def _make_gptoss_attn_config(
             inner_attention, window_size=(sliding_window_size - 1, 0)
         )
 
+    sinks_std = depth_scaled_std(0.02, layer_id)
     sinks_init = {
-        "sinks": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id))
+        "sinks": partial(
+            nn.init.trunc_normal_, std=sinks_std, a=-3 * sinks_std, b=3 * sinks_std
+        )
     }
 
     if fuse_qkv:
@@ -158,10 +162,14 @@ def _make_gptoss_experts_config(
     """Build a fully-specified GptOssGroupedExperts.Config for a single layer."""
     std = depth_scaled_std(0.02, layer_id)
     experts_init = {
-        "mlp1_weight_EGD": partial(nn.init.trunc_normal_, std=std),
-        "mlp1_bias_EG": partial(nn.init.trunc_normal_, std=std),
-        "mlp2_weight_EDF": partial(nn.init.trunc_normal_, std=std),
-        "mlp2_bias_ED": partial(nn.init.trunc_normal_, std=std),
+        "mlp1_weight_EGD": partial(
+            nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std
+        ),
+        "mlp1_bias_EG": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
+        "mlp2_weight_EDF": partial(
+            nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std
+        ),
+        "mlp2_bias_ED": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
     }
     return GptOssGroupedExperts.Config(
         dim=dim,

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
 
 
 _LINEAR_INIT = {
-    "weight": partial(nn.init.trunc_normal_, std=0.02),
+    "weight": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     "bias": nn.init.zeros_,
 }
 _NORM_INIT = {"weight": nn.init.ones_}
@@ -59,8 +59,9 @@ def _output_linear_init(dim: int) -> dict[str, Callable]:
 
 
 def _depth_init(layer_id: int) -> dict[str, Callable]:
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "weight": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
         "bias": nn.init.zeros_,
     }
 
@@ -99,8 +100,8 @@ def _build_llama3_layers(
                 feed_forward=make_ffn_config(
                     dim=dim,
                     hidden_dim=hidden_dim,
-                    w1_param_init=_LINEAR_INIT,
-                    w2w3_param_init=_depth_init(layer_id),
+                    w1w3_param_init=_LINEAR_INIT,
+                    w2_param_init=_depth_init(layer_id),
                 ),
             )
         )

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -46,7 +46,7 @@ __all__ = [
 
 
 _LINEAR_INIT = {
-    "weight": partial(nn.init.trunc_normal_, std=0.02),
+    "weight": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     "bias": nn.init.zeros_,
 }
 _NORM_INIT = {"weight": nn.init.ones_}
@@ -65,17 +65,20 @@ def _output_linear_init(dim: int) -> dict[str, Callable]:
 
 
 def _depth_init(layer_id: int) -> dict[str, Callable]:
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "weight": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
         "bias": nn.init.zeros_,
     }
 
 
 def _depth_experts_init(layer_id: int) -> dict[str, Callable]:
+    # Only w2 (output projection) gets the depth-scaled std; w1/w3 are inputs.
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02),
-        "w2_EDF": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
-        "w3_EFD": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
+        "w2_EDF": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
+        "w3_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     }
 
 
@@ -118,8 +121,8 @@ def _build_qwen3_layers(
                 feed_forward=make_ffn_config(
                     dim=dim,
                     hidden_dim=hidden_dim,
-                    w1_param_init=_LINEAR_INIT,
-                    w2w3_param_init=_depth_init(layer_id),
+                    w1w3_param_init=_LINEAR_INIT,
+                    w2_param_init=_depth_init(layer_id),
                 ),
             )
         )

--- a/torchtitan/models/qwen3_5/__init__.py
+++ b/torchtitan/models/qwen3_5/__init__.py
@@ -66,7 +66,7 @@ QWEN3_5_SPECIAL_TOKENS = {
 
 
 _LINEAR_INIT = {
-    "weight": partial(nn.init.trunc_normal_, std=0.02),
+    "weight": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     "bias": nn.init.zeros_,
 }
 _OFFSET_NORM_INIT = {"weight": nn.init.zeros_}
@@ -85,17 +85,20 @@ def _output_linear_init(dim: int) -> dict[str, Callable]:
 
 
 def _depth_init(layer_id: int) -> dict[str, Callable]:
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "weight": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "weight": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
         "bias": nn.init.zeros_,
     }
 
 
 def _depth_experts_init(layer_id: int) -> dict[str, Callable]:
+    # Only w2 (output projection) gets the depth-scaled std; w1/w3 are inputs.
+    std = depth_scaled_std(0.02, layer_id)
     return {
-        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02),
-        "w2_EDF": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
-        "w3_EFD": partial(nn.init.trunc_normal_, std=depth_scaled_std(0.02, layer_id)),
+        "w1_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
+        "w2_EDF": partial(nn.init.trunc_normal_, std=std, a=-3 * std, b=3 * std),
+        "w3_EFD": partial(nn.init.trunc_normal_, std=0.02, a=-3 * 0.02, b=3 * 0.02),
     }
 
 
@@ -123,8 +126,8 @@ def _shared_experts_config(
     ffn = make_ffn_config(
         dim=dim,
         hidden_dim=hidden_dim,
-        w1_param_init=_LINEAR_INIT,
-        w2w3_param_init=_depth_init(layer_id),
+        w1w3_param_init=_LINEAR_INIT,
+        w2_param_init=_depth_init(layer_id),
     )
     return SharedExperts.Config(
         w1=ffn.w1,
@@ -360,8 +363,8 @@ def _build_qwen35_layers(
                 feed_forward=make_ffn_config(
                     dim=dim,
                     hidden_dim=hidden_dim,
-                    w1_param_init=_LINEAR_INIT,
-                    w2w3_param_init=_depth_init(layer_id),
+                    w1w3_param_init=_LINEAR_INIT,
+                    w2_param_init=_depth_init(layer_id),
                 ),
                 attention_norm=_offset_norm(dim),
                 ffn_norm=_offset_norm(dim),


### PR DESCRIPTION
## Summary

Fixes two related weight-initialization bugs in the Llama3-family models and the shared SwiGLU `FeedForward`, reported in #3334.

### Bug 1 — truncation bounds are effectively useless

`_LINEAR_INIT` and `_depth_init` call `nn.init.trunc_normal_` **without** explicit `a`/`b`:

```python
_LINEAR_INIT = {"weight": partial(nn.init.trunc_normal_, std=0.02), ...}
```

`trunc_normal_` defaults to `a=-2.0, b=2.0` in **absolute** units. With `std=0.02` that is truncation at `2.0 / 0.02 = 100` standard deviations, so it never fires. This is inconsistent with `_output_linear_init` in the same files, which correctly clips at ±3σ (`a=-3*s, b=3*s`).

**Fix:** set explicit `a=-3*std, b=3*std` everywhere these inits are produced (`llama3`, `qwen3`, `deepseek_v3`, `qwen3_5`, and the analogous inits in `gpt_oss`).

### Bug 2 — depth-scaled init applied to the wrong projection

The SwiGLU forward is `w2(silu(w1(x)) * w3(x))`:

- `w1` — gate projection (`dim → hidden_dim`)
- `w3` — value projection (`dim → hidden_dim`)
- `w2` — output projection (`hidden_dim → dim`), the **only** one writing back into the residual stream

Depth-scaled init should therefore apply to `w2` alone. But `make_ffn_config` grouped `w2` and `w3` under a single `w2w3_param_init`, so the `w3` value projection was also depth-scaled. Because `w3` and `w2` are in series, a small `w3` feeds an already-small `w2`, making the FFN's residual contribution vanishingly small in deep models.

**Fix:** rename the args to `w1w3_param_init` / `w2_param_init` so `w1` and `w3` share the regular init and only `w2` is depth-scaled. The **same** bug existed in the MoE grouped-experts init (`_depth_experts_init`, where `w3_EFD` was depth-scaled alongside `w2_EDF`); fixed there too.

## Changes

- `torchtitan/models/common/config_utils.py` — `make_ffn_config` args `w1_param_init`/`w2w3_param_init` → `w1w3_param_init`/`w2_param_init`; only `w2` carries the depth init. Docstring documents the SwiGLU rationale.
- `llama3`, `qwen3`, `deepseek_v3`, `qwen3_5` — explicit ±3σ truncation bounds on `_LINEAR_INIT` / `_depth_init`; updated `make_ffn_config` call sites; fixed `w3_EFD` in `_depth_experts_init`.
- `gpt_oss` — explicit ±3σ bounds on `_depth_init`, attention `sinks_init`, and the grouped-experts init. Its structural init scheme (all-linears depth-scaled, fused `mlp1`/`mlp2` layout) is intentional and left unchanged, so Bug 2 does not apply there.
- `tests/unit_tests/test_feed_forward_init.py` — new unit test asserting (a) `w1`/`w3` share the input init and only `w2` is depth-scaled, and (b) the truncation bounds actually clip.

## Behavioral impact

This changes the initial weight distribution, so it is **not** loss-preserving by design — it makes init match the documented ±3σ truncation intent and the standard SwiGLU depth-scaling convention. Effects:

- Truncation now clips ~0.27% of samples at ±3σ instead of effectively never (minor).
- `w3` (value projection) is no longer suppressed by depth scaling — the intended fix, most impactful for deep models.

Existing pretrained checkpoints are unaffected (init only runs when training from scratch).

## Testing

- New `test_feed_forward_init.py` passes (builds the real `FeedForward`, runs `init_states`, and checks both fixes).
- `black` formatting clean on all touched files.

I'm resource-constrained on multi-GPU hardware, so I haven't run an end-to-end convergence comparison. Happy to coordinate with the team on a from-scratch convergence run if that's required for merge, per CONTRIBUTING.

Closes #3334
