### PR TITLE
[rl] swe_r2e: pluggable coding-agent (Claude Code) harness on Daytona

### DIFF
--- a/torchtitan/experiments/rl/examples/swe_r2e/.gitignore
+++ b/torchtitan/experiments/rl/examples/swe_r2e/.gitignore
@@ -1,0 +1,9 @@
+# Runtime artifacts produced by a run (not source).
+# Claude Code stream-json agent traces:
+trajectories/
+# training-view per-rollout traces:
+rollout_dumps/
+# launcher run logs:
+runlog/
+__pycache__/
+*.log

--- a/torchtitan/experiments/rl/examples/swe_r2e/README.md
+++ b/torchtitan/experiments/rl/examples/swe_r2e/README.md
@@ -1,0 +1,122 @@
+# SWE R2E coding-agent RL with a pluggable harness (Claude Code)
+
+Post-train a Qwen model on R2E-Gym SWE tasks where the rollout is driven by an
+**unmodified agentic CLI harness** (Claude Code first) running inside a cloud
+sandbox (Daytona). Every model turn the agent makes is captured as on-policy
+training data, graded by the R2E hidden tests, and fed to GRPO.
+
+This is the TorchTitan analogue of THUDM/slime's `examples/coding_agent_rl` -- a
+"virtual actor + reverse-proxy" design where the policy is served to an external
+agent over its own wire format.
+
+## How a rollout works
+
+```
+RLTrainer (controller, one asyncio loop)
+  SWER2ERollouter.run_group_rollouts(generate_fn, sample, group_size=K)
+    AnthropicAdapter  <- one HTTP server (127.0.0.1:SHIM_PORT) backed by generate_fn
+    per sibling (K):
+      boot_agent_sandbox(image)         Daytona sandbox + install node22 + claude
+      run_claude_code(... adapter_url)  claude -p, ANTHROPIC_BASE_URL -> adapter
+         claude (in sandbox) --HTTP--> DaytonaBridge (fs file-relay) --> AnthropicAdapter
+            adapter: render_ids / bridge_to_next_turn (TITO) -> generate_fn -> Completion
+            adapter records CapturedTurn(prompt_ids, completion_ids, logprobs) per turn
+      git_diff(tracked_only)            capture the agent's patch
+      evaluate_r2e(image, diff, r2e)    fresh sandbox: apply diff, run hidden tests
+      finish_session -> CapturedTurns -> RolloutTurns (reward on last turn env_rewards)
+  score (RewardR2E) -> advantage (GRPO) -> rollout_to_episodes -> Batcher -> backward
+```
+
+The key seam is `harness/adapters/anthropic.py`: it speaks the agent's Anthropic
+Messages wire format, but renders/generates with TorchTitan's own
+`renderers.Renderer` + `generate_fn`. Because it reuses prior turns' exact sampled
+tokens via `bridge_to_next_turn` (Token-In-Token-Out), each turn's prompt exactly
+extends `prev_prompt + prev_completion`, so a whole multi-turn trajectory packs
+into ONE training episode (assistant tokens trained, prompt/tool-result tokens
+masked). A Claude Code auto-compaction breaks the prefix and opens a new episode
+branch, exactly as `rollout_to_episodes` expects.
+
+Swapping Claude Code for another CLI agent (Codex/OpenCode/...) is a new run
+command (point its provider base URL at the adapter); the adapter, sandbox,
+grading, and training path are agent-agnostic.
+
+## Layout
+
+`harness/` (shared, agent-agnostic) is split along three orthogonal axes -- WHERE
+code runs, HOW the model is served, WHICH agent runs:
+
+- `harness/sandbox/`: `base.py` (the `Sandbox` contract + `make_sandbox` factory),
+  `daytona.py` (backend), `bridge.py` (Daytona fs file-relay).
+- `harness/adapters/`: `anthropic.py` (token-capturing Anthropic Messages
+  endpoint). Add an `openai.py` for Codex/OpenCode -- the token capture is shared.
+- `harness/agents/`: `claude_code.py` (install toolchain + run `claude -p` +
+  capture diff). Add a sibling per new CLI agent.
+
+So a new CLI agent = a new `agents/` runner (+ reuse/extend an `adapters/` wire
+module); a new sandbox provider = a new `sandbox/` backend.
+
+- `examples/swe_r2e/` (this folder): `data.py` (R2E JSONL dataset), `grading.py`
+  (R2E test-pass scoring), `rubric.py`, `rollouter.py`, `config_registry.py`,
+  `env.py` (placeholder), `run_swe_r2e_daytona.sh`, `local_smoke_harness.py`.
+
+## Run
+
+Prereqs: `DAYTONA_API_KEY` exported; `daytona` installed (`uv pip install daytona`);
+the TorchTitan RL dev env active (`TT_VENV_ENV` -> your venv setup script); an R2E
+JSONL (`PROMPT_DATA`, built with `prepare_r2e_data.py`); and the model's HF
+weights (`HF_ASSETS_PATH`). The Claude Code binary is downloaded inside the sandbox
+from its CDN (override via `SWE_CLAUDE_CDN`), so no host toolchain tarball is needed.
+
+Fastest full-pipeline smoke (2 GPUs, 1 task x 2 samples -> backward):
+
+```bash
+DAYTONA_API_KEY=dtn_... \
+  CONFIG=rl_grpo_qwen3_1_7b_swe_r2e \
+  PROMPT_DATA=/path/to/r2e.jsonl \
+  HF_ASSETS_PATH=/path/to/Qwen3-1.7B \
+  bash torchtitan/experiments/rl/examples/swe_r2e/run_swe_r2e_daytona.sh
+```
+
+Target model (6 GPUs): `CONFIG=rl_grpo_qwen3_8b_swe_r2e`, `HF_ASSETS_PATH=/path/to/Qwen3-8B`.
+
+Every sandbox gets a cloud-side auto-delete TTL (``TT_DAYTONA_AUTO_STOP_MIN`` /
+``TT_DAYTONA_AUTO_DELETE_MIN``) so an orphan self-reaps even if the job is SIGKILL'd (e.g.
+MAST preemption) and never runs its cleanup.
+
+Isolated harness debug (one sandbox, plain vLLM, no trainer):
+
+```bash
+PROMPT_DATA=.../easy_one.jsonl DAYTONA_API_KEY=dtn_... VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+  python -m torchtitan.experiments.rl.examples.swe_r2e.local_smoke_harness
+```
+
+## Knobs that matter
+
+| Var | Why |
+| --- | --- |
+| model `max_seq_len` (config) | == vLLM `max_model_len`. Claude Code's system + tool-schema prompt is 15k+ tokens; the qwen3 spec default 4096 truncates it to an empty generation. The configs raise it to 24576 via `_set_max_seq_len`. |
+| `SWE_MAX_CONTEXT_LEN` | Adapter per-turn budget; must stay under `max_seq_len` with room for one generation. |
+| `seq_len` (batcher) | Must exceed a full episode (`SWE_MAX_CONTEXT_LEN` + a turn's gen) or the episode is dropped during packing. |
+| `global_batch_size` | `num_tokens_target = global_batch_size * seq_len`; the controller boots rollout groups until met. Keep small for a smoke (1) so it runs ONE group. |
+| `SWE_CLAUDE_EXTRA_ARGS` | Disallows `Task`/`Agent` sub-agents (they run in separate git worktrees whose edits `git_diff` can't see -> reward-always-0) and useless headless tools. |
+| `SWE_ROLLOUT_CONCURRENCY` | Max concurrently-active rollouts (bridge/Daytona load cap). |
+| `SWE_REWARD_DENSE` | `1` switches grading from binary (1.0 iff solved) to the per-test pass fraction, giving within-group reward variance when a weaker policy solves nothing. |
+
+## What to expect (honest)
+
+Small models on a tight context score ~reward 0 on real R2E one-shot (zero
+advantage -> zero gradient), so a smoke proves the **pipeline** runs end to end,
+not a high score. Verified 2026-06-21: `rl_grpo_qwen3_1_7b_swe_r2e` ran 2 Claude
+Code rollouts in Daytona (26 / 5 turns), graded them, and completed GRPO Train
+Step 1 (`timing/step ~57s`). Meaningful reward needs a bigger model
+(8B / 30B-A3B), a larger context (~48k like slime), and many steps.
+
+## Models
+
+Five dense/MoE recipes in `config_registry.py`: `rl_grpo_qwen3_1_7b_swe_r2e`
+(fast smoke) and `rl_grpo_qwen3_8b_swe_r2e` (the documented target) are the two
+the run script wires; `rl_grpo_qwen3_14b_swe_r2e` and `rl_grpo_qwen3_32b_swe_r2e`
+(dense) and `rl_grpo_qwen3_30b_a3b_swe_r2e` (MoE) are larger scale-up configs.
+All need the matching Qwen3 HF weights on disk. NOTE the slime recipe's
+Qwen3.6-35B-A3B is a different (Megatron-only) model not in TorchTitan's qwen3
+registry; 30B-A3B is the closest TorchTitan MoE.

--- a/torchtitan/experiments/rl/examples/swe_r2e/__init__.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.rl.examples.swe_r2e.data import SWER2EDataset, SWER2ESample
+from torchtitan.experiments.rl.examples.swe_r2e.env import SWER2EEnv
+from torchtitan.experiments.rl.examples.swe_r2e.rollouter import SWER2ERollouter
+from torchtitan.experiments.rl.examples.swe_r2e.rubric import RewardR2E
+
+__all__ = [
+    "RewardR2E",
+    "SWER2EDataset",
+    "SWER2EEnv",
+    "SWER2ERollouter",
+    "SWER2ESample",
+]

--- a/torchtitan/experiments/rl/examples/swe_r2e/config_registry.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/config_registry.py
@@ -1,0 +1,318 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Config entry points for the SWE R2E coding-agent (Claude Code) example.
+
+``ConfigManager`` discovers these directly from the example module::
+
+    python -m torchtitan.experiments.rl.train \
+        --module swe_r2e --config rl_grpo_qwen3_8b_swe_r2e \
+        --hf_assets_path <path/to/Qwen3-8B>
+
+``hf_assets_path`` defaults to ``example_checkpoint/Qwen3-<size>`` (the same
+convention as the other RL examples); point it at your downloaded HF weights via
+the CLI flag above or the launcher's ``HF_ASSETS_PATH``. The R2E JSONL path comes
+from ``SWE_PROMPT_DATA`` (set by the launcher's ``PROMPT_DATA``).
+
+Models: 1.7B (fast full-pipeline smoke) and 8B (the documented target) are the two
+the run script wires; 14B and 32B (dense) and 30B-A3B (MoE) are larger scale-up
+recipes. All are TorchTitan-registered; point ``hf_assets_path`` at the weights.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.lr_scheduler import LRSchedulersContainer
+from torchtitan.components.optimizer import default_adamw
+from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import FullAC
+from torchtitan.experiments.rl.actors.generator import (
+    SamplingConfig,
+    VLLMCudagraphConfig,
+    VLLMGenerator,
+)
+from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
+from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
+from torchtitan.experiments.rl.examples.swe_r2e.data import SWER2EDataset
+from torchtitan.experiments.rl.examples.swe_r2e.rollouter import SWER2ERollouter
+from torchtitan.experiments.rl.losses import DAPOLoss
+from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
+from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
+from torchtitan.experiments.rl.renderer import RendererConfig
+from torchtitan.experiments.rl.trainer import RLTrainer
+from torchtitan.models.qwen3 import model_registry
+from torchtitan.protocols.model_spec import ModelSpec
+
+# R2E JSONL path, supplied by the launcher (PROMPT_DATA -> SWE_PROMPT_DATA).
+# Empty by default; SWER2EDataset raises a clear error if it is not set.
+_DEFAULT_DATA = os.environ.get("SWE_PROMPT_DATA", "")
+_CKPT_DIR = "torchtitan/experiments/rl/example_checkpoint"
+# qwen3 specs default max_seq_len to 4096; _set_max_seq_len raises every layer's
+# RoPE max_seq_len (== vLLM max_model_len) so a full coding-agent episode fits.
+_SWE_MAX_MODEL_LEN = 24576
+_SMOKE_SEQ_LEN = 24576
+
+
+def _set_max_seq_len(model_spec: ModelSpec, max_seq_len: int) -> None:
+    """Raise the model's context length by setting every layer's RoPE max_seq_len
+    (``ModelSpec.model.max_seq_len`` is a read-only property derived from it)."""
+    for layer in model_spec.model.layers:
+        rope = getattr(getattr(layer, "attention", None), "rope", None)
+        if rope is not None:
+            rope.max_seq_len = max_seq_len
+
+
+def rl_grpo_qwen3_1_7b_swe_r2e() -> RLTrainer.Config:
+    """Fast full-pipeline smoke: Qwen3-1.7B, 1 R2E task x 2 samples -> backward.
+
+    2 GPUs: 1 trainer (TP=1) + 1 generator (TP=1). Pairs with
+    ``run_swe_r2e_daytona.sh`` (Daytona sandbox, tight context). Proves the
+    sandbox -> Claude Code -> adapter -> grading -> GRPO step path end to end.
+    """
+    model_spec = model_registry("1.7B", attn_backend="varlen")
+    _set_max_seq_len(model_spec, _SWE_MAX_MODEL_LEN)
+    return RLTrainer.Config(
+        model_spec=model_spec,
+        hf_assets_path=f"{_CKPT_DIR}/Qwen3-1.7B",
+        num_steps=1,
+        num_groups_per_rollout_batch=1,
+        group_size=2,
+        num_validation_samples=0,
+        validation_freq=0,
+        compile=CompileConfig(enable=False),
+        rollouter=SWER2ERollouter.Config(
+            train_dataset=SWER2EDataset.Config(data_path=_DEFAULT_DATA, seed=42),
+            validation_dataset=SWER2EDataset.Config(
+                data_path=_DEFAULT_DATA, seed=99, shuffle=False
+            ),
+        ),
+        renderer=RendererConfig(name="qwen3"),
+        metrics=MetricsProcessor.Config(enable_wandb=False),
+        # global_batch_size=1 keeps the smoke to ONE rollout group (2 daytona
+        # sandboxes + 2 eval sandboxes): num_tokens_target = global_batch_size *
+        # seq_len, and the collection loop boots groups until that target is met.
+        # group_size=2 still gives a GRPO pair (advantages computed per group
+        # before batching); the batch trains on the packed episode(s) that fit.
+        batcher=Batcher.Config(
+            batch=BatchConfig(
+                local_batch_size=1, global_batch_size=1, seq_len=_SMOKE_SEQ_LEN
+            ),
+        ),
+        trainer=PolicyTrainer.Config(
+            optimizer=default_adamw(lr=1e-6),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=1, decay_type="linear", min_lr_factor=1.0
+            ),
+            training=TrainingConfig(),
+            # FullAC: long SWE episodes make the full-vocab fp32 logprob transient
+            # large; recompute the forward to fit.
+            ac_config=FullAC.Config(),
+            parallelism=ParallelismConfig(
+                data_parallel_shard_degree=1,
+                tensor_parallel_degree=1,
+            ),
+            checkpoint=CheckpointManager.Config(
+                enable=True,
+                initial_load_in_hf=True,
+                interval=10000,  # initial HF load only; no mid-run checkpoints
+                last_save_model_only=True,
+            ),
+            loss=DAPOLoss.Config(ratio_clip_low=0.2, ratio_clip_high=0.28),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            parallelism=InferenceParallelismConfig(
+                data_parallel_degree=1,
+                tensor_parallel_degree=1,
+            ),
+            gpu_memory_limit=0.6,
+            cudagraph=VLLMCudagraphConfig(enable=True, mode="FULL_DECODE_ONLY"),
+            checkpoint=CheckpointManager.Config(enable=False),
+            sampling=SamplingConfig(temperature=1.0, top_p=1.0, max_tokens=2048),
+        ),
+    )
+
+
+def rl_grpo_qwen3_8b_swe_r2e() -> RLTrainer.Config:
+    """Target smoke: Qwen3-8B, 1 R2E task x 2 samples -> backward.
+
+    6 GPUs: trainer TP=4 (fp32 master) + generator TP=2. Same recipe as the 1.7B
+    config; only the model and GPU split differ. Pairs with
+    ``run_swe_r2e_daytona.sh`` (CONFIG=rl_grpo_qwen3_8b_swe_r2e).
+    """
+    config = rl_grpo_qwen3_1_7b_swe_r2e()
+    config.model_spec = model_registry("8B", attn_backend="varlen")
+    _set_max_seq_len(config.model_spec, _SWE_MAX_MODEL_LEN)
+    config.hf_assets_path = f"{_CKPT_DIR}/Qwen3-8B"
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism, tensor_parallel_degree=4
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        parallelism=dataclasses.replace(
+            config.generator.parallelism, tensor_parallel_degree=2
+        ),
+    )
+    return config
+
+
+def rl_grpo_qwen3_30b_a3b_swe_r2e() -> RLTrainer.Config:
+    """Scale-up (MoE): Qwen3-30B-A3B on a SINGLE 8-GPU host.
+
+    TorchTitan RL uses separate (non-colocated) trainer/generator meshes, so 8 GPUs
+    are split 4 + 4. Fitting a 30B model in the trainer's 4 GPUs needs aggressive
+    memory savings (vs the search_r1 32B dense recipe which used a whole host for
+    FSDP and ran multi-generator on MAST):
+      - bf16 master weights (``dtype="bfloat16"``, no fp32 master) + ``Adam`` states
+        in bf16 (``implementation="fused_opt_states_bf16"``) roughly halve trainer
+        memory; FullAC recomputes activations.
+      - trainer FSDP-4 (``data_parallel_shard_degree=4``, TP=1); EP via FSDP.
+      - generator TP=4 + EP=4 (full expert parallelism across its 4 GPUs).
+
+    This is the closest single-host TorchTitan analogue of the slime Qwen3.6-35B-A3B
+    recipe (a different, Megatron-only model). For more headroom / real reward, run
+    multi-host on MAST (a whole host for the FSDP trainer + N generator hosts).
+    Requires the Qwen3-30B-A3B HF weights on disk.
+    """
+    config = rl_grpo_qwen3_1_7b_swe_r2e()
+    config.model_spec = model_registry("30B-A3B", attn_backend="varlen")
+    _set_max_seq_len(config.model_spec, _SWE_MAX_MODEL_LEN)
+    config.hf_assets_path = f"{_CKPT_DIR}/Qwen3-30B-A3B"
+    # bf16 master + bf16 Adam states to fit 30B in the trainer's 4 GPUs.
+    bf16_adam = default_adamw(lr=1e-6)
+    bf16_adam.implementation = "fused_opt_states_bf16"
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        optimizer=bf16_adam,
+        training=dataclasses.replace(config.trainer.training, dtype="bfloat16"),
+        ac_config=FullAC.Config(),
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=4,
+            tensor_parallel_degree=1,
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        gpu_memory_limit=0.5,
+        # MoE expert routing's dynamic shapes break vLLM CUDA graph capture
+        # ("Cannot copy between CPU and CUDA tensors during CUDA graph capture";
+        # see generator.py's MoE-cudagraph TODO) -> run the generator eager.
+        cudagraph=VLLMCudagraphConfig(enable=False),
+        parallelism=dataclasses.replace(
+            config.generator.parallelism,
+            tensor_parallel_degree=4,
+            expert_parallel_degree=4,
+        ),
+    )
+    return config
+
+
+def rl_grpo_qwen3_32b_swe_r2e() -> RLTrainer.Config:
+    """Qwen3-32B (dense) SWE-R2E: single-host FSDP-8 trainer + TP-8 generator.
+
+    The scale target. Trainer: FSDP across 8 GPUs (data_parallel_shard_degree=8,
+    TP=1) with bf16 master + bf16 AdamW states (fused_opt_states_bf16) + FullAC to
+    fit the long-context backward on one 80GB host (the full-vocab fp32 logprob
+    transient dominates memory at this seq_len). Generator is dense TP=8 with
+    decode-only CUDA graphs. ``group_size=4`` samples per prompt mirrors slime's
+    ``n_samples_per_prompt``. ``global_batch_size=8`` is the FSDP-8 trainer's
+    one-row-per-rank floor (below it ``gradient_accumulation_steps`` rounds to 0 and
+    no optimizer step runs).
+    """
+    config = rl_grpo_qwen3_1_7b_swe_r2e()
+    config.model_spec = model_registry("32B", attn_backend="varlen")
+    _set_max_seq_len(config.model_spec, _SWE_MAX_MODEL_LEN)
+    config.hf_assets_path = f"{_CKPT_DIR}/Qwen3-32B"
+    config.group_size = 4
+    config.num_steps = 1
+    bf16_adam = default_adamw(lr=1e-6)
+    bf16_adam.implementation = "fused_opt_states_bf16"
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        optimizer=bf16_adam,
+        training=dataclasses.replace(config.trainer.training, dtype="bfloat16"),
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=8,
+            tensor_parallel_degree=1,
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        # Coding-agent edits can be long; raise the per-turn generation cap. slime
+        # uses 8192 over a 38k context -> ~4096 ratio-matched to our 20480 budget
+        # (the adapter further caps each turn at budget - prompt_len).
+        sampling=dataclasses.replace(config.generator.sampling, max_tokens=4096),
+        parallelism=dataclasses.replace(
+            config.generator.parallelism,
+            tensor_parallel_degree=8,
+        ),
+    )
+    # global_batch_size must be a multiple of local_batch_size * trainer_dp_degree
+    # (1 * FSDP-8 = 8) or gradient_accumulation_steps rounds to 0 -> no optim step.
+    config.batcher = Batcher.Config(
+        batch=BatchConfig(
+            local_batch_size=1, global_batch_size=8, seq_len=_SMOKE_SEQ_LEN
+        ),
+    )
+    return config
+
+
+# 14B context cap. Kept below Qwen3-14B's 40960 native max: seq_len sets the
+# collection target (num_tokens_target = global_batch * seq_len), so an
+# over-large seq_len makes the loop over-collect rollouts (each shorter than
+# seq_len) to fill it. 32768 is ~1.3x the 32B run's 24576 with a saner target.
+_QWEN3_14B_MAX_LEN = 32768
+
+
+def rl_grpo_qwen3_14b_swe_r2e() -> RLTrainer.Config:
+    """Qwen3-14B (dense) SWE-R2E: FSDP-8 mixed-precision trainer + TP-4 generator(s).
+
+    14B leaves enough headroom (vs 32B) to keep fp32-master mixed precision AND a
+    larger context. Trainer: FSDP-8 (dp_shard=8, TP=1) with the default
+    TrainingConfig (dtype=float32 master + mixed_precision_param=bfloat16 compute +
+    fp32 reduce) + FullAC fit seq_len=40960 -- 14B's native context, ~1.7x the 32B
+    run's 24576 and closer to slime's long-context coding rollouts. Generator is
+    dense TP=4 (14B fits 4 GPUs); run ``--num_generators N`` for more parallel
+    rollout. Per-turn gen cap 8192 (slime's MAX_GEN_LEN). global_batch_size=8 is the
+    FSDP-8 one-row-per-rank floor; group_size=8, num_steps defaults to the smoke
+    (override on the CLI for a longer run).
+    """
+    config = rl_grpo_qwen3_1_7b_swe_r2e()
+    config.model_spec = model_registry("14B", attn_backend="varlen")
+    _set_max_seq_len(config.model_spec, _QWEN3_14B_MAX_LEN)
+    config.hf_assets_path = f"{_CKPT_DIR}/Qwen3-14B"
+    config.group_size = 8  # slime n_samples_per_prompt
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=8,
+            tensor_parallel_degree=1,
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        gpu_memory_limit=0.8,
+        sampling=dataclasses.replace(config.generator.sampling, max_tokens=8192),
+        parallelism=dataclasses.replace(
+            config.generator.parallelism,
+            tensor_parallel_degree=4,
+        ),
+    )
+    config.batcher = Batcher.Config(
+        batch=BatchConfig(
+            local_batch_size=1, global_batch_size=8, seq_len=_QWEN3_14B_MAX_LEN
+        ),
+    )
+    return config

