### PR TITLE
Fix missing f-prefix in dataloader resume warning

### DIFF
--- a/tests/unit_tests/test_dataloader.py
+++ b/tests/unit_tests/test_dataloader.py
@@ -84,6 +84,24 @@ class TestParallelAwareDataloader(unittest.TestCase):
         self.assertEqual(last_batch_input["input"].tolist(), [96, 97, 98, 99])
         self.assertEqual(last_batch_label.tolist(), [96, 97, 98, 99])
 
+    def test_load_state_dict_missing_rank_warning_includes_rank_id(self):
+        """The missing-rank warning must interpolate the actual rank key."""
+        dataloader = ParallelAwareDataloader(
+            DummyDataset(),
+            dp_rank=0,
+            dp_world_size=1,
+            batch_size=4,
+        )
+        # Non-empty state that lacks this rank's key hits the warning branch.
+        state_dict = {"dp_rank_1": b"", "world_size": 1}
+
+        with self.assertLogs(level="WARNING") as cm:
+            dataloader.load_state_dict(state_dict)
+
+        output = "\n".join(cm.output)
+        self.assertIn(dataloader._rank_id, output)
+        self.assertNotIn("{self._rank_id}", output)
+
     def test_validate_kwargs_rejects_invalid_kwargs(self):
         """Test that passing invalid kwargs raises ValueError."""
         dataset = DummyDataset()

--- a/torchtitan/components/dataloader.py
+++ b/torchtitan/components/dataloader.py
@@ -154,7 +154,7 @@ class ParallelAwareDataloader(StatefulDataLoader, BaseDataLoader):
         if self._rank_id not in state_dict:
             logger.warning(
                 f"DataLoader state is empty for dp rank {self.dp_rank}, "
-                "expected key {self._rank_id}"
+                f"expected key {self._rank_id}"
             )
             return
 


### PR DESCRIPTION
## Summary

`ParallelAwareDataloader.load_state_dict` logs a warning when a checkpoint contains no saved dataloader state for the current data-parallel rank. The warning is built from two adjacent string literals, but only the first carries the `f` prefix — so the second renders literally:

```
DataLoader state is empty for dp rank 0, expected key {self._rank_id}
```

The `{self._rank_id}` value (e.g. `dp_rank_0`) is the one piece of information the message exists to surface when debugging a resume / resharding mismatch, so the bug defeats the warning's purpose.

## Fix

Add the missing `f` prefix:

```python
logger.warning(
    f"DataLoader state is empty for dp rank {self.dp_rank}, "
    f"expected key {self._rank_id}"
)
```

Now logs: `... expected key dp_rank_0`. Logging-only change; no behavioral/numerical impact.

## Testing

Adds `test_load_state_dict_missing_rank_warning_includes_rank_id` to `tests/unit_tests/test_dataloader.py`, which drives the missing-rank branch and asserts the warning contains the actual rank id and not the literal `{self._rank_id}`. Verified it fails on `main` and passes with this change; `black` clean.
