### PR TITLE
Validate chunked loss chunking at config init

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -514,18 +514,43 @@ class TestChunkedCELoss(unittest.TestCase):
         """ChunkedCELoss must produce the same loss and gradients as the standard path."""
         self._assert_numerical_equivalence(B=2, L=8, D=32, V=64, num_chunks=4)
 
-    def test_uneven_sequence_chunks_raise(self):
-        """ChunkedCELoss should raise if num_chunks does not divide the sequence."""
-        B, D, V = 2, 32, 64
+    def test_validate_sequence_chunking_rejects_uneven_local_sequence(self):
+        """ChunkedCELoss should reject uneven local sequence chunks at init time."""
+        cases = (
+            (10, 1, 4),
+            (2, 1, 4),
+            (24, 2, 8),
+        )
 
-        for seq_len, num_chunks in ((10, 4), (2, 4)):
-            with self.subTest(seq_len=seq_len, num_chunks=num_chunks):
-                _, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
-                hidden_states = torch.randn(B, seq_len, D, requires_grad=True)
-                labels = torch.randint(0, V, (B, seq_len))
+        for seq_len, seq_shard_degree, num_chunks in cases:
+            with self.subTest(
+                seq_len=seq_len,
+                seq_shard_degree=seq_shard_degree,
+                num_chunks=num_chunks,
+            ):
+                with self.assertRaisesRegex(ValueError, "local sequence length"):
+                    ChunkedCELoss.validate_sequence_chunking(
+                        seq_len=seq_len,
+                        seq_shard_degree=seq_shard_degree,
+                        num_chunks=num_chunks,
+                    )
 
-                with self.assertRaisesRegex(ValueError, "evenly divisible"):
-                    chunked_loss(hidden_states, labels)
+    def test_validate_sequence_chunking_accepts_even_local_sequence(self):
+        """ChunkedCELoss should accept evenly chunked local sequences."""
+        ChunkedCELoss.validate_sequence_chunking(
+            seq_len=24,
+            seq_shard_degree=2,
+            num_chunks=4,
+        )
+
+    def test_validate_sequence_chunking_rejects_uneven_sequence_sharding(self):
+        """ChunkedCELoss should reject uneven sequence-dimension sharding."""
+        with self.assertRaisesRegex(ValueError, "global sequence length"):
+            ChunkedCELoss.validate_sequence_chunking(
+                seq_len=10,
+                seq_shard_degree=3,
+                num_chunks=2,
+            )
 
     def test_different_chunk_counts(self):
         """Loss should be the same regardless of num_chunks."""

--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -183,25 +183,26 @@ class TestGradAccumulator(unittest.TestCase):
         result = acc.result()
         torch.testing.assert_close(result, reference)
 
-    def test_accumulate_matches_cat_with_uneven_chunks(self):
-        """Verify GradAccumulator uses cumulative offsets for uneven chunks."""
+    def test_uneven_sequence_length_raises(self):
+        """Verify GradAccumulator rejects uneven sequence chunks."""
         B, L, D = 2, 10, 3
         num_chunks = 4
         reference = torch.arange(B * L * D, dtype=torch.float32).reshape(B, L, D)
-        chunks = torch.chunk(reference, num_chunks, dim=1)
-        self.assertNotEqual(len({chunk.shape[1] for chunk in chunks}), 1)
 
-        acc = GradAccumulator(
-            reference,
-            num_chunks=num_chunks,
-            seq_dim=1,
-            dtype=reference.dtype,
-        )
-        for chunk in chunks:
-            acc.add(chunk)
+        with self.assertRaisesRegex(ValueError, "evenly divisible"):
+            GradAccumulator(
+                reference,
+                num_chunks=num_chunks,
+                seq_dim=1,
+                dtype=reference.dtype,
+            )
 
-        result = acc.result()
-        torch.testing.assert_close(result, torch.cat(chunks, dim=1))
+    def test_unexpected_chunk_size_raises(self):
+        """Verify GradAccumulator rejects chunks with the wrong sequence length."""
+        acc = GradAccumulator(torch.randn(2, 8, 16), num_chunks=4, dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "expected chunk sequence length"):
+            acc.add(torch.randn(2, 3, 16))
 
     def test_accumulate_with_dtype_conversion(self):
         """Verify fp32 accumulation from bf16 chunks."""
