### PR TITLE
[dev] replace pre-commit with prek

### DIFF
--- a/.ci/docker/requirements-dev.txt
+++ b/.ci/docker/requirements-dev.txt
@@ -1,7 +1,7 @@
 expecttest>=0.2.0
 pytest==7.3.2
 pytest-cov
-pre-commit
+prek
 pyrefly==0.45.1
 transformers
 numpy

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@
 pip install -r requirements.txt -r requirements-dev.txt
 
 # Lint and format (required before any PR)
-pre-commit run --all-files
+prek run --all-files
 
 # Run unit tests
 pytest tests/ -x
@@ -135,7 +135,7 @@ this for the comments and docstrings you are adding or rewriting.
 
 ## PR Expectations
 
-1. **Lint first.** Run `pre-commit run --all-files` and fix all issues before
+1. **Lint first.** Run `prek run --all-files` and fix all issues before
    requesting review. CI linting failures waste everyone's time.
 2. **Show numerical proof.** Include loss comparison for any non-trivial change.
 3. **Explain "why" not just "what"** in the PR description.

--- a/.claude/rules/experiments.md
+++ b/.claude/rules/experiments.md
@@ -7,7 +7,7 @@ globs: torchtitan/experiments/**
 
 ## Looser Standards, Still Linted
 Code in experiments has more flexibility than core, but must still pass
-`pre-commit run --all-files`. No exceptions for linting.
+`prek run --all-files`. No exceptions for linting.
 
 ## Don't Modify Core for Experiments
 If an experiment needs behavior that core doesn't provide, work around it in the

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
           python -m pip install --force-reinstall --pre --index-url https://download.pytorch.org/whl/nightly/cu130 torch
-          pre-commit install-hooks
+          prek prepare-hooks
 
       - name: Get changed files
         id: changed-files
@@ -68,10 +68,10 @@ jobs:
         env:
           # Lychee will checks all links in .md and .py files in the next step
           SKIP: lychee-link-checker
-        run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
+        run: prek run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Check links with Lychee
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pre-commit run lychee-link-checker --all-files
+          prek run lychee-link-checker --all-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We actively welcome your pull requests.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code lints (`pre-commit run --all-files`).
+5. Make sure your code lints (`prek run --all-files`).
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ### Contributor License Agreement ("CLA")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Issues = "https://github.com/pytorch/torchtitan/issues"
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit",
+    "prek",
     "pytest",
     "pytest-cov",
     "expecttest", # test_tokenizer


### PR DESCRIPTION
For those who don't like to waste 20s on pre-commit hooks.

Timing table is with fresh empty hook caches.

Command | pre-commit timing | prek timing
-- | -- | --
prepare hook envs: pre-commit install-hooks / prek prepare-hooks | 20.76s | 1.93s
main lint, Lychee skipped: ... run --show-diff-on-failure --all-files | 10.84s | 11.92s
link checker only: ... run lychee-link-checker --all-files | 3.29s | 3.25s
full run: ... run --all-files | 11.58s | 11.69s
dependency install   | 7.46s | 6.78s
