### PR TITLE
[rl] Add a SLURM launcher for multi-node RL

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -86,31 +86,31 @@ We use a unified model definition from torchtitan for the trainer and generator,
 ## Multi-node on SLURM
 
 For configurations whose total GPU footprint exceeds a single node (e.g.
-`rl_grpo_qwen3_14b`: trainer TP=8 + generator TP=8 = 16 GPUs), run the
-controller from a login node and let Monarch's `SlurmJob` submit the worker
-allocation:
+`rl_grpo_qwen3_14b`: trainer TP=8 + generator TP=8 = 16 GPUs), invoke the
+`slurm_launcher` entry point and let it submit one sbatch covering the trainer
+plus one mesh per generator on disjoint nodes:
 
 ```bash
-RL_LAUNCHER=slurm \
-RL_SLURM_PARTITION=<partition> \
+RL_SLURM_PARTITION=h100 \
 RL_SLURM_GPUS_PER_NODE=8 \
 RL_SLURM_TIME=02:00:00 \
-RL_SLURM_QOS=<qos>          # optional, passed as #SBATCH --qos=...
-RL_SLURM_ACCOUNT=<account>  # optional, passed as #SBATCH --account=...
-python -m torchtitan.experiments.rl.train \
+RL_SLURM_QOS=h100_dev \
+RL_SLURM_ACCOUNT=pytorch \
+python -m torchtitan.experiments.rl.slurm_launcher \
     --module rl --config rl_grpo_qwen3_14b
 ```
 
-`train.py` constructs `SlurmJob(meshes={"trainer": N, "generator": M}, ...)`,
-which submits a single sbatch covering both meshes, waits for the
-allocation to start, and returns the `HostMesh` objects ready to spawn the
-trainer/generator proc meshes onto. Trainer and generator land on disjoint
-nodes; both world sizes must be divisible by `RL_SLURM_GPUS_PER_NODE`.
+Every world size must be divisible by `RL_SLURM_GPUS_PER_NODE`. `RL_SLURM_QOS`
+and `RL_SLURM_ACCOUNT` are optional, passed through as `#SBATCH --qos=...` /
+`--account=...`; substitute values for your cluster.
 
-For single-node runs on SLURM, omit `RL_LAUNCHER` and use a standard
-allocation (`salloc` or `sbatch --wrap "python -m ..."`); the in-process
-`this_host()` path partitions GPUs between trainer and generator without
-needing a launcher.
+Add `RL_SLURM_BATCH=1` to detach: the same command then submits an sbatch that
+runs both the workers and the controller (via `sbatch --wrap`), and the
+login-node process exits as soon as submission completes.
+
+For single-node SLURM runs, invoke `train` directly inside a standard
+allocation (`salloc` or `sbatch --wrap "python -m ..."`); `this_host()`
+partitions GPUs between trainer and generator with no launcher involved.
 
 ## Reproducibility
 

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -83,6 +83,35 @@ python -m torchtitan.experiments.rl.train --module alphabet_sort --config rl_grp
 
 We use a unified model definition from torchtitan for the trainer and generator, ensuring bitwise-identical models to address a class of subtle correctness bugs in RL for LLMs.
 
+## Multi-node on SLURM
+
+For configurations whose total GPU footprint exceeds a single node (e.g.
+`rl_grpo_qwen3_14b`: trainer TP=8 + generator TP=8 = 16 GPUs), run the
+controller from a login node and let Monarch's `SlurmJob` submit the worker
+allocation:
+
+```bash
+RL_LAUNCHER=slurm \
+RL_SLURM_PARTITION=<partition> \
+RL_SLURM_GPUS_PER_NODE=8 \
+RL_SLURM_TIME=02:00:00 \
+RL_SLURM_QOS=<qos>          # optional, passed as #SBATCH --qos=...
+RL_SLURM_ACCOUNT=<account>  # optional, passed as #SBATCH --account=...
+python -m torchtitan.experiments.rl.train \
+    --module rl --config rl_grpo_qwen3_14b
+```
+
+`train.py` constructs `SlurmJob(meshes={"trainer": N, "generator": M}, ...)`,
+which submits a single sbatch covering both meshes, waits for the
+allocation to start, and returns the `HostMesh` objects ready to spawn the
+trainer/generator proc meshes onto. Trainer and generator land on disjoint
+nodes; both world sizes must be divisible by `RL_SLURM_GPUS_PER_NODE`.
+
+For single-node runs on SLURM, omit `RL_LAUNCHER` and use a standard
+allocation (`salloc` or `sbatch --wrap "python -m ..."`); the in-process
+`this_host()` path partitions GPUs between trainer and generator without
+needing a launcher.
+
 ## Reproducibility
 
 We provide two independent tools for debugging and reproducibility. They address different sources of non-determinism and can be used separately or together.

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -86,6 +86,23 @@ python -m torchtitan.experiments.rl.train --module alphabet_sort --config rl_grp
 
 We use a unified model definition from torchtitan for the trainer and generator, ensuring bitwise-identical models to address a class of subtle correctness bugs in RL for LLMs.
 
+## Multi-node on SLURM
+
+Configurations whose total GPU footprint exceeds a single node (e.g.
+`rl_grpo_qwen3_14b`: trainer TP=8 + generator TP=8 = 16 GPUs) run through the
+`slurm_launcher` entry point, which submits one sbatch covering the trainer plus
+one mesh per generator on disjoint nodes:
+
+```bash
+RL_SLURM_PARTITION=h100 RL_SLURM_GPUS_PER_NODE=8 \
+python -m torchtitan.experiments.rl.slurm_launcher \
+    --module alphabet_sort --config rl_grpo_qwen3_14b
+```
+
+See [docs/multinode_slurm.md](docs/multinode_slurm.md) for the rest of the
+`RL_SLURM_*` variables, which process the controller runs in (`RL_SLURM_BATCH`),
+and where the logs land.
+
 ## Reproducibility
 
 We provide two independent tools for debugging and reproducibility. They address different sources of non-determinism and can be used separately or together.

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -19,7 +19,15 @@ import cloudpickle
 import torch
 import torch.distributed as dist
 import torchstore as ts
-from monarch.actor import Actor, Channel, current_rank, endpoint, Port, PortReceiver
+from monarch.actor import (
+    Actor,
+    Channel,
+    concurrent_endpoint,
+    current_rank,
+    endpoint,
+    Port,
+    PortReceiver,
+)
 from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import CompileConfig, Configurable, DebugConfig, OverrideConfig
@@ -957,7 +965,11 @@ class VLLMGenerator(Actor, Configurable):
                 f"before {endpoint_name}"
             )
 
-    @endpoint
+    # Concurrent, not a plain `@endpoint`: this body awaits `generation_future` to
+    # completion, and a plain endpoint holds the actor's message-dispatch loop for
+    # its whole duration. That pins the engine to one in-flight request no matter
+    # how many the controller fans out -- vLLM reports "Running: 1 reqs" forever.
+    @concurrent_endpoint
     @sl.log_trace_span("generate")
     async def generate(
         self,
@@ -1189,6 +1201,12 @@ class VLLMGenerator(Actor, Configurable):
             output_kind=RequestOutputKind.FINAL_ONLY,
         )
 
