### PR TITLE
[Checkpoint] clarify initial load and resume behavior

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -288,7 +288,8 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual(len(mock_save.call_args_list), 3)
         manager.close()
 
-    def test_load_returns_false_when_no_checkpoint_folder(self):
+    @mock.patch("torchtitan.components.checkpoint.logger")
+    def test_load_returns_false_when_no_checkpoint_folder(self, mock_logger):
         cfg = self.trainer_config.checkpoint
         cfg.folder = "nonexistent"
         manager = CheckpointManager(
@@ -302,6 +303,28 @@ class TestCheckpointManager(unittest.TestCase):
             base_folder=self.trainer_config.dump_folder,
         )
         self.assertFalse(manager.load(step=-1))
+        mock_logger.info.assert_any_call(
+            "No checkpoint was loaded because checkpoint.folder %s has no "
+            "valid checkpoints and no initial checkpoint source was provided.",
+            os.path.join(self.trainer_config.dump_folder, "nonexistent"),
+        )
+        manager.close()
+
+    def test_explicit_load_step_raises_when_checkpoint_folder_missing(self):
+        cfg = self.trainer_config.checkpoint
+        cfg.folder = "nonexistent"
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=self.trainer_config.checkpoint,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        with self.assertRaisesRegex(FileNotFoundError, "--checkpoint.load_step=5"):
+            manager.load(step=5)
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
@@ -328,9 +351,106 @@ class TestCheckpointManager(unittest.TestCase):
         res = manager.load(step=-1)
         expected = os.path.join(ckpt_folder, "step-5")
         mock_load.assert_called_once()
-        args, kwargs = mock_load.call_args
+        _, kwargs = mock_load.call_args
         self.assertEqual(kwargs.get("checkpoint_id"), expected)
         self.assertTrue(res)
+        manager.close()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    def test_initial_load_path_used_when_folder_has_no_valid_checkpoints(
+        self, mock_load, mock_rank
+    ):
+        initial_load_path = os.path.join(self.base_temp_dir, "initial", "step-100")
+        os.makedirs(initial_load_path, exist_ok=True)
+
+        cfg = self.trainer_config.checkpoint
+        cfg.initial_load_path = initial_load_path
+        cfg.initial_load_model_only = True
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=self.trainer_config.checkpoint,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+
+        res = manager.load(step=-1)
+
+        mock_load.assert_called_once()
+        _, kwargs = mock_load.call_args
+        self.assertEqual(kwargs.get("checkpoint_id"), initial_load_path)
+        self.assertTrue(res)
+        manager.close()
+
+    @mock.patch("torchtitan.components.checkpoint.logger")
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    def test_initial_load_path_errors_when_folder_has_valid_checkpoints(
+        self, mock_load, mock_rank, mock_logger
+    ):
+        initial_load_path = os.path.join(self.base_temp_dir, "initial", "step-100")
+        os.makedirs(initial_load_path, exist_ok=True)
+        ckpt_folder = os.path.join(self.test_folder, "checkpoints")
+        step_dir = os.path.join(ckpt_folder, "step-5")
+        os.makedirs(step_dir, exist_ok=True)
+        open(os.path.join(step_dir, ".metadata"), "w").close()
+
+        cfg = self.trainer_config.checkpoint
+        cfg.folder = "checkpoints"
+        cfg.initial_load_path = initial_load_path
+        cfg.initial_load_model_only = True
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=self.trainer_config.checkpoint,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "checkpoint.initial_load_path is provided but the "
+            "checkpoint.folder contains valid checkpoints",
+        ):
+            manager.load(step=-1)
+
+        mock_load.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        self.assertTrue(os.path.isdir(step_dir))
+        manager.close()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    def test_explicit_load_step_raises_when_checkpoint_step_missing(
+        self, mock_load, mock_rank
+    ):
+        ckpt_folder = os.path.join(self.test_folder, "checkpoints")
+        os.makedirs(ckpt_folder, exist_ok=True)
+
+        cfg = self.trainer_config.checkpoint
+        cfg.folder = "checkpoints"
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=self.trainer_config.checkpoint,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+
+        with self.assertRaisesRegex(FileNotFoundError, "--checkpoint.load_step=5"):
+            manager.load(step=5)
+
+        mock_load.assert_not_called()
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
@@ -397,7 +517,7 @@ class TestCheckpointManager(unittest.TestCase):
         cfg.last_save_model_only = False
         cfg.initial_load_model_only = True
         cfg.initial_load_path = path1
-        cfg.folder = ""
+        cfg.folder = "new_checkpoints"
         self.trainer_config.dump_folder = self.test_folder
         manager2 = CheckpointManager(
             dataloader=self.data_loader,
@@ -409,16 +529,17 @@ class TestCheckpointManager(unittest.TestCase):
             sd_adapter=None,
             base_folder=self.trainer_config.dump_folder,
         )
-        r1 = manager2.load(step=1)
+        r1 = manager2.load(step=-1)
         self.assertTrue(r1)
         mock_load.assert_called_once()