@@ -513,9 +514,18 @@ class TestChunkedCELoss(unittest.TestCase):
         """ChunkedCELoss must produce the same loss and gradients as the standard path."""
         self._assert_numerical_equivalence(B=2, L=8, D=32, V=64, num_chunks=4)
 
-    def test_numerical_equivalence_with_uneven_chunks(self):
-        """ChunkedCELoss must preserve gradients when sequence chunks are uneven."""
-        self._assert_numerical_equivalence(B=2, L=10, D=32, V=64, num_chunks=4)
+    def test_uneven_sequence_chunks_raise(self):
+        """ChunkedCELoss should raise if num_chunks does not divide the sequence."""
+        B, D, V = 2, 32, 64
+
+        for seq_len, num_chunks in ((10, 4), (2, 4)):
+            with self.subTest(seq_len=seq_len, num_chunks=num_chunks):
+                _, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
+                hidden_states = torch.randn(B, seq_len, D, requires_grad=True)
+                labels = torch.randint(0, V, (B, seq_len))
+
+                with self.assertRaisesRegex(ValueError, "evenly divisible"):
+                    chunked_loss(hidden_states, labels)
 
     def test_different_chunk_counts(self):
         """Loss should be the same regardless of num_chunks."""

--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -183,6 +183,26 @@ class TestGradAccumulator(unittest.TestCase):
         result = acc.result()
         torch.testing.assert_close(result, reference)
 
+    def test_accumulate_matches_cat_with_uneven_chunks(self):
+        """Verify GradAccumulator uses cumulative offsets for uneven chunks."""
+        B, L, D = 2, 10, 3
+        num_chunks = 4
+        reference = torch.arange(B * L * D, dtype=torch.float32).reshape(B, L, D)
+        chunks = torch.chunk(reference, num_chunks, dim=1)
+        self.assertNotEqual(len({chunk.shape[1] for chunk in chunks}), 1)
+
+        acc = GradAccumulator(
+            reference,
+            num_chunks=num_chunks,
+            seq_dim=1,
+            dtype=reference.dtype,
+        )
+        for chunk in chunks:
+            acc.add(chunk)
+
+        result = acc.result()
+        torch.testing.assert_close(result, torch.cat(chunks, dim=1))
+
     def test_accumulate_with_dtype_conversion(self):
         """Verify fp32 accumulation from bf16 chunks."""
         torch.manual_seed(42)
@@ -430,11 +450,8 @@ class TestChunkedCELoss(unittest.TestCase):
         chunked_loss.lm_head = model.output
         return model, chunked_loss
 
-    def test_numerical_equivalence(self):
-        """ChunkedCELoss must produce the same loss and gradients as the standard path."""
+    def _assert_numerical_equivalence(self, B, L, D, V, num_chunks):
         torch.manual_seed(42)
-        B, L, D, V = 2, 8, 32, 64
-        num_chunks = 4
 
         model_std, _ = self._make_model_and_loss(D, V, num_chunks)
         model_chunked, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
@@ -491,6 +508,14 @@ class TestChunkedCELoss(unittest.TestCase):
             rtol=1e-5,
             msg="Chunked and standard lm_head gradients should match",
         )
+
+    def test_numerical_equivalence(self):
+        """ChunkedCELoss must produce the same loss and gradients as the standard path."""
+        self._assert_numerical_equivalence(B=2, L=8, D=32, V=64, num_chunks=4)
+
+    def test_numerical_equivalence_with_uneven_chunks(self):
+        """ChunkedCELoss must preserve gradients when sequence chunks are uneven."""
+        self._assert_numerical_equivalence(B=2, L=10, D=32, V=64, num_chunks=4)
 
     def test_different_chunk_counts(self):
         """Loss should be the same regardless of num_chunks."""

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -501,7 +501,42 @@ class ChunkedCELoss(BaseLoss):
     @dataclass(kw_only=True, slots=True)
     class Config(BaseLoss.Config):
         num_chunks: int = 8