+    # Deliberately a plain `@endpoint`, unlike `generate`. `_model_state_dict_pull_request`
+    # and `_pull_model_state_dict_future` below are single-slot, so two overlapping pulls
+    # would clobber each other: the second overwrites the first's future, the engine loop
+    # then resolves the survivor with the wrong version and the clobbered caller never
+    # wakes. Serial dispatch is what currently makes that unreachable. Fix the single-slot
+    # handoff (see the TODO below) before making this concurrent.
     @endpoint
     @sl.log_trace_span("pull_model_state_dict")
     async def pull_model_state_dict(self, version: int) -> None:

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import torch
 import torchstore as ts
-from monarch.actor import Actor, current_rank, endpoint
+from monarch.actor import Actor, concurrent_endpoint, current_rank, endpoint
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.checkpoint_utils import canonical_fqn
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper
@@ -489,7 +489,11 @@ class PolicyTrainer(Actor, Configurable):
         """
         return self.checkpointer.save(step, last_step=last_step)
 
-    @endpoint
+    # Concurrent, not a plain `@endpoint`: the controller fires this in the background
+    # specifically so the weight handoff overlaps the next training step. A plain
+    # endpoint holds the dispatch loop for the whole push, which serializes it against
+    # the next `forward_backward` and cancels that overlap.
+    @concurrent_endpoint
     @sl.log_trace_span("push_model_state_dict")
     async def push_model_state_dict(self) -> None:
         """Stage model weights to a CPU StorageVolume for the generators to pull (TorchStore).