-        args1, kwargs1 = mock_load.call_args
+        _, kwargs1 = mock_load.call_args
         self.assertEqual(kwargs1.get("checkpoint_id"), path1)
-        # Phase 3: save new step under default folder, then load that
+        # Phase 3: save a new run checkpoint, then load it from the current folder.
         manager2.save(curr_step=2, last_step=True)
-        # Default folder is test_folder, so step-2 under that
-        step2_dir = os.path.join(self.test_folder, "step-2")
+        # New run checkpoints are saved under the configured output folder.
+        step2_dir = os.path.join(self.test_folder, "new_checkpoints", "step-2")
         self.assertTrue(os.path.isdir(step2_dir))
+        manager2.initial_load_path = None
         r2 = manager2.load(step=2)
         self.assertTrue(r2)
         self.assertEqual(mock_load.call_count, 2)

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -304,9 +304,7 @@ class TestCheckpointManager(unittest.TestCase):
         )
         self.assertFalse(manager.load(step=-1))
         mock_logger.info.assert_any_call(
-            "No checkpoint was loaded because checkpoint.folder %s has no "
-            "valid checkpoints and no initial checkpoint source was provided.",
-            os.path.join(self.trainer_config.dump_folder, "nonexistent"),
+            "No checkpoint was provided, this is a fresh start."
         )
         manager.close()
 
@@ -389,9 +387,12 @@ class TestCheckpointManager(unittest.TestCase):
     @mock.patch("torchtitan.components.checkpoint.logger")
     @mock.patch("torch.distributed.get_rank", return_value=0)
     @mock.patch("torchtitan.components.checkpoint.dcp.load")
-    def test_initial_load_path_errors_when_folder_has_valid_checkpoints(
+    def test_initial_load_path_ignored_when_folder_has_valid_checkpoints(
         self, mock_load, mock_rank, mock_logger
     ):
+        # Resuming from checkpoint.folder is the fault-tolerance path: all
+        # initial_* options are silently ignored so a job can keep the same
+        # arguments across automatic restarts.
         initial_load_path = os.path.join(self.base_temp_dir, "initial", "step-100")
         os.makedirs(initial_load_path, exist_ok=True)
         ckpt_folder = os.path.join(self.test_folder, "checkpoints")
@@ -414,16 +415,13 @@ class TestCheckpointManager(unittest.TestCase):
             base_folder=self.trainer_config.dump_folder,
         )
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "checkpoint.initial_load_path is provided but the "
-            "checkpoint.folder contains valid checkpoints",
-        ):
-            manager.load(step=-1)
+        res = manager.load(step=-1)
 
-        mock_load.assert_not_called()
+        self.assertTrue(res)
+        mock_load.assert_called_once()
+        _, kwargs = mock_load.call_args
+        self.assertEqual(kwargs.get("checkpoint_id"), step_dir)
         mock_logger.warning.assert_not_called()
-        self.assertTrue(os.path.isdir(step_dir))
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -239,8 +239,11 @@ class CheckpointManager(Configurable):
         This option specifies the path to the initial checkpoint to load, which is
         particularly useful for resuming training from a previous run with a
         different output path or when loading a checkpoint from a pre-trained model.
-        If the checkpoint folder for the current run is not empty,
-        located at {--dump_folder}/{--checkpoint.folder}, this option will be ignored.
+        It is an error to provide this option when the checkpoint folder for the
+        current run already contains a valid checkpoint, located at
+        {--dump_folder}/{--checkpoint.folder}. In that case the run is no longer a
+        fresh run and should resume from the intermediate checkpoint without
+        initial_load_path.
         This feature allows users to load an initial checkpoint from a different folder
         and continue training, saving new checkpoints to the specified folder without
         affecting the existing ones.
