### PR TITLE
[rl] Checkpoint + resume the RL training loop (#3735)

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -273,10 +273,23 @@ class PolicyTrainer(Actor, Configurable):
         )
 
     def state_dict(self) -> dict[str, Any]:
+        # Registered as the checkpoint's "train_state". policy_version is the
+        # number of completed optim steps (one per training step), so it doubles
+        # as the resume step counter.
         return {"policy_version": self.policy_version}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self.policy_version = state_dict["policy_version"]
+
+    @endpoint
+    async def get_policy_version(self) -> int:
+        """Return the current policy version.
+
+        After __init__ runs CheckpointManager.load(), this is the step a resumed
+        run restored from (0 for a fresh run). The controller reads it to resume
+        the training loop and to pull generator weights at the matching version.
+        """
+        return self.policy_version
 
     @endpoint
     async def close(self) -> None:

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -273,9 +273,8 @@ class PolicyTrainer(Actor, Configurable):
         )
 
     def state_dict(self) -> dict[str, Any]:
-        # Registered as the checkpoint's "train_state". policy_version is the
-        # number of completed optim steps (one per training step), so it doubles
-        # as the resume step counter.
+        # Checkpoint "train_state": policy_version == completed optim steps, so it
+        # doubles as the resume step counter.
         return {"policy_version": self.policy_version}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
@@ -283,12 +282,8 @@ class PolicyTrainer(Actor, Configurable):
 
     @endpoint
     async def get_policy_version(self) -> int:
-        """Return the current policy version.
-
-        After __init__ runs CheckpointManager.load(), this is the step a resumed
-        run restored from (0 for a fresh run). The controller reads it to resume
-        the training loop and to pull generator weights at the matching version.
-        """
+        """Current policy version: after load(), the step a resume restored from
+        (0 if fresh). The controller uses it to resume and re-sync generators."""
         return self.policy_version
 
     @endpoint

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -31,6 +31,7 @@ from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.batcher import BatchConfig, Batcher
 from torchtitan.experiments.rl.examples.search_r1.rollouter import SearchR1Rollouter
 from torchtitan.experiments.rl.losses import DAPOLoss
+from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
 from torchtitan.experiments.rl.rollout.advantage import AdvantageEstimator