--- a/torchtitan/experiments/rl/examples/swe_r2e/data.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/data.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""R2E-Gym (SWE) dataset for the coding-agent RL example.
+
+Reads a JSONL produced from R2E-Gym. Each row::
+
+    {
+      "prompt": <problem_statement>,
+      "label": <instance_id>,
+      "metadata": {
+        "instance_id", "image" (docker.io/...), "workdir" "/testbed",
+        "problem_statement",
+        "r2e": {"test_file_names", "test_file_codes", "expected_output_json"},
+        "pre_commands": <optional list[str]|str>
+      }
+    }
+
+The dataset is an endless, seeded stream of frozen ``SWER2ESample``s, mirroring
+``SearchR1Dataset``.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+from torchtitan.config import Configurable
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SWER2ESample:
+    """One R2E-Gym SWE task: a containerized repo, an issue, and hidden tests."""
+
+    instance_id: str
+    """Stable task id (e.g. ``orange3-4467fb9e92``)."""
+
+    image: str
+    """Docker image with the repo + interpreter (e.g. ``docker.io/namanjain12/...``)."""
+
+    workdir: str
+    """Repo path inside the sandbox (R2E default ``/testbed``)."""
+
+    problem_statement: str
+    """The issue body the agent must resolve."""
+
+    r2e: dict = field(default_factory=dict)
+    """Grading payload: ``test_file_names``, ``test_file_codes``, ``expected_output_json``."""
+
+    pre_commands: list[str] | str | None = None
+    """Optional baseline-alignment commands run before the agent / eval."""
+
+
+class SWER2EDataset(Configurable):
+    """Endless, seeded stream of R2E-Gym SWE samples loaded from a JSONL file."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        data_path: str = ""
+        """Path to the R2E JSONL file (required)."""
+
+        seed: int = 42
+        """Seed for the row-order shuffle."""
+
+        shuffle: bool = True
+        """Shuffle row order (reshuffling on each wrap). Set False for validation."""
+
+    def __init__(self, config: Config) -> None:
+        if not config.data_path:
+            raise ValueError("SWER2EDataset.Config.data_path is required")
+        samples: list[SWER2ESample] = []
+        with open(config.data_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                md = row.get("metadata") or {}
+                instance_id = (
+                    md.get("instance_id")
+                    or (row.get("label") if isinstance(row.get("label"), str) else None)
+                    or "unknown"
+                )
+                image = md.get("image")
+                workdir = md.get("workdir")
+                if not image or not workdir:
+                    raise ValueError(
+                        f"row {instance_id!r} missing image/workdir in metadata"
+                    )
+                samples.append(
+                    SWER2ESample(
+                        instance_id=instance_id,
+                        image=image,
+                        workdir=workdir,
+                        problem_statement=md.get("problem_statement")
+                        or _coerce_prompt(row.get("prompt")),
+                        r2e=md.get("r2e") or {},
+                        pre_commands=md.get("pre_commands"),
+                    )
+                )
+        if not samples:
+            raise ValueError(f"no rows found in {config.data_path}")
+        self._samples = samples
+
+        self._rng = random.Random(config.seed)
+        self._shuffle = config.shuffle
+        self._order = list(range(len(self._samples)))
+        if self._shuffle:
+            self._rng.shuffle(self._order)
+        self._pos = 0
+
+    def __iter__(self) -> Iterator[SWER2ESample]:
+        return self
+
+    def __next__(self) -> SWER2ESample:
+        if self._pos >= len(self._order):
+            if self._shuffle:
+                self._rng.shuffle(self._order)
+            self._pos = 0
+        idx = self._order[self._pos]
+        self._pos += 1
+        return self._samples[idx]
+
+    def state_dict(self) -> dict:
+        return {
+            "rng_state": self._rng.getstate(),
+            "order": list(self._order),
+            "pos": self._pos,
+        }
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        self._rng.setstate(state_dict["rng_state"])
+        self._order = list(state_dict["order"])
+        self._pos = state_dict["pos"]
+
+
+def _coerce_prompt(prompt) -> str:
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, list):
+        for m in prompt:
+            if isinstance(m, dict) and m.get("role") == "user":
+                content = m.get("content")
+                if isinstance(content, str):
+                    return content
+    return ""

--- a/torchtitan/experiments/rl/examples/swe_r2e/env.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/env.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Placeholder MessageEnv for the Claude Code coding-agent example.
+
+Unlike a native env-driven rollout (where the framework alternates env.step and
+generator calls), the coding-agent harness runs the *whole* agent loop inside the
+sandbox: Claude Code decides tool calls and edits files itself, talking to the
+on-box Anthropic adapter for each model turn. The framework's env <-> generator
+loop is therefore bypassed -- ``SWER2ERollouter`` overrides ``run_group_rollouts``
+to drive Claude Code directly.
+
+This class exists only to satisfy ``Rollouter.Config.message_env`` (a required
+field) and to carry the per-rollout task spec; its ``init``/``step`` are never
+called in the Claude Code flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from renderers import Message
+
+from torchtitan.experiments.rl.environment import (
+    MessageEnv,
+    MessageEnvInitOutput,
+    MessageEnvStepOutput,
+)
+from torchtitan.experiments.rl.examples.swe_r2e.data import SWER2ESample
+
+_NOT_DRIVEN_MSG = (
+    "SWER2EEnv is not driven via the env loop; SWER2ERollouter runs Claude "
+    "Code in the sandbox. See examples/swe_r2e/rollouter.py."
+)
+
+
+class SWER2EEnv(MessageEnv):
+    """Carries one R2E task spec. The agent loop runs in-sandbox (see module doc)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(MessageEnv.Config):
+        pass
+
+    def __init__(self, config: Config, *, env_input: SWER2ESample) -> None:
+        self.sample = env_input
+
+    async def init(self) -> MessageEnvInitOutput:
+        raise NotImplementedError(_NOT_DRIVEN_MSG)
+
+    async def step(self, completion_message: Message) -> MessageEnvStepOutput:
+        raise NotImplementedError(_NOT_DRIVEN_MSG)

--- a/torchtitan/experiments/rl/examples/swe_r2e/grading.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/grading.py
@@ -1,0 +1,155 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""R2E-Gym grading: score an agent's patch in a fresh sandbox.
+
+No-test-cheating guarantee: the eval sandbox is built from the SAME image but
+starts CLEAN (the agent never touched it), so only the model-produced diff affects
+reward. We apply the diff, inject the dataset's hidden tests, run pytest with
+junit-xml, and compare each test's status to ``expected_output_json`` -- the exact
+per-test match that r2egym's ``_calculate_reward_r2e`` uses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from torchtitan.experiments.rl.harness import apply_pre_commands, make_sandbox, Sandbox
+
+logger = logging.getLogger(__name__)
+
+_PATCH = "/workspace/__cagent_patch__.diff"
+
+
+async def evaluate_r2e(
+    *,
+    image: str,
+    workdir: str,
+    diff_text: str,
+    r2e: dict,
+    pre_commands: list[str] | str | None = None,
+    timeout_sec: int = 600,
+) -> tuple[float, bool, bool]:
+    """Returns ``(reward, solved, applied_cleanly)`` for an R2E task.
+
+    A fresh sandbox is booted from ``image``; ``pre_commands`` (e.g.
+    ``git checkout <base_sha> -f``) re-align the baseline, the agent's diff is
+    applied as root (R2E images run everything as root with the repo interpreter
+    on PATH), then the hidden tests run and are compared to the expected statuses.
+    """
+    async with make_sandbox(image) as ev:
+        if pre_commands:
+            await apply_pre_commands(ev, workdir, pre_commands, user="root")
+        applied = await _apply_diff(ev, workdir, diff_text, user="root")
+        if not applied:
+            return 0.0, False, False
+        reward, solved = await _run_r2e(ev, workdir, r2e, timeout_sec)
+        return reward, solved, True
+
+
+async def _apply_diff(
+    ev: Sandbox, workdir: str, diff_text: str, *, user: str = "root"
+) -> bool:
+    if not diff_text.strip():
+        return True
+    await ev.write_file(_PATCH, diff_text, user=user)
+    for cmd in [
+        f"cd {workdir} && git apply --3way --whitespace=nowarn {_PATCH}",
+        f"cd {workdir} && git apply --whitespace=nowarn {_PATCH}",
+        f"cd {workdir} && patch -p1 --no-backup-if-mismatch < {_PATCH}",
+    ]:
+        ec, _, _ = await ev.exec(cmd, user=user, check=False, timeout=120)
+        if ec == 0:
+            return True
+    return False
+
+
+def _parse_junit(xml_text: str) -> dict[str, str]:
+    """junit-xml -> ``{test_name: PASSED|FAILED|SKIPPED}``. Indexes each case under
+    both its bare name and ``Class.name`` so R2E expected keys (either form) match.
+    """
+    import xml.etree.ElementTree as ET
+
+    out: dict[str, str] = {}
+    try:
+        root = ET.fromstring(xml_text)
+    except Exception:
+        return out
+    for tc in root.iter("testcase"):
+        name = tc.get("name") or ""
+        cls = tc.get("classname") or ""
+        status = "PASSED"
+        for ch in tc:
+            tag = ch.tag.lower()
+            if tag in ("failure", "error"):
+                status = "FAILED"
+            elif tag == "skipped":
+                status = "SKIPPED"
+        if name:
+            out[name] = status
+            if cls:
+                out[f"{cls.split('.')[-1]}.{name}"] = status
+    return out
+
+
+def _r2e_fraction(parsed: dict[str, str], expected: dict[str, str]) -> float:
+    """Fraction of expected ``(test -> status)`` reproduced (0.0..1.0). Keys are
+    matched exactly, then by substring (like r2egym); 1.0 == fully solved."""
+    if not expected:
+        return 0.0
+    n_match = 0
+    for tname, estatus in expected.items():
+        key = (
+            tname
+            if tname in parsed
+            else next((k for k in parsed if tname in k or k in tname), None)
+        )
+        if key is not None and parsed[key] == estatus:
+            n_match += 1
+    return n_match / len(expected)
+
+
+async def _run_r2e(
+    ev: Sandbox, workdir: str, r2e: dict, timeout: int
+) -> tuple[float, bool]:
+    names = r2e.get("test_file_names") or []
+    codes = r2e.get("test_file_codes") or []
+    expected_raw = r2e.get("expected_output_json") or "{}"
+    expected = (
+        json.loads(expected_raw)
+        if isinstance(expected_raw, str)
+        else dict(expected_raw)
+    )
+
+    for name, code in zip(names, codes):
+        await ev.write_file(f"{workdir}/{name}", code, user="root")
+    # conftest.py / fixtures are auto-loaded; only run the test_* modules.
+    run_files = " ".join(n for n in names if os.path.basename(n).startswith("test"))
+    if not run_files:
+        return 0.0, False
+
+    xml = f"{workdir}/.r2e_junit.xml"
+    await ev.exec(
+        f"cd {workdir} && python -m pytest -p no:cacheprovider -q {run_files} "
+        f"--junit-xml={xml} > /tmp/r2e_pytest.log 2>&1 || true",
+        user="root",
+        env={"QT_QPA_PLATFORM": "offscreen", "MPLBACKEND": "Agg", "DISPLAY": ""},
+        check=False,
+        timeout=timeout,
+    )
+    parsed = _parse_junit(await ev.read_file(xml, user="root"))
+    # Default reward is binary (1.0 iff fully solved). SWE_REWARD_DENSE=1 opts into a
+    # dense per-test pass fraction (r2egym's _calculate_reward_r2e is per-test): the
+    # binary reward is sparse for a weaker policy (a GRPO group with no solve has
+    # all-zero reward -> zero advantage -> no gradient), whereas the fraction gives
+    # within-group variance (siblings reproducing more expected test outcomes score
+    # higher). Kept opt-in so the binary reward stays the default.
+    frac = _r2e_fraction(parsed, expected)
+    solved = frac >= 1.0
+    dense = os.environ.get("SWE_REWARD_DENSE", "0") == "1"
+    return (frac if dense else (1.0 if solved else 0.0)), solved