-        """Number of chunks to split the sequence into."""
+        """Number of chunks to split the local sequence into."""
+
+    @staticmethod
+    def validate_sequence_chunking(
+        *,
+        seq_len: int,
+        seq_shard_degree: int,
+        num_chunks: int,
+    ) -> None:
+        """Validate that chunked CE will split the local sequence evenly."""
+        if seq_len <= 0:
+            raise ValueError(f"ChunkedCELoss seq_len must be positive, got {seq_len}")
+        if seq_shard_degree <= 0:
+            raise ValueError(
+                "ChunkedCELoss seq_shard_degree must be positive, "
+                f"got {seq_shard_degree}"
+            )
+        if num_chunks <= 0:
+            raise ValueError(
+                f"ChunkedCELoss num_chunks must be positive, got {num_chunks}"
+            )
+        if seq_len % seq_shard_degree != 0:
+            raise ValueError(
+                "ChunkedCELoss requires the global sequence length to be evenly "
+                f"divisible by the sequence shard degree, got sequence length "
+                f"{seq_len} and sequence shard degree {seq_shard_degree}."
+            )
+
+        local_seq_len = seq_len // seq_shard_degree
+        if local_seq_len % num_chunks != 0:
+            raise ValueError(
+                "ChunkedCELoss requires the local sequence length to be evenly "
+                f"divisible by num_chunks, got global sequence length {seq_len}, "
+                f"sequence shard degree {seq_shard_degree}, local sequence length "
+                f"{local_seq_len}, and num_chunks {num_chunks}."
+            )
 
     def __init__(
         self,
@@ -509,6 +544,10 @@ class ChunkedCELoss(BaseLoss):
         *,
         compile_config: CompileConfig | None = None,
     ):
+        if config.num_chunks <= 0:
+            raise ValueError(
+                f"ChunkedCELoss num_chunks must be positive, got {config.num_chunks}"
+            )
         self.fn: LossFunction = cross_entropy_loss
         self._maybe_compile(compile_config)
         self.num_chunks = config.num_chunks
@@ -546,23 +585,6 @@ class ChunkedCELoss(BaseLoss):
 
         # Check if it's training model or validation mode
         requires_grad = hidden_states.requires_grad
-
-        if num_chunks <= 0:
-            raise ValueError(
-                f"ChunkedCELoss num_chunks must be positive, got {num_chunks}"
-            )
-
-        local_seq_len = (
-            hidden_states.to_local().shape[1]
-            if isinstance(hidden_states, DTensor)
-            else hidden_states.shape[1]
-        )
-        if local_seq_len % num_chunks != 0:
-            raise ValueError(
-                "ChunkedCELoss requires the local sequence length to be evenly "
-                f"divisible by num_chunks, got local sequence length {local_seq_len} "
-                f"and num_chunks {num_chunks}."
-            )
 
         # Chunking always operates on the *local* view: when ``t`` is a
         # Shard(1) DTensor, chunking the global view would distribute whole

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -365,6 +365,7 @@ class GradAccumulator:
         self.num_chunks = num_chunks
         self.seq_dim = seq_dim
         self._next_idx = 0
+        self._seq_offset = 0
         self._device_mesh: DeviceMesh | None = None
         # Captured from the first added chunk; see __init__ docstring.
         self._placements: tuple[Placement, ...] | None = None
@@ -411,13 +412,14 @@ class GradAccumulator:
             chunk_grad = chunk_grad.to(self._buffer.dtype)
 
         chunk_seq_len = chunk_grad.shape[self.seq_dim]
-        start = self._next_idx * chunk_seq_len
+        start = self._seq_offset
         end = start + chunk_seq_len
 
         slices = [slice(None)] * self._buffer.ndim
         slices[self.seq_dim] = slice(start, end)
         self._buffer[tuple(slices)] = chunk_grad
 
+        self._seq_offset = end
         self._next_idx += 1
 
     def result(self) -> torch.Tensor:

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -365,7 +365,6 @@ class GradAccumulator:
         self.num_chunks = num_chunks
         self.seq_dim = seq_dim
         self._next_idx = 0
-        self._seq_offset = 0
         self._device_mesh: DeviceMesh | None = None
         # Captured from the first added chunk; see __init__ docstring.
         self._placements: tuple[Placement, ...] | None = None
@@ -376,6 +375,17 @@ class GradAccumulator:
         else:
             local = reference
 
+        if num_chunks <= 0:
+            raise ValueError(f"num_chunks must be positive, got {num_chunks}")
+
+        seq_len = local.shape[seq_dim]
+        if seq_len % num_chunks != 0:
+            raise ValueError(
+                "GradAccumulator requires the sequence length to be evenly "
+                f"divisible by num_chunks, got sequence length {seq_len} "
+                f"and num_chunks {num_chunks}."
+            )
+        self._chunk_seq_len = seq_len // num_chunks
         self._buffer = torch.zeros_like(local, dtype=dtype)
 
     def add(self, chunk_grad: torch.Tensor) -> None:
@@ -412,14 +422,19 @@ class GradAccumulator:
             chunk_grad = chunk_grad.to(self._buffer.dtype)
 
         chunk_seq_len = chunk_grad.shape[self.seq_dim]
-        start = self._seq_offset
+        if chunk_seq_len != self._chunk_seq_len:
+            raise ValueError(
+                "GradAccumulator expected chunk sequence length "
+                f"{self._chunk_seq_len}, got {chunk_seq_len}."
+            )
+
+        start = self._next_idx * chunk_seq_len
         end = start + chunk_seq_len
 
         slices = [slice(None)] * self._buffer.ndim
         slices[self.seq_dim] = slice(start, end)
         self._buffer[tuple(slices)] = chunk_grad
 
-        self._seq_offset = end
         self._next_idx += 1
 
     def result(self) -> torch.Tensor:
@@ -531,6 +546,23 @@ class ChunkedCELoss(BaseLoss):
 
         # Check if it's training model or validation mode
         requires_grad = hidden_states.requires_grad
+
+        if num_chunks <= 0:
+            raise ValueError(
+                f"ChunkedCELoss num_chunks must be positive, got {num_chunks}"
+            )
+
+        local_seq_len = (
+            hidden_states.to_local().shape[1]
+            if isinstance(hidden_states, DTensor)
+            else hidden_states.shape[1]
+        )
+        if local_seq_len % num_chunks != 0:
+            raise ValueError(
+                "ChunkedCELoss requires the local sequence length to be evenly "
+                f"divisible by num_chunks, got local sequence length {local_seq_len} "
+                f"and num_chunks {num_chunks}."
+            )
 
         # Chunking always operates on the *local* view: when ``t`` is a
         # Shard(1) DTensor, chunking the global view would distribute whole

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -157,6 +157,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         f"divisible by sequence parallel degree ({sp_degree})."
                     )
 
+            if isinstance(self.loss, ChunkedCELoss.Config):
+                # ChunkedCELoss sees hidden states after the root decoder norm.
+                # That norm gathers TP sequence-parallel shards before lm_head,
+                # while CP keeps the local sequence dimension sharded.
+                ChunkedCELoss.validate_sequence_chunking(
+                    seq_len=self.training.seq_len,
+                    seq_shard_degree=self.parallelism.context_parallel_degree,
+                    num_chunks=self.loss.num_chunks,
+                )
+
         def to_dict(self) -> dict[str, Any]:
             d = {}
             for f in dataclasses.fields(self):


### PR DESCRIPTION
## Summary

Reject `ChunkedCELoss` configs whose local sequence length would not divide evenly by `num_chunks`, using trainer config-time validation instead of a runtime tensor-shape check.

## Details

- Add `ChunkedCELoss.validate_sequence_chunking()` to validate global sequence length, sequence-dimension shard degree, and chunk count together.
- Call the validation from `Trainer.Config.__post_init__` for `ChunkedCELoss` configs. At the chunked loss boundary, hidden states have passed through the root decoder norm: TP sequence shards are gathered before `lm_head`, while CP remains sharded on the sequence dimension, so the loss-local shard degree is `context_parallel_degree`.
- Keep `GradAccumulator` defensive by validating equal local chunk sizes if it is used directly.
- Update tests to cover uneven local chunks, uneven sequence sharding, and valid sharded chunking.

## Validation

- `python -m pytest -q tests/unit_tests/test_loss.py`
- `SKIP=pyrefly-check pre-commit run --files torchtitan/components/loss.py torchtitan/trainer.py tests/unit_tests/test_loss.py`
- `pre-commit run --files torchtitan/components/loss.py torchtitan/trainer.py tests/unit_tests/test_loss.py` currently fails only in the project-wide Pyrefly hook on unrelated existing errors in `torchtitan/hf_datasets/multimodal/mm_collator.py`, `torchtitan/models/common/moe.py`, `torchtitan/models/flux/model/autoencoder.py`, `torchtitan/models/qwen3_5/vision_encoder.py`, and `torchtitan/distributed/utils.py`; all other hooks pass.