### PR TITLE
Exclude ROCm from has_cuda_capability

### DIFF
--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -164,6 +164,12 @@ class RLTrainer(Configurable):
                     )
 
             if self.trainer.debug.batch_invariant:
+                if torch.version.hip is not None:
+                    raise ValueError(
+                        "batch_invariant mode is not supported on ROCm: the varlen "
+                        "attention path cannot force num_splits=1 (rejected by ROCm), "
+                        "so split-k reductions are non-deterministic."
+                    )
                 if not self.trainer.debug.deterministic:
                     raise ValueError("batch_invariant requires deterministic=True")
                 # TODO: Replace trainer dtype constraint to use mixed

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -149,8 +149,11 @@ class VarlenAttention(Module):
         # returns None when FA2 is the implicit default (SM < 9.0).
         # For FA3, only force num_splits=1 in batch-invariant mode
         # to prevent non-deterministic split-k reductions.
+        # ROCm's _flash_attention_forward rejects num_splits entirely.
         fa_impl = current_flash_attention_impl()
-        if fa_impl in (None, "FA2") or is_in_batch_invariant_mode():
+        if (
+            fa_impl in (None, "FA2") or is_in_batch_invariant_mode()
+        ) and torch.version.hip is None:
             varlen_kwargs["num_splits"] = 1
 
         # Forward enable_gqa from GQAttention when Q and KV head counts differ

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -24,9 +24,13 @@ def round_up(value: int, multiple: int) -> int:
 
 
 def has_cuda_capability(major: int, minor: int) -> bool:
-    return torch.cuda.is_available() and torch.cuda.get_device_capability() >= (
-        major,
-        minor,
+    # ponytail: torch.version.hip is None excludes ROCm — get_device_capability()
+    # returns a tuple on AMD too, so without this NVIDIA-only gates (e.g. FA3,
+    # SM89 fp8) wrongly fire on ROCm. Mirrors has_rocm_capability below.
+    return (
+        torch.cuda.is_available()
+        and torch.version.hip is None
+        and torch.cuda.get_device_capability() >= (major, minor)
     )
 
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -24,9 +24,7 @@ def round_up(value: int, multiple: int) -> int:
 
 
 def has_cuda_capability(major: int, minor: int) -> bool:
-    # ponytail: torch.version.hip is None excludes ROCm — get_device_capability()
-    # returns a tuple on AMD too, so without this NVIDIA-only gates (e.g. FA3,
-    # SM89 fp8) wrongly fire on ROCm. Mirrors has_rocm_capability below.
+    # torch.version.hip is None excludes ROCm (capability is a tuple on AMD too).
     return (
         torch.cuda.is_available()
         and torch.version.hip is None


### PR DESCRIPTION
## Problem

The **8 GPU Model Tests** ROCm leg (gpt_oss flavor) crashes at model
construction with:

```
ModuleNotFoundError: No module named 'flash_attn_interface'
```

Root cause: `has_cuda_capability(major, minor)` returns True on AMD GPUs.
`torch.cuda.is_available()` is True under ROCm, and
`torch.cuda.get_device_capability()` returns a tuple on AMD too, so a card
like gfx950 reporting `(9, 5)` satisfies `has_cuda_capability(9, 0)` and
NVIDIA-only gates fire on ROCm. The most visible one is the SM 9.0 FA3 path in
`VarlenAttention.__init__`:

```python
# Hopper (SM 9.0) uses FA3
if has_cuda_capability(9, 0):
    if current_flash_attention_impl() != "FA3":
        activate_flash_attention_impl("FA3")
```

`activate_flash_attention_impl("FA3")` imports `flash_attn_interface` (the
Hopper-only FA3 package — no ROCm build). FA3 was never reachable on ROCm; it
only entered due to the capability mis-detection.

## Fix

Two correct, self-contained ROCm bugs are addressed here:

1. **`tools/utils.py`** — add a `torch.version.hip is None` guard so
   `has_cuda_capability` means "real NVIDIA CUDA", mirroring the existing
   `has_rocm_capability` sibling. On ROCm the FA3 gate is skipped and attention
   falls back to the FA2/default varlen path. NVIDIA behavior is unchanged.
   This also fixes the same latent mis-detection for other NVIDIA-only gates
   that use this helper (fp8 SM89, MXFP SM100, flex-flash).

2. **`models/common/attention.py`** — the FA2/default path (now reached on
   ROCm for the first time) forces `num_splits=1` as a workaround for a
   CUDA-only FA2 NaN bug (pytorch/pytorch#179760). ROCm's
   `aten._flash_attention_forward` rejects the `num_splits` argument outright:

   ```
   RuntimeError: num_splits is not supported on ROCm
   ```

   Gate the workaround on `torch.version.hip is None` so ROCm never passes it.

## Scope

- [x] Construction-time FA3 crash removed (fix 1, deterministic).
- [x] `num_splits` rejection on the ROCm varlen forward removed (fix 2).

Both fixes are NVIDIA-no-op (guarded on `torch.version.hip is None`) and
unblock the ROCm varlen path generally — not just gpt_oss.

## Known follow-up (out of scope, upstream)

With the above, the gpt_oss attention-sink flavor gets further on ROCm but then
hits a **separate upstream bug**: ROCm's varlen `aten._flash_attention_forward`
returns the LSE in a per-sequence padded layout `(num_seqs, N, max_seqlen)`
instead of the packed `(N, total_q)` that CUDA returns and that the attention
sink-rescale path expects. That is a PyTorch ROCm-backend contract divergence,
not a torchtitan issue, and is tracked at **pytorch/pytorch#187872**. It is
intentionally not worked around here.