--- a/torchtitan/experiments/rl/examples/swe_r2e/local_smoke_harness.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/local_smoke_harness.py
@@ -1,0 +1,167 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Isolated harness smoke: real Claude Code in a Daytona sandbox <-> the Anthropic
+adapter backed by a plain vLLM engine (no Monarch trainer, no weight sync, no
+runaway collection loop). Boots exactly ONE sandbox for ONE sample and prints the
+captured turns + grade, so the sandbox -> Claude Code -> adapter -> grading path
+can be debugged independently of the RL training loop.
+
+    PROMPT_DATA=.../easy_one.jsonl DAYTONA_API_KEY=... \\
+        python -m torchtitan.experiments.rl.examples.swe_r2e.local_smoke_harness
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from vllm import LLM, SamplingParams
+
+from torchtitan.experiments.rl.actors.generator import SamplingConfig
+from torchtitan.experiments.rl.examples.swe_r2e.data import SWER2EDataset
+from torchtitan.experiments.rl.examples.swe_r2e.grading import evaluate_r2e
+from torchtitan.experiments.rl.harness import (
+    AnthropicAdapter,
+    boot_agent_sandbox,
+    git_diff,
+    run_claude_code,
+)
+from torchtitan.experiments.rl.renderer import RendererConfig
+from torchtitan.experiments.rl.types import Completion
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s"
+)
+logger = logging.getLogger("local_smoke_harness")
+
+MODEL = os.environ.get(
+    "MODEL", "torchtitan/experiments/rl/example_checkpoint/Qwen3-1.7B"
+)
+MAX_MODEL_LEN = int(os.environ.get("SWE_MAX_MODEL_LEN", "24576"))
+MAX_CONTEXT = int(os.environ.get("SWE_MAX_CONTEXT_LEN", "20480"))
+MAX_GEN = int(os.environ.get("MAX_GEN_LEN", "2048"))
+
+
+async def main() -> None:
+    renderer = RendererConfig(name="qwen3").build(tokenizer_path=MODEL)
+    stop_ids = renderer.get_stop_token_ids()
+    logger.info("renderer=%s stop_ids=%s", type(renderer).__name__, stop_ids)
+
+    llm = LLM(
+        model=MODEL,
+        dtype="bfloat16",
+        gpu_memory_utilization=0.6,
+        max_model_len=MAX_MODEL_LEN,
+        enforce_eager=True,
+    )
+
+    async def generate_fn(
+        prompt_token_ids, *, request_id, routing_session_id=None, sampling_config=None
+    ):
+        sc = sampling_config
+        sp = SamplingParams(
+            temperature=sc.temperature,
+            top_p=sc.top_p,
+            max_tokens=sc.max_tokens,
+            n=1,
+            stop_token_ids=sc.stop_token_ids or None,
+            logprobs=0,
+        )
+
+        def _run():
+            outs = llm.generate(
+                {"prompt_token_ids": list(prompt_token_ids)}, sp, use_tqdm=False
+            )
+            return outs[0].outputs[0]
+
+        o = await asyncio.to_thread(_run)
+        tok = list(o.token_ids)
+        if o.logprobs:
+            lps = [next(iter(d.values())).logprob for d in o.logprobs]
+        else:
+            lps = [0.0] * len(tok)
+        return Completion(
+            policy_version=0,
+            request_id=request_id,
+            token_ids=tok,
+            token_logprobs=lps,
+            finish_reason=o.finish_reason,
+        )
+
+    adapter = AnthropicAdapter(
+        renderer=renderer,
+        host=os.environ.get("SHIM_BIND_HOST", "127.0.0.1"),
+        port=int(os.environ.get("SHIM_PORT", "18031")),
+    )
+    await adapter.start()
+
+    ds = SWER2EDataset.Config(
+        data_path=os.environ["PROMPT_DATA"], seed=42, shuffle=False
+    ).build()
+    sample = next(iter(ds))
+    logger.info(
+        "sample=%s image=%s workdir=%s",
+        sample.instance_id,
+        sample.image,
+        sample.workdir,
+    )
+
+    sid = "smoke/sample=0"
+    sampling = SamplingConfig(
+        temperature=1.0, top_p=1.0, max_tokens=MAX_GEN, stop_token_ids=stop_ids
+    )
+    adapter.open_session(
+        sid,
+        generate_fn=generate_fn,
+        sampling=sampling,
+        routing_session_id=sid,
+        max_context_tokens=MAX_CONTEXT,
+    )
+
+    diff = ""
+    try:
+        async with boot_agent_sandbox(sample.image) as sb:
+            await run_claude_code(
+                sb,
+                workdir=sample.workdir,
+                session_id=sid,
+                adapter_url=adapter.url,
+                time_budget_sec=int(os.environ.get("SWE_TIME_BUDGET_SEC", "600")),
+                problem_statement=sample.problem_statement,
+                pre_commands=sample.pre_commands,
+            )
+            diff = await git_diff(sb, sample.workdir, tracked_only=True)
+    finally:
+        turns = await adapter.finish_session(sid)
+
+    print("\n===== HARNESS SMOKE RESULT =====")
+    print(f"captured turns: {len(turns)}")
+    for i, t in enumerate(turns[:12]):
+        print(
+            f"  turn {i}: prompt={len(t.prompt_token_ids)} "
+            f"completion={len(t.completion_token_ids)} "
+            f"finish={t.finish_reason} extends={t.extends_previous}"
+        )
+    print(f"diff length: {len(diff)} chars")
+    if diff:
+        print("diff head:\n" + diff[:600])
+
+    reward, solved, applied = await evaluate_r2e(
+        image=sample.image,
+        workdir=sample.workdir,
+        diff_text=diff,
+        r2e=sample.r2e,
+        pre_commands=sample.pre_commands,
+        timeout_sec=int(os.environ.get("SWE_EVAL_TIMEOUT_SEC", "400")),
+    )
+    print(f"REWARD={reward} solved={solved} applied={applied}")
+    await adapter.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/torchtitan/experiments/rl/examples/swe_r2e/prepare_r2e_data.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/prepare_r2e_data.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Build a SWE-R2E training JSONL from the R2E-Gym HuggingFace datasets.
+
+Each output row is exactly what ``SWER2EDataset`` (data.py) consumes::
+
+    {
+      "prompt": <problem_statement>,
+      "label":  <instance_id>,
+      "metadata": {
+        "instance_id", "image" (docker.io/...), "workdir": "/testbed",
+        "problem_statement",
+        "r2e": {"test_file_names", "test_file_codes", "expected_output_json"}
+      }
+    }
+
+The R2E-Gym datasets are sorted by repo, so a contiguous ``offset`` slice is a
+single project. To get a DIVERSE multi-repo training set we sample evenly across
+the whole split (``--num-points`` batches of ``--per-point`` rows spread by a
+stride), dedup by instance_id, and drop rows missing a problem_statement or the
+grading payload.
+
+Host egress (the HF datasets-server REST API) required -- on a fwdproxy box run
+with ``HTTPS_PROXY=http://fwdproxy:8080``. Example::
+
+    HTTPS_PROXY=http://fwdproxy:8080 python -m \
+        torchtitan.experiments.rl.examples.swe_r2e.prepare_r2e_data \
+        --dataset R2E-Gym/R2E-Gym-Lite --num-points 100 --per-point 8 \
+        --out r2e_train.jsonl
+
+Sizes (rows): R2E-Gym-Subset 4578, R2E-Gym-V1 7478, R2E-Gym-Lite 11788.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+_ROWS_URL = "https://datasets-server.huggingface.co/rows"
+_SIZE_URL = "https://datasets-server.huggingface.co/size"
+
+
+def _total_rows(dataset: str) -> int:
+    url = f"{_SIZE_URL}?dataset={urllib.parse.quote(dataset)}"
+    with urllib.request.urlopen(url, timeout=30) as r:
+        return json.load(r)["size"]["dataset"]["num_rows"]
+
+
+def _fetch(dataset: str, offset: int, length: int) -> list[dict]:
+    url = (
+        f"{_ROWS_URL}?dataset={urllib.parse.quote(dataset)}"
+        f"&config=default&split=train&offset={offset}&length={length}"
+    )
+    with urllib.request.urlopen(url, timeout=60) as r:
+        return [x["row"] for x in json.load(r)["rows"]]
+
+
+def _to_row(row: dict, image_prefix: str = "docker.io/") -> dict:
+    erc = json.loads(row["execution_result_content"])
+    instance_id = f"{row['repo_name']}-{row['commit_hash'][:10]}"
+    image = row["docker_image"]
+    if image_prefix and "/" in image and not image.startswith(image_prefix):
+        image = image_prefix + image
+    return {
+        "prompt": row["problem_statement"],
+        "label": instance_id,
+        "metadata": {
+            "instance_id": instance_id,
+            "image": image,
+            "workdir": "/testbed",
+            "problem_statement": row["problem_statement"],
+            "r2e": {
+                "test_file_names": erc["test_file_names"],
+                "test_file_codes": erc["test_file_codes"],
+                "expected_output_json": row["expected_output_json"],
+            },
+        },
+    }
+
+
+def _is_complete(row: dict) -> bool:
+    md = row["metadata"]
+    r2e = md.get("r2e") or {}
+    return bool(
+        (md.get("problem_statement") or "").strip()
+        and (md.get("image") or "").strip()
+        and (r2e.get("expected_output_json") or "").strip()
+        and r2e.get("test_file_codes")
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dataset", default="R2E-Gym/R2E-Gym-Lite")
+    ap.add_argument(
+        "--num-points", type=int, default=100, help="evenly-spread sample points"
+    )
+    ap.add_argument("--per-point", type=int, default=8, help="rows fetched per point")
+    ap.add_argument("--image-prefix", default="docker.io/")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    n = _total_rows(args.dataset)
+    stride = max(1, n // args.num_points)
+    by_id: dict[str, dict] = {}
+    for i in range(args.num_points):
+        offset = min(i * stride, max(0, n - args.per_point))
+        try:
+            for raw in _fetch(args.dataset, offset, args.per_point):
+                row = _to_row(raw, args.image_prefix)
+                if _is_complete(row):
+                    by_id.setdefault(row["metadata"]["instance_id"], row)
+        except Exception as e:  # noqa: BLE001 -- best-effort per point
+            print(f"  offset {offset}: {type(e).__name__}: {e}", file=sys.stderr)
+
+    with open(args.out, "w") as f:
+        for row in by_id.values():
+            f.write(json.dumps(row) + "\n")
+    print(
+        f"wrote {len(by_id)} unique complete tasks -> {args.out} ({args.dataset}, N={n})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/rl/examples/swe_r2e/rollouter.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/rollouter.py
@@ -1,0 +1,376 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Coding-agent (Claude Code) rollouter for R2E-Gym SWE tasks.
+
+Unlike the env-driven rollouters (search_r1, alphabet_sort), the agent loop runs
+*inside the sandbox*: Claude Code drives tool calls / file edits itself and talks
+to the on-box Anthropic adapter for each model turn. So this rollouter overrides
+``run_group_rollouts`` to, per sibling:
+
+    1. open an adapter session keyed by the rollout id;
+    2. boot a fresh sandbox from the task image + install the toolchain;
+    3. run ``claude -p`` against the adapter (via the Daytona file-relay bridge);
+    4. capture the agent's patch (``git diff``) and grade it in a clean sandbox;
+    5. drain the adapter's captured turns into ``RolloutTurn``s and stamp the
+       grade onto the last turn's ``env_rewards`` (read back by ``RewardR2E``).
+
+The standard rubric + advantage + ``rollout_to_episodes`` path then applies: each
+turn's prompt exactly extends ``prev_prompt + prev_completion`` (the adapter uses
+Token-In-Token-Out bridging), so a whole trajectory packs into one episode with
+assistant tokens trained and prompt / tool-result tokens masked out.
+
+Knobs read from env (the launcher sets these; see ``run_swe_r2e_*.sh``):
+  ``SHIM_BIND_HOST`` / ``SHIM_PORT``  adapter bind address (default 127.0.0.1:18001)
+  ``SWE_TIME_BUDGET_SEC``             per-agent wallclock (default 1200)
+  ``SWE_EVAL_TIMEOUT_SEC``            per-eval test run (default 400)
+  ``SWE_MAX_CONTEXT_LEN``             model context budget for per-turn gen cap
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from renderers import Renderer
+
+from torchtitan.experiments.rl.environment import TokenEnv
+from torchtitan.experiments.rl.examples.swe_r2e.data import SWER2EDataset, SWER2ESample
+from torchtitan.experiments.rl.examples.swe_r2e.env import SWER2EEnv
+from torchtitan.experiments.rl.examples.swe_r2e.grading import evaluate_r2e
+from torchtitan.experiments.rl.examples.swe_r2e.rubric import R2E_REWARD_KEY, RewardR2E
+from torchtitan.experiments.rl.harness import (
+    AnthropicAdapter,
+    boot_agent_sandbox,
+    git_diff,
+    run_claude_code,
+)
+from torchtitan.experiments.rl.rollout.advantage import AdvantageEstimator
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+from torchtitan.experiments.rl.rollout.types import (
+    GenerateFn,
+    Rollout,
+    RolloutGroup,
+    RolloutStatus,
+    RolloutTurn,
+)
+from torchtitan.experiments.rl.rubrics import Rubric
+
+if TYPE_CHECKING:
+    # Type-only: importing the generator module pulls in vLLM at import time.
+    from torchtitan.experiments.rl.actors.generator import SamplingConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int) -> int:
+    val = os.environ.get(name)
+    return int(val) if val and val.strip() else default
+
+
+# Cap concurrently-ACTIVE rollouts. Every live rollout drives a file-relay bridge
+# whose per-turn fs ops run on the controller's single asyncio loop; at the full
+# 8x8=64 fanout the 64 bridge poll loops + adapter handlers saturate the loop over
+# a high-latency host->daytona link and model replies stop coming back (the agent
+# sits in 'requesting' forever). Gating the boot+agent+grade body to a modest
+# number keeps the bridge responsive; all groups are still collected, in waves.
+_ROLLOUT_SEM: asyncio.Semaphore | None = None
+
+
+def _rollout_sem() -> asyncio.Semaphore:
+    global _ROLLOUT_SEM
+    if _ROLLOUT_SEM is None:
+        _ROLLOUT_SEM = asyncio.Semaphore(_env_int("SWE_ROLLOUT_CONCURRENCY", 16))
+    return _ROLLOUT_SEM
+
+
+class SWER2ERollouter(Rollouter):
+    """Drives Claude Code in a sandbox per sibling, then grades the patch (R2E)."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Rollouter.Config):
+        train_dataset: SWER2EDataset.Config = field(
+            default_factory=lambda: SWER2EDataset.Config(seed=42)
+        )
+        validation_dataset: SWER2EDataset.Config = field(
+            default_factory=lambda: SWER2EDataset.Config(seed=99, shuffle=False)
+        )
+        rubric: Rubric.Config = field(
+            default_factory=lambda: Rubric.Config(
+                reward_fns=[RewardR2E.Config(weight=1.0)],
+                # An errored / timed-out agent has no valid patch -> no learning signal.
+                error_reward=0.0,
+                truncation_reward=0.0,
+            )
+        )
+        # Placeholder env (the agent loop runs in-sandbox; see env.py).
+        message_env: SWER2EEnv.Config = field(default_factory=SWER2EEnv.Config)
+        token_env: TokenEnv.Config = field(default_factory=TokenEnv.Config)
+        advantage: AdvantageEstimator.Config = field(
+            default_factory=lambda: AdvantageEstimator.Config(should_std_normalize=True)
+        )
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self._shim_host = os.environ.get("SHIM_BIND_HOST", "127.0.0.1")
+        self._shim_port = _env_int("SHIM_PORT", 18001)
+        self._time_budget_sec = _env_int("SWE_TIME_BUDGET_SEC", 1200)
+        self._eval_timeout_sec = _env_int("SWE_EVAL_TIMEOUT_SEC", 400)
+        self._max_context_tokens = _env_int("SWE_MAX_CONTEXT_LEN", 32768)
+        # Whole-rollout wall-clock guard: agent budget + eval + boot/diff buffer.
+        self._guard_sec = self._time_budget_sec + self._eval_timeout_sec + 300
+        self._adapter: AnthropicAdapter | None = None
+        self._adapter_lock = asyncio.Lock()
+
+    async def _ensure_adapter(self, renderer: Renderer) -> AnthropicAdapter:
+        if self._adapter is None:
+            async with self._adapter_lock:
+                if self._adapter is None:
+                    adapter = AnthropicAdapter(
+                        renderer=renderer, host=self._shim_host, port=self._shim_port
+                    )
+                    await adapter.start()
+                    self._adapter = adapter
+        return self._adapter
+
+    async def run_group_rollouts(
+        self,
+        *,
+        generate_fn: GenerateFn,
+        sample: SWER2ESample,
+        group_id: str,
+        group_size: int,
+        sampling: "SamplingConfig",
+        renderer: Renderer,
+    ) -> RolloutGroup:
+        """Run + grade one prompt group of Claude Code coding-agent rollouts."""
+        adapter = await self._ensure_adapter(renderer)
+
+        rollouts = await asyncio.gather(
+            *(
+                self._run_claude_rollout(
+                    adapter=adapter,
+                    generate_fn=generate_fn,
+                    sample=sample,
+                    group_id=group_id,
+                    rollout_id=f"{group_id}/sample={i}",
+                    sampling=sampling,
+                    renderer=renderer,
+                )
+                for i in range(group_size)
+            )
+        )
+
+        # Standard scoring + advantage path (mirrors Rollouter.run_group_rollouts).
+        outputs = await self.score_group(rollouts, sample)
+        for rollout, output in zip(rollouts, outputs, strict=True):
+            rollout.reward = output.reward
+            rollout.reward_breakdown = output.reward_breakdown
+
+        group = RolloutGroup(group_id=group_id, rollouts=rollouts)
+        advantages = self.advantage_estimator(group)
+        for rollout, advantage in zip(group.rollouts, advantages, strict=True):
+            rollout.advantage = advantage
+        return group
+
+    async def _run_claude_rollout(
+        self,
+        *,
+        adapter: AnthropicAdapter,
+        generate_fn: GenerateFn,
+        sample: SWER2ESample,
+        group_id: str,
+        rollout_id: str,
+        sampling: "SamplingConfig",
+        renderer: Renderer,
+    ) -> Rollout:
+        """Boot a sandbox, run Claude Code against the adapter, grade the patch.
+
+        Always returns a ``Rollout`` (errors are caught and marked terminal) so one
+        bad sibling never fails the whole group.
+        """
+        adapter.open_session(
+            rollout_id,
+            generate_fn=generate_fn,
+            sampling=sampling,
+            routing_session_id=rollout_id,
+            max_context_tokens=self._max_context_tokens,
+        )
+
+        status = RolloutStatus.ERROR
+        reward = 0.0
+        solved = False
+        applied = False
+        diff_text = ""
+        error_msg = ""
+        # Gate the active body (acquire OUTSIDE the wall-clock guard so queueing for
+        # a slot is not charged against the rollout's time budget).
+        sem = _rollout_sem()
+        await sem.acquire()
+        try:
+            async with asyncio.timeout(self._guard_sec):
+                async with boot_agent_sandbox(sample.image) as sb:
+                    await run_claude_code(
+                        sb,
+                        workdir=sample.workdir,
+                        session_id=rollout_id,
+                        adapter_url=adapter.url,
+                        time_budget_sec=self._time_budget_sec,
+                        problem_statement=sample.problem_statement,
+                        pre_commands=sample.pre_commands,
+                    )
+                    diff_text = await git_diff(sb, sample.workdir, tracked_only=True)
+
+                reward, solved, applied = await evaluate_r2e(
+                    image=sample.image,
+                    workdir=sample.workdir,
+                    diff_text=diff_text,
+                    r2e=sample.r2e,
+                    pre_commands=sample.pre_commands,
+                    timeout_sec=self._eval_timeout_sec,
+                )
+                status = RolloutStatus.COMPLETED
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning("[swe_r2e] %s: wall-clock guard fired", rollout_id)
+            status = RolloutStatus.ERROR_TIMEOUT
+            error_msg = "wall_clock_timeout"
+        except Exception as e:
+            logger.exception("[swe_r2e] %s: rollout failed", rollout_id)
+            status = RolloutStatus.ERROR
+            error_msg = f"{type(e).__name__}: {e}"
+        finally:
+            sem.release()
+            captured = await adapter.finish_session(rollout_id)
+
+        # Drop empty-completion turns so rollout_to_episodes only sees trainable
+        # turns (a non-final empty completion would otherwise raise).
+        turns: list[RolloutTurn] = [
+            RolloutTurn(
+                prompt_token_ids=ct.prompt_token_ids,
+                completion_token_ids=ct.completion_token_ids,
+                completion_logprobs=ct.completion_logprobs,
+                policy_version=ct.policy_version,
+            )
+            for ct in captured
+            if ct.completion_token_ids
+        ]
+
+        if not turns:
+            # No trainable tokens (agent never produced a usable turn).
+            status = RolloutStatus.ERROR
+            if not error_msg:
+                # Distinguish "claude never reached the model" (captured == 0)
+                # from "claude ran but every turn was length-capped" (captured > 0,
+                # all empty) so the dumped trace says why turns is empty.
+                n_cap = len(captured)
+                n_empty = sum(1 for ct in captured if not ct.completion_token_ids)
+                error_msg = (
+                    f"no_trainable_turns: captured={n_cap} empty_completions={n_empty}"
+                )
+        else:
+            turns[-1].env_rewards = {
+                R2E_REWARD_KEY: float(reward),
+                "r2e_solved": float(solved),
+                "r2e_applied": float(applied),
+            }
+
+        logger.info(
+            "[swe_r2e] %s: status=%s reward=%.2f solved=%s applied=%s turns=%d",
+            rollout_id,
+            status,
+            reward,
+            solved,
+            applied,
+            len(turns),
+        )
+        self._maybe_dump_trace(
+            rollout_id=rollout_id,
+            sample=sample,
+            captured=captured,
+            renderer=renderer,
+            status=str(status),
+            reward=reward,
+            solved=solved,
+            applied=applied,
+            diff_text=diff_text,
+            error_msg=error_msg,
+        )
+        return Rollout(
+            group_id=group_id,
+            sample_id=rollout_id,
+            status=status,
+            turns=turns,
+        )
+
+    def _maybe_dump_trace(
+        self,
+        *,
+        rollout_id: str,
+        sample: SWER2ESample,
+        captured: list,
+        renderer: Renderer,
+        status: str,
+        reward: float,
+        solved: bool,
+        applied: bool,
+        diff_text: str,
+        error_msg: str = "",
+    ) -> None:
+        """Write a human-readable per-rollout training trace when
+        ``SWE_ROLLOUT_DUMP_DIR`` is set: the R2E task, grade, and every captured
+        turn's decoded model completion + token lengths + finish reason. This is
+        the *training view* (what the model generated and trains on each turn),
+        complementing Claude Code's own stream-json agent trace under
+        ``SWE_TRAJECTORY_DUMP_DIR``. Best-effort; never raises into the rollout."""
+        dump_dir = os.environ.get("SWE_ROLLOUT_DUMP_DIR", "")
+        if not dump_dir:
+            return
+        try:
+            tokenizer = getattr(renderer, "tokenizer", None) or getattr(
+                renderer, "_tokenizer", None
+            )
+
+            def _decode(ids: list[int]) -> str:
+                if tokenizer is None or not ids:
+                    return ""
+                return tokenizer.decode(ids, skip_special_tokens=False)
+
+            record = {
+                "rollout_id": rollout_id,
+                "instance_id": sample.instance_id,
+                "image": sample.image,
+                "status": status,
+                "error": error_msg,
+                "reward": reward,
+                "solved": solved,
+                "applied": applied,
+                "num_turns": len(captured),
+                "diff": diff_text,
+                "turns": [
+                    {
+                        "turn": i,
+                        "prompt_tokens": len(ct.prompt_token_ids),
+                        "completion_tokens": len(ct.completion_token_ids),
+                        "finish_reason": ct.finish_reason,
+                        "extends_previous": ct.extends_previous,
+                        # The model's generated text this turn (the trained tokens).
+                        "completion_text": _decode(ct.completion_token_ids),
+                    }
+                    for i, ct in enumerate(captured)
+                ],
+            }
+            os.makedirs(dump_dir, exist_ok=True)
+            safe = rollout_id.replace("/", "_")
+            path = os.path.join(dump_dir, f"{safe}.json")
+            with open(path, "w") as f:
+                json.dump(record, f, indent=2, ensure_ascii=False)
+            logger.info("[swe_r2e] rollout trace dumped: %s", path)
+        except Exception as e:
+            logger.warning("[swe_r2e] rollout trace dump failed: %s", e)

--- a/torchtitan/experiments/rl/examples/swe_r2e/rubric.py
+++ b/torchtitan/experiments/rl/examples/swe_r2e/rubric.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Reward for the R2E coding-agent example.
+
+Grading an R2E patch requires booting a fresh sandbox and running hidden tests,
+which the rollouter already does while collecting the rollout. So the reward fn
+does not re-grade: ``SWER2ERollouter`` stamps the grade onto the rollout's last
+turn ``env_rewards`` (key ``r2e_reward``) and this fn simply reads it back. This
+keeps the reward on the standard rubric/advantage path (and in the reward
+breakdown metric) without duplicating the expensive sandbox eval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torchtitan.experiments.rl.rollout.types import Rollout
+from torchtitan.experiments.rl.rubrics import RewardFn
+
+# env_rewards key the rollouter stamps the R2E grade under.
+R2E_REWARD_KEY = "r2e_reward"
+
+
+class RewardR2E(RewardFn):
+    """Reads the R2E reward the rollouter attached to the rollout: binary 0.0/1.0
+    (1.0 iff solved), or a 0.0-1.0 per-test pass fraction when SWE_REWARD_DENSE=1."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(RewardFn.Config):
+        pass
+
+    async def __call__(self, rollout: Rollout, env_input: object) -> float:
+        for turn in reversed(rollout.turns):
+            if R2E_REWARD_KEY in turn.env_rewards:
+                return float(turn.env_rewards[R2E_REWARD_KEY])
+        return 0.0

--- a/torchtitan/experiments/rl/examples/swe_r2e/run_swe_r2e_daytona.sh
+++ b/torchtitan/experiments/rl/examples/swe_r2e/run_swe_r2e_daytona.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Single-node SWE R2E coding-agent (Claude Code) RL on Daytona cloud sandboxes.
+#
+# Mirrors slime's run_qwen3_*_swe_r2e_daytona.sh but drives TorchTitan's RL loop:
+# the policy is served by the vLLM generator behind an on-box Anthropic adapter;
+# Claude Code runs in a Daytona sandbox per rollout, reaches the adapter via the
+# file-relay bridge, and every turn is captured as on-policy training tokens.
+#
+#   CONFIG=rl_grpo_qwen3_1_7b_swe_r2e  bash run_swe_r2e_daytona.sh   # fast smoke (2 GPUs)
+#   CONFIG=rl_grpo_qwen3_8b_swe_r2e    bash run_swe_r2e_daytona.sh   # target  (6 GPUs)
+#
+# Prereqs: DAYTONA_API_KEY exported; HF weights on disk at the config's
+# hf_assets_path. The Claude Code binary is downloaded inside the sandbox from its
+# CDN (override via SWE_CLAUDE_CDN), so no host toolchain tarballs are needed.
+# NOTE: no `set -u` -- .venv_rl_env.sh appends to possibly-unset LD_LIBRARY_PATH.
+set -ex
+export PYTHONUNBUFFERED=1
+
+CONFIG="${CONFIG:-rl_grpo_qwen3_1_7b_swe_r2e}"
+
+if [[ -z "${DAYTONA_API_KEY:-}" ]]; then
+  echo "ERROR: DAYTONA_API_KEY is not set (app.daytona.io key, dtn_...)." >&2
+  exit 1
+fi
+
+# ---- TorchTitan RL dev env (venv + CUDA libs); machine-specific, set TT_VENV_ENV ----
+TT_VENV_ENV="${TT_VENV_ENV:-${HOME}/torchtitan/.venv_rl_env.sh}"
+[[ -f "${TT_VENV_ENV}" ]] && source "${TT_VENV_ENV}"
+
+# Repo root = the dir 5 levels up from this script
+# (<repo>/torchtitan/experiments/rl/examples/swe_r2e/run_swe_r2e_daytona.sh).
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+WORKTREE="${WORKTREE:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
+export PYTHONPATH="${WORKTREE}:${PYTHONPATH:-}"
+cd "${WORKTREE}"
+
+# ---- Daytona sandbox backend (small per-sandbox quota) ----
+export TT_SANDBOX_BACKEND="daytona"
+export DAYTONA_API_KEY
+export TT_DAYTONA_CPU="${TT_DAYTONA_CPU:-2}"
+export TT_DAYTONA_MEM_GB="${TT_DAYTONA_MEM_GB:-2}"
+export TT_DAYTONA_DISK_GB="${TT_DAYTONA_DISK_GB:-5}"
+export TT_DAYTONA_CREATE_TIMEOUT="${TT_DAYTONA_CREATE_TIMEOUT:-900}"
+
+# ---- R2E dataset (JSONL); read by config_registry as SWE_PROMPT_DATA ----
+export SWE_PROMPT_DATA="${PROMPT_DATA:-${SWE_PROMPT_DATA:-}}"
+if [[ -z "${SWE_PROMPT_DATA}" ]]; then
+  echo "ERROR: set PROMPT_DATA to your R2E JSONL (build one with prepare_r2e_data.py)." >&2
+  exit 1
+fi
+
+# ---- agent + adapter knobs ----
+# SWE_MAX_CONTEXT_LEN must stay under the config's model max_seq_len (24576 for the
+# smokes) with room for a turn's generation; the adapter caps per-turn max_tokens
+# at (SWE_MAX_CONTEXT_LEN - prompt_len).
+MAX_CONTEXT_LEN="${SWE_MAX_CONTEXT_LEN:-20480}"
+AUTO_COMPACT_WINDOW="${AUTO_COMPACT_WINDOW:-16000}"
+export SWE_MAX_CONTEXT_LEN="${MAX_CONTEXT_LEN}"
+export SHIM_BIND_HOST="${SHIM_BIND_HOST:-127.0.0.1}"
+export SHIM_PORT="${SHIM_PORT:-18031}"
+export SWE_TIME_BUDGET_SEC="${SWE_TIME_BUDGET_SEC:-900}"
+export SWE_EVAL_TIMEOUT_SEC="${SWE_EVAL_TIMEOUT_SEC:-400}"
+export SWE_BOOT_CONCURRENCY="${SWE_BOOT_CONCURRENCY:-2}"
+# Claude Code's own stream-json agent trace (every Read/Edit/Bash/tool turn).
+export SWE_TRAJECTORY_DUMP_DIR="${SWE_TRAJECTORY_DUMP_DIR:-${WORKTREE}/torchtitan/experiments/rl/examples/swe_r2e/trajectories}"
+# Training-view trace: per-rollout decoded model completions + token lengths +
+# reward + diff (what the model actually generated and trains on each turn).
+export SWE_ROLLOUT_DUMP_DIR="${SWE_ROLLOUT_DUMP_DIR:-${WORKTREE}/torchtitan/experiments/rl/examples/swe_r2e/rollout_dumps}"
+# Disallow sub-agents (Task/Agent): they run in separate git worktrees whose edits
+# are invisible to git_diff (reward-always-0 bug). WebFetch/WebSearch/AskUserQuestion
+# are useless in headless -p mode. See slime LESSONS.md.
+SETTINGS_JSON="{\"permissions\":{\"defaultMode\":\"bypassPermissions\"},\"autoCompactEnabled\":true,\"autoCompactWindow\":${AUTO_COMPACT_WINDOW}}"
+export SWE_CLAUDE_EXTRA_ARGS="${SWE_CLAUDE_EXTRA_ARGS:---settings '${SETTINGS_JSON}' --disable-slash-commands --disallowedTools WebFetch WebSearch Task Agent AskUserQuestion}"
+
+# ---- proxy: daytona SDK (HTTP) needs fwdproxy; local NCCL/monarch loopback must not ----
+export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo}"
+export https_proxy="${https_proxy:-http://fwdproxy:8080}"
+export http_proxy="${http_proxy:-http://fwdproxy:8080}"
+export no_proxy="127.0.0.1,localhost,${MASTER_ADDR},$(hostname)"
+export NO_PROXY="${no_proxy}"
+
+mkdir -p "${SWE_TRAJECTORY_DUMP_DIR}"
+
+# Orphaned sandboxes self-reap via each sandbox's cloud-side auto-delete TTL
+# (TT_DAYTONA_AUTO_STOP_MIN / TT_DAYTONA_AUTO_DELETE_MIN), so no explicit cleanup is needed.
+
+# hf_assets_path defaults to example_checkpoint/Qwen3-<size>; override with the HF
+# weights on disk via HF_ASSETS_PATH (passed only when set).
+python3 -m torchtitan.experiments.rl.train \
+  --module swe_r2e --config "${CONFIG}" \
+  --metrics.no-enable-wandb \
+  ${HF_ASSETS_PATH:+--hf_assets_path "${HF_ASSETS_PATH}"} \
+  "$@"