@@ -93,11 +94,9 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
         ),
         generator=VLLMGenerator.Config(
             model_dtype="bfloat16",
-            parallelism=ParallelismConfig(
-                data_parallel_shard_degree=1,
+            parallelism=InferenceParallelismConfig(
+                data_parallel_degree=1,
                 tensor_parallel_degree=4,
-                data_parallel_replicate_degree=1,
-                enable_sequence_parallel=False,
             ),
             # cudagraph on: decode-only graphs (FULL_DECODE_ONLY) are safe at this
             # config's large batch; plain full graphs corrupted here before. See #3668.

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -74,9 +74,16 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
             ),
             checkpoint=CheckpointManager.Config(
                 enable=True,
+                # First run with an empty checkpoint folder loads the HF weights;
+                # subsequent restarts resume from the latest mid-run checkpoint.
                 initial_load_in_hf=True,
-                interval=10000,  # only the initial HF load; no mid-run checkpoints
-                last_save_model_only=True,
+                # Mid-run checkpoints every `interval` steps so a preempted long
+                # run resumes instead of restarting from step 1. last_save full
+                # (not model-only) so the final checkpoint is also resumable;
+                # keep_latest_k bounds disk use for the larger models.
+                interval=50,
+                last_save_model_only=False,
+                keep_latest_k=3,
             ),
             # DAPO-style clip-higher (asymmetric clip); no KL / reference model.
             loss=DAPOLoss.Config(

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -75,13 +75,9 @@ def rl_grpo_qwen3_1_7b_search_r1() -> RLTrainer.Config:
             ),
             checkpoint=CheckpointManager.Config(
                 enable=True,
-                # First run with an empty checkpoint folder loads the HF weights;
-                # subsequent restarts resume from the latest mid-run checkpoint.
-                initial_load_in_hf=True,
-                # Mid-run checkpoints every `interval` steps so a preempted long
-                # run resumes instead of restarting from step 1. last_save full
-                # (not model-only) so the final checkpoint is also resumable;
-                # keep_latest_k bounds disk use for the larger models.
+                initial_load_in_hf=True,  # first run loads HF; restarts resume from DCP
+                # Mid-run checkpoints so a preempted run resumes; full last save
+                # (not model-only) keeps it resumable; keep_latest_k caps disk.
                 interval=50,
                 last_save_model_only=False,
                 keep_latest_k=3,

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -106,16 +106,25 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             ngpu=8,
         ),
         OverrideDefinitions(
-            # Two runs sharing the same dump_folder: the first trains 2 steps and
-            # writes a full checkpoint at step 2; the second resumes from it and
-            # trains through step 4. The second run errors if resume is broken
-            # (missing checkpoint, wrong step, generator/policy-version mismatch).
+            # Two runs sharing the same dump_folder, with different parallelism
+            # to exercise resharding on resume:
+            #   run 1: trainer DP=2 (TP=1) + 2 generators (TP=2); train 2 steps,
+            #          write a full checkpoint at step 2.
+            #   run 2: trainer TP=2 (DP=1) + 1 generator (TP=4); resume from the
+            #          step-2 checkpoint and train through step 4.
+            # This covers (1) trainer DCP checkpoint resharding (DP->TP),
+            # (2) trainer->generator TorchStore resharding, and (3) the
+            # multi-generator vs single-generator paths. The second run errors
+            # if resume is broken. lr_scheduler.total_steps is pinned so the LR
+            # is identical across save/load.
             [
                 [
                     "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 2",
-                    "--trainer.parallelism.tensor_parallel_degree 2",
+                    "--num_generators 2",
+                    "--trainer.parallelism.data_parallel_shard_degree 2",
+                    "--trainer.parallelism.tensor_parallel_degree 1",
                     "--generator.parallelism.tensor_parallel_degree 2",
                     "--group_size 2",
                     "--batcher.batch.seq_len 1024",
@@ -125,13 +134,16 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--generator.debug.no_batch_invariant",
                     "--metrics.no-enable-wandb",
                     "--trainer.checkpoint.interval 2",
+                    "--trainer.lr_scheduler.total_steps 4",
                 ],
                 [
                     "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--num_steps 4",
+                    "--num_generators 1",
+                    "--trainer.parallelism.data_parallel_shard_degree 1",
                     "--trainer.parallelism.tensor_parallel_degree 2",
-                    "--generator.parallelism.tensor_parallel_degree 2",
+                    "--generator.parallelism.tensor_parallel_degree 4",
                     "--group_size 2",
                     "--batcher.batch.seq_len 1024",
                     "--renderer.enable-thinking False",
@@ -140,11 +152,12 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--generator.debug.no_batch_invariant",
                     "--metrics.no-enable-wandb",
                     "--trainer.checkpoint.interval 2",
+                    "--trainer.lr_scheduler.total_steps 4",
                 ],
             ],
-            "RL GRPO checkpoint save + resume",
+            "RL GRPO checkpoint save + resume (resharding)",
             "rl_grpo_checkpoint_resume",
-            ngpu=4,
+            ngpu=8,
         ),
     ]
 

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -105,6 +105,47 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             "rl_grpo_moe_debug_tp4_ep4",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            # Two runs sharing the same dump_folder: the first trains 2 steps and
+            # writes a full checkpoint at step 2; the second resumes from it and
+            # trains through step 4. The second run errors if resume is broken
+            # (missing checkpoint, wrong step, generator/policy-version mismatch).
+            [
+                [
+                    "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_0_6b_varlen",
+                    "--num_steps 2",
+                    "--trainer.parallelism.tensor_parallel_degree 2",
+                    "--generator.parallelism.tensor_parallel_degree 2",
+                    "--group_size 2",
+                    "--batcher.batch.seq_len 1024",
+                    "--renderer.enable-thinking False",
+                    "--generator.sampling.max_tokens 256",
+                    "--trainer.debug.no_batch_invariant",
+                    "--generator.debug.no_batch_invariant",
+                    "--metrics.no-enable-wandb",
+                    "--trainer.checkpoint.interval 2",
+                ],
+                [
+                    "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_0_6b_varlen",
+                    "--num_steps 4",
+                    "--trainer.parallelism.tensor_parallel_degree 2",
+                    "--generator.parallelism.tensor_parallel_degree 2",
+                    "--group_size 2",
+                    "--batcher.batch.seq_len 1024",
+                    "--renderer.enable-thinking False",
+                    "--generator.sampling.max_tokens 256",
+                    "--trainer.debug.no_batch_invariant",
+                    "--generator.debug.no_batch_invariant",
+                    "--metrics.no-enable-wandb",
+                    "--trainer.checkpoint.interval 2",
+                ],
+            ],
+            "RL GRPO checkpoint save + resume",
+            "rl_grpo_checkpoint_resume",
+            ngpu=4,
+        ),
     ]
 
 

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -205,6 +205,10 @@ class RLTrainer(Configurable):
         self.config = config
         self.trainer: PolicyTrainer | None = None
         self.generator_router: GeneratorRouter | None = None
