### PR TITLE
Raise GPT-OSS Dynamo recompile limit

### DIFF
--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from functools import partial
 
 import torch
-import torch._dynamo
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
@@ -192,19 +191,6 @@ class VLLMModelWrapper(Module):
         # Build model on meta device to avoid allocating full model on every GPU
         with torch.device("meta"):
             self.model = self.config.build()
-
-        # With TP, collectives may return AsyncCollectiveTensor (overlap
-        # path) or plain Tensor (sync path) depending on timing.  Dynamo
-        # specializes on tensor type, so each switch triggers a
-        # recompile.  Because of this, the default recompile_limit (8) is
-        # too low; exceeding it fails under
-        # fullgraph=True so set to 10 for now and bump to 12 for sliding window
-        has_sliding_window = any(
-            getattr(layer_cfg.attention, "sliding_window_size", None) is not None
-            for layer_cfg in model_config.layers
-        )
-        if compile_config.enable:
-            torch._dynamo.config.recompile_limit = 12 if has_sliding_window else 10
 
         self.model = self.parallelize_fn(
             model=self.model,

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -79,7 +79,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_moe_debug_varlen",
+                    "--config rl_grpo_gpt_oss_debug_varlen",
                     "--num_steps 5",
                     "--hf_assets_path tests/assets/tokenizer",
                     "--trainer.parallelism.tensor_parallel_degree 4",
@@ -101,7 +101,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--metrics.no-enable-wandb",
                 ],
             ],
-            "RL GRPO MoE TP=4 EP=4",
+            "RL GRPO GPT-OSS MoE varlen TP=4 EP=4",
             "rl_grpo_moe_debug_tp4_ep4",
             ngpu=8,
         ),

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -4,12 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch._dynamo
+
 from torchtitan.config import (
     CompileConfig,
     ParallelismConfig,
     TORCH_DTYPE_MAP,
     TrainingConfig,
 )
+
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
 from torchtitan.distributed.compile import apply_compile
@@ -21,6 +24,36 @@ from torchtitan.distributed.full_dtensor import (
     validate_config,
 )
 from torchtitan.models.gpt_oss.model import GptOssModel
+
+
+def _raise_dynamo_recompile_limit(
+    model: GptOssModel,
+) -> None:
+    # TP/EP sharding can compile a block before every DTensor local tensor has
+    # resolved from AsyncCollectiveTensor to a plain Tensor. Dynamo specializes
+    # on both states, and fullgraph=True turns the recompile cap into a hard
+    # failure instead of falling back. GPT-OSS needs a slightly higher cap
+    # because it alternates sliding-window and full-attention layers.
+    # TODO: remove once https://github.com/pytorch/pytorch/issues/187073 is fixed
+    min_recompile_limit = 12 if _has_sliding_window_attention(model) else 10
+    # PyTorch types this config as Literal[8], but runtime accepts larger ints.
+    # pyrefly: ignore [bad-assignment]
+    torch._dynamo.config.recompile_limit = max(
+        torch._dynamo.config.recompile_limit,
+        min_recompile_limit,
+    )
+
+
+def _has_sliding_window_attention(model: GptOssModel) -> bool:
+    for module in model.modules():
+        window_size = getattr(module, "window_size", None)
+        if (
+            isinstance(window_size, (tuple, list))
+            and len(window_size) > 0
+            and window_size[0] != -1
+        ):
+            return True
+    return False
 
 
 def parallelize_gptoss(
@@ -65,6 +98,8 @@ def parallelize_gptoss(
 
     # turn on per-TransformerBlock compile after AC wrapping and before FSDP
     if model_compile_enabled:
+        if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+            _raise_dynamo_recompile_limit(model)
         apply_compile(model, compile_config)
 
     # Skip FSDP wrapper for inference. FSDP's forward hooks


### PR DESCRIPTION
Fixes the gpt-oss FSDP+TP+EP+compile integration test with newer PyTorch.

GPT-OSS TP/EP compile can specialize on AsyncCollectiveTensor vs Tensor states, and sliding-window attention adds extra variants. Raise Dynamo's recompile limit locally for this path so fullgraph compile does not fail before all expected variants are cached.

The underlying Dynamo caching issue is tracked at https://github.com/pytorch/pytorch/issues/187073.