### PR TITLE
float8: enable on ROCm gfx942+ via has_rocm_capability

### DIFF
--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -16,7 +16,7 @@ from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import has_cuda_capability
+from torchtitan.tools.utils import has_cuda_capability, has_rocm_capability
 
 from .utils import module_filter_fn, swap_token_dispatcher
 
@@ -82,11 +82,16 @@ class Float8LinearConverter(QuantizationConverter):
         cfg = self.config
         filter_fqns = cfg.filter_fqns
 
-        if has_cuda_capability(8, 9) or (cfg.emulate and not cfg.model_compile_enabled):
+        if (
+            has_cuda_capability(8, 9)
+            or has_rocm_capability(9, 4)
+            or (cfg.emulate and not cfg.model_compile_enabled)
+        ):
             pass
         else:
             raise ValueError(
-                "Failed to swap to Float8Linear because float8 is only supported on SM89 or later. "
+                "Failed to swap to Float8Linear because float8 is only supported on "
+                "NVIDIA SM89 or later, or AMD gfx942 (MI300) or later. "
                 "To enable testing on older hardware, set `float8.emulate` to True in eager mode.",
             )
 
@@ -219,8 +224,11 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 "torchao is not installed. Please install it to use float8 MoE training."
             )
 
-        if not has_cuda_capability(8, 9):
-            raise ValueError("Float8 MoE training only supported on SM89 or later.")
+        if not (has_cuda_capability(8, 9) or has_rocm_capability(9, 4)):
+            raise ValueError(
+                "Float8 MoE training only supported on NVIDIA SM89 or later, "
+                "or AMD gfx942 (MI300) or later."
+            )
 
         if not self.config.model_compile_enabled:
             logger.warning(


### PR DESCRIPTION
## Summary

The float8 capability gates in `torchtitan/components/quantization/float8.py` used only `has_cuda_capability(8, 9)` (NVIDIA SM89+). PR #3738 hip-guarded `has_cuda_capability` so it returns `False` on all ROCm GPUs. That correctly fixes NVIDIA-only paths like FA3, but float8 is **not** NVIDIA-only: it runs on AMD gfx942 (MI300) and gfx950 (MI350) via torchao.

As a result, the ROCm leg of `8 GPU Integration Test on H100` regressed on three flavors:

```
ValueError: Failed to swap to Float8Linear because float8 is only supported on SM89 or later.
```

### Evidence this is a regression, not an unsupported path

Boundary is one commit wide:

| run | sha | result |
|---|---|---|
| 28048772279 | d10029de (18:42) | success |
| 28057651162 | b934b0c2 (21:16) = #3738 merge | failure |

In the last green ROCm run (job 83033682759, gfx950.8), all three float8 flavors trained and passed under `torch.compile`:

```
===== [float8] flavor: Float8 test (rc=0) =====
===== [fsdp+tp+cp+compile+float8] flavor: FSDP+async TP+PP+torch.compile+Float8 (rc=0) =====
===== [hsdp+cp+compile+float8] flavor: HSDP+CP+torch.compile+Float8 (rc=0) =====
```

So float8 genuinely works on gfx950; #3738's blanket hip-guard just removed that coverage.

## Fix

Gate on `has_rocm_capability(9, 4)` in addition to the NVIDIA path. This covers gfx942 (MI300, reports (9,4)) and gfx950 (MI350, (9,5)) while keeping gfx90a (MI250, no fp8) excluded. `emulate` is not a viable escape hatch here because two of the three flavors use `torch.compile`, which the emulate branch disallows.

Latent twin (not in this PR): `mx.py:70,165` gate MXFP on `has_cuda_capability(10, 0)`; MI350 supports MX, so #3738 also disabled those on ROCm. Not addressed here because no MXFP flavor currently runs on the ROCm leg.

## Test plan

- [ ] ROCm leg of `8 GPU Integration Test on H100` goes green on the three float8 flavors (requires `ciflow/8gpu`).
- [ ] NVIDIA/H100 leg unchanged.