### PR TITLE
[spmd] normalize partial to replicate on size-1 mesh axes in resolve_placements

### DIFF
--- a/torchtitan/protocols/sharding.py
+++ b/torchtitan/protocols/sharding.py
@@ -15,7 +15,7 @@ meshes.
 from dataclasses import dataclass, field
 
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor import Placement, Replicate, Shard
+from torch.distributed.tensor import Partial, Placement, Replicate, Shard
 
 from torchtitan.distributed.parallel_dims import MeshAxisName, SpmdLayout
 
@@ -133,13 +133,14 @@ def resolve_placements(
     it will be applied against. Missing declarations raise ``ValueError``;
     extra declarations (axes not in the mesh) are ignored.
 
-    ``Shard(d)`` on a size-1 mesh axis is normalized to ``Replicate()`` --
-    the two are operationally identical on a 1-rank axis, but DTensor's op
-    rules (placement-equality, view/reshape strict mode, ...) treat them
-    as distinct and reject ``Shard`` in places where ``Replicate`` would
-    work.
+    ``Shard(d)`` or ``Partial`` on a size-1 mesh axis is normalized to
+    ``Replicate()`` -- all three are operationally identical on a 1-rank axis
+    (no data is split, and a sum over a single rank is the identity), but
+    DTensor's op rules (placement-equality, view/reshape strict mode, ...)
+    treat them as distinct and reject ``Shard``/``Partial`` in places where
+    ``Replicate`` would work.
     """
-    # TODO(fegin): remove the ``Shard(d)`` on a size-1 mesh to ``Replicate()``
+    # TODO(fegin): remove the size-1 ``Shard(d)``/``Partial`` to ``Replicate()``
     # conversion once FlexShard replaces ``fully_shard``.
     assert mesh.mesh_dim_names is not None, "DeviceMesh must have named axes"
     placements = spmd_layout_to_dtensor_placements(layout)
@@ -154,7 +155,7 @@ def resolve_placements(
                 f"required: {list(mesh.mesh_dim_names)}."
             )
         p = placements[key]
-        if isinstance(p, Shard) and mesh.size(i) == 1:
+        if isinstance(p, (Shard, Partial)) and mesh.size(i) == 1:
             p = Replicate()
         result.append(p)
     return tuple(result)


### PR DESCRIPTION
`resolve_placements` already collapses `Shard(d) -> Replicate()` on a size-1 mesh axis. `Partial` has the exact same property but wasn't covered, which makes full-DTensor MoE crash on any config with a size-1 data-parallel axis. To reproduce, 
```
NGPU=2 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel ./run_train.sh \
      --parallelism.tensor_parallel_degree 2 \
      --parallelism.spmd_backend full_dtensor \
      --training.steps 2
```
Got
```
ValueError: GroupedExperts.num_local_tokens_per_expert_E: input DTensor has
  placements (Replicate(), Replicate()), but in_src_shardings expects
  (Partial(sum), Replicate())
```

### root cause
Under `full_dtensor`, the batch is sharded across the data-parallel axis. With `dp_shard == 1` that axis has a single rank, so there's nothing to split and the whole batch lives on that one rank, i.e. `Replicate` on the dp axis. In `torchtitan/models/common/moe.py`, 
  - dp_shard=1: scores_BLE placements = (Replicate, Replicate)
  - dp_shard=2: scores_BLE placements = (Shard(0), Replicate)  ← batch genuinely split and works well. 

When dp_shard=1, `routing_map_BLE = zeros_like(scores_BLE).scatter_(...)` inherits that placement, so it's `Replicate` on the dp axis too. The MoE per-expert token counts (`num_local_tokens_per_expert_E = routing_map.sum(dim=(0,1))`) are declared `Partial(sum)` on the data-parallel axis via `_tokens_per_expert_placement`, correct, because each dp rank processes different tokens and contributes a partial count. With `dp_shard == 1` the DP axis has a single rank, so the batch is not split and the runtime value comes out `Replicate` on that axis as shown above. `resolve_placements` only normalizes `Shard -> Replicate` on size-1 axes, not `Partial`, so the contract's expected keeps `Partial(sum)` while the actual value is `Replicate. _redistribute_inputs` then rejects the (numerically identical) mismatch.

### Fix
Extend the existing size-1 normalization in `resolve_placements` to cover `Partial` as well as `Shard`. 

Numerical test confirmed loss/gd_norm parity on dp_shard=2 after the fix.


 