### PR TITLE
Make generator actor aware of DP rank layout

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -459,6 +459,29 @@ class VLLMGenerator(Actor, Configurable):
             asyncio.Condition()
         )  # Signals to wake up when there is work
 
+        # --- Data-parallel rank layout ---
+        # Number of DP groups (vLLM pure DP degree); 1 disables data parallelism.
+        self._dp_degree = config.parallelism.data_parallel_degree
+        # Ranks per DP group: the TP (and any EP) ranks that share one DP replica.
+        ranks_per_dp = dist.get_world_size() // self._dp_degree
+        # Which DP group this rank belongs to (== vLLM's data_parallel_rank).
+        self._dp_group_idx = self._rank // ranks_per_dp
+        # Whether this rank is its group's TP-leader (the lowest rank in the group).
+        self._is_dp_master = self._rank % ranks_per_dp == 0
+
+        # Confirm the layout calculated above matches vLLM's
+        vllm_parallel_config = self._engine.vllm_config.parallel_config
+        assert vllm_parallel_config.data_parallel_size == self._dp_degree, (
+            f"DP layout mismatch on rank {self._rank}: our dp_size "
+            f"({self._dp_degree}) != vLLM data_parallel_size "
+            f"({vllm_parallel_config.data_parallel_size})"
+        )
+        assert vllm_parallel_config.data_parallel_rank == self._dp_group_idx, (
+            f"DP layout mismatch on rank {self._rank}: our dp_group_idx "
+            f"({self._dp_group_idx}) != vLLM data_parallel_rank "
+            f"({vllm_parallel_config.data_parallel_rank})"
+        )
+
         # Engine-loop INBOX (rank 0): requests the controller submits; the loop reads them to decide.
         self._queued_generation_requests: list[GenerationRequest] = []
         self._model_state_dict_pull_request: ModelStateDictPullRequest | None = None
@@ -632,18 +655,21 @@ class VLLMGenerator(Actor, Configurable):
                     continue  # back to the start for the next decision
 
                 if decision.action is LoopAction.STEP:
-                    # Add any newly-queued requests; all ranks add the identical set in FCFS order.
-                    if decision.requests:
+                    # Admit only this rank's DP-group slice. TP ranks in the same group
+                    # computes the same _dp_group_idx, so they add the identical set in
+                    # the same FCFS order.
+                    my_requests = decision.requests_by_dp[self._dp_group_idx]
+                    if my_requests:
                         # render_cmpl is vLLM's input pipeline (tokenize is a no-op for tokenized prompts);
                         # the high-level entry stays resilient to vLLM internals vs vllm.inputs.tokens_input.
                         engine_inputs = self._engine.renderer.render_cmpl(
                             [
                                 {"prompt_token_ids": request.prompt_token_ids}
-                                for request in decision.requests
+                                for request in my_requests
                             ]
                         )
                         for request, engine_input in zip(
-                            decision.requests, engine_inputs, strict=True
+                            my_requests, engine_inputs, strict=True
                         ):
                             self._engine.add_request(
                                 request_id=request.request_id,
@@ -684,22 +710,28 @@ class VLLMGenerator(Actor, Configurable):
             )
 
             if self._close_request is not None:
-                return LoopDecision(action=LoopAction.CLOSE, requests=[])
+                return LoopDecision(action=LoopAction.CLOSE, requests_by_dp=[])
 
             # A weight pull takes priority over admitting new requests.
             if self._model_state_dict_pull_request is not None:
                 return LoopDecision(
                     action=LoopAction.PULL_MODEL_STATE_DICT,
-                    requests=[],
+                    requests_by_dp=[],
                     pull_version=self._model_state_dict_pull_request.version,
                 )
 
             # STEP: admit whatever is queued (may be empty -> just keep stepping in-flight work).
