### PR TITLE
Switch to v1 vllm model runner

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -375,7 +375,7 @@ class VLLMGenerator(Actor, Configurable):
             (VarlenAttention.Config, FlexAttention.Config),
         ), "Only varlen and flex attention backends are allowed."
 
-        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
         set_batch_invariance(config.debug.batch_invariant)
         if config.debug.batch_invariant:
             # batch_invariant_ops (via set_batch_invariance) covers

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -269,9 +269,6 @@ def rl_grpo_gpt_oss_debug_varlen() -> RLTrainer.Config:
     group_size = 8
     return RLTrainer.Config(
         model_spec=gpt_oss_model_registry("debugmodel", attn_backend="varlen"),
-        # Debug tokenizer (vocab 2048, matches debugmodel); the gpt_oss renderer
-        # needs gpt-oss special tokens absent here, so use the qwen3 renderer
-        # like the other debug configs.
         hf_assets_path="tests/assets/tokenizer",
         num_steps=3,
         num_groups_per_rollout_batch=5,
@@ -279,7 +276,10 @@ def rl_grpo_gpt_oss_debug_varlen() -> RLTrainer.Config:
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
         group_size=group_size,
-        renderer=RendererConfig(name="gpt_oss", enable_thinking=False),
+        # Debug tokenizer (vocab 2048, matches debugmodel); the gpt_oss renderer
+        # needs gpt-oss special tokens absent here, so use the qwen3 renderer
+        # like the other debug configs.
+        renderer=RendererConfig(name="qwen3", enable_thinking=False),
         metrics=MetricsProcessor.Config(enable_wandb=True),
         batcher=Batcher.Config(
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),
@@ -327,7 +327,10 @@ def rl_grpo_gpt_oss_debug_varlen_batch_invariant() -> RLTrainer.Config:
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
         group_size=group_size,
-        renderer=RendererConfig(name="gpt-oss", enable_thinking=False),
+        # Debug tokenizer (vocab 2048, matches debugmodel); the gpt_oss renderer
+        # needs gpt-oss special tokens absent here, so use the qwen3 renderer
+        # like the other debug configs.
+        renderer=RendererConfig(name="qwen3", enable_thinking=False),
         metrics=MetricsProcessor.Config(enable_wandb=True),
         batcher=Batcher.Config(
             batch=BatchConfig(local_batch_size=2, global_batch_size=8, seq_len=2048),

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -102,7 +102,7 @@ def generate() -> None:
     if not isinstance(inner_attn, (VarlenAttention.Config, FlexAttention.Config)):
         raise ValueError("Only varlen and flex attention backends are supported.")
 
-    os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+    os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
     set_batch_invariance(gen_config.debug.batch_invariant)
     if gen_config.debug.batch_invariant:
         # batch_invariant_ops doesn't cover bmm; the MoE router gate is a bmm in

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -199,7 +199,7 @@ def build_inference_engine(config: RLTrainer.Config) -> LLMEngine:
     use_flex = isinstance(inner_attn, FlexAttention.Config)
 
     # Mirror the production VLLMGenerator so the test exercises the same
-    # batch-invariant path.
+    # batch-invariant path (v2 runner is required for the logprob-kernel patch).
     os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
     if use_flex:
         os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -199,8 +199,8 @@ def build_inference_engine(config: RLTrainer.Config) -> LLMEngine:
     use_flex = isinstance(inner_attn, FlexAttention.Config)
 
     # Mirror the production VLLMGenerator so the test exercises the same
-    # batch-invariant path (v2 runner is required for the logprob-kernel patch).
-    os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+    # batch-invariant path.
+    os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
     if use_flex:
         os.environ["VLLM_ATTENTION_BACKEND"] = "FLEX_ATTENTION"
         backend_enum = AttentionBackendEnum.FLEX_ATTENTION


### PR DESCRIPTION
We do not need V2 model runner for now. On the other hand, v2 runner has a bug which blocks it from being used with `DP>1` generator setup (see the PR description in https://github.com/pytorch/torchtitan/pull/3743).

As a result, switch back to V1.