### PR TITLE
Deduplicate FusedQKVLinear hooks and add HF adapter tests

### DIFF
--- a/tests/unit_tests/test_fused_qkv.py
+++ b/tests/unit_tests/test_fused_qkv.py
@@ -95,6 +95,36 @@ class TestFusedQKVCheckpointInterop(unittest.TestCase):
         self.assertTrue(torch.equal(wqkv_b[:, _HPK].reshape(-1), stock.wk.bias))
         self.assertTrue(torch.equal(wqkv_b[:, _HPK + 1].reshape(-1), stock.wv.bias))
 
+    def test_hf_adapter_roundtrip(self):
+        """HF adapter works with FusedQKVLinear's hook-produced wq/wk/wv keys."""
+        from torchtitan.models.llama3 import llama3_configs
+        from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
+        from torchtitan.models.qwen3 import qwen3_configs
+        from torchtitan.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
+
+        for config_name, configs, adapter_cls in (
+            ("llama3", llama3_configs, Llama3StateDictAdapter),
+            ("qwen3", qwen3_configs, Qwen3StateDictAdapter),
+        ):
+            with self.subTest(model=config_name):
+                model_config = configs["debugmodel_fused_qkv"](attn_backend="flex")
+                model = model_config.build()
+                model.eval()
+
+                sd_original = model.state_dict()
+                adapter = adapter_cls(model_config, hf_assets_path=None)
+
+                hf_sd = adapter.to_hf(sd_original)
+                sd_restored = adapter.from_hf(hf_sd)
+
+                model2 = model_config.build()
+                model2.load_state_dict(sd_restored)
+
+                sd_after = model2.state_dict()
+                self.assertEqual(set(sd_original.keys()), set(sd_after.keys()))
+                for k in sd_original:
+                    self.assertTrue(torch.equal(sd_original[k], sd_after[k]), k)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -701,62 +701,42 @@ class FusedQKVLinear(BaseQKVLinear):
         """Split fused ``wqkv`` into stock ``wq.weight``/``wk.weight``/``wv.weight``."""
         hd, hpk, r = module.head_dim, module.heads_per_kv, module.r_dim
 
-        wqkv_w = state_dict.pop(f"{prefix}wqkv.weight")
-        n_kv, in_f = wqkv_w.shape[0] // (r * hd), wqkv_w.shape[1]
-        w = wqkv_w.reshape(n_kv, r, hd, in_f)
-        state_dict[f"{prefix}wq.weight"] = w[:, :hpk].reshape(-1, in_f).contiguous()
-        state_dict[f"{prefix}wk.weight"] = w[:, hpk].reshape(-1, in_f).contiguous()
-        state_dict[f"{prefix}wv.weight"] = w[:, hpk + 1].reshape(-1, in_f).contiguous()
-
-        b_key = f"{prefix}wqkv.bias"
-        if b_key in state_dict:
-            b = state_dict.pop(b_key).reshape(n_kv, r, hd)
-            state_dict[f"{prefix}wq.bias"] = b[:, :hpk].reshape(-1).contiguous()
-            state_dict[f"{prefix}wk.bias"] = b[:, hpk].reshape(-1).contiguous()
-            state_dict[f"{prefix}wv.bias"] = b[:, hpk + 1].reshape(-1).contiguous()
+        for param, ndim in (("weight", 4), ("bias", 3)):
+            key = f"{prefix}wqkv.{param}"
+            if key not in state_dict:
+                continue
+            tensor = state_dict.pop(key)
+            n_kv = tensor.shape[0] // (r * hd)
+            tail = (tensor.shape[1],) if ndim == 4 else ()
+            w = tensor.reshape(n_kv, r, hd, *tail)
+            state_dict[f"{prefix}wq.{param}"] = (
+                w[:, :hpk].reshape(-1, *tail).contiguous()
+            )
+            state_dict[f"{prefix}wk.{param}"] = (
+                w[:, hpk].reshape(-1, *tail).contiguous()
+            )
+            state_dict[f"{prefix}wv.{param}"] = (
+                w[:, hpk + 1].reshape(-1, *tail).contiguous()
+            )
 
     @staticmethod
     def _merge_qkv_on_load(module, state_dict, prefix, *args) -> None:
         """Merge stock ``wq.weight``/``wk.weight``/``wv.weight`` back into ``wqkv``."""
         hd, hpk = module.head_dim, module.heads_per_kv
-        wq_key, wk_key, wv_key = (
-            f"{prefix}wq.weight",
-            f"{prefix}wk.weight",
-            f"{prefix}wv.weight",
-        )
 
-        if wq_key in state_dict and wk_key in state_dict and wv_key in state_dict:
-            wq, wk, wv = (
-                state_dict.pop(wq_key),
-                state_dict.pop(wk_key),
-                state_dict.pop(wv_key),
+        for param, ndim in (("weight", 4), ("bias", 3)):
+            keys = [f"{prefix}{w}.{param}" for w in ("wq", "wk", "wv")]
+            if not all(k in state_dict for k in keys):
+                continue
+            wq, wk, wv = (state_dict.pop(k) for k in keys)
+            n_kv = wk.shape[0] // hd
+            tail = (wq.shape[1],) if ndim == 4 else ()
+            q = wq.reshape(n_kv, hpk, hd, *tail)
+            k = wk.reshape(n_kv, 1, hd, *tail)
+            v = wv.reshape(n_kv, 1, hd, *tail)
+            state_dict[f"{prefix}wqkv.{param}"] = torch.cat([q, k, v], dim=1).reshape(
+                -1, *tail
             )
-            n_kv, in_f = wk.shape[0] // hd, wq.shape[1]
-            q = wq.reshape(n_kv, hpk, hd, in_f)
-            k = wk.reshape(n_kv, 1, hd, in_f)
-            v = wv.reshape(n_kv, 1, hd, in_f)
-            state_dict[f"{prefix}wqkv.weight"] = torch.cat([q, k, v], dim=1).reshape(
-                -1, in_f
-            )
-
-        bq_key, bk_key, bv_key = (
-            f"{prefix}wq.bias",
-            f"{prefix}wk.bias",
-            f"{prefix}wv.bias",
-        )
-        if bq_key in state_dict and bk_key in state_dict and bv_key in state_dict:
-            bq, bk, bv = (
-                state_dict.pop(bq_key),
-                state_dict.pop(bk_key),
-                state_dict.pop(bv_key),
-            )
-            n_kv = bk.shape[0] // hd
-            q_b = bq.reshape(n_kv, hpk, hd)
-            k_b = bk.reshape(n_kv, 1, hd)
-            v_b = bv.reshape(n_kv, 1, hd)
-            state_dict[f"{prefix}wqkv.bias"] = torch.cat(
-                [q_b, k_b, v_b], dim=1
-            ).reshape(-1)
 
 
 class GQAttention(BaseAttention):


### PR DESCRIPTION
Deduplicate weight/bias split and merge logic in
`_merge_qkv_on_load` and `_split_qkv_on_save` by iterating over ("weight", 4) and ("bias", 3) pairs.

Add `test_hf_adapter_roundtrip` verifying HF adapter consumes hook-produced wq/wk/wv keys correctly for both llama3 and qwen3 fused debug models.