-            requests, self._queued_generation_requests = (
+            queued, self._queued_generation_requests = (
                 self._queued_generation_requests,
                 [],
             )
-            return LoopDecision(action=LoopAction.STEP, requests=requests)
+            # TODO: route across DP groups via a routing strategy. For now all
+            # requests go to DP group 0.
+            requests_by_dp: list[list[GenerationRequest]] = [
+                [] for _ in range(self._dp_degree)
+            ]
+            requests_by_dp[0] = queued
+            return LoopDecision(action=LoopAction.STEP, requests_by_dp=requests_by_dp)
 
     def _process_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
         """RANK 0: resolve each finished request's future with its `Completion` (metrics included)."""
@@ -955,8 +987,10 @@ class LoopDecision:
 
     action: LoopAction
 
-    requests: list[GenerationRequest] | None = None
-    # requests to admit before a STEP burst (empty unless any queued)
+    requests_by_dp: list[list[GenerationRequest]] | None = None
+    # per-DP-group requests to admit before a STEP burst; index == DP group, fixed
+    # length data_parallel_degree. Each rank admits only its own group's slice.
+    # (empty unless any queued)
 
     pull_version: int | None = None
     # set iff action is PULL_MODEL_STATE_DICT

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -460,14 +460,12 @@ class VLLMGenerator(Actor, Configurable):
         )  # Signals to wake up when there is work
 
         # --- Data-parallel rank layout ---
-        # Number of DP groups (vLLM pure DP degree); 1 disables data parallelism.
+        # Number of vLLM DP ranks; 1 disables data parallelism.
         self._dp_degree = config.parallelism.data_parallel_degree
-        # Ranks per DP group: the TP (and any EP) ranks that share one DP replica.
-        ranks_per_dp = dist.get_world_size() // self._dp_degree
-        # Which DP group this rank belongs to (== vLLM's data_parallel_rank).
-        self._dp_group_idx = self._rank // ranks_per_dp
-        # Whether this rank is its group's TP-leader (the lowest rank in the group).
-        self._is_dp_master = self._rank % ranks_per_dp == 0
+        # Number of ranks per DP rank.
+        ranks_per_dp = config.parallelism.tensor_parallel_degree
+        # Which DP replica this rank belongs to (== vLLM's data_parallel_rank).
+        self._dp_rank = self._rank // ranks_per_dp
 
         # Confirm the layout calculated above matches vLLM's
         vllm_parallel_config = self._engine.vllm_config.parallel_config
@@ -476,9 +474,9 @@ class VLLMGenerator(Actor, Configurable):
             f"({self._dp_degree}) != vLLM data_parallel_size "
             f"({vllm_parallel_config.data_parallel_size})"
         )
-        assert vllm_parallel_config.data_parallel_rank == self._dp_group_idx, (
-            f"DP layout mismatch on rank {self._rank}: our dp_group_idx "
-            f"({self._dp_group_idx}) != vLLM data_parallel_rank "
+        assert vllm_parallel_config.data_parallel_rank == self._dp_rank, (
+            f"DP layout mismatch on rank {self._rank}: our dp_rank "
+            f"({self._dp_rank}) != vLLM data_parallel_rank "
             f"({vllm_parallel_config.data_parallel_rank})"
         )
 
@@ -655,21 +653,21 @@ class VLLMGenerator(Actor, Configurable):
                     continue  # back to the start for the next decision
 
                 if decision.action is LoopAction.STEP:
-                    # Admit only this rank's DP-group slice. TP ranks in the same group
-                    # computes the same _dp_group_idx, so they add the identical set in
-                    # the same FCFS order.
-                    my_requests = decision.requests_by_dp[self._dp_group_idx]
-                    if my_requests:
+                    # Admit only this rank's DP replica slice. TP ranks in the same
+                    # replica compute the same _dp_rank, so they add the identical
+                    # set in the same FCFS order.
+                    local_requests = decision.requests_per_dp_rank[self._dp_rank]
+                    if local_requests:
                         # render_cmpl is vLLM's input pipeline (tokenize is a no-op for tokenized prompts);
                         # the high-level entry stays resilient to vLLM internals vs vllm.inputs.tokens_input.
                         engine_inputs = self._engine.renderer.render_cmpl(
                             [
                                 {"prompt_token_ids": request.prompt_token_ids}
-                                for request in my_requests
+                                for request in local_requests
                             ]
                         )
                         for request, engine_input in zip(
-                            my_requests, engine_inputs, strict=True
+                            local_requests, engine_inputs, strict=True
                         ):
                             self._engine.add_request(
                                 request_id=request.request_id,
@@ -710,13 +708,13 @@ class VLLMGenerator(Actor, Configurable):
             )
 
             if self._close_request is not None:
-                return LoopDecision(action=LoopAction.CLOSE, requests_by_dp=[])
+                return LoopDecision(action=LoopAction.CLOSE, requests_per_dp_rank=[])
 
             # A weight pull takes priority over admitting new requests.
             if self._model_state_dict_pull_request is not None:
                 return LoopDecision(
                     action=LoopAction.PULL_MODEL_STATE_DICT,
-                    requests_by_dp=[],
+                    requests_per_dp_rank=[],
                     pull_version=self._model_state_dict_pull_request.version,
                 )
 
@@ -725,13 +723,16 @@ class VLLMGenerator(Actor, Configurable):
                 self._queued_generation_requests,
                 [],
             )
