### PR TITLE
ci: skip float8 integration tests on ROCm leg of 8 GPU H100 tests

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -38,6 +38,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             ],
             "Float8 test",
             "float8",
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [
@@ -65,6 +66,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "FSDP+async TP+PP+torch.compile+Float8",
             "fsdp+tp+cp+compile+float8",
             ngpu=8,
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [
@@ -79,6 +81,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             "HSDP+CP+torch.compile+Float8",
             "hsdp+cp+compile+float8",
             ngpu=8,
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
## Summary

The `8 GPU Integration Test on H100` workflow runs a ROCm leg (`linux.rocm.gpu.ecosystem.gfx950.8`). Three float8 flavors fail there with:

```
ValueError: Failed to swap to Float8Linear because float8 is only supported on SM89 or later.
```

torchtitan float8 is gated purely on `has_cuda_capability(8, 9)` (NVIDIA SM89+) in `torchtitan/components/quantization/float8.py` (lines 85 and 222), with no ROCm branch. `has_cuda_capability` is hip-guarded, so it is always `False` on ROCm and these flavors cannot pass there today. This is an unsupported path, not a flake.

This skips the three float8 flavors on the ROCm leg only, matching the existing `fsdp_symm_mem` / `deepseek_v3_fsdp+hybridep+compile` skip pattern in the same file:

- `float8`
- `fsdp+tp+cp+compile+float8`
- `hsdp+cp+compile+float8`

CUDA/H100 coverage is unchanged.

Enabling float8 on ROCm (via `has_rocm_capability` + a validated torchao fp8 gfx950 backend) is net-new feature work and out of scope here.

## Test plan

- [ ] ROCm leg of `8 GPU Integration Test on H100` no longer runs the three float8 flavors and goes green.
- [ ] CUDA/H100 leg still runs all flavors.