--- a/torchtitan/experiments/rl/harness/__init__.py
+++ b/torchtitan/experiments/rl/harness/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Pluggable coding-agent harness for TorchTitan RL.
+
+An external CLI agent (Claude Code first) runs unmodified inside a cloud sandbox
+and is pointed at an on-box wire-format adapter that serves the trained policy and
+captures every turn as on-policy training tokens. Three orthogonal axes, each its
+own subpackage:
+
+  - ``sandbox``: WHERE code runs -- provider-agnostic ``Sandbox`` contract +
+    the Daytona backend + the Daytona fs-relay ``bridge``.
+  - ``adapters``: HOW the model is served to the agent -- a token-capturing HTTP
+    endpoint per wire format (``anthropic`` for Claude Code; add ``openai`` for
+    Codex/OpenCode).
+  - ``agents``: WHICH CLI agent + how to launch it (``claude_code``).
+
+Adding a new CLI agent = a new ``agents`` runner (+ reuse/extend an ``adapters``
+wire module); a new sandbox provider = a new ``sandbox`` backend. R2E (SWE) task
+data + grading live in ``examples/swe_r2e``.
+"""
+
+from torchtitan.experiments.rl.harness.adapters import AnthropicAdapter, CapturedTurn
+from torchtitan.experiments.rl.harness.agents import (
+    apply_pre_commands,
+    boot_agent_sandbox,
+    git_diff,
+    run_claude_code,
+)
+from torchtitan.experiments.rl.harness.sandbox import (
+    DaytonaSandbox,
+    make_sandbox,
+    Sandbox,
+)
+
+__all__ = [
+    "AnthropicAdapter",
+    "CapturedTurn",
+    "DaytonaSandbox",
+    "Sandbox",
+    "apply_pre_commands",
+    "boot_agent_sandbox",
+    "git_diff",
+    "make_sandbox",
+    "run_claude_code",
+]

--- a/torchtitan/experiments/rl/harness/adapters/__init__.py
+++ b/torchtitan/experiments/rl/harness/adapters/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Wire-format adapters: HTTP endpoints that serve the trained policy to an
+external CLI agent in its native API dialect while capturing each turn as
+on-policy training tokens. ``anthropic`` covers the Anthropic Messages API
+(Claude Code); add an ``openai`` module for OpenAI Chat/Responses agents
+(Codex/OpenCode) -- the per-turn token capture is shared."""
+
+from torchtitan.experiments.rl.harness.adapters.anthropic import (
+    AnthropicAdapter,
+    CapturedTurn,
+)
+
+__all__ = ["AnthropicAdapter", "CapturedTurn"]