+        # Step to resume from: 0 for a fresh run, or the restored checkpoint
+        # step when resuming. Set in setup_async once the trainer has loaded
+        # any existing checkpoint.
+        self.start_step = 0
         self._proc_meshes = []
         self.metrics_processor: m.MetricsProcessor = config.metrics.build(
             log_dir=config.dump_folder,
@@ -382,11 +386,25 @@ class RLTrainer(Configurable):
         with sl.log_trace_span("torchstore_init"):
             await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
 
+        # Resume support: the trainer's __init__ already ran
+        # CheckpointManager.load(), which (when a checkpoint exists in its
+        # folder) restored the model, optimizer, LR scheduler, and
+        # policy_version. Read that version back so the loop resumes at the right
+        # step and the generators pull weights tagged with the matching version
+        # (0 for a fresh run).
+        self.start_step = self._get_rank_0_value(
+            await self.trainer.get_policy_version.call()
+        )
+        if self.start_step > 0:
+            logger.info("Resuming RL training from step %d", self.start_step)
+
         # Initial weight sync from trainer to generator
         with sl.log_trace_span("trainer_push_model_state_dict"):
             await self.trainer.push_model_state_dict.call()
         with sl.log_trace_span("generator_pull_model_state_dict"):
-            await self.generator_router.pull_model_state_dict(policy_version=0)
+            await self.generator_router.pull_model_state_dict(
+                policy_version=self.start_step
+            )
 
     @sl.log_trace_span("_collect_rollouts")
     async def _collect_rollouts(
@@ -638,12 +656,18 @@ class RLTrainer(Configurable):
     async def train(self):
         num_steps = self.config.num_steps
         num_groups = self.config.num_groups_per_rollout_batch
-        logger.info(f"Pre-training validation; then {num_steps} steps of RL training")
+        start_step = self.start_step  # 0 fresh, >0 when resuming a checkpoint
+        logger.info(
+            "Pre-training validation; then RL training steps %d..%d",
+            start_step + 1,
+            num_steps,
+        )
 
-        # collect validation metrics before training to compare before/after
-        pre_validation_metrics = await self.validate(step=0)
+        # Validation before training to compare before/after. On resume the
+        # baseline is the restored policy at `start_step`.
+        pre_validation_metrics = await self.validate(step=start_step)
         self.metrics_processor.log(
-            step=0,
+            step=start_step,
             metrics=pre_validation_metrics,
             is_validation=True,
         )
@@ -653,7 +677,7 @@ class RLTrainer(Configurable):
 
         sl.log_trace_instant("training_start")
 
-        for step in range(1, num_steps + 1):
+        for step in range(start_step + 1, num_steps + 1):
             sl.set_step(step)
 
             # Propagate the step counter to actors for structured logging.
@@ -812,6 +836,17 @@ class RLTrainer(Configurable):
             if not math.isfinite(fwd_bwd_metrics["loss/mean"]):
                 logger.error("Loss is NaN/Inf; training diverged")
                 break
+
+            # --- checkpoint ---
+            # Persist full training state (model + optimizer + LR scheduler +
+            # policy_version) so a preempted run can resume. The trainer's
+            # CheckpointManager only writes on its configured interval and on
+            # the final step; other steps are a no-op. Saved after the
+            # divergence check so a NaN step is not checkpointed.
+            with sl.log_trace_span("trainer_save_checkpoint"):
+                await self.trainer.save_checkpoint.call(
+                    step, last_step=(step == num_steps)
+                )
 
             # --- periodic validation ---
             # TODO(async): validation is generation-only, so overlap it with the next

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -391,7 +391,7 @@ class RLTrainer(Configurable):
             await self.trainer.get_policy_version.call()
         )
         if self.start_step > 0:
-            logger.info("Resuming RL training from step %d", self.start_step)
+            logger.info(f"Resuming RL training from step {self.start_step}")
 
         # Initial weight sync from trainer to generator
         with sl.log_trace_span("trainer_push_model_state_dict"):
@@ -653,9 +653,8 @@ class RLTrainer(Configurable):
         num_groups = self.config.num_groups_per_rollout_batch
         start_step = self.start_step  # 0 fresh, >0 when resuming a checkpoint
         logger.info(
-            "Pre-training validation; then RL training steps %d..%d",
-            start_step + 1,
-            num_steps,
+            f"Pre-training validation; then RL training steps "
+            f"{start_step + 1}..{num_steps}"
         )
 
         # Validation before training to compare before/after. On resume the

--- a/torchtitan/experiments/rl/trainer.py
+++ b/torchtitan/experiments/rl/trainer.py
@@ -205,9 +205,7 @@ class RLTrainer(Configurable):
         self.config = config
         self.trainer: PolicyTrainer | None = None
         self.generator_router: GeneratorRouter | None = None
-        # Step to resume from: 0 for a fresh run, or the restored checkpoint
-        # step when resuming. Set in setup_async once the trainer has loaded
-        # any existing checkpoint.
+        # Resume step (0 = fresh); set in setup_async from the loaded checkpoint.
         self.start_step = 0
         self._proc_meshes = []
         self.metrics_processor: m.MetricsProcessor = config.metrics.build(
@@ -386,12 +384,9 @@ class RLTrainer(Configurable):
         with sl.log_trace_span("torchstore_init"):
             await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
 
-        # Resume support: the trainer's __init__ already ran
-        # CheckpointManager.load(), which (when a checkpoint exists in its
-        # folder) restored the model, optimizer, LR scheduler, and
-        # policy_version. Read that version back so the loop resumes at the right
-        # step and the generators pull weights tagged with the matching version
-        # (0 for a fresh run).
+        # The trainer's __init__ already ran CheckpointManager.load(); read back
+        # the restored policy_version (0 if fresh) so the loop resumes at the
+        # right step and the generators pull weights at the matching version.
         self.start_step = self._get_rank_0_value(
             await self.trainer.get_policy_version.call()
         )
@@ -838,11 +833,9 @@ class RLTrainer(Configurable):
                 break
 
             # --- checkpoint ---
-            # Persist full training state (model + optimizer + LR scheduler +
-            # policy_version) so a preempted run can resume. The trainer's
-            # CheckpointManager only writes on its configured interval and on
-            # the final step; other steps are a no-op. Saved after the
-            # divergence check so a NaN step is not checkpointed.
+            # Save full training state for resume; CheckpointManager writes only
+            # on its interval and the final step. After the divergence check so a
+            # NaN step is not checkpointed.
             with sl.log_trace_span("trainer_save_checkpoint"):
                 await self.trainer.save_checkpoint.call(
                     step, last_step=(step == num_steps)


### PR DESCRIPTION
## Summary

Wire up mid-run checkpointing and resume for the RL trainer
(`torchtitan/experiments/rl/`). Fixes #3735.

## Why

`PolicyTrainer.save_checkpoint()` existed but was never called, and the loop ran
`range(1, num_steps + 1)`, so a preempted RL job restarted from step 1 and
discarded all progress (hit on a multi-host Search-R1 run that lost ~6h after a
MAST restart).

## What

- **Save**: call `trainer.save_checkpoint(step, last_step)` each step, after the
  divergence check (so a NaN step is not checkpointed). `CheckpointManager`
  writes only on its `interval` and the final step; intermediate saves are full
  (model + optimizer + LR scheduler + `policy_version`), hence resumable.
- **Resume**: `PolicyTrainer.__init__` already runs `CheckpointManager.load()`.
  A new `get_policy_version` endpoint lets the controller read the restored step,
  resume the loop from `start_step + 1`, and pull the generator weights at the
  matching policy version -- the RL-specific wrinkle from the issue: the
  generators must return to the trainer's restored version, not just reload the
  trainer.
- **Recipe**: `search_r1` enables mid-run checkpoints (`interval=50`, full last
  save, `keep_latest_k=3`). The interval / keep-last-N are existing
  `CheckpointManager.Config` knobs -- no new config surface.
- Also fixes a pre-existing `search_r1` bug: the generator was built with
  `ParallelismConfig` instead of `InferenceParallelismConfig`, so the recipe
  raised `AttributeError` at build. Folded in since this PR makes that recipe
  resumable and it should build.

`policy_version` == completed optim steps == checkpoint step, so it doubles as
the resume counter and the generator sync version. A fresh run (empty folder)
loads HF weights as before; once a DCP checkpoint exists in the folder, restart
resumes from it.

## Test

New `rl_grpo_checkpoint_resume` integration test (4 GPU): two runs over a shared
`dump_folder` -- the first trains 2 steps and writes a full checkpoint at step 2;
the second resumes from it and trains through step 4 (the second run errors if
resume is broken).

Manually verified on `alphabet_sort rl_grpo_qwen3_0_6b_flex`: run A saved
`step-2` (DCP metadata confirms model + optimizer + lr_scheduler +
`train_state.policy_version`); run B logged `Resuming RL training from step 2`,
trained steps 3-4, saved `step-4`.