### PR TITLE
Read config args from current sys.argv

### DIFF
--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
 import unittest
+from unittest import mock
 
 import pytest
 from torchtitan.config import ConfigManager
-from torchtitan.trainer import Trainer
 
 
 class TestConfigManager(unittest.TestCase):
@@ -30,6 +31,14 @@ class TestConfigManager(unittest.TestCase):
         )
         assert config.model_spec.name == "llama3"
         assert config.model_spec.flavor == "debugmodel"
+
+    def test_parse_args_uses_current_sys_argv(self):
+        """parse_args() without args reads sys.argv at call time."""
+        config_manager = ConfigManager()
+        argv = ["train.py", "--module", "nonexistent", "--config", "foo"]
+        with mock.patch.object(sys, "argv", argv):
+            with pytest.raises(ImportError, match="Cannot import module 'nonexistent'"):
+                config_manager.parse_args()
 
     def test_model_without_config_errors(self):
         """--module alone raises ValueError."""
@@ -148,6 +157,8 @@ class TestConfigManager(unittest.TestCase):
     def test_extend_trainer_config_directly(self):
         """Test that _merge_configs works to extend config types."""
         from dataclasses import dataclass
+
+        from torchtitan.trainer import Trainer
 
         @dataclass
         class CustomCheckpoint:

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -31,7 +31,9 @@ class ConfigManager:
     def __init__(self):
         self.register_tyro_rules(custom_registry)
 
-    def parse_args(self, args: list[str] = sys.argv[1:]):
+    def parse_args(self, args: list[str] | None = None):
+        if args is None:
+            args = sys.argv[1:]
         loaded_config, args = self._load_config(args)
         config_cls = type(loaded_config)
 


### PR DESCRIPTION
## Summary

Fix `ConfigManager.parse_args()` so the no-argument path reads `sys.argv[1:]` at call time instead of capturing it in the function default at import time.

## Root cause

The old default argument `args=sys.argv[1:]` was evaluated once when `torchtitan.config.manager` was imported. Callers that mutate `sys.argv` later and then call `parse_args()` without an explicit list could parse stale arguments.

## Changes

- Change the default to `None` and read `sys.argv[1:]` inside `parse_args()`.
- Add a regression test that patches `sys.argv` after import and calls `parse_args()` without arguments.
- Move the `Trainer` import into the one test that needs it, avoiding heavy collection-time imports for parser-only tests.

## Validation

- `python -m pytest -q tests/unit_tests/test_config_manager.py::TestConfigManager::test_parse_args_uses_current_sys_argv`
- `python -m pytest -q tests/unit_tests/test_config_manager.py::TestConfigManager::test_model_without_config_errors tests/unit_tests/test_config_manager.py::TestConfigManager::test_config_without_model_errors tests/unit_tests/test_config_manager.py::TestConfigManager::test_missing_both_errors tests/unit_tests/test_config_manager.py::TestConfigManager::test_invalid_model_errors tests/unit_tests/test_config_manager.py::TestConfigManager::test_parse_args_uses_current_sys_argv`
- `pre-commit run --files torchtitan/config/manager.py tests/unit_tests/test_config_manager.py`