### PR TITLE
Fix NoParallel output hook for multi-output modules (#3374)

### DIFF
--- a/tests/unit_tests/test_tensor_parallel.py
+++ b/tests/unit_tests/test_tensor_parallel.py
@@ -1,0 +1,107 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.parallel import parallelize_module
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.distributed.tensor_parallel import NoParallel
+
+
+class _SingleOutput(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.gate(x)
+
+
+class _MultiOutput(nn.Module):
+    """Mirrors the MoE router gate, which returns ``(logits, ...)``."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        logits = self.gate(x)
+        return logits, logits * 2.0, x.shape[0]
+
+
+class TestNoParallelOutput(DTensorTestBase):
+    """``NoParallel`` must handle modules that return more than one output."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _mesh(self):
+        return init_device_mesh(
+            self.device_type, (self.world_size,), mesh_dim_names=("tp",)
+        )
+
+    @with_comms
+    def test_single_output_unchanged(self):
+        torch.manual_seed(0)
+        dim = 8
+        mod = _SingleOutput(dim).to(self.device_type)
+        ref = mod.gate.weight.detach().clone()
+
+        mod = parallelize_module(mod, self._mesh(), NoParallel(use_local_output=True))
+        x = torch.randn(4, dim, device=self.device_type)
+        out = mod(x)
+
+        self.assertIsInstance(out, torch.Tensor)
+        self.assertNotIsInstance(out, DTensor)
+        torch.testing.assert_close(out, x @ ref.t())
+
+    @with_comms
+    def test_multi_output(self):
+        torch.manual_seed(0)
+        dim = 8
+        mod = _MultiOutput(dim).to(self.device_type)
+        ref = mod.gate.weight.detach().clone()
+
+        mod = parallelize_module(mod, self._mesh(), NoParallel(use_local_output=True))
+        x = torch.randn(4, dim, device=self.device_type)
+
+        # Without the fix this raises: 'tuple' object has no attribute 'placements'
+        logits, doubled, batch = mod(x)
+
+        for t in (logits, doubled):
+            self.assertIsInstance(t, torch.Tensor)
+            self.assertNotIsInstance(t, DTensor)
+        self.assertEqual(batch, 4)
+
+        expected = x @ ref.t()
+        torch.testing.assert_close(logits, expected)
+        torch.testing.assert_close(doubled, expected * 2.0)
+
+    @with_comms
+    def test_multi_output_keeps_dtensor_when_not_local(self):
+        torch.manual_seed(0)
+        dim = 8
+        mod = _MultiOutput(dim).to(self.device_type)
+        mod = parallelize_module(mod, self._mesh(), NoParallel(use_local_output=False))
+        x = torch.randn(4, dim, device=self.device_type)
+
+        logits, doubled, batch = mod(x)
+        for t in (logits, doubled):
+            self.assertIsInstance(t, DTensor)
+        self.assertEqual(batch, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -15,6 +15,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import distribute_module, DTensor, Replicate
 from torch.distributed.tensor.parallel import ParallelStyle
 from torch.distributed.tensor.placement_types import Placement
+from torch.utils._pytree import tree_map
 
 from torchtitan.config import CompileConfig, ParallelismConfig
 from torchtitan.tools.logging import logger
@@ -74,12 +75,19 @@ class NoParallel(ParallelStyle):
         output_layout: Placement,
         use_local_output: bool,
         mod: nn.Module,
-        outputs: DTensor,
+        outputs: Any,
         device_mesh: DeviceMesh,
-    ) -> torch.Tensor | DTensor:
-        if outputs.placements != (output_layout,):
-            outputs = outputs.redistribute(placements=(output_layout,), async_op=True)
-        return outputs.to_local() if use_local_output else outputs
+    ) -> Any:
+        # tree_map over outputs handles modules that return more than one value
+        # (e.g. the router gate); non-DTensor outputs pass through unchanged.
+        def _prepare(output: Any) -> Any:
+            if not isinstance(output, DTensor):
+                return output
+            if output.placements != (output_layout,):
+                output = output.redistribute(placements=(output_layout,), async_op=True)
+            return output.to_local() if use_local_output else output
+
+        return tree_map(_prepare, outputs)
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         return distribute_module(


### PR DESCRIPTION
## Summary

Fixes #3374. `NoParallel`'s output hook crashes on modules that return more than one value.

`NoParallel._prepare_output_fn` assumed the wrapped module returns a single `DTensor` and accessed `outputs.placements` directly. Modules that return a tuple — e.g. the MoE router gate, which returns `(logits, ...)` — hit:

```
AttributeError: 'tuple' object has no attribute 'placements'
```

(full traceback in #3374; reproducible via the eager path of the script in #3345).

## Fix

Map the existing redistribute / `to_local` logic over every output with `torch.utils._pytree.tree_map`, applying the configured `output_layout` / `use_local_output` to each `DTensor` output and leaving non-`DTensor` outputs (ints, `None`, etc.) untouched:

```python
def _prepare(output: Any) -> Any:
    if not isinstance(output, DTensor):
        return output
    if output.placements != (output_layout,):
        output = output.redistribute(placements=(output_layout,), async_op=True)
    return output.to_local() if use_local_output else output

return tree_map(_prepare, outputs)
```

The single-output path is unchanged: a lone `DTensor` is a pytree leaf, so `tree_map` applies `_prepare` to it directly and returns the same result as before. This matches the resolution suggested in the issue ("apply the same `output_layout` and `local_output_grad_placements` to every output via a `tree_map`").

## Behavioral impact

Loss-neutral. For single-output modules the result is identical; for multi-output modules it replaces a hard crash with the intended per-output handling. No numerical change.

## Testing

Adds `tests/unit_tests/test_tensor_parallel.py` (CPU / gloo via `DTensorTestBase`), covering:
- `test_single_output_unchanged` — regression: single-output modules behave exactly as before.
- `test_multi_output` — the bug: a module returning `(tensor, tensor, int)` now works; both DTensor outputs are redistributed/localized and the non-tensor output passes through.
- `test_multi_output_keeps_dtensor_when_not_local` — `use_local_output=False` keeps every output a `DTensor`.

Verified the new `test_multi_output` fails on `main` with the original `AttributeError` and passes with this change. `black` clean on all touched files.