--- a/torchtitan/experiments/rl/harness/adapters/anthropic.py
+++ b/torchtitan/experiments/rl/harness/adapters/anthropic.py
@@ -1,0 +1,633 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Anthropic Messages adapter that turns an external CLI agent into on-policy RL data.
+
+The adapter exposes an Anthropic ``/v1/messages`` endpoint that the unmodified
+agent is pointed at. Per turn it renders the agent's message history into prompt
+token ids (Token-In-Token-Out via ``renderer.bridge_to_next_turn``, reusing prior
+turns' exact tokens so a multi-turn trajectory packs into ONE episode), samples via
+``generate_fn``, and records a ``CapturedTurn`` (prompt/completion ids + logprobs).
+``finish_session`` drains the recorded turns for ``rollout_to_episodes``.
+
+Token legend (this module): ``ids`` = token id lists; a *turn* is one
+agent<->model HTTP round trip; a *session* is one agent run (one rollout sibling).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import json
+import logging
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+from aiohttp import web
+
+from renderers import Message, Renderer, ToolSpec
+from renderers.base import ToolCallParseStatus
+
+from torchtitan.experiments.rl.rollout.types import GenerateFn
+
+if TYPE_CHECKING:
+    # Type-only: importing the generator module pulls in vLLM at import time.
+    from torchtitan.experiments.rl.actors.generator import SamplingConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True, slots=True)
+class CapturedTurn:
+    """Exact token snapshot for one agent<->model turn (one HTTP round trip)."""
+
+    prompt_token_ids: list[int]
+    completion_token_ids: list[int]
+    completion_logprobs: list[float]
+    policy_version: int | None
+    finish_reason: str | None
+    # Whether this turn's prompt continues the previous turn's prompt+completion
+    # (TITO-bridged). False marks a history rewrite (compaction) -> episode branch.
+    extends_previous: bool
+
+
+@dataclass
+class _Session:
+    """Per-rollout adapter state (one Claude Code run)."""
+
+    generate_fn: GenerateFn
+    sampling: "SamplingConfig"
+    routing_session_id: str
+    max_context_tokens: int = 0
+    tools: list[ToolSpec] | None = None
+    # TITO continuation state.
+    last_prompt_ids: list[int] = field(default_factory=list)
+    last_completion_ids: list[int] = field(default_factory=list)
+    prev_msg_hashes: list[str] = field(default_factory=list)
+    prev_system_hash: str = ""
+    req_count: int = 0
+    turns: list[CapturedTurn] = field(default_factory=list)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+# Aiohttp app keys.
+_ADAPTER_KEY = web.AppKey("adapter", object)
+
+
+# ---------------------------------------------------------------------------
+# Hashing + Anthropic <-> renderers.Message translation (pure helpers)
+# ---------------------------------------------------------------------------
+def _strip_cache_control(obj: Any) -> Any:
+    """Drop ``cache_control`` markers Claude Code sprinkles into blocks; they vary
+    turn-to-turn and would defeat prefix-stable hashing."""
+    if isinstance(obj, dict):
+        return {
+            k: _strip_cache_control(v) for k, v in obj.items() if k != "cache_control"
+        }
+    if isinstance(obj, list):
+        return [_strip_cache_control(x) for x in obj]
+    return obj
+
+
+def _hash(obj: Any) -> str:
+    payload = json.dumps(
+        _strip_cache_control(obj), sort_keys=True, ensure_ascii=False, default=str
+    ).encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()[:12]
+
+
+def _flatten(content: Any) -> str:
+    """Anthropic content -> plain text: text / tool_result(content) joined by
+    newline; images replaced with a placeholder."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: list[str] = []
+    for b in content:
+        if isinstance(b, dict):
+            t = b.get("type")
+            if t == "text":
+                parts.append(b.get("text", ""))
+            elif t == "tool_result":
+                parts.append(_flatten(b.get("content")))
+            elif t == "image":
+                parts.append("[image omitted]")
+        elif isinstance(b, str):
+            parts.append(b)
+    return "\n".join(p for p in parts if p)
+
+
+def _anthropic_tools_to_tool_specs(
+    anth_tools: list[dict] | None,
+) -> list[ToolSpec] | None:
+    """Anthropic tool defs -> renderers ``ToolSpec`` (OpenAI function schema)."""
+    if not anth_tools:
+        return None
+    specs: list[ToolSpec] = []
+    for t in anth_tools:
+        if not isinstance(t, dict) or "name" not in t:
+            continue
+        specs.append(
+            {
+                "name": t["name"],
+                "description": t.get("description", ""),
+                "parameters": t.get("input_schema")
+                or t.get("parameters")
+                or {"type": "object", "properties": {}},
+            }
+        )
+    return specs or None
+
+
+def _translate_messages(anth_messages: list[dict], system: Any | None) -> list[Message]:
+    """Anthropic messages (+ optional top-level system) -> renderers Messages.
+
+    System content is merged into ONE leading system message (some chat templates,
+    e.g. Qwen3.x, hard-require system-first). user tool_result blocks become
+    ``role="tool"`` messages; assistant tool_use blocks become OpenAI
+    ``tool_calls``. Reasoning is carried as ``reasoning_content``.
+    """
+    system_parts: list[str] = []
+    if system:
+        system_parts.append(_flatten(system))
+    out: list[Message] = []
+    for m in anth_messages:
+        if not isinstance(m, dict):
+            continue
+        role, content = m.get("role"), m.get("content")
+        if role == "user":
+            blocks = (
+                content
+                if isinstance(content, list)
+                else [{"type": "text", "text": _flatten(content)}]
+            )
+            for b in blocks:
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    out.append({"role": "tool", "content": _flatten(b.get("content"))})
+                elif isinstance(b, dict) and b.get("type") == "text":
+                    out.append({"role": "user", "content": b.get("text", "")})
+                else:
+                    out.append({"role": "user", "content": _flatten(b)})
+        elif role == "assistant":
+            texts: list[str] = []
+            thinkings: list[str] = []
+            tool_calls: list[dict] = []
+            blocks = (
+                content
+                if isinstance(content, list)
+                else [{"type": "text", "text": _flatten(content)}]
+            )
+            for b in blocks:
+                if not isinstance(b, dict):
+                    continue
+                bt = b.get("type")
+                if bt == "text":
+                    texts.append(b.get("text", ""))
+                elif bt == "thinking":
+                    thinkings.append(b.get("thinking", ""))
+                elif bt == "tool_use":
+                    tool_calls.append(
+                        {
+                            "type": "function",
+                            "id": b.get("id", f"toolu_{secrets.token_hex(6)}"),
+                            "function": {
+                                "name": b.get("name", "tool"),
+                                "arguments": b.get("input") or {},
+                            },
+                        }
+                    )
+            msg: Message = {"role": "assistant", "content": "".join(texts)}
+            if thinkings:
+                msg["reasoning_content"] = "".join(thinkings)
+            if tool_calls:
+                msg["tool_calls"] = tool_calls
+            out.append(msg)
+        elif role == "system":
+            system_parts.append(_flatten(content))
+    if system_parts:
+        out.insert(
+            0, {"role": "system", "content": "\n".join(p for p in system_parts if p)}
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Completion -> Anthropic content blocks
+# ---------------------------------------------------------------------------
+def _tool_input(arguments: Any) -> dict:
+    """Coerce a parsed tool-call argument value into a JSON object for claude."""
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+            return parsed if isinstance(parsed, dict) else {"value": parsed}
+        except json.JSONDecodeError:
+            return {"_raw": arguments}
+    return {}
+
+
+def _completion_to_blocks(
+    renderer: Renderer, token_ids: list[int], tools: list[ToolSpec] | None
+) -> tuple[list[dict], str]:
+    """Parse completion tokens -> (Anthropic content blocks, stop_reason hint).
+
+    stop_reason hint is ``"tool_use"`` when any OK tool call was parsed, else
+    ``"end_turn"``; the caller upgrades it to ``"max_tokens"`` on a length finish.
+    """
+    parsed = renderer.parse_response(token_ids=token_ids, tools=tools)
+    blocks: list[dict] = []
+    if parsed.reasoning_content:
+        blocks.append({"type": "thinking", "thinking": parsed.reasoning_content})
+    if parsed.content:
+        blocks.append({"type": "text", "text": parsed.content})
+    has_tool = False
+    for tc in parsed.tool_calls:
+        if tc.status != ToolCallParseStatus.OK or not tc.name:
+            continue
+        has_tool = True
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": tc.id or f"toolu_{secrets.token_hex(8)}",
+                "name": tc.name,
+                "input": _tool_input(tc.arguments),
+            }
+        )
+    if not blocks:
+        blocks.append({"type": "text", "text": ""})
+    return blocks, ("tool_use" if has_tool else "end_turn")
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+class AnthropicAdapter:
+    """Anthropic Messages-compatible HTTP server, backed by a TorchTitan ``generate_fn``.
+
+    Lifecycle::
+
+        adapter = AnthropicAdapter(renderer=renderer)
+        await adapter.start()                       # binds host:port on this loop
+        adapter.open_session(sid, generate_fn=gf, sampling=sp, routing_session_id=sid)
+        ...  # the in-sandbox agent dials /v1/messages with Bearer <sid>
+        turns = await adapter.finish_session(sid)   # list[CapturedTurn]
+        await adapter.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        renderer: Renderer,
+        host: str = "127.0.0.1",
+        port: int = 18001,
+    ) -> None:
+        self.renderer = renderer
+        self.host = host
+        self.port = port
+        self.store: dict[str, _Session] = {}
+        self.closed: set[str] = set()
+        self.app = web.Application(client_max_size=256 * 1024 * 1024)
+        self.app[_ADAPTER_KEY] = self
+        self.app.router.add_post("/v1/messages", _handle_messages)
+        self.app.router.add_post("/v1/messages/count_tokens", _count_tokens)
+        self.app.router.add_get("/healthz", _ok)
+        self.app.router.add_get("/v1/models", _ok)
+        self._runner: web.AppRunner | None = None
+
+    async def start(self) -> "AnthropicAdapter":
+        self._runner = web.AppRunner(self.app, handler_cancellation=True)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        logger.info("[anthropic_adapter] serving on http://%s:%d", self.host, self.port)
+        return self
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def open_session(
+        self,
+        sid: str,
+        *,
+        generate_fn: GenerateFn,
+        sampling: "SamplingConfig",
+        routing_session_id: str | None = None,
+        max_context_tokens: int = 0,
+    ) -> None:
+        if sid in self.store:
+            raise ValueError(
+                f"session_id {sid!r} already open; sids must be unique per run"
+            )
+        self.closed.discard(sid)
+        self.store[sid] = _Session(
+            generate_fn=generate_fn,
+            sampling=sampling,
+            routing_session_id=routing_session_id or sid,
+            max_context_tokens=int(max_context_tokens or 0),
+        )
+
+    async def finish_session(self, sid: str) -> list[CapturedTurn]:
+        """Close the session and return its captured turns (idempotent)."""
+        self.closed.add(sid)
+        session = self.store.pop(sid, None)
+        if session is None:
+            return []
+        return list(session.turns)
+
+
+# ---------------------------------------------------------------------------
+# Request handling
+# ---------------------------------------------------------------------------
+def _request_session_id(request: web.Request) -> str:
+    auth = request.headers.get("Authorization", "")
+    if auth.lower().startswith("bearer "):
+        sid = auth[7:].strip()
+        if sid:
+            return sid
+    api_key = request.headers.get("X-Api-Key")
+    if api_key:
+        return api_key.strip()
+    return "default"
+
+
+def _plan_prompt(
+    adapter: AnthropicAdapter, session: _Session, body: dict
+) -> tuple[list[int], bool]:
+    """Decide this turn's prompt token ids and whether it extends the previous turn.
+
+    append (TITO bridge): the request continues the last turn's history (same
+    system + matching message prefix + an echoed assistant turn), so extend
+    ``last_prompt_ids + last_completion_ids`` with only the new tool/user messages.
+    new/wipe (full render): first turn or a history rewrite (compaction); render
+    the whole conversation -- a wipe deliberately breaks the prefix so
+    ``rollout_to_episodes`` opens a new episode branch.
+    """
+    anth_messages = body.get("messages") or []
+    system = body.get("system")
+    msg_hashes = [_hash(m) for m in anth_messages]
+    system_hash = _hash(system) if system is not None else session.prev_system_hash
+
+    if session.tools is None:
+        session.tools = _anthropic_tools_to_tool_specs(body.get("tools"))
+
+    seen = len(session.prev_msg_hashes)
+    can_append = (
+        session.req_count > 0
+        and bool(session.last_completion_ids)
+        and system_hash == session.prev_system_hash
+        and len(msg_hashes) > seen
+        and msg_hashes[:seen] == session.prev_msg_hashes
+        and isinstance(anth_messages[seen], dict)
+        and anth_messages[seen].get("role") == "assistant"
+    )
+
+    if can_append:
+        new_messages = _translate_messages(anth_messages[seen + 1 :], system=None)
+        # bridge_to_next_turn refuses assistant messages; the tail after an echoed
+        # assistant turn is tool/user only, but guard anyway.
+        if all(m.get("role") != "assistant" for m in new_messages):
+            bridged = adapter.renderer.bridge_to_next_turn(
+                previous_prompt_ids=session.last_prompt_ids,
+                previous_completion_ids=session.last_completion_ids,
+                new_messages=new_messages,
+                tools=session.tools,
+            )
+            if bridged is not None:
+                session.prev_msg_hashes = msg_hashes
+                session.prev_system_hash = system_hash
+                return list(bridged.token_ids), True
+
+    # new / wipe: full re-render.
+    chat = _translate_messages(anth_messages, system=system)
+    prompt_ids = adapter.renderer.render_ids(
+        chat, tools=session.tools, add_generation_prompt=True
+    )
+    session.prev_msg_hashes = msg_hashes
+    session.prev_system_hash = system_hash
+    # extends_previous False only when there WAS a previous turn (a real rewrite);
+    # the very first turn is the episode's natural start, not a branch.
+    return prompt_ids, session.req_count == 0
+
+
+async def _handle_messages(request: web.Request) -> web.StreamResponse:
+    body = await request.json()
+    sid = _request_session_id(request)
+    adapter: AnthropicAdapter = request.app[_ADAPTER_KEY]
+    if sid in adapter.closed:
+        return web.Response(status=503, text="session closed")
+    session = adapter.store.get(sid)
+    if session is None:
+        return web.Response(status=404, text=f"unknown session {sid!r}")
+
+    async with session.lock:
+        prompt_ids, extends_previous = _plan_prompt(adapter, session, body)
+
+        # Per-turn generation cap: respect the model context budget so a long
+        # prompt does not overflow max_model_len mid-trajectory.
+        sampling = session.sampling
+        if session.max_context_tokens > 0:
+            remaining = session.max_context_tokens - len(prompt_ids)
+            if remaining <= 0:
+                # Prompt already over budget: end the trajectory cleanly with an
+                # empty completion (recorded so the merge sees a length finish).
+                session.turns.append(
+                    CapturedTurn(
+                        prompt_token_ids=list(prompt_ids),
+                        completion_token_ids=[],
+                        completion_logprobs=[],
+                        policy_version=None,
+                        finish_reason="length",
+                        extends_previous=extends_previous,
+                    )
+                )
+                # Streaming clients (stream=True) abort with "Stream ended ..." on a
+                # one-shot JSON body, so emit SSE for them; JSON otherwise.
+                empty_blocks = [{"type": "text", "text": ""}]
+                if body.get("stream") is True or "text/event-stream" in (
+                    request.headers.get("Accept", "")
+                ):
+                    return await _stream_response(
+                        request, empty_blocks, "max_tokens", len(prompt_ids), 0
+                    )
+                return web.json_response(
+                    _message_response(
+                        body, empty_blocks, "max_tokens", len(prompt_ids), 0
+                    )
+                )
+            if remaining < sampling.max_tokens:
+                sampling = dataclasses.replace(sampling, max_tokens=remaining)
+
+        # Per-call nonce: a slow one-shot reply can make the client retry the same
+        # turn; with handler_cancellation the first handler is cancelled before it
+        # appends, so a stable id would collide as "already in flight". The nonce
+        # makes each submission distinct.
+        request_id = (
+            f"{session.routing_session_id}/turn={len(session.turns)}"
+            f"/{secrets.token_hex(4)}"
+        )
+        completion = await session.generate_fn(
+            prompt_token_ids=prompt_ids,
+            request_id=request_id,
+            routing_session_id=session.routing_session_id,
+            sampling_config=sampling,
+        )
+        if completion is None:
+            return web.Response(status=502, text="generator returned no completion")
+
+        session.turns.append(
+            CapturedTurn(
+                prompt_token_ids=list(prompt_ids),
+                completion_token_ids=list(completion.token_ids),
+                completion_logprobs=list(completion.token_logprobs),
+                policy_version=completion.policy_version,
+                finish_reason=completion.finish_reason,
+                extends_previous=extends_previous,
+            )
+        )
+        session.last_prompt_ids = list(prompt_ids)
+        session.last_completion_ids = list(completion.token_ids)
+        session.req_count += 1
+
+        logger.info(
+            "[anthropic_adapter] %s turn=%d: prompt=%d max_tokens=%d out=%d finish=%s",
+            session.routing_session_id,
+            len(session.turns) - 1,
+            len(prompt_ids),
+            sampling.max_tokens,
+            len(completion.token_ids),
+            completion.finish_reason,
+        )
+
+        blocks, stop = _completion_to_blocks(
+            adapter.renderer, completion.token_ids, session.tools
+        )
+        if completion.finish_reason == "length":
+            stop = "max_tokens"
+        in_tok, out_tok = len(prompt_ids), len(completion.token_ids)
+
+    if body.get("stream") is True or "text/event-stream" in request.headers.get(
+        "Accept", ""
+    ):
+        return await _stream_response(request, blocks, stop, in_tok, out_tok)
+    return web.json_response(_message_response(body, blocks, stop, in_tok, out_tok))
+
+
+def _message_response(
+    body: dict, blocks: list[dict], stop_reason: str, in_tok: int, out_tok: int
+) -> dict:
+    return {
+        "id": f"msg_{secrets.token_hex(12)}",
+        "type": "message",
+        "role": "assistant",
+        "model": body.get("model", "titan-actor"),
+        "content": blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {"input_tokens": in_tok, "output_tokens": out_tok},
+    }
+
+
+async def _stream_response(
+    request: web.Request,
+    blocks: list[dict],
+    stop_reason: str,
+    in_tok: int,
+    out_tok: int,
+) -> web.StreamResponse:
+    """Emit the reply as an Anthropic Messages SSE stream (message_start,
+    per-block start/delta/stop, message_delta, message_stop). The adapter only
+    streams after the full generation, so this is one-shot SSE."""
+    out = web.StreamResponse(
+        status=200,
+        headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+    await out.prepare(request)
+
+    async def send(event: str, data: dict) -> None:
+        await out.write(
+            f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n".encode()
+        )
+
+    await send(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": f"msg_{secrets.token_hex(12)}",
+                "type": "message",
+                "role": "assistant",
+                "model": "titan-actor",
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": in_tok, "output_tokens": 0},
+            },
+        },
+    )
+    for idx, block in enumerate(blocks):
+        bt = block["type"]
+        if bt == "thinking":
+            start = {"type": "thinking", "thinking": ""}
+            delta = {"type": "thinking_delta", "thinking": block["thinking"]}
+        elif bt == "text":
+            start = {"type": "text", "text": ""}
+            delta = {"type": "text_delta", "text": block["text"]}
+        else:  # tool_use
+            start = {
+                "type": "tool_use",
+                "id": block["id"],
+                "name": block["name"],
+                "input": {},
+            }
+            delta = {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(block["input"], ensure_ascii=False),
+            }
+        await send(
+            "content_block_start",
+            {"type": "content_block_start", "index": idx, "content_block": start},
+        )
+        await send(
+            "content_block_delta",
+            {"type": "content_block_delta", "index": idx, "delta": delta},
+        )
+        await send("content_block_stop", {"type": "content_block_stop", "index": idx})
+
+    await send(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"input_tokens": in_tok, "output_tokens": out_tok},
+        },
+    )
+    await send("message_stop", {"type": "message_stop"})
+    return out
+
+
+# count_tokens runs every turn; claude uses it as a hint, not a hard budget.
+async def _count_tokens(request: web.Request) -> web.Response:
+    return web.json_response({"input_tokens": 0})
+
+
+async def _ok(request: web.Request) -> web.Response:
+    return web.json_response({"ok": True})