@@ -802,11 +805,11 @@ class CheckpointManager(Configurable):
         """Load the checkpoint for the given step.
 
         This function orchestrates the states loading process.
-        If the local checkpoint folder does not yet exist, it attempts an initial load
-        from a specified path (in either native or HF format) or performs loading using
-        provided HF assets path from the state dict adapter. Otherwise, it retrieves
-        the checkpoint corresponding to the specified step, defaulting to the latest
-        available if the `step` is -1.
+        If the local checkpoint folder contains a valid checkpoint, it retrieves the
+        checkpoint corresponding to the specified step, defaulting to the latest
+        available if the `step` is -1. Otherwise, it attempts an initial load from a
+        specified path (in either native or HF format) or performs loading using
+        provided HF assets path from the state dict adapter.
 
         Args:
             step (int, optional): The training step to restore.
@@ -823,7 +826,18 @@ class CheckpointManager(Configurable):
         from_hf = False
         from_quantized = False
 
-        if not filesystem.exists(self.folder):
+        has_checkpoint_folder = filesystem.exists(self.folder)
+        load_step = -1
+        if has_checkpoint_folder:
+            load_step = self._find_load_step() if step == -1 else step
+
+        if step != -1 and not has_checkpoint_folder:
+            raise FileNotFoundError(
+                f"--checkpoint.load_step={step} not found because "
+                f"checkpoint.folder {self.folder} does not exist"
+            )
+
+        if not has_checkpoint_folder or load_step == -1:
             model_only = self.initial_load_model_only
             from_hf = self.initial_load_in_hf
             from_quantized = self.initial_load_in_hf_quantized
@@ -865,25 +879,30 @@ class CheckpointManager(Configurable):
                 )
 
             else:
+                logger.info(
+                    "No checkpoint was loaded because checkpoint.folder %s has no "
+                    "valid checkpoints and no initial checkpoint source was provided.",
+                    self.folder,
+                )
                 return False
 
         else:
             if self.initial_load_path:
-                logger.warning(
+                raise ValueError(
                     "checkpoint.initial_load_path is provided but the "
-                    "checkpoint.folder exists. Checkpointer will use the checkpoints "
-                    f"from the checkpoint.folder {self.folder}."
+                    "checkpoint.folder contains valid checkpoints. Remove "
+                    "checkpoint.initial_load_path to resume from checkpoint.folder "
+                    f"{self.folder}, or set checkpoint.folder to a directory with "
+                    "no valid checkpoints for a fresh initial load."
                 )
             if self.initial_load_in_hf:
                 logger.warning(
                     "checkpoint.initial_load_in_hf is True but the checkpoint.folder "
-                    "exists. Checkpointer will not load from HF safetensors"
+                    "contains valid checkpoints. Checkpointer will not load from HF "
+                    "safetensors"
                 )
 
-            step = self._find_load_step() if step == -1 else step
-            if step == -1:
-                return False
-
+            step = load_step
             model_only = step == 0
             checkpoint_id = self._create_checkpoint_id(step)
 

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -239,11 +239,8 @@ class CheckpointManager(Configurable):
         This option specifies the path to the initial checkpoint to load, which is
         particularly useful for resuming training from a previous run with a
         different output path or when loading a checkpoint from a pre-trained model.
-        It is an error to provide this option when the checkpoint folder for the
-        current run already contains a valid checkpoint, located at
-        {--dump_folder}/{--checkpoint.folder}. In that case the run is no longer a
-        fresh run and should resume from the intermediate checkpoint without
-        initial_load_path.
+        If the checkpoint folder for the current run is not empty,
+        located at {--dump_folder}/{--checkpoint.folder}, this option will be ignored.
         This feature allows users to load an initial checkpoint from a different folder
         and continue training, saving new checkpoints to the specified folder without
         affecting the existing ones.
@@ -837,7 +834,7 @@ class CheckpointManager(Configurable):
                 f"checkpoint.folder {self.folder} does not exist"
             )
 
-        if not has_checkpoint_folder or load_step == -1:
+        if load_step == -1:
             model_only = self.initial_load_model_only
             from_hf = self.initial_load_in_hf
             from_quantized = self.initial_load_in_hf_quantized
@@ -879,29 +876,15 @@ class CheckpointManager(Configurable):
                 )
 
             else:
-                logger.info(
-                    "No checkpoint was loaded because checkpoint.folder %s has no "
-                    "valid checkpoints and no initial checkpoint source was provided.",
-                    self.folder,
-                )
+                logger.info("No checkpoint was provided, this is a fresh start.")
                 return False
 
         else:
-            if self.initial_load_path:
-                raise ValueError(
-                    "checkpoint.initial_load_path is provided but the "
-                    "checkpoint.folder contains valid checkpoints. Remove "
-                    "checkpoint.initial_load_path to resume from checkpoint.folder "
-                    f"{self.folder}, or set checkpoint.folder to a directory with "
-                    "no valid checkpoints for a fresh initial load."
-                )
-            if self.initial_load_in_hf:
-                logger.warning(
-                    "checkpoint.initial_load_in_hf is True but the checkpoint.folder "
-                    "contains valid checkpoints. Checkpointer will not load from HF "
-                    "safetensors"
-                )
-
+            # This is the fault-tolerance branch: checkpoint.folder already
+            # contains valid checkpoints from a previous run, so we resume from
+            # it and all initial_* options are ignored by design. This allows a
+            # job to keep the same arguments across automatic restarts after
+            # failures.
             step = load_step
             model_only = step == 0
             checkpoint_id = self._create_checkpoint_id(step)


### PR DESCRIPTION
## Summary

- Take the initial-load branch when `checkpoint.folder` has no valid
  checkpoint (`load_step == -1`), not only when the folder is missing.
- Raise `FileNotFoundError` for an explicit `--checkpoint.load_step` when
  the folder does not exist.
- Log an info message on fresh start instead of returning silently.
- Resume behavior is unchanged: `initial_*` options are ignored by design
  for fault tolerance. Per review, the warnings there were removed and
  replaced with a comment.

## Motivation

`load()` chose between initial load and resume solely by whether
`checkpoint.folder` exists, causing two silent failures:

1. Folder exists but has no valid checkpoint (e.g. crash before the first
   save): `initial_load_path` / HF initial load was silently skipped and
   training started from scratch.
2. An explicit `--checkpoint.load_step=N` with a missing folder was
   silently ignored.