--- a/torchtitan/experiments/rl/docs/multinode_slurm.md
+++ b/torchtitan/experiments/rl/docs/multinode_slurm.md
@@ -1,0 +1,84 @@
+# Multi-node RL on SLURM
+
+This document covers running the RL loop across more than one node with the
+`slurm_launcher` entry point: the environment variables it reads, which process
+the controller runs in, and where the logs land. For the minimal invocation, see
+the "Multi-node on SLURM" section of `torchtitan/experiments/rl/README.md`.
+
+## Submitting a job
+
+For configurations whose total GPU footprint exceeds a single node (e.g.
+`rl_grpo_qwen3_14b`: trainer TP=8 + generator TP=8 = 16 GPUs), invoke the
+`slurm_launcher` entry point and let it submit one sbatch covering the trainer
+plus one mesh per generator on disjoint nodes:
+
+```bash
+RL_SLURM_PARTITION=h100 \
+RL_SLURM_GPUS_PER_NODE=8 \
+RL_SLURM_TIME=02:00:00 \
+RL_SLURM_QOS=h100_dev \
+RL_SLURM_ACCOUNT=pytorch \
+python -m torchtitan.experiments.rl.slurm_launcher \
+    --module alphabet_sort --config rl_grpo_qwen3_14b
+```
+
+Every world size must be divisible by `RL_SLURM_GPUS_PER_NODE`. `RL_SLURM_QOS`
+and `RL_SLURM_ACCOUNT` are optional, passed through as `#SBATCH --qos=...` /
+`--account=...`; substitute values for your cluster.
+
+Add `RL_SLURM_BATCH=1` to detach: the login-node process then exits as soon as
+the sbatch is in, and the controller runs inside the allocation instead. See
+[Where the controller runs](#where-the-controller-runs) for what moves where.
+
+For single-node SLURM runs, invoke `train` directly inside a standard
+allocation (`salloc` or `sbatch --wrap "python -m ..."`); `this_host()`
+partitions GPUs between trainer and generator with no launcher involved.
+
+## Where the controller runs
+
+The allocation only ever holds *workers*: one Monarch worker process per node,
+with nodes handed out in allocation order to `trainer` first, then
+`generator_0`, `generator_1`, ... The *controller* -- the process that parses the
+config, builds the actor meshes on those workers, and runs the training loop --
+is a separate process, and `RL_SLURM_BATCH` picks which side of the allocation it
+lives on.
+
+| | controller process | survives logout | run ends when |
+| --- | --- | --- | --- |
+| external (default) | your login-node shell | no | the controller exits, or the allocation hits its time limit |
+| `RL_SLURM_BATCH=1` | inside the allocation, on its first node | yes | the controller exits (the runner then frees the allocation) |
+
+**External controller (default).** The generated sbatch body is only
+`srun <python> -c <worker bootstrap>`. The controller is the login-node process
+you typed the command into: it submits, waits for the allocation to start,
+attaches to the workers over TCP, and drives training in the foreground. Kill it
+or drop the ssh session and the run goes with it. Logs stream to your terminal,
+which makes this the mode to iterate in.
+
+**Batch (`RL_SLURM_BATCH=1`).** The login-node process does nothing but submit.
+The sbatch body becomes `python -m monarch._src.job._slurm_batch <the same
+launcher command>`, which SLURM runs on the allocation's first node -- the same
+node the `trainer` mesh's first worker lands on. No extra node is requested for
+the controller, so it shares that node's CPU and host memory with a worker. That
+in-allocation runner:
+
+1. seeds one worker per node with `srun --ntasks-per-node=1`;
+2. re-executes your launcher command with `MONARCH_BATCH_JOB=1`, which tells
+   `slurm_launcher` to skip resubmission and reconnect to *this* allocation
+   through the `BatchJob` that the submit step cached in
+   `./.monarch/job_state.pkl`;
+3. terminates the workers in a `finally`, so the allocation is released with the
+   controller's exit status instead of lingering to its time limit.
+
+Because step 2 is a literal re-execution, the in-allocation controller inherits
+the argv, the environment (sbatch propagates the submit environment), and the
+working directory of your login-node command. Two consequences: relative paths
+such as `--hf_assets_path` must resolve from the directory you submitted from,
+and `.monarch/job_state.pkl` is resolved relative to that same directory on both
+sides -- so two concurrent batch submissions from one directory clobber each
+other's cached job. Submit them from separate directories.
+
+Worker and controller output both land in the job's stdout/stderr,
+`slurm_<jobid>_torchtitan_rl_<pid>.{out,err}`, written to the directory you
+submitted from (Monarch's `log_dir` defaults to the submitting process's cwd).
+Follow a detached run with `tail -f` on the `.out`.

--- a/torchtitan/experiments/rl/slurm_launcher.py
+++ b/torchtitan/experiments/rl/slurm_launcher.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SLURM entry point for the RL controller.
+
+Use this module's ``__main__`` instead of ``train.py`` when you want Monarch's
+``SlurmJob`` to submit the worker allocation:
+
+  python -m torchtitan.experiments.rl.slurm_launcher \\
+      --module rl --config rl_grpo_qwen3_14b
+
+Two modes are supported:
+
+- External controller (default): submit a worker allocation and drive training
+  from the calling (login-node) process.
+- Batch (``RL_SLURM_BATCH=1``): submit one allocation that runs the workers AND
+  re-runs this same command inside the allocation as the controller, then exit
+  the login-node process. The in-allocation rerun has ``MONARCH_BATCH_JOB=1``
+  set by Monarch and reconnects to the workers via the cached ``BatchJob``.
+
+Single-node and MAST runs do not use this module -- they call
+``train.run(config, host_meshes)`` directly with their own host meshes (or
+``None`` for ``this_host()``).
+"""
+
+import asyncio
+import logging
+import os
+import shlex
+import sys
+
+from monarch.job import job_load, SlurmJob
+
+from torchtitan.config import ConfigManager
+from torchtitan.experiments.rl.train import (
+    _compute_generator_world_size,
+    _compute_trainer_world_size,
+    HostMeshes,
+    run,
+)
+from torchtitan.experiments.rl.trainer import RLTrainer
+
+
+logger = logging.getLogger(__name__)
+
+
+def _generator_mesh_names(num_generators: int) -> list[str]:
+    """Host-mesh names for the generators.
+
+    Single source for the names so the side that *creates* the meshes and the
+    side that *reads them back* off the JobState cannot drift.
+    """
+    return [f"generator_{i}" for i in range(num_generators)]
+
+
+def _build_slurm_job(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> tuple[SlurmJob, int]:
+    """Build the ``SlurmJob`` spec from ``RL_SLURM_*`` env; return ``(job,
+    gpus_per_node)``.
+
+    Trainer and generators land on disjoint nodes: the trainer gets
+    ``trainer_world_size`` GPUs and each of ``num_generators`` generators gets
+    ``per_generator_world_size`` GPUs, every role occupying whole nodes (its
+    world size must be divisible by ``RL_SLURM_GPUS_PER_NODE``).
+
+    Env vars:
+      RL_SLURM_PARTITION    (required)
+      RL_SLURM_GPUS_PER_NODE (optional, default 8)
+      RL_SLURM_TIME         (optional, HH:MM:SS)
+      RL_SLURM_QOS          (optional, e.g. h100_dev)
+      RL_SLURM_ACCOUNT      (optional, e.g. pytorch)
+      RL_SLURM_CPUS_PER_TASK (optional; partition default if unset, often too small)
+      RL_SLURM_MEM          (optional; partition default if unset, often too small)
+    """
+    partition = os.environ.get("RL_SLURM_PARTITION")
+    if not partition:
+        raise ValueError(
+            "the SLURM launcher requires RL_SLURM_PARTITION to be set"
+        )
+    gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
+    time_limit = os.environ.get("RL_SLURM_TIME")  # HH:MM:SS, optional
+    qos = os.environ.get("RL_SLURM_QOS")
+    account = os.environ.get("RL_SLURM_ACCOUNT")
+    cpus_per_task_env = os.environ.get("RL_SLURM_CPUS_PER_TASK")
+    cpus_per_task = int(cpus_per_task_env) if cpus_per_task_env else None
+    mem = os.environ.get("RL_SLURM_MEM")
+
+    if trainer_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"trainer_world_size ({trainer_world_size}) must be divisible "
+            f"by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    if per_generator_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"per_generator_world_size ({per_generator_world_size}) must be "
+            f"divisible by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    trainer_nodes = trainer_world_size // gpus_per_node
+    generator_nodes = per_generator_world_size // gpus_per_node
+    meshes = {"trainer": trainer_nodes}
+    for name in _generator_mesh_names(num_generators):
+        meshes[name] = generator_nodes
+
+    # SlurmJob takes partition/time/gpus_per_node directly; anything else
+    # (qos, account, ...) goes through slurm_args, templated as `#SBATCH <arg>`
+    # lines into the generated sbatch script.
+    extra_slurm_args: list[str] = []
+    if qos:
+        extra_slurm_args.append(f"--qos={qos}")
+    if account:
+        extra_slurm_args.append(f"--account={account}")
+    logger.info(
+        "Building SlurmJob: trainer=%d node(s), %d generator(s) x %d node(s), "
+        "gpus_per_node=%d, partition=%s, qos=%s, account=%s, cpus_per_task=%s, "
+        "mem=%s",
+        trainer_nodes,
+        num_generators,
+        generator_nodes,
+        gpus_per_node,
+        partition,
+        qos or "(default)",
+        account or "(default)",
+        cpus_per_task if cpus_per_task is not None else "(default)",
+        mem or "(default)",
+    )
+
+    job = SlurmJob(
+        meshes=meshes,
+        gpus_per_node=gpus_per_node,
+        partition=partition,
+        time_limit=time_limit,
+        cpus_per_task=cpus_per_task,
+        mem=mem,
+        job_name="torchtitan_rl",
+        slurm_args=extra_slurm_args,
+        # Workers must use the same Python the controller runs.
+        python_exe=sys.executable,
+        # Don't let SlurmJob fall through to its share_node() codepath (triggered
+        # when exclusive=False AND partition is set), which would query
+        # clusterscope for cpus_per_task / mem and overwrite the values above.
+        exclusive=True,
+    )
+    return job, gpus_per_node
+
+
+def _host_meshes_from_state(
+    state, num_generators: int, gpus_per_node: int
+) -> HostMeshes:
+    """Read the trainer/generator host meshes off a JobState, by name."""
+    return HostMeshes(
+        trainer=state.trainer,
+        generators=[getattr(state, n) for n in _generator_mesh_names(num_generators)],
+        gpus_per_node=gpus_per_node,
+    )
+
+
+def _self_command() -> str:
+    """The shell command that re-runs the SLURM entry point as the in-allocation
+    client: same module and args, same interpreter."""
+    return shlex.join(
+        [
+            sys.executable,
+            "-m",
+            "torchtitan.experiments.rl.slurm_launcher",
+            *sys.argv[1:],
+        ]
+    )
+
+
+def maybe_submit_batch_job(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> bool:
+    """Login-node batch launch.
+
+    With ``RL_SLURM_BATCH=1``, submit one allocation that runs the workers AND
+    re-runs this exact command as the in-allocation controller
+    (``apply(client_script=...)``), then return True so the caller exits without
+    training. The in-allocation rerun has ``MONARCH_BATCH_JOB=1`` set and
+    reconnects through :func:`acquire_host_meshes`.
+
+    Returns False when batch mode is not requested, or when already running as
+    the in-allocation client.
+    """
+    if os.environ.get("RL_SLURM_BATCH") != "1":
+        return False
+    if os.environ.get("MONARCH_BATCH_JOB") == "1":
+        return False  # already the in-allocation client -- don't resubmit
+    job, _ = _build_slurm_job(
+        trainer_world_size, per_generator_world_size, num_generators
+    )
+    job.apply(client_script=_self_command())
+    logger.info(
+        "Submitted batch allocation %s; the controller runs inside it. Logs under %s",
+        job._slurm_job_id,
+        job._log_dir,
+    )
+    return True
+
+
+def acquire_host_meshes(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> HostMeshes:
+    """Acquire the trainer/generator host meshes from SLURM.
+
+    - In-allocation batch client (``MONARCH_BATCH_JOB=1``): reconnect to the
+      workers the runner started via the cached job; no new submission and no
+      spec rebuild.
+    - External controller: submit a worker allocation and drive training from
+      this process.
+    """
+    if os.environ.get("MONARCH_BATCH_JOB") == "1":
+        # Reconnect to the allocation the submit step cached.
+        state = job_load().state()
+        gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
+        return _host_meshes_from_state(state, num_generators, gpus_per_node)
+    job, gpus_per_node = _build_slurm_job(
+        trainer_world_size, per_generator_world_size, num_generators
+    )
+    job.apply()
+    return _host_meshes_from_state(job.state(), num_generators, gpus_per_node)
+
+
+def main() -> None:
+    config = ConfigManager().parse_args()
+    assert isinstance(config, RLTrainer.Config)
+    tws = _compute_trainer_world_size(config.trainer.parallelism)
+    gws = _compute_generator_world_size(config.generator.parallelism)
+    # Login-node batch submitter exits as soon as the sbatch is in.
+    if maybe_submit_batch_job(tws, gws, config.num_generators):
+        return
+    host_meshes = acquire_host_meshes(tws, gws, config.num_generators)
+    asyncio.run(
+        run(
+            config,
+            trainer_world_size=tws,
+            per_generator_world_size=gws,
+            host_meshes=host_meshes,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/rl/slurm_launcher.py
+++ b/torchtitan/experiments/rl/slurm_launcher.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SLURM entry point for the RL controller.
+
+Use this module's ``__main__`` instead of ``train.py`` when you want Monarch's
+``SlurmJob`` to submit the worker allocation:
+
+  python -m torchtitan.experiments.rl.slurm_launcher \\
+      --module alphabet_sort --config rl_grpo_qwen3_14b
+
+Two modes are supported:
+
+- External controller (default): submit a worker allocation and drive training
+  from the calling (login-node) process.
+- Batch (``RL_SLURM_BATCH=1``): submit one allocation that runs the workers AND
+  re-runs this same command inside the allocation as the controller, then exit
+  the login-node process. The in-allocation rerun has ``MONARCH_BATCH_JOB=1``
+  set by Monarch and reconnects to the workers via the cached ``BatchJob``.
+
+Single-node and MAST runs do not use this module -- they call
+``train.run(config, host_meshes=...)`` directly with their own host meshes (or
+``None`` for ``this_host()``).
+"""
+
+import asyncio
+import logging
+import os
+import shlex
+import sys
+
+from monarch.job import job_load, SlurmJob
+
+from torchtitan.config import ConfigManager
+from torchtitan.experiments.rl.controller import Controller
+from torchtitan.experiments.rl.train import (
+    _compute_generator_world_size,
+    _compute_trainer_world_size,
+    HostMeshes,
+    run,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _generator_mesh_names(num_generators: int) -> list[str]:
+    """Host-mesh names for the generators.
+
+    Single source for the names so the side that *creates* the meshes and the
+    side that *reads them back* off the JobState cannot drift.
+    """
+    return [f"generator_{i}" for i in range(num_generators)]
+
+
+def _build_slurm_job(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> tuple[SlurmJob, int]:
+    """Build the ``SlurmJob`` spec from ``RL_SLURM_*`` env; return ``(job,
+    gpus_per_node)``.
+
+    Trainer and generators land on disjoint nodes: the trainer gets
+    ``trainer_world_size`` GPUs and each of ``num_generators`` generators gets
+    ``per_generator_world_size`` GPUs, every role occupying whole nodes (its
+    world size must be divisible by ``RL_SLURM_GPUS_PER_NODE``).
+
+    Env vars:
+      RL_SLURM_PARTITION    (required)
+      RL_SLURM_GPUS_PER_NODE (optional, default 8)
+      RL_SLURM_TIME         (optional, HH:MM:SS)
+      RL_SLURM_QOS          (optional, e.g. h100_dev)
+      RL_SLURM_ACCOUNT      (optional, e.g. pytorch)
+      RL_SLURM_CPUS_PER_TASK (optional; partition default if unset, often too small)
+      RL_SLURM_MEM          (optional; partition default if unset, often too small)
+    """
+    partition = os.environ.get("RL_SLURM_PARTITION")
+    if not partition:
+        raise ValueError("the SLURM launcher requires RL_SLURM_PARTITION to be set")
+    gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
+    time_limit = os.environ.get("RL_SLURM_TIME")  # HH:MM:SS, optional
+    qos = os.environ.get("RL_SLURM_QOS")
+    account = os.environ.get("RL_SLURM_ACCOUNT")
+    cpus_per_task_env = os.environ.get("RL_SLURM_CPUS_PER_TASK")
+    cpus_per_task = int(cpus_per_task_env) if cpus_per_task_env else None
+    mem = os.environ.get("RL_SLURM_MEM")
+
+    if trainer_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"trainer_world_size ({trainer_world_size}) must be divisible "
+            f"by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    if per_generator_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"per_generator_world_size ({per_generator_world_size}) must be "
+            f"divisible by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    trainer_nodes = trainer_world_size // gpus_per_node
+    generator_nodes = per_generator_world_size // gpus_per_node
+    meshes = {"trainer": trainer_nodes}
+    for name in _generator_mesh_names(num_generators):
+        meshes[name] = generator_nodes
+
+    # SlurmJob takes partition/time/gpus_per_node directly; anything else
+    # (qos, account, ...) goes through slurm_args, templated as `#SBATCH <arg>`
+    # lines into the generated sbatch script.
+    extra_slurm_args: list[str] = []
+    if qos:
+        extra_slurm_args.append(f"--qos={qos}")
+    if account:
+        extra_slurm_args.append(f"--account={account}")
+    logger.info(
+        "Building SlurmJob: trainer=%d node(s), %d generator(s) x %d node(s), "
+        "gpus_per_node=%d, partition=%s, qos=%s, account=%s, cpus_per_task=%s, "
+        "mem=%s",
+        trainer_nodes,
+        num_generators,
+        generator_nodes,
+        gpus_per_node,
+        partition,
+        qos or "(default)",
+        account or "(default)",
+        cpus_per_task if cpus_per_task is not None else "(default)",
+        mem or "(default)",
+    )
+
+    job = SlurmJob(
+        meshes=meshes,
+        gpus_per_node=gpus_per_node,
+        partition=partition,
+        time_limit=time_limit,
+        cpus_per_task=cpus_per_task,
+        mem=mem,
+        job_name="torchtitan_rl",
+        slurm_args=extra_slurm_args,
+        # Workers must use the same Python the controller runs.
+        python_exe=sys.executable,
+        # Don't let SlurmJob fall through to its share_node() codepath (triggered
+        # when exclusive=False AND partition is set), which would query
+        # clusterscope for cpus_per_task / mem and overwrite the values above.
+        exclusive=True,
+    )
+    return job, gpus_per_node
+
+
+def _host_meshes_from_state(
+    state, num_generators: int, gpus_per_node: int
+) -> HostMeshes:
+    """Read the trainer/generator host meshes off a JobState, by name."""
+    return HostMeshes(
+        trainer=state.trainer,
+        generators=[getattr(state, n) for n in _generator_mesh_names(num_generators)],
+        gpus_per_node=gpus_per_node,
+    )
+
+
+def _self_command() -> str:
+    """The shell command that re-runs the SLURM entry point as the in-allocation
+    client: same module and args, same interpreter."""
+    return shlex.join(
+        [
+            sys.executable,
+            "-m",
+            "torchtitan.experiments.rl.slurm_launcher",
+            *sys.argv[1:],
+        ]
+    )
+
+
+def maybe_submit_batch_job(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> bool:
+    """Login-node batch launch.
+
+    With ``RL_SLURM_BATCH=1``, submit one allocation that runs the workers AND
+    re-runs this exact command as the in-allocation controller
+    (``apply(client_script=...)``), then return True so the caller exits without
+    training. The in-allocation rerun has ``MONARCH_BATCH_JOB=1`` set and
+    reconnects through :func:`acquire_host_meshes`.
+
+    Returns False when batch mode is not requested, or when already running as
+    the in-allocation client.
+    """
+    if os.environ.get("RL_SLURM_BATCH") != "1":
+        return False
+    if os.environ.get("MONARCH_BATCH_JOB") == "1":
+        return False  # already the in-allocation client -- don't resubmit
+    job, _ = _build_slurm_job(
+        trainer_world_size, per_generator_world_size, num_generators
+    )
+    job.apply(client_script=_self_command())
+    logger.info(
+        "Submitted batch allocation %s; the controller runs inside it. Logs under %s",
+        job._slurm_job_id,
+        job._log_dir,
+    )
+    return True
+
+
+def acquire_host_meshes(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> HostMeshes:
+    """Acquire the trainer/generator host meshes from SLURM.
+
+    - In-allocation batch client (``MONARCH_BATCH_JOB=1``): reconnect to the
+      workers the runner started via the cached job; no new submission and no
+      spec rebuild.
+    - External controller: submit a worker allocation and drive training from
+      this process.
+    """
+    if os.environ.get("MONARCH_BATCH_JOB") == "1":
+        # Reconnect to the allocation the submit step cached.
+        state = job_load().state()
+        gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
+        return _host_meshes_from_state(state, num_generators, gpus_per_node)
+    job, gpus_per_node = _build_slurm_job(
+        trainer_world_size, per_generator_world_size, num_generators
+    )
+    job.apply()
+    return _host_meshes_from_state(job.state(), num_generators, gpus_per_node)
+
+
+def main() -> None:
+    config = ConfigManager().parse_args()
+    assert isinstance(config, Controller.Config)
+    tws = _compute_trainer_world_size(config.trainer.parallelism)
+    gws = _compute_generator_world_size(config.generator.parallelism)
+    # Login-node batch submitter exits as soon as the sbatch is in.
+    if maybe_submit_batch_job(tws, gws, config.num_generators):
+        return
+    host_meshes = acquire_host_meshes(tws, gws, config.num_generators)
+    asyncio.run(
+        run(
+            config,
+            trainer_world_size=tws,
+            per_generator_world_size=gws,
+            host_meshes=host_meshes,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -25,7 +25,6 @@ python3 -m torchtitan.experiments.rl.train \
 import asyncio
 import logging
 import os
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -35,7 +34,6 @@ os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import monarch
 from monarch.actor import HostMesh, ProcMesh, this_host
-from monarch.job import SlurmJob
 
 from torchtitan.config import ConfigManager, ParallelismConfig
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
@@ -133,122 +131,6 @@ class HostMeshes:
     trainer: HostMesh
     generators: list[HostMesh]
     gpus_per_node: int
-
-
-def _maybe_launch_slurm_job(
-    trainer_world_size: int,
-    per_generator_world_size: int,
-    num_generators: int,
-) -> HostMeshes | None:
-    """Launch a Monarch SlurmJob and return HostMeshes when requested via env.
-
-    Activated by ``RL_LAUNCHER=slurm``. Submits one sbatch covering the trainer
-    and every generator on disjoint nodes: the trainer gets
-    ``trainer_world_size`` GPUs and each of ``num_generators`` generators gets
-    ``per_generator_world_size`` GPUs, every role occupying whole nodes (its
-    world size must be divisible by ``RL_SLURM_GPUS_PER_NODE``). For single-node
-    or colocated runs, omit ``RL_LAUNCHER`` and use the in-process
-    ``this_host()`` path instead.
-
-    Env vars:
-      RL_SLURM_PARTITION    (required)
-      RL_SLURM_GPUS_PER_NODE (optional, default 8)
-      RL_SLURM_TIME         (optional, HH:MM:SS)
-      RL_SLURM_QOS          (optional, e.g. h100_dev)
-      RL_SLURM_ACCOUNT      (optional, e.g. ram)
-      RL_SLURM_CPUS_PER_TASK (optional; partition default if unset, often too small)
-      RL_SLURM_MEM          (optional; partition default if unset, often too small)
-
-    Returns None when ``RL_LAUNCHER`` is unset or not ``slurm``.
-    """
-    launcher = os.environ.get("RL_LAUNCHER", "").lower()
-    if launcher != "slurm":
-        return None
-
-    partition = os.environ.get("RL_SLURM_PARTITION")
-    if not partition:
-        raise ValueError("RL_LAUNCHER=slurm requires RL_SLURM_PARTITION to be set")
-    gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
-    time_limit = os.environ.get("RL_SLURM_TIME")  # HH:MM:SS, optional
-    qos = os.environ.get("RL_SLURM_QOS")
-    account = os.environ.get("RL_SLURM_ACCOUNT")
-    cpus_per_task_env = os.environ.get("RL_SLURM_CPUS_PER_TASK")
-    cpus_per_task = int(cpus_per_task_env) if cpus_per_task_env else None
-    mem = os.environ.get("RL_SLURM_MEM")
-
-    if trainer_world_size % gpus_per_node != 0:
-        raise ValueError(
-            f"trainer_world_size ({trainer_world_size}) must be divisible "
-            f"by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
-        )
-    if per_generator_world_size % gpus_per_node != 0:
-        raise ValueError(
-            f"per_generator_world_size ({per_generator_world_size}) must be "
-            f"divisible by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
-        )
-    trainer_nodes = trainer_world_size // gpus_per_node
-    generator_nodes = per_generator_world_size // gpus_per_node
-    # Disjoint nodes per role: the trainer plus one host mesh per generator.
-    meshes = {"trainer": trainer_nodes}
-    for i in range(num_generators):
-        meshes[f"generator_{i}"] = generator_nodes
-
-    # SlurmJob takes partition/time/gpus_per_node directly; anything else
-    # (qos, account, ...) goes through slurm_args, which is templated as
-    # `#SBATCH <arg>` lines into the generated sbatch script.
-    extra_slurm_args: list[str] = []
-    if qos:
-        extra_slurm_args.append(f"--qos={qos}")
-    if account:
-        extra_slurm_args.append(f"--account={account}")
-    logger.info(
-        "Launching SlurmJob: trainer=%d node(s), %d generator(s) x %d node(s), "
-        "gpus_per_node=%d, partition=%s, qos=%s, account=%s, "
-        "cpus_per_task=%s, mem=%s",
-        trainer_nodes,
-        num_generators,
-        generator_nodes,
-        gpus_per_node,
-        partition,
-        qos or "(default)",
-        account or "(default)",
-        cpus_per_task if cpus_per_task is not None else "(default)",
-        mem or "(default)",
-    )
-
-    job = SlurmJob(
-        meshes=meshes,
-        gpus_per_node=gpus_per_node,
-        partition=partition,
-        time_limit=time_limit,
-        cpus_per_task=cpus_per_task,
-        mem=mem,
-        job_name="torchtitan_rl",
-        slurm_args=extra_slurm_args,
-        # The worker srun must use the same Python the controller is
-        # running.
-        python_exe=sys.executable,
-        # Don't let SlurmJob fall through to its share_node() codepath
-        # (triggered when exclusive=False AND partition is set), which
-        # would query clusterscope for cpus_per_task / mem and quietly
-        # overwrite the values we just set.
-        exclusive=True,
-    )
-    if os.environ.get("MONARCH_BATCH_JOB") == "1":
-        # In-allocation batch client: the controller runs inside the allocation
-        # the submitter already created. Reconnect to the workers the runner
-        # started (via the cached BatchJob) instead of submitting a new job.
-        state = job.state()
-    else:
-        job.apply()
-        state = job.state()
-    return HostMeshes(
-        trainer=state.trainer,
-        generators=[
-            getattr(state, f"generator_{i}") for i in range(num_generators)
-        ],
-        gpus_per_node=gpus_per_node,
-    )
 
 
 def _compute_trainer_world_size(p: ParallelismConfig) -> int:
@@ -361,9 +243,17 @@ def spawn_proc_mesh(
     return trainer_mesh, generator_meshes
 
 
-async def main():
-    config = ConfigManager().parse_args()
-    assert isinstance(config, RLTrainer.Config)
+async def run(
+    config: RLTrainer.Config,
+    *,
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    host_meshes: HostMeshes | None,
+) -> None:
+    """Run training given an already-resolved ``HostMeshes`` (or ``None`` for
+    single-node ``this_host()``). Launcher-agnostic: SLURM, MAST, and direct
+    local runs all funnel through here.
+    """
     sl.init_structured_logger(
         source="rl_controller",
         output_dir=config.dump_folder,
@@ -374,13 +264,6 @@ async def main():
 
     rl_trainer: RLTrainer = config.build()
     try:
-        trainer_world_size = _compute_trainer_world_size(config.trainer.parallelism)
-        per_generator_world_size = _compute_generator_world_size(
-            config.generator.parallelism
-        )
-        host_meshes = _maybe_launch_slurm_job(
-            trainer_world_size, per_generator_world_size, config.num_generators
-        )
         trainer_mesh, generator_meshes = spawn_proc_mesh(
             trainer_world_size,
             per_generator_world_size,
@@ -396,6 +279,21 @@ async def main():
         logger.info("Interrupted; attempting graceful shutdown...")
     finally:
         await rl_trainer.close()
+
+
+async def main():
+    config = ConfigManager().parse_args()
+    assert isinstance(config, RLTrainer.Config)
+    trainer_world_size = _compute_trainer_world_size(config.trainer.parallelism)
+    per_generator_world_size = _compute_generator_world_size(
+        config.generator.parallelism
+    )
+    await run(
+        config,
+        trainer_world_size=trainer_world_size,
+        per_generator_world_size=per_generator_world_size,
+        host_meshes=None,
+    )
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -234,8 +234,14 @@ def _maybe_launch_slurm_job(
         # overwrite the values we just set.
         exclusive=True,
     )
-    job.apply()
-    state = job.state()
+    if os.environ.get("MONARCH_BATCH_JOB") == "1":
+        # In-allocation batch client: the controller runs inside the allocation
+        # the submitter already created. Reconnect to the workers the runner
+        # started (via the cached BatchJob) instead of submitting a new job.
+        state = job.state()
+    else:
+        job.apply()
+        state = job.state()
     return HostMeshes(
         trainer=state.trainer,
         generators=[

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -25,6 +25,7 @@ python3 -m torchtitan.experiments.rl.train \
 import asyncio
 import logging
 import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -32,7 +33,9 @@ from dataclasses import dataclass
 # imports transitively importing torch.
 os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
+import monarch
 from monarch.actor import HostMesh, ProcMesh, this_host
+from monarch.job import SlurmJob
 
 from torchtitan.config import ConfigManager, ParallelismConfig
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
@@ -41,6 +44,47 @@ from torchtitan.observability import structured_logger as sl
 
 
 logger = logging.getLogger(__name__)
+
+
+# Opt-in escape hatch when ibverbs RDMA is detected but unstable on the node
+# (e.g. RDMABuffer create fails despite is_ibverbs_available() being True).
+# RL_RDMA_DISABLE_IBVERBS=1 forces Monarch to use its TCP fallback transport.
+# The TCP fallback's per-chunk default timeout (3s) is also too short for full
+# state-dict transfers, so we also monkey-patch read_into/write_from to pass a
+# much larger timeout. torchstore calls these without a timeout kwarg.
+#
+# Must be installed in every process that calls RDMABuffer.read_into /
+# write_from -- not just the controller. The actual RDMA ops run in the
+# worker subprocesses spawned by SlurmJob, which boot from
+# `run_worker_loop_forever` and never import this module's top-level code.
+# So _bootstrap calls this helper again per-subprocess.
+def _install_rdma_tcp_fallback() -> None:
+    if os.environ.get("RL_RDMA_DISABLE_IBVERBS") != "1":
+        return
+
+    monarch.configure(rdma_disable_ibverbs=True)
+
+    from monarch._src.rdma.rdma import RDMABuffer
+
+    if getattr(RDMABuffer, "_titan_rl_tcp_timeout_patched", False):
+        return
+
+    tcp_timeout_s = int(os.environ.get("RL_RDMA_TCP_TIMEOUT_S", "300"))
+    orig_read_into = RDMABuffer.read_into
+    orig_write_from = RDMABuffer.write_from
+
+    def read_into_with_timeout(self, dst, *, timeout=tcp_timeout_s):
+        return orig_read_into(self, dst, timeout=timeout)
+
+    def write_from_with_timeout(self, src, *, timeout=tcp_timeout_s):
+        return orig_write_from(self, src, timeout=timeout)
+
+    RDMABuffer.read_into = read_into_with_timeout
+    RDMABuffer.write_from = write_from_with_timeout
+    RDMABuffer._titan_rl_tcp_timeout_patched = True
+
+
+_install_rdma_tcp_fallback()
 
 
 class PerHostProvisioner:
@@ -76,6 +120,11 @@ class PerHostProvisioner:
             # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
             import torch  # noqa: F401
 
+            # RDMA TCP fallback patch must be installed in every worker subprocess.
+            # Workers boot from `run_worker_loop_forever` and don't import this
+            # module's top-level code, so do it here before any actor RPC runs.
+            _install_rdma_tcp_fallback()
+
         return _bootstrap
 
 
@@ -84,6 +133,116 @@ class HostMeshes:
     trainer: HostMesh
     generators: list[HostMesh]
     gpus_per_node: int
+
+
+def _maybe_launch_slurm_job(
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    num_generators: int,
+) -> HostMeshes | None:
+    """Launch a Monarch SlurmJob and return HostMeshes when requested via env.
+
+    Activated by ``RL_LAUNCHER=slurm``. Submits one sbatch covering the trainer
+    and every generator on disjoint nodes: the trainer gets
+    ``trainer_world_size`` GPUs and each of ``num_generators`` generators gets
+    ``per_generator_world_size`` GPUs, every role occupying whole nodes (its
+    world size must be divisible by ``RL_SLURM_GPUS_PER_NODE``). For single-node
+    or colocated runs, omit ``RL_LAUNCHER`` and use the in-process
+    ``this_host()`` path instead.
+
+    Env vars:
+      RL_SLURM_PARTITION    (required)
+      RL_SLURM_GPUS_PER_NODE (optional, default 8)
+      RL_SLURM_TIME         (optional, HH:MM:SS)
+      RL_SLURM_QOS          (optional, e.g. h100_dev)
+      RL_SLURM_ACCOUNT      (optional, e.g. ram)
+      RL_SLURM_CPUS_PER_TASK (optional; partition default if unset, often too small)
+      RL_SLURM_MEM          (optional; partition default if unset, often too small)
+
+    Returns None when ``RL_LAUNCHER`` is unset or not ``slurm``.
+    """
+    launcher = os.environ.get("RL_LAUNCHER", "").lower()
+    if launcher != "slurm":
+        return None
+
+    partition = os.environ.get("RL_SLURM_PARTITION")
+    if not partition:
+        raise ValueError("RL_LAUNCHER=slurm requires RL_SLURM_PARTITION to be set")
+    gpus_per_node = int(os.environ.get("RL_SLURM_GPUS_PER_NODE", "8"))
+    time_limit = os.environ.get("RL_SLURM_TIME")  # HH:MM:SS, optional
+    qos = os.environ.get("RL_SLURM_QOS")
+    account = os.environ.get("RL_SLURM_ACCOUNT")
+    cpus_per_task_env = os.environ.get("RL_SLURM_CPUS_PER_TASK")
+    cpus_per_task = int(cpus_per_task_env) if cpus_per_task_env else None
+    mem = os.environ.get("RL_SLURM_MEM")
+
+    if trainer_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"trainer_world_size ({trainer_world_size}) must be divisible "
+            f"by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    if per_generator_world_size % gpus_per_node != 0:
+        raise ValueError(
+            f"per_generator_world_size ({per_generator_world_size}) must be "
+            f"divisible by RL_SLURM_GPUS_PER_NODE ({gpus_per_node})"
+        )
+    trainer_nodes = trainer_world_size // gpus_per_node
+    generator_nodes = per_generator_world_size // gpus_per_node
+    # Disjoint nodes per role: the trainer plus one host mesh per generator.
+    meshes = {"trainer": trainer_nodes}
+    for i in range(num_generators):
+        meshes[f"generator_{i}"] = generator_nodes
+
+    # SlurmJob takes partition/time/gpus_per_node directly; anything else
+    # (qos, account, ...) goes through slurm_args, which is templated as
+    # `#SBATCH <arg>` lines into the generated sbatch script.
+    extra_slurm_args: list[str] = []
+    if qos:
+        extra_slurm_args.append(f"--qos={qos}")
+    if account:
+        extra_slurm_args.append(f"--account={account}")
+    logger.info(
+        "Launching SlurmJob: trainer=%d node(s), %d generator(s) x %d node(s), "
+        "gpus_per_node=%d, partition=%s, qos=%s, account=%s, "
+        "cpus_per_task=%s, mem=%s",
+        trainer_nodes,
+        num_generators,
+        generator_nodes,
+        gpus_per_node,
+        partition,
+        qos or "(default)",
+        account or "(default)",
+        cpus_per_task if cpus_per_task is not None else "(default)",
+        mem or "(default)",
+    )
+
+    job = SlurmJob(
+        meshes=meshes,
+        gpus_per_node=gpus_per_node,
+        partition=partition,
+        time_limit=time_limit,
+        cpus_per_task=cpus_per_task,
+        mem=mem,
+        job_name="torchtitan_rl",
+        slurm_args=extra_slurm_args,
+        # The worker srun must use the same Python the controller is
+        # running.
+        python_exe=sys.executable,
+        # Don't let SlurmJob fall through to its share_node() codepath
+        # (triggered when exclusive=False AND partition is set), which
+        # would query clusterscope for cpus_per_task / mem and quietly
+        # overwrite the values we just set.
+        exclusive=True,
+    )
+    job.apply()
+    state = job.state()
+    return HostMeshes(
+        trainer=state.trainer,
+        generators=[
+            getattr(state, f"generator_{i}") for i in range(num_generators)
+        ],
+        gpus_per_node=gpus_per_node,
+    )
 
 
 def _compute_trainer_world_size(p: ParallelismConfig) -> int:
@@ -213,10 +372,13 @@ async def main():
         per_generator_world_size = _compute_generator_world_size(
             config.generator.parallelism
         )
+        host_meshes = _maybe_launch_slurm_job(
+            trainer_world_size, per_generator_world_size, config.num_generators
+        )
         trainer_mesh, generator_meshes = spawn_proc_mesh(
             trainer_world_size,
             per_generator_world_size,
-            host_meshes=None,
+            host_meshes=host_meshes,
             num_generators=config.num_generators,
         )
         await rl_trainer.setup_async(

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -278,7 +278,20 @@ def spawn_proc_mesh(
     return trainer_mesh, generator_meshes
 
 
-async def main():
+async def run(
+    config: Controller.Config,
+    *,
+    trainer_world_size: int,
+    per_generator_world_size: int,
+    host_meshes: HostMeshes | None,
+) -> None:
+    """Drive training given already-resolved world sizes and host meshes.
+
+    ``host_meshes=None`` means single-node: partition ``this_host()`` between
+    the trainer and generators via ``CUDA_VISIBLE_DEVICES``. A non-None
+    ``HostMeshes`` places each role on its own hosts (e.g. the SLURM launcher).
+    Launcher-agnostic: local, SLURM, and MAST runs all funnel through here.
+    """
     # Monarch is making breaking changes to its message dispatching mechanism.
     # The recommended way to maintain the current behavior, which is what we want,
     # is to use @concurrent_endpoint. But that decorator is not available in
@@ -288,8 +301,6 @@ async def main():
     # https://github.com/meta-pytorch/monarch/pull/4211
     os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
 
-    config = ConfigManager().parse_args()
-    assert isinstance(config, Controller.Config)
     sl.init_structured_logger(
         source="rl_controller",
         output_dir=config.dump_folder,
@@ -300,14 +311,10 @@ async def main():
 
     rl_trainer: Controller = config.build()
     try:
-        trainer_world_size = _compute_trainer_world_size(config.trainer.parallelism)
-        per_generator_world_size = _compute_generator_world_size(
-            config.generator.parallelism
-        )
         trainer_mesh, generator_meshes = spawn_proc_mesh(
             trainer_world_size,
             per_generator_world_size,
-            host_meshes=None,
+            host_meshes=host_meshes,
             num_generators=config.num_generators,
             generator_env=breakable_cudagraph_env(config.generator),
         )
@@ -320,6 +327,21 @@ async def main():
         logger.info("Interrupted; attempting graceful shutdown...")
     finally:
         await rl_trainer.close()
+
+
+async def main():
+    config = ConfigManager().parse_args()
+    assert isinstance(config, Controller.Config)
+    trainer_world_size = _compute_trainer_world_size(config.trainer.parallelism)
+    per_generator_world_size = _compute_generator_world_size(
+        config.generator.parallelism
+    )
+    await run(
+        config,
+        trainer_world_size=trainer_world_size,
+        per_generator_world_size=per_generator_world_size,
+        host_meshes=None,
+    )
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -41,6 +41,7 @@ from torchtitan.config import ConfigManager, ParallelismConfig
 from torchtitan.experiments.rl.controller import Controller
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.observability import structured_logger as sl
+from torchtitan.tools.logging import init_logger
 
 
 logger = logging.getLogger(__name__)
@@ -292,14 +293,16 @@ async def run(
     ``HostMeshes`` places each role on its own hosts (e.g. the SLURM launcher).
     Launcher-agnostic: local, SLURM, and MAST runs all funnel through here.
     """
-    # Monarch is making breaking changes to its message dispatching mechanism.
-    # The recommended way to maintain the current behavior, which is what we want,
-    # is to use @concurrent_endpoint. But that decorator is not available in
-    # monarch's stable release yet. So we pin this env var for now, until the
-    # new release is cut. More details can be found in:
-    # https://github.com/meta-pytorch/monarch/pull/4243
-    # https://github.com/meta-pytorch/monarch/pull/4211
-    os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
+    # The controller is a plain client process, not a monarch actor, so nothing
+    # else configures its logging -- the actors each call init_logger() in their
+    # own __init__. Without this the root logger has no handler and sits at
+    # WARNING, so every controller logger.info (the per-step console metrics and
+    # the [weight-sync] dial line below) is dropped and warnings fall through to
+    # logging.lastResort on stderr. It used to work only by accident: torchstore
+    # installs a root handler at import, but only when
+    # HYPERACTOR_CODEC_MAX_FRAME_LENGTH is unset -- and the batch launcher sets
+    # that var in the submitting process, which sbatch then exports to the job.
+    init_logger()
 
     sl.init_structured_logger(
         source="rl_controller",


### PR DESCRIPTION
## Summary

Multi-node RL had no launcher: `train.py` assumed `this_host()`, so any config whose
trainer plus generators exceed one node's GPUs was unrunnable outside MAST. This wires
monarch's `SlurmJob` in behind a separate entry point.

**Bottom of a 3-PR stack** (stack #4084):

| | PR | what |
| --- | --- | --- |
| 1 | **this one** | SLURM launcher |
| 2 | #4082 | weight-sync transport + CPU-staging dials |
| 3 | #4083 | standalone weight-sync transport benchmark |

## Details

`slurm_launcher.py` computes node counts from the config's own world sizes and submits
one sbatch covering the trainer plus one mesh per generator on disjoint nodes. It
supports both places the controller can live, which is the part worth reviewing:

- **external (default)** -- the login-node process submits, attaches to the workers
  over TCP, and drives training in the foreground.
- **`RL_SLURM_BATCH=1`** -- the sbatch body runs monarch's in-allocation runner, which
  re-executes the launcher with `MONARCH_BATCH_JOB=1`. That flag is what makes the
  re-execution *reconnect* to the current allocation through the cached `BatchJob`
  instead of submitting a second one.

`train.py` gains `run(config, *, trainer_world_size, per_generator_world_size,
host_meshes)` -- just `main()` with argument parsing and world-size computation lifted
out. That is what keeps `train.py` free of SLURM imports: local (`host_meshes=None` ->
`this_host()`), SLURM, and MAST all call one function, and `slurm_launcher` imports
`HostMeshes` from `train.py` rather than restating it. `main()` is now a thin wrapper,
so **the local path is unchanged**.

Cluster specifics are env vars rather than config fields because they describe the
allocation, not the run: `RL_SLURM_PARTITION` (required), plus optional
`GPUS_PER_NODE` / `TIME` / `QOS` / `ACCOUNT`. Two workarounds are load-bearing:
`python_exe=sys.executable` so workers boot the controller's venv, and
`exclusive=True` because `SlurmJob`'s `share_node()` would otherwise silently
overwrite `cpus_per_task` and `mem`.

## Test plan

- Launcher validated end-to-end on h100 -- single-node colocated `rl_grpo_qwen3_0_6b_varlen`
  and 2-node `rl_grpo_qwen3_14b`, both COMPLETED with SLURM-enforced teardown and no
  dangling workers -- and later as part of a 2-node GB300 run. Those runs predate this
  exact revision, which has since been rebased across ~20 `main` commits.
- `pre-commit run` clean. No new tests: the launcher's surface is SLURM submission,
  which CPU unit tests can't exercise.
- The local `this_host()` path is covered by the existing RL test suite, unchanged here.

## Dependencies

- [x] https://github.com/meta-pytorch/monarch/pull/4281
- [ ] https://github.com/meta-pytorch/monarch/pull/4619 -- multi-node *attach* needs
      monarch to resolve the worker bind address and the controller dial address to the
      same string. Where they disagree (node name -> IPv6 GUA via `/etc/hosts` locally,
      IPv4 via DNS remotely), attach dies at `MESH_ATTACH_CONFIG_TIMEOUT`. A monarch
      install predating that fix fails attach on such a fabric.