--- a/torchtitan/experiments/rl/harness/agents/__init__.py
+++ b/torchtitan/experiments/rl/harness/agents/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Per-CLI-agent runners: install the agent binary in a sandbox and launch it
+pointed at a wire-format adapter. ``claude_code`` runs Claude Code against the
+Anthropic adapter; add a sibling module (e.g. ``codex``) for another CLI agent."""
+
+from torchtitan.experiments.rl.harness.agents.claude_code import (
+    apply_pre_commands,
+    boot_agent_sandbox,
+    git_diff,
+    run_claude_code,
+)
+
+__all__ = [
+    "apply_pre_commands",
+    "boot_agent_sandbox",
+    "git_diff",
+    "run_claude_code",
+]

--- a/torchtitan/experiments/rl/harness/agents/claude_code.py
+++ b/torchtitan/experiments/rl/harness/agents/claude_code.py
@@ -1,0 +1,360 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Claude Code coding-agent runner over the ``Sandbox`` contract.
+
+This is the pluggable *harness*: an unmodified Claude Code CLI binary runs headless
+inside a sandbox and is pointed at our on-box Anthropic adapter (which serves the
+trained policy and captures every turn as training tokens). The harness itself is
+agent-agnostic plumbing -- swapping Claude Code for another CLI that speaks an
+OpenAI/Anthropic-compatible API is a matter of a different run command.
+
+Responsibilities:
+  - ``boot_agent_sandbox``: create a fresh sandbox from the task image and install
+    the Claude Code CLI by downloading the self-contained binary from its CDN
+    inside the sandbox (no-op if the image already ships it).
+  - ``ensure_agent_user``: create an unprivileged ``agent`` user that owns workdir.
+  - ``run_claude_code``: write the problem statement, (for Daytona) start the
+    file-relay bridge, spawn ``claude -p`` pointed at the adapter, poll a done
+    marker, and dump the agent trajectory.
+  - ``git_diff``: capture the agent's patch for grading.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shlex
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from torchtitan.experiments.rl.harness.sandbox import (
+    DaytonaSandbox,
+    make_sandbox,
+    Sandbox,
+)
+
+logger = logging.getLogger(__name__)
+
+SWE_BOOT_CONCURRENCY = int(os.environ.get("SWE_BOOT_CONCURRENCY", "8"))
+SWE_BOOT_RETRIES = int(os.environ.get("SWE_BOOT_RETRIES", "2"))
+# Claude Code CDN (GCS): the self-contained ``linux-x64/claude`` binary is fetched
+# from here INSIDE the sandbox (its own fast egress) instead of uploaded from the
+# controller. ``{CDN}/stable`` -> version; ``{CDN}/{version}/linux-x64/claude`` ->
+# binary.
+CLAUDE_CDN = os.environ.get(
+    "SWE_CLAUDE_CDN",
+    "https://storage.googleapis.com/"
+    "claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases",
+)
+CC_PROMPT = os.environ.get(
+    "SWE_CC_PROMPT",
+    "Read PROBLEM_STATEMENT.md in the current directory and resolve the issue. "
+    "Edit source files only (do NOT touch tests). After editing, run the relevant "
+    "tests to verify your fix passes. Use the project's OWN interpreter to run "
+    "code/tests (e.g. `.venv/bin/python -m pytest ...` from the repo root), NOT "
+    "the system `python3` (it lacks the repo's dependencies). Do NOT modify "
+    "PROBLEM_STATEMENT.md and do NOT commit. When finished, print a one-line "
+    "summary and exit.",
+)
+
+# Trajectory lives under HOME, outside the repo workdir, so the agent cannot Read
+# its own huge trajectory mid-run and blow its context.
+_TRAJ_PATH = "/home/agent/claude_code_trajectory.jsonl"
+
+# Anthropic model name the adapter answers to; arbitrary (the adapter ignores it).
+ADAPTER_MODEL_NAME = "titan-actor"
+
+_BOOT_SEM: asyncio.Semaphore | None = None
+
+
+@asynccontextmanager
+async def boot_agent_sandbox(image: str) -> AsyncIterator[Sandbox]:
+    """Boot a fresh sandbox and install the Claude Code toolchain.
+
+    Creates the sandbox from the task image (backend chosen by
+    ``TT_SANDBOX_BACKEND``) and installs the Claude Code CLI by downloading the
+    self-contained binary from its CDN INSIDE the sandbox (the sandbox's own fast
+    egress), retries transient boot failures, and closes the sandbox when the
+    caller leaves the context.
+    """
+    global _BOOT_SEM
+    if _BOOT_SEM is None:
+        _BOOT_SEM = asyncio.Semaphore(SWE_BOOT_CONCURRENCY)
+
+    sb = None
+    last_err: Exception | None = None
+    for attempt in range(SWE_BOOT_RETRIES):
+        cand = make_sandbox(image)
+        try:
+            async with _BOOT_SEM:
+                await cand.__aenter__()
+                try:
+                    await install_toolchain(cand)
+                except BaseException:
+                    await cand.__aexit__(None, None, None)
+                    raise
+            sb = cand
+            break
+        except Exception as e:
+            last_err = e
+            logger.warning(
+                "[claude_code] provision attempt %d/%d failed: %s: %s",
+                attempt + 1,
+                SWE_BOOT_RETRIES,
+                type(e).__name__,
+                str(e)[:200],
+            )
+            await asyncio.sleep(1 + attempt)
+    if sb is None:
+        assert last_err is not None
+        raise last_err
+    try:
+        yield sb
+    finally:
+        await sb.__aexit__(None, None, None)
+
+
+async def install_toolchain(sb: Sandbox) -> None:
+    """Install Claude Code by downloading the self-contained CDN binary INSIDE the
+    sandbox in one exec (sandbox egress is fast; avoids uploading a ~76MB tarball
+    over a slow link). No-op if claude already present.
+    """
+    ec, _, _ = await sb.exec("claude --version", user="root", timeout=60, check=False)
+    if ec == 0:
+        return
+    await sb.exec(
+        "set -e\n"
+        f"ver=$(curl -fsSL {CLAUDE_CDN}/stable)\n"
+        f'curl -fsSL -o /usr/local/bin/claude "{CLAUDE_CDN}/$ver/linux-x64/claude"\n'
+        "chmod 0755 /usr/local/bin/claude\n"
+        "claude --version\n",
+        user="root",
+        timeout=300,
+        check=True,
+    )
+
+
+async def ensure_agent_user(sb: Sandbox, workdir: str) -> None:
+    """Create the unprivileged 'agent' user that owns workdir + can git diff.
+
+    A pre-seeded settings file pre-acks bypass-permissions so claude-code starts
+    headless without an onboarding prompt.
+    """
+    await sb.exec(
+        f"id agent >/dev/null 2>&1 || useradd -m -s /bin/bash agent && "
+        f"chown -R agent:agent /home/agent {workdir} && "
+        f"git config --system --add safe.directory '*' && id agent && "
+        f"mkdir -p /home/agent/.claude && "
+        f'echo \'{{"hasCompletedOnboarding": true, "bypassPermissionsModeAccepted": true}}\' '
+        f"| tee /home/agent/.claude.json /home/agent/.claude/settings.json > /dev/null && "
+        f"chown -R agent:agent /home/agent/.claude /home/agent/.claude.json",
+        user="root",
+        check=True,
+        timeout=60,
+    )
+    # R2E images keep the repo interpreter under /root (uv-managed venv symlinked
+    # into /root/.local), which the unprivileged 'agent' user cannot traverse or
+    # exec -> claude's own `.venv/bin/python` test runs fail. Grant read+exec so
+    # the agent can self-verify with the project's python. Best-effort.
+    await sb.exec(
+        "[ -d /root/.local ] && chmod a+rx /root && chmod -R a+rX /root/.local || true",
+        user="root",
+        check=False,
+        timeout=120,
+    )
+
+
+async def apply_pre_commands(
+    sb: Sandbox, workdir: str, pre: list[str] | str, *, user: str = "agent"
+) -> None:
+    """Run dataset ``pre_commands`` (e.g. ``git checkout <base_sha> -f``).
+
+    Keeps the work sandbox baseline aligned with eval; skipping in the work sandbox
+    would make the model's diff context mismatch the eval base -> apply failures.
+    """
+    body = (
+        pre.replace("\\n", "\n")
+        if isinstance(pre, str)
+        else "\n".join(c for c in (pre or []) if c)
+    )
+    pre_path = f"{workdir}/__cagent_pre__.sh"
+    await sb.write_file(pre_path, "set -e\n" + body, user=user)
+    await sb.exec(
+        f"chmod 755 {pre_path} && cd {workdir} && bash {pre_path}",
+        user=user,
+        check=False,
+        timeout=600,
+    )
+
+
+async def run_claude_code(
+    sb: Sandbox,
+    *,
+    workdir: str,
+    session_id: str,
+    adapter_url: str,
+    time_budget_sec: int,
+    problem_statement: str = "",
+    pre_commands: list[str] | str | None = None,
+    prompt: str | None = None,
+) -> int:
+    """Prepare the SWE workspace, write PROBLEM_STATEMENT.md, then run Claude Code.
+
+    For a Daytona sandbox (which cannot dial back to an inbound-firewalled box),
+    start the file-relay bridge and point claude at the in-sandbox proxy instead of
+    the unreachable host URL. Returns the agent process exit code (``-2`` on budget
+    exceeded).
+    """
+    await ensure_agent_user(sb, workdir)
+    if pre_commands:
+        await apply_pre_commands(sb, workdir, pre_commands)
+    await sb.write_file(
+        f"{workdir}/PROBLEM_STATEMENT.md", problem_statement or "", user="agent"
+    )
+
+    bridge = None
+    cc_adapter_url = adapter_url
+    if isinstance(sb, DaytonaSandbox):
+        from torchtitan.experiments.rl.harness.sandbox import start_bridge
+
+        bridge = await start_bridge(sb, adapter_url)
+        cc_adapter_url = bridge.local_url
+    try:
+        rc = await _spawn_claude_code(
+            sb,
+            workdir=workdir,
+            session_id=session_id,
+            adapter_url=cc_adapter_url,
+            prompt=prompt or CC_PROMPT,
+            time_budget_sec=time_budget_sec,
+        )
+        # Pull claude-code's stream-json trajectory out before the sandbox dies so
+        # the human-readable agent trace (Read/Edit/Bash/tool turns) survives.
+        await dump_trajectory(sb, workdir, session_id)
+        return rc
+    finally:
+        if bridge is not None:
+            await bridge.stop()
+
+
+async def dump_trajectory(sb: Sandbox, workdir: str, session_id: str) -> None:
+    """Best-effort copy of ``claude_code_trajectory.jsonl`` from the sandbox to
+    ``SWE_TRAJECTORY_DUMP_DIR`` on the host. No-op if the dir is unset."""
+    dump_dir = os.environ.get("SWE_TRAJECTORY_DUMP_DIR", "")
+    if not dump_dir:
+        return
+    try:
+        traj = await sb.read_file(_TRAJ_PATH, user="agent")
+        if not (traj or "").strip():
+            return
+        os.makedirs(dump_dir, exist_ok=True)
+        safe = session_id.replace("/", "_")
+        path = os.path.join(dump_dir, f"{safe}.jsonl")
+        with open(path, "w") as f:
+            f.write(traj)
+        logger.info("[claude_code] trajectory dumped: %s (%d bytes)", path, len(traj))
+    except Exception as e:
+        logger.warning("[claude_code] trajectory dump failed: %s", e)
+
+
+async def _spawn_claude_code(
+    sb: Sandbox,
+    *,
+    workdir: str,
+    session_id: str,
+    adapter_url: str,
+    prompt: str,
+    time_budget_sec: int,
+) -> int:
+    """Spawn claude-code detached + poll a done-marker file.
+
+    A gateway may reset a long-lived foreground exec, so the launcher writes the
+    exit code into a marker file that we poll every 5s via short RPCs (which also
+    keeps the sandbox alive against idle GC).
+    """
+    done = f"{workdir}/.cagent_done"
+    launcher = f"{workdir}/.cagent_run.sh"
+    traj = _TRAJ_PATH
+
+    launcher_body = (
+        "#!/bin/bash\n"
+        f"cd {workdir}\n"
+        "export HOME=/home/agent\n"
+        f"/usr/local/bin/claude -p {json.dumps(prompt)} "
+        "--permission-mode bypassPermissions "
+        "--output-format stream-json --include-partial-messages "
+        "--include-hook-events --verbose "
+        f"{os.environ.get('SWE_CLAUDE_EXTRA_ARGS', '').strip()} "
+        f"2>&1 | tee {shlex.quote(traj)}\n"
+        f"echo $? > {done}\n"
+    )
+    await sb.write_file(launcher, launcher_body, user="agent")
+    await sb.exec(f"chmod +x {launcher}", user="agent", timeout=30)
+
+    env = {
+        "ANTHROPIC_BASE_URL": adapter_url,
+        "ANTHROPIC_AUTH_TOKEN": session_id,
+        "ANTHROPIC_MODEL": ADAPTER_MODEL_NAME,
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+        # The file-relay delivers the reply in one shot after full generation;
+        # these three knobs stop the client from timing out / retrying while it
+        # waits (no incremental bytes until gen ends).
+        "API_TIMEOUT_MS": os.environ.get("SWE_API_TIMEOUT_MS", "900000"),
+        "API_FORCE_IDLE_TIMEOUT": "0",
+        "CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK": "1",
+    }
+    env_keys = ",".join(env.keys())
+    await sb.exec(
+        f"runuser -u agent --whitelist-environment={env_keys}"
+        f" -- bash -c 'setsid {launcher} < /dev/null > /dev/null 2>&1 &'",
+        user="root",
+        env=env,
+        timeout=30,
+        check=True,
+    )
+
+    deadline = time.time() + time_budget_sec
+    exit_code = -2  # convention: -2 = budget exceeded
+    while time.time() < deadline:
+        await asyncio.sleep(5)
+        ec, out, _ = await sb.exec(
+            f"test -f {done} && cat {done}", user="agent", timeout=15, check=False
+        )
+        if ec == 0:
+            try:
+                exit_code = int((out or "").strip() or "-1")
+            except ValueError:
+                exit_code = -1
+            break
+    return exit_code
+
+
+async def git_diff(
+    sb: Sandbox, workdir: str, *, tracked_only: bool = False, user: str = "agent"
+) -> str:
+    """Capture the agent's patch.
+
+    ``tracked_only=True`` skips ``git add -N .`` so pre-existing untracked
+    environment artifacts (e.g. R2E images carry ``datasets/``, ``install.sh``,
+    ``run_tests.sh`` in the working tree) are not captured as spurious new-file
+    sections that would break ``git apply`` in the evaluator.
+    """
+    add = "" if tracked_only else "git add -N . && "
+    cmd = (
+        f"cd {workdir} && {add}"
+        f"git diff -- . ':(exclude)PROBLEM_STATEMENT.md' "
+        f"':(exclude)claude_code_trajectory.jsonl' "
+        f"':(exclude).cagent_done' ':(exclude).cagent_run.sh' "
+        f"':(exclude)__cagent_pre__.sh'"
+    )
+    _, out, _ = await sb.exec(cmd, user=user, timeout=120)
+    return out

--- a/torchtitan/experiments/rl/harness/sandbox/__init__.py
+++ b/torchtitan/experiments/rl/harness/sandbox/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Provider-agnostic sandbox/container resource for agent rollouts.
+
+``base`` defines the ``Sandbox`` contract + ``make_sandbox`` factory; ``daytona``
+is the backend; ``bridge`` is the Daytona-specific HTTP file-relay that lets an
+in-sandbox agent reach the on-box adapter.
+"""
+
+from torchtitan.experiments.rl.harness.sandbox.base import (
+    ExecResult,
+    FileContent,
+    make_sandbox,
+    Sandbox,
+)
+from torchtitan.experiments.rl.harness.sandbox.bridge import DaytonaBridge, start_bridge
+from torchtitan.experiments.rl.harness.sandbox.daytona import DaytonaSandbox
+
+__all__ = [
+    "DaytonaBridge",
+    "DaytonaSandbox",
+    "ExecResult",
+    "FileContent",
+    "Sandbox",
+    "make_sandbox",
+    "start_bridge",
+]