-            # TODO: route across DP groups via a routing strategy. For now all
-            # requests go to DP group 0.
-            requests_by_dp: list[list[GenerationRequest]] = [
+            # TODO: route across DP ranks via a routing strategy. For now all
+            # requests go to DP rank 0.
+            requests_per_dp_rank: list[list[GenerationRequest]] = [
                 [] for _ in range(self._dp_degree)
             ]
-            requests_by_dp[0] = queued
-            return LoopDecision(action=LoopAction.STEP, requests_by_dp=requests_by_dp)
+            requests_per_dp_rank[0] = queued
+            return LoopDecision(
+                action=LoopAction.STEP,
+                requests_per_dp_rank=requests_per_dp_rank,
+            )
 
     def _process_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
         """RANK 0: resolve each finished request's future with its `Completion` (metrics included)."""
@@ -987,9 +988,9 @@ class LoopDecision:
 
     action: LoopAction
 
-    requests_by_dp: list[list[GenerationRequest]] | None = None
-    # per-DP-group requests to admit before a STEP burst; index == DP group, fixed
-    # length data_parallel_degree. Each rank admits only its own group's slice.
+    requests_per_dp_rank: list[list[GenerationRequest]] | None = None
+    # Per-DP-rank requests to admit before a STEP burst; index == DP rank, fixed
+    # length data_parallel_degree. Each rank admits only its own DP-rank slice.
     # (empty unless any queued)
 
     pull_version: int | None = None

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -85,21 +85,23 @@ def test_step_drains_the_queue() -> None:
     request = _request()
     generator = _bare_generator(pending=[request])
     decision = asyncio.run(generator._decide_next_action())
-    # DP=1: a single group holds the whole batch.
-    assert decision.action is LoopAction.STEP and decision.requests_by_dp == [[request]]
+    # DP=1: a single DP rank holds the whole batch.
+    assert decision.action is LoopAction.STEP and decision.requests_per_dp_rank == [
+        [request]
+    ]
     assert generator._queued_generation_requests == []  # drained into the decision
 
 
 def test_step_with_empty_queue_when_only_in_flight_work_remains() -> None:
     # No queue, no pull, but the engine still has in-flight requests to step.
     decision = asyncio.run(_bare_generator(unfinished=True)._decide_next_action())
-    assert decision.action is LoopAction.STEP and decision.requests_by_dp == [[]]
+    assert decision.action is LoopAction.STEP and decision.requests_per_dp_rank == [[]]
 
 
 def test_step_routes_all_requests_to_dp0_for_now() -> None:
-    # Hardcoded routing: every queued request lands in group 0; other groups empty.
+    # Hardcoded routing: every queued request lands on DP rank 0; other ranks empty.
     requests = [_request("r0"), _request("r1")]
     generator = _bare_generator(pending=requests, dp_size=3)
     decision = asyncio.run(generator._decide_next_action())
     assert decision.action is LoopAction.STEP
-    assert decision.requests_by_dp == [requests, [], []]
+    assert decision.requests_per_dp_rank == [requests, [], []]

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -38,6 +38,7 @@ def _bare_generator(
     model_state_dict_pull_request: ModelStateDictPullRequest | None = None,
     pending: list[GenerationRequest] | None = None,
     unfinished: bool = False,
+    dp_size: int = 1,
 ) -> VLLMGenerator:
     # Bypass __init__ (which builds the vLLM engine); set only the loop's state.
     generator = object.__new__(VLLMGenerator)
@@ -46,12 +47,13 @@ def _bare_generator(
     generator._model_state_dict_pull_request = model_state_dict_pull_request
     generator._queued_generation_requests = pending or []
     generator._engine = _FakeEngine(unfinished=unfinished)
+    generator._dp_degree = dp_size
     return generator
 
 
-def _request() -> GenerationRequest:
+def _request(request_id: str = "r0") -> GenerationRequest:
     return GenerationRequest(
-        request_id="r0",
+        request_id=request_id,
         prompt_token_ids=[1, 2],
         sampling=SamplingConfig(),
     )
@@ -83,11 +85,21 @@ def test_step_drains_the_queue() -> None:
     request = _request()
     generator = _bare_generator(pending=[request])
     decision = asyncio.run(generator._decide_next_action())
-    assert decision.action is LoopAction.STEP and decision.requests == [request]
+    # DP=1: a single group holds the whole batch.
+    assert decision.action is LoopAction.STEP and decision.requests_by_dp == [[request]]
     assert generator._queued_generation_requests == []  # drained into the decision
 
 
 def test_step_with_empty_queue_when_only_in_flight_work_remains() -> None:
     # No queue, no pull, but the engine still has in-flight requests to step.
     decision = asyncio.run(_bare_generator(unfinished=True)._decide_next_action())
-    assert decision.action is LoopAction.STEP and decision.requests == []
+    assert decision.action is LoopAction.STEP and decision.requests_by_dp == [[]]
+
+
+def test_step_routes_all_requests_to_dp0_for_now() -> None:
+    # Hardcoded routing: every queued request lands in group 0; other groups empty.
+    requests = [_request("r0"), _request("r1")]
+    generator = _bare_generator(pending=requests, dp_size=3)
+    decision = asyncio.run(generator._decide_next_action())
+    assert decision.action is LoopAction.STEP
+    assert decision.requests_by_dp == [requests, [], []]


### PR DESCRIPTION
Currently when generator's `data_parallel_degree > 1`, generator will simply send the same requests to all DP ranks to process, but only use the results from DP rank 0, and discard the results from other DP ranks. This PR changes that.

Specifically, it:
* make each generator actor aware of its DP rank layout. 
* when rank 0 makes `LoopDecision`, it will assign requests by DP ranks in its `requests_per_dp_rank` field. And actors will only process requests belong to its own DP rank.
* *For now*, rank 0 will assign all requests to DP rank 0. This will enable us to test whether our vllm integration supports splitting request among DP ranks.
  * In a future PR, will replace the "hardcode DP rank 0" with a routing logic. 

When testing this PR, I encountered a vllm bug in its v2 model runner. Specifically,
* the bug was fixed in its v1 runner in https://github.com/vllm-project/vllm/pull/28774
* But the same fix was not applied in the v2 runner.

So we have this disvergence:
* v1: V1 has [the fix](https://github.com/vllm-project/vllm/blob/40e552212126717cf59dd493c2057dfdd5a1259e/vllm/v1/worker/gpu_model_runner.py#L4120) 
* v2 does not have it. Instead it returns [early in v2 for zero token](https://github.com/vllm-project/vllm/blob/40e552212126717cf59dd493c2057dfdd5a1259e/vllm/v1/worker/gpu/model_runner.py#L1120).

To workaround, I switched the MOE model config to v1 runner. This PR also adds a field `use_v2_model_runner` to `VLLMGenerator.Config` to make the switch possible.

### What does the bug break

Let us assume we have DP=2, TP=2, EP=4. The change of this PR will route all requests to DP0, which leads to a busy DP0, and idle DP1.

vllm has logic in place to accommodate the idle DP problem. In `def has_unfinished_requests`, when DP > 1, it [does a all-reduce](https://github.com/vllm-project/vllm/blob/main/vllm/config/parallel.py#L694) to check if any rank still has unfinished requests, if yes, the idle rank will [execute a dummy batch](https://github.com/vllm-project/vllm/blob/11b56b2ff28eae32a1e65c051c24b50f3c39e03d/vllm/v1/engine/llm_engine.py#L197). Executing the dummy batch means the idle DP rank will enters the collective in `step()`.

Normally, the busy rank, i.e. DP0 should also enters the collective in `step()`. That is the whole point of the dummy batch. However, when DP0's `total_num_scheduled_tokens == 0`, in v2 runner, DP0 will return early, without entering the collective. That makes DP1's `step()` not having a pair from DP0. Furthermore, DP0 will move to its next iteration, which it will issue a different collective. DP0 and DP1's collective will collide, and we will see error like:

```
terminate called after throwing an instance of 'gloo::EnforceNotMet'
  what():  [enforce fail at /__w/pytorch/pytorch/third_party/gloo/gloo/transport/tcp/pair.cc:464] op.preamble.length <= op.nbytes. 8 vs 4. Received data size doesn't match expected size. Is there a distributed collective mismatch in your code?
```

## Test plan

Note: the trunk is broken for the MOE configs. I had to patch locally with [this change](https://github.com/pytorch/torchtitan/commit/57eb339ed4eba5ec21e2dcfa22f4f4265a6ae94d) to workaround.

Run the `rl_grpo_qwen3_30b_a3b_varlen` config locally to verify it still works.