--- a/torchtitan/experiments/rl/harness/sandbox/base.py
+++ b/torchtitan/experiments/rl/harness/sandbox/base.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Provider-agnostic sandbox contract + backend factory.
+
+The contract is intentionally small: async context management, command execution,
+and file read/write. A coding-agent example builds its task-specific setup, agent
+runner, and grader on top of this without depending on one sandbox provider.
+The backend lives in a sibling module (``daytona.py``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+ExecResult = tuple[int, str, str]  # (exit_code, stdout, stderr)
+FileContent = str | bytes | Path
+
+
+@runtime_checkable
+class Sandbox(Protocol):
+    """Minimal async sandbox interface used by agent rollouts.
+
+    ``write_file`` accepts either in-memory content (``str``/``bytes``) or a
+    host ``Path`` to stream into the sandbox.
+    """
+
+    sandbox_id: str
+
+    async def __aenter__(self) -> Sandbox:
+        ...
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        ...
+
+    async def exec(
+        self,
+        cmd: str,
+        *,
+        user: str = "root",
+        env: dict[str, str] | None = None,
+        timeout: int = 120,
+        check: bool = False,
+    ) -> ExecResult:
+        ...
+
+    async def write_file(
+        self, sandbox_path: str, content: FileContent, *, user: str = "root"
+    ) -> None:
+        ...
+
+    async def read_file(self, sandbox_path: str, *, user: str = "root") -> str:
+        ...
+
+
+def _getenv(name: str, default: str = "") -> str:
+    """Return the env var's value, or ``default`` if it is unset or blank."""
+    value = os.environ.get(name)
+    return value if value is not None and value.strip() else default
+
+
+def make_sandbox(image: str, **kwargs) -> Sandbox:
+    """Factory: build the sandbox backend selected by ``TT_SANDBOX_BACKEND``.
+
+    Only ``daytona`` -> ``DaytonaSandbox`` is bundled; the factory is the seam for
+    adding another provider as a new ``sandbox`` backend. The backend is imported
+    lazily so a missing optional SDK (``daytona``) only errors when it is selected.
+    """
+    backend = _getenv("TT_SANDBOX_BACKEND", default="daytona").lower()
+    if backend != "daytona":
+        raise ValueError(
+            f"unknown sandbox backend {backend!r}; only 'daytona' is bundled"
+        )
+    from torchtitan.experiments.rl.harness.sandbox.daytona import DaytonaSandbox
+
+    return DaytonaSandbox(image, **kwargs)

--- a/torchtitan/experiments/rl/harness/sandbox/bridge.py
+++ b/torchtitan/experiments/rl/harness/sandbox/bridge.py
@@ -1,0 +1,313 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""File-relay bridge: Claude Code in a Daytona sandbox <-> the inbound-firewalled
+adapter on this trainer box.
+
+Daytona refuses ``ssh -R``, so we relay HTTP over the Daytona ``fs`` control
+plane: the agent hits an in-sandbox proxy that writes a req file; the host poller
+downloads it and replays to the adapter, then uploads a resp file the proxy reads
+back. One-shot delivery is equivalent to a dial-back since token capture happens
+host-side in the adapter regardless.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+SPOOL = "/tmp/cagent_bridge"
+REQ_DIR = f"{SPOOL}/req"
+RESP_DIR = f"{SPOOL}/resp"
+DEFAULT_PORT = 18001
+
+# Hop-by-hop / length headers we must not blindly forward to the adapter.
+_DROP_REQ_HEADERS = {
+    "host",
+    "content-length",
+    "accept-encoding",
+    "connection",
+    "transfer-encoding",
+}
+
+# In-sandbox proxy. Pure stdlib, kept 3.6+ compatible for old sandbox pythons.
+# Threaded so concurrent agent connections and per-response long-polls don't
+# head-of-line block each other.
+_PROXY_SRC = r"""
+import sys, os, json, time, base64, uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+PORT = int(sys.argv[1])
+SPOOL = sys.argv[2]
+REQ = os.path.join(SPOOL, "req")
+RESP = os.path.join(SPOOL, "resp")
+WAIT = float(sys.argv[3]) if len(sys.argv) > 3 else 900.0
+
+class TS(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+class H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _relay(self, method):
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            length = 0
+        body = self.rfile.read(length) if length else b""
+        rid = uuid.uuid4().hex
+        req = {
+            "method": method,
+            "path": self.path,
+            "headers": dict(self.headers.items()),
+            "body_b64": base64.b64encode(body).decode("ascii"),
+        }
+        jp = os.path.join(REQ, rid + ".json")
+        with open(jp + ".tmp", "w") as f:
+            json.dump(req, f)
+        os.rename(jp + ".tmp", jp)
+        open(os.path.join(REQ, rid + ".ready"), "w").close()
+
+        donep = os.path.join(RESP, rid + ".done")
+        respp = os.path.join(RESP, rid + ".json")
+        deadline = time.time() + WAIT
+        while time.time() < deadline:
+            if os.path.exists(donep):
+                with open(respp) as f:
+                    resp = json.load(f)
+                rbody = base64.b64decode(resp.get("body_b64", ""))
+                self.send_response(int(resp.get("status", 200)))
+                for k, v in (resp.get("headers") or {}).items():
+                    if k.lower() in ("content-length", "transfer-encoding", "connection"):
+                        continue
+                    self.send_header(k, v)
+                self.send_header("Content-Length", str(len(rbody)))
+                self.end_headers()
+                self.wfile.write(rbody)
+                for p in (donep, respp):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+                return
+            time.sleep(0.04)
+        self.send_response(504)
+        self.send_header("Content-Length", "13")
+        self.end_headers()
+        self.wfile.write(b"bridge timeout")
+
+    def do_POST(self):
+        self._relay("POST")
+
+    def do_GET(self):
+        self._relay("GET")
+
+    def log_message(self, *a):
+        pass
+
+for d in (REQ, RESP):
+    try:
+        os.makedirs(d)
+    except OSError:
+        pass
+TS(("127.0.0.1", PORT), H).serve_forever()
+"""
+
+
+class DaytonaBridge:
+    def __init__(
+        self,
+        sb,
+        host_adapter_url: str,
+        *,
+        port: int = DEFAULT_PORT,
+        poll_interval: float | None = None,
+    ):
+        import os
+
+        self._sb = sb  # DaytonaSandbox wrapper (has .daytona -> AsyncSandbox)
+        self._fs = sb.daytona.fs
+        self.host_adapter_url = host_adapter_url.rstrip("/")
+        self.port = port
+        # The host busy-polls each sandbox's req dir over the Daytona fs API; at a
+        # large rollout fanout (e.g. 8 prompts x 8 samples = 64 live bridges) a tight
+        # interval blows past the account's fs request-rate cap (Tier 3 ~833 req/s):
+        # 64 / 0.05s = 1280 list_files/s. 0.2s -> 320/s leaves headroom for the
+        # per-turn download/upload calls. Adds at most poll_interval to per-turn
+        # latency, negligible against multi-second generation. Tune via env.
+        if poll_interval is None:
+            poll_interval = float(os.environ.get("SWE_BRIDGE_POLL_INTERVAL", "0.2"))
+        self.poll_interval = poll_interval
+        self._task: asyncio.Task | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._inflight: set[str] = set()
+        self._processed: set[str] = set()
+
+    @property
+    def local_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def start(self, *, ready_timeout: float = 60.0) -> "DaytonaBridge":
+        await self._sb.exec(f"mkdir -p {REQ_DIR} {RESP_DIR}", user="root", check=True)
+        await self._sb.write_file(
+            "/tmp/daytona_bridge_proxy.py", _PROXY_SRC, user="root"
+        )
+        # Detached: short RPC returns immediately, proxy keeps serving.
+        await self._sb.exec(
+            "setsid bash -c 'nohup python3 /tmp/daytona_bridge_proxy.py "
+            f"{self.port} {SPOOL} 900 > /tmp/daytona_bridge_proxy.log 2>&1 &' "
+            "< /dev/null > /dev/null 2>&1",
+            user="root",
+            check=True,
+            timeout=30,
+        )
+        # trust_env=False so the loopback adapter call ignores the box's fwdproxy.
+        self._session = aiohttp.ClientSession(trust_env=False)
+        self._task = asyncio.create_task(
+            self._poll_loop(), name=f"daytona-bridge-{self._sb.sandbox_id[:8]}"
+        )
+        await self._wait_ready(ready_timeout)
+        return self
+
+    async def _wait_ready(self, timeout: float) -> None:
+        # Round-trip a real /healthz through proxy -> relay -> adapter so the
+        # agent never starts before the full path is live.
+        deadline = asyncio.get_event_loop().time() + timeout
+        # urllib, not curl: python3 is guaranteed in-sandbox; curl is not.
+        probe = (
+            'python3 -c "import urllib.request as u,sys;'
+            f"sys.stdout.write(str(u.urlopen('{self.local_url}/healthz',timeout=8).status))\" "
+            "2>/dev/null"
+        )
+        last = ""
+        while asyncio.get_event_loop().time() < deadline:
+            rc, out, _ = await self._sb.exec(probe, user="root", timeout=20)
+            last = (out or "").strip()
+            if last == "200":
+                logger.info("[daytona_bridge] ready: %s/healthz -> 200", self.local_url)
+                return
+            await asyncio.sleep(1.0)
+        raise RuntimeError(
+            f"daytona bridge not ready after {timeout}s (last healthz={last!r})"
+        )
+
+    async def _poll_loop(self) -> None:
+        try:
+            while True:
+                try:
+                    files = await self._fs.list_files(REQ_DIR)
+                    names = {getattr(f, "name", "") for f in files}
+                    for ready in [n for n in names if n.endswith(".ready")]:
+                        rid = ready[: -len(".ready")]
+                        if rid in self._inflight or rid in self._processed:
+                            continue
+                        if f"{rid}.json" not in names:
+                            continue
+                        self._inflight.add(rid)
+                        asyncio.create_task(self._handle(rid))
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.debug("[daytona_bridge] poll error: %s", e)
+                await asyncio.sleep(self.poll_interval)
+        except asyncio.CancelledError:
+            pass
+
+    async def _handle(self, rid: str) -> None:
+        try:
+            raw = await self._fs.download_file(f"{REQ_DIR}/{rid}.json")
+            req = json.loads(raw)
+            status, headers, body = await self._forward(req)
+            payload = json.dumps(
+                {
+                    "status": status,
+                    "headers": headers,
+                    "body_b64": base64.b64encode(body).decode("ascii"),
+                }
+            ).encode("utf-8")
+            await self._fs.upload_file(payload, f"{RESP_DIR}/{rid}.json")
+            await self._fs.upload_file(b"", f"{RESP_DIR}/{rid}.done")
+        except Exception as e:
+            logger.warning("[daytona_bridge] handle %s failed: %s", rid[:8], e)
+            try:
+                err = json.dumps(
+                    {
+                        "status": 502,
+                        "headers": {"Content-Type": "text/plain"},
+                        "body_b64": base64.b64encode(
+                            f"bridge error: {e}".encode()
+                        ).decode("ascii"),
+                    }
+                ).encode("utf-8")
+                await self._fs.upload_file(err, f"{RESP_DIR}/{rid}.json")
+                await self._fs.upload_file(b"", f"{RESP_DIR}/{rid}.done")
+            except Exception:
+                pass
+        finally:
+            self._processed.add(rid)
+            self._inflight.discard(rid)
+            for suffix in (".ready", ".json"):
+                try:
+                    await self._fs.delete_file(f"{REQ_DIR}/{rid}{suffix}")
+                except Exception:
+                    pass
+
+    async def _forward(self, req: dict) -> tuple[int, dict, bytes]:
+        method = req.get("method", "POST")
+        path = req.get("path", "/")
+        headers = {
+            k: v
+            for k, v in (req.get("headers") or {}).items()
+            if k.lower() not in _DROP_REQ_HEADERS
+        }
+        body = base64.b64decode(req.get("body_b64", ""))
+        url = self.host_adapter_url + path
+        assert self._session is not None
+        async with self._session.request(
+            method,
+            url,
+            data=body if body else None,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=900),
+        ) as resp:
+            rbody = await resp.read()
+            ctype = resp.headers.get("Content-Type", "application/json")
+            return resp.status, {"Content-Type": ctype}, rbody
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+        try:
+            await self._sb.exec(
+                "pkill -f daytona_bridge_proxy.py || true", user="root", timeout=15
+            )
+        except Exception:
+            pass
+
+
+async def start_bridge(
+    sb, host_adapter_url: str, *, port: int = DEFAULT_PORT
+) -> DaytonaBridge:
+    """Start the file-relay bridge for ``sb`` and return a started handle whose
+    ``local_url`` the in-sandbox agent should use as ``ANTHROPIC_BASE_URL``."""
+    bridge = DaytonaBridge(sb, host_adapter_url, port=port)
+    return await bridge.start()

--- a/torchtitan/experiments/rl/harness/sandbox/daytona.py
+++ b/torchtitan/experiments/rl/harness/sandbox/daytona.py
@@ -1,0 +1,287 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Daytona cloud sandbox backend.
+
+Boots a remote cloud container from a Docker image. Meant for boxes that cannot
+expose an inbound port to the cloud (an internal dev box): the agent inside the
+sandbox reaches the on-box Anthropic adapter through a file-relay bridge over the
+Daytona ``fs`` API (see ``bridge.py``), not a direct dial-back.
+
+Ported from THUDM/slime ``slime/agent/sandbox.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+from pathlib import Path
+
+from torchtitan.experiments.rl.harness.sandbox.base import (
+    _getenv,
+    ExecResult,
+    FileContent,
+)
+
+logger = logging.getLogger(__name__)
+
+# Label stamped on every sandbox we create, so cleanup can target ONLY our
+# sandboxes (never another tenant's) when sharing a Daytona account.
+HARNESS_LABELS = {"owner": "titan_swe_r2e"}
+
+
+# Process-wide AsyncDaytona client, shared by every sandbox in this worker: one
+# client = one pooled TLS session reused across all concurrent rollouts. A
+# per-sandbox client instead opens its own pool, and the handshake storm under a
+# many-way boot fanout over a high-latency link times out the exec requests.
+_SHARED_CLIENT = None
+_SHARED_CLIENT_LOCK = None
+
+
+async def _get_shared_client(*, api_key: str | None, api_url, target):
+    global _SHARED_CLIENT, _SHARED_CLIENT_LOCK
+    import asyncio
+
+    from daytona import AsyncDaytona, DaytonaConfig  # type: ignore
+
+    if not api_key:
+        raise RuntimeError(
+            "DAYTONA_API_KEY is not set; required for the daytona sandbox backend."
+        )
+    if _SHARED_CLIENT_LOCK is None:
+        _SHARED_CLIENT_LOCK = asyncio.Lock()
+    async with _SHARED_CLIENT_LOCK:
+        if _SHARED_CLIENT is None:
+            cfg = DaytonaConfig(api_key=api_key, api_url=api_url, target=target)
+            _SHARED_CLIENT = AsyncDaytona(cfg)
+    return _SHARED_CLIENT
+
+
+class DaytonaSandbox:
+    """Async sandbox over a Daytona cloud sandbox (https://daytona.io).
+
+    Daytona builds a snapshot wrapping any public image on first ``create`` and
+    runs ``process.exec`` as the image's default user. R2E-Gym images default to
+    ``root`` with the repo interpreter on ``PATH``, so ``exec`` runs as root and
+    drops to an unprivileged user via ``runuser`` when asked. ``fs`` writes as
+    root, so ``write_file`` uploads then chowns.
+
+    Env knobs:
+      ``DAYTONA_API_KEY``                  -- API key (required).
+      ``DAYTONA_API_URL`` / ``DAYTONA_TARGET`` -- override cloud endpoint/region.
+      ``TT_DAYTONA_CPU``                   -- vCPUs per sandbox (default 2).
+      ``TT_DAYTONA_MEM_GB``                -- memory GiB per sandbox (default 4).
+      ``TT_DAYTONA_DISK_GB``               -- disk GiB per sandbox (default 10).
+      ``TT_DAYTONA_CREATE_TIMEOUT``        -- snapshot-build/boot wait (default 900s).
+    """
+
+    def __init__(self, image: str, *, timeout: int | None = None, **_ignored) -> None:
+        self.image = image
+        self.timeout = timeout
+        self._client = None
+        self._sb = None
+        self.sandbox_id = ""
+
+    @property
+    def daytona(self):
+        """Underlying ``daytona.AsyncSandbox`` (for the fs-relay bridge)."""
+        return self._sb
+
+    async def __aenter__(self) -> DaytonaSandbox:
+        import asyncio
+        import random
+
+        from daytona import CreateSandboxFromImageParams, Resources  # type: ignore
+
+        self._client = await _get_shared_client(
+            api_key=_getenv("DAYTONA_API_KEY"),
+            api_url=_getenv("DAYTONA_API_URL") or None,
+            target=_getenv("DAYTONA_TARGET") or None,
+        )
+        cpu = int(_getenv("TT_DAYTONA_CPU", default="2"))
+        mem = int(_getenv("TT_DAYTONA_MEM_GB", default="4"))
+        disk = int(_getenv("TT_DAYTONA_DISK_GB", default="10"))
+        create_timeout = float(_getenv("TT_DAYTONA_CREATE_TIMEOUT", default="900"))
+        # Cloud-side TTL so an orphan (left by a SIGKILL'd run that never reached
+        # __aexit__, e.g. MAST preemption) self-reaps: once it goes idle it
+        # auto-stops after auto_stop minutes, then auto-deletes immediately
+        # (auto_delete=0). A live rollout keeps the sandbox active (the host polls
+        # its fs continuously via the bridge), so it is never stopped mid-run.
+        auto_stop = int(_getenv("TT_DAYTONA_AUTO_STOP_MIN", default="30"))
+        auto_delete = int(_getenv("TT_DAYTONA_AUTO_DELETE_MIN", default="0"))
+        params = CreateSandboxFromImageParams(
+            image=self.image,
+            resources=Resources(cpu=cpu, memory=mem, disk=disk),
+            labels=HARNESS_LABELS,
+            auto_stop_interval=auto_stop,
+            auto_delete_interval=auto_delete,
+        )
+        # Daytona create transiently 401s a valid key under a concurrent boot burst.
+        # Retry with jittered backoff so a wide fanout does not retry in lockstep.
+        retries = int(_getenv("TT_DAYTONA_CREATE_RETRIES", default="5"))
+        backoff = 5.0
+        for attempt in range(retries + 1):
+            try:
+                self._sb = await self._client.create(params, timeout=create_timeout)
+                break
+            except Exception as e:
+                if attempt >= retries:
+                    raise
+                logger.warning(
+                    "daytona create failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    retries + 1,
+                    e,
+                )
+                await asyncio.sleep(backoff * (0.5 + random.random()))
+                backoff = min(backoff * 2, 60.0)
+        self.sandbox_id = self._sb.id
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        # Delete only this sandbox; never close the process-wide shared client --
+        # other concurrent rollouts are still using its pooled connections.
+        try:
+            if self._sb is not None:
+                await self._client.delete(self._sb)
+        except Exception as e:
+            logger.warning("daytona delete %s failed: %s", self.sandbox_id[:8], e)
+
+    async def exec(
+        self,
+        cmd: str,
+        *,
+        user: str = "root",
+        env: dict[str, str] | None = None,
+        timeout: int = 120,
+        check: bool = False,
+    ) -> ExecResult:
+        # A high-latency host->daytona link (e.g. cross-region MAST -> daytona-US)
+        # can make even a fast command's exec request time out. Raise every exec's
+        # timeout floor via TT_DAYTONA_EXEC_TIMEOUT_MIN (default 0 = unchanged).
+        import os
+
+        timeout = max(timeout, int(os.environ.get("TT_DAYTONA_EXEC_TIMEOUT_MIN", "0")))
+        # exec lands as root on R2E images; drop privileges with runuser when a
+        # non-root user is requested. Inline env as `env K=V` (not the SDK env=)
+        # so the whole command is self-contained for the session API below.
+        env_prefix = (
+            "env " + " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items()) + " "
+            if env
+            else ""
+        )
+        if user and user != "root":
+            keys = ",".join((env or {}).keys())
+            wl = f"--whitelist-environment={keys} " if keys else ""
+            inner = f"runuser -u {shlex.quote(user)} {wl}-- bash -c {shlex.quote(cmd)}"
+        else:
+            inner = f"bash -c {shlex.quote(cmd)}"
+        rc, out = await self._session_exec(env_prefix + inner, timeout=timeout)
+        if check and rc != 0:
+            raise RuntimeError(
+                f"daytona exec failed (exit={rc}): {cmd[:120]}\n{out[:400]}"
+            )
+        return rc, out, ""
+
+    async def _session_exec(self, full: str, *, timeout: int) -> tuple[int, str]:
+        """Run ``full`` via the session API (create_session +
+        execute_session_command(run_async) + poll) so a slow host->daytona link
+        does not trip the exec-call timeout. Do NOT delete the session -- Daytona
+        kills its child processes, which would kill the backgrounded claude.
+        """
+        import asyncio
+        import os
+        import random
+        import uuid
+
+        from daytona import SessionExecuteRequest
+
+        retries = int(os.environ.get("TT_DAYTONA_EXEC_RETRIES", "5"))
+        backoff = 5.0
+        sid = cid = ""
+        for attempt in range(retries + 1):
+            try:
+                sid = uuid.uuid4().hex
+                await self._sb.process.create_session(sid)
+                resp = await self._sb.process.execute_session_command(
+                    sid,
+                    SessionExecuteRequest(command=full, run_async=True),
+                    timeout=timeout,
+                )
+                cid = resp.cmd_id
+                if not cid:
+                    raise RuntimeError("daytona session exec returned no cmd_id")
+                break
+            except Exception:
+                try:
+                    await self._sb.process.delete_session(sid)
+                except Exception:
+                    pass
+                if attempt >= retries:
+                    raise
+                # Jittered backoff: spread retries over [0.5, 1.5)x so a wide
+                # fanout does not retry in lockstep against the same rate limit.
+                await asyncio.sleep(backoff * (0.5 + random.random()))
+                backoff = min(backoff * 2, 60.0)
+
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout + 120.0
+
+        async def poll():
+            # Daytona briefly returns an empty exit_code mid-command; the SDK then
+            # raises "convert exit code to int". Treat only that as "still running".
+            try:
+                return await self._sb.process.get_session_command(sid, cid)
+            except Exception as e:
+                if "convert exit code" in str(e):
+                    return None
+                raise
+
+        cmd = await poll()
+        polls = 0
+        while cmd is None or cmd.exit_code is None:
+            if loop.time() > deadline:
+                raise TimeoutError(
+                    f"daytona exec poll exceeded {timeout + 120:.0f}s "
+                    f"(sandbox likely stopped/deleted); cmd={full[:80]}"
+                )
+            await asyncio.sleep(0.1 if polls < 5 else 1.0)
+            cmd = await poll()
+            polls += 1
+
+        logs = await self._sb.process.get_session_command_logs(sid, cid)
+        out = getattr(logs, "stdout", "") or ""
+        err = getattr(logs, "stderr", "") or ""
+        return int(cmd.exit_code), out + err
+
+    async def write_file(
+        self, sandbox_path: str, content: FileContent, *, user: str = "root"
+    ) -> None:
+        import os
+
+        parent = os.path.dirname(sandbox_path) or "/"
+        await self.exec(f"mkdir -p {shlex.quote(parent)}", user="root", check=False)
+        if isinstance(content, Path):
+            data = content.read_bytes()
+        elif isinstance(content, bytes):
+            data = content
+        else:
+            data = str(content).encode("utf-8")
+        # fs.upload_file writes as root; chown afterwards for non-root owners.
+        await self._sb.fs.upload_file(data, sandbox_path)
+        if user and user != "root":
+            await self.exec(
+                f"chown {shlex.quote(user)}:{shlex.quote(user)} {shlex.quote(sandbox_path)}",
+                user="root",
+                check=False,
+            )
+
+    async def read_file(self, sandbox_path: str, *, user: str = "root") -> str:
+        # root can read any file; the user arg is accepted for protocol parity.
+        rc, out, _ = await self.exec(
+            f"cat {shlex.quote(sandbox_path)}", user="root", timeout=60
+        )
+        return out if rc == 0 else ""


### PR DESCRIPTION
## What

A TorchTitan RL example (`swe_r2e`) that post-trains a Qwen model on R2E-Gym SWE
tasks where the rollout is driven by an **unmodified agentic CLI harness (Claude
Code)** running inside a **Daytona** cloud sandbox. An on-box Anthropic-Messages
adapter serves the trained policy to the agent and captures every model turn as
on-policy training tokens; R2E hidden tests grade the agent's patch for the reward.

This is the TorchTitan analogue of THUDM/slime's `coding_agent_rl` and Meta
msl/rl's "virtual actor + reverse-proxy" pattern.

## How it works

```
RLTrainer (controller)
  SWER2ERollouter.run_group_rollouts(generate_fn, sample, group_size=K)
    AnthropicAdapter  <- one HTTP endpoint backed by the controller's generate_fn
    per sibling:
      boot Daytona sandbox (R2E image) + install Claude Code (self-contained CDN binary)
      claude -p  ANTHROPIC_BASE_URL -> adapter (via the Daytona fs-relay bridge)
         adapter: render_ids / bridge_to_next_turn (TITO) -> generate_fn -> Completion
                  records (prompt_ids, completion_ids, logprobs) per turn
      git diff -> evaluate_r2e (fresh sandbox: apply diff, run hidden tests) -> reward
  rubric -> GRPO advantage -> rollout_to_episodes -> Batcher -> backward
```

The adapter reuses prior turns' exact sampled tokens via the renderer's
`bridge_to_next_turn` (Token-In-Token-Out), so each turn's prompt exactly extends
`prev_prompt + prev_completion` and a whole multi-turn trajectory packs into **one**
training episode (assistant tokens trained, prompt / tool-result tokens masked); a
Claude Code auto-compaction breaks the prefix and opens a new episode branch,
exactly as `rollout_to_episodes` expects.

Because an inbound-firewalled trainer box cannot accept a dial-back from the public
Daytona cloud (Daytona refuses `ssh -R`), `bridge.py` relays the agent's HTTP over
Daytona's `fs` API: the in-sandbox proxy writes a request file, the host polls and
replays it to the adapter, then uploads a response file. One-shot delivery is
equivalent to a dial-back since token capture happens host-side regardless.

## Layout (three orthogonal axes)

- `harness/sandbox/` -- WHERE code runs: `Sandbox` contract + `make_sandbox`, the
  Daytona backend, and the Daytona fs-relay `bridge`.
- `harness/adapters/` -- HOW the model is served: a token-capturing wire-format
  endpoint (`anthropic`; add `openai` for Codex/OpenCode -- capture is shared).
- `harness/agents/` -- WHICH CLI agent + how to launch it (`claude_code`).
- `examples/swe_r2e/` -- the R2E task: `data`, `grading`, `rubric`, `rollouter`,
  `config_registry` (1.7B / 8B / 14B / 32B dense + 30B-A3B MoE), launcher, isolated
  smoke harness.

Adding a new CLI agent = a new `agents/` runner (+ reuse/extend an `adapters/` wire
module); a new sandbox provider = a new `sandbox/` backend.

## Sandbox cleanup (no zombies, incl. SIGKILL)

Two layers: (1) per-rollout delete on context exit; (2) a cloud-side **auto-delete
TTL** on every sandbox (`TT_DAYTONA_AUTO_STOP_MIN` / `AUTO_DELETE_MIN`) so an orphan
self-reaps even if the process is SIGKILL'd (e.g. preemption) and never runs its
exit path.

## Verification

End to end on Daytona: Claude Code rollouts -> R2E grading -> GRPO backward.
- Single 8xH100 host: `Train | Step 1` backward for **Qwen3-1.7B** (~83s) and
  **Qwen3-8B** (~82s, `bit_wise/logprob_diff/max` 0.39).
- Multi-host (4x H200): **Qwen3-32B**, 8 prompts x 8 samples, binary R2E reward,
  24 training steps. Pass rate trends up across the run -- by thirds
  **1.66% -> 2.73% -> 3.71%** (highest single step 8.6%, 11/128 solved), solving
  tasks across scrapy / pillow / numpy / orange3 / datalad. The signal is real but
  sparse (binary reward at ~2-3% pass leaves only ~1-2 of 16 GRPO groups per step
  with within-group variance) -- `grading.py` has an opt-in dense per-test-fraction
  reward (`SWE_REWARD_DENSE`) to densify it.

`pre-commit` clean. 30B-A3B fits one host (FSDP-4 bf16 trainer + TP4/EP4 generator)
but MoE breaks vLLM cudagraph capture, so the generator runs eager -- practical 30B
needs the MoE-cudagraph fix or multi-host; the config is included for that follow-up.

## Run

```bash
DAYTONA_API_KEY=dtn_... CONFIG=rl_grpo_qwen3_1_7b_swe_r2e \
  PROMPT_DATA=/path/to/r2e.jsonl HF_ASSETS_PATH=/path/to/Qwen3-1.7B \
  bash torchtitan/experiments/rl/examples/swe_r2e/run_swe_r2e_daytona.sh
```

The Claude Code binary is downloaded inside the sandbox from its CDN (override via
`SWE_CLAUDE_CDN`), so no host toolchain is needed. See `examples/swe_r2e/README.md`
for prereqs and knobs.

## Status

Draft / experiment. Proves the pipeline end to end and shows a real (if sparse)
upward reward trend at 32B; small models score ~reward 0 on one-shot R2E (zero
advantage). Meaningful reward needs a bigger model + larger context + many steps
(and/or the dense reward).
